### PR TITLE
Make `participate_in_dap` true in prod and false everywhere else

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -209,7 +209,7 @@ development:
   nonessential_email_banlist: '["banned_email@gmail.com"]'
   otp_delivery_blocklist_findtime: '5'
   otp_delivery_blocklist_maxretry: '10'
-  participate_in_dap:
+  participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
@@ -314,7 +314,7 @@ production:
   nonessential_email_banlist: '[]'
   otp_delivery_blocklist_findtime: '5'
   otp_delivery_blocklist_maxretry: '10'
-  participate_in_dap: 'false'
+  participate_in_dap: 'true'
   password_pepper:
   piv_cac_service_url:
   piv_cac_verify_token_secret:
@@ -422,7 +422,7 @@ test:
   otps_per_ip_limit: '3'
   otps_per_ip_period: '10'
   otps_per_ip_track_only_mode: 'false'
-  participate_in_dap:
+  participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f


### PR DESCRIPTION
**Why**: To match the configs in the deployed environments. This prevents deployed envs from having to override this config.