### PR TITLE
Retire the PIV/CAC login feature flag

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -130,8 +130,7 @@ module OpenidConnect
     end
 
     def pii_requested_but_locked?
-      FeatureManagement.allow_piv_cac_login? &&
-        sp_session && sp_session_ial > 1 &&
+      sp_session && sp_session_ial > 1 &&
         UserDecorator.new(current_user).identity_verified? &&
         user_session[:decrypted_pii].blank?
     end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -39,7 +39,7 @@
     ) %>
   </div>
 <% end %>
-<% if FeatureManagement.allow_piv_cac_login? && @ial && desktop_device? %>
+<% if @ial && desktop_device? %>
   <div class='margin-x-neg-1 margin-y-4'>
     <%= link_to(
       t('account.login.piv_cac'),

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -197,7 +197,6 @@ development:
   issuers_with_email_nameid_format: ''
   liveness_checking_enabled: 'true'
   lockout_period_in_minutes: '10'
-  login_with_piv_cac: 'true'
   logins_per_email_and_ip_limit: '5'
   logins_per_ip_limit: '5'
   logins_per_ip_track_only_mode: 'false'
@@ -303,7 +302,6 @@ production:
   issuers_with_email_nameid_format: sp1,sp2
   liveness_checking_enabled: 'false'
   lockout_period_in_minutes: '10'
-  login_with_piv_cac: 'false'
   logins_per_email_and_ip_limit: '5'
   logins_per_ip_limit: '5'
   logins_per_ip_track_only_mode: 'true'
@@ -411,7 +409,6 @@ test:
   lexisnexis_trueid_account_id: 'test_account'
   liveness_checking_enabled: 'false'
   lockout_period_in_minutes: '5'
-  login_with_piv_cac: 'true'
   logins_per_email_and_ip_limit: '2'
   logins_per_ip_limit: '3'
   logins_per_ip_track_only_mode: 'false'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,15 +75,13 @@ Rails.application.routes.draw do
       get '/active' => 'users/sessions#active'
       post '/sessions/keepalive' => 'users/sessions#keepalive'
 
-      if FeatureManagement.allow_piv_cac_login?
-        get '/login/piv_cac' => 'users/piv_cac_login#new'
-        get '/login/piv_cac_account_not_found' => 'users/piv_cac_login#account_not_found'
-        get '/login/piv_cac_did_not_work' => 'users/piv_cac_login#did_not_work'
-        get '/login/piv_cac_temporary_error' => 'users/piv_cac_login#temporary_error'
-        get '/login/present_piv_cac' => 'users/piv_cac_login#redirect_to_piv_cac_service'
-        get '/login/password' => 'password_capture#new', as: :capture_password
-        post '/login/password' => 'password_capture#create'
-      end
+      get '/login/piv_cac' => 'users/piv_cac_login#new'
+      get '/login/piv_cac_account_not_found' => 'users/piv_cac_login#account_not_found'
+      get '/login/piv_cac_did_not_work' => 'users/piv_cac_login#did_not_work'
+      get '/login/piv_cac_temporary_error' => 'users/piv_cac_login#temporary_error'
+      get '/login/present_piv_cac' => 'users/piv_cac_login#redirect_to_piv_cac_service'
+      get '/login/password' => 'password_capture#new', as: :capture_password
+      post '/login/password' => 'password_capture#create'
 
       get '/account_reset/request' => 'account_reset/request#show'
       post '/account_reset/request' => 'account_reset/request#create'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -16,10 +16,6 @@ class FeatureManagement
       !env.piv_cac_verify_token_url
   end
 
-  def self.allow_piv_cac_login?
-    AppConfig.env.login_with_piv_cac == 'true'
-  end
-
   def self.development_and_identity_pki_disabled?
     # This controls if we try to hop over to identity-pki or just throw up
     # a screen asking for a Subject or one of a list of error conditions.


### PR DESCRIPTION
**Why**: This feature is deployed all the way to production, tested, and stable.