### PR TITLE
Opt in to Webpack(er) chunk splitting

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -107,7 +107,7 @@ module FormHelper
   def validated_form_for(record, options = {}, &block)
     options[:data] ||= {}
     options[:data][:validate] = true
-    javascript_pack_tag_once('form-validation')
+    javascript_packs_tag_once('form-validation')
     simple_form_for(record, options, &block)
   end
 end

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -12,7 +12,7 @@ module ScriptHelper
 
   def javascript_packs_tag_once(*names, prepend: false)
     @scripts ||= []
-    if (prepend)
+    if prepend
       @scripts = names | @scripts
     else
       @scripts = @scripts | names

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 # rubocop:disable Rails/HelperInstanceVariable
 module ScriptHelper
   include Webpacker::Helper
@@ -12,9 +10,13 @@ module ScriptHelper
     tag
   end
 
-  def javascript_packs_tag_once(*names)
-    @scripts ||= Set.new
-    @scripts.merge(names)
+  def javascript_packs_tag_once(*names, prepend: false)
+    @scripts ||= []
+    if (prepend)
+      @scripts = names | @scripts
+    else
+      @scripts = @scripts | names
+    end
     nil
   end
 

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -12,9 +12,9 @@ module ScriptHelper
     tag
   end
 
-  def javascript_pack_tag_once(name)
+  def javascript_packs_tag_once(*names)
     @scripts ||= Set.new
-    @scripts.add(name)
+    @scripts.merge(names)
     nil
   end
 

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -15,7 +15,7 @@ module ScriptHelper
     if prepend
       @scripts = names | @scripts
     else
-      @scripts = @scripts | names
+      @scripts |= names
     end
     nil
   end

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -19,7 +19,7 @@ module ScriptHelper
   end
 
   def render_javascript_pack_once_tags
-    javascript_pack_tag(*@scripts) if @scripts
+    javascript_packs_with_chunks_tag(*@scripts) if @scripts
   end
 end
 # rubocop:enable Rails/HelperInstanceVariable

--- a/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
+++ b/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
@@ -37,8 +37,10 @@ module TwoFactorAuthCode
 
     def js
       <<~JS
-        var test = #{decorated_user.lockout_time_remaining} * 1000;
-        window.LoginGov.countdownTimer(document.getElementById('#{COUNTDOWN_ID}'), test);
+        document.addEventListener('DOMContentLoaded', function() {
+          var test = #{decorated_user.lockout_time_remaining} * 1000;
+          window.LoginGov.countdownTimer(document.getElementById('#{COUNTDOWN_ID}'), test);
+        });
       JS
     end
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,4 +19,4 @@
 
 <%= render 'shared/password_accordion' %>
 
-<%=  javascript_pack_tag 'pw-strength' %>
+<%=  javascript_packs_with_chunks_tag 'pw-strength' %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,4 +19,4 @@
 
 <%= render 'shared/password_accordion' %>
 
-<%=  javascript_packs_with_chunks_tag 'pw-strength' %>
+<%=  javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -19,4 +19,4 @@
 
 <%= render 'shared/password_accordion' %>
 
-<%= javascript_packs_with_chunks_tag 'pw-strength' %>
+<%= javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -19,4 +19,4 @@
 
 <%= render 'shared/password_accordion' %>
 
-<%= javascript_pack_tag 'pw-strength' %>
+<%= javascript_packs_with_chunks_tag 'pw-strength' %>

--- a/app/views/idv/cac/verify.html.erb
+++ b/app/views/idv/cac/verify.html.erb
@@ -66,5 +66,5 @@
   </div>
 </div>
 
-<% javascript_pack_tag_once 'form-steps-wait' %>
+<% javascript_packs_tag_once 'form-steps-wait' %>
 <%= render 'idv/cac/start_over_or_cancel' %>

--- a/app/views/idv/cac/welcome.html.erb
+++ b/app/views/idv/cac/welcome.html.erb
@@ -94,4 +94,4 @@
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
 <% end %>
 
