### PR TITLE
Allow AgencySeeder to populate abbreviations

### DIFF
--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -4,4 +4,5 @@ class Agency < ApplicationRecord
   has_many :service_providers, inverse_of: :agency
   # rubocop:enable Rails/HasManyOrHasOneDependent
   validates :name, presence: true
+  validates :abbreviation, uniqueness: { case_sensitive: false, allow_nil: true }
 end

--- a/app/services/agency_seeder.rb
+++ b/app/services/agency_seeder.rb
@@ -13,7 +13,6 @@ class AgencySeeder
   def run
     agencies.each do |agency_id, config|
       agency = Agency.find_by(id: agency_id)
-      config.delete('abbreviation')
       if agency
         agency.update!(config)
       else

--- a/db/migrate/20210223011217_add_uniqueness_to_agency_abbreviation.rb
+++ b/db/migrate/20210223011217_add_uniqueness_to_agency_abbreviation.rb
@@ -1,0 +1,7 @@
+class AddUniquenessToAgencyAbbreviation < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :agencies, :abbreviation, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_185311) do
+ActiveRecord::Schema.define(version: 2021_02_23_011217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2021_02_18_185311) do
   create_table "agencies", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation"
+    t.index ["abbreviation"], name: "index_agencies_on_abbreviation", unique: true
     t.index ["name"], name: "index_agencies_on_name", unique: true
   end
 

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -8,5 +8,6 @@ describe Agency do
     let(:agency) { build_stubbed(:agency) }
 
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:abbreviation).case_insensitive.allow_nil }
   end
 end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe AgencySeeder do
 
     subject(:run) { instance.run }
 
-    # This implictly validates that the `abbreviation` attribute in the YAML is
-    # ignored
     it 'inserts agencies into the database from agencies.yml' do
       expect { run }.to change(Agency, :count)
     end


### PR DESCRIPTION
Now that the schema has been updated to include the abbreviation column,
we can start to pull them in from the YAML file. The fixture and
localdev files should already include abbreviations.

We'll follow this up with a PR to add the uniqueness and null
constraints to the column once they're all populated.