### PR TITLE
LG-3484: Migrate BassCSS align module to USWDS

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -12,7 +12,6 @@
 @import 'basscss-sass/type-scale';
 @import 'basscss-sass/utility-typography';
 @import 'basscss-sass/utility-layout';
-@import 'basscss-sass/align';
 @import 'basscss-sass/white-space';
 @import 'basscss-sass/positions';
 @import 'basscss-sass/responsive-states';

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -4,7 +4,7 @@
       <div class="my1 ml2 sm-m0 col col-4">
         <%= link_to image_tag(asset_url('logo.svg'),
                               alt: APP_NAME,
-                              class: 'align-bottom',
+                              class: 'text-bottom',
                               width: 170), root_path %>
       </div>
       <div class="right-align col col-8 pr1 authnav-greeting">

--- a/app/views/accounts/_personal_key_item_heading.html.erb
+++ b/app/views/accounts/_personal_key_item_heading.html.erb
@@ -1,4 +1,4 @@
 <div class='col'>
-  <%= image_tag asset_url('p-key.svg'), width: 16, class: 'mr1 align-middle' %>
+  <%= image_tag asset_url('p-key.svg'), width: 16, class: 'mr1 text-middle' %>
 </div>
 <%= t('account.items.personal_key') %>

--- a/app/views/accounts/_unphishable_badge.html.erb
+++ b/app/views/accounts/_unphishable_badge.html.erb
@@ -1,5 +1,5 @@
 <span>
   <%= image_tag asset_url('alert/unphishable.svg'), width: 16,
-                class: 'mr1 align-middle', id: 'unphishable_badge' %>
+                class: 'mr1 text-middle', id: 'unphishable_badge' %>
   <%= t('headings.account.unphishable') %>
 </span>

--- a/app/views/accounts/_verified_account_badge.html.erb
+++ b/app/views/accounts/_verified_account_badge.html.erb
@@ -1,5 +1,5 @@
 <span>
   <%= image_tag asset_url('alert/success.svg'), width: 16,
-    class: 'mr1 align-middle', id: 'verified_account_badge', alt: '' %>
+    class: 'mr1 text-middle', id: 'verified_account_badge', alt: '' %>
   <%= t('headings.account.verified_account') %>
 </span>

--- a/app/views/devise/sessions/_return_to_service_provider.html.erb
+++ b/app/views/devise/sessions/_return_to_service_provider.html.erb
@@ -3,6 +3,6 @@
     "‹ #{t('links.back_to_sp',
     sp: decorated_session.sp_name)}",
     decorated_session.sp_return_url,
-    class: 'inline-block align-bottom',
+    class: 'inline-block text-bottom',
   ) %>
 </div>

--- a/app/views/idv/cac/welcome.html.erb
+++ b/app/views/idv/cac/welcome.html.erb
@@ -12,7 +12,7 @@
 
 <ul class="list-reset">
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       1
     </div>
     <div class="mr1 inline-block">
@@ -24,7 +24,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       2
     </div>
     <div class="mr1 inline-block">
@@ -36,7 +36,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       3
     </div>
     <div class="mr1 inline-block">
@@ -48,7 +48,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       4
     </div>
     <div class="mr1 inline-block">
@@ -60,7 +60,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       5
     </div>
     <div class="mr1 inline-block">

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -12,7 +12,7 @@
 
 <ul class='list-reset'>
   <li class='pt2 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       1
     </div>
     <div class='mr1 inline-block'>
@@ -26,7 +26,7 @@
     </div>
   </li>
   <li class='pt2 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       2
     </div>
     <div class='mr1 inline-block'>
@@ -40,7 +40,7 @@
     </div>
   </li>
   <li class='pt2 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       3
     </div>
     <div class='mr1 inline-block'>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -16,7 +16,7 @@
 
   <ul class='list-reset'>
     <li class='pt2 pb1'>
-      <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+      <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
         <%= step += 1 %>
       </div>
       <div class='mr1 inline-block'>
@@ -31,7 +31,7 @@
     </li>
     <% if liveness_checking_enabled? %>
     <li class='pt2 pb1'>
-      <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+      <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
         <%= step += 1 %>
       </div>
       <div class='mr1 inline-block'>
@@ -46,7 +46,7 @@
     </li>
     <% end %>
     <li class='pt2 pb1'>
-      <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+      <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
         <%= step += 1 %>
       </div>
       <div class='mr1 inline-block'>
@@ -60,7 +60,7 @@
       </div>
     </li>
     <li class='pt2 pb1'>
-      <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+      <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
         <%= step += 1 %>
       </div>
       <div class='mr1 inline-block'>
@@ -74,7 +74,7 @@
       </div>
     </li>
     <li class='pt2 pb1'>
-      <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+      <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
         <%= step += 1 %>
       </div>
       <div class='mr1 inline-block'>

--- a/app/views/idv/in_person/welcome.html.erb
+++ b/app/views/idv/in_person/welcome.html.erb
@@ -14,7 +14,7 @@
 
 <ul class="list-reset">
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       1
     </div>
     <div class="mr1 inline-block">
