### PR TITLE
Log trace_id in events.log and production.log (LG-4174)

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -45,6 +45,7 @@ class Analytics
       hostname: request.host,
       pid: Process.pid,
       service_provider: sp,
+      trace_id: request.headers['X-Amzn-Trace-Id'],
     }.merge!(browser_attributes)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,8 @@ module Upaya
       event.payload[:timestamp] = Time.zone.now.iso8601
       event.payload[:uuid] = SecureRandom.uuid
       event.payload[:pid] = Process.pid
-      event.payload.except(:params, :headers)
+      event.payload[:trace_id] = event.payload[:headers]['X-Amzn-Trace-Id']
+      event.payload.except(:params, :headers, :request, :response)
     end
 
     # Use a custom log formatter to get timestamp

--- a/spec/config/lograge_spec.rb
+++ b/spec/config/lograge_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'lograge' do
+  describe 'custom payload' do
+    let(:event) do
+      ActiveSupport::Notifications::Event.new(
+        'process_action.action_controller',
+        start,
+        finish,
+        transaction_id,
+        controller: 'Users::SessionsController',
+        action: 'new',
+        request: FakeRequest.new(headers: headers),
+        params: { foo: 'bar' },
+        headers: headers,
+        path: '/',
+        response: instance_double(ActionDispatch::Response),
+      )
+    end
+
+    let(:start) { Time.zone.now }
+    let(:finish) { Time.zone.now }
+    let(:transaction_id) { SecureRandom.uuid }
+    let(:amzn_trace_id) { SecureRandom.hex }
+    let(:headers) do
+      { 'X-Amzn-Trace-Id' => amzn_trace_id }
+    end
+
+    let(:now) { Time.zone.now }
+
+    it 'adds in timestamp, uuid, and pid, trace_id and omits extra noise' do
+      payload = Timecop.freeze(now) do
+        Rails.application.config.lograge.custom_options.call(event)
+      end
+
+      expect(payload).to_not include(:params, :headers, :request, :response)
+
+      expect(payload).to match(
+        timestamp: now.iso8601,
+        uuid: /\A[0-9a-f-]+\Z/, # rough UUID regex
+        pid: Process.pid,
+        controller: 'Users::SessionsController',
+        action: 'new',
+        path: '/',
+        trace_id: amzn_trace_id,
+      )
+    end
+  end
+end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -19,23 +19,22 @@ describe Analytics do
   end
 
   let(:ahoy) { instance_double(FakeAhoyTracker) }
+  let(:current_user) { build_stubbed(:user, uuid: '123') }
 
-  before { allow(FakeAhoyTracker).to receive(:new).and_return(ahoy) }
+  subject(:analytics) do
+    Analytics.new(
+      user: current_user,
+      request: FakeRequest.new,
+      sp: 'http://localhost:3000',
+      ahoy: ahoy,
+    )
+  end
 
   describe '#track_event' do
     it 'identifies the user and sends the event to the backend' do
-      user = build_stubbed(:user, uuid: '123')
-
-      analytics = Analytics.new(
-        user: user,
-        request: FakeRequest.new,
-        sp: 'http://localhost:3000',
-        ahoy: ahoy,
-      )
-
       analytics_hash = {
         event_properties: {},
-        user_id: user.uuid,
+        user_id: current_user.uuid,
       }
 
       expect(ahoy).to receive(:track).
@@ -47,13 +46,6 @@ describe Analytics do
     it 'tracks the user passed in to the track_event method' do
       current_user = build_stubbed(:user, uuid: '123')
       tracked_user = build_stubbed(:user, uuid: '456')
-
-      analytics = Analytics.new(
-        user: current_user,
-        request: FakeRequest.new,
-        sp: 'http://localhost:3000',
-        ahoy: ahoy,
-      )
 
       analytics_hash = {
         event_properties: {},

--- a/spec/support/fake_request.rb
+++ b/spec/support/fake_request.rb
@@ -1,4 +1,10 @@
 class FakeRequest
+  attr_reader :headers
+
+  def initialize(headers: {})
+    @headers = headers
+  end
+
   def remote_ip
     '127.0.0.1'
   end
@@ -9,10 +15,6 @@ class FakeRequest
 
   def host
     'fake_host'
-  end
-
-  def headers
-    'fake_headers'
   end
 
   def cookies


### PR DESCRIPTION
* Also removes some `request` and `response` noise from `production.log`
* Adds specs for lograge payload formatter