-<%= javascript_packs_with_chunks_tag 'clipboard' %>
+<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/idv/cac/welcome.html.erb
+++ b/app/views/idv/cac/welcome.html.erb
@@ -94,4 +94,4 @@
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
 <% end %>
 
-<%= javascript_pack_tag 'clipboard' %>
+<%= javascript_packs_with_chunks_tag 'clipboard' %>

--- a/app/views/idv/doc_auth/_submit_with_spinner.html.erb
+++ b/app/views/idv/doc_auth/_submit_with_spinner.html.erb
@@ -3,4 +3,4 @@
 </button>
 <%= render 'idv/doc_auth/spinner' %>
 <div class='clearfix'></div>
-<%= javascript_packs_with_chunks_tag 'submit-with-spinner' %>
+<%= javascript_packs_tag_once 'submit-with-spinner' %>

--- a/app/views/idv/doc_auth/_submit_with_spinner.html.erb
+++ b/app/views/idv/doc_auth/_submit_with_spinner.html.erb
@@ -3,4 +3,4 @@
 </button>
 <%= render 'idv/doc_auth/spinner' %>
 <div class='clearfix'></div>
-<%= javascript_pack_tag 'submit-with-spinner' %>
+<%= javascript_packs_with_chunks_tag 'submit-with-spinner' %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -41,5 +41,5 @@
 <%= render 'idv/doc_auth/start_over_or_cancel' %>
 
 <% if FeatureManagement.doc_capture_polling_enabled? %>
-  <%= javascript_pack_tag 'doc_capture_polling' %>
+  <%= javascript_packs_with_chunks_tag 'doc_capture_polling' %>
 <% end %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -41,5 +41,5 @@
 <%= render 'idv/doc_auth/start_over_or_cancel' %>
 
 <% if FeatureManagement.doc_capture_polling_enabled? %>
-  <%= javascript_packs_with_chunks_tag 'doc_capture_polling' %>
+  <%= javascript_packs_tag_once 'doc_capture_polling' %>
 <% end %>

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -77,5 +77,4 @@
   <%= link_to(t('links.cancel'), idv_cancel_path, class: 'h5') %>
 </div>
 
-<%= javascript_pack_tag('clipboard') %>
-<%= javascript_pack_tag('ial2-consent-button') %>
+<%= javascript_packs_with_chunks_tag 'clipboard', 'ial2-consent-button' %>

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -77,4 +77,4 @@
   <%= link_to(t('links.cancel'), idv_cancel_path, class: 'h5') %>
 </div>
 
-<%= javascript_packs_with_chunks_tag 'clipboard', 'ial2-consent-button' %>
+<%= javascript_packs_tag_once 'clipboard', 'ial2-consent-button' %>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -105,4 +105,4 @@
 </div>
 
 <%= render 'idv/doc_auth/start_over_or_cancel' %>
-<%= javascript_pack_tag 'upload-step' %>
+<%= javascript_packs_with_chunks_tag 'upload-step' %>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -105,4 +105,4 @@
 </div>
 
 <%= render 'idv/doc_auth/start_over_or_cancel' %>
-<%= javascript_packs_with_chunks_tag 'upload-step' %>
+<%= javascript_packs_tag_once 'upload-step' %>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -61,5 +61,5 @@
   </div>
 </div>
 
-<% javascript_pack_tag_once 'form-steps-wait' %>
+<% javascript_packs_tag_once 'form-steps-wait' %>
 <%= render 'idv/doc_auth/start_over_or_cancel' %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -117,7 +117,7 @@
   <% end %>
 
 
