### PR TITLE
Clean up KMS stubbing

### DIFF
--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -103,8 +103,20 @@ describe Encryption::ContextlessKmsClient do
       allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
 
       stub_mapped_aws_kms_client(
-        long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
-        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2',
+        [
+          {
+            plaintext: long_kms_plaintext[0..long_kms_plaintext_chunksize - 1],
+            ciphertext: 'chunk1',
+            key_id: AppConfig.env.aws_kms_key_id,
+            region: AppConfig.env.aws_region,
+          },
+          {
+            plaintext: long_kms_plaintext[long_kms_plaintext_chunksize..-1],
+            ciphertext: 'chunk2',
+            key_id: AppConfig.env.aws_kms_key_id,
+            region: AppConfig.env.aws_region,
+          },
+        ],
       )
       allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
     end

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -1,49 +1,53 @@
 require 'rails_helper'
 
 describe Encryption::MultiRegionKmsClient do
-  before do
-    stub_mapped_aws_kms_client(
-      'a' * 3000 => 'kms1',
-      'b' * 3000 => 'kms2',
-    )
-
-    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
-    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Layout/LineLength
-  end
-
-  let(:first_plaintext) { 'a' * 3000 }
-  let(:second_plaintext) { 'b' * 3000 }
-  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
-
-  let(:kms_regions) { %w[us-west-2 us-east-1] }
-  let(:current_aws_region) { 'us-west-2' }
-
-  let(:regionalized_kms_ciphertext) do
-    region_hash = {}
-    kms_regions.each do |r|
-      region_hash[r] = Base64.strict_encode64('kms1')
-    end
-    { regions: region_hash }.to_json
-  end
-
-  let(:legacy_kms_ciphertext) { 'kms1' }
-
   let(:kms_enabled) { true }
   let(:kms_multi_region_enabled) { true }
+  let(:aws_kms_regions) { %w[us-north-1 us-south-1] }
+  let(:aws_region) { 'us-north-1' }
 
-  let(:aws_key_id) { AppConfig.env.aws_kms_key_id }
+  before do
+    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).
+      and_return(kms_multi_region_enabled)
+    allow(AppConfig.env).to receive(:aws_kms_regions).and_return(aws_kms_regions.to_json)
+    allow(AppConfig.env).to receive(:aws_region).and_return(aws_region)
+
+    stub_mapped_aws_kms_client(
+      [
+        { plaintext: plaintext, ciphertext: 'k1:us-north-1', key_id: 'key1', region: 'us-north-1' },
+        { plaintext: plaintext, ciphertext: 'k1:us-south-1', key_id: 'key1', region: 'us-south-1' },
+      ],
+    )
+  end
+
+  let(:plaintext) { 'a' * 3000 }
+  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
+
+  let(:regionalized_kms_ciphertext) do
+    {
+      regions: {
+        'us-north-1' => Base64.strict_encode64('k1:us-north-1'),
+        'us-south-1' => Base64.strict_encode64('k1:us-south-1'),
+      },
+    }.to_json
+  end
+
+  let(:legacy_kms_ciphertext) { 'k1:us-north-1' }
 
   describe '#encrypt' do
+    let(:aws_key_id) { 'key1' }
+
     context 'with multi region enabled' do
       it 'encrypts with KMS' do
-        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
+        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
         expect(result).to eq(regionalized_kms_ciphertext)
       end
     end
     context 'with multi region disabled' do
       let(:kms_multi_region_enabled) { false }
       it 'encrypts with KMS' do
-        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
+        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
         expect(result).to eq(legacy_kms_ciphertext)
       end
     end
@@ -53,23 +57,23 @@ describe Encryption::MultiRegionKmsClient do
     context 'with a multi region ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(regionalized_kms_ciphertext, encryption_context)
-        expect(result).to eq(first_plaintext)
+        expect(result).to eq(plaintext)
       end
     end
 
     context 'with a legacy ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(legacy_kms_ciphertext, encryption_context)
-        expect(result).to eq(first_plaintext)
+        expect(result).to eq(plaintext)
       end
     end
 
     it 'decrypts successfully if the default region is not present' do
       non_default_ciphertext = {
-        regions: { 'us-east-1' => Base64.strict_encode64('kms1') },
+        regions: { 'us-north-1' => Base64.strict_encode64('k1:us-north-1') },
       }.to_json
       result = subject.decrypt(non_default_ciphertext, encryption_context)
-      expect(result).to eq(first_plaintext)
+      expect(result).to eq(plaintext)
     end
 
     it 'errors if none of the encryption regions are present' do
@@ -88,22 +92,22 @@ describe Encryption::MultiRegionKmsClient do
       partially_valid_ciphertext = {
         regions: {
           foo: 'kms1',
-          'us-west-2': Base64.strict_encode64('kms2'),
+          'us-south-1': Base64.strict_encode64('k1:us-south-1'),
         },
       }.to_json
       result = subject.decrypt(partially_valid_ciphertext, encryption_context)
-      expect(result).to eq(second_plaintext)
+      expect(result).to eq(plaintext)
     end
 
     it 'decrypts in default region where multiple regions present' do
       multi_region_ciphertext = {
         regions: {
-          'us-west-2': Base64.strict_encode64('kms1'),
-          'us-east-1': Base64.strict_encode64('kms2'),
+          'us-north-1': Base64.strict_encode64('k1:us-north-1'),
+          'us-south-1': Base64.strict_encode64('k1:us-south-1'),
         },
       }.to_json
       result = subject.decrypt(multi_region_ciphertext, encryption_context)
-      expect(result).to eq(first_plaintext)
+      expect(result).to eq(plaintext)
     end
   end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -37,15 +37,10 @@ module AwsKmsClientHelper
   end
 
   def stub_aws_kms_client_invalid_ciphertext(ciphered_key = random_str)
-    allow(Figaro.env).to receive(:aws_region).and_return('us-north-by-northwest-1')
-    allow(Figaro.env).to receive(:aws_kms_region_configs).and_return([
-      { region: 'us-north-by-northwest-1', key_id: 'key1' },
-      { region: 'us-south-by-southwest-1', key_id: 'key2' },
-    ].to_json)
-
+    aws_key_id = AppConfig.env.aws_kms_key_id
     Aws.config[:kms] = {
       stub_responses: {
-        encrypt: { ciphertext_blob: ciphered_key, key_id: 'key1' },
+        encrypt: { ciphertext_blob: ciphered_key, key_id: aws_key_id },
         decrypt: 'InvalidCiphertextException',
       },
     }

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -11,7 +11,7 @@ module AwsKmsClientHelper
   end
 
   # Configs is an array of:
-  # [ { ciphertext:, plaintext:, key_id:, region: }]
+  # [{ ciphertext:, plaintext:, key_id:, region: }]
   def stub_mapped_aws_kms_client(configs)
     encryptor = proc do |context|
       config = configs.find do |c|


### PR DESCRIPTION
Ports the updated stubbing and hopefully clearer tests from https://github.com/18F/identity-idp/pull/4242

Inspired by https://github.com/18F/identity-idp/pull/4686, which caught an error when we changed region names

This PR also uses all fake names so it doesn't rely on specific config values