### PR TITLE
update identity-doc-auth to ignore Acuant 438/439 errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'faraday'
 gem 'foundation_emails'
 gem 'hiredis'
 gem 'http_accept_language'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.3'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.4'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.3'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 4e1e09d7e5eb673dfbc1e301feacc74859d25d29
-  tag: v0.3.3
+  revision: dbde3a5df72f94792da618aca8fcacaca819717b
+  tag: v0.3.4
   specs:
-    identity-doc-auth (0.3.3)
+    identity-doc-auth (0.3.4)
       activesupport
       faraday
 


### PR DESCRIPTION
Pull in changes from https://github.com/18F/identity-doc-auth/pull/10