### PR TITLE
Remove array spread ([...x]) since babel seems to transpile it wrong

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,10 @@
       {
         "selector": "NewExpression[callee.name='Event']",
         "message": "Use CustomEvent constructor with polyfill for Internet Explorer"
+      },
+      {
+        "selector": "ArrayExpression > SpreadElement",
+        "message": "Don't use array spread, issue with IE 11 (use Array.from instead)"
       }
     ],
     "no-unused-expressions": "off",
@@ -67,7 +71,8 @@
     {
       "files": "spec/javascripts/**/*",
       "rules": {
-        "react/jsx-props-no-spreading": "off"
+        "react/jsx-props-no-spreading": "off",
+        "no-restricted-syntax": "off"
       }
     }
   ]

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -169,7 +169,7 @@ function FormSteps({
 
     // Don't proceed if field errors have yet to be resolved.
     if (activeErrors.length && activeErrors.length > unknownFieldErrors.length) {
-      setActiveErrors([...activeErrors]);
+      setActiveErrors(Array.from(activeErrors));
       didSubmitWithErrors.current = true;
       return;
     }

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -175,6 +175,6 @@ export class FormStepsWait {
 }
 
 loadPolyfills(['fetch', 'custom-event']).then(() => {
-  const forms = [...document.querySelectorAll('[data-form-steps-wait]')];
+  const forms = Array.from(document.querySelectorAll('[data-form-steps-wait]'));
   forms.forEach((form) => new FormStepsWait(form).bind());
 });

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -12,7 +12,7 @@ const PATTERN_TYPES = ['dob', 'personal-key', 'ssn', 'state_id_number', 'zipcode
  */
 function disableFormSubmit(event) {
   const form = /** @type {HTMLFormElement} */ (event.target);
-  [...form.querySelectorAll('button:not([type]),[type="submit"]')].forEach((submit) => {
+  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((submit) => {
     /** @type {HTMLInputElement|HTMLButtonElement} */ (submit).disabled = true;
   });
 }
@@ -61,14 +61,15 @@ function validateInput(input) {
  * @param {HTMLFormElement} form Form to initialize.
  */
 export function initialize(form) {
-  /** @type {HTMLInputElement[]} */ ([...form.querySelectorAll('.field')]).forEach(validateInput);
+  /** @type {HTMLInputElement[]} */
+  const fields = Array.from(form.querySelectorAll('.field'));
+  fields.forEach(validateInput);
   form.addEventListener('submit', disableFormSubmit);
 }
 
 loadPolyfills(['classlist']).then(() => {
-  const forms = /** @type {HTMLFormElement[]} */ ([
-    ...document.querySelectorAll('form[data-validate]'),
-  ]);
+  /** @type {HTMLFormElement[]} */
+  const forms = Array.from(document.querySelectorAll('form[data-validate]'));
 
   forms.forEach(initialize);
 });

--- a/app/javascript/packs/spinner-button.js
+++ b/app/javascript/packs/spinner-button.js
@@ -76,5 +76,5 @@ export class SpinnerButton {
   }
 }
 
-const wrappers = [...document.querySelectorAll('.spinner-button')];
+const wrappers = Array.from(document.querySelectorAll('.spinner-button'));
 wrappers.forEach((wrapper) => new SpinnerButton(wrapper).bind());


### PR DESCRIPTION
- Resulted in errors in IE 11
- See https://github.com/babel/babel/issues/8449


I wasn't sure of a good way to enforce this? Should we disable array spread syntax in our transpiler until fixed?

I found the usages by searching:
```
git grep -l  "\[.*\.\.\." -- "app/*.js*" 
```
but this would not find cases if we did an array spread across multiple lines, hoping that we don't for now 😬 