### PR TITLE
Run local Lambda functions as thread with POSTed result

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -18,11 +18,7 @@ module Idv
           dob_year_only: AppConfig.env.proofing_send_partial_dob == 'true',
           trace_id: trace_id,
         },
-      ).run do |idv_result|
-        document_capture_session.store_proofing_result(idv_result[:resolution_result])
-
-        nil
-      end
+      ).run
     end
 
     def proof_address(document_capture_session, trace_id:)
@@ -33,11 +29,7 @@ module Idv
       LambdaJobs::Runner.new(
         job_class: Idv::Proofer.address_job_class,
         args: { applicant_pii: @applicant, callback_url: callback_url, trace_id: trace_id },
-      ).run do |idv_result|
-        document_capture_session.store_proofing_result(idv_result[:address_result])
-
-        nil
-      end
+      ).run
     end
 
     private

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -18,7 +18,11 @@ module Idv
           dob_year_only: AppConfig.env.proofing_send_partial_dob == 'true',
           trace_id: trace_id,
         },
-      ).run
+      ).run do |idv_result|
+        document_capture_session.store_proofing_result(idv_result[:resolution_result])
+
+        nil
+      end
     end
 
     def proof_address(document_capture_session, trace_id:)
@@ -29,7 +33,11 @@ module Idv
       LambdaJobs::Runner.new(
         job_class: Idv::Proofer.address_job_class,
         args: { applicant_pii: @applicant, callback_url: callback_url, trace_id: trace_id },
-      ).run
+      ).run do |idv_result|
+        document_capture_session.store_proofing_result(idv_result[:address_result])
+
+        nil
+      end
     end
 
     private

--- a/app/services/lambda_jobs/runner.rb
+++ b/app/services/lambda_jobs/runner.rb
@@ -19,7 +19,7 @@ module LambdaJobs
         )
       else
         Thread.new do
-          sleep AppConfig.env.aws_lambda_proofing_enabled.to_i
+          sleep AppConfig.env.aws_lambda_proofing_local_delay_in_seconds.to_i
 
           job_class.handle(
             event: args,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -45,6 +45,8 @@ available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
 aws_kms_multi_region_enabled: 'false'
+aws_lambda_proofing_enabled: 'false'
+aws_lambda_proofing_local_delay_in_seconds: '0'
 cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 deleted_user_accounts_report_configs: '[]'
@@ -156,7 +158,7 @@ development:
   acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
-  address_proof_result_lambda_token: 123ABC
+  address_proof_result_lambda_token: ABC123
   attribute_cost: 4000$8$4$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
   attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111", "cost":


### PR DESCRIPTION
**Why**: To more realistically simulate how a lambda function result is communicated back to the IdP, to simplify by eliminating local_callback handling to reduce redundant code, and to allow developers the option to simulate a delayed function response by configuration value.

_Status:_ Kinda just putting this out there as a "Does this seem like something we want?", also because I needed to emulate a real delay in proofing results in local development (not currently possible?). Tests may fail. Not attached to it.