-  <%= javascript_packs_with_chunks_tag(
+  <%= javascript_packs_tag_once(
     'clipboard',
     'ial2-consent-button',
     'document-capture-welcome',

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -117,7 +117,9 @@
   <% end %>
 
 
-  <%= javascript_pack_tag('clipboard') %>
-  <%= javascript_pack_tag('ial2-consent-button') %>
-  <%= javascript_pack_tag('document-capture-welcome') %>
+  <%= javascript_packs_with_chunks_tag(
+    'clipboard',
+    'ial2-consent-button',
+    'document-capture-welcome',
+  ) %>
 <% end %>

--- a/app/views/idv/in_person/bar_code.html.erb
+++ b/app/views/idv/in_person/bar_code.html.erb
@@ -67,4 +67,4 @@
 
 <%= render 'idv/in_person/start_over_or_cancel' %>
 
-<%= javascript_packs_with_chunks_tag 'clipboard' %>
+<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/idv/in_person/bar_code.html.erb
+++ b/app/views/idv/in_person/bar_code.html.erb
@@ -67,4 +67,4 @@
 
 <%= render 'idv/in_person/start_over_or_cancel' %>
 
-<%= javascript_pack_tag 'clipboard' %>
+<%= javascript_packs_with_chunks_tag 'clipboard' %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -58,4 +58,4 @@
   <%= link_to t('links.cancel'), idv_cancel_path, class: 'h5' %>
 </div>
 
-<% javascript_pack_tag_once 'form-steps-wait' %>
+<% javascript_packs_tag_once 'form-steps-wait' %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -132,5 +132,5 @@
   window.LoginGov = window.LoginGov || {};
   window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
 <% end %>
-<%= javascript_packs_with_chunks_tag 'document-capture' %>
+<%= javascript_packs_tag_once 'document-capture' %>
 <%= stylesheet_packs_with_chunks_tag 'document-capture' %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -132,5 +132,5 @@
   window.LoginGov = window.LoginGov || {};
   window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
 <% end %>
-<%= javascript_pack_tag 'document-capture' %>
-<%= stylesheet_pack_tag 'document-capture' %>
+<%= javascript_packs_with_chunks_tag 'document-capture' %>
+<%= stylesheet_packs_with_chunks_tag 'document-capture' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,7 @@
   <![endif]-->
   <%= javascript_include_tag 'application' %>
   <%= javascript_include_tag 'i18n-strings.' + I18n.locale.to_s %>
-  <%= javascript_pack_tag 'application' %>
+  <%= javascript_packs_with_chunks_tag 'application' %>
   <%= csrf_meta_tags %>
 
   <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,6 @@
   <![endif]-->
   <%= javascript_include_tag 'application' %>
   <%= javascript_include_tag 'i18n-strings.' + I18n.locale.to_s %>
-  <%= javascript_packs_with_chunks_tag 'application' %>
   <%= csrf_meta_tags %>
 
   <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
@@ -76,6 +75,9 @@
 
   <div id="session-timeout-cntnr"></div>
 
+  <%= javascript_packs_tag_once 'application' %>
+  <%= render_javascript_pack_once_tags %>
+
   <% if current_user # Render the JS snipped that collects platform authenticator analytics %>
   <div data-platform-authenticator-enabled="true"></div>
   <%= auto_session_timeout_js %>
@@ -83,7 +85,6 @@
   <%= auto_session_expired_js %>
   <% end %>
 
-  <%= render_javascript_pack_once_tags %>
   <%= render 'shared/dap_analytics' if AppConfig.env.participate_in_dap == 'true' && !session_with_trust? %>
 </body>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -75,7 +75,7 @@
 
   <div id="session-timeout-cntnr"></div>
 
-  <%= javascript_packs_tag_once 'application' %>
+  <%= javascript_packs_tag_once 'application', prepend: true %>
   <%= render_javascript_pack_once_tags %>
 
   <% if current_user # Render the JS snipped that collects platform authenticator analytics %>

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -23,4 +23,4 @@
   <% end %>
 </div>
 
-<%= javascript_pack_tag 'reactivate-account-modal' %>
+<%= javascript_packs_with_chunks_tag 'reactivate-account-modal' %>

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -23,4 +23,4 @@
   <% end %>
 </div>
 
-<%= javascript_packs_with_chunks_tag 'reactivate-account-modal' %>
+<%= javascript_packs_tag_once 'reactivate-account-modal' %>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'saml-post' %>
+    <%= javascript_packs_with_chunks_tag 'saml-post' %>
   </head>
   <body>
     <div class="container sm-py4">

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_packs_with_chunks_tag 'saml-post' %>
+    <%= javascript_packs_tag_once 'saml-post' %>
   </head>
   <body>
     <div class="container sm-py4">

--- a/app/views/service_provider_mfa/new.html.erb
+++ b/app/views/service_provider_mfa/new.html.erb
@@ -37,4 +37,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_pack_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>

--- a/app/views/service_provider_mfa/new.html.erb
+++ b/app/views/service_provider_mfa/new.html.erb
@@ -37,4 +37,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_tag_once("webauthn-unhide-signup") %>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -41,4 +41,4 @@
                 'data-toggle': 'modal' %>
 </p>
 <%= render 'shared/personal_key_confirmation_modal', code: code, update_path: update_path %>
-<%== javascript_packs_with_chunks_tag 'personal-key-page-controller', 'clipboard' %>
+<%== javascript_packs_tag_once 'personal-key-page-controller', 'clipboard' %>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -41,5 +41,4 @@
                 'data-toggle': 'modal' %>
 </p>
 <%= render 'shared/personal_key_confirmation_modal', code: code, update_path: update_path %>
-<%== javascript_pack_tag 'personal-key-page-controller' %>
-<%== javascript_pack_tag 'clipboard' %>
+<%== javascript_packs_with_chunks_tag 'personal-key-page-controller', 'clipboard' %>

--- a/app/views/shared/_spinner-button.html.erb
+++ b/app/views/shared/_spinner-button.html.erb
@@ -27,4 +27,4 @@ locals:
                 class: 'spinner-button__action-message usa-sr-only' %>
   <% end %>
 <% end %>
-<% javascript_pack_tag_once 'spinner-button' %>
+<% javascript_packs_tag_once 'spinner-button' %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -26,4 +26,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_packs_with_chunks_tag 'pw-strength' %>
+<%= javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -26,4 +26,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_pack_tag 'pw-strength' %>
+<%= javascript_packs_with_chunks_tag 'pw-strength' %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -55,4 +55,4 @@
                           MarketingSite.privacy_act_statement_url) %>
 </p>
 
-<%= javascript_packs_with_chunks_tag 'email-validation' %>
+<%= javascript_packs_tag_once 'email-validation' %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -55,4 +55,4 @@
                           MarketingSite.privacy_act_statement_url) %>
 </p>
 
