### PR TITLE
add autoloader check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ jobs:
           command: |
             mkdir /tmp/test-results
             ./cc-test-reporter before-build
+            bin/rails zeitwerk:check
 
             bundle exec rake knapsack:rspec
             yarn test


### PR DESCRIPTION
Runs `bin/rails zeitwerk:check` to ensure we are not doing anything that doesn't comply with the autoloader. This would ideally run during the `lint` step, but it requires some config to be set up (at least `config/application.yml`) so it gets run during tests after test setup.

I tested with a commit that introduces a bad class and it does fail on CI as expected.

Upgrade guide section that describes the rake task is here: [link](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#project-structure)