### PR TITLE
LG-2658 Fix test PKI development app built into IDP

### DIFF
--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -10,7 +10,7 @@
 
 <div class="sm-col-9 sm-ml-28p">
   <%= form_tag do %>
-    <%= hidden_field_tag(:referer, @referrer) %>
+    <%= hidden_field_tag(:redirect_uri, @referrer) %>
     <div class="clearfix mxn1">
       <div class="col col-12 px1">
         <legend class="mb1 h4 serif bold">


### PR DESCRIPTION
**Why**: redirect_uri was added to pki to remove dependence on request.referer but the test app was never updated to use it.