### PR TITLE
LG-4040: Log doc auth events to event.log

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -193,7 +193,11 @@ function AcuantCapture(
                 result = 'success';
               }
 
-              addPageAction('documentCapture.acuantWebSDKResult', { result });
+              addPageAction({
+                key: 'documentCapture.acuantWebSDKResult',
+                label: 'IdV: Acuant web SDK photo analyzed',
+                payload: { result },
+              });
 
               setIsCapturingEnvironment(false);
             }}

--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -3,9 +3,21 @@ import { createContext } from 'react';
 /** @typedef {Record<string,string|number|boolean|null>} Payload */
 
 /**
+ * @typedef PageAction
+ *
+ * @property {string} key Short, camel-cased, dot-namespaced key describing event.
+ * @property {string} label Long-form, human-readable label describing event action.
+ * @property {Payload} payload Additional payload arguments to log with action.
+ */
+
+/**
+ * @typedef {(action: PageAction)=>void} AddPageAction
+ */
+
+/**
  * @typedef AnalyticsContext
  *
- * @prop {(name:string,payload?:Payload)=>void} addPageAction Log an action with optional payload.
+ * @prop {AddPageAction} addPageAction Log an action with optional payload.
  */
 
 const AnalyticsContext = createContext(

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -72,9 +72,13 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
           )
           .then((response) => {
             const traceId = response.headers.get('X-Amzn-Trace-Id');
-            addPageAction('documentCapture.asyncUpload', {
-              success: response.ok,
-              trace_id: traceId,
+            addPageAction({
+              key: 'documentCapture.asyncUpload',
+              label: 'IdV: document capture async upload submitted',
+              payload: {
+                success: response.ok,
+                trace_id: traceId,
+              },
             });
 
             if (!response.ok) {

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -29,6 +29,7 @@
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,
+  log_endpoint: api_logger_url,
 } %>
 <div class="js-fallback">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -271,8 +271,12 @@ describe('document-capture/components/acuant-capture', () => {
 
       const error = await findByText('errors.doc_auth.photo_glare');
       expect(
-        addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
-          result: 'glare',
+        addPageAction.calledWith({
+          key: 'documentCapture.acuantWebSDKResult',
+          label: 'IdV: Acuant web SDK photo analyzed',
+          payload: {
+            result: 'glare',
+          },
         }),
       ).to.be.true();
 
@@ -311,8 +315,12 @@ describe('document-capture/components/acuant-capture', () => {
 
       const error = await findByText('errors.doc_auth.photo_blurry');
       expect(
-        addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
-          result: 'blurry',
+        addPageAction.calledWith({
+          key: 'documentCapture.acuantWebSDKResult',
+          label: 'IdV: Acuant web SDK photo analyzed',
+          payload: {
+            result: 'blurry',
+          },
         }),
       ).to.be.true();
 
@@ -409,8 +417,12 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
       await waitForElementToBeRemoved(error);
       expect(
-        addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
-          result: 'success',
+        addPageAction.calledWith({
+          key: 'documentCapture.acuantWebSDKResult',
+          label: 'IdV: Acuant web SDK photo analyzed',
+          payload: {
+            result: 'success',
+          },
         }),
       ).to.be.true();
     });

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -167,8 +167,11 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           await onChange.getCall(0).args[0].foo_image_url;
           expect(addPageAction.calledOnce).to.be.true();
           expect(addPageAction.getCall(0).args).to.deep.equal([
-            'documentCapture.asyncUpload',
-            { success: true, trace_id: null },
+            {
+              key: 'documentCapture.asyncUpload',
+              label: 'IdV: document capture async upload submitted',
+              payload: { success: true, trace_id: null },
+            },
           ]);
         });
       });
@@ -203,8 +206,11 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           await onChange.getCall(0).args[0].foo_image_url.catch(() => {});
           expect(addPageAction.calledOnce).to.be.true();
           expect(addPageAction.getCall(0).args).to.deep.equal([
-            'documentCapture.asyncUpload',
-            { success: false, trace_id: '1-67891233-abcdef012345678912345678' },
+            {
+              key: 'documentCapture.asyncUpload',
+              label: 'IdV: document capture async upload submitted',
+              payload: { success: false, trace_id: '1-67891233-abcdef012345678912345678' },
+            },
           ]);
         });
       });


### PR DESCRIPTION
Related: #4574 (LG-3975)

**Why**: As a login.gov engineer, I want to be able to query frontend errors in CloudWatch, in addition to New Relic, so that I don't have to cross-reference NR when debugging problems.

**Implementation Notes:**

To support formatting the event consistent with other analytics keys, the API of the existing `addPageAction` was modified to accept both short `key` and human-readable `label`, used for NewRelic and CloudWatch respectively.

Other options could include:

- Using only one or the other. (Q: What to do about historical NewRelic data?)
- Creating separate methods for each
  - Downside: We're otherwise sending the same payload data