### PR TITLE
[skip release notes] Allow SP to send skip_encryption for non-encrypted SAML response (LG-3859)

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -148,10 +148,20 @@ module SamlIdpAuthConcern
       name_id_format: name_id_format,
       authn_context_classref: requested_authn_context,
       reference_id: active_identity.session_uuid,
-      encryption: current_service_provider.encryption_opts,
+      encryption: encryption_opts,
       signature: saml_response_signature_options,
       signed_response_message: current_service_provider.signed_response_message_requested,
     )
+  end
+
+  def encryption_opts
+    url = URI.parse request.original_url
+    query_params = Rack::Utils.parse_nested_query url.query
+    if query_params['skip_encryption'].present? && current_service_provider.skip_encryption_allowed
+      nil
+    else
+      current_service_provider.encryption_opts
+    end
   end
 
   def saml_response_signature_options

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -155,9 +155,8 @@ module SamlIdpAuthConcern
   end
 
   def encryption_opts
-    url = URI.parse request.original_url
-    query_params = Rack::Utils.parse_nested_query url.query
-    if query_params['skip_encryption'].present? && current_service_provider.skip_encryption_allowed
+    query_params = UriService.params(request.original_url)
+    if query_params[:skip_encryption].present? && current_service_provider.skip_encryption_allowed
       nil
     else
       current_service_provider.encryption_opts

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -81,6 +81,10 @@ class NullServiceProvider
 
   def encryption_opts; end
 
+  def skip_encryption_allowed
+    false
+  end
+
   def allow_prompt_login
     false
   end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -49,12 +49,10 @@ class ServiceProvider < ApplicationRecord
 
   def skip_encryption_allowed
     config = AppConfig.env.skip_encryption_allowed_list
-    if config
-      @allowed_list ||= JSON.parse(config, symbolize_names: true)
-      @allowed_list.include? issuer
-    else
-      false
-    end
+    return false unless config
+    
+    @allowed_list ||= JSON.parse(config, symbolize_names: true)
+    @allowed_list.include? issuer
   end
 
   def live?

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -47,6 +47,16 @@ class ServiceProvider < ApplicationRecord
     }
   end
 
+  def skip_encryption_allowed
+    config = AppConfig.env.skip_encryption_allowed_list
+    if config
+      @allowed_list ||= JSON.parse(config, symbolize_names: true)
+      @allowed_list.include? issuer
+    else
+      false
+    end
+  end
+
   def live?
     active? && approved?
   end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -49,9 +49,9 @@ class ServiceProvider < ApplicationRecord
 
   def skip_encryption_allowed
     config = AppConfig.env.skip_encryption_allowed_list
-    return false unless config
+    return false if config.blank?
     
-    @allowed_list ||= JSON.parse(config, symbolize_names: true)
+    @allowed_list ||= JSON.parse(config)
     @allowed_list.include? issuer
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -233,6 +233,7 @@ development:
   scrypt_cost: 10000$8$1$
   secret_key_base: development_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
+  skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
   sps_over_quota_limit_notify_email_list: '[]'
   telephony_adapter: test
   use_dashboard_service_providers: 'true'
@@ -342,6 +343,7 @@ production:
   scrypt_cost: 10000$8$1$
   secret_key_base:
   session_encryption_key:
+  skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:int"]'
   sps_over_quota_limit_notify_email_list: '[]'
   telephony_adapter: pinpoint
   use_dashboard_service_providers: 'false'

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -174,4 +174,23 @@ describe ServiceProvider do
       end
     end
   end
+
+  describe '#skip_encryption_allowed' do
+    context 'SP in allowed list' do
+      before do
+        allow(AppConfig.env).to receive(:skip_encryption_allowed_list).
+          and_return('["http://localhost:3000"]')
+      end
+
+      it 'allows the SP to optionally skip encrypting the SAML response' do
+        expect(service_provider.skip_encryption_allowed).to be(true)
+      end
+    end
+
+    context 'SP not in allowed list' do
+      it 'does not allow the SP to optionally skip encrypting the SAML response' do
+        expect(service_provider.skip_encryption_allowed).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows a configured list of SAML SP's that are configured to encrypt responses to optionally skip the encryption by passing the param `skip_encryption=true` with the request. This is being done so that the SAML Sinatra app can have this option, making it easier to debug SAML issues.