### PR TITLE
A new internal API to allow frontend clients to log info on the server (LG-3975)

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -1,0 +1,33 @@
+class FrontendLogController < ApplicationController
+
+  respond_to :json
+
+  def create
+    if user_fully_authenticated?
+      log_level, payload = log_params
+      case log_level
+      when 'error'
+        Rails.logger.error { payload.to_json }
+      when 'warn'
+        Rails.logger.warn { payload.to_json }
+      when 'debug'
+        Rails.logger.debug { payload.to_json }
+      else
+        Rails.logger.info { payload.to_json }
+      end
+
+      render json: { success: true }, status: :ok
+    else
+      render json: { success: false }, status: :unauthorized
+    end
+
+  rescue ActionController::ParameterMissing => pm
+    render json: { success: false, error_message: pm.to_s }, status: :bad_request
+  end
+
+  private
+
+  def log_params
+    params.require([:log_level, :payload])
+  end
+end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -4,17 +4,8 @@ class FrontendLogController < ApplicationController
 
   def create
     if user_fully_authenticated?
-      log_level, payload = log_params
-      case log_level
-      when 'error'
-        Rails.logger.error { payload.to_json }
-      when 'warn'
-        Rails.logger.warn { payload.to_json }
-      when 'debug'
-        Rails.logger.debug { payload.to_json }
-      else
-        Rails.logger.info { payload.to_json }
-      end
+      event, payload = log_params
+      analytics.track_event(event, payload)
 
       render json: { success: true }, status: :ok
     else
@@ -28,6 +19,6 @@ class FrontendLogController < ApplicationController
   private
 
   def log_params
-    params.require([:log_level, :payload])
+    params.require([:event, :payload])
   end
 end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -2,23 +2,40 @@ class FrontendLogController < ApplicationController
 
   respond_to :json
 
+  before_action :check_user_authenticated
+  before_action :validate_parameter_types
+
   def create
-    if user_fully_authenticated?
-      event, payload = log_params
-      analytics.track_event(event, payload)
+    analytics.track_event(log_params[:event], log_params[:payload].to_h)
 
-      render json: { success: true }, status: :ok
-    else
-      render json: { success: false }, status: :unauthorized
-    end
-
-  rescue ActionController::ParameterMissing => pm
-    render json: { success: false, error_message: pm.to_s }, status: :bad_request
+    render json: { success: true }, status: :ok
   end
 
   private
 
   def log_params
-    params.require([:event, :payload])
+    params.permit(:event, payload: {})
+  end
+
+  def check_user_authenticated
+    return if user_fully_authenticated?
+
+    render json: { success: false }, status: :unauthorized
+  end
+
+  def validate_parameter_types
+    return if valid_event? && valid_payload?
+
+    render json: { success: false, error_message: 'incorrect parameter types' },
+           status: :bad_request
+  end
+
+  def valid_event?
+    log_params[:event].is_a?(String) && log_params[:event].present?
+  end
+
+  def valid_payload?
+    payload = log_params[:payload].to_h
+    payload.is_a?(Hash) && payload.present?
   end
 end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -6,7 +6,8 @@ class FrontendLogController < ApplicationController
   before_action :validate_parameter_types
 
   def create
-    analytics.track_event(log_params[:event], log_params[:payload].to_h)
+    event = "Frontend: #{log_params[:event]}"
+    analytics.track_event(event, log_params[:payload].to_h)
 
     render json: { success: true }, status: :ok
   end
@@ -32,8 +33,7 @@ class FrontendLogController < ApplicationController
 
   def valid_event?
     log_params[:event].is_a?(String) &&
-      log_params[:event].present? &&
-      analytics.allowable_frontend_events.include?(log_params[:event])
+      log_params[:event].present?
   end
 
   def valid_payload?

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -31,7 +31,9 @@ class FrontendLogController < ApplicationController
   end
 
   def valid_event?
-    log_params[:event].is_a?(String) && log_params[:event].present?
+    log_params[:event].is_a?(String) &&
+      log_params[:event].present? &&
+      analytics.allowable_frontend_events.include?(log_params[:event])
   end
 
   def valid_payload?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -65,6 +65,13 @@ class Analytics
     }
   end
 
+  def allowable_frontend_events
+    [
+      FRONTEND_DOC_AUTH_ASYNC_UPLOAD,
+      FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT,
+    ]
+  end
+
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET = 'Account Reset'.freeze
   ACCOUNT_DELETE_SUBMITTED = 'Account Delete submitted'.freeze
