### PR TITLE
Allow some leeway when validating OIDC token iat

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -3,6 +3,8 @@ class OpenidConnectTokenForm
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers
 
+  ISSUED_AT_LEEWAY_SECONDS = 10.seconds.to_i
+
   ATTRS = %i[
     client_assertion
     client_assertion_type
@@ -104,10 +106,11 @@ class OpenidConnectTokenForm
     return if identity.blank?
 
     payload, _headers = JWT.decode(client_assertion, service_provider.ssl_cert.public_key, true,
-                                   algorithm: 'RS256', verify_iat: true,
-                                   iss: client_id, verify_iss: true,
-                                   sub: client_id, verify_sub: true)
+                                   algorithm: 'RS256', iss: client_id,
+                                   verify_iss: true, sub: client_id,
+                                   verify_sub: true)
     validate_aud_claim(payload)
+    validate_iat(payload)
   rescue JWT::DecodeError => err
     errors.add(:client_assertion, err.message)
   end
@@ -120,6 +123,14 @@ class OpenidConnectTokenForm
 
     errors.add(:client_assertion,
                t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url))
+  end
+
+  def validate_iat(payload)
+    iat = payload['iat']
+    return true if iat.blank?
+    return true if iat.is_a?(Numeric) && (iat.to_i - ISSUED_AT_LEEWAY_SECONDS) < Time.zone.now.to_i
+
+    errors.add(:client_assertion, t('openid_connect.token.errors.invalid_iat'))
   end
 
   def service_provider

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -126,9 +126,9 @@ class OpenidConnectTokenForm
   end
 
   def validate_iat(payload)
+    return true unless payload.key?('iat')
     iat = payload['iat']
-    return true if iat.blank?
-    return true if iat.is_a?(Numeric) && (iat.to_i - ISSUED_AT_LEEWAY_SECONDS) < Time.zone.now.to_i
+    return true if iat.is_a?(Integer) && (iat.to_i - ISSUED_AT_LEEWAY_SECONDS) < Time.zone.now.to_i
 
     errors.add(:client_assertion, t('openid_connect.token.errors.invalid_iat'))
   end

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -28,6 +28,8 @@ en:
         invalid_code: is invalid either because it expired, or it doesn't match any
           user. Please see our documentation at https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier did not match code_challenge
+        invalid_iat: iat must be an integer Unix timestamp representing a time in
+          the past
     user_info:
       errors:
         malformed_authorization: Malformed Authorization header

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -28,6 +28,8 @@ es:
         invalid_code: no es válido porque ha caducado o no coincide con ningún usuario.
           Consulte nuestra documentación en https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier no coincide con code_challenge
+        invalid_iat: iat debe ser una marca de tiempo entera de Unix que represente
+          un tiempo en el pasado
     user_info:
       errors:
         malformed_authorization: Título de autorización mal formado

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -29,6 +29,8 @@ fr:
           ne correspond à aucun utilisateur. Veuillez consulter notre documentation
           à https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier ne correspondait pas à code_challenge
+        invalid_iat: iat doit être un horodatage Unix entier représentant une heure
+          dans le passé
     user_info:
       errors:
         malformed_authorization: Forme de l'en-tête d'autorisation non valide

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe OpenidConnectTokenForm do
         context 'with no issued time' do
           before { jwt_payload.except!(:iat) }
 
-          it 'is invalid' do
+          it 'is still valid' do
             expect(valid?).to eq(true)
           end
         end


### PR DESCRIPTION
The `ruby-jwt` library is very strict on the `iat` field and is not configurable on that, so we have to roll our own. The igov OIDC [specification](https://openid.net/specs/openid-igov-openid-connect-1_0.html#rfc.section.2.3) allows for the value to be within "acceptable ranges", but isn't defined further:

>The "expiration", "issued at", and "not before" timestamps for the token are dates (integer number of seconds since from 1970-01-01T00:00:00Z UTC) within acceptable ranges.

I picked 10 seconds of leeway because most partners having issues with this have reported fixing the skew by adding 1-5 seconds, and 10 should be more than enough to fix that while still ensuring we aren't allowing tokens issued far into the future.

Closes #4315 