### PR TITLE
LG-4105: Log analytics events for skipped upload step

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -196,6 +196,9 @@ Layout/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
 Style/PercentLiteralDelimiters:
   # Specify the default preferred delimiter for all types with the 'default' key
   # Override individual delimiters (even with default specified) by specifying

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -27,7 +27,7 @@ module Idv
     end
 
     def update_if_skipping_upload
-      return unless params[:step] == 'upload' && flow_session&.[](:skip_upload_step)
+      return if params[:step] != 'upload' || !flow_session || !flow_session[:skip_upload_step]
       track_step_visited
       update
     end

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -9,6 +9,8 @@ module Idv
     include IdvSession # remove if we retire the non docauth LOA3 flow
     include Flow::FlowStateMachine
 
+    before_action :update_if_skipping_upload
+
     FSM_SETTINGS = {
       step_url: :idv_doc_auth_step_url,
       final_url: :idv_review_url,
@@ -22,6 +24,12 @@ module Idv
 
     def redirect_if_pending_profile
       redirect_to verify_account_url if current_user.decorate.pending_profile_requires_verification?
+    end
+
+    def update_if_skipping_upload
+      return unless params[:step] == 'upload' && flow_session&.[](:skip_upload_step)
+      track_step_visited
+      update
     end
 
     def extend_timeout_using_meta_refresh_for_select_paths

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -14,11 +14,8 @@ module Flow
     end
 
     def show
-      step = current_step
-      analytics.track_event(analytics_visited, analytics_properties) if @analytics_id
-      Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(step, :view, true)
-      register_campaign
-      render_step(step, flow.flow_session)
+      track_step_visited
+      render_step(current_step, flow.flow_session)
     end
 
     def update
@@ -44,6 +41,12 @@ module Flow
 
     def current_step
       params[:step]&.underscore
+    end
+
+    def track_step_visited
+      analytics.track_event(analytics_visited, analytics_properties) if @analytics_id
+      Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(current_step, :view, true)
+      register_campaign
     end
 
     def register_campaign

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -19,6 +19,7 @@ module Idv
       private
 
       def skip_to_capture
+        # See: Idv::DocAuthController#update_if_skipping_upload
         flow_session[:skip_upload_step] = true
       end
 

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -19,18 +19,7 @@ module Idv
       private
 
       def skip_to_capture
-        # For funnel integrity, log upload step as completed.
-        @flow.analytics.track_event("#{Analytics::DOC_AUTH} visited", step: 'upload', step_count: 1)
-        @flow.analytics.track_event(
-          "#{Analytics::DOC_AUTH} submitted", step: 'upload', step_count: 1, success: true
-        )
-        Funnel::DocAuth::RegisterStep.new(user_id, sp_session[:issuer]).call(:upload, :view, true)
-
-        # Skips to `document_capture` step.
-        mark_step_complete(:upload)
-        mark_step_complete(:send_link)
-        mark_step_complete(:link_sent)
-        mark_step_complete(:email_sent)
+        flow_session[:skip_upload_step] = true
       end
 
       def no_camera_redirect

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -19,7 +19,11 @@ module Idv
       private
 
       def skip_to_capture
-        # For funnel integrity, log upload step as visited.
+        # For funnel integrity, log upload step as completed.
+        @flow.analytics.track_event("#{Analytics::DOC_AUTH} visited", step: 'upload', step_count: 1)
+        @flow.analytics.track_event(
+          "#{Analytics::DOC_AUTH} submitted", step: 'upload', step_count: 1, success: true
+        )
         Funnel::DocAuth::RegisterStep.new(user_id, sp_session[:issuer]).call(:upload, :view, true)
 
         # Skips to `document_capture` step.

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -139,32 +139,6 @@ describe Idv::DocAuthController do
       expect(response).to redirect_to idv_doc_auth_step_url(step: :upload)
     end
 
-    context 'skipping upload step' do
-      before do
-        user = create(:user, :signed_up)
-        stub_sign_in(user)
-        DocAuthLog.create(user_id: user.id)
-        put :update, params: { step: 'welcome', ial2_consent_given: true, skip_upload: true }
-      end
-
-      it 'progresses to document capture' do
-        expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
-      end
-
-      it 'logs analytics for upload step' do
-        log = DocAuthLog.last
-        expect(log.upload_view_count).to eq 1
-        expect(log.upload_view_at).not_to be_nil
-
-        expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::DOC_AUTH + ' visited', step: 'upload', step_count: 1
-        )
-        expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::DOC_AUTH + ' submitted', step: 'upload', step_count: 1, success: true
-        )
-      end
-    end
-
     it 'redirects from welcome to no camera error' do
       result = {
         success: false,

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -151,10 +151,17 @@ describe Idv::DocAuthController do
         expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
       end
 
-      it 'logs funnel events for upload step' do
+      it 'logs analytics for upload step' do
         log = DocAuthLog.last
         expect(log.upload_view_count).to eq 1
         expect(log.upload_view_at).not_to be_nil
+
+        expect(@analytics).to have_received(:track_event).ordered.with(
+          Analytics::DOC_AUTH + ' visited', step: 'upload', step_count: 1
+        )
+        expect(@analytics).to have_received(:track_event).ordered.with(
+          Analytics::DOC_AUTH + ' submitted', step: 'upload', step_count: 1, success: true
+        )
       end
     end
 

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -38,7 +38,7 @@ feature 'doc auth welcome step' do
 
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_welcome_step
-      find('label', :text => /^By checking this box/).click
+      find('label', text: /^By checking this box/).click
       click_continue
     end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -19,12 +19,17 @@ Capybara.javascript_driver = :headless_chrome
 Webdrivers.cache_time = 86_400
 
 Capybara.register_driver(:headless_chrome_mobile) do |app|
+  user_agent_string = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) ' \
+                      'AppleWebKit/537.36 (KHTML, like Gecko) ' \
+                      'HeadlessChrome/88.0.4324.150 Safari/537.36'
+
   browser_options = Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--no-sandbox'
   browser_options.args << '--disable-dev-shm-usage'
   browser_options.args << '--window-size=414,736'
