### PR TITLE
LG-4097: Fix "Submit" button always appearing disabled on document capture review step

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -4,7 +4,7 @@ import FormSteps from './form-steps';
 import { UploadFormEntriesError } from '../services/upload';
 import DocumentsStep, { documentsStepValidator } from './documents-step';
 import SelfieStep, { selfieStepValidator } from './selfie-step';
-import ReviewIssuesStep from './review-issues-step';
+import ReviewIssuesStep, { reviewIssuesStepValidator } from './review-issues-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import ServiceProviderContext from '../context/service-provider';
@@ -87,6 +87,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
           name: 'review',
           title: t('doc_auth.headings.review_issues'),
           form: ReviewIssuesStep,
+          validator: reviewIssuesStepValidator,
           footer: DesktopDocumentDisclosure,
         },
       ]

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -162,6 +162,10 @@ function FormSteps({
   }
 
   const unknownFieldErrors = activeErrors.filter((error) => !fields.current[error.field]?.element);
+  const isValidStep = step.validator?.(values) ?? true;
+  const hasUnresolvedFieldErrors =
+    activeErrors.length && activeErrors.length > unknownFieldErrors.length;
+  const canContinue = isValidStep && !hasUnresolvedFieldErrors;
 
   /**
    * Increments state to the next step, or calls onComplete callback if the current step is the last
@@ -173,7 +177,7 @@ function FormSteps({
     event.preventDefault();
 
     // Don't proceed if field errors have yet to be resolved.
-    if (activeErrors.length && activeErrors.length > unknownFieldErrors.length) {
+    if (hasUnresolvedFieldErrors) {
       setActiveErrors(Array.from(activeErrors));
       didSubmitWithErrors.current = true;
       return;
@@ -202,8 +206,6 @@ function FormSteps({
 
   const { form: Form, footer: Footer, name, title } = step;
   const isLastStep = stepIndex + 1 === steps.length;
-
-  const canContinue = (step.validator?.(values) ?? true) && !activeErrors.length;
 
   return (
     <form ref={formRef} onSubmit={toNextStep}>

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -23,6 +23,22 @@ import './review-issues-step.scss';
 const DOCUMENT_SIDES = ['front', 'back'];
 
 /**
+ * @param {Partial<ReviewIssuesStepValue>=} value
+ *
+ * @return {boolean} Whether the value is valid for the review issues step.
+ */
+function reviewIssuesStepValidator(value = {}) {
+  const hasDocuments = DOCUMENT_SIDES.every((side) => !!value[side]);
+
+  // Absent availability of service provider context here, this relies on the fact that:
+  // 1) The review step is only shown with an existing, complete set of values.
+  // 2) Clearing an existing value sets it as null, but doesn't remove the key from the object.
+  const hasSelfieIfApplicable = !('selfie' in value) || !!value.selfie;
+
+  return hasDocuments && hasSelfieIfApplicable;
+}
+
+/**
  * @param {import('./form-steps').FormStepComponentProps<ReviewIssuesStepValue>} props Props object.
  */
 function ReviewIssuesStep({
@@ -129,3 +145,5 @@ function ReviewIssuesStep({
 }
 
 export default withBackgroundEncryptedUpload(ReviewIssuesStep);
+
+export { reviewIssuesStepValidator };

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
-import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
 import { render as baseRender, fireEvent } from '@testing-library/react';
 import httpUpload, {
   UploadFormEntriesError,

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/dom';
+import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import { render as baseRender, fireEvent } from '@testing-library/react';
 import httpUpload, {
   UploadFormEntriesError,
@@ -248,6 +248,7 @@ describe('document-capture/components/document-capture', () => {
     uploadError.formEntryErrors = [
       { field: 'front', message: 'Image has glare' },
       { field: 'back', message: 'Please fill in this field' },
+      { message: 'An unknown error occurred' },
     ].map(toFormEntryError);
     const { getByLabelText, getByText, getAllByText, findAllByText, findAllByRole } = render(
       <AcuantContextProvider sdkSrc="about:blank">
@@ -255,6 +256,7 @@ describe('document-capture/components/document-capture', () => {
       </AcuantContextProvider>,
       {
         uploadError,
+        expectedUploads: 2,
       },
     );
 
@@ -275,7 +277,7 @@ describe('document-capture/components/document-capture', () => {
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(continueButton);
 
-    const submitButton = getByText('forms.buttons.submit.default');
+    let submitButton = getByText('forms.buttons.submit.default');
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
@@ -283,9 +285,10 @@ describe('document-capture/components/document-capture', () => {
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 
-    const notices = await findAllByRole('alert');
-    expect(notices[0].textContent).to.equal('Image has glare');
-    expect(notices[1].textContent).to.equal('Please fill in this field');
+    let notices = await findAllByRole('alert');
+    expect(notices[0].textContent).to.equal('An unknown error occurred');
+    expect(notices[1].textContent).to.equal('Image has glare');
+    expect(notices[2].textContent).to.equal('Please fill in this field');
 
     expect(console).to.have.loggedError(/^Error: Uncaught/);
     expect(console).to.have.loggedError(
@@ -297,6 +300,39 @@ describe('document-capture/components/document-capture', () => {
 
     const hasValueSelected = !!getByLabelText('doc_auth.headings.document_capture_front');
     expect(hasValueSelected).to.be.true();
+
+    // Submit button should be disabled until field errors are resolved.
+    submitButton = getByText('forms.buttons.submit.default');
+    expect(submitButton.classList.contains('btn-disabled')).to.be.true();
+    userEvent.upload(
+      getByLabelText('doc_auth.headings.document_capture_front'),
+      new window.File([''], 'upload.png', { type: 'image/png' }),
+    );
+    userEvent.upload(
+      getByLabelText('doc_auth.headings.document_capture_back'),
+      new window.File([''], 'upload.png', { type: 'image/png' }),
+    );
+
+    // Once fields are changed, their notices should be cleared. If all field-specific errors are
+    // addressed, submit should be enabled once more.
+    notices = await findAllByRole('alert');
+    const errorNotices = notices.filter((notice) => notice.classList.contains('usa-alert--error'));
+    expect(errorNotices).to.have.lengthOf(1);
+    expect(errorNotices[0].textContent).to.equal('An unknown error occurred');
+    expect(submitButton.classList.contains('btn-disabled')).to.be.false();
+
+    // Verify re-submission. It will fail again, but test can at least assure that the interstitial
+    // screen is shown once more.
+    userEvent.click(submitButton);
+    const interstitialHeading = getByText('doc_auth.headings.interstitial');
+    expect(interstitialHeading).to.be.ok();
+
+    await findAllByRole('alert');
+
+    expect(console).to.have.loggedError(/^Error: Uncaught/);
+    expect(console).to.have.loggedError(
+      /React will try to recreate this component tree from scratch using the error boundary you provided/,
+    );
   });
 
   it('redirects from a server error', async () => {

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -5,12 +5,59 @@ import {
   ServiceProviderContext,
   UploadContextProvider,
 } from '@18f/identity-document-capture';
-import ReviewIssuesStep from '@18f/identity-document-capture/components/review-issues-step';
+import ReviewIssuesStep, {
+  reviewIssuesStepValidator,
+} from '@18f/identity-document-capture/components/review-issues-step';
 import { render } from '../../../support/document-capture';
 import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/review-issues-step', () => {
   const sandbox = useSandbox();
+
+  describe('reviewIssuesStepValidator', () => {
+    it('returns false if given undefined value', () => {
+      const isValid = reviewIssuesStepValidator();
+
+      expect(isValid).to.be.false();
+    });
+
+    it('returns false if either of front or back are absent', () => {
+      for (const key of ['front', 'back']) {
+        const isValid = reviewIssuesStepValidator({ [key]: new window.Blob() });
+
+        expect(isValid).to.be.false();
+      }
+    });
+
+    it('returns true if front and back are given, and selfie is not applicable', () => {
+      const isValid = reviewIssuesStepValidator({
+        front: new window.Blob(),
+        back: new window.Blob(),
+      });
+
+      expect(isValid).to.be.true();
+    });
+
+    it('returns false if selfie is applicable and missing', () => {
+      const isValid = reviewIssuesStepValidator({
+        front: new window.Blob(),
+        back: new window.Blob(),
+        selfie: null,
+      });
+
+      expect(isValid).to.be.false();
+    });
+
+    it('returns true if selfie is applicable and given', () => {
+      const isValid = reviewIssuesStepValidator({
+        front: new window.Blob(),
+        back: new window.Blob(),
+        selfie: new window.Blob(),
+      });
+
+      expect(isValid).to.be.true();
+    });
+  });
 
   it('renders with front, back, and selfie inputs', () => {
     const { getByLabelText } = render(<ReviewIssuesStep />);


### PR DESCRIPTION
**Why**: So that the user isn't confused by the presence of what appears to be a disabled button, and therefore more likely to abandon their proofing attempt.

This involved updating logic to omit consideration of non-field-associated errors with a document capture submission. Active errors contains both field-specific and general messages, e.g. received from a failed validation attempt. The latter will never become unresolved by changing field values. Only disable continue if the step is invalid OR if there are field-specific errors yet to be addressed.
