### PR TITLE
Skip devDependencies in deploy build step

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -29,7 +29,7 @@ bundle install --deployment --jobs 4 \
     --binstubs "$bundle_dir/bin" \
     --without 'deploy development doc test'
 
-bundle exec yarn install
+bundle exec yarn install --prod
 
 set +x
 


### PR DESCRIPTION
**Why**: We should not need to install devDependencies in deployed environments, as they should not expect to be needed for build or for runtime. This may improve build time by reducing dependency preparation time, and avoid imposing requirements on deployed environments for dependencies which are only relevant for development (see #4680).

__Status:__ Currently for testing. May not be mergeable, pending:

1. Need to audit existing dependencies to make sure they're categorized correctly
   - Then update [dependencies documentation](https://github.com/18F/identity-idp/blob/master/docs/frontend.md#dependencies) to remark that the distinction _is_ meaningful for build
2. May want to change how we build and deploy IDP artifacts (assets, etc). [See related Slack discussion](https://gsa-tts.slack.com/archives/C16RSBG49/p1613757479260100).
3. May want to consider setting up CircleCI to match this behavior except when running JavaScript tests, which may require breaking up the existing `build` task.