### PR TITLE
Implement headless USPS in-person proofing (LG-3855)

### DIFF
--- a/app/services/usps_in_person_proofer.rb
+++ b/app/services/usps_in_person_proofer.rb
@@ -1,0 +1,190 @@
+class UspsInPersonProofer
+  attr_reader :token, :token_expires_at
+
+  # Makes a request to retrieve a new OAuth token
+  # and modifies self to store the token and when
+  # it expires (15 minutes).
+  # @return [String] the token
+  def retrieve_token!
+    body = request_token
+    @token_expires_at = Time.zone.now + body['expires_in']
+    @token = "#{body['token_type']} #{body['access_token']}"
+  end
+
+  def token_expired?
+    @token_expires_at.nil? || @token_expires_at.past?
+  end
+
+  # Makes HTTP request to authentication endpoint
+  # and modifies self to store the token and when
+  # it expires (15 minutes).
+  # @return [Hash] API response
+  def request_token
+    url = "#{root_url}/oauth/authenticate"
+    body = {
+      username: AppConfig.env.usps_ipp_username,
+      password: AppConfig.env.usps_ipp_password,
+      grant_type: 'implicit',
+      response_type: 'token',
+      client_id: '424ada78-62ae-4c53-8e3a-0b737708a9db',
+      scope: 'ivs.ippaas.apis',
+    }.to_json
+    resp = faraday.post(url, body, request_headers)
+
+    if resp.success?
+      JSON.parse(resp.body)
+    else
+      { error: 'Failed to get token', response: resp }
+    end
+  end
+
+  # Makes HTTP request to get nearby in-person proofing facilities
+  # Requires address, city, state and zip code.
+  # @param location [Object]
+  # @return [Hash] API response
+  def request_facilities(location)
+    url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList"
+    body = {
+      sponsorID: sponsor_id,
+      streetAddress: location.address,
+      city: location.city,
+      state: location.state,
+      zipCode: location.zip_code,
+    }.to_json
+
+    headers = request_headers.merge({
+      'Authorization' => @token,
+      'RequestID' => request_id,
+    })
+
+    resp = faraday.post(url, body, headers)
+
+    if resp.success?
+      JSON.parse(resp.body)
+    else
+      { error: 'failed to get facilities', response: resp }
+    end
+  end
+
+  # Makes HTTP request to enroll an applicant in in-person proofing.
+  # Requires first name, last name, address, city, state, zip code, email address and a generated
+  # unique ID. The unique ID must be no longer than 18 characters.
+  # USPS sends an email to the email address with instructions and the enrollment code.
+  # The API response also includes the enrollment code which should be
+  # stored with the unique ID to be able to request the status of proofing.
+  # @param applicant [Object]
+  # @return [Hash] API response
+  def request_enroll(applicant)
+    url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant"
+    body = {
+      sponsorID: sponsor_id,
+      uniqueID: applicant.unique_id,
+      firstName: applicant.first_name,
+      lastName: applicant.last_name,
+      streetAddress: applicant.address,
+      city: applicant.city,
+      state: applicant.state,
+      zipCode: applicant.zip_code,
+      emailAddress: applicant.email,
+      IPPAssuranceLevel: '1.5',
+    }.to_json
+
+    headers = request_headers.merge({
+      'Authorization' => @token,
+      'RequestID' => request_id,
+    })
+
+    resp = faraday.post(url, body, headers)
+
+    if resp.success?
+      JSON.parse(resp.body)
+    else
+      { error: 'failed to get enroll', response: resp }
+    end
+  end
+
+  # Makes HTTP request to retrieve proofing status
+  # Requires the applicant's enrollment code and unique ID.
+  # When proofing is complete the API returns 200 status.
+  # If the applicant has not been to the post office, has proofed recently,
+  # or there is another issue, the API returns a 400 status with an error message.
+  # @param unique_id [String]
+  # @param enrollment_code [String]
+  # @return [Hash] API response
+  def request_proofing_results(unique_id, enrollment_code)
+    url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults"
+    body = {
+      sponsorID: sponsor_id,
+      uniqueID: unique_id,
+      enrollmentCode: enrollment_code,
+    }.to_json
+
+    headers = request_headers.merge({
+      'Authorization' => @token,
+      'RequestID' => request_id,
+    })
+
+    resp = faraday.post(url, body, headers)
+
+    if resp.success?
+      JSON.parse(resp.body)
+    elsif resp.status == 400 && resp.headers['content-type'] == 'application/json'
+      JSON.parse(resp.body)
+    else
+      { error: 'failed to get proofing results', response: resp }
+    end
+  end
+
+  # Makes HTTP request to retrieve enrollment code
+  # If an applicant has a currently valid enrollment code, it will be returned.
+  # If they do not, a new one will be generated and returned. USPS sends the applicant an email with
+  # instructions and the enrollment code.
+  # Requires the applicant's unique ID.
+  # @param unique_id [String]
+  # @return [Hash] API response
+  def request_enrollment_code(unique_id)
+    url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/requestEnrollmentCode"
+    body = {
+      sponsorID: sponsor_id,
+      uniqueID: unique_id,
+    }.to_json
+
+    headers = request_headers.merge({
+      'Authorization' => @token,
+      'RequestID' => request_id,
+    })
+
+    resp = faraday.post(url, body, headers)
+
+    if resp.success?
+      JSON.parse(resp.body)
+    else
+      resp
+    end
+  end
+
+  def root_url
+    AppConfig.env.usps_ipp_root_url
+  end
+
+  def sponsor_id
+    AppConfig.env.usps_ipp_sponsor_id.to_i
+  end
+
+  def request_id
+    SecureRandom.uuid
+  end
+
+  def faraday
+    Faraday.new do |conn|
+      conn.options.timeout = 10
+      conn.options.read_timeout = 10
+      conn.options.open_timeout = 10
+      conn.options.write_timeout = 10
+    end
+  end
+
+  def request_headers
+    { 'Content-Type' => 'application/json; charset=utf-8' }
+  end
+end

