### PR TITLE
remove deprecated analytics route

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,7 +1,0 @@
-class AnalyticsController < ApplicationController
-  skip_before_action :verify_authenticity_token
-
-  def create
-    head :ok
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   match '/api/openid_connect/token' => 'openid_connect/token#options', via: :options
   get '/api/openid_connect/userinfo' => 'openid_connect/user_info#show'
   post '/api/risc/security_events' => 'risc/security_events#create'
-  post '/analytics' => 'analytics#create'
 
   # SAML secret rotation paths
   SamlEndpoint.suffixes.each do |suffix|


### PR DESCRIPTION
Follow up to #4699

This should not be merged until after the next release