### PR TITLE
allow Numeric for iat field on OIDC tokens

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -128,7 +128,7 @@ class OpenidConnectTokenForm
   def validate_iat(payload)
     return true unless payload.key?('iat')
     iat = payload['iat']
-    return true if iat.is_a?(Integer) && (iat.to_i - ISSUED_AT_LEEWAY_SECONDS) < Time.zone.now.to_i
+    return true if iat.is_a?(Numeric) && (iat.to_i - ISSUED_AT_LEEWAY_SECONDS) < Time.zone.now.to_i
 
     errors.add(:client_assertion, t('openid_connect.token.errors.invalid_iat'))
   end

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -28,8 +28,8 @@ en:
         invalid_code: is invalid either because it expired, or it doesn't match any
           user. Please see our documentation at https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier did not match code_challenge
-        invalid_iat: iat must be an integer Unix timestamp representing a time in
-          the past
+        invalid_iat: iat must be an integer or floating point Unix timestamp representing
+          a time in the past
     user_info:
       errors:
         malformed_authorization: Malformed Authorization header

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -28,8 +28,8 @@ es:
         invalid_code: no es válido porque ha caducado o no coincide con ningún usuario.
           Consulte nuestra documentación en https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier no coincide con code_challenge
-        invalid_iat: iat debe ser una marca de tiempo entera de Unix que represente
-          un tiempo en el pasado
+        invalid_iat: iat debe ser una marca de tiempo Unix de punto flotante o entero
+          que represente un tiempo en el pasado
     user_info:
       errors:
         malformed_authorization: Título de autorización mal formado

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -29,8 +29,8 @@ fr:
           ne correspond à aucun utilisateur. Veuillez consulter notre documentation
           à https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier ne correspondait pas à code_challenge
-        invalid_iat: iat doit être un horodatage Unix entier représentant une heure
-          dans le passé
+        invalid_iat: iat doit être un horodatage Unix entier ou à virgule flottante
+          représentant une heure dans le passé
     user_info:
       errors:
         malformed_authorization: Forme de l'en-tête d'autorisation non valide


### PR DESCRIPTION
A partner reported having issues with the `iat` field from I suspect the changes in #4504. `ruby-jwt` allows Numeric instead of integer (https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/verify.rb#L48), so my hunch is that we're receiving a Float.