### PR TITLE
Make AgencySeeder ignore the abbreviation attribute

### DIFF
--- a/app/services/agency_seeder.rb
+++ b/app/services/agency_seeder.rb
@@ -1,13 +1,19 @@
 # Update Agency from config/agencies.yml (all environments in rake db:seed)
 class AgencySeeder
-  def initialize(rails_env: Rails.env, deploy_env: LoginGov::Hostdata.env)
+  def initialize(
+    rails_env: Rails.env,
+    deploy_env: LoginGov::Hostdata.env,
+    yaml_path: 'config'
+  )
     @rails_env = rails_env
     @deploy_env = deploy_env
+    @yaml_path = yaml_path
   end
 
   def run
     agencies.each do |agency_id, config|
       agency = Agency.find_by(id: agency_id)
+      config.delete('abbreviation')
       if agency
         agency.update!(config)
       else
@@ -18,10 +24,10 @@ class AgencySeeder
 
   private
 
-  attr_reader :rails_env, :deploy_env
+  attr_reader :rails_env, :deploy_env, :yaml_path
 
   def agencies
-    file = remote_setting || Rails.root.join('config', 'agencies.yml').read
+    file = remote_setting || Rails.root.join(yaml_path, 'agencies.yml').read
     content = ERB.new(file).result
     YAML.safe_load(content).fetch(rails_env, {})
   end

--- a/config/agencies.localdev.yml
+++ b/config/agencies.localdev.yml
@@ -1,119 +1,176 @@
 test:
   1:
     name: 'DHS'
+    abbreviation: 'DHS'
   2:
     name: 'OPM'
+    abbreviation: 'OPM'
   3:
     name: 'EOP'
+    abbreviation: 'EOP'
   4:
     name: 'RRB'
+    abbreviation: 'RRB'
   5:
     name: 'NGA'
+    abbreviation: 'NGA'
   6:
     name: 'DOT'
+    abbreviation: 'DOT'
   7:
     name: 'USSS'
+    abbreviation: 'USSS'
   8:
     name: 'DOD'
+    abbreviation: 'DOD'
   9:
     name: 'GSA'
+    abbreviation: 'GSA'
   10:
     name: 'DOE'
+    abbreviation: 'DOE'
   11:
     name: 'USDA'
+    abbreviation: 'USDA'
   12:
     name: 'HUD'
+    abbreviation: 'HUD'
   13:
     name: 'SEC'
+    abbreviation: 'SEC'
   14:
     name: 'DOL'
+    abbreviation: 'DOL'
   15:
     name: 'USAID'
+    abbreviation: 'USAID'
   16:
     name: 'DOI'
+    abbreviation: 'DOI'
   17:
     name: 'SBA'
+    abbreviation: 'SBA'
   18:
     name: 'NLRB'
+    abbreviation: 'NLRB'
   19:
     name: 'HHS'
+    abbreviation: 'HHS'
 
 development:
   1:
     name: 'DHS'
+    abbreviation: 'DHS'
   2:
     name: 'OPM'
+    abbreviation: 'OPM'
   3:
     name: 'EOP'
+    abbreviation: 'EOP'
   4:
     name: 'RRB'
+    abbreviation: 'RRB'
   5:
     name: 'NGA'
+    abbreviation: 'NGA'
   6:
     name: 'DOT'
+    abbreviation: 'DOT'
   7:
     name: 'USSS'
+    abbreviation: 'USSS'
   8:
     name: 'DOD'
+    abbreviation: 'DOD'
   9:
     name: 'GSA'
+    abbreviation: 'GSA'
   10:
     name: 'DOE'
+    abbreviation: 'DOE'
   11:
     name: 'USDA'
+    abbreviation: 'USDA'
   12:
     name: 'HUD'
+    abbreviation: 'HUD'
   13:
     name: 'SEC'
+    abbreviation: 'SEC'
   14:
     name: 'DOL'
+    abbreviation: 'DOL'
   15:
     name: 'USAID'
+    abbreviation: 'USAID'
   16:
     name: 'DOI'
+    abbreviation: 'DOI'
   17:
     name: 'SBA'
+    abbreviation: 'SBA'
   18:
     name: 'NLRB'
+    abbreviation: 'NLRB'
   19:
     name: 'HHS'
+    abbreviation: 'HHS'
 
 production:
   1:
     name: 'DHS'
+    abbreviation: 'DHS'
   2:
     name: 'OPM'
+    abbreviation: 'OPM'
   3:
     name: 'EOP'
+    abbreviation: 'EOP'
   4:
     name: 'RRB'
+    abbreviation: 'RRB'
   5:
     name: 'NGA'
+    abbreviation: 'NGA'
   6:
     name: 'DOT'
+    abbreviation: 'DOT'
   7:
     name: 'USSS'
+    abbreviation: 'USSS'
   8:
     name: 'DOD'
+    abbreviation: 'DOD'
   9:
     name: 'GSA'
+    abbreviation: 'GSA'
   10:
     name: 'DOE'
+    abbreviation: 'DOE'
   11:
     name: 'USDA'
+    abbreviation: 'USDA'
   12:
     name: 'HUD'
+    abbreviation: 'HUD'
   13:
     name: 'SEC'
+    abbreviation: 'SEC'
   14:
     name: 'DOL'
+    abbreviation: 'DOL'
   15:
     name: 'USAID'
+    abbreviation: 'USAID'
   16:
     name: 'DOI'
+    abbreviation: 'DOI'
   17:
     name: 'SBA'
+    abbreviation: 'SBA'
   18:
     name: 'NLRB'
+    abbreviation: 'NLRB'
   19:
     name: 'HHS'
+    abbreviation: 'HHS'

--- a/spec/fixtures/agencies.yml
+++ b/spec/fixtures/agencies.yml
@@ -1,0 +1,10 @@
+test:
+  1:
+    name: 'DHS'
+    abbreviation: 'DHS'
+  2:
+    name: 'OPM'
+    abbreviation: 'OPM'
+  3:
+    name: 'EOP'
+    abbreviation: 'EOP'

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AgencySeeder do
-  subject(:instance) { AgencySeeder.new(rails_env: rails_env, deploy_env: deploy_env) }
+  subject(:instance) do
+    AgencySeeder.new(
+      rails_env: rails_env,
+      deploy_env: deploy_env,
+      yaml_path: 'spec/fixtures',
+    )
+  end
   let(:rails_env) { 'test' }
   let(:deploy_env) { 'int' }
 
@@ -10,6 +16,8 @@ RSpec.describe AgencySeeder do
 
     subject(:run) { instance.run }
 
+    # This implictly validates that the `abbreviation` attribute in the YAML is
+    # ignored
     it 'inserts agencies into the database from agencies.yml' do
       expect { run }.to change(Agency, :count)
     end


### PR DESCRIPTION
Temporarily ignore the abbreviation attribute in agencies.yml to allow
the config repo updates to be merged without breaking the IdP while we
work on adding the Partnerships data model to the IdP schema. We will
ultimately add the attribute to the `agencies` table and at that point
remove this change.

Also updates the localdev template YAML file and adds an explicit
fixture file for testing.

This should be safe to run even if there is no `abbreviation` attribute present in the YAML.