### PR TITLE
Make sure Continue button doesn't get accidentally hidden (LG-4173)

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -30,3 +30,6 @@ linters:
           - 'btn-(small|big|narrow|transparent)'
           - 'border-(black|gray|white|aqua|orange|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
         suggestion: 'Use USWDS classes instead of BassCSS.'
+      - deprecated:
+          - 'js-consent-form'
+        suggestion: 'Rename classes that are known to be hidden by the Hush plugin'

--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,6 +1,6 @@
 import { hasCamera, isCameraCapableMobile } from '@18f/identity-device';
 
-const form = document.querySelector('.js-consent-form');
+const form = document.querySelector('.js-consent-continue-form');
 
 if (form && isCameraCapableMobile()) {
   (async () => {

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -92,7 +92,7 @@
   <%= validated_form_for :doc_auth,
                          url: url_for,
                          method: 'put',
-                         html: { autocomplete: 'off', role: 'form', class: 'margin-top-2 js-consent-form' } do |f| %>
+                         html: { autocomplete: 'off', role: 'form', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
     <br/>
     <label class="margin-top-neg-1 margin-bottom-4" for="ial2_consent_given">
       <div class="checkbox">

--- a/spec/support/deprecated_classes.rb
+++ b/spec/support/deprecated_classes.rb
@@ -10,7 +10,7 @@ class ActionView::Helpers::TagHelper::TagBuilder
 
   def modified_tag_option(key, value, *rest)
     original_result = original_tag_option(key, value, *rest)
-    return original_result unless [:class, 'class'].include?(key)
+    return original_result unless key.to_s == 'class'
     attribute, classes = original_result.split('=')
     classes = classes.tr('"', '').split(/ +/)
     regex = self.class.deprecated_classes.find { |r| classes.any? { |c| r =~ c } }

--- a/spec/support/deprecated_classes.rb
+++ b/spec/support/deprecated_classes.rb
@@ -10,7 +10,7 @@ class ActionView::Helpers::TagHelper::TagBuilder
 
   def modified_tag_option(key, value, *rest)
     original_result = original_tag_option(key, value, *rest)
-    return original_result unless key == :class
+    return original_result unless [:class, 'class'].include?(key)
     attribute, classes = original_result.split('=')
     classes = classes.tr('"', '').split(/ +/)
     regex = self.class.deprecated_classes.find { |r| classes.any? { |c| r =~ c } }


### PR DESCRIPTION
By the Hush plugin: https://oblador.github.io/hush/

I think it would probably be overkill to add their source to our ERBlint... but it's something we can consider if this happens again: https://github.com/oblador/hush/blob/master/data/vendor/fanboy-cookiemonster.txt#L11309
