### PR TITLE
LG-4085 add ial level to sp redirect event

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -137,7 +137,8 @@ module OpenidConnect
     end
 
     def track_events
-      analytics.track_event(Analytics::SP_REDIRECT_INITIATED)
+      ial = sp_session[:ial2] ? 2 : 1
+      analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: ial)
       Db::SpReturnLog::AddReturn.call(request_id, current_user.id)
       increment_monthly_auth_count
       add_sp_cost(:authentication)

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -102,7 +102,8 @@ class SamlIdpController < ApplicationController
   end
 
   def track_events
-    analytics.track_event(Analytics::SP_REDIRECT_INITIATED)
+    ial = sp_session[:ial2] ? 2 : 1
+    analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: ial)
     Db::SpReturnLog::AddReturn.call(request_id, current_user.id)
     increment_monthly_auth_count
     add_sp_cost(:authentication)


### PR DESCRIPTION
WHY:
As a partner with IAL1 and AIL2 authentication, I want a report on the IAL level for each authentication, so I can confirm that I am being charged correctly.

Partners are unable release code that allows users to step up from IAL1 to IAL2, because we are not able to verify in the event logs what IAL level was requested for each authentication. We do have the sp_return_logs, but that does not show the activity leading up to the re-direct back to the SP.