### PR TITLE
Make `identity_pki_disabled` config false by default in prod

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -57,7 +57,6 @@ enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'
 gpo_designated_receiver_pii: '{}'
 ial2_recovery_request_valid_for_minutes: '15'
-identity_pki_disabled: 'true'
 identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '6'
 idv_max_attempts: '3'
@@ -193,6 +192,8 @@ development:
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
+  identity_pki_disabled: 'false'
+  identity_pki_local_dev: 'true'
   issuers_with_email_nameid_format: ''
   liveness_checking_enabled: 'true'
   lockout_period_in_minutes: '10'
@@ -211,8 +212,6 @@ development:
   otp_delivery_blocklist_maxretry: '10'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  identity_pki_disabled: 'false'
-  identity_pki_local_dev: 'true'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   piv_cac_verify_token_url: https://localhost:8443/
@@ -300,6 +299,7 @@ production:
   expired_letters_auth_token:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue:
+  identity_pki_disabled: 'false'
   issuers_with_email_nameid_format: sp1,sp2
   liveness_checking_enabled: 'false'
   lockout_period_in_minutes: '10'
@@ -406,6 +406,7 @@ test:
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
+  identity_pki_disabled: 'true'
   issuers_with_email_nameid_format: https://rp1.serviceprovider.com/auth/saml/metadata
   lexisnexis_trueid_account_id: 'test_account'
   liveness_checking_enabled: 'false'


### PR DESCRIPTION
**Why**: The sandbox setup script launches a PKI for sandboxes. Upper envs have identity-pki instances as well. There is no reason for all envs to need to override this.