-<%= javascript_pack_tag 'email-validation' %>
+<%= javascript_packs_with_chunks_tag 'email-validation' %>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -100,4 +100,4 @@
 
 <%= render 'shared/cancel', link: @referrer %>
 
-<%= javascript_pack_tag 'clipboard' %>
+<%= javascript_packs_with_chunks_tag 'clipboard' %>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -100,4 +100,4 @@
 
 <%= render 'shared/cancel', link: @referrer %>
 
-<%= javascript_packs_with_chunks_tag 'clipboard' %>
+<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -55,4 +55,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_packs_with_chunks_tag 'webauthn-unhide-signin' %>
+<%= javascript_packs_tag_once 'webauthn-unhide-signin' %>

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -55,4 +55,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_pack_tag 'webauthn-unhide-signin' %>
+<%= javascript_packs_with_chunks_tag 'webauthn-unhide-signin' %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -59,5 +59,4 @@
 <% end %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>
 
-<%== javascript_pack_tag 'clipboard' %>
-<%== javascript_pack_tag 'webauthn-authenticate' %>
+<%== javascript_packs_with_chunks_tag 'clipboard', 'webauthn-authenticate' %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -59,4 +59,4 @@
 <% end %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>
 
-<%== javascript_packs_with_chunks_tag 'clipboard', 'webauthn-authenticate' %>
+<%== javascript_packs_tag_once 'clipboard', 'webauthn-authenticate' %>

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -59,4 +59,4 @@
   </div>
 <% end %>
 
