### PR TITLE
LG-4105: Log upload step funnel view event when skipping

### DIFF
--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -19,6 +19,9 @@ module Idv
       private
 
       def skip_to_capture
+        # For funnel integrity, log upload step as visited.
+        Funnel::DocAuth::RegisterStep.new(user_id, sp_session[:issuer]).call(:upload, :view, true)
+
         # Skips to `document_capture` step.
         mark_step_complete(:upload)
         mark_step_complete(:send_link)


### PR DESCRIPTION
**Why**: The "Upload" step exists to encourage users to user their mobile phone to complete document verification. We skip this step if the user is already on a mobile phone. However, this negatively impacts funnel reporting because the number of "view" events for the Upload step can often appear lower than subsequent steps, due to the fact that we're not recording mobile users skipping the step. The changes proposed here mark the upload step as viewed if the user is skipping it.

**Implementation Notes:**

This normally happens in `FlowStateMachine#show`:

https://github.com/18F/identity-idp/blob/87f9b5b59ee16fda09f89008147958ba423d21df/app/services/flow/flow_state_machine.rb#L16-L22

We don't have easy access to the flow state machine from an individual step.

A couple alternatives considered:

- Move this logic to the `mark_step_complete` method, if we're concerned about logging these events consistently for all step completions. However, we use `mark_step_complete` to skip over a handful of steps we may not want to actually log as being "viewed" or "submitted", e.g. `link_sent` hybrid step. Furthermore, not all steps log submission, e.g. `upload` only has `upload_view_at` ([source](https://github.com/18F/identity-idp/blob/87f9b5b59ee16fda09f89008147958ba423d21df/db/schema.rb#L115-L116)).
- Consider `upload` as an ["optional show step"](https://github.com/18F/identity-idp/blob/87f9b5b59ee16fda09f89008147958ba423d21df/app/services/idv/flows/doc_auth_flow.rb#L15-L17) since it is largely treated as optional. However, this may be a large departure from how we consider `upload` as part of the funnel and require more significant effort.