### PR TITLE
POC: Switch PIV/CAC workflow from 302s to AJAX

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -14,10 +14,16 @@ module Users
 
     def redirect_to_piv_cac_service
       create_piv_cac_nonce
-      redirect_to PivCacService.piv_cac_service_link(
-        nonce: piv_cac_nonce,
-        redirect_uri: login_piv_cac_url,
+      url = PivCacService.piv_cac_service_link(
+          nonce: piv_cac_nonce,
+          redirect_uri: login_piv_cac_url,
       )
+      respond_to do |format|
+        format.html { redirect_to url }
+        format.json do
+          render json: { redirect_to: url }.to_json, status: :ok
+        end
+      end
     end
 
     def account_not_found; end

--- a/app/javascript/packs/piv-cac-button.js
+++ b/app/javascript/packs/piv-cac-button.js
@@ -1,0 +1,111 @@
+/**
+ * @typedef PivCacButtonElements
+ *
+ * @prop {HTMLDivElement} wrapper
+ * @prop {HTMLButtonElement|HTMLInputElement|HTMLLinkElement} button
+ * @prop {HTMLDivElement?} actionMessage
+ */
+
+/**
+ * @typedef PivCacButtonOptions
+ *
+ * @prop {number} longWaitDurationMs
+ */
+
+/** @type {PivCacButtonOptions} */
+const DEFAULT_OPTIONS = {
+  longWaitDurationMs: 15000,
+};
+
+export class PivCacButton {
+  constructor(wrapper) {
+    /** @type {PivCacButtonElements} */
+    this.elements = {
+      wrapper,
+      button: wrapper.querySelector('a,button:not([type]),[type="submit"],[type="button"]'),
+      actionMessage: wrapper.querySelector('.piv-cac-button__action-message'),
+    };
+
+    this.options = {
+      ...DEFAULT_OPTIONS,
+      ...this.elements.wrapper.dataset,
+    };
+
+    this.options.longWaitDurationMs = Number(this.options.longWaitDurationMs);
+  }
+
+  bind() {
+    this.elements.button.addEventListener('click', (e) => {
+      e.preventDefault();
+      this.toggleSpinner(true);
+
+      console.log('Handling PIV/CAC redirects in the background');
+
+      window
+        .fetch(`${this.elements.button.href}.json`)
+        .then((response) => {
+          console.log(`Handling IdP response with status ${response.status}`);
+          return response.json();
+        })
+        .then((data) => {
+          console.log(`Redirecting to ${data.redirect_to}`);
+          return window.fetch(`${data.redirect_to}&format=json`);
+        })
+        .then((response) => {
+          console.log(`Handling pivcac response with status ${response.status}`);
+          return response.json();
+        })
+        .then((data) => {
+          console.log(`Redirecting to ${data.redirect_to}`);
+
+          window.location.href = data.redirect_to;
+          return true;
+        })
+        .catch(() => {
+          console.log('Timed out or other error');
+          window.location.href = '/login/piv_cac_did_not_work';
+          return false;
+        });
+    });
+    this.elements.wrapper.addEventListener('spinner.start', () => this.toggleSpinner(true));
+    this.elements.wrapper.addEventListener('spinner.stop', () => this.toggleSpinner(false));
+  }
+
+  /**
+   * @param {boolean} isVisible
+   */
+  toggleSpinner(isVisible) {
+    const { wrapper, button, actionMessage } = this.elements;
+    wrapper.classList.toggle('piv-cac-button--spinner-active', isVisible);
+
+    // Avoid setting disabled immediately to allow click event to propagate for form submission.
+    setTimeout(() => {
+      if (isVisible) {
+        button.setAttribute('disabled', '');
+      } else {
+        button.removeAttribute('disabled');
+      }
+    }, 0);
+
+    if (actionMessage) {
+      actionMessage.textContent = isVisible
+        ? /** @type {string} */ (actionMessage.dataset.message)
+        : '';
+    }
+
+    window.clearTimeout(this.longWaitTimeout);
+    if (isVisible) {
+      this.longWaitTimeout = window.setTimeout(
+        () => this.handleLongWait(),
+        this.options.longWaitDurationMs,
+      );
+    }
+  }
+
+  handleLongWait() {
+    this.elements.actionMessage?.classList.remove('usa-sr-only');
+  }
+}
+
+const wrappers = Array.from(document.querySelectorAll('.piv-cac-button'));
+wrappers.forEach((wrapper) => new PivCacButton(wrapper).bind());

--- a/app/views/shared/_piv-cac-button.html.erb
+++ b/app/views/shared/_piv-cac-button.html.erb
@@ -1,0 +1,30 @@
+<%#
+yields: Button or link markup (required).
+locals:
+* action_message: Message describing the action being performed, shown visually to users when the
+                  animation has been active for a long time, and immediately to users of assistive
+                  technology.
+* class: Additional class names to add to alert wrapper.
+%>
+<%
+  content = yield.presence or raise "no block content given"
+  classes = ['piv-cac-button']
+  classes << local_assigns[:class] if local_assigns[:class]
+%>
+<%= tag.div class: classes do %>
+  <div class="piv-cac-button__content">
+    <%= content %>
+    <span class="piv-cac-button__spinner" aria-hidden="true">
+      <span class="piv-cac-button__spinner-dot"></span>
+      <span class="piv-cac-button__spinner-dot"></span>
+      <span class="piv-cac-button__spinner-dot"></span>
+    </span>
+  </div>
+  <% if local_assigns[:action_message] %>
+    <%= tag.div '',
+                role: 'status',
+                data: { message: action_message },
+                class: 'piv-cac-button__action-message usa-sr-only' %>
+  <% end %>
+<% end %>
+<% javascript_packs_tag_once 'piv-cac-button' %>

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -8,7 +8,7 @@
   <%= raw @presenter.info %>
 </p>
 
-<%= render 'shared/spinner-button' do %>
+<%= render 'shared/piv-cac-button' do %>
   <%= link_to @presenter.piv_cac_capture_text,
               @presenter.piv_cac_service_link,
               class: 'btn btn-primary' %>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,6 +9,9 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
+  if Rails.env.production?
+    connect_src << URI(AppConfig.env.piv_cac_service_url.gsub('{random}', '*')).host
+  end
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src


### PR DESCRIPTION
In order to mitigate issues with PIN entry delays leading to timeouts
and better manage the PIV/CAC request flow it might be advantageous to
use AJAX requests instead of normal redirects. This commit adds the
necessary JS as well as a JSON response to the `/login/present_piv_cac`
endpoint. It does NOT include tests and is not intended to be a long-
term solutions but rather is simply meant to demonstrate feasibility of
this approach.