### PR TITLE
give doc auth async analytics events unique messages

### DIFF
--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -67,7 +67,7 @@ module Idv
 
       def async_state
         if verify_document_capture_session.nil?
-          failed_to_load_document_capture_analytics
+          document_capture_analytics('failed to load verify_document_capture_session')
 
           return timed_out
         end
@@ -91,13 +91,13 @@ module Idv
       end
 
       def delete_async
-        failed_to_load_document_capture_analytics
+        document_capture_analytics('deleting verify_document_capture_session_uuid_key')
         flow_session.delete(verify_document_capture_session_uuid_key)
       end
 
-      def failed_to_load_document_capture_analytics
+      def document_capture_analytics(message)
         data = {
-          error: 'failed to load verify_document_capture_session',
+          error: message,
           uuid: flow_session[verify_document_capture_session_uuid_key],
         }
 


### PR DESCRIPTION
`delete_async` and failing to find the session are generating the same message, which is misleading and makes things harder to follow. This PR gives them unique messages