### PR TITLE
Update smoke tests to check out SHA deployed to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,9 @@ jobs:
     environment:
       MONITOR_ENV: STAGING
     steps:
-      - checkout
+      - jq/install
+      - checkout-deployed-sha:
+          sha_url: https://idp.staging.login.gov/api/deploy.json
       - bundle-yarn-install
       - run:
           name: "Smoke tests"
@@ -302,7 +304,7 @@ workflows:
           filters:
             branches:
               only:
-                - stages/staging
+                - master
     jobs:
       - smoketest-staging
 


### PR DESCRIPTION
Now that staging is deployed from the `master` branch, the smoke tests that look at `stages/staging` will be looking at the code in the wrong spot

This updates to be similar to what we do for `int` and `dev` environments, load the code to match the SHA that is currently deployed there
