### PR TITLE
LG-3767: Reorder MFA options and improve accuracy of secure labels

### DIFF
--- a/app/presenters/two_factor_authentication/auth_app_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/auth_app_selection_presenter.rb
@@ -6,7 +6,7 @@ module TwoFactorAuthentication
 
     # :reek:UtilityFunction
     def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.more_secure_label')
+      I18n.t('two_factor_authentication.two_factor_choice_options.secure_label')
     end
   end
 end

--- a/app/presenters/two_factor_authentication/phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/phone_selection_presenter.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
     end
 
     def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.secure_label')
+      I18n.t('two_factor_authentication.two_factor_choice_options.less_secure_label')
     end
 
     private

--- a/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
@@ -5,7 +5,7 @@ module TwoFactorAuthentication
     end
 
     def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.secure_label')
+      I18n.t('two_factor_authentication.two_factor_choice_options.more_secure_label')
     end
   end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -9,7 +9,7 @@ class TwoFactorOptionsPresenter
   end
 
   def options
-    totp_option + webauthn_option + phone_options + piv_cac_option + backup_code_option
+    webauthn_option + piv_cac_option + totp_option + phone_options + backup_code_option
   end
 
   def icon

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -16,10 +16,10 @@ describe TwoFactorOptionsPresenter do
   describe '#options' do
     it 'supplies all the options for a user' do
       expect(presenter.options.map(&:class)).to eq [
-        TwoFactorAuthentication::AuthAppSelectionPresenter,
         TwoFactorAuthentication::WebauthnSelectionPresenter,
-        TwoFactorAuthentication::PhoneSelectionPresenter,
         TwoFactorAuthentication::PivCacSelectionPresenter,
+        TwoFactorAuthentication::AuthAppSelectionPresenter,
+        TwoFactorAuthentication::PhoneSelectionPresenter,
         TwoFactorAuthentication::BackupCodeSelectionPresenter,
       ]
     end
@@ -44,9 +44,9 @@ describe TwoFactorOptionsPresenter do
 
       it 'supplies all the options except phone' do
         expect(presenter.options.map(&:class)).to eq [
-          TwoFactorAuthentication::AuthAppSelectionPresenter,
           TwoFactorAuthentication::WebauthnSelectionPresenter,
           TwoFactorAuthentication::PivCacSelectionPresenter,
+          TwoFactorAuthentication::AuthAppSelectionPresenter,
           TwoFactorAuthentication::BackupCodeSelectionPresenter,
         ]
       end


### PR DESCRIPTION
**Why**: Previous labels were decided to not accurately reflect the security and preference of options.

Per acceptance criteria, labels and ordering are now:

- Security Key (More Secure)
- Government employee ID (More Secure)
- Authentication application (Secure)
- Phone (Less Secure)
- Backup codes (Less Secure)

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/103910828-47ed7d00-50d3-11eb-9cc2-8ea25280face.png)

Per acceptance criteria for baseline metrics and [related Slack discussion](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1609873861084600), capability exists to query logs to determine MFA submission drop-off and authentication option choices. These have been captured for the week of 11/11/20-11/18/20 and for the date 01/05/21.