### PR TITLE
LG-3483: Fail tests when using tag helper with deprecated class

### DIFF
--- a/spec/support/deprecated_classes.rb
+++ b/spec/support/deprecated_classes.rb
@@ -1,14 +1,23 @@
-RSpec.configure do |config|
-  deprecated = YAML.safe_load(File.read(File.expand_path('../../../.erb-lint.yml', __FILE__))).
-    dig('linters', 'DeprecatedClasses', 'rule_set').
-    flat_map { |rule| rule['deprecated'] }
-
-  pattern = Regexp.new "(^|\\b)(#{deprecated.join('|')})(\\b|$)"
-
-  config.before(:each) do
-    allow_any_instance_of(ActionView::Helpers::TagHelper::TagBuilder).
-      to receive(:tag_options).
-      with(hash_excluding(class: pattern), anything).
-      and_call_original
+class ActionView::Helpers::TagHelper::TagBuilder
+  def self.deprecated_classes
+    @deprecated_classes ||= begin
+      YAML.safe_load(File.read(File.expand_path('../../../.erb-lint.yml', __FILE__))).
+        dig('linters', 'DeprecatedClasses', 'rule_set').
+        flat_map { |rule| rule['deprecated'] }.
+        map { |regex_str| Regexp.new "^#{regex_str}$" }
+    end
   end
+
+  def modified_tag_option(key, value, *rest)
+    original_result = original_tag_option(key, value, *rest)
+    return original_result unless key == :class
+    attribute, classes = original_result.split('=')
+    classes = classes.tr('"', '').split(/ +/)
+    regex = self.class.deprecated_classes.find { |r| classes.any? { |c| r =~ c } }
+    raise "CSS class '#{value}' matched regex for deprecated classes #{regex}" if regex
+    original_result
+  end
+
+  alias_method :original_tag_option, :tag_option
+  alias_method :tag_option, :modified_tag_option
 end

--- a/spec/support/deprecated_classes.rb
+++ b/spec/support/deprecated_classes.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  deprecated = YAML.safe_load(File.read(File.expand_path('../../../.erb-lint.yml', __FILE__))).
+    dig('linters', 'DeprecatedClasses', 'rule_set').
+    flat_map { |rule| rule['deprecated'] }
+
+  pattern = Regexp.new "(^|\\b)(#{deprecated.join('|')})(\\b|$)"
+
+  config.before(:each) do
+    allow_any_instance_of(ActionView::Helpers::TagHelper::TagBuilder).
+      to receive(:tag_options).
+      with(hash_excluding(class: pattern), anything).
+      and_call_original
+  end
+end


### PR DESCRIPTION
**Why**: As a developer, I expect that RSpec automated render testing will prevent me from adding deprecated classes, so that I'm not working against the effort to transition from BassCSS to USWDS.

Implemented using RSpec mock expecting any occurrence of tag builder to not be invoked using a `class` option including one of the classes configured in ERBLint as deprecated (see #4599).

**Testing Instructions:**

Try to add a deprecated class to tag helper in view covered by RSpec tests.

Example:

```diff
diff --git a/app/views/shared/_nav_branded.html.erb b/app/views/shared/_nav_branded.html.erb
index 2e124797a..448b0fe74 100644
--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -5,5 +5,5 @@
     <span class='absolute top-0 bottom-0 border-right my1 sm-my2'></span>
   </div>
   <%= image_tag(decorated_session.sp_logo_url, height: 40,
-                alt: decorated_session.sp_name, class: 'inline-block text-middle') %>
+                alt: decorated_session.sp_name, class: 'inline-block align-middle') %>
 </nav>

```