### PR TITLE
Attempt to fix spec flakiness by adding an optional wait

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -53,7 +53,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -67,7 +67,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -81,7 +81,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -53,7 +53,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps
-      click_idv_continue
+      click_idv_continue(wait: true)
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -67,7 +67,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue
+      click_idv_continue(wait: true)
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -81,7 +81,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue
+      click_idv_continue(wait: true)
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -128,7 +128,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_all_doc_auth_steps(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
-    click_idv_continue
+    click_idv_continue(wait: true)
   end
 
   def mock_doc_auth_no_name_pii(method)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -128,7 +128,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_all_doc_auth_steps(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
-    click_idv_continue(wait: true)
+    click_idv_continue
   end
 
   def mock_doc_auth_no_name_pii(method)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -128,10 +128,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_all_doc_auth_steps(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
-    click_idv_continue
-    # In JavaScript contexts, a spinner is shown while verification is in-progress. The only
-    # reliable measure of completion is that the page eventually navigates away.
-    expect(page).to_not have_current_path(idv_doc_auth_verify_step, wait: 10)
+    click_idv_continue(wait: true)
   end
 
   def mock_doc_auth_no_name_pii(method)

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -29,8 +29,10 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: '(703) 555-5555'
   end
 
-  def click_idv_continue
+  def click_idv_continue(wait: false)
+    url = current_path
     click_on t('forms.buttons.continue'), match: :first
+    expect(page).to_not have_current_path(url, wait: 10) if wait
   end
 
   def choose_idv_otp_delivery_method_sms

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -29,7 +29,7 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: '(703) 555-5555'
   end
 
-  def click_idv_continue(wait: true)
+  def click_idv_continue(wait: false)
     url = current_path
     click_on t('forms.buttons.continue'), match: :first
     expect(page).to_not have_current_path(url, wait: 10) if wait

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -29,7 +29,7 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: '(703) 555-5555'
   end
 
-  def click_idv_continue(wait: false)
+  def click_idv_continue(wait: true)
     url = current_path
     click_on t('forms.buttons.continue'), match: :first
     expect(page).to_not have_current_path(url, wait: 10) if wait


### PR DESCRIPTION
- We show a spinner on these steps so the tests needs to
  wait for the URL to change to be able to consistently
  click the continue button


Example spec failures before, these reproduced locally before adding this patch

```
     Capybara::ElementNotFound:
       Unable to find field :user_password that is not disabled
     # ./spec/features/accessibility/idv_pages_spec.rb:57:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:95:in `block (2 levels) in <top (required)>'
```