### PR TITLE
LG-3816 Fix doc auth SSN enter extra digits breaks continue Part 2

### DIFF
--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -53,6 +53,7 @@ function formatSSNFieldAndLimitLength() {
         const maxLength = 9 + (this.value.match(/-/g) || []).length;
         if (this.value.length > maxLength) {
           this.value = this.value.slice(0, maxLength);
+          this.checkValidity();
         }
       }
 


### PR DESCRIPTION
**Why**: Entering extra digits required a second click