### PR TITLE
Add separate feature flag to disable VOIP checks entirely

### DIFF
--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -74,7 +74,7 @@ class NewPhoneForm
   end
 
   def validate_not_voip
-    return if phone.blank?
+    return if phone.blank? || !FeatureManagement.voip_check?
 
     @phone_info = Telephony.phone_info(phone)
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -142,6 +142,7 @@ usps_ipp_password: ''
 usps_ipp_root_url: ''
 usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
+voip_check: 'false'
 voip_block: 'false'
 voip_allowed_phones: '[]'
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -136,6 +136,11 @@ class FeatureManagement
     !Rails.env.test? && AppConfig.env.log_to_stdout == 'true'
   end
 
+  # Whether or not we can call the phone_info endpoint at all
+  def self.voip_check?
+    AppConfig.env.voip_check == 'true'
+  end
+
   # Whether or not we should block VOIP phone numbers
   def self.voip_block?
     AppConfig.env.voip_block == 'true'

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 describe Users::PhoneSetupController do
-  before { allow(FeatureManagement).to receive(:voip_block?).and_return(true) }
+  before do
+    allow(FeatureManagement).to receive(:voip_check?).and_return(true)
+    allow(FeatureManagement).to receive(:voip_block?).and_return(true)
+  end
 
   describe 'GET index' do
     context 'when signed out' do

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -78,6 +78,7 @@ describe 'Add a new phone number' do
 
   scenario 'adding a VOIP phone' do
     allow(FeatureManagement).to receive(:voip_block?).and_return(true)
+    allow(FeatureManagement).to receive(:voip_check?).and_return(true)
 
     user = create(:user, :signed_up)
 


### PR DESCRIPTION
VOIP checking was added in #4601, but feature flagged

We made the decision to *always* check the type of the phone, but only conditionally enforce in #4610

We have a current urgent need to disable using the VOIP check endpoint entirely, so this adds a new feature flag that overrides the previous ones so we don't make network requests

The changeset is small, take a look at the previous PRs for context