### PR TITLE
Rescue Pinpoint timeout errors in Telephony gem (LG-3925)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.3'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.2'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
-gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.7'
+gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.8'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'main'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: ebc61fc878f9413c32b6b1a0a6c82866f86ad60c
-  tag: v0.1.7
+  revision: 3dd8a3e91c58565aa4188ac1ec7622c2665d04ae
+  tag: v0.1.8
   specs:
-    identity-telephony (0.1.7)
+    identity-telephony (0.1.8)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n


### PR DESCRIPTION
Updates IDP to use telephony gem updates in https://github.com/18F/identity-telephony/pull/35