### PR TITLE
Don't allow identity proofing in prod without SP context (LG-3942)

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -42,8 +42,8 @@ module IdvSession
   end
 
   def sp_context_needed?
-    return if sp_session.present?
-    return unless LoginGov::Hostdata.env == 'prod'
+    return if sp_from_sp_session.present?
+    return if LoginGov::Hostdata.env != 'prod'
 
     redirect_to account_url
   end

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -40,4 +40,11 @@ module IdvSession
   def idv_attempter_throttled?
     Throttler::IsThrottled.call(current_user.id, :idv_resolution)
   end
+
+  def sp_context_needed?
+    return if sp_session.present?
+    return unless LoginGov::Hostdata.env == 'prod'
+
+    redirect_to account_url
+  end
 end

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -5,6 +5,7 @@ class IdvController < ApplicationController
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_needed, only: [:fail]
   before_action :profile_needs_reactivation?, only: [:index]
+  before_action :sp_context_needed?, only: [:index]
 
   def index
     if decorated_session.requested_more_recent_verification?

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -69,6 +69,37 @@ describe IdvController do
         expect(response).to redirect_to account_url
       end
     end
+
+    context 'no SP context' do
+      before do
+        stub_sign_in
+        session[:sp] = {}
+      end
+
+      context 'prod environment' do
+        before do
+          allow(LoginGov::Hostdata).to receive(:env).and_return('prod')
+        end
+
+        it 'redirects back to the account page' do
+          get :index
+
+          expect(response).to redirect_to account_url
+        end
+      end
+
+      context 'non-prod environment' do
+        before do
+          allow(LoginGov::Hostdata).to receive(:env).and_return('staging')
+        end
+
+        it 'begins the identity proofing process' do
+          get :index
+
+          expect(response).to redirect_to idv_doc_auth_url
+        end
+      end
+    end
   end
 
   describe '#activated' do


### PR DESCRIPTION
If a user signs in directly to secure.login.gov, then attempts to go to the `/verify` path, they will be redirected back to the account page. This only applies to the production environments. Being redirected to the verify path via request from an SP is not affected.