### PR TITLE
Skip migration check when idp_run_migrations is true

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'foundation_emails'
 gem 'hiredis'
 gem 'http_accept_language'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.3'
-gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'v0.4.3'
+gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.3'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
 gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'foundation_emails'
 gem 'hiredis'
 gem 'http_accept_language'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.3'
-gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.2'
+gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'margolis-env-json'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
 gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'foundation_emails'
 gem 'hiredis'
 gem 'http_accept_language'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.3'
-gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'margolis-env-json'
+gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'v0.4.3'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
 gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 GIT
   remote: https://github.com/18F/identity-hostdata.git
   revision: 9febec459b8f46b34ee783feddf454005e8c9c77
-  branch: v0.4.3
+  tag: v0.4.3
   specs:
     identity-hostdata (0.4.3)
       aws-sdk-s3 (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 00adecd0dc4931bab5b5c2a3ad471daf01ade73f
-  branch: margolis-env-json
+  revision: 9febec459b8f46b34ee783feddf454005e8c9c77
+  branch: v0.4.3
   specs:
     identity-hostdata (0.4.3)
       aws-sdk-s3 (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 305533690ab16a3fd24f19512061691e25e937ff
-  tag: v0.4.2
+  revision: 00adecd0dc4931bab5b5c2a3ad471daf01ade73f
+  branch: margolis-env-json
   specs:
-    identity-hostdata (0.4.2)
+    identity-hostdata (0.4.3)
       aws-sdk-s3 (~> 1.8)
 
 GIT

--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -5,6 +5,8 @@ namespace :db do
 
     if LoginGov::Hostdata.instance_role == 'migration'
       warn('Skipping pending migration check on migration instance')
+    elsif LoginGov::Hostdata.config.dig(:default_attributes, :login_dot_gov, :idp_run_migrations)
+      warn('Skipping pending migration check, idp_run_migrations=true')
     else
       ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
     end


### PR DESCRIPTION
Implements a request from @bleachbyte to skip the migration check when a certain config is set in the JSON

Depends on https://github.com/18F/identity-hostdata/pull/14/, leaving this as a draft until that one is merged & published