@@ -96,6 +103,8 @@ class Analytics
   FORGET_ALL_BROWSERS_SUBMITTED = 'Forget All Browsers Submitted'.freeze
   FORGET_ALL_BROWSERS_VISITED = 'Forget All Browsers Visited'.freeze
   FRONTEND_BROWSER_CAPABILITIES = 'Frontend: Browser capabilities'.freeze
+  FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT = 'documentCapture.acuantWebSDKResult'.freeze
+  FRONTEND_DOC_AUTH_ASYNC_UPLOAD = 'documentCapture.asyncUpload'.freeze
   IAL2_RECOVERY = 'IAL2 Recovery'.freeze # visited or submitted is appended
   IAL2_RECOVERY_REQUEST = 'IAL2 Recovery Request'.freeze
   IAL2_RECOVERY_REQUEST_VISITED = 'IAL2 Recovery Request Visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -65,13 +65,6 @@ class Analytics
     }
   end
 
-  def allowable_frontend_events
-    [
-      FRONTEND_DOC_AUTH_ASYNC_UPLOAD,
-      FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT,
-    ]
-  end
-
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET = 'Account Reset'.freeze
   ACCOUNT_DELETE_SUBMITTED = 'Account Delete submitted'.freeze
@@ -103,8 +96,6 @@ class Analytics
   FORGET_ALL_BROWSERS_SUBMITTED = 'Forget All Browsers Submitted'.freeze
   FORGET_ALL_BROWSERS_VISITED = 'Forget All Browsers Visited'.freeze
   FRONTEND_BROWSER_CAPABILITIES = 'Frontend: Browser capabilities'.freeze
-  FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT = 'documentCapture.acuantWebSDKResult'.freeze
-  FRONTEND_DOC_AUTH_ASYNC_UPLOAD = 'documentCapture.asyncUpload'.freeze
   IAL2_RECOVERY = 'IAL2 Recovery'.freeze # visited or submitted is appended
   IAL2_RECOVERY_REQUEST = 'IAL2 Recovery Request'.freeze
   IAL2_RECOVERY_REQUEST_VISITED = 'IAL2 Recovery Request Visited'.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   post '/api/service_provider' => 'service_provider#update'
   post '/api/verify/images' => 'idv/image_uploads#create'
+  post '/api/logger' => 'frontend_log#create'
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   get '/openid_connect/logout' => 'openid_connect/logout#index'

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe FrontendLogController do
+  describe '#create' do
+    subject(:action) { post :create, params: params }
+
+    let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
+    let(:log_level) { 'info' }
+    let(:params) { { log_level: log_level, payload: { message: 'To be logged...' } } }
+
+    context 'user is signed in' do
+      before do
+        sign_in user
+      end
+
+      it 'succeeds' do
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(response.status).to eq(200)
+        expect(json[:success]).to eq(true)
+      end
+
+      context 'missing a parameter' do
+        it 'rejects a request without specifying log_level' do
+          params.delete(:log_level)
+          action
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(response.status).to eq(400)
+          expect(json[:success]).to eq(false)
+        end
+
+        it 'rejects a request without specifying payload' do
+          params.delete(:payload)
+          action
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(response.status).to eq(400)
+          expect(json[:success]).to eq(false)
+        end
+      end
+    end
+
+    context 'user is not signed in' do
+      it 'returns unauthorized' do
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(response.status).to eq(401)
+        expect(json[:success]).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -26,6 +26,28 @@ describe FrontendLogController do
         expect(json[:success]).to eq(true)
       end
 
+      context 'invalid param' do
+        it 'rejects a non-hash payload' do
+          expect(@analytics).not_to receive(:track_event)
+
+          params[:payload] = 'abc'
+          action
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json[:success]).to eq(false)
+        end
+
+        it 'rejects a non-string event' do
+          expect(@analytics).not_to receive(:track_event)
+
+          params[:event] = { abc: 'abc' }
+          action
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json[:success]).to eq(false)
+        end
+      end
+
       context 'missing a parameter' do
         it 'rejects a request without specifying event' do
           expect(@analytics).not_to receive(:track_event)

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -16,9 +16,13 @@ describe FrontendLogController do
     context 'user is signed in' do
       before do
         sign_in user
+        stub_analytics
       end
 
       it 'succeeds' do
+        expect(@analytics).to receive(:track_event).
+          with(params[:event], params[:payload])
+
         action
 
         expect(response).to have_http_status(:ok)
@@ -27,6 +31,8 @@ describe FrontendLogController do
 
       context 'unallowed event type' do
         it 'rejects a request with an event that is not allowed' do
