### PR TITLE
Add a reasonable default for the AWS region config

### DIFF
--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -59,7 +59,7 @@ module Encryption
     def find_available_region(regions)
       regions.each do |region, cipher|
         region_client = @aws_clients[region]
-        return CipherData.new(region_client, cipher) if region_client
+        return CipherData.new(region_client, Base64.strict_decode64(cipher)) if region_client
       end
       raise EncryptionError, 'No supported region found in ciphertext'
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -44,6 +44,7 @@ async_wait_timeout_seconds: '60'
 available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
+aws_region: 'us-west-2'
 aws_kms_multi_region_enabled: 'false'
 database_statement_timeout: '2500'
 deleted_user_accounts_report_configs: '[]'
@@ -163,7 +164,6 @@ development:
     }]'
   aws_kms_key_id: alias/login-dot-gov-development-keymaker
   aws_logo_bucket:
-  aws_region: us-east-1
   aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
@@ -270,7 +270,6 @@ production:
   attribute_encryption_key:
   attribute_encryption_key_queue:
   aws_kms_key_id:
-  aws_region:
   aws_kms_regions: '["us-west-2"]'
   aws_logo_bucket:
   backup_codes_as_only_2fa:
@@ -377,7 +376,6 @@ test:
     "4000$8$4$" }, { "key": "22222222222222222222222222222222", "cost": "4000$8$4$"
     }]'
   aws_kms_key_id: alias/login-dot-gov-test-keymaker
-  aws_region: us-east-1
   aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -16,7 +16,7 @@ describe Encryption::MultiRegionKmsClient do
   let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
 
   let(:kms_regions) { %w[us-west-2 us-east-1] }
-  let(:current_aws_region) { 'us-east-1' }
+  let(:current_aws_region) { 'us-west-2' }
 
   let(:regionalized_kms_ciphertext) do
     region_hash = {}
@@ -88,7 +88,7 @@ describe Encryption::MultiRegionKmsClient do
       partially_valid_ciphertext = {
         regions: {
           foo: 'kms1',
-          'us-west-2': 'kms2',
+          'us-west-2': Base64.strict_encode64('kms2'),
         },
       }.to_json
       result = subject.decrypt(partially_valid_ciphertext, encryption_context)
@@ -98,8 +98,8 @@ describe Encryption::MultiRegionKmsClient do
     it 'decrypts in default region where multiple regions present' do
       multi_region_ciphertext = {
         regions: {
-          'us-east-1': Base64.strict_encode64('kms1'),
-          'us-west-2': Base64.strict_encode64('kms2'),
+          'us-west-2': Base64.strict_encode64('kms1'),
+          'us-east-1': Base64.strict_encode64('kms2'),
         },
       }.to_json
       result = subject.decrypt(multi_region_ciphertext, encryption_context)


### PR DESCRIPTION
**Why**: To enable us to slim down our config files by specifying a reasonable default