### PR TITLE
Rename document_capture_session in verify actions

### DIFF
--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -69,10 +69,6 @@ module Flow
       @flow.render_json(json, status: status)
     end
 
-    def reset
-      @flow.flow_session = {}
-    end
-
     def amzn_trace_id
       request.headers['X-Amzn-Trace-Id']
     end

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -69,6 +69,10 @@ module Flow
       @flow.render_json(json, status: status)
     end
 
+    def reset
+      @flow.flow_session = {}
+    end
+
     def amzn_trace_id
       request.headers['X-Amzn-Trace-Id']
     end

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -29,23 +29,23 @@ module Idv
       end
 
       def enqueue_job
-        document_capture_session = create_document_capture_session(
+        verify_document_capture_session = create_document_capture_session(
           verify_document_capture_session_uuid_key,
         )
-        document_capture_session.requested_at = Time.zone.now
-        document_capture_session.create_doc_auth_session
+        verify_document_capture_session.requested_at = Time.zone.now
+        verify_document_capture_session.create_doc_auth_session
 
         @flow.analytics.track_event(
           Analytics::DOC_AUTH_ASYNC,
           info: 'creating document capture session',
-          id: document_capture_session.id,
-          uuid: document_capture_session.uuid,
-          result_id: document_capture_session.result_id,
+          id: verify_document_capture_session.id,
+          uuid: verify_document_capture_session.uuid,
+          result_id: verify_document_capture_session.result_id,
           flow_session_key: flow_session[verify_document_capture_session_uuid_key],
         )
 
         callback_url = Rails.application.routes.url_helpers.document_proof_result_url(
-          result_id: document_capture_session.result_id,
+          result_id: verify_document_capture_session.result_id,
         )
 
         LambdaJobs::Runner.new(
@@ -63,15 +63,15 @@ module Idv
             trace_id: amzn_trace_id,
           },
         ).run do |doc_auth_result|
-            document_result = doc_auth_result.to_h.fetch(:document_result, {})
-            dcs = DocumentCaptureSession.new(result_id: document_capture_session.result_id)
-            dcs.store_doc_auth_result(
-              result: document_result.except(:pii_from_doc),
-              pii: document_result[:pii_from_doc],
-            )
+          document_result = doc_auth_result.to_h.fetch(:document_result, {})
+          dcs = DocumentCaptureSession.new(result_id: verify_document_capture_session.result_id)
+          dcs.store_doc_auth_result(
+            result: document_result.except(:pii_from_doc),
+            pii: document_result[:pii_from_doc],
+          )
 
-            nil
-          end
+          nil
+        end
       end
     end
   end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -60,7 +60,7 @@ module Idv
 
       def verify_document_capture_session
         return @verify_document_capture_session if defined?(@verify_document_capture_session)
-        @verify_document_capture_session = DocumentCaptureSession.find_by
+        @verify_document_capture_session = DocumentCaptureSession.find_by(
           uuid: flow_session[verify_document_capture_session_uuid_key]
         )
       end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -61,7 +61,7 @@ module Idv
       def verify_document_capture_session
         return @verify_document_capture_session if defined?(@verify_document_capture_session)
         @verify_document_capture_session = DocumentCaptureSession.find_by(
-          uuid: flow_session[verify_document_capture_session_uuid_key]
+          uuid: flow_session[verify_document_capture_session_uuid_key],
         )
       end
 

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -10,7 +10,7 @@ module Idv
       def process_async_state(current_async_state)
         form = ApiDocumentVerificationStatusForm.new(
           async_state: current_async_state,
-          document_capture_session: document_capture_session,
+          verify_document_capture_session: verify_document_capture_session,
         )
 
         form_response = form.submit
@@ -58,25 +58,26 @@ module Idv
         add_cost(:acuant_result) if result.to_h[:billed]
       end
 
