### PR TITLE
remove aal field from service_provider (LG-4119)

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -2,7 +2,7 @@ require 'fingerprinter'
 require 'identity_validations'
 
 class ServiceProvider < ApplicationRecord
-  self.ignored_columns = %w[deal_id agency]
+  self.ignored_columns = %w[deal_id agency aal]
 
   belongs_to :agency
 
@@ -50,7 +50,7 @@ class ServiceProvider < ApplicationRecord
   def skip_encryption_allowed
     config = AppConfig.env.skip_encryption_allowed_list
     return false if config.blank?
-    
+
     @allowed_list ||= JSON.parse(config)
     @allowed_list.include? issuer
   end

--- a/db/migrate/20210126181906_remove_aal_from_service_providers.rb
+++ b/db/migrate/20210126181906_remove_aal_from_service_providers.rb
@@ -1,0 +1,5 @@
+class RemoveAalFromServiceProviders < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :service_providers, :aal }
+  end
+end

--- a/db/migrate/20210126181906_remove_aal_from_service_providers.rb
+++ b/db/migrate/20210126181906_remove_aal_from_service_providers.rb
@@ -1,5 +1,5 @@
 class RemoveAalFromServiceProviders < ActiveRecord::Migration[6.1]
   def change
-    safety_assured { remove_column :service_providers, :aal }
+    safety_assured { remove_column :service_providers, :aal, :integer }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_20_220857) do
+ActiveRecord::Schema.define(version: 2021_01_26_181906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -474,7 +474,6 @@ ActiveRecord::Schema.define(version: 2021_01_20_220857) do
     t.string "redirect_uris", default: [], array: true
     t.integer "agency_id"
     t.text "failure_to_proof_url"
-    t.integer "aal"
     t.integer "ial"
     t.boolean "piv_cac", default: false
     t.boolean "piv_cac_scoped_by_email", default: false


### PR DESCRIPTION
Follow-up to #4605 which has been deployed to production so this may be safely merged/migrated.