### PR TITLE
[LG-4063] Add rake task to seed users from a CSV file

### DIFF
--- a/app/services/user_seeder.rb
+++ b/app/services/user_seeder.rb
@@ -1,0 +1,121 @@
+class UserSeeder
+  def self.run(**opts)
+    new(**opts).run
+  end
+
+  def initialize(**options)
+    @csv_file = options[:csv_file]
+    file = File.read(csv_file)
+    @csv = CSV.parse(file, headers: true)
+    validate_csv_headers
+    @email_domain = options[:email_domain]
+    validate_email_domain
+    @deploy_env = options[:deploy_env] || LoginGov::Hostdata.env
+  rescue Errno::ENOENT
+    raise ArgumentError.new("#{csv_file} does not exist")
+  end
+
+  # Seed the users whose PII is specified in the CSV file. Raises an
+  # ArgumentError if an email address is already taken and uses a transaction to
+  # avoid partial completion.
+  #
+  # @return [Integer] the number of users created
+  def run
+    validate_environment
+
+    ActiveRecord::Base.transaction do
+      @csv.each_with_index do |row, i|
+        email = "user#{i}@#{email_domain}"
+        row['email_address'] = email
+        row['password'] = PASSWORD
+        ee = EncryptedAttribute.new_from_decrypted(email)
+
+        User.create!(email_fingerprint: ee.fingerprint) do |user|
+          codes = setup_user(user: user, ee: ee)
+          row['codes'] = codes.join('|')
+
+          personal_key = create_profile(user: user, row: row)
+          row['personal_key'] = personal_key
+        end
+      end
+    end
+
+    save_updated_csv
+
+    csv.length # the number of saved users
+  rescue ActiveRecord::RecordNotUnique
+    msg = "email domain #{email_domain} invalid - would overwrite existing users"
+    raise ArgumentError.new(msg)
+  end
+
+  private
+
+  PASSWORD = 'S00per Seekr3t'.freeze
+
+  PII_ATTRS = %w[
+    first_name
+    middle_name
+    last_name
+    dob
+    ssn
+    phone
+    address1
+    address2
+    city
+    state
+    zipcode
+  ].freeze
+
+  attr_reader :csv_file, :csv, :email_domain, :deploy_env
+
+  def validate_csv_headers
+    return if (PII_ATTRS - csv.first.to_h.keys).empty?
+
+    msg = "#{csv_file} must be a CSV file with headers #{PII_ATTRS.join(',')}"
+    raise ArgumentError.new(msg)
+  end
+
+  def validate_email_domain
+    return if ValidateEmail.valid?("user@#{email_domain}")
+
+    raise ArgumentError.new("#{email_domain} is not a valid hostname")
+  end
+
+  def validate_environment
+    return unless %w[prod staging].include? deploy_env
+
+    raise StandardError.new('This cannot be run in staging or production')
+  end
+
+  def setup_user(user:, ee:)
+    user.encrypted_email = ee.encrypted
+    user.reset_password(PASSWORD, PASSWORD)
+    Event.create(user_id: user.id, event_type: :account_created)
+    # rubocop:disable Rails/SkipsModelValidations
+    user.email_addresses.update_all(confirmed_at: Time.zone.now)
+    # rubocop:enable Rails/SkipsModelValidations
+    generator = BackupCodeGenerator.new(user)
+    generator.generate.tap do |codes|
+      generator.save(codes)
+    end
+  end
+
+  def create_profile(user:, row:)
+    profile = Profile.new(user: user)
+    pii_hash = row.to_h.slice(*PII_ATTRS).transform_keys(&:to_sym)
+    pii = Pii::Attributes.new_from_hash(pii_hash)
+    personal_key = profile.encrypt_pii(pii, PASSWORD)
+    profile.verified_at = Time.zone.now
+    profile.activate
+
+    personal_key
+  end
+
+  def save_updated_csv
+    new_filename = csv_file.gsub('.csv', '-updated.csv')
+    CSV.open(new_filename, 'wb') do |new_csv|
+      new_csv << @csv.first.to_h.keys
+      @csv.each { |row| new_csv << row.to_h.values }
+    end
+  end
+end

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -1,0 +1,23 @@
+namespace :partners do
+  desc 'Provision dummy IAL2 users from CSV file'
+  task seed_users: :environment do
+    options = {
+      csv_file: ENV['CSV_FILE'],
+      email_domain: ENV['EMAIL_DOMAIN'],
+    }
+
+    if options.values.any?(&:nil?)
+      puts 'You must define the environment variables CSV_FILE and EMAIL_DOMAIN'
+      exit(-1)
+    end
+
+    begin
+      count = UserSeeder.run(**options)
+      puts "#{count} users created"
+      puts 'Complete!'
+    rescue ArgumentError, StandardError => e
+      puts "ERROR: #{e.message}"
+      exit(-1)
+    end
+  end
+end

