### PR TITLE
Fix JavaScript pack output for SAML post-binding template

### DIFF
--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_packs_tag_once 'saml-post' %>
+    <%= javascript_packs_with_chunks_tag 'saml-post' %>
   </head>
   <body>
     <div class="container sm-py4">


### PR DESCRIPTION
**Why:** So that users are redirected automatically when completing SAML authentication.

In #4553, all JavaScript packs were changed to use the `javascript_packs_tag_once` helper, which is intended to be used in rendering all JavaScript chunks once at the bottom of the page. However, this must be complemented by a call to the `render_javascript_pack_once_tags` helper. This exists in the base template, but since the `saml_post_binding` view doesn't inherit from this template, the helper is never called, and therefore the script is never added to the page.

Since we don't need to worry as much about deduplicating script chunks on this page, we can simply call directly to Webpacker's `javascript_packs_with_chunks_tag` helper. Alternatively, we could add the call to `render_javascript_pack_once_tags` somewhere within the page template (ideally toward the bottom of markup).

In making these changes, I checked to confirm there are no other instances of views not inheriting from the base template where script enqueuing via `javascript_packs_tag_once` is occurring.