@@ -26,7 +26,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       2
     </div>
     <div class="mr1 inline-block">
@@ -38,7 +38,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       3
     </div>
     <div class="mr1 inline-block">
@@ -50,7 +50,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       4
     </div>
     <div class="mr1 inline-block">
@@ -62,7 +62,7 @@
     </div>
   </li>
   <li class="pt2 pb1">
-    <div class="inline-block mr2 mt1 align-top circle circle-number bg-blue white">
+    <div class="inline-block mr2 mt1 text-top circle circle-number bg-blue white">
       5
     </div>
     <div class="mr1 inline-block">

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -17,7 +17,7 @@
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
                        maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH, autocomplete: 'one-time-code', type: 'tel') %>
   </div>
-  <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>
+  <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary text-top sm-col-6 col-12' %>
   <br/>
   <br/>
 <% end %>

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -1,9 +1,9 @@
 <nav class='nav-branded vertical-align bg-light-blue center relative'>
   <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: '',
-                class: 'inline-block align-middle') %>
+                class: 'inline-block text-middle') %>
   <div class='px-12p inline-block'>
     <span class='absolute top-0 bottom-0 border-right my1 sm-my2'></span>
   </div>
   <%= image_tag(decorated_session.sp_logo_url, height: 40,
-                alt: decorated_session.sp_name, class: 'inline-block align-middle') %>
+                alt: decorated_session.sp_name, class: 'inline-block text-middle') %>
 </nav>

--- a/app/views/shared/_nav_lite.html.erb
+++ b/app/views/shared/_nav_lite.html.erb
@@ -1,5 +1,5 @@
 <nav class='nav-nonbranded vertical-align bg-light-blue center'>
-  <%= link_to root_path, class: 'inline-block align-middle' do %>
-    <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME, class: 'align-middle') %>
+  <%= link_to root_path, class: 'inline-block text-middle' do %>
+    <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME, class: 'text-middle') %>
   <% end %>
 </nav>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -92,7 +92,7 @@
         </fieldset>
       </div>
       <div class="col col-6 sm-col-5 px1">
-        <%= button_tag(class: 'btn btn-primary col-12 align-top') { 'Proceed' } %>
+        <%= button_tag(class: 'btn btn-primary col-12 text-top') { 'Proceed' } %>
       </div>
     </div>
   <% end %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -27,7 +27,7 @@
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
   <%= submit_tag t('forms.buttons.submit.default'),
-                 class: 'btn btn-primary align-top sm-col-6 col-12' %>
+                 class: 'btn btn-primary text-top sm-col-6 col-12' %>
 
   <br/><br/>
   <div class="flex flex-row flex-align-center flex-wrap">

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -27,7 +27,7 @@
                   t('forms.messages.remember_device'),
                   class: 'blue mr2' %>
   </div>
-  <%= submit_tag 'Submit', class: 'btn btn-primary align-top' %>
+  <%= submit_tag 'Submit', class: 'btn btn-primary text-top' %>
 <% end %>
 
 <%= render 'shared/fallback_links', presenter: @presenter %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -6,7 +6,7 @@
 <%= form_tag(@presenter.piv_cac_service_link) do %>
 <ul class='list-reset'>
   <li class='pt0 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       1
     </div>
     <label class="h1 mr1 inline-block margin-bottom-1 bold" for="nickname">
@@ -21,7 +21,7 @@
     <hr>
   </li>
   <li class='pt1 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       2
     </div>
     <div class='mr1 inline-block mb2'>
@@ -32,7 +32,7 @@
     <hr>
   </li>
   <li class='pt1 pb1'>
-    <div class='inline-block mr2 mt1 align-top circle circle-number bg-blue white'>
+    <div class='inline-block mr2 mt1 text-top circle circle-number bg-blue white'>
       3
     </div>
     <div class='mr1 inline-block'>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -60,7 +60,7 @@
                 'aria-labelledby': 'totp-label' %>
           </div>
           <div class="col col-6 sm-col-5 px1">
-            <%= submit_tag t('forms.buttons.submit.default'), class: 'col-12 btn btn-primary align-top' %>
+            <%= submit_tag t('forms.buttons.submit.default'), class: 'col-12 btn btn-primary text-top' %>
           </div>
         </div>
         <div class="border border-light-blue rounded-lg px2 py1 mt3">

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -35,7 +35,7 @@
    <% end %>
    <br>
    <%= link_to t('forms.webauthn_setup.continue'), '#', method: :get,
-           class: 'btn btn-primary btn-wide align-top', id: 'continue-button' %>
+           class: 'btn btn-primary btn-wide text-top', id: 'continue-button' %>
 </div>
 
 <div class='spinner hidden' id='spinner'>


### PR DESCRIPTION
**Why**: As a user, I expect that login.gov has a consistent visual style, and that my page load times are not prolonged by loading redundant CSS.

As a developer, I expect that existing references to BassCSS module classes are replaced with equivalent USWDS or ad hoc alternatives, so that we can successfully migrate away from and eliminate our dependency on BassCSS.

---

Approach: Replace "align-" classes with USWDS equivalent, based on technical discovery document.