### PR TITLE
Handle non-JSON contents from keepalive, ping endpoints (LG-4167)

### DIFF
--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -5,6 +5,7 @@ var timeoutUrl = "<%= j timeout_url %>";
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);
+var initialTime = new Date();
 
 var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
 var keepaliveEl = document.getElementById('session-keepalive-btn');
@@ -20,13 +21,28 @@ keepaliveEl.addEventListener('click', keepalive, false);
 var pingTimeout;
 var countdownInterval;
 
+function notifyNewRelic(error, actionName) {
+  if (typeof newrelic !== 'object') {
+    return;
+  }
+
+  newrelic.addPageAction('Session Auto Logout', {
+    duration_ms: new Date() - initialTime,
+    action_name: actionName,
+    error: error.message
+  });
+}
+
 function ping() {
   var request = new XMLHttpRequest();
   request.open('GET', '/active', true);
 
   request.onload = function() {
-    if (request.status >= 200 && request.status < 400) {
+    try {
       success(JSON.parse(request.responseText));
+    } catch (error) {
+      notifyNewRelic(error);
+      window.LoginGov.autoLogout(timeoutUrl, 'ping');
     }
   };
 
@@ -72,9 +88,12 @@ function keepalive() {
   request.setRequestHeader('X-CSRF-Token', csrfToken);
 
   request.onload = function() {
-    if (request.status >= 200 && request.status < 400) {
+    try {
       success(JSON.parse(request.responseText));
       modal.hide();
+    } catch (error) {
+      notifyNewRelic(error);
+      window.LoginGov.autoLogout(timeoutUrl, 'keepalive');
     }
   };
 

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -21,14 +21,15 @@ keepaliveEl.addEventListener('click', keepalive, false);
 var pingTimeout;
 var countdownInterval;
 
-function notifyNewRelic(error, actionName) {
+function notifyNewRelic(request, error, actionName) {
   if (typeof newrelic !== 'object') {
     return;
   }
 
   newrelic.addPageAction('Session Auto Logout', {
-    duration_ms: new Date() - initialTime,
     action_name: actionName,
+    request_status: request.status,
+    time_elapsed_ms: new Date() - initialTime,
     error: error.message
   });
 }
@@ -41,8 +42,7 @@ function ping() {
     try {
       success(JSON.parse(request.responseText));
     } catch (error) {
-      notifyNewRelic(error);
-      window.LoginGov.autoLogout(timeoutUrl, 'ping');
+      notifyNewRelic(request, error, 'ping');
     }
   };
 
@@ -92,8 +92,7 @@ function keepalive() {
       success(JSON.parse(request.responseText));
       modal.hide();
     } catch (error) {
-      notifyNewRelic(error);
-      window.LoginGov.autoLogout(timeoutUrl, 'keepalive');
+      notifyNewRelic(request, error, 'keepalive');
     }
   };
 

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -26,7 +26,7 @@ function notifyNewRelic(request, error, actionName) {
     return;
   }
 
-  newrelic.addPageAction('Session Auto Logout', {
+  newrelic.addPageAction('Session Ping Error', {
     action_name: actionName,
     request_status: request.status,
     time_elapsed_ms: new Date() - initialTime,


### PR DESCRIPTION
We're seeing a decent number of JSON parse errors in our NewRelic logging, this should handle that more gracefully

This is a big change in behavior, currently the code will essentially no-op when it gets a bad response from the server, this new behavior will force an autologout, which looks like this:

<img width="678" alt="Screen Shot 2021-02-12 at 11 24 20 AM" src="https://user-images.githubusercontent.com/458784/107813184-0d57af80-6d25-11eb-961a-403a0227e55d.png">


Since this could potentially force a premature autologout, I figured maybe we could at least start collecting notes on how long people had been on their page for (the `duration_ms` value), so if we see a lot of durations that are too small it's a hint that we need to fix another underlying problem?

Potentially we could also deploy this in "monitor-only" mode, where we just log what we see and not implement autologout just yet