-<%= javascript_packs_with_chunks_tag 'clipboard' %>
+<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -59,4 +59,4 @@
   </div>
 <% end %>
 
-<%= javascript_pack_tag 'clipboard' %>
+<%= javascript_packs_with_chunks_tag 'clipboard' %>

--- a/app/views/users/backup_code_setup/depleted.html.erb
+++ b/app/views/users/backup_code_setup/depleted.html.erb
@@ -16,4 +16,4 @@
 <% end %>
 
 <div class="mt2 pt1 border-top"></div>
-<%= javascript_pack_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>

--- a/app/views/users/backup_code_setup/depleted.html.erb
+++ b/app/views/users/backup_code_setup/depleted.html.erb
@@ -16,4 +16,4 @@
 <% end %>
 
 <div class="mt2 pt1 border-top"></div>
-<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_tag_once("webauthn-unhide-signup") %>

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -19,4 +19,4 @@
   <% end %>
 </div>
 
-<%= javascript_pack_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -19,4 +19,4 @@
   <% end %>
 </div>
 
-<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_tag_once("webauthn-unhide-signup") %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -21,4 +21,4 @@
 
 <%= render 'shared/cancel', link: account_path %>
 
-<%= javascript_packs_with_chunks_tag 'pw-strength' %>
+<%= javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -21,4 +21,4 @@
 
 <%= render 'shared/cancel', link: account_path %>
 
-<%= javascript_pack_tag 'pw-strength' %>
+<%= javascript_packs_with_chunks_tag 'pw-strength' %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -37,5 +37,5 @@
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
 
   <%= stylesheet_link_tag 'intl-tel-input/build/css/intlTelInput' %>
-  <%= javascript_packs_with_chunks_tag 'intl-tel-input' %>
+  <%= javascript_packs_tag_once 'intl-tel-input' %>
 </div>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -37,5 +37,5 @@
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
 
   <%= stylesheet_link_tag 'intl-tel-input/build/css/intlTelInput' %>
-  <%= javascript_pack_tag 'intl-tel-input' %>
+  <%= javascript_packs_with_chunks_tag 'intl-tel-input' %>
 </div>

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -29,4 +29,4 @@
 <%= render 'shared/cancel', link: account_path %>
 
 <%= stylesheet_link_tag 'intl-tel-input/build/css/intlTelInput' %>
-<%= javascript_pack_tag 'intl-tel-input' %>
+<%= javascript_packs_with_chunks_tag 'intl-tel-input' %>

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -29,4 +29,4 @@
 <%= render 'shared/cancel', link: account_path %>
 
 <%= stylesheet_link_tag 'intl-tel-input/build/css/intlTelInput' %>
-<%= javascript_packs_with_chunks_tag 'intl-tel-input' %>
+<%= javascript_packs_tag_once 'intl-tel-input' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -74,4 +74,4 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
-<%= javascript_pack_tag 'clipboard' %>
+<%= javascript_packs_with_chunks_tag 'clipboard' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -74,4 +74,4 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
-<%= javascript_packs_with_chunks_tag 'clipboard' %>
+<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -42,4 +42,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_tag_once("webauthn-unhide-signup") %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -42,4 +42,4 @@
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>
 
-<%= javascript_pack_tag("webauthn-unhide-signup") %>
+<%= javascript_packs_with_chunks_tag("webauthn-unhide-signup") %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -54,4 +54,4 @@
 
 <%= render 'shared/cancel_or_back_to_options' %>
 
-<%= javascript_packs_with_chunks_tag 'clipboard', 'webauthn-setup' %>
+<%= javascript_packs_tag_once 'clipboard', 'webauthn-setup' %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -54,5 +54,4 @@
 
 <%= render 'shared/cancel_or_back_to_options' %>
 
-<%= javascript_pack_tag 'clipboard' %>
-<%= javascript_pack_tag 'webauthn-setup' %>
+<%= javascript_packs_with_chunks_tag 'clipboard', 'webauthn-setup' %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -6,6 +6,10 @@ environment.loaders.delete('moduleSass');
 environment.loaders.delete('moduleCss');
 environment.loaders.delete('css');
 
