### PR TITLE
Add spinner button to phone step

### DIFF
--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -26,8 +26,19 @@
   <br/>
 </div>
 
-<%= validated_form_for(@idv_form, url: idv_phone_path,
-                       html: { autocomplete: 'off', method: :put, role: 'form', class: 'mt2' }) do |f| %>
+<%= validated_form_for(@idv_form,
+                       url: idv_phone_path,
+                       data: {
+                         form_steps_wait: '',
+                         wait_step_path: idv_phone_path,
+                         poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
+                       },
+                       html: {
+                         autocomplete: 'off',
+                         method: :put,
+                         role: 'form',
+                         class: 'mt2',
+                       }) do |f| %>
  <%= f.label :phone, label: t('idv.form.phone'), class: 'bold' %>
  <%= f.input :phone, required: true, input_html: { aria: { invalid: false }, class: 'sm-col-8' }, label: false,
    wrapper_html: { class: 'mr2' } %>
@@ -36,9 +47,15 @@
     <%= render 'idv/phone/verification_options' %>
   <% end %>
 
-  <%= f.button :submit, t('forms.buttons.continue'), class: 'btn-wide mt3 sm-col-6 col-12' %>
+  <%= render 'shared/spinner-button',
+             action_message: t('doc_auth.info.verifying'),
+             class: 'mt3' do %>
+    <%= f.button :submit, t('forms.buttons.continue'), class: 'btn-wide sm-col-6 col-12' %>
+  <% end %>
 <% end %>
 
 <div class="mt2 pt1 border-top">
   <%= link_to t('links.cancel'), idv_cancel_path, class: 'h5' %>
 </div>
+
+<% javascript_pack_tag_once 'form-steps-wait' %>

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -43,7 +43,7 @@ feature 'Accessibility on IDV pages', :js do
       complete_all_doc_auth_steps
       click_continue
 
-      expect(current_path).to eq idv_review_path
+      expect(page).to have_current_path(idv_review_path, wait: 5)
       expect(page).to be_accessible.according_to :section508, :"best-practice"
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -15,14 +15,17 @@ feature 'idv phone step' do
       expect(page).to have_current_path(idv_otp_delivery_method_path)
     end
 
-    it 'redirects to the confirmation step when the phone matches the 2fa phone number' do
+    it 'redirects to the confirmation step when the phone matches the 2fa phone number', js: true do
       user = user_with_2fa
       start_idv_from_sp
       complete_idv_steps_before_phone_step(user)
       fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)
-      click_idv_continue
 
-      expect(page).to have_content(t('idv.titles.session.review'))
+      expect(page).to have_selector('.spinner-button')
+      click_idv_continue
+      expect(page).to have_selector('.spinner-button--spinner-active')
+
+      expect(page).to have_content(t('idv.titles.session.review'), wait: 1)
       expect(page).to have_current_path(idv_review_path)
     end
 


### PR DESCRIPTION
Adds the new pretty spinner button (instead of old waiting page) to the phone step, which lives outside the flow controller
 
<img width="400" alt="Screen Shot 2020-12-30 at 9 10 59 AM" src="https://user-images.githubusercontent.com/458784/103369512-2d862480-4a7f-11eb-99ac-5d0aae265744.png">
