### PR TITLE
split out the pii validation into a separately logged event (LG-4147)

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -31,9 +31,6 @@ module Idv
             doc_pii_form_response.to_h.merge(user_id: user_uuid),
           )
           store_pii(client_response) if client_response.success? && doc_pii_form_response.success?
-
-          # merge the doc_pii_form_response for the presenter below
-          image_form_response = image_form_response.merge(doc_pii_form_response)
         end
       end
 
@@ -42,6 +39,7 @@ module Idv
         form_response: presenter_response(
           image_form_response,
           client_response,
+          doc_pii_form_response,
         ),
         url_options: url_options,
       )
@@ -93,7 +91,12 @@ module Idv
         call(client_response)
     end
 
-    def presenter_response(form_response, client_response)
+    def presenter_response(image_form_response, client_response, doc_pii_form_response)
+      form_response = image_form_response
+      if doc_pii_form_response.present?
+        form_response = image_form_response.merge(doc_pii_form_response)
+      end
+
       return client_response if form_response.success? && client_response.present?
       form_response
     end

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -40,9 +40,9 @@ module Idv
       presenter = ImageUploadResponsePresenter.new(
         form: image_form,
         form_response: presenter_response(
-          image_form_response,
-          client_response,
-          doc_pii_form_response,
+          image_form_response: image_form_response,
+          client_response: client_response,
+          doc_pii_form_response: doc_pii_form_response,
         ),
         url_options: url_options,
       )
@@ -94,13 +94,13 @@ module Idv
         call(client_response)
     end
 
-    def presenter_response(image_form_response, client_response, doc_pii_form_response)
+    def presenter_response(image_form_response:, client_response:, doc_pii_form_response:)
       # image form wasn't valid
       return image_form_response unless image_form_response.success?
 
       # doc_pii_form exists, but wasn't valid
       if doc_pii_form_response.present? && !doc_pii_form_response.success?
-        return doc_pii_form_response.presence
+        return doc_pii_form_response
       end
 
       client_response

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -108,6 +108,7 @@ class Analytics
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
+  IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
   IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -222,6 +222,13 @@ describe Idv::ImageUploadsController do
           user_id: user.uuid,
         )
 
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+          success: true,
+          errors: {},
+          user_id: user.uuid,
+        )
+
         action
 
         expect_funnel_update_counts(user, 1)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -236,7 +236,7 @@ describe Idv::ImageUploadsController do
         before do
           IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
             method: :get_results,
-            response: IdentityDocAuth::Response.new({
+            response: IdentityDocAuth::Response.new(
               success: true,
               errors: {},
               extra: { result: 'Passed', billed: true },
@@ -246,7 +246,7 @@ describe Idv::ImageUploadsController do
                 state: state,
                 dob: dob,
               },
-            }),
+            ),
           )
         end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -14,6 +14,7 @@ describe Idv::ImageUploadsController do
         document_capture_session_uuid: document_capture_session.uuid,
       }
     end
+    let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
     before do
       Funnel::DocAuth::RegisterStep.new(user.id, '').call('welcome', :view, true)
