### PR TITLE
update oauth gem to patch vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth (0.5.4)
+    oauth (0.5.5)
     octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2016-11086