### PR TITLE
Log phone type even if we're not blocking VOIP numbers

### DIFF
--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -74,9 +74,11 @@ class NewPhoneForm
   end
 
   def validate_not_voip
-    return if phone.blank? || !FeatureManagement.voip_block?
+    return if phone.blank?
 
     @phone_info = Telephony.phone_info(phone)
+
+    return unless FeatureManagement.voip_block?
 
     if @phone_info.type == :voip &&
        !FeatureManagement.voip_allowed_phones.include?(parsed_phone.e164)

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -193,10 +193,11 @@ describe NewPhoneForm do
           expect(FeatureManagement).to receive(:voip_block?).and_return(false)
         end
 
-        it 'allows voip numbers, does not even make a voip check' do
-          expect(Telephony).to_not receive(:phone_info)
+        it 'does a voip check but does not enforce it' do
+          expect(Telephony).to receive(:phone_info).and_call_original
 
           expect(result.success?).to eq(true)
+          expect(result.to_h).to include(phone_type: :voip)
         end
       end
     end


### PR DESCRIPTION
Previous we'd skip the check if the feature flag was off, now we run the check always