### PR TITLE
LG-4175: Control Acuant Web SDK load by device type

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -166,7 +166,7 @@ function AcuantCapture(
   },
   ref,
 ) {
-  const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
+  const { isReady, isAcuantLoaded, isError, isCameraSupported } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { addPageAction } = useContext(AnalyticsContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
@@ -235,7 +235,8 @@ function AcuantCapture(
     if (event.target === inputRef.current) {
       const shouldStartEnvironmentCapture =
         hasCapture && capture !== 'user' && !isForceUploading.current;
-      const shouldStartSelfieCapture = capture === 'user' && !isForceUploading.current;
+      const shouldStartSelfieCapture =
+        isAcuantLoaded && capture === 'user' && !isForceUploading.current;
 
       if (!allowUpload || shouldStartSelfieCapture || shouldStartEnvironmentCapture) {
         event.preventDefault();

--- a/app/javascript/packages/document-capture/context/acuant.jsx
+++ b/app/javascript/packages/document-capture/context/acuant.jsx
@@ -66,9 +66,13 @@ function AcuantContextProvider({
   children,
 }) {
   const { isMobile } = useContext(DeviceContext);
+  // Only mobile devices should load the Acuant SDK. Consider immediately ready otherwise.
   const [isReady, setIsReady] = useState(!isMobile);
   const [isAcuantLoaded, setIsAcuantLoaded] = useState(false);
   const [isError, setIsError] = useState(false);
+  // If the user is on a mobile device, it can't be known that the camera is supported until after
+  // Acuant SDK loads, so assign a value of `null` as representing this unknown state. Other device
+  // types should treat camera as unsupported, since it's not relevant for Acuant SDK usage.
   const [isCameraSupported, setIsCameraSupported] = useState(isMobile ? null : false);
   const value = useMemo(
     () => ({ isReady, isAcuantLoaded, isError, isCameraSupported, endpoint, credentials }),
@@ -76,6 +80,7 @@ function AcuantContextProvider({
   );
 
   useEffect(() => {
+    // If state is already ready (via consideration of device type), skip loading Acuant SDK.
     if (isReady) {
       return;
     }

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -140,36 +140,36 @@ loadPolyfills(['fetch', 'crypto']).then(async () => {
     window.fetch(keepAliveEndpoint, { method: 'POST', headers: { 'X-CSRF-Token': csrf } });
 
   render(
-    <AcuantContextProvider
-      credentials={getMetaContent('acuant-sdk-initialization-creds')}
-      endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
-    >
-      <UploadContextProvider
-        endpoint={/** @type {string} */ (appRoot.getAttribute('data-endpoint'))}
-        statusEndpoint={/** @type {string} */ (appRoot.getAttribute('data-status-endpoint'))}
-        statusPollInterval={
-          Number(appRoot.getAttribute('data-status-poll-interval-ms')) || undefined
-        }
-        method={isAsyncForm ? 'PUT' : 'POST'}
-        csrf={csrf}
-        isMockClient={isMockClient}
-        backgroundUploadURLs={backgroundUploadURLs}
-        backgroundUploadEncryptKey={backgroundUploadEncryptKey}
-        formData={formData}
+    <DeviceContext.Provider value={device}>
+      <AcuantContextProvider
+        credentials={getMetaContent('acuant-sdk-initialization-creds')}
+        endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
       >
-        <I18nContext.Provider value={i18n.strings}>
-          <ServiceProviderContext.Provider value={getServiceProvider()}>
-            <AnalyticsContext.Provider value={{ addPageAction }}>
-              <AssetContext.Provider value={assets}>
-                <DeviceContext.Provider value={device}>
+        <UploadContextProvider
+          endpoint={/** @type {string} */ (appRoot.getAttribute('data-endpoint'))}
+          statusEndpoint={/** @type {string} */ (appRoot.getAttribute('data-status-endpoint'))}
+          statusPollInterval={
+            Number(appRoot.getAttribute('data-status-poll-interval-ms')) || undefined
+          }
+          method={isAsyncForm ? 'PUT' : 'POST'}
+          csrf={csrf}
+          isMockClient={isMockClient}
+          backgroundUploadURLs={backgroundUploadURLs}
+          backgroundUploadEncryptKey={backgroundUploadEncryptKey}
+          formData={formData}
+        >
+          <I18nContext.Provider value={i18n.strings}>
+            <ServiceProviderContext.Provider value={getServiceProvider()}>
+              <AnalyticsContext.Provider value={{ addPageAction }}>
+                <AssetContext.Provider value={assets}>
                   <DocumentCapture isAsyncForm={isAsyncForm} onStepChange={keepAlive} />
-                </DeviceContext.Provider>
-              </AssetContext.Provider>
-            </AnalyticsContext.Provider>
-          </ServiceProviderContext.Provider>
-        </I18nContext.Provider>
-      </UploadContextProvider>
-    </AcuantContextProvider>,
+                </AssetContext.Provider>
+              </AnalyticsContext.Provider>
+            </ServiceProviderContext.Provider>
+          </I18nContext.Provider>
+        </UploadContextProvider>
+      </AcuantContextProvider>
+    </DeviceContext.Provider>,
     appRoot,
   );
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -1,4 +1,4 @@
-import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
+import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
 import AcuantCaptureCanvas from '@18f/identity-document-capture/components/acuant-capture-canvas';
 import { render, useAcuant } from '../../../support/document-capture';
 
@@ -7,9 +7,11 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
   it('waits for initialization', () => {
     render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCaptureCanvas />
-      </AcuantContextProvider>,
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCaptureCanvas />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
     );
 
     // At this point, it's assumed `window.AcuantCameraUI.start` has not been called. This can't be
@@ -32,9 +34,11 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
   it('ends on unmount', () => {
     const { unmount } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCaptureCanvas />
-      </AcuantContextProvider>,
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCaptureCanvas />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
     );
 
     initialize();

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -608,6 +608,9 @@ describe('document-capture/components/acuant-capture', () => {
       );
 
       userEvent.click(getByLabelText('Image'));
+
+      // It would be expected that if AcuantCaptureCanvas was rendered, an error would be thrown at
+      // this point, since it references Acuant globals not loaded.
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -505,11 +505,11 @@ describe('document-capture/components/acuant-capture', () => {
         <I18nContext.Provider
           value={{ 'doc_auth.buttons.take_or_upload_picture': '<lg-upload>Upload</lg-upload>' }}
         >
-          <AcuantContextProvider sdkSrc="about:blank">
-            <DeviceContext.Provider value={{ isMobile: true }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <AcuantContextProvider sdkSrc="about:blank">
               <AcuantCapture label="Image" allowUpload={false} />
-            </DeviceContext.Provider>
-          </AcuantContextProvider>
+            </AcuantContextProvider>
+          </DeviceContext.Provider>
         </I18nContext.Provider>,
       );
 
@@ -526,9 +526,11 @@ describe('document-capture/components/acuant-capture', () => {
 
     it('still captures selfie value when upload disallowed', () => {
       const { getByLabelText } = render(
-        <AcuantContextProvider sdkSrc="about:blank">
-          <AcuantCapture label="Image" capture="user" allowUpload={false} />
-        </AcuantContextProvider>,
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" capture="user" allowUpload={false} />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
       );
 
       initialize();
@@ -540,34 +542,69 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.start.called).to.be.false();
       expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.true();
     });
-  });
 
-  context('desktop', () => {
-    it('renders without capture button while acuant is not ready and on desktop', () => {
+    it('does not show hint if capture is supported', () => {
       const { getByText } = render(
-        <DeviceContext.Provider value={{ isMobile: false }}>
+        <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
       );
 
-      expect(() => getByText('doc_auth.buttons.take_picture')).to.throw();
-    });
-
-    it('optionally disallows upload', () => {
-      const { getByText } = render(
-        <AcuantContextProvider sdkSrc="about:blank">
-          <DeviceContext.Provider value={{ isMobile: false }}>
-            <AcuantCapture label="Image" allowUpload={false} />
-          </DeviceContext.Provider>
-        </AcuantContextProvider>,
-      );
+      initialize();
 
       expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
-
-      initialize();
     });
+
+    it('shows hint if capture is not supported', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      initialize({ isSuccess: false });
+
+      const hint = getByText('doc_auth.tips.document_capture_hint');
+
+      expect(hint).to.be.ok();
+    });
+
+    it('captures selfie', async () => {
+      const onChange = sinon.stub();
+      const { getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" capture="user" onChange={onChange} />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      initialize({
+        startSelfieCapture: sinon.stub().callsArgWithAsync(0, ''),
+      });
+
+      const button = getByLabelText('Image');
+      const defaultPrevented = !fireEvent.click(button);
+
+      expect(defaultPrevented).to.be.true();
+      expect(window.AcuantCameraUI.start.called).to.be.false();
+      expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.true();
+      await waitFor(() => expect(onChange.calledOnce).to.be.true());
+    });
+  });
+
+  it('optionally disallows upload', () => {
+    const { getByText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture label="Image" allowUpload={false} />
+      </AcuantContextProvider>,
+    );
+
+    expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
   });
 
   it('renders with custom className', () => {
@@ -592,53 +629,6 @@ describe('document-capture/components/acuant-capture', () => {
     expect(onChange.getCall(0).args).to.deep.equal([null]);
   });
 
-  it('does not show hint if capture is supported', () => {
-    const { getByText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" />
-      </AcuantContextProvider>,
-    );
-
-    initialize();
-
-    expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
-  });
-
-  it('shows hint if capture is not supported', () => {
-    const { getByText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" />
-      </AcuantContextProvider>,
-    );
-
-    initialize({ isSuccess: false });
-
-    const hint = getByText('doc_auth.tips.document_capture_hint');
-
-    expect(hint).to.be.ok();
-  });
-
-  it('captures selfie', async () => {
-    const onChange = sinon.stub();
-    const { getByLabelText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" capture="user" onChange={onChange} />
-      </AcuantContextProvider>,
-    );
-
-    initialize({
-      startSelfieCapture: sinon.stub().callsArgWithAsync(0, ''),
-    });
-
-    const button = getByLabelText('Image');
-    const defaultPrevented = !fireEvent.click(button);
-
-    expect(defaultPrevented).to.be.true();
-    expect(window.AcuantCameraUI.start.called).to.be.false();
-    expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.true();
-    await waitFor(() => expect(onChange.calledOnce).to.be.true());
-  });
-
   it('restricts accepted file types', () => {
     const { getByLabelText } = render(
       <AcuantContextProvider sdkSrc="about:blank">
@@ -656,15 +646,11 @@ describe('document-capture/components/acuant-capture', () => {
     const addPageAction = sinon.mock();
     const { getByLabelText } = render(
       <AnalyticsContext.Provider value={{ addPageAction }}>
-        <DeviceContext.Provider value={{ isMobile: true }}>
-          <AcuantContextProvider sdkSrc="about:blank">
-            <AcuantCapture label="Image" analyticsPrefix="image" />
-          </AcuantContextProvider>
-        </DeviceContext.Provider>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCapture label="Image" analyticsPrefix="image" />
+        </AcuantContextProvider>
       </AnalyticsContext.Provider>,
     );
-
-    initialize({ isCameraSupported: false });
 
     const input = getByLabelText('Image');
     userEvent.upload(input, validUpload);

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -597,6 +597,20 @@ describe('document-capture/components/acuant-capture', () => {
     });
   });
 
+  context('desktop', () => {
+    it('does not render acuant capture canvas for environmental capture', () => {
+      const { getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: false }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      userEvent.click(getByLabelText('Image'));
+    });
+  });
+
   it('optionally disallows upload', () => {
     const { getByText } = render(
       <AcuantContextProvider sdkSrc="about:blank">

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -92,9 +92,11 @@ describe('document-capture/components/document-capture', () => {
 
   it('progresses through steps to completion', async () => {
     const { getByLabelText, getByText, getAllByText, findAllByText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <DocumentCapture />
-      </AcuantContextProvider>,
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <DocumentCapture />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
     );
 
     initialize();
@@ -186,9 +188,6 @@ describe('document-capture/components/document-capture', () => {
       },
     );
 
-    initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
-
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
@@ -201,7 +200,7 @@ describe('document-capture/components/document-capture', () => {
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    fireEvent.click(selfieInput);
+    userEvent.upload(selfieInput, validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 
@@ -252,9 +251,6 @@ describe('document-capture/components/document-capture', () => {
       },
     );
 
-    initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
-
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
@@ -267,7 +263,7 @@ describe('document-capture/components/document-capture', () => {
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    fireEvent.click(selfieInput);
+    userEvent.upload(selfieInput, validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 
@@ -338,7 +334,6 @@ describe('document-capture/components/document-capture', () => {
           }),
       });
 
-    initialize({ isCameraSupported: false });
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
 
@@ -406,9 +401,6 @@ describe('document-capture/components/document-capture', () => {
       </UploadContextProvider>,
     );
 
-    initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
-
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
@@ -421,7 +413,7 @@ describe('document-capture/components/document-capture', () => {
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    fireEvent.click(selfieInput);
+    userEvent.upload(selfieInput, validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 
@@ -455,9 +447,6 @@ describe('document-capture/components/document-capture', () => {
       { uploadError },
     );
 
-    initialize({ isCameraSupported: false });
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
-
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
@@ -472,7 +461,7 @@ describe('document-capture/components/document-capture', () => {
     expect(onStepChange.callCount).to.equal(1);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    fireEvent.click(selfieInput);
+    userEvent.upload(selfieInput, validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
     expect(onStepChange.callCount).to.equal(1);

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -1,27 +1,49 @@
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import sinon from 'sinon';
-import { AcuantContextProvider } from '@18f/identity-document-capture';
+import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
 import SelfieStep from '@18f/identity-document-capture/components/selfie-step';
 import { render, useAcuant } from '../../../support/document-capture';
 
 describe('document-capture/components/selfie-step', () => {
-  const { initialize } = useAcuant();
+  context('mobile', () => {
+    const { initialize } = useAcuant();
 
-  it('calls onChange callback with uploaded image', async () => {
-    const onChange = sinon.stub();
-    const { getByLabelText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <SelfieStep onChange={onChange} />
-      </AcuantContextProvider>,
-    );
-    initialize();
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '8J+Riw==');
+    it('calls onChange callback with uploaded image', async () => {
+      const onChange = sinon.stub();
+      const { getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <SelfieStep onChange={onChange} />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+      initialize();
+      window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '8J+Riw==');
 
-    userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
+      userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
 
-    await waitFor(() =>
-      expect(onChange.getCall(0).args[0].selfie).to.equal('data:image/jpeg;base64,8J+Riw=='),
-    );
+      await waitFor(() =>
+        expect(onChange.getCall(0).args[0].selfie).to.equal('data:image/jpeg;base64,8J+Riw=='),
+      );
+    });
+  });
+
+  context('desktop', () => {
+    it('calls onChange callback with uploaded image', async () => {
+      const onChange = sinon.stub();
+      const { getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: false }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <SelfieStep onChange={onChange} />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      const file = new window.File([], 'image.png', { type: 'image/png' });
+      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_selfie'), file);
+
+      await waitFor(() => expect(onChange.getCall(0).args[0].selfie).to.equal(file));
+    });
   });
 });


### PR DESCRIPTION
**Why**: To avoid script errors in browsers which cannot support Acuant SDK, and to avoid loading Acuant SDK at all in environments where it's not expected to be used.

Prior to these changes, we would always load the Acuant SDK, regardless whether it was planned to be used (i.e. for mobile capture). This was partly toward the expectation that we could use the Acuant SDK to generate metrics for images uploaded in the desktop flow (LG-3436). However, there are also cases where browser requirements of the Acuant SDK script may cause it to fail to load. Specifically, Internet Explorer cannot load the script because it contains modern script syntax (ECMAScript 2015+). This was overlooked in-part because we prevent Internet Explorer users from proceeding to this step of the flow, but importantly we only do this if the service provider requires liveness. Between browser support and the fact that we don't currently use Acuant SDK to generate metrics about uploaded images on desktop, we should prevent loading the script unless it's known to be used.

**Implementation Notes:**

Previously, the implementation of React components consuming from AcuantContext would assume that the Acuant script would eventually be loaded. Thus, the proposed changes here introduce a new context property `isAcuantLoaded` that helps differentiate from existing combinations of properties. "Readiness" now considers whether the user is on a mobile device, and Acuant context is set as immediately ready for desktop users (where `isAcuantLoaded` is set to false).

**Review Notes:** It may be easier to review by using [GitHub's settings to hide whitespace changes](https://user-images.githubusercontent.com/1779930/108734198-36362c80-74fd-11eb-9e92-8a84ef9e5ff0.png), since a bulk of changes are introducing or rearranging a wrapping `<DeviceContext.Provider>` element within test specs.