### PR TITLE
LG-4001: Fix async verify step alert flashes not being shown

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -17,7 +17,7 @@ module Idv
       elsif async_state.in_progress?
         render :wait
       elsif async_state.timed_out?
-        flash[:info] = I18n.t('idv.failure.timeout')
+        flash[:error] = I18n.t('idv.failure.timeout')
         render :new
       elsif async_state.done?
         async_state_done(async_state)

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -17,7 +17,7 @@ module Idv
       elsif async_state.in_progress?
         render :wait
       elsif async_state.timed_out?
-        flash[:error] = I18n.t('idv.failure.timeout')
+        flash.now[:error] = I18n.t('idv.failure.timeout')
         render :new
       elsif async_state.done?
         async_state_done(async_state)

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -69,14 +69,13 @@ export class FormStepsWait {
   }
 
   renderError() {
-    // TODO: Assign data-error-message on forms to be picked up here.
     const { errorMessage } = this.options;
     if (errorMessage) {
       const errorRoot = document.createElement('div');
-      this.elements.form.prepend(errorRoot);
+      this.elements.form.appendChild(errorRoot);
 
       render(
-        <Alert type="error" className="margin-bottom-4">
+        <Alert type="error" className="margin-top-2">
           {errorMessage}
         </Alert>,
         errorRoot,

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -132,7 +132,7 @@ export class FormStepsWait {
 
   async poll() {
     const { waitStepPath } = this.options;
-    const response = await window.fetch(waitStepPath, { method: 'HEAD' });
+    const response = await window.fetch(waitStepPath);
     this.handleResponse(response);
   }
 }

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -60,6 +60,7 @@ export class FormStepsWait {
     const { waitStepPath, pollIntervalMs } = this.options;
     if (response.status >= 500) {
       this.renderError();
+      this.stopSpinner();
     } else if (response.redirected && new URL(response.url).pathname !== waitStepPath) {
       window.location.href = response.url;
     } else {
@@ -80,9 +81,19 @@ export class FormStepsWait {
         </Alert>,
         errorRoot,
       );
-
-      // TODO: Stop spinner button from spinning.
     }
+  }
+
+  /**
+   * Stops any active spinner buttons associated with this form.
+   */
+  stopSpinner() {
+    const { form } = this.elements;
+    const event = new window.CustomEvent('spinner.stop', { bubbles: true });
+    // Spinner button may be within the form, or an ancestor. To handle both cases, dispatch a
+    // bubbling event on the innermost element that could be associated with a spinner button.
+    const target = form.querySelector('.spinner-button--spinner-active') || form;
+    target.dispatchEvent(event);
   }
 
   async poll() {
@@ -92,7 +103,7 @@ export class FormStepsWait {
   }
 }
 
-loadPolyfills(['fetch']).then(() => {
+loadPolyfills(['fetch', 'custom-event']).then(() => {
   const forms = [...document.querySelectorAll('[data-form-steps-wait]')];
   forms.forEach((form) => new FormStepsWait(form).bind());
 });

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -1,4 +1,4 @@
-import { render } from 'react-dom';
+import { render, unmountComponentAtNode } from 'react-dom';
 import { Alert } from '@18f/identity-components';
 import { loadPolyfills } from '@18f/identity-polyfill';
 
@@ -82,6 +82,9 @@ export class FormStepsWait {
     const { form } = this.elements;
     const { action, method } = form;
 
+    // Clear error, if present.
+    this.renderError('');
+
     const response = await window.fetch(action, {
       method,
       body: new window.FormData(form),
@@ -140,14 +143,16 @@ export class FormStepsWait {
       return;
     }
 
-    errorRoot.innerHTML = '';
-
-    render(
-      <Alert type="error" className="margin-bottom-4">
-        {message}
-      </Alert>,
-      errorRoot,
-    );
+    if (message) {
+      render(
+        <Alert type="error" className="margin-bottom-4">
+          {message}
+        </Alert>,
+        errorRoot,
+      );
+    } else {
+      unmountComponentAtNode(errorRoot);
+    }
   }
 
   /**

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -14,6 +14,7 @@ import { loadPolyfills } from '@18f/identity-polyfill';
  * @prop {number} pollIntervalMs Poll interval.
  * @prop {string} waitStepPath URL path to wait step, used in polling.
  * @prop {string=} errorMessage Message to show on unhandled server error.
+ * @prop {string=} alertTarget DOM selector of HTML element to which alert should render.
  */
 
 /** @type {FormStepsWaitOptions} */
@@ -107,11 +108,20 @@ export class FormStepsWait {
    * @param {string} message Error message text.
    */
   renderError(message) {
-    const errorRoot = document.createElement('div');
-    this.elements.form.appendChild(errorRoot);
+    const { alertTarget } = this.options;
+    if (!alertTarget) {
+      return;
+    }
+
+    const errorRoot = document.querySelector(alertTarget);
+    if (!errorRoot) {
+      return;
+    }
+
+    errorRoot.innerHTML = '';
 
     render(
-      <Alert type="error" className="margin-top-2">
+      <Alert type="error" className="margin-bottom-4">
         {message}
       </Alert>,
       errorRoot,

--- a/app/javascript/packs/spinner-button.js
+++ b/app/javascript/packs/spinner-button.js
@@ -35,21 +35,40 @@ export class SpinnerButton {
   }
 
   bind() {
-    this.elements.button.addEventListener('click', () => this.showSpinner());
+    this.elements.button.addEventListener('click', () => this.toggleSpinner(true));
+    this.elements.wrapper.addEventListener('spinner.start', () => this.toggleSpinner(true));
+    this.elements.wrapper.addEventListener('spinner.stop', () => this.toggleSpinner(false));
   }
 
-  showSpinner() {
+  /**
+   * @param {boolean} isVisible
+   */
+  toggleSpinner(isVisible) {
     const { wrapper, button, actionMessage } = this.elements;
-    wrapper.classList.add('spinner-button--spinner-active');
+    wrapper.classList.toggle('spinner-button--spinner-active', isVisible);
 
     // Avoid setting disabled immediately to allow click event to propagate for form submission.
-    setTimeout(() => button.setAttribute('disabled', ''), 0);
+    setTimeout(() => {
+      if (isVisible) {
+        button.setAttribute('disabled', '');
+      } else {
+        button.removeAttribute('disabled');
+      }
+    }, 0);
 
     if (actionMessage) {
-      actionMessage.textContent = /** @type {string} */ (actionMessage.dataset.message);
+      actionMessage.textContent = isVisible
+        ? /** @type {string} */ (actionMessage.dataset.message)
+        : '';
     }
 
-    setTimeout(() => this.handleLongWait(), this.options.longWaitDurationMs);
+    window.clearTimeout(this.longWaitTimeout);
+    if (isVisible) {
+      this.longWaitTimeout = window.setTimeout(
+        () => this.handleLongWait(),
+        this.options.longWaitDurationMs,
+      );
+    }
   }
 
   handleLongWait() {

--- a/app/services/idv/steps/cac/verify_wait_step_show.rb
+++ b/app/services/idv/steps/cac/verify_wait_step_show.rb
@@ -16,7 +16,7 @@ module Idv
           elsif current_async_state.in_progress?
             nil
           elsif current_async_state.timed_out?
-            flash[:info] = I18n.t('idv.failure.timeout')
+            flash[:error] = I18n.t('idv.failure.timeout')
             delete_async
             mark_step_incomplete(:verify)
           elsif current_async_state.done?

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -15,7 +15,7 @@ module Idv
         elsif current_async_state.in_progress?
           nil
         elsif current_async_state.timed_out?
-          flash[:info] = I18n.t('idv.failure.timeout')
+          flash[:error] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         elsif current_async_state.done?

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -15,7 +15,7 @@ module Idv
         elsif current_async_state.in_progress?
           nil
         elsif current_async_state.timed_out?
-          flash[:info] = I18n.t('idv.failure.timeout')
+          flow_session[:error_message] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         elsif current_async_state.done?
@@ -31,7 +31,6 @@ module Idv
         delete_async
 
         if response.success?
-          flash[:success] = I18n.t('doc_auth.forms.doc_success')
           mark_step_complete(:verify_wait)
         else
           mark_step_incomplete(:verify)

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -15,7 +15,7 @@ module Idv
         elsif current_async_state.in_progress?
           nil
         elsif current_async_state.timed_out?
-          flow_session[:error_message] = I18n.t('idv.failure.timeout')
+          flash[:error] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         elsif current_async_state.done?

--- a/app/views/idv/cac/verify.html.erb
+++ b/app/views/idv/cac/verify.html.erb
@@ -1,3 +1,5 @@
+<div id="form-steps-wait-alert"></div>
+
 <% title t('cac_proofing.titles.cac_proofing') %>
 
 <h5 class="my1 caps bold accent-blue">
@@ -57,6 +59,7 @@
           data: {
             form_steps_wait: '',
             error_message: t("idv.failure.sessions.exception"),
+            alert_target: '#form-steps-wait-alert',
             wait_step_path: idv_cac_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
           },

--- a/app/views/idv/cac/verify.html.erb
+++ b/app/views/idv/cac/verify.html.erb
@@ -56,6 +56,7 @@
           class: 'button_to read-after-submit',
           data: {
             form_steps_wait: '',
+            error_message: t("idv.failure.sessions.exception"),
             wait_step_path: idv_cac_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
           },

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -1,11 +1,3 @@
-<% if flow_session[:error_message] %>
-  <%= render 'shared/alert', {
-    type: 'error',
-    class: 'margin-bottom-4',
-    message: flow_session[:error_message],
-  } %>
-<% end %>
-
 <% title t('titles.doc_auth.verify') %>
 
 <h1 class='h3 my0'>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -1,3 +1,11 @@
+<% if flow_session[:error_message] %>
+  <%= render 'shared/alert', {
+    type: 'error',
+    class: 'margin-bottom-4',
+    message: flow_session[:error_message],
+  } %>
+<% end %>
+
 <% title t('titles.doc_auth.verify') %>
 
 <h1 class='h3 my0'>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -59,6 +59,7 @@
           class: 'button_to read-after-submit',
           data: {
             form_steps_wait: '',
+            error_message: t("idv.failure.sessions.exception"),
             wait_step_path: idv_doc_auth_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
           },

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -1,3 +1,5 @@
+<div id="form-steps-wait-alert"></div>
+
 <% title t('titles.doc_auth.verify') %>
 
 <h1 class='h3 my0'>
@@ -52,6 +54,7 @@
           data: {
             form_steps_wait: '',
             error_message: t("idv.failure.sessions.exception"),
+            alert_target: '#form-steps-wait-alert',
             wait_step_path: idv_doc_auth_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
           },

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -1,3 +1,9 @@
+<%= render 'shared/alert', {
+  type: 'success',
+  class: 'margin-bottom-4',
+  message: I18n.t('doc_auth.forms.doc_success'),
+} %>
+
 <% title t('idv.titles.phone') %>
 
 <h1 class="h3 my0">

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -1,8 +1,10 @@
-<%= render 'shared/alert', {
-  type: 'success',
-  class: 'margin-bottom-4',
-  message: I18n.t('doc_auth.forms.doc_success'),
-} %>
+<div id="form-steps-wait-alert">
+  <%= render 'shared/alert', {
+    type: 'success',
+    class: 'margin-bottom-4',
+    message: I18n.t('doc_auth.forms.doc_success'),
+  } %>
+</div>
 
 <% title t('idv.titles.phone') %>
 
@@ -37,6 +39,7 @@
                        data: {
                          form_steps_wait: '',
                          error_message: t("idv.failure.sessions.exception"),
+                         alert_target: '#form-steps-wait-alert',
                          wait_step_path: idv_phone_path,
                          poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
                        },

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -36,6 +36,7 @@
                        url: idv_phone_path,
                        data: {
                          form_steps_wait: '',
+                         error_message: t("idv.failure.sessions.exception"),
                          wait_step_path: idv_phone_path,
                          poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
                        },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build": "true"
   },
   "dependencies": {
-    "basscss-sass": "^3.0.0",
     "@babel/core": "^7.12.10",
     "@babel/eslint-parser": "^7.12.1",
     "@babel/eslint-plugin": "^7.12.1",
@@ -25,6 +24,8 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
     "@babel/register": "^7.12.10",
+    "@rails/webpacker": "^5.2.1",
+    "basscss-sass": "^3.0.0",
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.6.0",
     "clipboard": "^2.0.6",
@@ -33,10 +34,9 @@
     "identity-style-guide": "^3.0.0",
     "intl-tel-input": "^17.0.8",
     "libphonenumber-js": "^1.9.6",
+    "postcss-clean": "^1.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "@rails/webpacker": "^5.2.1",
-    "postcss-clean": "^1.1.0",
     "source-map-loader": "^1.1.3",
     "zxcvbn": "^4.4.2"
   },
@@ -47,6 +47,7 @@
     "@testing-library/react-hooks": "^3.7.0",
     "@testing-library/user-event": "^12.6.0",
     "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "eslint": "^7.16.0",

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -71,7 +71,7 @@ describe Idv::PhoneController do
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
 
       get :new
-      expect(flash[:info]).to include t('idv.failure.timeout')
+      expect(flash[:error]).to include t('idv.failure.timeout')
       expect(response).to render_template :new
       put :create, params: { idv_phone_form: { phone: good_phone } }
       get :new

--- a/spec/features/idv/cac/verify_step_spec.rb
+++ b/spec/features/idv/cac/verify_step_spec.rb
@@ -56,4 +56,52 @@ feature 'cac proofing verify info step' do
       expect(page).to have_current_path(idv_cac_proofing_success_step)
     end
   end
+
+  context 'javascript enabled', js: true do
+    around do |example|
+      # Adjust the wait time to give the frontend time to poll for results.
+      Capybara.using_wait_time(5) do
+        example.run
+      end
+    end
+
+    it 'proceeds to the next page upon confirmation' do
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_phone_path)
+      expect(page).to have_content(t('doc_auth.forms.doc_success'))
+    end
+
+    context 'resolution failure' do
+      let(:skip_step_completion) { true }
+
+      it 'does not proceed to the next page' do
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_ssn_step
+        fill_out_ssn_form_with_ssn_that_fails_resolution
+        click_idv_continue
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_session_errors_warning_path)
+
+        click_on t('idv.failure.button.warning')
+
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+      end
+    end
+
+    context 'async timed out' do
+      it 'allows resubmitting form' do
+        allow(DocumentCaptureSession).to receive(:find_by).
+          and_return(nil)
+
+        click_continue
+        expect(page).to have_content(t('idv.failure.timeout'))
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+        click_continue
+        expect(page).to have_current_path(idv_phone_path)
+      end
+    end
+  end
 end

--- a/spec/features/idv/cac/verify_step_spec.rb
+++ b/spec/features/idv/cac/verify_step_spec.rb
@@ -58,6 +58,11 @@ feature 'cac proofing verify info step' do
   end
 
   context 'javascript enabled', js: true do
+    before do
+      sign_in_and_2fa_user
+      complete_cac_proofing_steps_before_verify_step
+    end
+
     around do |example|
       # Adjust the wait time to give the frontend time to poll for results.
       Capybara.using_wait_time(5) do
@@ -66,41 +71,21 @@ feature 'cac proofing verify info step' do
     end
 
     it 'proceeds to the next page upon confirmation' do
-      click_idv_continue
+      click_continue
 
-      expect(page).to have_current_path(idv_phone_path)
-      expect(page).to have_content(t('doc_auth.forms.doc_success'))
-    end
-
-    context 'resolution failure' do
-      let(:skip_step_completion) { true }
-
-      it 'does not proceed to the next page' do
-        sign_in_and_2fa_user
-        complete_doc_auth_steps_before_ssn_step
-        fill_out_ssn_form_with_ssn_that_fails_resolution
-        click_idv_continue
-        click_idv_continue
-
-        expect(page).to have_current_path(idv_session_errors_warning_path)
-
-        click_on t('idv.failure.button.warning')
-
-        expect(page).to have_current_path(idv_doc_auth_verify_step)
-      end
+      expect(page).to have_current_path(idv_cac_proofing_success_step)
     end
 
     context 'async timed out' do
       it 'allows resubmitting form' do
-        allow(DocumentCaptureSession).to receive(:find_by).
-          and_return(nil)
+        allow(DocumentCaptureSession).to receive(:find_by).and_return(nil)
 
         click_continue
         expect(page).to have_content(t('idv.failure.timeout'))
-        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        expect(page).to have_current_path(idv_cac_proofing_verify_step)
         allow(DocumentCaptureSession).to receive(:find_by).and_call_original
         click_continue
-        expect(page).to have_current_path(idv_phone_path)
+        expect(page).to have_current_path(idv_cac_proofing_success_step)
       end
     end
   end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -5,10 +5,13 @@ feature 'doc auth verify step' do
   include DocAuthHelper
   include InPersonHelper
 
+  let(:skip_step_completion) { false }
   let(:max_attempts) { idv_max_attempts }
   before do
-    sign_in_and_2fa_user
-    complete_doc_auth_steps_before_verify_step
+    unless skip_step_completion
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_verify_step
+    end
   end
 
   it 'is on the correct page' do
@@ -213,10 +216,59 @@ feature 'doc auth verify step' do
         and_return(nil)
 
       click_continue
+      expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_doc_auth_verify_step)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
       click_continue
       expect(page).to have_current_path(idv_phone_path)
+    end
+  end
+
+  context 'javascript enabled', js: true do
+    around do |example|
+      # Adjust the wait time to give the frontend time to poll for results.
+      Capybara.using_wait_time(5) do
+        example.run
+      end
+    end
+
+    it 'proceeds to the next page upon confirmation' do
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_phone_path)
+      expect(page).to have_content(t('doc_auth.forms.doc_success'))
+    end
+
+    context 'resolution failure' do
+      let(:skip_step_completion) { true }
+
+      it 'does not proceed to the next page' do
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_ssn_step
+        fill_out_ssn_form_with_ssn_that_fails_resolution
+        click_idv_continue
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_session_errors_warning_path)
+
+        click_on t('idv.failure.button.warning')
+
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+      end
+    end
+
+    context 'async timed out' do
+      it 'allows resubmitting form' do
+        allow(DocumentCaptureSession).to receive(:find_by).
+          and_return(nil)
+
+        click_continue
+        expect(page).to have_content(t('idv.failure.timeout'))
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+        click_continue
+        expect(page).to have_current_path(idv_phone_path)
+      end
     end
   end
 end

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -138,6 +138,7 @@ feature 'idv phone step' do
   end
 
   it_behaves_like 'async timed out'
+
   context 'javascript enabled', js: true do
     around do |example|
       # Adjust the wait time to give the frontend time to poll for results.

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -119,6 +119,36 @@ feature 'idv phone step' do
     expect(page).to have_current_path(idv_doc_auth_step_path(step: :welcome))
   end
 
+  shared_examples 'async timed out' do
+    it 'allows resubmitting form' do
+      user = user_with_2fa
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step(user)
+
+      allow(DocumentCaptureSession).to receive(:find_by).and_return(nil)
+
+      fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)
+      click_idv_continue
+      expect(page).to have_content(t('idv.failure.timeout'))
+      expect(page).to have_current_path(idv_phone_path)
+      allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+      click_idv_continue
+      expect(page).to have_current_path(idv_review_path)
+    end
+  end
+
+  it_behaves_like 'async timed out'
+  context 'javascript enabled', js: true do
+    around do |example|
+      # Adjust the wait time to give the frontend time to poll for results.
+      Capybara.using_wait_time(5) do
+        example.run
+      end
+    end
+
+    it_behaves_like 'async timed out'
+  end
+
   context 'cancelling IdV' do
     it_behaves_like 'cancel at idv step', :phone
     it_behaves_like 'cancel at idv step', :phone, :oidc

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -23,7 +23,13 @@ describe('FormStepsWait', () => {
 
   function createForm({ action, method, options }) {
     document.body.innerHTML = `
-      <form action="${action}" method="${method}" data-form-steps-wait="">
+      <form
+        action="${action}"
+        method="${method}"
+        data-form-steps-wait=""
+        data-alert-target="#alert-target"
+      >
+        <div id="alert-target"></div>
         <input type="hidden" name="foo" value="bar">
       </form>
     `;

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -43,7 +43,7 @@ describe('FormStepsWait', () => {
     mock.verify();
   });
 
-  it('reloads on failed submit', (done) => {
+  it('stops spinner on failed submit', (done) => {
     const action = new URL('/', window.location).toString();
     const method = 'post';
     const form = createForm({ action, method });
@@ -51,10 +51,10 @@ describe('FormStepsWait', () => {
     sandbox
       .stub(window, 'fetch')
       .withArgs(action, sandbox.match({ method }))
-      .resolves({ ok: false });
-    defineProperty(window, 'location', { value: { reload: done } });
+      .resolves({ ok: false, status: 500 });
 
     fireEvent.submit(form);
+    form.addEventListener('spinner.stop', () => done());
   });
 
   it('navigates on redirected response', (done) => {

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -44,18 +44,10 @@ describe('FormStepsWait', () => {
   });
 
   describe('failure', () => {
-    /** @type {HTMLFormElement} */
-    let form;
+    const action = new URL('/', window.location).toString();
+    const method = 'post';
 
-    let errorMessage = beforeEach(() => {
-      const action = new URL('/', window.location).toString();
-      const method = 'post';
-      form = createForm({ action, method });
-      if (errorMessage) {
-        form.setAttribute('data-error-message', errorMessage);
-      }
-
-      new FormStepsWait(form).bind();
+    beforeEach(() => {
       sandbox
         .stub(window, 'fetch')
         .withArgs(action, sandbox.match({ method }))
@@ -63,12 +55,22 @@ describe('FormStepsWait', () => {
     });
 
     it('stops spinner', (done) => {
+      const form = createForm({ action, method });
+      new FormStepsWait(form).bind();
       fireEvent.submit(form);
       form.addEventListener('spinner.stop', () => done());
     });
 
     context('error message configured', () => {
-      errorMessage = 'An error occurred!';
+      const errorMessage = 'An error occurred!';
+
+      /** @type {HTMLFormElement} */
+      let form;
+      beforeEach(() => {
+        form = createForm({ action, method });
+        form.setAttribute('data-error-message', errorMessage);
+        new FormStepsWait(form).bind();
+      });
 
       it('shows message', async () => {
         fireEvent.submit(form);

--- a/spec/javascripts/packs/spinner-button-spec.js
+++ b/spec/javascripts/packs/spinner-button-spec.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
-import { getByRole } from '@testing-library/dom';
+import { getByRole, fireEvent } from '@testing-library/dom';
 import { SpinnerButton } from '../../../app/javascript/packs/spinner-button';
 
 describe('SpinnerButton', () => {
@@ -101,5 +101,16 @@ describe('SpinnerButton', () => {
     expect(status.classList.contains('usa-sr-only')).to.be.true();
     clock.tick(1);
     expect(status.classList.contains('usa-sr-only')).to.be.false();
+  });
+
+  it('supports external dispatched events to control spinner', () => {
+    const wrapper = createWrapper();
+    const spinnerButton = new SpinnerButton(wrapper);
+    spinnerButton.bind();
+
+    fireEvent(wrapper, new window.CustomEvent('spinner.start'));
+    expect(wrapper.classList.contains('spinner-button--spinner-active')).to.be.true();
+    fireEvent(wrapper, new window.CustomEvent('spinner.stop'));
+    expect(wrapper.classList.contains('spinner-button--spinner-active')).to.be.false();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
   "include": [
     "app/javascript/packages",
     "app/javascript/packs/document-capture.jsx",
-    "app/javascript/packs/form-steps-wait.js",
+    "app/javascript/packs/form-steps-wait.jsx",
     "app/javascript/packs/form-validation.js",
     "app/javascript/packs/intl-tel-input.js",
     "app/javascript/packs/spinner-button.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,6 +1219,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-dom@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@*":
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"


### PR DESCRIPTION
Related (optionally blocked by): #4553

**Why**: Redirects from JavaScript-based form-steps-wait behavior will cause flash messages to be dropped. To make "sticky", use existing flow_session error message for error messages, and statically render success on following phone step view.

**Why**: As a user, I expect that I am informed when the server encounters an unhandled error, so that I can retry my request later, and am not left confused by an infinitely-spinning spinner.