@@ -25,7 +26,6 @@ describe Idv::ImageUploadsController do
       it 'returns error status when not provided image fields' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:success]).to eq(false)
         expect(json[:errors]).to eq [
@@ -63,7 +63,6 @@ describe Idv::ImageUploadsController do
       it 'returns an error' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:errors]).to eq [
           { field: 'front', message: I18n.t('doc_auth.errors.not_a_file') },
@@ -76,7 +75,6 @@ describe Idv::ImageUploadsController do
         it 'translates errors using the locale param' do
           action
 
-          json = JSON.parse(response.body, symbolize_names: true)
           expect(response.status).to eq(400)
           expect(json[:errors]).to eq [
             { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
@@ -113,7 +111,6 @@ describe Idv::ImageUploadsController do
         params.delete(:document_capture_session_uuid)
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:success]).to eq(false)
         expect(json[:errors]).to eq [
@@ -125,7 +122,6 @@ describe Idv::ImageUploadsController do
         params[:document_capture_session_uuid] = 'bad uuid'
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:success]).to eq(false)
         expect(json[:errors]).to eq [
@@ -141,7 +137,6 @@ describe Idv::ImageUploadsController do
 
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json).to eq({
                               success: false,
@@ -156,7 +151,6 @@ describe Idv::ImageUploadsController do
 
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(429)
         expect(json).to eq({
                               success: false,
@@ -195,7 +189,6 @@ describe Idv::ImageUploadsController do
       it 'returns a successful response and modifies the session' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(200)
         expect(json[:success]).to eq(true)
         expect(document_capture_session.reload.load_result.success?).to eq(true)
@@ -233,6 +226,141 @@ describe Idv::ImageUploadsController do
 
         expect_funnel_update_counts(user, 1)
       end
+
+      context 'but doc_pii validation fails' do
+        let(:first_name) { 'FAKEY' }
+        let(:last_name) { 'MCFAKERSON' }
+        let(:state) { 'ND' }
+        let(:dob) { '10/06/1938' }
+
+        before do
+          IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
+            method: :get_results,
+            response: IdentityDocAuth::Response.new({
+              success: true,
+              errors: {},
+              extra: { result: 'Passed', billed: true },
+              pii_from_doc: {
+                first_name: first_name,
+                last_name: last_name,
+                state: state,
+                dob: dob,
+              },
+            }),
+          )
+        end
+
+        context 'due to invalid Name' do
+          let(:first_name) { nil }
+
+          it 'tracks name validation errors in analytics' do
+            stub_analytics
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+              success: true,
+              errors: {},
+              user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+              success: true,
+              errors: {},
+              billed: true,
+              exception: nil,
+              result: 'Passed',
+              user_id: user.uuid,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+              success: false,
+              errors: {
+                pii: [I18n.t('doc_auth.errors.lexis_nexis.full_name_check')],
+              },
+              user_id: user.uuid,
+            )
+
+            action
+          end
+        end
+
+        context 'due to invalid State' do
+          let(:state) { 'Maryland' }
+
+          it 'tracks state validation errors in analytics' do
+            stub_analytics
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+              success: true,
+              errors: {},
+              user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+              success: true,
+              errors: {},
+              billed: true,
+              exception: nil,
+              result: 'Passed',
+              user_id: user.uuid,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+              success: false,
+              errors: {
+                pii: [I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')],
+              },
+              user_id: user.uuid,
+            )
+
+            action
+          end
+        end
+
+        context 'but doc_pii validation fails due to invalid DOB' do
+          let(:dob) { nil }
+
+          it 'tracks dob validation errors in analytics' do
+            stub_analytics
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+              success: true,
+              errors: {},
+              user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+              success: true,
+              errors: {},
+              billed: true,
+              exception: nil,
+              result: 'Passed',
+              user_id: user.uuid,
+            )
+
+            expect(@analytics).to receive(:track_event).with(
+              Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+              success: false,
+              errors: {
+                pii: [I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks')],
+              },
+              user_id: user.uuid,
+            )
+
+            action
+          end
+        end
+      end
     end
 
     context 'when image upload fails' do
@@ -249,7 +377,6 @@ describe Idv::ImageUploadsController do
       it 'returns an error response' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:success]).to eq(false)
         expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
@@ -292,7 +419,6 @@ describe Idv::ImageUploadsController do
       it 'returns error from yaml file' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
         expect(json[:errors]).to eq [
           {
@@ -337,7 +463,6 @@ describe Idv::ImageUploadsController do
       it 'returns error' do
         action
 
-        json = JSON.parse(response.body, symbolize_names: true)
         expect(response.status).to eq(400)
         expect(json[:success]).to eq(false)
         expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)


### PR DESCRIPTION
Previously, the pii validation result was merged into the form validation result and logged after the doc_auth client result. This resulted in having a success reported on the form after the doc_auth failed.

This PR logs the form validation immediately, then the doc_auth client response, then the pii validation as it's own event.