### PR TITLE
remove deprecated async proofing result functionality

### DIFF
--- a/app/services/proofing_session_async_result.rb
+++ b/app/services/proofing_session_async_result.rb
@@ -2,9 +2,7 @@
 
 # This is used by resolution and address proofing
 # Idv::Agent#proof_resolution and Idv::Agent#proof_address
-# NOTE: remove pii key after next deploy
-ProofingSessionAsyncResult = Struct.new(:id, :pii, :result, :status,
-                                                  keyword_init: true) do
+ProofingSessionAsyncResult = Struct.new(:id, :result, :status, keyword_init: true) do
   self::NONE = 'none'
   self::IN_PROGRESS = 'in_progress'
   self::DONE = 'done'
@@ -31,18 +29,10 @@ ProofingSessionAsyncResult = Struct.new(:id, :pii, :result, :status,
   end
 
   def done?
-    status == ProofingSessionAsyncResult::DONE || result.present?
+    status == ProofingSessionAsyncResult::DONE
   end
 
   def in_progress?
-    status == ProofingSessionAsyncResult::IN_PROGRESS ||
-      pii.present?
-  end
-
-  def done
-    ProofingSessionAsyncResult.new(
-      result: result.deep_symbolize_keys,
-      status: :done,
-    )
+    status == ProofingSessionAsyncResult::IN_PROGRESS
   end
 end

--- a/spec/controllers/idv/usps_controller_spec.rb
+++ b/spec/controllers/idv/usps_controller_spec.rb
@@ -51,19 +51,6 @@ describe Idv::UspsController do
 
       expect(response).to render_template :wait
     end
-
-    # can be removed after next deploy
-    it 'renders wait page while job is in progress using old session structure' do
-      allow(controller).to receive(:async_state).and_return(
-        ProofingSessionAsyncResult.new(
-          status: nil,
-          pii: { first_name: Faker::Name.first_name },
-        ),
-      )
-      get :index
-
-      expect(response).to render_template :wait
-    end
   end
 
   describe '#create' do

--- a/spec/services/proofing_session_async_result_spec.rb
+++ b/spec/services/proofing_session_async_result_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ProofingSessionAsyncResult do
   let(:id) { SecureRandom.uuid }
-  let(:pii) { { 'first_name' => 'Testy', 'last_name' => 'Testerson' } }
+  let(:status) { ProofingSessionAsyncResult::DONE }
   let(:idv_result) { { errors: {}, messages: ['some message'] } }
 
   context 'EncryptedRedisStructStorage' do
     it 'works with EncryptedRedisStructStorage' do
-      result = ProofingSessionAsyncResult.new(id: id, pii: pii, result: idv_result)
+      result = ProofingSessionAsyncResult.new(id: id, status: status, result: idv_result)
 
       EncryptedRedisStructStorage.store(result)
 
@@ -16,7 +16,7 @@ RSpec.describe ProofingSessionAsyncResult do
       )
 
       expect(loaded_result.id).to eq(id)
-      expect(loaded_result.pii).to eq(pii.deep_symbolize_keys)
+      expect(loaded_result.status).to eq(status)
 
       expect(loaded_result.result).to eq(idv_result.deep_symbolize_keys)
     end


### PR DESCRIPTION
#4498 introduced a new storage format for async proofing and deprecated the old one. It's been deployed so it's safe to remove the old structure