### PR TITLE
Retire `cac_proofing_enabled` feature flag

### DIFF
--- a/app/controllers/idv/cac_controller.rb
+++ b/app/controllers/idv/cac_controller.rb
@@ -2,7 +2,6 @@ module Idv
   class CacController < ApplicationController
     include PivCacConcern
 
-    before_action :render_404_if_disabled
     before_action :confirm_two_factor_authenticated
     before_action :cac_callback
 
@@ -25,10 +24,6 @@ module Idv
     end
 
     private
-
-    def render_404_if_disabled
-      render_not_found unless AppConfig.env.cac_proofing_enabled == 'true'
-    end
 
     def cac_callback
       return unless request.path == idv_cac_step_path(:present_cac) && params[:token]

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -61,8 +61,7 @@ class IdvController < ApplicationController
   end
 
   def proof_with_cac?
-    AppConfig.env.cac_proofing_enabled == 'true' &&
-      (Db::EmailAddress::HasGovOrMil.call(current_user) ||
-      current_user.piv_cac_configurations.any?)
+    Db::EmailAddress::HasGovOrMil.call(current_user) ||
+      current_user.piv_cac_configurations.any?
   end
 end

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -36,7 +36,7 @@
   </p>
 <% end %>
 
-<% if AppConfig.env.cac_proofing_enabled == 'true' && desktop_device? %>
+<% if desktop_device? %>
   <p>
     <strong><%= t('doc_auth.info.use_cac') %></strong>
     <%= link_to(t('doc_auth.info.use_cac_link'), idv_cac_step_path(step: :choose_method)) %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -45,7 +45,6 @@ available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
 aws_kms_multi_region_enabled: 'false'
-cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 deleted_user_accounts_report_configs: '[]'
 disallow_ial2_recovery:

--- a/spec/features/idv/cac/use_cac_step_spec.rb
+++ b/spec/features/idv/cac/use_cac_step_spec.rb
@@ -8,7 +8,7 @@ feature 'use cac step' do
     strip_tags(t('doc_auth.info.use_cac', link: t('doc_auth.info.use_cac_link')))
   end
 
-  it 'shows cac proofing option if cac proofing is enabled' do
+  it 'shows cac proofing option if cac proofing on desktop' do
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_upload_step
 
@@ -16,15 +16,6 @@ feature 'use cac step' do
 
     click_link t('doc_auth.info.use_cac_link')
     expect(page).to have_current_path(idv_cac_proofing_choose_method_step)
-  end
-
-  it 'does not show cac proofing option if cac proofing is disabled' do
-    allow(AppConfig.env).to receive(:cac_proofing_enabled).and_return('false')
-
-    sign_in_and_2fa_user
-    complete_doc_auth_steps_before_upload_step
-
-    expect(page).to_not have_content use_cac_content
   end
 
   it 'does not show cac proofing option on mobile' do


### PR DESCRIPTION
**Why**: CAC proofing is enabled everywhere