+          expect(@analytics).not_to receive(:track_event)
+
           params[:event] = 'custom event'
           action
 
@@ -37,6 +43,8 @@ describe FrontendLogController do
 
       context 'missing a parameter' do
         it 'rejects a request without specifying event' do
+          expect(@analytics).not_to receive(:track_event)
+
           params.delete(:event)
           action
 
@@ -45,6 +53,8 @@ describe FrontendLogController do
         end
 
         it 'rejects a request without specifying payload' do
+          expect(@analytics).not_to receive(:track_event)
+
           params.delete(:payload)
           action
 
@@ -56,6 +66,10 @@ describe FrontendLogController do
 
     context 'user is not signed in' do
       it 'returns unauthorized' do
+        stub_analytics
+
+        expect(@analytics).not_to receive(:track_event)
+
         action
 
         expect(response).to have_http_status(:unauthorized)

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -5,12 +5,9 @@ describe FrontendLogController do
     subject(:action) { post :create, params: params }
 
     let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
-    let(:params) do
-      {
-        event: Analytics::FRONTEND_DOC_AUTH_ASYNC_UPLOAD,
-        payload: { message: 'To be logged...' },
-      }
-    end
+    let(:event) { 'Custom Event' }
+    let(:payload) { { message: 'To be logged...' } }
+    let(:params) { { event: event, payload: payload } }
     let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
     context 'user is signed in' do
@@ -21,24 +18,12 @@ describe FrontendLogController do
 
       it 'succeeds' do
         expect(@analytics).to receive(:track_event).
-          with(params[:event], params[:payload])
+          with("Frontend: #{event}", payload)
 
         action
 
         expect(response).to have_http_status(:ok)
         expect(json[:success]).to eq(true)
-      end
-
-      context 'unallowed event type' do
-        it 'rejects a request with an event that is not allowed' do
-          expect(@analytics).not_to receive(:track_event)
-
-          params[:event] = 'custom event'
-          action
-
-          expect(response).to have_http_status(:bad_request)
-          expect(json[:success]).to eq(false)
-        end
       end
 
       context 'missing a parameter' do

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -5,8 +5,7 @@ describe FrontendLogController do
     subject(:action) { post :create, params: params }
 
     let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
-    let(:log_level) { 'info' }
-    let(:params) { { log_level: log_level, payload: { message: 'To be logged...' } } }
+    let(:params) { { event: 'custom event', payload: { message: 'To be logged...' } } }
 
     context 'user is signed in' do
       before do
@@ -22,8 +21,8 @@ describe FrontendLogController do
       end
 
       context 'missing a parameter' do
-        it 'rejects a request without specifying log_level' do
-          params.delete(:log_level)
+        it 'rejects a request without specifying event' do
+          params.delete(:event)
           action
 
           json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -6,8 +6,10 @@ describe FrontendLogController do
 
     let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
     let(:params) { { event: 'custom event', payload: { message: 'To be logged...' } } }
+    let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
     context 'user is signed in' do
+
       before do
         sign_in user
       end
@@ -15,8 +17,7 @@ describe FrontendLogController do
       it 'succeeds' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(json[:success]).to eq(true)
       end
 
@@ -25,8 +26,8 @@ describe FrontendLogController do
           params.delete(:event)
           action
 
-          json = JSON.parse(response.body, symbolize_names: true)
-          expect(response.status).to eq(400)
+          # json = JSON.parse(response.body, symbolize_names: true)
+          expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
         end
 
@@ -34,8 +35,8 @@ describe FrontendLogController do
           params.delete(:payload)
           action
 
-          json = JSON.parse(response.body, symbolize_names: true)
-          expect(response.status).to eq(400)
+          # json = JSON.parse(response.body, symbolize_names: true)
+          expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
         end
       end
@@ -45,8 +46,8 @@ describe FrontendLogController do
       it 'returns unauthorized' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
-        expect(response.status).to eq(401)
+        # json = JSON.parse(response.body, symbolize_names: true)
+        expect(response).to have_http_status(:unauthorized)
         expect(json[:success]).to eq(false)
       end
     end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -13,6 +13,13 @@ class FakeAnalytics
   def track_mfa_submit_event(_attributes)
     # no-op
   end
+
+  def allowable_frontend_events
+    [
+      Analytics::FRONTEND_DOC_AUTH_ASYNC_UPLOAD,
+      Analytics::FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT,
+    ]
+  end
 end
 
 RSpec::Matchers.define :have_logged_event do |event_name, attributes|


### PR DESCRIPTION
A simple API endpoint to allow the frontend client to send objects to be logged on the server.