+// Note: Because chunk splitting is enabled by default as of Webpacker 6+, this line can be removed
+// when upgrading.
+environment.splitChunks();
+
 // Some files under `node_modules` should be compiled by Babel:
 // 1. Yarn workspace package symlinks, by package name starting with `@18f/identity-`.
 // 2. Specific dependencies that don't compile their own code to run safely in legacy browsers.

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe ScriptHelper do
     end
   end
 
-  describe '#javascript_pack_tag_once' do
+  describe '#javascript_packs_tag_once' do
     it 'returns nil' do
-      output = javascript_pack_tag_once('application')
+      output = javascript_packs_tag_once('application')
 
       expect(output).to be_nil
     end
@@ -28,9 +28,8 @@ RSpec.describe ScriptHelper do
 
     context 'scripts enqueued' do
       before do
-        javascript_pack_tag_once('application')
-        javascript_pack_tag_once('application')
-        javascript_pack_tag_once('clipboard')
+        javascript_packs_tag_once('application', 'clipboard')
+        javascript_packs_tag_once('application')
       end
 
       it 'prints all unique packs' do

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -36,9 +36,16 @@ RSpec.describe ScriptHelper do
       it 'prints all unique packs' do
         output = render_javascript_pack_once_tags
 
-        expect(output).to have_css('script', count: 2, visible: false)
-        expect(output).to have_css('script[src^="/packs-test/js/application-"]', visible: false)
-        expect(output).to have_css('script[src^="/packs-test/js/clipboard-"]', visible: false)
+        expect(output).to have_css(
+          'script[src^="/packs-test/js/application-"]',
+          count: 1,
+          visible: false,
+        )
+        expect(output).to have_css(
+          'script[src^="/packs-test/js/clipboard-"]',
+          count: 1,
+          visible: false,
+        )
       end
     end
   end

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -28,20 +28,30 @@ RSpec.describe ScriptHelper do
 
     context 'scripts enqueued' do
       before do
-        javascript_packs_tag_once('application', 'clipboard')
-        javascript_packs_tag_once('application')
+        javascript_packs_tag_once('clipboard', 'clipboard')
+        javascript_packs_tag_once('document-capture')
+        javascript_packs_tag_once('application', prepend: true)
       end
 
-      it 'prints all unique packs' do
+      it 'prints all unique packs in order' do
         output = render_javascript_pack_once_tags
 
+        application_pack_selector = 'script[src^="/packs-test/js/application-"]'
+        clipboard_pack_selector = 'script[src^="/packs-test/js/clipboard-"]'
+        document_capture_pack_selector = 'script[src^="/packs-test/js/document-capture-"]'
+
         expect(output).to have_css(
-          'script[src^="/packs-test/js/application-"]',
+          application_pack_selector,
           count: 1,
           visible: false,
         )
         expect(output).to have_css(
-          'script[src^="/packs-test/js/clipboard-"]',
+          "#{application_pack_selector} ~ #{clipboard_pack_selector}",
+          count: 1,
+          visible: false,
+        )
+        expect(output).to have_css(
+          "#{clipboard_pack_selector} ~ #{document_capture_pack_selector}",
           count: 1,
           visible: false,
         )


### PR DESCRIPTION
**Why**:

- Since it is the default behavior as of the upcoming Webpacker 6+ release, it will make a future upgrade easier.
  - See: https://github.com/rails/webpacker/blob/1aca8aa/6_0_upgrade.md
    - >Change `javascript_pack_tag` and `stylesheet_pack_tag` to `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag`
- It will allow for reuse of large shared dependencies (e.g. using React outside of the document capture pack without bundling a new copy of React into each pack where it is used).
  - This effort was prompted by a desire to use React outside the document capture screen (specifically to reuse the existing Alert React component)
- Conceptually well-aligned to javascript_pack_tag_once, facilitating eventual migration to render all applicable scripts once at the bottom of each page.
  - See: https://web.dev/render-blocking-resources/