### PR TITLE
Fix MFA logging for default phone

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -80,7 +80,8 @@ module TwoFactorAuthentication
         context: context,
         multi_factor_auth_method: params[:otp_delivery_preference],
         confirmation_for_add_phone: confirmation_for_add_phone?,
-        phone_configuration_id: user_session[:phone_id],
+        phone_configuration_id: user_session[:phone_id] ||
+          current_user.default_phone_configuration&.id,
       }
     end
   end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -41,7 +41,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         context: 'authentication',
         multi_factor_auth_method: 'sms',
         confirmation_for_add_phone: false,
-        phone_configuration_id: nil,
+        phone_configuration_id: subject.current_user.default_phone_configuration.id,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -83,7 +83,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
-          phone_configuration_id: nil,
+          phone_configuration_id: subject.current_user.default_phone_configuration.id,
         }
         stub_analytics
         expect(@analytics).to receive(:track_mfa_submit_event).
@@ -129,7 +129,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
-          phone_configuration_id: nil,
+          phone_configuration_id: subject.current_user.default_phone_configuration.id,
         }
 
         stub_analytics
@@ -178,7 +178,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
-          phone_configuration_id: nil,
+          phone_configuration_id: subject.current_user.default_phone_configuration.id,
         }
 
         stub_analytics
@@ -364,7 +364,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               confirmation_for_add_phone: true,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',
-              phone_configuration_id: nil,
+              phone_configuration_id: subject.current_user.default_phone_configuration.id,
             }
 
             expect(@analytics).to have_received(:track_event).


### PR DESCRIPTION
**Why**: It wasn't logging correctly when the user didn't choose the phone and thus used the default phone.