### PR TITLE
Set aria-invalid on SSN field through JS (LG-3699)

### DIFF
--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -42,8 +42,7 @@ function formatSSNFieldAndLimitLength() {
         }
         const didFormat = input.value !== value;
         if (didFormat) {
-          const isValid = input.checkValidity();
-          input.setAttribute('aria-invalid', !isValid);
+          input.checkValidity();
         }
       }
 
@@ -54,8 +53,7 @@ function formatSSNFieldAndLimitLength() {
         const maxLength = 9 + (this.value.match(/-/g) || []).length;
         if (this.value.length > maxLength) {
           this.value = this.value.slice(0, maxLength);
-          const isValid = this.checkValidity();
-          input.setAttribute('aria-invalid', !isValid);
+          this.checkValidity();
         }
       }
 

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -55,7 +55,7 @@ function formatSSNFieldAndLimitLength() {
         if (this.value.length > maxLength) {
           this.value = this.value.slice(0, maxLength);
           const isValid = this.checkValidity();
-          input.setAttribute('aria-invaid', !isValid);
+          input.setAttribute('aria-invalid', !isValid);
         }
       }
 

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -43,7 +43,7 @@ function formatSSNFieldAndLimitLength() {
         const didFormat = input.value !== value;
         if (didFormat) {
           const isValid = input.checkValidity();
-          input.setAttribute('aria-invaid', !isValid);
+          input.setAttribute('aria-invalid', !isValid);
         }
       }
 

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -42,7 +42,8 @@ function formatSSNFieldAndLimitLength() {
         }
         const didFormat = input.value !== value;
         if (didFormat) {
-          input.checkValidity();
+          const isValid = input.checkValidity();
+          input.setAttribute('aria-invaid', !isValid);
         }
       }
 
@@ -53,7 +54,8 @@ function formatSSNFieldAndLimitLength() {
         const maxLength = 9 + (this.value.match(/-/g) || []).length;
         if (this.value.length > maxLength) {
           this.value = this.value.slice(0, maxLength);
-          this.checkValidity();
+          const isValid = this.checkValidity();
+          input.setAttribute('aria-invaid', !isValid);
         }
       }
 

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -20,7 +20,7 @@ feature 'doc auth ssn step' do
     it 'proceeds to the next page with valid info', js: true do
       fill_out_ssn_form_ok
       expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('false')
-      click_idv_continue
+      click_idv_continue(wait: true)
 
       expect(page).to have_current_path(idv_doc_auth_verify_step)
     end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -17,15 +17,17 @@ feature 'doc auth ssn step' do
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
     end
 
-    it 'proceeds to the next page with valid info' do
+    it 'proceeds to the next page with valid info', js: true do
       fill_out_ssn_form_ok
+      expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('false')
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_verify_step)
     end
 
-    it 'does not proceed to the next page with invalid info' do
+    it 'does not proceed to the next page with invalid info', js: true do
       fill_out_ssn_form_fail
+      expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('true')
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -28,7 +28,7 @@ feature 'doc auth ssn step' do
     it 'does not proceed to the next page with invalid info', js: true do
       fill_out_ssn_form_fail
       expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('true')
-      click_idv_continue(wait: true)
+      click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -28,7 +28,7 @@ feature 'doc auth ssn step' do
     it 'does not proceed to the next page with invalid info', js: true do
       fill_out_ssn_form_fail
       expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('true')
-      click_idv_continue
+      click_idv_continue(wait: true)
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end


### PR DESCRIPTION
Chrome+Voiceover use `aria-invalid` to label a field as "invalid" or not in voiceover:

| state | screenshot |
| --- | ---- |
| valid state (9 digits) | <img width="665" alt="Screen Shot 2021-02-05 at 12 57 58 PM" src="https://user-images.githubusercontent.com/458784/107088649-20610180-67b2-11eb-8790-89eb4dc44761.png"> |
| invalid state (9 letters) | <img width="681" alt="Screen Shot 2021-02-05 at 12 57 32 PM" src="https://user-images.githubusercontent.com/458784/107088675-2ce55a00-67b2-11eb-9f08-fc7204cedeb8.png"> |


