### PR TITLE
Re-add the migration to drop the AAL column

### DIFF
--- a/db/migrate/20210126181906_remove_aal_from_service_providers.rb
+++ b/db/migrate/20210126181906_remove_aal_from_service_providers.rb
@@ -1,0 +1,5 @@
+class RemoveAalFromServiceProviders < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :service_providers, :aal, :integer }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -452,7 +452,6 @@ ActiveRecord::Schema.define(version: 2021_01_29_150956) do
     t.string "redirect_uris", default: [], array: true
     t.integer "agency_id"
     t.text "failure_to_proof_url"
-    t.integer "aal"
     t.integer "ial"
     t.boolean "piv_cac", default: false
     t.boolean "piv_cac_scoped_by_email", default: false


### PR DESCRIPTION
**Why**: We no longer read from the AAL column