--- a/spec/fixtures/invalid_user_csv.csv
+++ b/spec/fixtures/invalid_user_csv.csv
@@ -1,0 +1,3 @@
+wrong,header
+a,b
+c,d

--- a/spec/fixtures/valid_user_csv.csv
+++ b/spec/fixtures/valid_user_csv.csv
@@ -1,0 +1,3 @@
+phone,ssn,first_name,middle_name,last_name,dob,address1,address2,city,state,zipcode
+(123) 456-7890,111223333,Jane,,Doe,1951-06-09,13 Street Street,,Town,GA,30022
+(234) 567-8901,111223334,Jim,,Doe,1950-06-09,13 Street Street,,Town,GA,30022

--- a/spec/lib/tasks/partners_rake_spec.rb
+++ b/spec/lib/tasks/partners_rake_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'partners rake tasks' do
+  before do
+    Rake.application.rake_require 'tasks/partners'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'partners:seed_users' do
+    let(:task) { 'partners:seed_users' }
+    let!(:prev_csv_file) { ENV['CSV_FILE'] }
+    let!(:prev_email_domain) { ENV['EMAIL_DOMAIN'] }
+
+    around do |ex|
+      ex.run
+    rescue SystemExit
+    end
+
+    after do
+      ENV['CSV_FILE'] = prev_csv_file
+      ENV['EMAIL_DOMAIN'] = prev_email_domain
+      Rake.application[task].reenable
+    end
+
+    context 'with missing CSV_FILE' do
+      before do
+        ENV.delete('CSV_FILE')
+        ENV['EMAIL_DOMAIN'] = 'foo.com'
+      end
+
+      it 'displays an error message' do
+        expect { Rake::Task[task].invoke }.to \
+          output("You must define the environment variables CSV_FILE and EMAIL_DOMAIN\n").to_stdout
+      end
+
+      it 'exits' do
+        allow($stdout).to receive(:puts) # suppress output
+        expect { Rake::Task[task].invoke }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'with missing EMAIL_DOMAIN' do
+      before do
+        ENV['CSV_FILE'] = 'foo.csv'
+        ENV.delete('EMAIL_DOMAIN')
+      end
+
+      it 'displays an error message' do
+        expect { Rake::Task[task].invoke }.to \
+          output("You must define the environment variables CSV_FILE and EMAIL_DOMAIN\n").to_stdout
+      end
+
+      it 'exits' do
+        allow($stdout).to receive(:puts) # suppress output
+        expect { Rake::Task[task].invoke }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'with both ENV variables' do
+      before do
+        ENV['CSV_FILE'] = 'spec/fixtures/valid_user_csv.csv'
+        ENV['EMAIL_DOMAIN'] = 'foo.com'
+      end
+
+      it 'works with valid input' do
+        expect { Rake::Task[task].invoke }.to \
+          output("2 users created\nComplete!\n").to_stdout
+
+        # clean up
+        output_file = ENV['CSV_FILE'].gsub('.csv', '-updated.csv')
+        File.delete(output_file)
+      end
+
+      it 'displays a helpful error message with errors' do
+        allow(UserSeeder).to receive(:run).and_raise(ArgumentError.new('foo'))
+
+        expect { Rake::Task[task].invoke }.to output("ERROR: foo\n").to_stdout
+      end
+
+      it 'exits with errors' do
+        allow($stdout).to receive(:puts) # suppress output
+        allow(UserSeeder).to receive(:run).and_raise(ArgumentError.new('foo'))
+
+        expect { Rake::Task[task].invoke }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/services/user_seeder_spec.rb
+++ b/spec/services/user_seeder_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe UserSeeder do
+  let(:valid_fixture) { 'spec/fixtures/valid_user_csv.csv' }
+
+  describe '.new' do
+    it 'raises the appropriate error with missing CSV file' do
+      opts = { csv_file: 'does_not_exist.csv', email_domain: 'foo.com' }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /does not exist/)
+    end
+
+    it 'raises the appropriate error with invalid CSV file' do
+      opts = {
+        csv_file: 'spec/fixtures/invalid_user_csv.csv',
+        email_domain: 'foo.com',
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /must be a CSV file with headers/)
+    end
+
+    it 'raises the appropriate error with invalid email domain' do
+      opts = { csv_file: valid_fixture, email_domain: 'foo_com' }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /is not a valid hostname/)
+    end
+  end
+
+  describe '.run' do
+    it 'raises the appropriate error when running in prod' do
+      opts = { csv_file: valid_fixture, email_domain: 'foo.com', deploy_env: 'prod' }
+
+      expect { described_class.run(**opts) }.to \
+        raise_error(StandardError, /This cannot be run in staging or production/)
+    end
+
+    it 'raises the appropriate error when running in staging' do
+      opts = { csv_file: valid_fixture, email_domain: 'foo.com', deploy_env: 'staging' }
+
+      expect { described_class.run(**opts) }.to \
+        raise_error(StandardError, /This cannot be run in staging or production/)
+    end
+
+    it 'defaults to the value in LoginGov::Hostdata.env' do
+      opts = { csv_file: valid_fixture, email_domain: 'foo.com' }
+      allow(LoginGov::Hostdata).to receive(:env).and_return('prod')
+
+      expect { described_class.run(**opts) }.to \
+        raise_error(StandardError, /This cannot be run in staging or production/)
+    end
+
+    context 'when an email address is already taken' do
+      let(:taken_email) { 'user1@foo.com' }
+      let(:opts) { { csv_file: valid_fixture, email_domain: 'foo.com' } }
+
+      before { create_user_with_email(taken_email) }
+
+      it 'raises the appropriate error' do
+        expect { described_class.run(**opts) }.to \
+          raise_error(ArgumentError, /invalid - would overwrite existing users/)
+      end
+
+      it 'does not persist any users' do
+        described_class.run(**opts)
+      rescue ArgumentError
+        expect(User.count).to eq(1)
+      end
+
+      def create_user_with_email(email)
+        ee = EncryptedAttribute.new_from_decrypted(email)
+        user = User.create!(email_fingerprint: ee.fingerprint)
+        user.encrypted_email = ee.encrypted
+        user.reset_password('S00per Seekret', 'S00per Seekret')
+        # rubocop:disable Rails/SkipsModelValidations
+        user.email_addresses.update_all(confirmed_at: Time.zone.now)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+    end
+
+    context 'with valid inputs' do
+      let(:opts) { { csv_file: valid_fixture, email_domain: 'foo.com' } }
+      let(:output_file) { valid_fixture.gsub('.csv', '-updated.csv') }
+
+      after { File.delete(output_file) }
+
+      it 'creates the right number of users' do
+        expect { described_class.run(**opts) }.to change { User.count }.by(2)
+      end
+
+      it 'returns the number of users created' do
+        expect(described_class.run(**opts)).to eq(2)
+      end
+
+      it 'creates verified users' do
+        described_class.run(**opts)
+
+        expect(User.all.all? { |u| u.active_profile.present? }).to be_truthy
+      end
+
+      it 'saves the credentials to a CSV' do
+        described_class.run(**opts)
+
+        expect(File.read(output_file)).to \
+          match(/email_address,password,codes,personal_key\n/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the rake task `partners:seed_users` which requires two environment
variables to be set - CSV_FILE and EMAIL_DOMAIN. These are passed to a
`UserSeeder` service object that validates the inputs, ensures that this
task does not run in the upper environments, and proceeds unless it
would cause an existing user to be overwritten. It also then saves a
modified CSV file that includes the backup codes and personal key for
each created user.

---

~Not complete - still need to add tests and clean some things up - but wanted to throw this up for review. Let me know what you think!~

~To Do:~
* [x] ~add better validations for file presence and email domain validity~
* [x] ~add tests~
* [x] ~switch to `create!` instead of `find_or_create_by!` since we want it to fail if we were overriding any user~
* [x] ~prevent from running in prod or staging~