### PR TITLE
Consistently end MFA options with dots

### DIFF
--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -140,18 +140,18 @@ en:
       less_secure_label: Less secure
       more_secure_label: More Secure
       phone: Phone
-      phone_info_html: Get security codes by text message (SMS) or phone call
+      phone_info_html: Get security codes by text message (SMS) or phone call.
       piv_cac: Government employee ID
       piv_cac_info_html: Insert your government or military PIV or CAC card and enter
-        your PIN
+        your PIN.
       second_phone: Second phone
       second_phone_info_html: Get security codes by text message (SMS) or phone call
         to a secondary phone number (one that is not %{phone})
       secure_label: Secure
       sms: Text message / SMS
-      sms_info_html: Get your security code via text message / SMS
+      sms_info_html: Get your security code via text message / SMS.
       voice: Phone call
-      voice_info_html: Get your security code via phone call
+      voice_info_html: Get your security code via phone call.
       webauthn: Security key
       webauthn_info_html: Use a security key that you have. It’s a physical device
         that you plug in or that is built in to your computer or phone (it often looks

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -142,7 +142,7 @@ es:
     two_factor_choice_options:
       auth_app: Aplicación de autenticación
       auth_app_info_html: Obtenga códigos de una aplicación en su teléfono, computadora
-        o tableta
+        o tableta.
       backup_code: No tengo ninguno de los anteriores
       backup_code_info_html: Le daremos 10 códigos para usar y guardar en un lugar
         seguro. Puede usar códigos de respaldo como su único método de autenticación.
@@ -150,19 +150,19 @@ es:
       more_secure_label: Más seguridad
       phone: Teléfono
       phone_info_html: Obtenga códigos de seguridad por mensaje de texto (SMS) o llamada
-        telefónica
+        telefónica.
       piv_cac: Identificación de empleado del gobierno
       piv_cac_info_html: Inserte su tarjeta gubernamental o militar PIV o CAC e ingrese
-        su PIN
+        su PIN.
       second_phone: Segundo telefono
       second_phone_info_html: Obtenga códigos de seguridad por mensaje de texto (SMS)
         o llamada telefónica a un número de teléfono secundario (uno que no sea %{phone})
       secure_label: Seguro
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto
-        / SMS
+        / SMS.
       voice: Llamada telefónica
-      voice_info_html: Obtenga su código de seguridad a través de una llamada telefónica
+      voice_info_html: Obtenga su código de seguridad a través de una llamada telefónica.
       webauthn: Llave de seguridad
       webauthn_info_html: Use una llave de seguridad que tenga. Es un dispositivo
         físico que se conecta o que está integrado en su computadora o teléfono (a

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -141,7 +141,7 @@ fr:
     two_factor_choice_options:
       auth_app: Application d'authentification
       auth_app_info_html: Obtenir des codes d'une application sur votre téléphone,
-        votre ordinateur ou votre tablette
+        votre ordinateur ou votre tablette.
       backup_code: Je n'ai rien de ce qui précède
       backup_code_info_html: Nous vous donnerons 10 codes à utiliser et à conserver
         dans un endroit sûr. Vous pouvez utiliser des codes de sauvegarde comme seule
@@ -149,18 +149,18 @@ fr:
       less_secure_label: Moins de protection
       more_secure_label: Plus de protection
       phone: Téléphone
-      phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique
+      phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique.
       piv_cac: Numéro d'employé du gouvernement
       piv_cac_info_html: Insérez votre carte PIV ou CAC du gouvernement ou militaire
-        et entrez votre code PIN
+        et entrez votre code PIN.
       second_phone: Deuxième téléphone
       second_phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique
         vers un numéro de téléphone secondaire (autre que %{phone})
       secure_label: A une protection
       sms: SMS
-      sms_info_html: Obtenez votre code de sécurité par SMS
+      sms_info_html: Obtenez votre code de sécurité par SMS.
       voice: Appel téléphonique
-      voice_info_html: Obtenez votre code de sécurité par appel téléphonique
+      voice_info_html: Obtenez votre code de sécurité par appel téléphonique.
       webauthn: Clé de sécurité
       webauthn_info_html: Utilisez une clé de sécurité que vous avez. C’est un périphérique
         physique que vous branchez ou qui est intégré à votre ordinateur ou à votre


### PR DESCRIPTION
Context (Slack): https://gsa-tts.slack.com/archives/CNCGEHG1G/p1610125610097400?thread_ts=1610047071.093900&cid=CNCGEHG1G

**Why**: So that all options are consistent, rather than some ending with dots, and others not.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/104240541-3a652980-542a-11eb-989d-da3889a86dba.png)