--- a/app/services/usps_in_person_proofer.rb
+++ b/app/services/usps_in_person_proofer.rb
@@ -11,8 +11,8 @@ class UspsInPersonProofer
     @token = "#{body['token_type']} #{body['access_token']}"
   end
 
-  def token_expired?
-    @token_expires_at.nil? || @token_expires_at.past?
+  def token_valid?
+    @token.present? && @token_expires_at.present? && @token_expires_at.future?
   end
 
   # Makes HTTP request to authentication endpoint

--- a/app/services/usps_in_person_proofer.rb
+++ b/app/services/usps_in_person_proofer.rb
@@ -52,10 +52,10 @@ class UspsInPersonProofer
       zipCode: location.zip_code,
     }.to_json
 
-    headers = request_headers.merge({
+    headers = request_headers.merge(
       'Authorization' => @token,
       'RequestID' => request_id,
-    })
+    )
 
     resp = faraday.post(url, body, headers)
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -138,6 +138,10 @@ usps_download_sftp_timeout: '5'
 usps_upload_enabled: 'false'
 usps_upload_sftp_timeout: '5'
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2", "http://idmanagement.gov/ns/assurance/ial/0", "http://idmanagement.gov/ns/assurance/ial/2?strict=true", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo", "http://idmanagement.gov/ns/assurance/aal/2", "http://idmanagement.gov/ns/assurance/aal/3", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true"]'
+usps_ipp_password: ''
+usps_ipp_root_url: ''
+usps_ipp_sponsor_id: ''
+usps_ipp_username: ''
 
 development:
   aal_authn_context_enabled: 'true'

--- a/spec/fixtures/usps_ipp_responses/request_enroll_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_enroll_response.json
@@ -1,0 +1,4 @@
+{
+  "enrollmentCode": "2048702198804353",
+  "responseMessage": "Applicant 123456789 successfully processed"
+}

--- a/spec/fixtures/usps_ipp_responses/request_enrollment_code_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_enrollment_code_response.json
@@ -1,0 +1,4 @@
+{
+  "enrollmentCode": "2048702198804358",
+  "responseMessage": "Applicant 123456789 successfully processed"
+}

