### PR TITLE
"Allow browser camera access" error message is persistent (LG-3952)

### DIFF
--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -76,6 +76,7 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
           videoRef.current.srcObject = stream;
           videoRef.current.play();
           setIsCapturing(true);
+          setIsAccessRejected(false);
         }),
       )
       .catch(


### PR DESCRIPTION
Set access rejected to false when selfie video capture is successful to avoid having a persistent error message if you first deny access.

I wasn't sure if `useEffect` was a better place to set this, or if it should be set in both?