### PR TITLE
Drop doc_captures table

### DIFF
--- a/db/migrate/20201218142021_drop_doc_capture.rb
+++ b/db/migrate/20201218142021_drop_doc_capture.rb
@@ -1,0 +1,15 @@
+class DropDocCapture < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :doc_captures do |t|
+      t.integer :user_id, null: false
+      t.string :request_token, null: false
+      t.datetime :requested_at, null: false
+      t.string :acuant_token
+      t.boolean :ial2_strict
+      t.string :issuer
+      t.timestamps
+      t.index :request_token, name: :index_doc_captures_on_request_token, unique: true
+      t.index :user_id, name: :index_doc_captures_on_user_id, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,19 +197,6 @@ ActiveRecord::Schema.define(version: 2021_01_20_220857) do
     t.index ["user_id"], name: "index_doc_auths_on_user_id"
   end
 
-  create_table "doc_captures", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "request_token", null: false
-    t.datetime "requested_at", null: false
-    t.string "acuant_token"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "ial2_strict"
-    t.string "issuer"
-    t.index ["request_token"], name: "index_doc_captures_on_request_token", unique: true
-    t.index ["user_id"], name: "index_doc_captures_on_user_id", unique: true
-  end
-
   create_table "document_capture_sessions", force: :cascade do |t|
     t.string "uuid"
     t.string "result_id"


### PR DESCRIPTION
**Why**: Because after #4508 is merged, we won't be using this table. We will be using document_capture_sessions instead.