### PR TITLE
LG-4129: Add test case for cancelled IAL2 session

### DIFF
--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -70,6 +70,19 @@ feature 'doc auth link sent step' do
       visit current_path
     end
 
+    context 'user cancels flow session' do
+      before do
+        click_on t('links.cancel')
+        click_on t('forms.buttons.cancel')
+
+        visit idv_doc_auth_link_sent_step
+      end
+
+      it 'redirects to welcome step' do
+        expect(page).to have_current_path(idv_doc_auth_welcome_step)
+      end
+    end
+
     it 'refreshes page 4x with meta refresh extending timeout by 40 min and can start over' do
       3.times do
         expect(page).to have_css 'meta[http-equiv="refresh"]', visible: false


### PR DESCRIPTION
**Why**: Follow-up task from https://github.com/18F/identity-idp/pull/4620#issuecomment-768440198

Fails prior to f6e4e07:

```
Failures:

  1) doc auth link sent step behaves like with doc capture polling disabled user cancels flow session redirects to welcome step
     Failure/Error: meta_refresh_count = flow_session[:meta_refresh_count].to_i
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     Shared Example Group: "with doc capture polling disabled" called from ./spec/features/idv/doc_auth/link_sent_step_spec.rb:113
     # ./app/controllers/idv/doc_auth_controller.rb:31:in `extend_timeout_using_meta_refresh_for_select_paths'
     # ./lib/utf8_sanitizer.rb:16:in `call'
     # ./lib/headers_filter.rb:13:in `call'
     # ./config/initializers/secure_headers.rb:86:in `call'
     # ./spec/features/idv/doc_auth/link_sent_step_spec.rb:91:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:95:in `block (2 levels) in <top (required)>'
```