+  browser_options.args << "--user-agent='#{user_agent_string}'"
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,6 +30,7 @@ Capybara.register_driver(:headless_chrome_mobile) do |app|
   browser_options.args << '--disable-dev-shm-usage'
   browser_options.args << '--window-size=414,736'
   browser_options.args << "--user-agent='#{user_agent_string}'"
+  browser_options.args << '--use-fake-device-for-media-stream'
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -79,6 +79,8 @@ module DocAuthHelper
 
   def complete_doc_auth_steps_before_document_capture_step(expect_accessible: false)
     complete_doc_auth_steps_before_upload_step(expect_accessible: expect_accessible)
+    # JavaScript-enabled mobile devices will skip directly to document capture, so stop as complete.
+    return if page.current_path == idv_doc_auth_document_capture_step
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
     click_on t('doc_auth.info.upload_computer_link')
   end


### PR DESCRIPTION
This is an follow-up (amendment) to: #4625

This pull request ensures that we're logging analytics events for having visited and submitted the upload step when skipping it in the mobile-user flow.

In #4625, skipping the upload step was modified to also update the funnel database entry to reflect that the step was viewed. After further discussion with @amathews-fs who'd hoped to use this data for constructing a CloudWatch-based dashboard, we discovered that this is only one of two pieces of logging data, the other occurring alongside the funnel logging in `FlowStateMachine::show`:

https://github.com/18F/identity-idp/blob/444dff5722fbbb488e42cf3dcb33ba1194862e3f/app/services/flow/flow_state_machine.rb#L18-L19

**Implementation Notes:**

There are two commits, each of which approach this from a different angle:

- fcb484d is a more simplistic implementation, following the precedent to effectively emulate the same logging that occurs in a traditional view / submit.
- a25e9a2 is more involved, but takes the approach of actually triggering the logic associated with a view / submit, to avoid needing to reimplement logging behaviors.

The latter is most recent and is currently what's proposed here, though I have no strong attachment to it if the simpler option would be sufficient.