### PR TITLE
Remove unused second_phone locale strings

### DIFF
--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -143,7 +143,7 @@ en:
       phone_info_html: Get security codes by text message (SMS) or phone call
       piv_cac: Government employee ID
       piv_cac_info_html: Insert your government or military PIV or CAC card and enter
-        your PIN.
+        your PIN
       secure_label: Secure
       sms: Text message / SMS
       sms_info_html: Get your security code via text message / SMS

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -143,10 +143,7 @@ en:
       phone_info_html: Get security codes by text message (SMS) or phone call
       piv_cac: Government employee ID
       piv_cac_info_html: Insert your government or military PIV or CAC card and enter
-        your PIN
-      second_phone: Second phone
-      second_phone_info_html: Get security codes by text message (SMS) or phone call
-        to a secondary phone number (one that is not %{phone})
+        your PIN.
       secure_label: Secure
       sms: Text message / SMS
       sms_info_html: Get your security code via text message / SMS

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -154,9 +154,6 @@ es:
       piv_cac: Identificación de empleado del gobierno
       piv_cac_info_html: Inserte su tarjeta gubernamental o militar PIV o CAC e ingrese
         su PIN
-      second_phone: Segundo telefono
-      second_phone_info_html: Obtenga códigos de seguridad por mensaje de texto (SMS)
-        o llamada telefónica a un número de teléfono secundario (uno que no sea %{phone})
       secure_label: Seguro
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -153,9 +153,6 @@ fr:
       piv_cac: Numéro d'employé du gouvernement
       piv_cac_info_html: Insérez votre carte PIV ou CAC du gouvernement ou militaire
         et entrez votre code PIN
-      second_phone: Deuxième téléphone
-      second_phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique
-        vers un numéro de téléphone secondaire (autre que %{phone})
       secure_label: A une protection
       sms: SMS
       sms_info_html: Obtenez votre code de sécurité par SMS


### PR DESCRIPTION
**Why**: Unused. Previously part of "second phone" option for MFA setup (see ae65f01efe54bebe1aedee69066c9fbebb224a63, fae1e2be04ecea35747bf8fa1f8b3b6a4392efa4)

Not entirely sure why this is not being marked by `i18n-tasks` as being unused, since it's not explicitly ignored ([source](https://github.com/18F/identity-idp/blob/a66c0a081fec150e4c9bff25934846b9c8884b1c/config/i18n-tasks.yml#L92-L131)), though these translations are referenced by interpolated strings:

https://github.com/18F/identity-idp/blob/a66c0a081fec150e4c9bff25934846b9c8884b1c/app/presenters/two_factor_authentication/selection_presenter.rb#L16-L22