### PR TITLE
Refactor async proofing data storage

### DIFF
--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -59,17 +59,13 @@ module Idv
     end
 
     def pii(address_pii)
-      merge_non_address_pii(address_pii.dup)
+      address_pii.dup.merge(non_address_pii)
     end
 
-    def merge_non_address_pii(hash)
-      pii_h = pii_to_h
-      %w[first_name middle_name last_name dob phone ssn].each do |key|
-        hash[key] = pii_h[key]
-      end
-
-      hash[:uuid_prefix] = ServiceProvider.from_issuer(sp_session[:issuer]).app_id
-      hash
+    def non_address_pii
+      pii_to_h.
+        slice(*%w[first_name middle_name last_name dob phone ssn]).
+        merge(uuid_prefix: ServiceProvider.from_issuer(sp_session[:issuer]).app_id)
     end
 
     def pii_to_h

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -205,7 +205,7 @@ module Idv
     def async_state
       dcs_uuid = idv_session.idv_usps_document_capture_session_uuid
       dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
-      return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
+      return ProofingSessionAsyncResult.none if dcs_uuid.nil?
       return timed_out if dcs.nil?
 
       proofing_job_result = dcs.load_proofing_result
@@ -241,7 +241,7 @@ module Idv
     def timed_out
       flash[:info] = I18n.t('idv.failure.timeout')
       delete_async
-      ProofingDocumentCaptureSessionResult.timed_out
+      ProofingSessionAsyncResult.timed_out
     end
   end
 end

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -64,7 +64,7 @@ module Idv
 
     def non_address_pii
       pii_to_h.
-        slice(*%w[first_name middle_name last_name dob phone ssn]).
+        slice('first_name', 'middle_name', 'last_name', 'dob', 'phone', 'ssn').
         merge(uuid_prefix: ServiceProvider.from_issuer(sp_session[:issuer]).app_id)
     end
 

--- a/app/controllers/lambda_callback/address_proof_result_controller.rb
+++ b/app/controllers/lambda_callback/address_proof_result_controller.rb
@@ -1,11 +1,16 @@
 module LambdaCallback
   class AddressProofResultController < AuthTokenController
     def create
-      dcs = DocumentCaptureSession.new
-      dcs.result_id = result_id_parameter
-      dcs.store_proofing_result(address_result_parameter.to_h)
+      dcs = DocumentCaptureSession.find_by(result_id: result_id_parameter)
 
-      track_exception_in_result(address_result_parameter)
+      if dcs
+        dcs.store_proofing_result(address_result_parameter.to_h)
+
+        track_exception_in_result(address_result_parameter)
+      else
+        NewRelic::Agent.notice_error('AddressProofResult result_id not found')
+        head :not_found
+      end
     end
 
     private

--- a/app/controllers/lambda_callback/resolution_proof_result_controller.rb
+++ b/app/controllers/lambda_callback/resolution_proof_result_controller.rb
@@ -1,11 +1,16 @@
 module LambdaCallback
   class ResolutionProofResultController < AuthTokenController
     def create
-      dcs = DocumentCaptureSession.new
-      dcs.result_id = result_id_parameter
-      dcs.store_proofing_result(resolution_result_parameter)
+      dcs = DocumentCaptureSession.find_by(result_id: result_id_parameter)
 