--- a/spec/fixtures/usps_ipp_responses/request_facilities_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_facilities_response.json
@@ -1,0 +1,224 @@
+{
+  "postOffices": [
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "0.54 mi",
+      "streetAddress": "606 E JUNEAU AVE",
+      "city": "MILWAUKEE",
+      "phone": "414-289-0809",
+      "name": "JUNEAU",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53202"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 8:00 PM"
+        },
+        {
+          "saturdayHours": "Closed"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "0.66 mi",
+      "streetAddress": "345 W SAINT PAUL AVE",
+      "city": "MILWAUKEE",
+      "phone": "414-270-2308",
+      "name": "MILWAUKEE",
+      "zip4": "3099",
+      "state": "WI",
+      "zip5": "53203"
+    },
+    {
+      "parking": "None",
+      "hours": [
+        {
+          "weekdayHours": "8:30 AM - 5:00 PM"
+        },
+        {
+          "saturdayHours": "8:30 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "1.38 mi",
+      "streetAddress": "1301 N 12TH ST",
+      "city": "MILWAUKEE",
+      "phone": "414-342-3335",
+      "name": "HILLTOP",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53205"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "8:00 AM - 5:00 PM"
+        },
+        {
+          "saturdayHours": "8:30 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "1.86 mi",
+      "streetAddress": "1416 S 11TH ST",
+      "city": "MILWAUKEE",
+      "phone": "414-671-4581",
+      "name": "HARBOR",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53204"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 4:30 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "2.03 mi",
+      "streetAddress": "2650 N DR MARTIN LUTHER KING JR DR",
+      "city": "MILWAUKEE",
+      "phone": "414-562-1449",
+      "name": "DR MARTIN LUTHER KING JR",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53212"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "8:30 AM - 4:30 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "2.37 mi",
+      "streetAddress": "2656 N TEUTONIA AVE",
+      "city": "MILWAUKEE",
+      "phone": "414-562-3117",
+      "name": "TEUTONIA",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53206"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 5:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "2.88 mi",
+      "streetAddress": "3421 W VLIET ST",
+      "city": "MILWAUKEE",
+      "phone": "414-342-3339",
+      "name": "MID CITY",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53208"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "8:30 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 1:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "3.61 mi",
+      "streetAddress": "1620 E CAPITOL DR",
+      "city": "MILWAUKEE",
+      "phone": "414-332-2241",
+      "name": "SHOREWOOD",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53211"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "8:00 AM - 5:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 12:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "3.63 mi",
+      "streetAddress": "1603 E OKLAHOMA AVE",
+      "city": "MILWAUKEE",
+      "phone": "414-481-0204",
+      "name": "BAY VIEW SAINT FRANCIS",
+      "zip4": "9998",
+      "state": "WI",
+      "zip5": "53207"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:30 AM - 2:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "4.19 mi",
+      "streetAddress": "4300 W LINCOLN AVE",
+      "city": "MILWAUKEE",
+      "phone": "414-643-0443",
+      "name": "WEST MILWAUKEE",
+      "zip4": "5012",
+      "state": "WI",
+      "zip5": "53219"
+    }
+  ]
+}

--- a/spec/fixtures/usps_ipp_responses/request_failed_proofing_results_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_failed_proofing_results_response.json
@@ -1,0 +1,15 @@
+{
+  "status": "In-person failed",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197604352",
+  "primaryIdType": "Uniformed Services identification card",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "secondaryIdType": "Deed of Trust",
+  "failureReason": "Clerk indicates that ID name or address does not match source data.",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346707",
+  "ippAssuranceLevel": "1.5"
+}

--- a/spec/fixtures/usps_ipp_responses/request_in_progress_proofing_results_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_in_progress_proofing_results_response.json
@@ -1,0 +1,3 @@
+{
+  "responseMessage": "Customer has not been to a post office to complete IPP"
+}

--- a/spec/fixtures/usps_ipp_responses/request_passed_proofing_results_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_passed_proofing_results_response.json
@@ -1,0 +1,13 @@
+{
+  "status": "In-person passed",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197504352",
+  "primaryIdType": "State driver's license",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346701",
+  "ippAssuranceLevel": "1.5"
+}

--- a/spec/fixtures/usps_ipp_responses/request_token_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_token_response.json
@@ -1,0 +1,5 @@
+{
+  "token_type": "Bearer",
+  "access_token": "==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7==",
+  "expires_in": 900
+}

--- a/spec/services/usps_in_person_proofer_spec.rb
+++ b/spec/services/usps_in_person_proofer_spec.rb
@@ -159,31 +159,31 @@ RSpec.describe UspsInPersonProofer do
 
   def stub_request_token
     stub_request(:post, %r{/oauth/authenticate}).to_return(
-      status: 200, body: UspsIppFixtures.request_token_response, headers: {},
+      status: 200, body: UspsIppFixtures.request_token_response,
     )
   end
 
   def stub_request_facilities
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
-      status: 200, body: UspsIppFixtures.request_facilities_response, headers: {},
+      status: 200, body: UspsIppFixtures.request_facilities_response,
     )
   end
 
   def stub_request_enroll
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
-      status: 200, body: UspsIppFixtures.request_enroll_response, headers: {},
+      status: 200, body: UspsIppFixtures.request_enroll_response,
     )
   end
 
   def stub_request_failed_proofing_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
-      status: 200, body: UspsIppFixtures.request_failed_proofing_results_response, headers: {},
+      status: 200, body: UspsIppFixtures.request_failed_proofing_results_response,
     )
   end
 
   def stub_request_passed_proofing_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
