### PR TITLE
LG-3813: Extend session timeout on document capture step changes

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -44,12 +44,13 @@ export const except = (object, ...keys) =>
  * @typedef DocumentCaptureProps
  *
  * @prop {boolean=} isAsyncForm Whether submission should poll for async response.
+ * @prop {()=>void=} onStepChange Callback triggered on step change.
  */
 
 /**
  * @param {DocumentCaptureProps} props
  */
-function DocumentCapture({ isAsyncForm = false }) {
+function DocumentCapture({ isAsyncForm = false, onStepChange }) {
   const [formValues, setFormValues] = useState(/** @type {Record<string,any>?} */ (null));
   const [submissionError, setSubmissionError] = useState(/** @type {Error=} */ (undefined));
   const { t } = useI18n();
@@ -140,6 +141,7 @@ function DocumentCapture({ isAsyncForm = false }) {
         initialValues={submissionError && formValues ? formValues : undefined}
         initialActiveErrors={initialActiveErrors}
         onComplete={submitForm}
+        onStepChange={onStepChange}
         autoFocus={!!submissionError}
       />
     </>

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -7,6 +7,7 @@ import PromptOnNavigate from './prompt-on-navigate';
 import useI18n from '../hooks/use-i18n';
 import useHistoryParam from '../hooks/use-history-param';
 import useForceRender from '../hooks/use-force-render';
+import useDidUpdateEffect from '../hooks/use-did-update-effect';
 
 /**
  * @typedef FormStepError
@@ -65,6 +66,7 @@ import useForceRender from '../hooks/use-force-render';
  * @prop {FormStepError<Record<string,Error>>[]=} initialActiveErrors Errors to initialize state.
  * @prop {boolean=} autoFocus Whether to automatically focus heading on mount.
  * @prop {(values:Record<string,any>)=>void=} onComplete Form completion callback.
+ * @prop {()=>void=} onStepChange Callback triggered on step change.
  */
 
 /**
@@ -102,6 +104,7 @@ function getFieldActiveErrorFieldElement(errors, fields) {
 function FormSteps({
   steps = [],
   onComplete = () => {},
+  onStepChange = () => {},
   initialValues = {},
   initialActiveErrors = [],
   autoFocus,
@@ -132,6 +135,8 @@ function FormSteps({
       headingRef.current.focus();
     }
   }, []);
+
+  useDidUpdateEffect(onStepChange, [step]);
 
   /**
    * Returns array of form errors for the current set of values.

--- a/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
+++ b/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
@@ -1,6 +1,9 @@
 import { useRef, useEffect } from 'react';
 
 /**
+ * A hook behaving the same as useEffect in invoking the given callback when dependencies change,
+ * but does not call the callback during initial mount.
+ *
  * @type {typeof useEffect}
  */
 function useDidUpdateEffect(callback, deps) {

--- a/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
+++ b/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
@@ -1,0 +1,18 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * @type {typeof useEffect}
+ */
+function useDidUpdateEffect(callback, deps) {
+  const isMounting = useRef(true);
+
+  useEffect(() => {
+    if (isMounting.current) {
+      isMounting.current = false;
+    } else {
+      callback();
+    }
+  }, deps);
+}
+
+export default useDidUpdateEffect;

--- a/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
+++ b/app/javascript/packages/document-capture/hooks/use-did-update-effect.js
@@ -2,7 +2,8 @@ import { useRef, useEffect } from 'react';
 
 /**
  * A hook behaving the same as useEffect in invoking the given callback when dependencies change,
- * but does not call the callback during initial mount.
+ * but does not call the callback during initial mount or when unmounting. It can be considered as
+ * similar to ReactComponent#componentDidUpdate.
  *
  * @type {typeof useEffect}
  */

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -30,6 +30,7 @@
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,
   log_endpoint: api_logger_url,
+  keep_alive_endpoint: sessions_keepalive_url,
 } %>
 <div class="js-fallback">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -99,6 +99,25 @@ describe('document-capture/components/form-steps', () => {
     expect(getByText('forms.buttons.continue')).to.be.ok();
   });
 
+  it('calls onStepChange callback on step change', () => {
+    const onStepChange = sinon.spy();
+    const { getByText } = render(<FormSteps steps={STEPS} onStepChange={onStepChange} />);
+
+    userEvent.click(getByText('forms.buttons.continue'));
+
+    expect(onStepChange.calledOnce).to.be.true();
+  });
+
+  it('does not call onStepChange if step does not progress due to validation error', () => {
+    const onStepChange = sinon.spy();
+    const { getByText } = render(<FormSteps steps={STEPS} onStepChange={onStepChange} />);
+
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
+
+    expect(onStepChange.callCount).to.equal(1);
+  });
+
   it('renders submit button at last step', async () => {
     const { getByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
 

--- a/spec/javascripts/packages/document-capture/hooks/use-did-update-effect-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-did-update-effect-spec.jsx
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+import { renderHook } from '@testing-library/react-hooks';
+import useDidUpdateEffect from '@18f/identity-document-capture/hooks/use-did-update-effect';
+
+describe('document-capture/hooks/use-did-update-effect', () => {
+  context('no dependencies', () => {
+    it('does not call callback during mount', () => {
+      const callback = sinon.spy();
+      renderHook(() => useDidUpdateEffect(callback));
+
+      expect(callback.called).to.be.false();
+    });
+
+    it('calls callback after update', () => {
+      const callback = sinon.spy();
+      const { rerender } = renderHook(() => useDidUpdateEffect(callback));
+
+      rerender();
+
+      expect(callback.calledOnce).to.be.true();
+    });
+  });
+
+  context('dependencies', () => {
+    it('does not call callback during mount', () => {
+      const callback = sinon.spy();
+      renderHook(({ dep }) => useDidUpdateEffect(callback, [dep]), { initialProps: { dep: 'a' } });
+
+      expect(callback.called).to.be.false();
+    });
+
+    it('does not call callback after update if deps are same', () => {
+      const callback = sinon.spy();
+      const { rerender } = renderHook(({ dep }) => useDidUpdateEffect(callback, [dep]), {
+        initialProps: { dep: 'a' },
+      });
+
+      rerender({ dep: 'a' });
+
+      expect(callback.called).to.be.false();
+    });
+
+    it('calls callback after update if deps change', () => {
+      const callback = sinon.spy();
+      const { rerender } = renderHook(({ dep }) => useDidUpdateEffect(callback, [dep]), {
+        initialProps: { dep: 'a' },
+      });
+
+      rerender({ dep: 'b' });
+
+      expect(callback.calledOnce).to.be.true();
+    });
+  });
+});


### PR DESCRIPTION
**Why**: As a user, I expect that independent screens of document capture step ("Documents", "Selfie", etc) are treated the same as any other step in the identity proofing flow such that my session is extended when transitioning from one step to the next, so that I don't prematurely encounter a "Your session is about to expire" dialog if it takes me a while to complete the process.

**Notes:**

There was some technical discovery required by the ticket, addressed here:

- The dialog is shown when a result of a call to the `/active` endpoint returns a `remaining_time` less than the given threshold. Thus, it is enough to extend the session timeout to prevent the dialog from being shown in the same page session ([source](https://github.com/18F/identity-idp/blob/2c046dde969637328ace67a31a1627e7e11b7f2b/app/views/session_timeout/_ping.js.erb#L40-L42)).
- Most interactions which incur a call to a server-side endpoint will extend the user's session. This includes asynchronous upload / logging, as well as the final submission to verify results. Thus, only the step changes (documents to selfie) were considered missing as far as behaviors which would be expected to extend the user session timeout.