-      track_exception_in_result(resolution_result_parameter)
+      if dcs
+        dcs.store_proofing_result(resolution_result_parameter)
+
+        track_exception_in_result(resolution_result_parameter)
+      else
+        NewRelic::Agent.notice_error('ResolutionProofResult result_id not found')
+        head :not_found
+      end
     end
 
     private

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -48,14 +48,14 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   def load_proofing_result
-    EncryptedRedisStructStorage.load(result_id, type: ProofingDocumentCaptureSessionResult)
+    EncryptedRedisStructStorage.load(result_id, type: ProofingSessionAsyncResult)
   end
 
   def create_proofing_session
     EncryptedRedisStructStorage.store(
-      ProofingDocumentCaptureSessionResult.new(
+      ProofingSessionAsyncResult.new(
         id: generate_result_id,
-        status: ProofingDocumentCaptureSessionResult::IN_PROGRESS,
+        status: ProofingSessionAsyncResult::IN_PROGRESS,
         result: nil,
       ),
       expires_in: AppConfig.env.async_wait_timeout_seconds.to_i,
@@ -65,10 +65,10 @@ class DocumentCaptureSession < ApplicationRecord
 
   def store_proofing_result(proofing_result)
     EncryptedRedisStructStorage.store(
-      ProofingDocumentCaptureSessionResult.new(
+      ProofingSessionAsyncResult.new(
         id: result_id,
         result: proofing_result,
-        status: ProofingDocumentCaptureSessionResult::DONE,
+        status: ProofingSessionAsyncResult::DONE,
       ),
       expires_in: AppConfig.env.async_wait_timeout_seconds.to_i,
     )

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This is used by hybrid doc auth capture
 DocumentCaptureSessionResult = Struct.new(:id, :success, :pii, keyword_init: true) do
   def self.redis_key_prefix
     'dcs:result'

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -39,7 +39,7 @@ module Idv
         form_response
       end
 
-      # @param [ProofingDocumentCaptureSessionResult] async_result
+      # @param [ProofingSessionAsyncResult] async_result
       def async_state_done(async_result)
         doc_pii_form_result = Idv::DocPiiForm.new(async_result.pii).submit
 

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -21,7 +21,7 @@ module Idv
     def async_state
       dcs_uuid = idv_session.idv_phone_step_document_capture_session_uuid
       dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
-      return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
+      return ProofingSessionAsyncResult.none if dcs_uuid.nil?
       return timed_out if dcs.nil?
 
       proofing_job_result = dcs.load_proofing_result
@@ -152,7 +152,7 @@ module Idv
 
     def timed_out
       delete_async
-      ProofingDocumentCaptureSessionResult.timed_out
+      ProofingSessionAsyncResult.timed_out
     end
 
     def delete_async

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -7,7 +7,7 @@ module Idv
 
     def submit(step_params)
       self.step_params = step_params
-      idv_session.previous_phone_step_params = { phone: step_params[:phone] }
+      idv_session.previous_phone_step_params = step_params.slice(:phone)
       proof_address
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -10,6 +10,7 @@ module Idv
       pii
       previous_phone_step_params
       previous_profile_step_params
+      previous_usps_step_params
       profile_confirmation
       profile_id
       profile_step_params

--- a/app/services/idv/steps/cac/verify_step.rb
+++ b/app/services/idv/steps/cac/verify_step.rb
@@ -18,7 +18,7 @@ module Idv
           )
 
           document_capture_session.requested_at = Time.zone.now
-          document_capture_session.store_proofing_pii_from_doc(pii_from_doc)
+          document_capture_session.create_proofing_session
 
           Idv::Agent.new(pii_from_doc).proof_resolution(
             document_capture_session,

--- a/app/services/idv/steps/cac/verify_wait_step_show.rb
+++ b/app/services/idv/steps/cac/verify_wait_step_show.rb
@@ -43,11 +43,11 @@ module Idv
         def async_state
           dcs_uuid = flow_session[cac_verify_document_capture_session_uuid_key]
           dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
-          return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
-          return ProofingDocumentCaptureSessionResult.timed_out if dcs.nil?
+          return ProofingSessionAsyncResult.none if dcs_uuid.nil?
+          return ProofingSessionAsyncResult.timed_out if dcs.nil?
 
           proofing_job_result = dcs.load_proofing_result
-          return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+          return ProofingSessionAsyncResult.timed_out if proofing_job_result.nil?
 
           proofing_job_result
         end

--- a/app/services/idv/steps/recover_verify_step.rb
+++ b/app/services/idv/steps/recover_verify_step.rb
@@ -18,7 +18,7 @@ module Idv
         )
 
         document_capture_session.requested_at = Time.zone.now
-        document_capture_session.store_proofing_pii_from_doc(pii_from_doc)
+        document_capture_session.create_proofing_session
 
         Idv::Agent.new(pii_from_doc).proof_resolution(
           document_capture_session,

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -10,16 +10,15 @@ module Idv
       private
 
       def process_async_state(current_async_state)
-        case current_async_state.status
-        when :none
+        if current_async_state.none?
           mark_step_incomplete(:verify)
-        when :in_progress
+        elsif current_async_state.in_progress?
           nil
-        when :timed_out
+        elsif current_async_state.timed_out?
           flash[:info] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
-        when :done
+        elsif current_async_state.done?
           async_state_done(current_async_state)
         end
       end
@@ -27,7 +26,7 @@ module Idv
       def async_state_done(current_async_state)
         add_proofing_costs(current_async_state.result)
         response = idv_result_to_form_response(current_async_state.result)
-        response = check_ssn(current_async_state.pii) if response.success?
+        response = check_ssn(flow_session[:pii_from_doc]) if response.success?
         summarize_result_and_throttle_failures(response)
         delete_async
 
@@ -49,11 +48,7 @@ module Idv
         proofing_job_result = dcs.load_proofing_result
         return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
 
-        if proofing_job_result.result
-          proofing_job_result.done
-        elsif proofing_job_result.pii
-          ProofingDocumentCaptureSessionResult.in_progress
-        end
+        proofing_job_result
       end
 
       def delete_async

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -42,11 +42,11 @@ module Idv
       def async_state
         dcs_uuid = flow_session[recover_verify_document_capture_session_uuid_key]
         dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
-        return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
-        return ProofingDocumentCaptureSessionResult.timed_out if dcs.nil?
+        return ProofingSessionAsyncResult.none if dcs_uuid.nil?
+        return ProofingSessionAsyncResult.timed_out if dcs.nil?
 
         proofing_job_result = dcs.load_proofing_result
-        return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+        return ProofingSessionAsyncResult.timed_out if proofing_job_result.nil?
 
         proofing_job_result
       end

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -17,7 +17,7 @@ module Idv
         )
 
         document_capture_session.requested_at = Time.zone.now
-        document_capture_session.store_proofing_pii_from_doc(pii_from_doc)
+        document_capture_session.create_proofing_session
 
         idv_agent.proof_resolution(
           document_capture_session,

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -43,11 +43,11 @@ module Idv
       def async_state
         dcs_uuid = flow_session[verify_step_document_capture_session_uuid_key]
         dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
-        return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
-        return ProofingDocumentCaptureSessionResult.timed_out if dcs.nil?
+        return ProofingSessionAsyncResult.none if dcs_uuid.nil?
+        return ProofingSessionAsyncResult.timed_out if dcs.nil?
 
         proofing_job_result = dcs.load_proofing_result
-        return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+        return ProofingSessionAsyncResult.timed_out if proofing_job_result.nil?
 
         proofing_job_result
       end

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -10,16 +10,15 @@ module Idv
       private
 
       def process_async_state(current_async_state)
-        case current_async_state.status
-        when :none
+        if current_async_state.none?
           mark_step_incomplete(:verify)
-        when :in_progress
+        elsif current_async_state.in_progress?
           nil
-        when :timed_out
+        elsif current_async_state.timed_out?
           flash[:info] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
-        when :done
+        elsif current_async_state.done?
           async_state_done(current_async_state)
         end
       end
@@ -27,7 +26,7 @@ module Idv
       def async_state_done(current_async_state)
         add_proofing_costs(current_async_state.result)
         response = idv_result_to_form_response(current_async_state.result)
-        response = check_ssn(current_async_state.pii) if response.success?
+        response = check_ssn(flow_session[:pii_from_doc]) if response.success?
         summarize_result_and_throttle_failures(response)
         delete_async
 
@@ -50,11 +49,7 @@ module Idv
         proofing_job_result = dcs.load_proofing_result
         return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
 
-        if proofing_job_result.result
-          proofing_job_result.done
-        elsif proofing_job_result.pii
-          ProofingDocumentCaptureSessionResult.in_progress
-        end
+        proofing_job_result
       end
 
       def delete_async

--- a/app/services/proofing_document_capture_session_result.rb
+++ b/app/services/proofing_document_capture_session_result.rb
@@ -1,28 +1,42 @@
 # frozen_string_literal: true
 
+# This is used by resolution and address proofing
+# Idv::Agent#proof_resolution and Idv::Agent#proof_address
+# NOTE: remove pii key after next deploy
 ProofingDocumentCaptureSessionResult = Struct.new(:id, :pii, :result, :status,
                                                   keyword_init: true) do
+  self::NONE = 'none'
+  self::IN_PROGRESS = 'in_progress'
+  self::DONE = 'done'
+  self::TIMED_OUT = 'timed_out'
+
   def self.redis_key_prefix
     'dcs-proofing:result'
   end
 
   def self.none
-    new(status: :none)
+    new(status: ProofingDocumentCaptureSessionResult::NONE)
   end
 
   def self.timed_out
-    new(status: :timed_out)
+    new(status: ProofingDocumentCaptureSessionResult::TIMED_OUT)
   end
 
-  def self.in_progress
-    new(status: :in_progress)
+  def timed_out?
+    status == ProofingDocumentCaptureSessionResult::TIMED_OUT
   end
 
-  alias_method :pii_from_doc, :pii
+  def done?
+    status == ProofingDocumentCaptureSessionResult::DONE
+  end
+
+  def in_progress?
+    status == ProofingDocumentCaptureSessionResult::IN_PROGRESS ||
+      pii.present?
+  end
 
   def done
     ProofingDocumentCaptureSessionResult.new(
-      pii: pii.deep_symbolize_keys,
       result: result.deep_symbolize_keys,
       status: :done,
     )

--- a/app/services/proofing_session_async_result.rb
+++ b/app/services/proofing_session_async_result.rb
@@ -3,7 +3,7 @@
 # This is used by resolution and address proofing
 # Idv::Agent#proof_resolution and Idv::Agent#proof_address
 # NOTE: remove pii key after next deploy
-ProofingDocumentCaptureSessionResult = Struct.new(:id, :pii, :result, :status,
+ProofingSessionAsyncResult = Struct.new(:id, :pii, :result, :status,
                                                   keyword_init: true) do
   self::NONE = 'none'
   self::IN_PROGRESS = 'in_progress'
@@ -15,28 +15,32 @@ ProofingDocumentCaptureSessionResult = Struct.new(:id, :pii, :result, :status,
   end
 
   def self.none
-    new(status: ProofingDocumentCaptureSessionResult::NONE)
+    new(status: ProofingSessionAsyncResult::NONE)
   end
 
   def self.timed_out
-    new(status: ProofingDocumentCaptureSessionResult::TIMED_OUT)
+    new(status: ProofingSessionAsyncResult::TIMED_OUT)
+  end
+
+  def none?
+    status == ProofingSessionAsyncResult::NONE
   end
 
   def timed_out?
-    status == ProofingDocumentCaptureSessionResult::TIMED_OUT
+    status == ProofingSessionAsyncResult::TIMED_OUT
   end
 
   def done?
-    status == ProofingDocumentCaptureSessionResult::DONE
+    status == ProofingSessionAsyncResult::DONE || result.present?
   end
 
   def in_progress?
-    status == ProofingDocumentCaptureSessionResult::IN_PROGRESS ||
+    status == ProofingSessionAsyncResult::IN_PROGRESS ||
       pii.present?
   end
 
   def done
-    ProofingDocumentCaptureSessionResult.new(
+    ProofingSessionAsyncResult.new(
       result: result.deep_symbolize_keys,
       status: :done,
     )

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -83,7 +83,7 @@ describe Idv::PhoneController do
       # in progress behavior
       document_capture_session = DocumentCaptureSession.create(user_id: user.id,
                                                                requested_at: Time.zone.now)
-      document_capture_session.store_proofing_pii_from_doc({})
+      document_capture_session.create_proofing_session
 
       subject.idv_session.idv_phone_step_document_capture_session_uuid =
         document_capture_session.uuid
@@ -168,10 +168,10 @@ describe Idv::PhoneController do
           expect(response).to redirect_to idv_review_path
 
           expected_applicant = {
-            first_name: 'Some',
-            last_name: 'One',
-            phone: normalized_phone,
-            uuid_prefix: nil,
+            'first_name' => 'Some',
+            'last_name' => 'One',
+            'phone' => normalized_phone,
+            'uuid_prefix' => nil,
           }
 
           expect(subject.idv_session.applicant).to eq expected_applicant

--- a/spec/controllers/idv/usps_controller_spec.rb
+++ b/spec/controllers/idv/usps_controller_spec.rb
@@ -43,8 +43,8 @@ describe Idv::UspsController do
 
     it 'renders wait page while job is in progress' do
       allow(controller).to receive(:async_state).and_return(
-        ProofingDocumentCaptureSessionResult.new(
-          status: ProofingDocumentCaptureSessionResult::IN_PROGRESS,
+        ProofingSessionAsyncResult.new(
+          status: ProofingSessionAsyncResult::IN_PROGRESS,
         ),
       )
       get :index
@@ -55,7 +55,7 @@ describe Idv::UspsController do
     # can be removed after next deploy
     it 'renders wait page while job is in progress using old session structure' do
       allow(controller).to receive(:async_state).and_return(
-        ProofingDocumentCaptureSessionResult.new(
+        ProofingSessionAsyncResult.new(
           status: nil,
           pii: { first_name: Faker::Name.first_name },
         ),

--- a/spec/controllers/idv/usps_controller_spec.rb
+++ b/spec/controllers/idv/usps_controller_spec.rb
@@ -43,7 +43,22 @@ describe Idv::UspsController do
 
     it 'renders wait page while job is in progress' do
       allow(controller).to receive(:async_state).and_return(
-        ProofingDocumentCaptureSessionResult.in_progress,
+        ProofingDocumentCaptureSessionResult.new(
+          status: ProofingDocumentCaptureSessionResult::IN_PROGRESS,
+        ),
+      )
+      get :index
+
+      expect(response).to render_template :wait
+    end
+
+    # can be removed after next deploy
+    it 'renders wait page while job is in progress using old session structure' do
+      allow(controller).to receive(:async_state).and_return(
+        ProofingDocumentCaptureSessionResult.new(
+          status: nil,
+          pii: { first_name: Faker::Name.first_name },
+        ),
       )
       get :index
 

--- a/spec/controllers/lambda_callback/address_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/address_proof_result_controller_spec.rb
@@ -12,7 +12,7 @@ describe LambdaCallback::AddressProofResultController do
 
       it 'accepts and stores successful address proofing results' do
         applicant = { phone: Faker::PhoneNumber.cell_phone }
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_address(document_capture_session, trace_id: trace_id)
         proofer_result = document_capture_session.load_proofing_result[:result]
 
@@ -28,7 +28,7 @@ describe LambdaCallback::AddressProofResultController do
           phone: IdentityIdpFunctions::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER,
         }
 
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_address(document_capture_session, trace_id: trace_id)
         proofer_result = document_capture_session.load_proofing_result[:result]
 
@@ -50,7 +50,7 @@ describe LambdaCallback::AddressProofResultController do
           phone: IdentityIdpFunctions::AddressMockClient::PROOFER_TIMEOUT_PHONE_NUMBER,
         }
 
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_address(document_capture_session, trace_id: trace_id)
         proofer_result = document_capture_session.load_proofing_result[:result]
 

--- a/spec/controllers/lambda_callback/resolution_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/resolution_proof_result_controller_spec.rb
@@ -14,7 +14,7 @@ describe LambdaCallback::ResolutionProofResultController do
         applicant = { first_name: Faker::Name.first_name, ssn: Faker::IDNumber.valid,
                       zipcode: Faker::Address.zip_code, state_id_number: '123',
                       state_id_type: 'drivers_license', state_id_jurisdiction: 'WI' }
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_resolution(
           document_capture_session,
           should_proof_state_id: true,
@@ -32,7 +32,7 @@ describe LambdaCallback::ResolutionProofResultController do
       it 'accepts and stores unsuccessful resolution proofing results' do
         applicant = { first_name: 'Bad Name', ssn: Faker::IDNumber.valid,
                       zipcode: Faker::Address.zip_code }
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_resolution(
           document_capture_session,
           should_proof_state_id: false,
@@ -57,7 +57,7 @@ describe LambdaCallback::ResolutionProofResultController do
         applicant = { first_name: 'Time', ssn: Faker::IDNumber.valid,
                       zipcode: Faker::Address.zip_code }
 
-        document_capture_session.store_proofing_pii_from_doc(applicant)
+        document_capture_session.create_proofing_session
         Idv::Agent.new(applicant).proof_resolution(
           document_capture_session,
           should_proof_state_id: false,

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -37,7 +37,7 @@ describe Idv::PhoneStep do
 
       subject.submit(phone: good_phone)
 
-      expect(subject.async_state.done?).to eq true
+      expect(subject.async_state).to be_done
       result = subject.async_state_done(subject.async_state)
       expect(result).to be_kind_of(FormResponse)
       expect(result.success?).to eq(true)

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -37,7 +37,7 @@ describe Idv::PhoneStep do
 
       subject.submit(phone: good_phone)
 
-      expect(subject.async_state.status).to eq :done
+      expect(subject.async_state.done?).to eq true
       result = subject.async_state_done(subject.async_state)
       expect(result).to be_kind_of(FormResponse)
       expect(result.success?).to eq(true)
@@ -54,7 +54,7 @@ describe Idv::PhoneStep do
       extra = { vendor: { messages: [], context: context, exception: nil, timed_out: false } }
 
       subject.submit(phone: bad_phone)
-      expect(subject.async_state.status).to eq :done
+      expect(subject.async_state.done?).to eq true
       result = subject.async_state_done(subject.async_state)
 
       expect(result).to be_kind_of(FormResponse)
@@ -70,7 +70,7 @@ describe Idv::PhoneStep do
       original_step_attempts = idv_session.step_attempts[:phone]
 
       subject.submit(phone: bad_phone)
-      expect(subject.async_state.status).to eq :done
+      expect(subject.async_state.done?).to eq true
       _result = subject.async_state_done(subject.async_state)
 
       expect(idv_session.step_attempts[:phone]).to eq(original_step_attempts + 1)
@@ -96,7 +96,7 @@ describe Idv::PhoneStep do
       user.phone_configurations = [build(:phone_configuration, user: user, phone: good_phone)]
 
       subject.submit(phone: good_phone)
-      expect(subject.async_state.status).to eq :done
+      expect(subject.async_state.done?).to eq true
       result = subject.async_state_done(subject.async_state)
 
       expect(result.success?).to eq(true)
@@ -106,7 +106,7 @@ describe Idv::PhoneStep do
 
     it 'does not mark the phone as confirmed if it does not match 2FA phone' do
       subject.submit(phone: good_phone)
-      expect(subject.async_state.status).to eq :done
+      expect(subject.async_state.done?).to eq true
       result = subject.async_state_done(subject.async_state)
 
       expect(result.success?).to eq(true)
@@ -119,7 +119,7 @@ describe Idv::PhoneStep do
     context 'when there are idv attempts remaining' do
       it 'returns :warning' do
         subject.submit(phone: bad_phone)
-        expect(subject.async_state.status).to eq :done
+        expect(subject.async_state.done?).to eq true
         _result = subject.async_state_done(subject.async_state)
 
         expect(subject.failure_reason).to eq(:warning)
@@ -131,7 +131,7 @@ describe Idv::PhoneStep do
         idv_session.step_attempts[:phone] = idv_max_attempts - 1
 
         subject.submit(phone: bad_phone)
-        expect(subject.async_state.status).to eq :done
+        expect(subject.async_state.done?).to eq true
         _result = subject.async_state_done(subject.async_state)
 
         expect(subject.failure_reason).to eq(:fail)
@@ -141,7 +141,7 @@ describe Idv::PhoneStep do
     context 'when the vendor raises a timeout exception' do
       it 'returns :timeout' do
         subject.submit(phone: timeout_phone)
-        expect(subject.async_state.status).to eq :done
+        expect(subject.async_state.done?).to eq true
         _result = subject.async_state_done(subject.async_state)
 
         expect(subject.failure_reason).to eq(:timeout)
@@ -151,7 +151,7 @@ describe Idv::PhoneStep do
     context 'when the vendor raises an exception' do
       it 'returns :jobfail' do
         subject.submit(phone: fail_phone)
-        expect(subject.async_state.status).to eq :done
+        expect(subject.async_state.done?).to eq true
         _result = subject.async_state_done(subject.async_state)
 
         expect(subject.failure_reason).to eq(:jobfail)

--- a/spec/services/proofing_session_async_result_spec.rb
+++ b/spec/services/proofing_session_async_result_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-RSpec.describe ProofingDocumentCaptureSessionResult do
+RSpec.describe ProofingSessionAsyncResult do
   let(:id) { SecureRandom.uuid }
   let(:pii) { { 'first_name' => 'Testy', 'last_name' => 'Testerson' } }
   let(:idv_result) { { errors: {}, messages: ['some message'] } }
 
   context 'EncryptedRedisStructStorage' do
     it 'works with EncryptedRedisStructStorage' do
-      result = ProofingDocumentCaptureSessionResult.new(id: id, pii: pii, result: idv_result)
+      result = ProofingSessionAsyncResult.new(id: id, pii: pii, result: idv_result)
 
       EncryptedRedisStructStorage.store(result)
 
       loaded_result = EncryptedRedisStructStorage.load(
-        id, type: ProofingDocumentCaptureSessionResult
+        id, type: ProofingSessionAsyncResult
       )
 
       expect(loaded_result.id).to eq(id)


### PR DESCRIPTION
Previously, the async proofing process would store the arguments used for the vendor proofing call as backgrounds jobs were intended to load inputs from Redis instead of figuring out how to have the background job store encrypt its arguments.  We use lambdas, so the storage of arguments isn't needed, and this refactor no longer stores the PII in redis.

There is a bit of complication to this because in the synchronous process the form data that gets submitted is sometimes used after the proofer vendor returns a response, and the redis-stored PII was kind of a stand-in for that. To work with that, the `previous_..._params` pattern was copied to save the user's input and then used as necessary after the vendor returns a successful response.