### PR TITLE
Restore pointer cursor to selfie capture overlay "button"

### DIFF
--- a/app/javascript/packages/document-capture/components/selfie-capture.scss
+++ b/app/javascript/packages/document-capture/components/selfie-capture.scss
@@ -63,10 +63,10 @@ div.selfie-capture__label[tabindex="-1"]:focus { // scss-lint:disable Qualifying
 .selfie-capture__consent-overlay-button {
   appearance: none;
   background: none;
+  cursor: pointer;
   border: 0;
   height: 100%;
   left: 0;
-  cursor: pointer;
   position: absolute;
   top: 0;
   width: 100%;

--- a/app/javascript/packages/document-capture/components/selfie-capture.scss
+++ b/app/javascript/packages/document-capture/components/selfie-capture.scss
@@ -66,6 +66,7 @@ div.selfie-capture__label[tabindex="-1"]:focus { // scss-lint:disable Qualifying
   border: 0;
   height: 100%;
   left: 0;
+  cursor: pointer;
   position: absolute;
   top: 0;
   width: 100%;

--- a/app/javascript/packages/document-capture/components/selfie-capture.scss
+++ b/app/javascript/packages/document-capture/components/selfie-capture.scss
@@ -63,8 +63,8 @@ div.selfie-capture__label[tabindex="-1"]:focus { // scss-lint:disable Qualifying
 .selfie-capture__consent-overlay-button {
   appearance: none;
   background: none;
-  cursor: pointer;
   border: 0;
+  cursor: pointer;
   height: 100%;
   left: 0;
   position: absolute;


### PR DESCRIPTION
**Why**: Upgrading from `identity-style-guide` 2.2.3 to 3.0.0 involves upgrading from `uswds` 2.0.3 to 2.9.0 which involves upgrading from `normalize.css` 3.0.3 to 8.0.1. In `normalize.css` 4.1.0, opinionated button cursor styles were removed, and must be manually applied where desired.

See:

- https://github.com/necolas/normalize.css/pull/563
- https://github.com/necolas/normalize.css/blob/master/CHANGELOG.md#410-april-11-2016
- https://github.com/uswds/uswds/pull/3215