### PR TITLE
LG-4137 Reduce noise from known error cases in NewRelic

### DIFF
--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -8,6 +8,7 @@ class IdentityLinker
   end
 
   def link_identity(**extra_attrs)
+    return unless user && provider.present?
     process_ial(extra_attrs)
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -113,9 +113,9 @@ describe IdentityLinker do
         to raise_error(ArgumentError)
     end
 
-    it 'fails when given a nil provider' do
+    it 'does not link to an identity record if the provider is nil' do
       linker = IdentityLinker.new(user, nil)
-      expect { linker.link_identity }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(linker.link_identity).to eq(nil)
     end
 
     it 'can link two different clients to the same rails_session_id' do


### PR DESCRIPTION
**Why**: The identity linker creates an identity record if we have a valid sp.  There are situations where there is no sp, ie the user verifies directly with login.gov and not through an sp.  For those conditions just return nil.