### PR TITLE
LG-4001: Update spinner notice failure message to suggest to try again

### DIFF
--- a/app/views/idv/cac/verify.html.erb
+++ b/app/views/idv/cac/verify.html.erb
@@ -58,7 +58,7 @@
           class: 'button_to read-after-submit',
           data: {
             form_steps_wait: '',
-            error_message: t("idv.failure.sessions.exception"),
+            error_message: t('idv.failure.exceptions.internal_error'),
             alert_target: '#form-steps-wait-alert',
             wait_step_path: idv_cac_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -53,7 +53,7 @@
           class: 'button_to read-after-submit',
           data: {
             form_steps_wait: '',
-            error_message: t("idv.failure.sessions.exception"),
+            error_message: t('idv.failure.exceptions.internal_error'),
             alert_target: '#form-steps-wait-alert',
             wait_step_path: idv_doc_auth_step_path(step: :verify_wait),
             poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -38,7 +38,7 @@
                        url: idv_phone_path,
                        data: {
                          form_steps_wait: '',
-                         error_message: t("idv.failure.sessions.exception"),
+                         error_message: t('idv.failure.exceptions.internal_error'),
                          alert_target: '#form-steps-wait-alert',
                          wait_step_path: idv_phone_path,
                          poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -39,6 +39,8 @@ en:
         link: please contact us
         text_html: If you keep getting these errors, %{link}, or try again tomorrow.
       exceptions:
+        internal_error: There was an internal error processing your request. Please
+          try again.
         link: please contact us
         text_html: Please try again. If you keep getting these errors, %{link}.
       help:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -41,6 +41,8 @@ es:
         text_html: Si sigues recibiendo estos errores, %{link} o vuelve a intentarlo
           mañana.
       exceptions:
+        internal_error: Hubo un error interno al procesar su solicitud. Inténtalo
+          de nuevo.
         link: contáctanos
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
       help:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -41,8 +41,8 @@ es:
         text_html: Si sigues recibiendo estos errores, %{link} o vuelve a intentarlo
           mañana.
       exceptions:
-        internal_error: Hubo un error interno al procesar su solicitud. Inténtalo
-          de nuevo.
+        internal_error: Se produjo un error interno al procesar tu solicitud. Por
+          favor, inténtalo de nuevo.
         link: contáctanos
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
       help:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -43,6 +43,8 @@ fr:
         text_html: Si vous continuez à recevoir ces erreurs, %{link} ou réessayez
           demain.
       exceptions:
+        internal_error: Une erreur interne s'est produite lors du traitement de votre
+          demande. Veuillez réessayer.
         link: contactez-nous
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       help:


### PR DESCRIPTION
**Why**: Per acceptance feedback, for consistency with other error alert messaging and to give actionability to the error, include the text "Please try again" as part of the unhandled server error notice shown in IAL2 steps where spinner buttons are used (verify, phone).

**Screenshot:**

Before|After
---|---
![Screen Shot 2021-01-20 at 10 00 39 AM](https://user-images.githubusercontent.com/1779930/105193688-c05a3200-5b06-11eb-8e43-9b6db7518143.png)|![Screen Shot 2021-01-20 at 10 00 27 AM](https://user-images.githubusercontent.com/1779930/105193695-c223f580-5b06-11eb-848e-f5b84e49cf48.png)

**Implementation notes:**

The existing string could not be updated in-place because it is used as a heading in other views ([example](https://github.com/18F/identity-idp/blob/c91fa88de2492ad4a418c45fc3dfffb7904ed79e/app/views/idv/session_errors/exception.html.erb#L5)).

I'd also considered using a concatenation of existing strings `idv.failure.sessions.exception` and `idv.failure.exceptions.text_html`, but (a) this would not be strictly consistent with other alert messages which use only the text "Please try again" and (b) would require to bring in or refactor [document capture i18n string formatting](https://github.com/18F/identity-idp/blob/c91fa88de2492ad4a418c45fc3dfffb7904ed79e/app/javascript/packages/document-capture/hooks/use-i18n.js#L6-L49).