### PR TITLE
Ensure i18n in JS Redirects (LG-4002)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,11 @@
       {
         "selector": "ArrayExpression > SpreadElement",
         "message": "Don't use array spread, issue with IE 11 (use Array.from instead)"
+      },
+      {
+        "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
+        "message": 'Do not assign window.location.href to a string or string template to avoid losing i18n parameters',
+
       }
     ],
     "no-unused-expressions": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -41,8 +41,7 @@
       },
       {
         "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
-        "message": 'Do not assign window.location.href to a string or string template to avoid losing i18n parameters',
-
+        "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
       }
     ],
     "no-unused-expressions": "off",

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -23,7 +23,7 @@ module SessionTimeoutWarningHelper
       render partial: 'session_timeout/ping',
              formats: [:js],
              locals: {
-               timeout_path: timeout_url,
+               timeout_url: timeout_url,
                warning: warning,
                start: start,
                frequency: frequency,

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -23,6 +23,7 @@ module SessionTimeoutWarningHelper
       render partial: 'session_timeout/ping',
              formats: [:js],
              locals: {
+               timeout_path: timeout_url,
                warning: warning,
                start: start,
                frequency: frequency,

--- a/app/javascript/app/utils/auto-logout.js
+++ b/app/javascript/app/utils/auto-logout.js
@@ -1,5 +1,5 @@
-export default () => {
+export default (path) => {
   window.onbeforeunload = null;
   window.onunload = null;
-  window.location.href = '/timeout';
+  window.location.href = path;
 };

--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -2,12 +2,13 @@ const WebAuthn = require('../app/webauthn');
 
 function webauthn() {
   // If webauthn is not supported redirect back to the 2fa options list
-  if (!WebAuthn.isWebAuthnEnabled()) {
-    window.location.href = '/login/two_factor/options';
-  }
-
   const webauthnInProgressContainer = document.getElementById('webauthn-auth-in-progress');
   const webauthnSuccessContainer = document.getElementById('webauthn-auth-successful');
+
+  if (!WebAuthn.isWebAuthnEnabled()) {
+    const href = webauthnInProgressContainer.getAttribute('data-webauthn-not-enabled-url');
+    window.location.href = href;
+  }
 
   WebAuthn.verifyWebauthnDevice({
     userChallenge: document.getElementById('user_challenge').value,

--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -2,7 +2,7 @@ const WebAuthn = require('../app/webauthn');
 
 function webauthn() {
   if (window.location.href.indexOf('?error=') === -1 && !WebAuthn.isWebAuthnEnabled()) {
-    window.location.href = '/webauthn_setup?error=NotSupportedError';
+    window.location.search = '?error=NotSupportedError';
   }
   const continueButton = document.getElementById('continue-button');
   continueButton.addEventListener('click', () => {
@@ -23,7 +23,7 @@ function webauthn() {
         document.getElementById('webauthn_form').submit();
       })
       .catch(function (err) {
-        window.location.href = `/webauthn_setup?error=${err.name}`;
+        window.location.search = `?error=${err.name}`;
       });
   });
   const input = document.getElementById('nickname');

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -43,7 +43,7 @@ function success(data) {
       show_warning = time_remaining < warning
 
   if (!data.live) {
-    window.LoginGov.autoLogout(timeout_path);
+    window.LoginGov.autoLogout(timeoutPath);
     return;
   }
 

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,6 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
+var timeoutPath = "<%= timeout_path %>";
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);
@@ -42,7 +43,7 @@ function success(data) {
       show_warning = time_remaining < warning
 
   if (!data.live) {
-    window.LoginGov.autoLogout();
+    window.LoginGov.autoLogout(timeout_path);
     return;
   }
 

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,7 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
-var timeoutPath = "<%= timeout_path %>";
+var timeoutPath = <%= timeout_path.to_json %>;
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,7 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
-var timeoutPath = <%= timeout_path.to_json %>;
+var timeoutPath = "<%= j timeout_path %>";
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,7 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
-var timeoutPath = "<%= j timeout_path %>";
+var timeoutUrl = "<%= j timeout_url %>";
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);
@@ -43,7 +43,7 @@ function success(data) {
       show_warning = time_remaining < warning
 
   if (!data.live) {
-    window.LoginGov.autoLogout(timeoutPath);
+    window.LoginGov.autoLogout(timeoutUrl);
     return;
   }
 

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -17,7 +17,7 @@
   <%= hidden_field_tag :signature, '', id: 'signature' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
 
-  <%= content_tag :div, id: 'webauthn-auth-in-progress', data: { webauth_not_enabled_url: login_two_factor_options_path } do %>
+  <%= content_tag :div, id: 'webauthn-auth-in-progress', data: { webauthn_not_enabled_url: login_two_factor_options_path } do %>
     <div class="spinner" id="spinner">
       <div class="col-12 center mb2">
         <%= image_tag(asset_url('spinner.gif'),
@@ -31,7 +31,7 @@
       <%= t('forms.webauthn_setup.login_text') %>
     </p>
     <%= render 'shared/fallback_links', presenter: @presenter %>
-  </div>
+  <% end %>
 
   <div id='webauthn-auth-successful' class="hidden">
     <div class="col-12 center mb2">

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -17,7 +17,7 @@
   <%= hidden_field_tag :signature, '', id: 'signature' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
 
-  <div id='webauthn-auth-in-progress' data-webauthn-not-enabled-url='<%= login_two_factor_options_path %>'>
+  <%= content_tag :div, id: 'webauthn-auth-in-progress', data: { webauth_not_enabled_url: login_two_factor_options_path } do %>
     <div class="spinner" id="spinner">
       <div class="col-12 center mb2">
         <%= image_tag(asset_url('spinner.gif'),

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -17,7 +17,7 @@
   <%= hidden_field_tag :signature, '', id: 'signature' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
 
-  <div id='webauthn-auth-in-progress'>
+  <div id='webauthn-auth-in-progress' data-webauthn-not-enabled-url='<%= login_two_factor_options_path %>'>
     <div class="spinner" id="spinner">
       <div class="col-12 center mb2">
         <%= image_tag(asset_url('spinner.gif'),


### PR DESCRIPTION
We were hardcoding some paths for js redirects which resulted in dropping the locale path.

There were a few strategies to prevent it:

1. Render the path with a helper method in JS as a JS variable
2. Render a data attribute on an element that JS can fetch when redirecting
3. If the path is the same as the current page, use `window.location.search` instead

To prevent using href in this way in the future, @aduth came up with an ESLint rule to prevent it.