### PR TITLE
validate OIDC authorize form's client_id parameter does not contain null byte

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -65,6 +65,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def service_provider
+    return NullServiceProvider.new(issuer: nil) if client_id && client_id.include?("\x00")
     @_service_provider ||= ServiceProvider.from_issuer(client_id)
   end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -137,6 +137,15 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
+    context 'with a client_id containing a null byte' do
+      let(:client_id) { "not_a_real_client_id\x00" }
+      it 'has errors' do
+        expect(valid?).to eq(false)
+        expect(form.errors[:client_id]).
+          to include(t('openid_connect.authorization.errors.bad_client_id'))
+      end
+    end
+
     context 'nonce' do
       context 'without a nonce' do
         let(:nonce) { nil }


### PR DESCRIPTION
We're returning a 500 if the `client_id` parameter contains a null byte: [New Relic](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiN2FjOGJkMzYtNGRmYS0xMWViLWIxZWEtMDI0MmFjMTEwMDA4XzBfMjEyNDEiLCJmaWx0ZXJzIjpbeyJrZXkiOiJlcnJvci5leHBlY3RlZCIsInZhbHVlIjoibm90IHRydWUifSx7ImtleSI6ImVycm9yLmNsYXNzIiwidmFsdWUiOiJBcmd1bWVudEVycm9yIiwibGlrZSI6ZmFsc2V9XSwibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3IiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5USXhNelk0TlRnIn0&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5USXhNelk0TlRnIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ&platform[timeRange][duration]=604800000)