### PR TITLE
Fix error on bad password during password verification

### DIFF
--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -7,19 +7,17 @@ module Users
     before_action :confirm_personal_key
 
     def new
-      @verify_password_form = VerifyPasswordForm.new(
-        user: current_user,
-        password: '',
-        decrypted_pii: decrypted_pii,
-      )
+      @decrypted_pii = decrypted_pii
     end
 
     def update
+      @decrypted_pii = decrypted_pii
       result = verify_password_form.submit
 
       if result.success?
         handle_success(result)
       else
+        flash[:error] = t('errors.messages.password_incorrect')
         render :new
       end
     end

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -17,7 +17,6 @@
 
 <div class='mt4'>
   <%=  accordion('review-verified-info', t('idv.messages.review.intro')) do %>
-    <% decrypted_pii = @verify_password_form.decrypted_pii %>
-    <%= render 'shared/pii_review', pii: decrypted_pii, phone: decrypted_pii[:phone] %>
+    <%= render 'shared/pii_review', pii: @decrypted_pii, phone: @decrypted_pii[:phone] %>
   <% end %>
 </div>

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -58,6 +58,7 @@ describe Users::VerifyPasswordController do
 
       describe '#update' do
         let(:form) { instance_double(VerifyPasswordForm) }
+        let(:pii) { { dob: Time.zone.today } }
 
         before do
           expect(controller).to receive(:verify_password_form).and_return(form)
@@ -79,8 +80,11 @@ describe Users::VerifyPasswordController do
         end
 
         context 'without valid password' do
+          render_views
+
           it 'renders the new template' do
             allow(form).to receive(:submit).and_return(response_bad)
+            allow(controller).to receive(:decrypted_pii).and_return(pii)
 
             put :update, params: { user: { password: user.password } }
 


### PR DESCRIPTION
`@verify_password_form` is expected to be defined to render `:new`, but the instance variable is never set in the `update` call.

This results in an error if the form validation fails: [New Relic error](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiZTU3ZmFkNmMtNGU5Yi0xMWViLWIxZWEtMDI0MmFjMTEwMDA4XzBfMjQ0MDEiLCJmaWx0ZXJzIjpbeyJrZXkiOiJlcnJvci5leHBlY3RlZCIsInZhbHVlIjoibm90IHRydWUifSx7ImtleSI6ImVycm9yLmNsYXNzIiwidmFsdWUiOiJBY3Rpb25WaWV3OjpUZW1wbGF0ZTo6RXJyb3IiLCJsaWtlIjpmYWxzZX1dLCJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlJZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGcifQ&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5USXhNelk0TlRnIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ&platform[timeRange][duration]=604800000)

The template uses `@verify_password_form` strictly for the pii, so I moved the variable assignment up and out of the template and explicitly pass in `@decrypted_pii` now.

The test also unexpectedly passes because controller specs do not render the view, and enabling view rendering causes the spec to fail.