### PR TITLE
LG-4108: Assign analytics user for CaptureDocController (hybrid flow)

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -60,5 +60,9 @@ module Idv
     def document_capture_session_uuid
       params['document-capture-session']
     end
+
+    def analytics_user
+      user_id_from_token ? User.find(user_id_from_token) : super
+    end
   end
 end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -24,6 +24,17 @@ feature 'doc capture document capture step' do
     allow_any_instance_of(DeviceDetector).to receive(:device_type).and_return('mobile')
   end
 
+  it 'logs events as the inherited user' do
+    allow(Analytics).to receive(:new).and_return(fake_analytics)
+    expect(Analytics).to receive(:new).with(hash_including(user: user))
+    visit current_path
+
+    expect(fake_analytics).to have_logged_event(
+      Analytics::CAPTURE_DOC + ' visited',
+      step: 'document_capture',
+    )
+  end
+
   context 'when liveness checking is enabled' do
     let(:liveness_enabled) { 'true' }
 
@@ -91,8 +102,8 @@ feature 'doc capture document capture step' do
     end
 
     it 'proceeds to the next page with valid info and logs analytics info' do
-      allow_any_instance_of(ApplicationController).
-        to receive(:analytics).and_return(fake_analytics)
+      allow(Analytics).to receive(:new).and_return(fake_analytics)
+      expect(Analytics).to receive(:new).with(hash_including(user: user))
 
       attach_and_submit_images
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -2,10 +2,11 @@ class FakeAnalytics
   attr_reader :events
 
   def initialize
-    @events = Hash.new { |hash, key| hash[key] = [] }
+    @events = Hash.new
   end
 
   def track_event(event, attributes = {})
+    events[event] ||= []
     events[event] << attributes
     nil
   end


### PR DESCRIPTION
**Why**: So that events logged during hybrid flow are associated with the user who had initiated the document capture session.

**Implementation Notes:**

Extends [`ApplicationController#analytics_user`](https://github.com/18F/identity-idp/blob/7e851cbd7d1c41f9e5059b3819eab19e13a2a00c/app/controllers/application_controller.rb#L57-L59) using [`FlowStateMachine#user_id_from_token`](https://github.com/18F/identity-idp/blob/7e851cbd7d1c41f9e5059b3819eab19e13a2a00c/app/services/flow/flow_state_machine.rb#L60-L62) to be picked up via [`ApplicationController#analytics`](https://github.com/18F/identity-idp/blob/7e851cbd7d1c41f9e5059b3819eab19e13a2a00c/app/controllers/application_controller.rb#L52-L55) for calls to `analytics.track_event`.