### PR TITLE
LG-4129: Return 401 for capture doc status of cancelled IAL2 flow session

### DIFF
--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -11,6 +11,7 @@ module Idv
     private
 
     def document_capture_session_poll_render_result
+      return { plain: 'Unauthorized', status: :unauthorized } unless flow_session
       session_uuid = flow_session[:document_capture_session_uuid]
       document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
       return { plain: 'Unauthorized', status: :unauthorized } unless document_capture_session

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -25,7 +25,7 @@ module Idv
     end
 
     def extend_timeout_using_meta_refresh_for_select_paths
-      return unless request.path == idv_doc_auth_step_path(step: :link_sent)
+      return unless request.path == idv_doc_auth_step_path(step: :link_sent) && flow_session
       max_10min_refreshes = AppConfig.env.doc_auth_extend_timeout_by_minutes.to_i / 10
       return if max_10min_refreshes <= 0
       meta_refresh_count = flow_session[:meta_refresh_count].to_i

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -26,6 +26,17 @@ describe Idv::CaptureDocStatusController do
       end
     end
 
+    context 'when flow session expires' do
+      let(:flow_session) { nil }
+
+      it 'returns unauthorized' do
+        get :show
+
+        expect(response.status).to eq(401)
+        expect(response.body).to eq('Unauthorized')
+      end
+    end
+
     context 'when session does not exist' do
       let(:flow_session) { {} }
 


### PR DESCRIPTION
**Why**: If the user's flow session is cancelled, we should return a sensible status code, following prior art for a capture session which can't be found.