### PR TITLE
LG-3480: Add ERBLint to forbid deprecated classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ jobs:
             yarn run lint
             yarn run typecheck
             bundle exec rubocop
+            make lint_erb
             make check_asset_strings
             NODE_ENV=production ./bin/webpack && yarn es5-safe
   build-release-container:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,35 @@
+EnableDefaultLinters: false
+linters:
+  DeprecatedClasses:
+    enabled: true
+    rule_set:
+      - deprecated:
+          - 'align-(top|middle|bottom|baseline)'
+          - '(left)-align'
+          - 'justify'
+          - 'nowrap'
+          - 'line-height-[3]'
+          - 'list-style-none'
+          - 'table(-cell)?'
+          - 'fit'
+          - 'max-width-[1-4]'
+          - 'mxn[4]'
+          - 'm[trbly]?-auto'
+          - 'pxn[1-4]'
+          - 'p[trblxy]?-auto'
+          - 'fixed'
+          - 'z[1-4]'
+          - 'col-(right|[579])'
+          - 'sm-col-11?'
+          - '(md|lg)-col(-right|[1-9][0-2]?)?'
+          - '(sm|md|lg)-flex'
+          - 'flex-(column|none)'
+          - '(items|self|justify|content)-(start|end|center|baseline|stretch)'
+          - 'order-([0-3]|last)'
+          - 'not-rounded'
+          - 'rounded-(top|right|bottom|left)'
+          - '(md|lg)-hide'
+          - '(xs|md|lg)-show'
+          - 'btn-(small|big|narrow|transparent)'
+          - 'border-(black|gray|white|aqua|orange|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
+        suggestion: 'Use USWDS classes instead of BassCSS.'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -21,7 +21,7 @@ linters:
           - 'z[1-4]'
           - 'col-(right|[579])'
           - 'sm-col-11?'
-          - '(md|lg)-col(-right|[1-9][0-2]?)?'
+          - '(md|lg)-col(-(right|[1-9][0-2]?))?'
           - '(sm|md|lg)-flex'
           - 'flex-(column|none)'
           - '(items|self|justify|content)-(start|end|center|baseline|stretch)'

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development, :test do
   gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'bootsnap', '~> 1.5.0', require: false
   gem 'bullet', '>= 6.0.2'
+  gem 'erb_lint', '~> 0.0.37'
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'knapsack'
   gem 'nokogiri', '~> 1.11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :development, :test do
   gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'bootsnap', '~> 1.5.0', require: false
   gem 'bullet', '>= 6.0.2'
-  gem 'erb_lint', '~> 0.0.37'
+  gem 'erb_lint', '~> 0.0.37', require: false
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'knapsack'
   gem 'nokogiri', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,14 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    better_html (1.0.15)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindata (2.4.8)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -282,6 +290,14 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.7)
     equalizer (0.0.11)
+    erb_lint (0.0.37)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     errbase (0.2.0)
     erubi (1.10.0)
     exception_notification (4.4.3)
@@ -334,6 +350,7 @@ GEM
       thor
     highline (2.0.3)
     hiredis (0.6.3)
+    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
     httparty (0.18.1)
@@ -613,6 +630,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    smart_properties (1.15.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -723,6 +741,7 @@ DEPENDENCIES
   devise (~> 4.7.2)
   dotiw (>= 4.0.1)
   email_spec
+  erb_lint (~> 0.0.37)
   exception_notification (>= 4.4.0)
   factory_bot_rails (>= 5.2.0)
   faker

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,17 @@ docker_setup:
 check: lint test
 
 lint:
+	@echo "--- erb-lint ---"
+	make lint_erb
 	@echo "--- rubocop ---"
 	bundle exec rubocop
 	@echo "--- fasterer ---"
 	bundle exec fasterer
 	@echo "--- eslint ---"
 	yarn run lint
+
+lint_erb:
+	bundle exec erblint app/views/**/*.erb
 
 lintfix:
 	@echo "--- rubocop fix ---"


### PR DESCRIPTION
**Why**: As a developer, I expect that static analysis tooling will prevent me from adding deprecated classes, so that I'm not contributing against the effort to transition from BassCSS to USWDS.

Includes classes marked in [LG-3261 technical research](https://docs.google.com/document/d/1OBu44bFFOmgXvFl4e_K_ECSdcuWQPql4jtKNH9E-vsY/edit#) as not being in use, plus alignment classes migrated as of LG-3484 (#4540).

An important caveat is that ERBLint is only able to detect classes assigned through a `class="..."` HTML assignment, and not via a Rails tag helper (e.g. `image_tag(..., class: '...')`).