### PR TITLE
LG-3964: Prevent page submission when clicking TOTP code "Copy" button

### DIFF
--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -40,6 +40,7 @@
         <div class="px2 py1 mt1 border border-dashed border-navy">
           <div class="inline fs-20p caps monospace" id="qr-code"><%= @code %></div>
           <button class="clipboard ml2 right mt-tiny btn btn-primary p0 w-60p bg-light-blue blue h6 regular border-box center"
+                  type="button"
                   data-clipboard-text="<%= @code.upcase %>">
             <%= t('links.copy') %>
           </button>

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -40,7 +40,7 @@ describe 'users/totp_setup/new.html.erb' do
     it 'has a button to copy the QR code' do
       render
 
-      expect(rendered).to have_button(t('links.copy'))
+      expect(rendered).to have_button(t('links.copy'), type: 'button')
     end
 
     it 'has the correct aria-labelledby on the nickname field' do


### PR DESCRIPTION
**Why**: It's not expected that clicking "Copy" should validate the form or attempt to submit the form. Only "Submit" button should do this.

The default `type` of a `<button>` element is `submit` ([see documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)).

**Pending:**

- [ ] Spec