-      def document_capture_session
-        return @document_capture_session if defined?(@document_capture_session)
-        dcs_uuid = flow_session[verify_document_capture_session_uuid_key]
-        @document_capture_session = DocumentCaptureSession.find_by(uuid: dcs_uuid)
+      def verify_document_capture_session
+        return @verify_document_capture_session if defined?(@verify_document_capture_session)
+        @verify_document_capture_session = DocumentCaptureSession.find_by
+          uuid: flow_session[verify_document_capture_session_uuid_key]
+        )
       end
 
       def async_state
-        if document_capture_session.nil?
+        if verify_document_capture_session.nil?
           failed_to_load_document_capture_analytics
 
           return timed_out
         end
 
-        proofing_job_result = document_capture_session.load_doc_auth_async_result
+        proofing_job_result = verify_document_capture_session.load_doc_auth_async_result
         if proofing_job_result.nil?
           @flow.analytics.track_event(Analytics::DOC_AUTH_ASYNC,
                                       error: 'failed to load async result',
-                                      uuid: document_capture_session.uuid,
-                                      result_id: document_capture_session.result_id,
+                                      uuid: verify_document_capture_session.uuid,
+                                      result_id: verify_document_capture_session.result_id,
                                      )
           return timed_out
         end
@@ -96,7 +97,7 @@ module Idv
 
       def failed_to_load_document_capture_analytics
         data = {
-          error: 'failed to load document_capture_session',
+          error: 'failed to load verify_document_capture_session',
           uuid: flow_session[verify_document_capture_session_uuid_key],
         }
 

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -10,7 +10,7 @@ module Idv
       def process_async_state(current_async_state)
         form = ApiDocumentVerificationStatusForm.new(
           async_state: current_async_state,
-          verify_document_capture_session: verify_document_capture_session,
+          document_capture_session: verify_document_capture_session,
         )
 
         form_response = form.submit

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -18,15 +18,15 @@ describe Idv::Actions::VerifyDocumentStatusAction do
 
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH_ASYNC,
-        error: 'failed to load document_capture_session',
+        error: 'failed to load verify_document_capture_session',
         uuid: nil,
       )
     end
 
     it 'calls analytics if timed out from no result in document capture session' do
-      document_capture_session = DocumentCaptureSession.new(uuid: 'uuid', result_id: 'result_id')
+      verify_document_capture_session = DocumentCaptureSession.new(uuid: 'uuid', result_id: 'result_id')
 
-      expect(subject).to receive(:document_capture_session).and_return(document_capture_session).
+      expect(subject).to receive(:verify_document_capture_session).and_return(verify_document_capture_session).
         at_least(:once)
       expect(controller).to receive(:analytics).and_return(fake_analytics).twice
       response = subject.call
@@ -34,8 +34,8 @@ describe Idv::Actions::VerifyDocumentStatusAction do
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH_ASYNC,
         error: 'failed to load async result',
-        uuid: document_capture_session.uuid,
-        result_id: document_capture_session.result_id,
+        uuid: verify_document_capture_session.uuid,
+        result_id: verify_document_capture_session.result_id,
       )
     end
   end

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -24,10 +24,13 @@ describe Idv::Actions::VerifyDocumentStatusAction do
     end
 
     it 'calls analytics if timed out from no result in document capture session' do
-      verify_document_capture_session = DocumentCaptureSession.new(uuid: 'uuid', result_id: 'result_id')
+      verify_document_capture_session = DocumentCaptureSession.new(
+        uuid: 'uuid',
+        result_id: 'result_id',
+      )
 
-      expect(subject).to receive(:verify_document_capture_session).and_return(verify_document_capture_session).
-        at_least(:once)
+      expect(subject).to receive(:verify_document_capture_session).
+        and_return(verify_document_capture_session).at_least(:once)
       expect(controller).to receive(:analytics).and_return(fake_analytics).twice
       response = subject.call
 


### PR DESCRIPTION
**Why**: Disambiguate from DocAuthBaseStep#document_capture_session

This is a cleanup I made why trying to trace through the IDV code to debug the smoke tests