### PR TITLE
Add async background uploads for review step

### DIFF
--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -6,6 +6,7 @@ import AcuantCapture from './acuant-capture';
 import SelfieCapture from './selfie-capture';
 import FormErrorMessage from './form-error-message';
 import ServiceProviderContext from '../context/service-provider';
+import withBackgroundEncryptedUpload from '../higher-order/with-background-encrypted-upload';
 import './review-issues-step.scss';
 
 /**
@@ -127,4 +128,4 @@ function ReviewIssuesStep({
   );
 }
 
-export default ReviewIssuesStep;
+export default withBackgroundEncryptedUpload(ReviewIssuesStep);


### PR DESCRIPTION
**Why**: Otherwise, in environments where async upload is enabled, changing images in the review step would not upload the new file, therefore likely causing the user to become stuck due to the fact that the original images would be used in the resubmission.