### PR TITLE
LG-4127 Fix duplicate entries in GPO file

### DIFF
--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -10,9 +10,9 @@ module Users
       usps_mail = Idv::UspsMail.new(current_user)
       @mail_spammed = usps_mail.mail_spammed?
       @verify_account_form = VerifyAccountForm.new(user: current_user)
+      @send_letter_throttled = Throttler::IsThrottled.call(current_user.id, :idv_send_letter)
       return unless FeatureManagement.reveal_usps_code?
       @code = session[:last_usps_confirmation_code]
-      @send_letter_throttled = Throttler::IsThrottled.call(current_user.id, :idv_send_letter)
     end
 
     def create

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -12,6 +12,7 @@ module Users
       @verify_account_form = VerifyAccountForm.new(user: current_user)
       return unless FeatureManagement.reveal_usps_code?
       @code = session[:last_usps_confirmation_code]
+      @send_letter_throttled = Throttler::IsThrottled.call(current_user.id, :idv_send_letter)
     end
 
     def create

--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -9,6 +9,7 @@ class Throttle < ApplicationRecord
     reset_password_email: 4,
     idv_resolution: 5,
     idv_send_link: 6,
+    idv_send_letter: 7,
   }
 
   THROTTLE_CONFIG = {
@@ -35,6 +36,10 @@ class Throttle < ApplicationRecord
     idv_send_link: {
       max_attempts: (AppConfig.env.idv_send_link_max_attempts || 5).to_i,
       attempt_window: (AppConfig.env.idv_send_link_attempt_window_in_minutes || 10).to_i,
+    },
+    idv_send_letter: {
+      max_attempts: (AppConfig.env.idv_send_letter_max_attempts || 1).to_i,
+      attempt_window: (AppConfig.env.idv_send_letter_window_in_minutes || 60*24*5).to_i,
     },
   }.freeze
 

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -20,7 +20,8 @@ class UspsConfirmationMaker
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
 
-    Throttler::IsThrottledElseIncrement.call(profile&.user&.id, :idv_send_letter)
+    user_id = profile&.user&.id
+    Throttler::IsThrottledElseIncrement.call(user_id, :idv_send_letter) if user_id
     update_proofing_cost
   end
 

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -20,6 +20,7 @@ class UspsConfirmationMaker
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
 
+    Throttler::IsThrottledElseIncrement.call(profile&.user&.id, :idv_send_letter)
     update_proofing_cost
   end
 

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 <% end %>
 
-<% if FeatureManagement.enable_usps_verification? && !@mail_spammed %>
+<% if FeatureManagement.enable_usps_verification? && !@mail_spammed && !@send_letter_throttled %>
   <%= link_to t('idv.messages.usps.resend'), idv_usps_path, class: 'block mb2' %>
 <% end %>
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -62,6 +62,8 @@ identity_pki_disabled: 'true'
 identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '6'
 idv_max_attempts: '3'
+idv_send_letter_window_in_minutes: '7200'
+idv_send_letter_max_attempts: '1'
 idv_send_link_attempt_window_in_minutes: '10'
 idv_send_link_max_attempts: '5'
 in_person_proofing_enabled:

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -412,6 +412,7 @@ test:
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
+  idv_send_letter_max_attempts: '2'
   issuers_with_email_nameid_format: https://rp1.serviceprovider.com/auth/saml/metadata
   lexisnexis_trueid_account_id: 'test_account'
   liveness_checking_enabled: 'false'

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Users::VerifyAccountController do
     context 'user is throttled from sending letters' do
       render_views
       before do
-        Throttler::IsThrottledElseIncrement.call(current_user.id, :idv_send_letter)
+        AppConfig.env.idv_send_letter_max_attempts.to_i.times do
+          Throttler::IsThrottledElseIncrement.call(current_user.id, :idv_send_letter)
+        end
       end
 
       it 'does not contain a link to send a letter' do


### PR DESCRIPTION
**Why**: Users are able to request another letter before it is even possible for the letter to arrive. (ie within 24 hours)
**How**: Throttle sending letters to once every 5 days and conditionally show the send another letter link