### PR TITLE
Improve test reliability by waiting for spinner buttons in test button helper

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -41,9 +41,9 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
 
-      expect(page).to have_current_path(idv_review_path, wait: 5)
+      expect(page).to have_current_path(idv_review_path)
       expect(page).to be_accessible.according_to :section508, :"best-practice"
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -53,7 +53,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -67,7 +67,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -81,7 +81,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
-      click_idv_continue(wait: true)
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -20,7 +20,7 @@ feature 'doc auth ssn step' do
     it 'proceeds to the next page with valid info', js: true do
       fill_out_ssn_form_ok
       expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('false')
-      click_idv_continue(wait: true)
+      click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_verify_step)
     end

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -21,11 +21,9 @@ feature 'idv phone step' do
       complete_idv_steps_before_phone_step(user)
       fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)
 
-      expect(page).to have_selector('.spinner-button')
       click_idv_continue
-      expect(page).to have_selector('.spinner-button--spinner-active')
 
-      expect(page).to have_content(t('idv.titles.session.review'), wait: 1)
+      expect(page).to have_content(t('idv.titles.session.review'))
       expect(page).to have_current_path(idv_review_path)
     end
 

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -44,9 +44,9 @@ feature 'Password recovery via personal key' do
     click_on t('links.account.reactivate.without_key')
     click_on t('forms.buttons.continue')
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: new_password
-    click_continue
+    click_idv_continue
     acknowledge_and_confirm_personal_key
     click_agree_and_continue
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -128,7 +128,10 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_all_doc_auth_steps(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
-    click_idv_continue(wait: true)
+    click_idv_continue
+    # In JavaScript contexts, a spinner is shown while verification is in-progress. The only
+    # reliable measure of completion is that the page eventually navigates away.
+    expect(page).to_not have_current_path(idv_doc_auth_verify_step, wait: 10)
   end
 
   def mock_doc_auth_no_name_pii(method)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -129,9 +129,6 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
     expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
     click_idv_continue
-    # In JavaScript contexts, a spinner is shown while verification is in-progress. The only
-    # reliable measure of completion is that the page eventually navigates away.
-    expect(page).to_not have_current_path(idv_doc_auth_verify_step, wait: 10)
   end
 
   def mock_doc_auth_no_name_pii(method)

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -30,10 +30,9 @@ module IdvHelper
   end
 
   def click_idv_continue
-    button = find_button(t('forms.buttons.continue'), match: :first)
-    button.click
+    click_on t('forms.buttons.continue'), match: :first
     # If button shows spinner when clicked, wait for it to finish.
-    expect(button).to have_no_ancestor('.spinner-button.spinner-button--spinner-active', wait: 10)
+    expect(page).to have_no_css('.spinner-button.spinner-button--spinner-active', wait: 10)
   end
 
   def choose_idv_otp_delivery_method_sms

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -29,10 +29,8 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: '(703) 555-5555'
   end
 
-  def click_idv_continue(wait: false)
-    url = current_path
+  def click_idv_continue
     click_on t('forms.buttons.continue'), match: :first
-    expect(page).to_not have_current_path(url, wait: 10) if wait
   end
 
   def choose_idv_otp_delivery_method_sms

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -30,7 +30,10 @@ module IdvHelper
   end
 
   def click_idv_continue
-    click_on t('forms.buttons.continue'), match: :first
+    button = find_button(t('forms.buttons.continue'), match: :first)
+    button.click
+    # If button shows spinner when clicked, wait for it to finish.
+    expect(button).to have_no_ancestor('.spinner-button.spinner-button--spinner-active', wait: 10)
   end
 
   def choose_idv_otp_delivery_method_sms


### PR DESCRIPTION
Previously: #4651

#4651 fixes a number of cases where clicking "Continue" in a JavaScript context on a few steps in the identity proofing flow could fail due to a race condition where the button triggers a spinner to be shown. I discovered in a failing build of #4650 that there are at least a couple other instance of this that will need to be updated as well ([example](https://github.com/18F/identity-idp/blob/444dff5722fbbb488e42cf3dcb33ba1194862e3f/spec/features/users/password_recovery_via_recovery_code_spec.rb#L46-L48)).

This pull request tries an alternative to an idea explored in #4651 to build this into the default behavior of `click_idv_button`, but rather than expecting the page to navigate, instead wait for the spinner to stop spinning (or disappear) if one exists.

I notice a bit of inconsistency in tests between using `click_continue` and `click_idv_continue` helpers, where they can typically be interchangeable except for the behavior implemented here. Not proposing anything at the moment, though ideally we could simplify this, or at least make it more obvious that `click_idv_continue` should be used exclusively in testing these flows.