-      status: 200, body: UspsIppFixtures.request_passed_proofing_results_response, headers: {},
+      status: 200, body: UspsIppFixtures.request_passed_proofing_results_response,
     )
   end
 

--- a/spec/services/usps_in_person_proofer_spec.rb
+++ b/spec/services/usps_in_person_proofer_spec.rb
@@ -1,0 +1,203 @@
+require 'rails_helper'
+
+RSpec.describe UspsInPersonProofer do
+  let(:subject) { UspsInPersonProofer.new }
+
+  describe '#retrieve_token!' do
+    it 'sets token and token_expires_at' do
+      stub_request_token
+      subject.retrieve_token!
+
+      expect(subject.token).to be_present
+      expect(subject.token_expires_at).to be_present
+    end
+  end
+
+  describe '#request_facilities' do
+    it 'returns facilities' do
+      stub_request_token
+      stub_request_facilities
+      location = double('Location',
+        address: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zip_code: Faker::Address.zip_code,
+      )
+
+      subject.retrieve_token!
+      facilities = subject.request_facilities(location)
+
+      facility = facilities['postOffices'][0]
+      expect(facility['distance']).to be_present
+      expect(facility['streetAddress']).to be_present
+      expect(facility['city']).to be_present
+      expect(facility['phone']).to be_present
+      expect(facility['name']).to be_present
+      expect(facility['zip5']).to be_present
+      expect(facility['state']).to be_present
+    end
+  end
+
+  describe '#request_facilities' do
+    it 'returns facilities' do
+      stub_request_token
+      stub_request_facilities
+      location = double('Location',
+        address: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zip_code: Faker::Address.zip_code,
+      )
+
+      subject.retrieve_token!
+      facilities = subject.request_facilities(location)
+
+      facility = facilities['postOffices'][0]
+      expect(facility['distance']).to be_present
+      expect(facility['streetAddress']).to be_present
+      expect(facility['city']).to be_present
+      expect(facility['phone']).to be_present
+      expect(facility['name']).to be_present
+      expect(facility['zip5']).to be_present
+      expect(facility['state']).to be_present
+    end
+  end
+
+  describe '#request_enroll' do
+    it 'returns enrollment information' do
+      stub_request_token
+      stub_request_enroll
+      applicant = double('applicant',
+        address: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zip_code: Faker::Address.zip_code,
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        email: Faker::Internet.safe_email,
+        unique_id: '123456789',
+      )
+
+      subject.retrieve_token!
+      enrollment = subject.request_enroll(applicant)
+      expect(enrollment['enrollmentCode']).to be_present
+      expect(enrollment['responseMessage']).to be_present
+    end
+  end
+
+  describe '#request_proofing_results' do
+    it 'returns failed enrollment information' do
+      stub_request_token
+      stub_request_failed_proofing_results
+
+      applicant = double('applicant',
+        unique_id: '123456789',
+        enrollment_code: '123456789',
+      )
+
+      subject.retrieve_token!
+      proofing_results = subject.request_proofing_results(
+        applicant.unique_id,
+        applicant.enrollment_code,
+      )
+      expect(proofing_results['status']).to eq 'In-person failed'
+      expect(proofing_results['fraudSuspected']).to eq false
+    end
+
+    it 'returns passed enrollment information' do
+      stub_request_token
+      stub_request_passed_proofing_results
+
+      applicant = double('applicant',
+        unique_id: '123456789',
+        enrollment_code: '123456789',
+      )
+
+      subject.retrieve_token!
+      proofing_results = subject.request_proofing_results(
+        applicant.unique_id,
+        applicant.enrollment_code,
+      )
+      expect(proofing_results['status']).to eq 'In-person passed'
+      expect(proofing_results['fraudSuspected']).to eq false
+    end
+
+    it 'returns in-progress enrollment information' do
+      stub_request_token
+      stub_request_in_progress_proofing_results
+
+      applicant = double('applicant',
+        unique_id: '123456789',
+        enrollment_code: '123456789',
+      )
+
+      subject.retrieve_token!
+      proofing_results = subject.request_proofing_results(
+        applicant.unique_id,
+        applicant.enrollment_code,
+      )
+      expect(proofing_results['responseMessage']).to eq(
+        'Customer has not been to a post office to complete IPP',
+      )
+    end
+  end
+
+  describe '#request_enrollment_code' do
+    it 'returns enrollment information' do
+      stub_request_token
+      stub_request_enrollment_code
+      applicant = double('applicant',
+        unique_id: '123456789',
+      )
+
+      subject.retrieve_token!
+      enrollment = subject.request_enrollment_code(applicant)
+      expect(enrollment['enrollmentCode']).to be_present
+      expect(enrollment['responseMessage']).to be_present
+    end
+  end
+
+  def stub_request_token
+    stub_request(:post, %r{/oauth/authenticate}).to_return(
+      status: 200, body: UspsIppFixtures.request_token_response, headers: {},
+    )
+  end
+
+  def stub_request_facilities
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
+      status: 200, body: UspsIppFixtures.request_facilities_response, headers: {},
+    )
+  end
+
+  def stub_request_enroll
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
+      status: 200, body: UspsIppFixtures.request_enroll_response, headers: {},
+    )
+  end
+
+  def stub_request_failed_proofing_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200, body: UspsIppFixtures.request_failed_proofing_results_response, headers: {},
+    )
+  end
+
+  def stub_request_passed_proofing_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200, body: UspsIppFixtures.request_passed_proofing_results_response, headers: {},
+    )
+  end
+
+  def stub_request_in_progress_proofing_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 400, body: UspsIppFixtures.request_in_progress_proofing_results_response,
+      headers: { 'content-type' => 'application/json' }
+    )
+  end
+
+  def stub_request_enrollment_code
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/requestEnrollmentCode}).to_return(
+      status: 200, body: UspsIppFixtures.request_enrollment_code_response,
+      headers: { 'content-type' => 'application/json' }
+    )
+  end
+end

