### PR TITLE
Pass base path for ERBLint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 	yarn run lint
 
 lint_erb:
-	bundle exec erblint "app/views/**/*.erb"
+	bundle exec erblint app/views
 
 lintfix:
 	@echo "--- rubocop fix ---"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 	yarn run lint
 
 lint_erb:
-	bundle exec erblint app/views/**/*.erb
+	bundle exec erblint "app/views/**/*.erb"
 
 lintfix:
 	@echo "--- rubocop fix ---"


### PR DESCRIPTION
Previously: #4599

**Why**: So that `make lint_erb` matches all files (276), not just some (101).

I don't recall this having been an issue in my initial implementation.

A few alternatives exist which all solve the problem:

- Call as `bundle exec erblint --lint-all`
- Quote glob pattern string
- Pass path (as proposed)

I think the original issue may be caused by differences in shell glob expansion when run through Make? The existing `bundle exec` call works fine when run standalone.

In any case, the current proposal is based on a bit of sleuthing to determine that the file argument passing supports directories, and by passing directories uses the default glob pattern ([source](https://github.com/Shopify/erb-lint/blob/6179ee2d9d681a6ec4dd02351a1e30eefa748d3d/lib/erb_lint/cli.rb#L156-L157)).