### PR TITLE
Move phone validation scripts to intl-tel-input pack

### DIFF
--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -1,10 +1,13 @@
 const INTERNATIONAL_CODE_REGEX = /^\+(\d+) |^1 /;
 
+// @ts-ignore
 const { I18n } = window.LoginGov;
 
 const selectedInternationCodeOption = () => {
-  const dropdown = document.querySelector('[data-international-phone-form] .international-code');
-  return dropdown.item(dropdown.selectedIndex);
+  const dropdown = /** @type {HTMLSelectElement} */ (document.querySelector(
+    '[data-international-phone-form] .international-code',
+  ));
+  return /** @type {HTMLOptionElement} */ (dropdown.item(dropdown.selectedIndex));
 };
 
 const unsupportedInternationalPhoneOTPDeliveryWarningMessage = () => {
@@ -51,14 +54,14 @@ const updateOTPDeliveryMethods = () => {
     return;
   }
 
-  const phoneLabel = phoneRadio.parentNode.parentNode;
+  const phoneLabel = /** @type {Element} */ (phoneRadio.parentNode).parentNode;
   const deliveryMethodHint = document.querySelector('#otp_delivery_preference_instruction');
 
   const warningMessage = unsupportedInternationalPhoneOTPDeliveryWarningMessage();
   if (warningMessage) {
     disablePhoneState(phoneRadio, phoneLabel, smsRadio, deliveryMethodHint, warningMessage);
   } else {
-    enablePhoneState(phoneRadio, phoneLabel, smsRadio, deliveryMethodHint);
+    enablePhoneState(phoneRadio, phoneLabel, deliveryMethodHint);
   }
 };
 
@@ -74,7 +77,9 @@ const updateInternationalCodeInPhone = (phone, newCode) =>
   phone.replace(new RegExp(`^\\+?(\\d+\\s+|${newCode})?`), `+${newCode} `);
 
 const updateInternationalCodeInput = () => {
-  const phoneInput = document.querySelector('[data-international-phone-form] .phone');
+  const phoneInput = /** @type {HTMLInputElement} */ (document.querySelector(
+    '[data-international-phone-form] .phone',
+  ));
   const phone = phoneInput.value;
   const inputInternationalCode = internationalCodeFromPhone(phone);
   const selectedInternationalCode = selectedInternationCodeOption().dataset.countryCode;

--- a/app/javascript/app/phone-validation.js
+++ b/app/javascript/app/phone-validation.js
@@ -21,13 +21,16 @@ const updatePlaceholder = (phoneInput) => {
 };
 
 const checkPhoneValidity = () => {
+  /** @type {HTMLInputElement?} */
   const sendCodeButton = document.querySelector(
     '[data-international-phone-form] input[name=commit]',
   );
+  /** @type {HTMLInputElement?} */
   const phoneInput =
     document.querySelector('[data-international-phone-form] .phone') ||
     document.querySelector('[data-international-phone-form] .new-phone');
   updatePlaceholder(phoneInput);
+  /** @type {HTMLInputElement?} */
   const countryCodeInput = document.querySelector(
     '[data-international-phone-form] .international-code',
   );

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,8 +4,6 @@ require('../app/pw-toggle');
 require('../app/checkbox');
 require('../app/form-field-format');
 require('../app/radio-btn');
-require('../app/phone-internationalization');
-require('../app/phone-validation');
 require('../app/print-personal-key');
 require('../app/i18n-dropdown');
 require('../app/platform-authenticator');

--- a/app/javascript/packs/intl-tel-input.js
+++ b/app/javascript/packs/intl-tel-input.js
@@ -1,6 +1,8 @@
 import { loadPolyfills } from '@18f/identity-polyfill';
 import 'intl-tel-input/build/js/utils.js';
 import * as intlTelInput from 'intl-tel-input/build/js/intlTelInput';
+import '../app/phone-internationalization';
+import '../app/phone-validation';
 
 /**
  * @param {HTMLDivElement} iti


### PR DESCRIPTION
**Why**: Reduce size of main application bundle, which is loaded in all paths. Phone validation dependencies (notably `libphonenumber-js`) are quite large, and are only used in the context of the `intl-tel-input` pack (screens with phone input).

**Impact:**

Reduction of about 57% in application bundle (55.8kb to 24.1kb gzipped).

(Note: Locally disabled chunk splitting to generate these results to be more readable)

_Before:_

```
   js/application-8b2a6c3ef1bc883aa56f.js    196 KiB    0, 1  [emitted] [immutable]         application
js/application-8b2a6c3ef1bc883aa56f.js.br   47.9 KiB          [emitted]
js/application-8b2a6c3ef1bc883aa56f.js.gz   55.8 KiB          [emitted]
```

_After:_

```
   js/application-d3084ec0f1f8843f2518.js   75.9 KiB    0, 1  [emitted] [immutable]         application
js/application-d3084ec0f1f8843f2518.js.br   21.3 KiB          [emitted]
js/application-d3084ec0f1f8843f2518.js.gz   24.1 KiB          [emitted]
```