### PR TITLE
Apply custom responsive padding only at corresponding viewport

### DIFF
--- a/app/assets/stylesheets/components/_space-addon.scss
+++ b/app/assets/stylesheets/components/_space-addon.scss
@@ -1,5 +1,7 @@
 .tablet\:padding-x-10 {
-  @include u-padding-x(10);
+  @include at-media(tablet) {
+    @include u-padding-x(10);
+  }
 }
 
 .margin-top-neg-3 {


### PR DESCRIPTION
Regression introduced in: #4650

**Why**: So that excessive padding doesn't occur unintentionally at smaller viewports.

Whitespace utilities prefixed with viewport tags are expected to have those utilities apply only at that viewport size.

A custom class `tablet:padding-x-10` was included in #4650 since there was direct equivalent to BassCSS's `sm-px6`, but it was mistakenly not qualified for viewport sizes in how it applied.

Before|After
---|---
![Screen Shot 2021-02-09 at 8 25 28 AM](https://user-images.githubusercontent.com/1779930/107370703-53a4d880-6ab1-11eb-8a9b-55a2277ea1bd.png)|![Screen Shot 2021-02-09 at 8 25 11 AM](https://user-images.githubusercontent.com/1779930/107370710-56073280-6ab1-11eb-9d14-6c836261d6f6.png)
