### PR TITLE
Add a step_count attribute to the doc auth event logs

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -15,7 +15,7 @@ module Flow
 
     def show
       step = current_step
-      analytics.track_event(analytics_visited, step: step) if @analytics_id
+      analytics.track_event(analytics_visited, analytics_properties) if @analytics_id
       Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(step, :view, true)
       register_campaign
       render_step(step, flow.flow_session)
@@ -24,7 +24,9 @@ module Flow
     def update
       step = current_step
       result = flow.handle(step)
-      analytics.track_event(analytics_submitted, result.to_h.merge(step: step)) if @analytics_id
+      if @analytics_id
+        analytics.track_event(analytics_submitted, result.to_h.merge(analytics_properties))
+      end
       register_update_step(step, result)
       if flow.json
         render json: flow.json, status: flow.http_status
@@ -156,6 +158,20 @@ module Flow
 
     def analytics_optional_step
       [@analytics_id, 'optional submitted'].join(' ')
+    end
+
+    def analytics_properties
+      current_step_name = "#{current_step.to_s}_#{action_name}"
+      current_flow_step_counts[current_step_name] ||= 0
+      {
+        step: current_step,
+        step_count: current_flow_step_counts[current_step_name] += 1,
+      }
+    end
+
+    def current_flow_step_counts
+      current_session["#{@name}_flow_step_counts"] ||= {}
+      current_session["#{@name}_flow_step_counts"]
     end
 
     def next_step

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -115,10 +115,12 @@ describe Idv::CaptureDocController do
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::CAPTURE_DOC + ' visited', hash_including(step: 'capture_complete', step_count: 1)
+          Analytics::CAPTURE_DOC + ' visited',
+          hash_including(step: 'capture_complete', step_count: 1),
         )
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::CAPTURE_DOC + ' visited', hash_including(step: 'capture_complete', step_count: 2)
+          Analytics::CAPTURE_DOC + ' visited',
+          hash_including(step: 'capture_complete', step_count: 2),
         )
       end
 

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -99,12 +99,26 @@ describe Idv::CaptureDocController do
 
       it 'tracks analytics' do
         mock_next_step(:capture_complete)
-        result = { step: 'capture_complete' }
+        result = { step: 'capture_complete', step_count: 1 }
 
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).with(
           Analytics::CAPTURE_DOC + ' visited', result
+        )
+      end
+
+      it 'increments the analytics step counts on subsequent submissions' do
+        mock_next_step(:capture_complete)
+
+        get :show, params: { step: 'capture_complete' }
+        get :show, params: { step: 'capture_complete' }
+
+        expect(@analytics).to have_received(:track_event).ordered.with(
+          Analytics::CAPTURE_DOC + ' visited', hash_including(step: 'capture_complete', step_count: 1)
+        )
+        expect(@analytics).to have_received(:track_event).ordered.with(
+          Analytics::CAPTURE_DOC + ' visited', hash_including(step: 'capture_complete', step_count: 2)
         )
       end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -122,10 +122,10 @@ describe Idv::DocAuthController do
       put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
 
       expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 1),
+        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 1)
       )
       expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 2),
+        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 2)
       )
     end
 

--- a/spec/controllers/idv/recovery_controller_spec.rb
+++ b/spec/controllers/idv/recovery_controller_spec.rb
@@ -105,7 +105,7 @@ describe Idv::RecoveryController do
       end
 
       it 'tracks analytics' do
-        result = { step: 'recover' }
+        result = { step: 'recover', step_count: 1 }
 
         get :show, params: { step: 'recover' }
 


### PR DESCRIPTION
This commit adds a "step_count" attributes that is incremented by 1 every time a step is invoked. The step counts are also independent for visits and submissions.

This allows us to build funnels in cloud watch by filtering for logs that have a step count of 1.