--- a/spec/services/usps_in_person_proofer_spec.rb
+++ b/spec/services/usps_in_person_proofer_spec.rb
@@ -27,39 +27,14 @@ RSpec.describe UspsInPersonProofer do
       subject.retrieve_token!
       facilities = subject.request_facilities(location)
 
-      facility = facilities['postOffices'][0]
-      expect(facility['distance']).to be_present
-      expect(facility['streetAddress']).to be_present
-      expect(facility['city']).to be_present
-      expect(facility['phone']).to be_present
-      expect(facility['name']).to be_present
-      expect(facility['zip5']).to be_present
-      expect(facility['state']).to be_present
-    end
-  end
-
-  describe '#request_facilities' do
-    it 'returns facilities' do
-      stub_request_token
-      stub_request_facilities
-      location = double('Location',
-        address: Faker::Address.street_address,
-        city: Faker::Address.city,
-        state: Faker::Address.state_abbr,
-        zip_code: Faker::Address.zip_code,
-      )
-
-      subject.retrieve_token!
-      facilities = subject.request_facilities(location)
-
-      facility = facilities['postOffices'][0]
-      expect(facility['distance']).to be_present
-      expect(facility['streetAddress']).to be_present
-      expect(facility['city']).to be_present
-      expect(facility['phone']).to be_present
-      expect(facility['name']).to be_present
-      expect(facility['zip5']).to be_present
-      expect(facility['state']).to be_present
+      facility = facilities[0]
+      expect(facility.distance).to be_present
+      expect(facility.address).to be_present
+      expect(facility.city).to be_present
+      expect(facility.phone).to be_present
+      expect(facility.name).to be_present
+      expect(facility.zip_code).to be_present
+      expect(facility.state).to be_present
     end
   end
 

--- a/spec/support/usps_ipp_fixtures.rb
+++ b/spec/support/usps_ipp_fixtures.rb
@@ -1,0 +1,38 @@
+class UspsIppFixtures
+  def self.request_token_response
+    load_response_fixture('request_token_response.json')
+  end
+
+  def self.request_facilities_response
+    load_response_fixture('request_facilities_response.json')
+  end
+
+  def self.request_enroll_response
+    load_response_fixture('request_enroll_response.json')
+  end
+
+  def self.request_failed_proofing_results_response
+    load_response_fixture('request_failed_proofing_results_response.json')
+  end
+
+  def self.request_passed_proofing_results_response
+    load_response_fixture('request_passed_proofing_results_response.json')
+  end
+
+  def self.request_in_progress_proofing_results_response
+    load_response_fixture('request_in_progress_proofing_results_response.json')
+  end
+
+  def self.request_enrollment_code_response
+    load_response_fixture('request_enrollment_code_response.json')
+  end
+
+  def self.load_response_fixture(filename)
+    path = File.join(
+      File.dirname(__FILE__),
+      '../fixtures/usps_ipp_responses',
+      filename,
+    )
+    File.read(path)
+  end
+end


### PR DESCRIPTION
The aim was to be able to make the API calls that we'd use during the course of someone in-person proofing, and document some of the more surprising parts of the API to better prepare for the future integration. I wanted to keep it small and self-contained, so it notably doesn't subclass `Proofer` and the token storage is not intuitive.