### PR TITLE
Update identity-validations to use main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.2'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
 gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.7'
-gem 'identity_validations', github: '18F/identity-validations', branch: 'master'
+gem 'identity_validations', github: '18F/identity-validations', branch: 'main'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'
 gem 'local_time'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GIT
 GIT
   remote: https://github.com/18F/identity-validations.git
   revision: 31d041f479d5479940b9c6c67a3ee37786ace68c
-  branch: master
+  branch: main
   specs:
     identity_validations (0.3.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,10 +55,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-validations.git
-  revision: 31d041f479d5479940b9c6c67a3ee37786ace68c
+  revision: 26253af02f472d3023062efd5c7a3920b0db5f9c
   branch: main
   specs:
-    identity_validations (0.3.1)
+    identity_validations (0.3.2)
 
 GIT
   remote: https://github.com/18F/saml_idp.git


### PR DESCRIPTION
Running into an error updating the bundle:

```
Could not find gem 'identity_validations' in https://github.com/18F/identity-validations.git (at master@74a84fa).
The source does not contain any versions of 'identity_validations'
```

The IDP is also on 0.3.1, but there's a 0.3.2 update from May: https://github.com/18F/identity-validations/pull/7 and I wasn't sure if we wanted to bring that in