### PR TITLE
LG-4148: Add frontend logging for document capture image manual upload (Redo)

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -1,0 +1,15 @@
+module Idv
+  module DocumentCaptureConcern
+    def override_document_capture_step_csp
+      return if params[:step] != 'document_capture'
+
+      SecureHeaders.append_content_security_policy_directives(
+        request,
+        # required to run wasm until wasm-eval is available
+        script_src: ['\'unsafe-eval\''],
+        # required for retrieving image dimensions from uploaded images
+        img_src: ['blob:'],
+      )
+    end
+  end
+end

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -1,9 +1,11 @@
 module Idv
   class CaptureDocController < ApplicationController
     before_action :ensure_user_id_in_session
-    before_action :add_unsafe_eval_to_capture_steps
 
     include Flow::FlowStateMachine
+    include Idv::DocumentCaptureConcern
+
+    before_action :override_document_capture_step_csp
 
     FSM_SETTINGS = {
       step_url: :idv_capture_doc_step_url,
@@ -23,16 +25,6 @@ module Idv
 
       analytics.track_event(FSM_SETTINGS[:analytics_id], result.to_h)
       process_result(result)
-    end
-
-    def add_unsafe_eval_to_capture_steps
-      return unless current_step == 'document_capture'
-
-      # required to run wasm until wasm-eval is available
-      SecureHeaders.append_content_security_policy_directives(
-        request,
-        script_src: ['\'unsafe-eval\''],
-      )
     end
 
     def process_result(result)

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -4,11 +4,12 @@ module Idv
     before_action :redirect_if_mail_bounced
     before_action :redirect_if_pending_profile
     before_action :extend_timeout_using_meta_refresh_for_select_paths
-    before_action :add_unsafe_eval_to_capture_steps
 
     include IdvSession # remove if we retire the non docauth LOA3 flow
     include Flow::FlowStateMachine
+    include Idv::DocumentCaptureConcern
 
+    before_action :override_document_capture_step_csp
     before_action :update_if_skipping_upload
 
     FSM_SETTINGS = {
@@ -48,16 +49,6 @@ module Idv
 
     def flow_session
       user_session['idv/doc_auth']
-    end
-
-    def add_unsafe_eval_to_capture_steps
-      return unless params[:step] == 'document_capture'
-
-      # required to run wasm until wasm-eval is available
-      SecureHeaders.append_content_security_policy_directives(
-        request,
-        script_src: ['\'unsafe-eval\''],
-      )
     end
   end
 end

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -32,14 +32,14 @@ import './acuant-capture.scss';
  */
 
 /**
- * @typedef {"acuant"} ImageSource
+ * @typedef {"acuant"|"upload"} ImageSource
  */
 
 /**
  * @typedef ImageAnalyticsPayload
  *
- * @prop {number} width
- * @prop {number} height
+ * @prop {number?} width Image width, or null if unknown.
+ * @prop {number?} height Image height, or null if unknown.
  * @prop {string?} mimeType Mime type, or null if unknown.
  * @prop {ImageSource} source Method by which image was added.
  */
@@ -126,6 +126,27 @@ function getDocumentTypeLabel(documentType) {
 }
 
 /**
+ * @param {File} file Image file.
+ *
+ * @return {Promise<{width: number?, height: number?}>}
+ */
+export function getImageDimensions(file) {
+  let objectURL;
+  return file.type.indexOf('image/') === 0
+    ? new Promise((resolve) => {
+        objectURL = window.URL.createObjectURL(file);
+        const image = new window.Image();
+        image.onload = () => resolve({ width: image.width, height: image.height });
+        image.onerror = () => resolve({ width: null, height: null });
+        image.src = objectURL;
+      }).then(({ width, height }) => {
+        window.URL.revokeObjectURL(objectURL);
+        return { width, height };
+      })
+    : Promise.resolve({ width: null, height: null });
+}
+
+/**
  * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK
  * in supported devices.
  *
@@ -175,6 +196,32 @@ function AcuantCapture(
   function onChangeAndResetError(nextValue) {
     setOwnErrorMessage(null);
     onChange(nextValue);
+  }
+
+  /**
+   * Handler for file input change events.
+   *
+   * @param {File?} nextValue Next value, if set.
+   */
+  function onUpload(nextValue) {
+    if (nextValue) {
+      getImageDimensions(nextValue).then(({ width, height }) => {
+        /** @type {ImageAnalyticsPayload} */
+        const analyticsPayload = {
+          width,
+          height,
+          mimeType: nextValue.type,
+          source: 'upload',
+        };
+
+        addPageAction({
+          label: `IdV: ${analyticsPrefix} added`,
+          payload: analyticsPayload,
+        });
+      });
+    }
+
+    onChangeAndResetError(nextValue);
   }
 
   /**
@@ -309,7 +356,7 @@ function AcuantCapture(
         value={value}
         errorMessage={ownErrorMessage ?? errorMessage}
         onClick={startCaptureOrTriggerUpload}
-        onChange={onChangeAndResetError}
+        onChange={onUpload}
         onError={() => setOwnErrorMessage(null)}
       />
       <div className="margin-top-2">

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -130,7 +130,7 @@ function getDocumentTypeLabel(documentType) {
  *
  * @return {Promise<{width: number?, height: number?}>}
  */
-export function getImageDimensions(file) {
+function getImageDimensions(file) {
   let objectURL;
   return file.type.indexOf('image/') === 0
     ? new Promise((resolve) => {

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -23,7 +23,7 @@ import usePrevious from '../hooks/use-previous';
  * @prop {Blob|string|null|undefined} value Current value.
  * @prop {ReactNode=} errorMessage Error to show.
  * @prop {(event:ReactMouseEvent)=>void=} onClick Input click handler.
- * @prop {(nextValue:Blob?)=>void=} onChange Input change handler.
+ * @prop {(nextValue:File?)=>void=} onChange Input change handler.
  * @prop {(message:ReactNode)=>void=} onError Callback to trigger if upload error occurs.
  */
 

--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -5,7 +5,7 @@ import { createContext } from 'react';
 /**
  * @typedef PageAction
  *
- * @property {string} key Short, camel-cased, dot-namespaced key describing event.
+ * @property {string=} key Short, camel-cased, dot-namespaced key describing event.
  * @property {string} label Long-form, human-readable label describing event action.
  * @property {Payload} payload Additional payload arguments to log with action.
  */

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -98,7 +98,10 @@ const device = {
 
 /** @type {import('@18f/identity-document-capture/context/analytics').AddPageAction} */
 function addPageAction(action) {
-  /** @type {DocumentCaptureGlobal} */ (window).newrelic?.addPageAction(action.key, action.payload);
+  const { newrelic } = /** @type {DocumentCaptureGlobal} */ (window);
+  if (action.key && newrelic) {
+    newrelic.addPageAction(action.key, action.payload);
+  }
 
   window.fetch(logEndpoint, {
     method: 'POST',

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@testing-library/user-event": "^12.6.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "canvas": "^2.6.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "eslint": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@testing-library/user-event": "^12.6.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "canvas": "^2.6.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "eslint": "^7.16.0",

--- a/spec/controllers/concerns/idv/document_capture_concern_spec.rb
+++ b/spec/controllers/concerns/idv/document_capture_concern_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Idv::DocumentCaptureConcern, type: :controller do
+  controller ApplicationController do
+    include Idv::DocumentCaptureConcern
+
+    before_action :override_document_capture_step_csp
+
+    def index; end
+  end
+
+  describe '#override_document_capture_step_csp' do
+    it 'sets the headers for the document capture step' do
+      get :index, params: { step: 'document_capture' }
+
+      csp = response.request.headers.env['secure_headers_request_config'].csp
+      expect(csp.script_src).to include("'unsafe-eval'")
+      expect(csp.img_src).to include('blob:')
+    end
+
+    it 'does not set headers for any other step' do
+      get :index, params: { step: 'some_other_step' }
+
+      secure_header_config = response.request.headers.env['secure_headers_request_config']
+      expect(secure_header_config).to be_nil
+    end
+  end
+end

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -123,27 +123,6 @@ describe Idv::CaptureDocController do
           hash_including(step: 'capture_complete', step_count: 2),
         )
       end
-
-      it 'add unsafe-eval to the CSP for capture steps' do
-        steps = %i[document_capture]
-        steps.each do |step|
-          mock_next_step(step)
-
-          get :show, params: { step: step }
-
-          script_src = response.request.headers.env['secure_headers_request_config'].csp.script_src
-          expect(script_src).to include("'unsafe-eval'")
-        end
-      end
-
-      it 'does not add unsafe-eval to the CSP for non-capture steps' do
-        mock_next_step(:capture_complete)
-
-        get :show, params: { step: 'capture_complete' }
-
-        secure_header_config = response.request.headers.env['secure_headers_request_config']
-        expect(secure_header_config).to be_nil
-      end
     end
   end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -82,24 +82,6 @@ describe Idv::DocAuthController do
         Analytics::DOC_AUTH + ' visited', hash_including(step: 'welcome', step_count: 2)
       )
     end
-
-    it 'add unsafe-eval to the CSP for the doucment capture step' do
-      mock_next_step(:document_capture)
-
-      get :show, params: { step: :document_capture }
-
-      script_src = response.request.headers.env['secure_headers_request_config'].csp.script_src
-      expect(script_src).to include("'unsafe-eval'")
-    end
-
-    it 'does not add unsafe-eval to the CSP for non-capture steps' do
-      mock_next_step(:ssn)
-
-      get :show, params: { step: 'ssn' }
-
-      secure_header_config = response.request.headers.env['secure_headers_request_config']
-      expect(secure_header_config).to be_nil
-    end
   end
 
   describe '#update' do

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -5,14 +5,12 @@ import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import AcuantCapture, {
   ACCEPTABLE_GLARE_SCORE,
   ACCEPTABLE_SHARPNESS_SCORE,
-  getImageDimensions,
 } from '@18f/identity-document-capture/components/acuant-capture';
 import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import I18nContext from '@18f/identity-document-capture/context/i18n';
 import { render, useAcuant } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
-import useDefineProperty from '../../../support/define-property';
 
 const ACUANT_CAPTURE_SUCCESS_RESULT = {
   image: {
@@ -38,41 +36,10 @@ const ACUANT_CAPTURE_BLURRY_RESULT = {
 
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
-  const defineProperty = useDefineProperty();
 
   let validUpload;
   before(async () => {
     validUpload = await getFixtureFile('doc_auth_images/id-back.jpg');
-  });
-
-  describe('getImageDimensions', () => {
-    it('returns null properties if file is not image', async () => {
-      const file = await getFixtureFile('agencies.yml');
-      const dimensions = await getImageDimensions(file);
-
-      expect(dimensions.width).to.be.null();
-      expect(dimensions.height).to.be.null();
-    });
-
-    it('returns null properties if image cannot be loaded', async () => {
-      // Force image loading to error.
-      defineProperty(window.Image.prototype, 'src', {
-        set() {
-          this.onerror();
-        },
-      });
-      const dimensions = await getImageDimensions(validUpload);
-
-      expect(dimensions.width).to.be.null();
-      expect(dimensions.height).to.be.null();
-    });
-
-    it('returns image dimensions', async () => {
-      const dimensions = await getImageDimensions(validUpload);
-
-      expect(dimensions.width).to.be.a('number');
-      expect(dimensions.height).to.be.a('number');
-    });
   });
 
   context('mobile', () => {
@@ -706,10 +673,10 @@ describe('document-capture/components/acuant-capture', () => {
     expect(addPageAction).to.have.been.calledWith({
       label: 'IdV: image added',
       payload: {
-        height: 700,
+        height: sinon.match.number,
         mimeType: 'image/jpeg',
         source: 'upload',
-        width: 1070,
+        width: sinon.match.number,
       },
     });
   });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -5,11 +5,14 @@ import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import AcuantCapture, {
   ACCEPTABLE_GLARE_SCORE,
   ACCEPTABLE_SHARPNESS_SCORE,
+  getImageDimensions,
 } from '@18f/identity-document-capture/components/acuant-capture';
 import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import I18nContext from '@18f/identity-document-capture/context/i18n';
 import { render, useAcuant } from '../../../support/document-capture';
+import { getFixtureFile } from '../../../support/file';
+import useDefineProperty from '../../../support/define-property';
 
 const ACUANT_CAPTURE_SUCCESS_RESULT = {
   image: {
@@ -35,6 +38,42 @@ const ACUANT_CAPTURE_BLURRY_RESULT = {
 
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
+  const defineProperty = useDefineProperty();
+
+  let validUpload;
+  before(async () => {
+    validUpload = await getFixtureFile('doc_auth_images/id-back.jpg');
+  });
+
+  describe('getImageDimensions', () => {
+    it('returns null properties if file is not image', async () => {
+      const file = await getFixtureFile('agencies.yml');
+      const dimensions = await getImageDimensions(file);
+
+      expect(dimensions.width).to.be.null();
+      expect(dimensions.height).to.be.null();
+    });
+
+    it('returns null properties if image cannot be loaded', async () => {
+      // Force image loading to error.
+      defineProperty(window.Image.prototype, 'src', {
+        set() {
+          this.onerror();
+        },
+      });
+      const dimensions = await getImageDimensions(validUpload);
+
+      expect(dimensions.width).to.be.null();
+      expect(dimensions.height).to.be.null();
+    });
+
+    it('returns image dimensions', async () => {
+      const dimensions = await getImageDimensions(validUpload);
+
+      expect(dimensions.width).to.be.a('number');
+      expect(dimensions.height).to.be.a('number');
+    });
+  });
 
   context('mobile', () => {
     it('renders with assumed capture button support while acuant is not ready and on mobile', () => {
@@ -215,14 +254,12 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
     });
 
-    it('renders retry button when value and capture supported', () => {
+    it('renders retry button when value and capture supported', async () => {
+      const selfie = await getFixtureFile('doc_auth_images/selfie.jpg');
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
-            <AcuantCapture
-              label="Image"
-              value={new window.File([], 'image.svg', { type: 'image/svg+xml' })}
-            />
+            <AcuantCapture label="Image" value={selfie} />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
       );
@@ -237,23 +274,28 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('renders upload button when value and capture not supported', () => {
-      const { getByText } = render(
+      const onChange = sinon.spy();
+      const onClick = sinon.spy();
+      const { getByText, getByLabelText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
-            <AcuantCapture
-              label="Image"
-              value={new window.File([], 'image.svg', { type: 'image/svg+xml' })}
-            />
+            <AcuantCapture label="Image" onChange={onChange} />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
       );
 
       initialize({ isCameraSupported: false });
 
-      const button = getByText('doc_auth.buttons.upload_picture');
-      expect(button).to.be.ok();
+      const input = getByLabelText('Image');
 
-      userEvent.click(button);
+      // Since file input prompt occurs by button click proxy to input, we must fire upload event
+      // directly at the input. At least ensure that clicking button does "click" input.
+      input.addEventListener('click', onClick);
+      userEvent.click(getByText('doc_auth.buttons.upload_picture'));
+      expect(onClick).to.have.been.calledOnce();
+
+      userEvent.upload(input, validUpload);
+      expect(onChange).to.have.been.calledWith(validUpload);
     });
 
     it('renders error message if capture succeeds but photo glare exceeds threshold', async () => {
@@ -567,15 +609,12 @@ describe('document-capture/components/acuant-capture', () => {
     expect(container.firstChild.classList.contains('my-custom-class')).to.be.true();
   });
 
-  it('clears a selected value', () => {
+  it('clears a selected value', async () => {
+    const image = await getFixtureFile('doc_auth_images/id-front.jpg');
     const onChange = sinon.spy();
     const { getByLabelText } = render(
       <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture
-          label="Image"
-          value={new window.File([], 'image.svg', { type: 'image/svg+xml' })}
-          onChange={onChange}
-        />
+        <AcuantCapture label="Image" value={image} onChange={onChange} />
       </AcuantContextProvider>,
     );
 
@@ -644,5 +683,34 @@ describe('document-capture/components/acuant-capture', () => {
     const input = getByLabelText('Image');
 
     expect(input.getAttribute('accept')).to.equal('image/jpeg,image/png,image/bmp,image/tiff');
+  });
+
+  it('logs metrics for manual upload', async () => {
+    const addPageAction = sinon.mock();
+    const { getByLabelText } = render(
+      <AnalyticsContext.Provider value={{ addPageAction }}>
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" analyticsPrefix="image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>
+      </AnalyticsContext.Provider>,
+    );
+
+    initialize({ isCameraSupported: false });
+
+    const input = getByLabelText('Image');
+    userEvent.upload(input, validUpload);
+
+    await new Promise((resolve) => addPageAction.callsFake(resolve));
+    expect(addPageAction).to.have.been.calledWith({
+      label: 'IdV: image added',
+      payload: {
+        height: 700,
+        mimeType: 'image/jpeg',
+        source: 'upload',
+        width: 1070,
+      },
+    });
   });
 });

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -18,6 +18,7 @@ import DocumentCapture, {
 import { expect } from 'chai';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
 import { useSandbox } from '../../../support/sinon';
+import { getFixture, getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/document-capture', () => {
   const onSubmit = useDocumentCaptureForm();
@@ -29,6 +30,13 @@ describe('document-capture/components/document-capture', () => {
   }
 
   let originalHash;
+  let validUpload;
+  let validSelfieBase64;
+
+  before(async () => {
+    validUpload = await getFixtureFile('doc_auth_images/id-front.jpg');
+    validSelfieBase64 = await getFixture('doc_auth_images/selfie.jpg', 'base64');
+  });
 
   beforeEach(() => {
     originalHash = window.location.hash;
@@ -98,11 +106,11 @@ describe('document-capture/components/document-capture', () => {
         glare: 70,
         sharpness: 70,
         image: {
-          data: 'data:image/png;base64,',
+          data: validSelfieBase64,
         },
       });
     });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
     // Continue is enabled (but grayed out).Attempting to proceed without providing values will
     // trigger error messages.
@@ -118,7 +126,7 @@ describe('document-capture/components/document-capture', () => {
     // Providing values should remove errors progressively.
     fireEvent.change(getByLabelText('doc_auth.headings.document_capture_front'), {
       target: {
-        files: [new window.File([''], 'upload.png', { type: 'image/png' })],
+        files: [validUpload],
       },
     });
     await waitFor(() => expect(getAllByText('simple_form.required.text')).to.have.lengthOf(1));
@@ -179,19 +187,13 @@ describe('document-capture/components/document-capture', () => {
     );
 
     initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(continueButton);
 
@@ -251,19 +253,13 @@ describe('document-capture/components/document-capture', () => {
     );
 
     initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(continueButton);
 
@@ -294,14 +290,8 @@ describe('document-capture/components/document-capture', () => {
     // Submit button should be disabled until field errors are resolved.
     submitButton = getByText('forms.buttons.submit.default');
     expect(submitButton.classList.contains('btn-disabled')).to.be.true();
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
 
     // Once fields are changed, their notices should be cleared. If all field-specific errors are
     // addressed, submit should be enabled once more.
@@ -349,14 +339,8 @@ describe('document-capture/components/document-capture', () => {
       });
 
     initialize({ isCameraSupported: false });
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
 
     userEvent.click(getByText('forms.buttons.submit.default'));
     await waitFor(() => window.location.hash === '#teapot');
@@ -423,19 +407,13 @@ describe('document-capture/components/document-capture', () => {
     );
 
     initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(continueButton);
 
@@ -478,19 +456,13 @@ describe('document-capture/components/document-capture', () => {
     );
 
     initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_front'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_back'),
-      new window.File([''], 'upload.png', { type: 'image/png' }),
-    );
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(continueButton);
     expect(onStepChange.callCount).to.equal(1);

--- a/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
@@ -1,11 +1,15 @@
 import FileImage from '@18f/identity-document-capture/components/file-image';
 import { render } from '../../../support/document-capture';
+import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/file-image', () => {
+  let file;
+  before(async () => {
+    file = await getFixtureFile('doc_auth_images/id-back.jpg');
+  });
+
   it('renders span prior to load', () => {
-    const { container } = render(
-      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="image" />,
-    );
+    const { container } = render(<FileImage file={file} alt="image" />);
 
     expect(container.childNodes).to.have.lengthOf(1);
     const loader = container.childNodes[0];
@@ -17,40 +21,28 @@ describe('document-capture/components/file-image', () => {
   });
 
   it('renders a given file object as an image', async () => {
-    const { findByAltText } = render(
-      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="image" />,
-    );
+    const { findByAltText } = render(<FileImage file={file} alt="image" />);
 
     const image = await findByAltText('image');
 
-    expect(image.getAttribute('src')).to.match(/^data:image\/png;base64,/);
+    expect(image.getAttribute('src')).to.match(/^data:image\/jpeg;base64,/);
     expect(Array.from(image.classList.values())).to.have.members(['document-capture-file-image']);
   });
 
   it('renders a a changed file object as an image', async () => {
-    const { findByAltText, rerender } = render(
-      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="first image" />,
-    );
+    const { findByAltText, rerender } = render(<FileImage file={file} alt="first image" />);
 
     await findByAltText('first image');
 
-    rerender(
-      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="second image" />,
-    );
+    rerender(<FileImage file={file} alt="second image" />);
 
     const image = await findByAltText('second image');
 
-    expect(image.getAttribute('src')).to.match(/^data:image\/png;base64,/);
+    expect(image.getAttribute('src')).to.match(/^data:image\/jpeg;base64,/);
   });
 
   it('renders with className', async () => {
-    const { findByAltText } = render(
-      <FileImage
-        file={new window.File([''], 'demo', { type: 'image/png' })}
-        alt="image"
-        className="my-class"
-      />,
-    );
+    const { findByAltText } = render(<FileImage file={file} alt="image" className="my-class" />);
 
     const image = await findByAltText('image');
 

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -10,8 +10,14 @@ import FileInput, {
 } from '@18f/identity-document-capture/components/file-input';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import { render } from '../../../support/document-capture';
+import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/file-input', () => {
+  let file;
+  before(async () => {
+    file = await getFixtureFile('doc_auth_images/id-front.jpg');
+  });
+
   describe('getAcceptPattern', () => {
     it('returns a pattern for audio matching', () => {
       const accept = 'audio/*';
@@ -141,37 +147,7 @@ describe('document-capture/components/file-input', () => {
 
   it('renders a value preview for a blob', async () => {
     const { container, findByRole, getByLabelText } = render(
-      <FileInput label="File" value={new window.Blob([], { type: 'image/png' })} />,
-    );
-
-    const preview = await findByRole('img', { hidden: true });
-    const input = getByLabelText('File');
-
-    expect(input).to.be.ok();
-    expect(preview.getAttribute('src')).to.match(/^data:image\/png;base64,/);
-    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
-      'doc_auth.forms.change_file',
-    );
-  });
-
-  it('renders a value preview for a file', async () => {
-    const { container, findByRole, getByLabelText } = render(
-      <FileInput label="File" value={new window.File([], 'demo.png', { type: 'image/png' })} />,
-    );
-
-    const preview = await findByRole('img', { hidden: true });
-    const input = getByLabelText('File');
-
-    expect(input).to.be.ok();
-    expect(preview.getAttribute('src')).to.match(/^data:image\/png;base64,/);
-    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
-      'doc_auth.forms.selected_file: demo.png doc_auth.forms.change_file',
-    );
-  });
-
-  it('renders a value preview for a data URL', async () => {
-    const { container, findByRole, getByLabelText } = render(
-      <FileInput label="File" value="data:image/jpeg;base64,8J+Riw==" />,
+      <FileInput label="File" value={new window.Blob([file], { type: 'image/jpeg' })} />,
     );
 
     const preview = await findByRole('img', { hidden: true });
@@ -179,6 +155,39 @@ describe('document-capture/components/file-input', () => {
 
     expect(input).to.be.ok();
     expect(preview.getAttribute('src')).to.match(/^data:image\/jpeg;base64,/);
+    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
+      'doc_auth.forms.change_file',
+    );
+  });
+
+  it('renders a value preview for a file', async () => {
+    const { container, findByRole, getByLabelText } = render(
+      <FileInput label="File" value={file} />,
+    );
+
+    const preview = await findByRole('img', { hidden: true });
+    const input = getByLabelText('File');
+
+    expect(input).to.be.ok();
+    expect(preview.getAttribute('src')).to.match(/^data:image\/jpeg;base64,/);
+    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
+      'doc_auth.forms.selected_file: id-front.jpg doc_auth.forms.change_file',
+    );
+  });
+
+  it('renders a value preview for a data URL', async () => {
+    const { container, findByRole, getByLabelText } = render(
+      <FileInput
+        label="File"
+        value="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+      />,
+    );
+
+    const preview = await findByRole('img', { hidden: true });
+    const input = getByLabelText('File');
+
+    expect(input).to.be.ok();
+    expect(preview.getAttribute('src')).to.match(/^data:image\/png;base64,/);
     expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
       'doc_auth.forms.change_file',
     );
@@ -201,7 +210,6 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('calls onChange with next value', () => {
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
@@ -212,21 +220,19 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('allows changing the selected value', () => {
-    const file1 = new window.File([''], 'upload1.png', { type: 'image/png' });
-    const file2 = new window.File([''], 'upload2.png', { type: 'image/png' });
+    const file2 = new window.File([file], 'file2.jpg');
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file1);
+    userEvent.upload(input, file);
     userEvent.upload(input, file2);
 
-    expect(onChange.getCall(0).args[0]).to.equal(file1);
+    expect(onChange.getCall(0).args[0]).to.equal(file);
     expect(onChange.getCall(1).args[0]).to.equal(file2);
   });
 
   it('allows clearing the selected value', () => {
-    const file = new window.File([''], 'upload1.png', { type: 'image/png' });
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
@@ -260,7 +266,7 @@ describe('document-capture/components/file-input', () => {
         <FileInput
           label="File"
           bannerText="File goes here"
-          value={new window.File([], 'demo.png', { type: 'image/png' })}
+          value="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
         />
       </DeviceContext.Provider>,
     );
@@ -289,7 +295,6 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('shows an error state', () => {
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const { getByLabelText, getByText } = render(
@@ -304,7 +309,6 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('allows customization of invalid file type error message', () => {
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const { getByLabelText, getByText } = render(
@@ -325,7 +329,6 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('shows an error from rendering parent', () => {
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const props = { label: 'File', accept: ['text/*'], onChange, onError };
@@ -345,18 +348,17 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('shows an updated state', () => {
-    const file1 = new window.File([''], 'upload.png', { type: 'image/png' });
-    const file2 = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file2 = new window.File([file], 'file2.jpg');
 
     const { getByText, rerender } = render(<FileInput label="File" />);
 
     expect(() => getByText('forms.file_input.file_updated')).to.throw();
 
-    rerender(<FileInput label="File" value={file1} />);
+    rerender(<FileInput label="File" value={file} />);
 
     expect(() => getByText('forms.file_input.file_updated')).to.throw();
 
-    rerender(<FileInput label="File" value={file1} />);
+    rerender(<FileInput label="File" value={file} />);
 
     expect(() => getByText('forms.file_input.file_updated')).to.throw();
 
@@ -370,14 +372,13 @@ describe('document-capture/components/file-input', () => {
   });
 
   it('allows customization of updated file text', () => {
-    const file1 = new window.File([''], 'upload.png', { type: 'image/png' });
-    const file2 = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file2 = new window.File([file], 'file2.jpg');
 
     const { getByText, rerender } = render(<FileInput label="File" fileUpdatedText="Updated" />);
 
     expect(() => getByText('Updated')).to.throw();
 
-    rerender(<FileInput label="File" fileUpdatedText="Updated" value={file1} />);
+    rerender(<FileInput label="File" fileUpdatedText="Updated" value={file} />);
 
     expect(() => getByText('Updated')).to.throw();
 

--- a/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
@@ -5,6 +5,7 @@ import { I18nContext } from '@18f/identity-document-capture';
 import SelfieCapture from '@18f/identity-document-capture/components/selfie-capture';
 import { render } from '../../../support/document-capture';
 import { useSandbox } from '../../../support/sinon';
+import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/selfie-capture', () => {
   // Since DOM globals are stubbed with sandbox, ensure that cleanup is the first task, as otherwise
@@ -25,7 +26,10 @@ describe('document-capture/components/selfie-capture', () => {
   );
 
   const track = { stop: sinon.stub() };
-  const value = new window.File([], 'image.png', { type: 'image/png' });
+  let value;
+  before(async () => {
+    value = await getFixtureFile('doc_auth_images/selfie.jpg');
+  });
 
   let originalMediaDevices;
   let originalMediaStream;

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -4,6 +4,7 @@ import dirtyChai from 'dirty-chai';
 import sinonChai from 'sinon-chai';
 import { createDOM, useCleanDOM } from './support/dom';
 import { chaiConsoleSpy, useConsoleLogSpy } from './support/console';
+import { createObjectURLAsDataURL } from './support/file';
 
 chai.use(dirtyChai);
 chai.use(sinonChai);
@@ -17,6 +18,8 @@ const dom = createDOM();
 global.window = dom.window;
 global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
 global.window.crypto = new Crypto(); // In the future (Node >=15), use native webcrypto: https://nodejs.org/api/webcrypto.html
+global.window.URL.createObjectURL = createObjectURLAsDataURL;
+global.window.URL.revokeObjectURL = () => {};
 global.navigator = window.navigator;
 global.document = window.document;
 global.Document = window.Document;

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -20,6 +20,11 @@ global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
 global.window.crypto = new Crypto(); // In the future (Node >=15), use native webcrypto: https://nodejs.org/api/webcrypto.html
 global.window.URL.createObjectURL = createObjectURLAsDataURL;
 global.window.URL.revokeObjectURL = () => {};
+Object.defineProperty(global.window.Image.prototype, 'src', {
+  set() {
+    this.onload();
+  },
+});
 global.navigator = window.navigator;
 global.document = window.document;
 global.Document = window.Document;

--- a/spec/javascripts/support/dom.js
+++ b/spec/javascripts/support/dom.js
@@ -10,8 +10,18 @@ export function createDOM() {
   const dom = new JSDOM('', {
     url: 'http://example.test',
     resources: new (class extends ResourceLoader {
+      /**
+       * @param {string} url
+       * @param {import('jsdom').FetchOptions} options
+       */
       // eslint-disable-next-line class-methods-use-this
-      fetch(url) {
+      fetch(url, options) {
+        if (url.startsWith('data:') && options.element instanceof window.HTMLImageElement) {
+          const [header, content] = url.split(',');
+          const isBase64 = header.endsWith(';base64');
+          return Promise.resolve(Buffer.from(content, isBase64 ? 'base64' : 'utf-8'));
+        }
+
         return url === 'about:blank'
           ? Promise.resolve(Buffer.from(''))
           : Promise.reject(new Error('Failed to load'));

--- a/spec/javascripts/support/file.js
+++ b/spec/javascripts/support/file.js
@@ -1,0 +1,51 @@
+import { join, basename, extname } from 'path';
+import { promises as fs } from 'fs';
+
+/**
+ * Rough approximation of assumed mime type by file extension. This is very incomplete, and assumes
+ * files which would be used as fixtures. For a more complete implementation, consider pulling in a
+ * package like `mime-types`.
+ *
+ * @see https://www.npmjs.com/package/mime-types
+ *
+ * @type {Record<string,string>}
+ */
+const MIME_TYPES_BY_EXTENSION = {
+  '.jpg': 'image/jpeg',
+};
+
+/**
+ * @typedef {File & {rawBuffer: Buffer}} LoginGovTestFile
+ */
+
+/**
+ * @param {string} fixturePath
+ * @param {BufferEncoding=} encoding
+ *
+ * @return {Promise<Buffer|string>}
+ */
+export function getFixture(fixturePath, encoding) {
+  const path = join(__dirname, '../../fixtures', fixturePath);
+  return fs.readFile(path, encoding);
+}
+
+/**
+ * @param {string} fixturePath Path relative fixtures directory.
+ *
+ * @return {Promise<LoginGovTestFile>}
+ */
+export async function getFixtureFile(fixturePath) {
+  const rawBuffer = /** @type {Buffer} */ (await getFixture(fixturePath));
+  const type = MIME_TYPES_BY_EXTENSION[extname(fixturePath)];
+  const file = new window.File([rawBuffer], basename(fixturePath), { type });
+  return Object.assign(file, { rawBuffer });
+}
+
+/**
+ * @param {LoginGovTestFile} file
+ *
+ * @return {string} Data URL
+ */
+export function createObjectURLAsDataURL(file) {
+  return `data:${file.type};base64,${file.rawBuffer.toString('base64')}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,15 +2437,6 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
   integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
-canvas@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.6.1.tgz#0d087dd4d60f5a5a9efa202757270abea8bef89e"
-  integrity sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==
-  dependencies:
-    nan "^2.14.0"
-    node-pre-gyp "^0.11.0"
-    simple-get "^3.0.3"
-
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
@@ -3241,13 +3232,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -3266,11 +3250,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -3378,11 +3357,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -4341,13 +4315,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -4841,7 +4808,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4879,13 +4846,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4990,7 +4950,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -5949,11 +5909,6 @@ mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 mini-css-extract-plugin@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
@@ -6007,27 +5962,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -6144,7 +6084,7 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.13.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -6175,15 +6115,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-needle@^2.2.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
-  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -6268,22 +6199,6 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
-  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
-
 node-releases@^1.1.67:
   version "1.1.67"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
@@ -6318,14 +6233,6 @@ node-sass@^4.14.1:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -6369,27 +6276,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6397,7 +6283,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -6612,7 +6498,7 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -7864,16 +7750,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
@@ -8232,7 +8108,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8309,7 +8185,7 @@ sass-loader@^8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8381,7 +8257,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8550,20 +8426,6 @@ signal-exit@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
-
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
-  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
-simple-get@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
-  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -9016,11 +8878,6 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
@@ -9116,19 +8973,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 tar@^6.0.2:
   version "6.0.5"
@@ -9919,7 +9763,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,15 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
   integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
+canvas@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.6.1.tgz#0d087dd4d60f5a5a9efa202757270abea8bef89e"
+  integrity sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==
+  dependencies:
+    nan "^2.14.0"
+    node-pre-gyp "^0.11.0"
+    simple-get "^3.0.3"
+
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
@@ -3232,6 +3241,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -3250,6 +3266,11 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -3357,6 +3378,11 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -4315,6 +4341,13 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -4808,7 +4841,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4846,6 +4879,13 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
+ignore-walk@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4950,10 +4990,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
-  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -5909,6 +5949,11 @@ mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 mini-css-extract-plugin@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
@@ -5962,12 +6007,27 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
     yallist "^4.0.0"
+
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -6084,10 +6144,10 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-nan@^2.12.1, nan@^2.13.2:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanoid@3.1.12:
   version "3.1.12"
@@ -6115,6 +6175,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+needle@^2.2.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
+  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -6199,6 +6268,22 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
+node-pre-gyp@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
+  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 node-releases@^1.1.67:
   version "1.1.67"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
@@ -6233,6 +6318,14 @@ node-sass@^4.14.1:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
+
+nopt@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
+  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -6276,6 +6369,27 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+npm-bundled@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
+npm-packlist@^1.1.6:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
+  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+    npm-normalize-package-bin "^1.0.1"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6283,7 +6397,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -6498,7 +6612,7 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0:
+osenv@0, osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -7750,6 +7864,16 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
@@ -8108,7 +8232,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8185,7 +8309,7 @@ sass-loader@^8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@~1.2.4:
+sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8257,7 +8381,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8426,6 +8550,20 @@ signal-exit@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
+  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -8878,6 +9016,11 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
 style-loader@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
@@ -8973,6 +9116,19 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
+
+tar@^4:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
 
 tar@^6.0.2:
   version "6.0.5"
@@ -9763,7 +9919,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
This is a redo of #4675, which was reverted in #4680 due to incompatibility with the `canvas` dependency.

This is an exact copy of the original (or more precisely, a revert of 5f109fb), plus changes in the commit 07503fa to remove `canvas` references. In practice, this means no test coverage for `getImageDimensions` utility function of the `AcuantCapture` component.