### PR TITLE
LG-3756: Upgrade intl-tel-input from 16.0.7 to 17.0

### DIFF
--- a/app/javascript/packs/intl-tel-input.js
+++ b/app/javascript/packs/intl-tel-input.js
@@ -2,25 +2,30 @@ import { loadPolyfills } from '@18f/identity-polyfill';
 import 'intl-tel-input/build/js/utils.js';
 import * as intlTelInput from 'intl-tel-input/build/js/intlTelInput';
 
-function intlTelInputNormalize() {
+/**
+ * @param {HTMLDivElement} iti
+ */
+function intlTelInputNormalize(iti) {
   // remove duplicate items in the country list
-  const dupUsOption = document.querySelectorAll('#country-listbox #iti-item-us')[1];
-  if (dupUsOption) {
-    /** @type {HTMLElement} */ (dupUsOption.parentNode).removeChild(dupUsOption);
-  }
-  const dupCanOption = document.querySelectorAll('#country-listbox #iti-item-ca')[1];
-  if (dupCanOption) {
-    /** @type {HTMLElement} */ (dupCanOption.parentNode).removeChild(dupCanOption);
-  }
+  /** @type {NodeListOf<HTMLLIElement>} */
+  const preferred = iti.querySelectorAll('.iti__preferred');
+  preferred.forEach((listItem) => {
+    const { countryCode } = listItem.dataset;
+    /** @type {NodeListOf<HTMLLIElement>} */
+    const duplicates = iti.querySelectorAll(`.iti__standard[data-country-code="${countryCode}"]`);
+    duplicates.forEach((duplicateListItem) => {
+      duplicateListItem.parentNode?.removeChild(duplicateListItem);
+    });
+  });
   // set accessibility label
-  const flagContainer = document.querySelectorAll('.iti__flag-container');
+  const flagContainer = iti.querySelectorAll('.iti__flag-container');
   if (flagContainer) {
     [].slice.call(flagContainer).forEach((element) => {
       element.setAttribute('aria-label', 'Country code');
     });
   }
   // fix knapsack error where aria-owns requires aria-expanded, use pop-up instead
-  const selectedFlag = document.querySelectorAll('.iti__flag-container .iti__selected-flag');
+  const selectedFlag = iti.querySelectorAll('.iti__flag-container .iti__selected-flag');
   if (selectedFlag) {
     [].slice.call(selectedFlag).forEach((element) => {
       element.setAttribute('aria-haspopup', 'true');
@@ -55,5 +60,7 @@ loadPolyfills(['custom-event']).then(() => {
     }
   });
 
-  intlTelInputNormalize();
+  /** @type {NodeListOf<HTMLDivElement>} */
+  const itiElements = document.querySelectorAll('.iti');
+  itiElements.forEach(intlTelInputNormalize);
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "focus-trap": "^6.1.3",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^3.0.0",
-    "intl-tel-input": "^16.0.7",
+    "intl-tel-input": "^17.0.8",
     "libphonenumber-js": "^1.7.26",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -102,7 +102,7 @@ feature 'Two Factor Authentication' do
 
   def select_country_and_type_phone_number(country:, number:)
     find('.iti__flag').click
-    find(".iti__country[id='iti-item-#{country}']").click
+    find(".iti__country[data-country-code='#{country}']").click
     phone_field.send_keys(number)
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4987,10 +4987,10 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-intl-tel-input@^16.0.7:
-  version "16.0.11"
-  resolved "https://registry.yarnpkg.com/intl-tel-input/-/intl-tel-input-16.0.11.tgz#6ab98d93b4995bd25463841ab30996ab7c9ec7b5"
-  integrity sha512-ouuoUDVM+iYtLJFwWAqATFWGxTIt/HTtWVVVIBRQdhbnjAkDU0gdzpk2JJn4i3Ttqvymo9Z5MkQr8zcxmVe2vg==
+intl-tel-input@^17.0.8:
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/intl-tel-input/-/intl-tel-input-17.0.8.tgz#e1b38e27a6c941b713b757ecf7b1f9f345f88c80"
+  integrity sha512-Jf7IdNCSJrWMBbcLQJ8I3nVYnJ5xRODJhPa+0QFcTsg82E332DbMDKnzTBkEID4Q1I7Nf8+96WzmMveadRbxxg==
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
**Why**: As a user, I want login.gov to not have unused or out of date apps, so that I can use the fastest and most secure app possible.

See changelog: https://github.com/jackocnr/intl-tel-input/blob/master/CHANGELOG.md

Specific upgrade conflicts:

- Reliance on specific element IDs, now assigned uniquely by intl-tel-input
- Reliance on duplicate list item element IDs, now assigned uniquely by intl-tel-input