### PR TITLE
LG-3756: Remove redundant normalize.css dependency

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -1,4 +1,3 @@
-@import 'normalize.css/normalize';
 @import 'hint.css/hint';
 
 @import 'basscss-sass/defaults';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "identity-style-guide": "^3.0.0",
     "intl-tel-input": "^16.0.7",
     "libphonenumber-js": "^1.7.26",
-    "normalize.css": "^4.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "zxcvbn": "^4.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6289,11 +6289,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-normalize.css@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-4.2.0.tgz#21d66cc557154d4379fd1e079ec7de58a379b099"
-  integrity sha1-IdZsxVcVTUN5/R4HnsfeWKN5sJk=
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
**Why**: As a user, I want login.gov to not have unused or out of date apps, so that I can use the fastest and most secure app possible

- Remove unnecessary dependencies (LG-3756)
- Reduce bundle size
- Avoid conflicts between disparate versions

See related: https://github.com/18F/identity-site/pull/475

>Normalize.css is still included, but not directly referenced, and instead inherited through USWDS [[1]](https://github.com/uswds/uswds/blob/b0e7ea3800e5bb5960e0925716cf5363375ee613/config/gulp/sass.js#L60-L61) [[2]](https://github.com/uswds/uswds/blob/3dc296ec56cd621fe52d918701fd94621d96a198/src/stylesheets/packages/_global.scss#L3).

**Impact:**

There's a marginal decrease in size of the primary `application.css` stylesheet:

_Before:_ 464.2kb (69.4kb gzipped)

_After:_ 461.9kb (68.7 kb gzipped)