### PR TITLE
Fix image upload 500 (LG-4154)

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -31,6 +31,7 @@ module Idv
     end
 
     def remaining_attempts
+      return nil unless document_capture_session
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end
 
@@ -77,6 +78,7 @@ module Idv
     end
 
     def throttled_else_increment
+      return unless document_capture_session
       @throttled = Throttler::IsThrottledElseIncrement.call(
         document_capture_session.user_id,
         :idv_acuant,

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -108,6 +108,32 @@ describe Idv::ImageUploadsController do
       end
     end
 
+    context 'when document capture session is invalid' do
+      it 'returns error status when document_capture_session is not provided' do
+        params.delete(:document_capture_session_uuid)
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(response.status).to eq(400)
+        expect(json[:success]).to eq(false)
+        expect(json[:errors]).to eq [
+          { field: 'document_capture_session', message: 'Please fill in this field.' },
+        ]
+      end
+
+      it 'returns error status when document_capture_session is invalid' do
+        params[:document_capture_session_uuid] = 'bad uuid'
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(response.status).to eq(400)
+        expect(json[:success]).to eq(false)
+        expect(json[:errors]).to eq [
+          { field: 'document_capture_session', message: 'Please fill in this field.' },
+        ]
+      end
+    end
+
     context 'throttling' do
       it 'returns remaining_attempts with error' do
         params.delete(:front)


### PR DESCRIPTION
An invalid document capture session will still try to access the user_id due to the throttling logic and raise a 500.

I figured it made more sense to skip the throttle logic than use the `&.user_id` and have the throttle key be nil?