### PR TITLE
[LG-3974] Add Seeder objects for Agreements data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,13 @@ jobs:
             cp config/application.yml.default config/application.yml
             cp config/service_providers.localdev.yml config/service_providers.yml
             cp config/agencies.localdev.yml config/agencies.yml
+            cp config/iaa_gtcs{.localdev,}.yml
+            cp config/iaa_orders{.localdev,}.yml
+            cp config/iaa_statuses{.localdev,}.yml
+            cp config/integration_statuses{.localdev,}.yml
+            cp config/integrations{.localdev,}.yml
+            cp config/partner_account_statuses{.localdev,}.yml
+            cp config/partner_accounts{.localdev,}.yml
             cp -a keys.example keys
             cp -a certs.example certs
             cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ Vagrantfile
 /config/aws.yml
 /config/service_providers.yml
 /config/agencies.yml
+/config/iaa_gtcs.yml
+/config/iaa_orders.yml
+/config/iaa_statuses.yml
+/config/integration_statuses.yml
+/config/integrations.yml
+/config/partner_account_statuses.yml
+/config/partner_accounts.yml
 /coverage
 /db/*.sqlite3
 /doc/search_stats.csv

--- a/app/services/agreements/base_seeder.rb
+++ b/app/services/agreements/base_seeder.rb
@@ -1,0 +1,59 @@
+module Agreements
+  class BaseSeeder
+    def initialize(rails_env: Rails.env, yaml_path: 'config')
+      @rails_env = rails_env
+      @yaml_path = yaml_path
+    end
+
+    def run
+      records.each do |key, config|
+        config = process_config(key, config)
+        record = record_class.find_or_initialize_by(
+          primary_attribute_bundle(config),
+        )
+        record.assign_attributes(config)
+        record.save!
+      end
+      after_seed
+    end
+
+    private
+
+    attr_reader :rails_env, :yaml_path
+
+    # The following methods need to be defined in the child class
+    #
+    # The model class (assumed to be nested under the Agreements module)
+    # def record_class
+    #   Foo
+    # end
+    #
+    # The filename of the YAML file to be read
+    # def filename
+    #   'foo.yml'
+    # end
+    #
+    # The attribute used as the primariy identifier for a given record (e.g. for
+    #   IAA orders it would be both iaa_gtc_id and order_number)
+    # def primary_attribute_bundle(config)
+    #   { 'name' => config['name'] }
+    # end
+    #
+    # The method to process the config so it is ready to be passed to
+    #   ActiveRecord (e.g. filter for permitted keys and include top-level YAML
+    #   key)
+    # def process_config(key, config)
+    #   config.slice(%w[allow_key1 allow_key2 allow_key3].merge(name: key)
+    # end
+
+    # Override this method to run additional code after the initial records are
+    # seeded
+    def after_seed; end
+
+    def records
+      file = Rails.root.join(yaml_path, filename).read
+      content = ERB.new(file).result
+      YAML.safe_load(content).fetch(rails_env, {})
+    end
+  end
+end

--- a/app/services/agreements/iaa_gtc_seeder.rb
+++ b/app/services/agreements/iaa_gtc_seeder.rb
@@ -1,0 +1,30 @@
+module Agreements
+  class IaaGtcSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      IaaGtc
+    end
+
+    def filename
+      'iaa_gtcs.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'gtc_number' => config['gtc_number'] }
+    end
+
+    def process_config(gtc_number, config)
+      config['partner_account'] =
+        PartnerAccount.find_by!(requesting_agency: config['partner_account'])
+      config['iaa_status'] =
+        IaaStatus.find_by!(name: config['iaa_status'])
+
+      permitted_attrs =
+        %w[mod_number start_date end_date estimated_amount iaa_status partner_account]
+      config.slice(*permitted_attrs).merge('gtc_number' => gtc_number)
+    end
+  end
+end

--- a/app/services/agreements/iaa_order_seeder.rb
+++ b/app/services/agreements/iaa_order_seeder.rb
@@ -1,0 +1,51 @@
+module Agreements
+  class IaaOrderSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      IaaOrder
+    end
+
+    def filename
+      'iaa_orders.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'iaa_gtc_id' => config['iaa_gtc'].id, 'order_number' => config['order_number'] }
+    end
+
+    def process_config(_key, config)
+      config['iaa_gtc'] = IaaGtc.find_by!(gtc_number: config['iaa_gtc'])
+      config['iaa_status'] =
+        IaaStatus.find_by!(name: config['iaa_status'])
+
+      # this is used in the after_seed method to generate the associated
+      # IntegrationUsages after the IaaOrders are created / updated.
+      @associated_integrations ||= {}
+      key = [config['iaa_gtc'].id, config['order_number']]
+      @associated_integrations[key] = config['integrations']
+
+      permitted_attrs =
+        %w[order_number mod_number start_date end_date estimated_amount iaa_status iaa_gtc]
+      config.slice(*permitted_attrs)
+    end
+
+    def after_seed
+      return if @associated_integrations.blank?
+
+      @associated_integrations.each do |(iaa_gtc_id, order_number), integrations|
+        next if integrations.blank?
+
+        order = IaaOrder.find_by!(iaa_gtc_id: iaa_gtc_id, order_number: order_number)
+
+        integrations.each do |issuer|
+          integration = Integration.find_by!(issuer: issuer)
+          IntegrationUsage.find_or_create_by!(iaa_order: order, integration: integration)
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/agreements/iaa_status_seeder.rb
+++ b/app/services/agreements/iaa_status_seeder.rb
@@ -1,0 +1,24 @@
+module Agreements
+  class IaaStatusSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      IaaStatus
+    end
+
+    def filename
+      'iaa_statuses.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'name' => config['name'] }
+    end
+
+    def process_config(name, config)
+      permitted_attrs = %w[order partner_name]
+      config.slice(*permitted_attrs).merge('name' => name)
+    end
+  end
+end

--- a/app/services/agreements/integration_seeder.rb
+++ b/app/services/agreements/integration_seeder.rb
@@ -1,0 +1,31 @@
+module Agreements
+  class IntegrationSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      Integration
+    end
+
+    def filename
+      'integrations.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'issuer' => config['issuer'] }
+    end
+
+    def process_config(issuer, config)
+      config['partner_account'] =
+        PartnerAccount.find_by!(requesting_agency: config['partner_account'])
+      config['integration_status'] =
+        IntegrationStatus.find_by!(name: config['integration_status'])
+      config['service_provider'] = ServiceProvider.find_by!(issuer: issuer)
+
+      permitted_attrs =
+        %w[name dashboard_identifier service_provider integration_status partner_account]
+      config.slice(*permitted_attrs).merge('issuer' => issuer)
+    end
+  end
+end

--- a/app/services/agreements/integration_status_seeder.rb
+++ b/app/services/agreements/integration_status_seeder.rb
@@ -1,0 +1,24 @@
+module Agreements
+  class IntegrationStatusSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      IntegrationStatus
+    end
+
+    def filename
+      'integration_statuses.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'name' => config['name'] }
+    end
+
+    def process_config(name, config)
+      permitted_attrs = %w[order partner_name]
+      config.slice(*permitted_attrs).merge('name' => name)
+    end
+  end
+end

--- a/app/services/agreements/partner_account_seeder.rb
+++ b/app/services/agreements/partner_account_seeder.rb
@@ -1,0 +1,28 @@
+module Agreements
+  class PartnerAccountSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      PartnerAccount
+    end
+
+    def filename
+      'partner_accounts.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'requesting_agency' => config['requesting_agency'] }
+    end
+
+    def process_config(requesting_agency, config)
+      config['agency'] = Agency.find_by!(abbreviation: config['agency'])
+      config['partner_account_status'] =
+        PartnerAccountStatus.find_by!(name: config['partner_account_status'])
+
+      permitted_attrs = %w[name agency partner_account_status crm_id became_partner]
+      config.slice(*permitted_attrs).merge('requesting_agency' => requesting_agency)
+    end
+  end
+end

--- a/app/services/agreements/partner_account_status_seeder.rb
+++ b/app/services/agreements/partner_account_status_seeder.rb
@@ -1,0 +1,24 @@
+module Agreements
+  class PartnerAccountStatusSeeder < BaseSeeder
+    # The core functionality of this class is defined in BaseSeeder
+
+    private
+
+    def record_class
+      PartnerAccountStatus
+    end
+
+    def filename
+      'partner_account_statuses.yml'
+    end
+
+    def primary_attribute_bundle(config)
+      { 'name' => config['name'] }
+    end
+
+    def process_config(name, config)
+      permitted_attrs = %w[order partner_name]
+      config.slice(*permitted_attrs).merge('name' => name)
+    end
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -32,6 +32,15 @@ Dir.chdir APP_ROOT do
   puts "== Linking agencies.yml =="
   run "test -r config/agencies.yml || ln -sv agencies.localdev.yml config/agencies.yml"
 
+  puts "== Linking Agreements YAML files =="
+  run "test -r config/iaa_gtcs.yml || ln -sv iaa_gtcs.localdev.yml config/iaa_gtcs.yml"
+  run "test -r config/iaa_orders.yml || ln -sv iaa_orders.localdev.yml config/iaa_orders.yml"
+  run "test -r config/iaa_statuses.yml || ln -sv iaa_statuses.localdev.yml config/iaa_statuses.yml"
+  run "test -r config/integration_statuses.yml || ln -sv integration_statuses.localdev.yml config/integration_statuses.yml"
+  run "test -r config/integrations.yml || ln -sv integrations.localdev.yml config/integrations.yml"
+  run "test -r config/partner_account_statuses.yml || ln -sv partner_account_statuses.localdev.yml config/partner_account_statuses.yml"
+  run "test -r config/partner_accounts.yml || ln -sv partner_accounts.localdev.yml config/partner_accounts.yml"
+
   puts "== Copying logstash.conf =="
   run "cat logstash.conf.example | sed 's/path_to_repo/#{APP_ROOT.to_s.gsub('/', '\/')}/g' > logstash.conf"
 

--- a/config/iaa_gtcs.localdev.yml
+++ b/config/iaa_gtcs.localdev.yml
@@ -1,0 +1,33 @@
+development:
+  LGCBPFY190002:
+    mod_number: 0
+    start_date: "2017-02-15"
+    end_date: "2022-02-14"
+    estimated_amount: 2_741_892
+    iaa_status: active
+    partner_account: DHS-CBP
+
+  LGTTSFY190003:
+    mod_number: 1
+    start_date: "2018-04-08"
+    end_date: "2023-04-31"
+    estimated_amount: 1_759_839
+    iaa_status: active
+    partner_account: GSA-FAS-TTS
+
+test:
+  LGCBPFY190002:
+    mod_number: 0
+    start_date: "2017-02-15"
+    end_date: "2022-02-14"
+    estimated_amount: 2_741_892
+    iaa_status: active
+    partner_account: DHS-CBP
+
+  LGTTSFY190003:
+    mod_number: 1
+    start_date: "2018-04-08"
+    end_date: "2023-04-31"
+    estimated_amount: 1_759_839
+    iaa_status: active
+    partner_account: GSA-FAS-TTS

--- a/config/iaa_orders.localdev.yml
+++ b/config/iaa_orders.localdev.yml
@@ -1,0 +1,63 @@
+development:
+  "LGCBPFY190002 Order 3":
+    iaa_gtc: LGCBPFY190002
+    order_number: 3
+    mod_number: 0
+    start_date: "2020-02-15"
+    end_date: "2021-02-14"
+    estimated_amount: 1_181_292.21
+    pricing_model: 2
+    iaa_status: active
+    approved_apps:
+      - "Foo"
+      - "Bar"
+      - "Baz"
+    integrations:
+      - "https://rp1.serviceprovider.com/auth/saml/metadata"
+
+  "LGTTSFY190003 Order 2":
+    iaa_gtc: LGTTSFY190003
+    order_number: 2
+    mod_number: 1
+    start_date: "2020-05-01"
+    end_date: "2021-04-31"
+    estimated_amount: 959_839.12
+    pricing_model: 3
+    iaa_status: active
+    approved_apps:
+      - "One app"
+      - "Another app"
+    integrations:
+      - "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"
+
+test:
+  "LGCBPFY190002 Order 3":
+    iaa_gtc: LGCBPFY190002
+    order_number: 3
+    mod_number: 0
+    start_date: "2020-02-15"
+    end_date: "2021-02-14"
+    estimated_amount: 1_181_292.21
+    pricing_model: 2
+    iaa_status: active
+    approved_apps:
+      - "Foo"
+      - "Bar"
+      - "Baz"
+    integrations:
+      - "https://rp1.serviceprovider.com/auth/saml/metadata"
+
+  "LGTTSFY190003 Order 2":
+    iaa_gtc: LGTTSFY190003
+    order_number: 2
+    mod_number: 1
+    start_date: "2020-05-01"
+    end_date: "2021-04-31"
+    estimated_amount: 959_839.12
+    pricing_model: 3
+    iaa_status: active
+    approved_apps:
+      - "One app"
+      - "Another app"
+    integrations:
+      - "https://aal3.serviceprovider.com/auth/saml/metadata"

--- a/config/iaa_statuses.localdev.yml
+++ b/config/iaa_statuses.localdev.yml
@@ -1,0 +1,19 @@
+development:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  active:
+    order: 200
+
+test:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  active:
+    order: 200

--- a/config/integration_statuses.localdev.yml
+++ b/config/integration_statuses.localdev.yml
@@ -1,0 +1,19 @@
+development:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  live:
+    order: 200
+
+test:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  live:
+    order: 200

--- a/config/integrations.localdev.yml
+++ b/config/integrations.localdev.yml
@@ -1,0 +1,25 @@
+development:
+  "https://rp1.serviceprovider.com/auth/saml/metadata":
+    partner_account: DHS-CBP
+    name: "Test Agency App"
+    dashboard_identifier: 123
+    integration_status: live
+
+  "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost":
+    partner_account: GSA-FAS-TTS
+    name: "Test SP"
+    dashboard_identifier: 456
+    integration_status: live
+
+test:
+  "https://rp1.serviceprovider.com/auth/saml/metadata":
+    partner_account: DHS-CBP
+    name: "Test Agency App"
+    dashboard_identifier: 123
+    integration_status: live
+
+  "https://aal3.serviceprovider.com/auth/saml/metadata":
+    partner_account: GSA-FAS-TTS
+    name: "Test SP"
+    dashboard_identifier: 456
+    integration_status: live

--- a/config/partner_account_statuses.localdev.yml
+++ b/config/partner_account_statuses.localdev.yml
@@ -1,0 +1,19 @@
+development:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  active:
+    order: 200
+
+test:
+  step1:
+    order: 0
+    partner_name: pending
+  step2:
+    order: 100
+    partner_name: pending
+  active:
+    order: 200

--- a/config/partner_accounts.localdev.yml
+++ b/config/partner_accounts.localdev.yml
@@ -1,0 +1,41 @@
+development:
+  DHS-CBP:
+    name: "U.S. Customs and Border Protection"
+    agency: DHS
+    partner_account_status: active
+    crm_id: 123456
+    became_partner: "2018-09-20"
+    contacts:
+      - "first.person@cbp.dhs.gov"
+      - "second.person@cbp.dhs.gov"
+
+  GSA-FAS-TTS:
+    name: "Technology Transformation Services"
+    agency: GSA
+    partner_account_status: active
+    crm_id: 234567
+    became_partner: "2019-04-16"
+    contacts:
+      - "first.person@gsa.gov"
+      - "second.person@gsa.gov"
+
+test:
+  DHS-CBP:
+    name: "U.S. Customs and Border Protection"
+    agency: DHS
+    partner_account_status: active
+    crm_id: 123456
+    became_partner: "2018-09-20"
+    contacts:
+      - "first.person@cbp.dhs.gov"
+      - "second.person@cbp.dhs.gov"
+
+  GSA-FAS-TTS:
+    name: "Technology Transformation Services"
+    agency: GSA
+    partner_account_status: active
+    crm_id: 234567
+    became_partner: "2019-04-16"
+    contacts:
+      - "first.person@gsa.gov"
+      - "second.person@gsa.gov"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,3 +3,12 @@ ServiceProviderSeeder.new.run
 
 # add config/agencies.yml
 AgencySeeder.new.run
+
+# add partnerships / agreements data, note that the order matters!
+Agreements::PartnerAccountStatusSeeder.new.run
+Agreements::PartnerAccountSeeder.new.run
+Agreements::IaaStatusSeeder.new.run
+Agreements::IaaGtcSeeder.new.run
+Agreements::IntegrationStatusSeeder.new.run
+Agreements::IntegrationSeeder.new.run
+Agreements::IaaOrderSeeder.new.run

--- a/spec/fixtures/iaa_gtcs.yml
+++ b/spec/fixtures/iaa_gtcs.yml
@@ -1,0 +1,11 @@
+# We need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed. This also depends on the
+# values in config/ for associated records.
+production:
+  LGCBPFY180002:
+    mod_number: 0
+    start_date: "2017-02-15"
+    end_date: "2022-02-14"
+    estimated_amount: 200
+    iaa_status: step1
+    partner_account: DHS-CBP

--- a/spec/fixtures/iaa_orders.yml
+++ b/spec/fixtures/iaa_orders.yml
@@ -1,0 +1,19 @@
+# We need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed. This also depends on the
+# values in config/ for associated records.
+production:
+  "LGCBPFY190002 Order 4":
+    iaa_gtc: LGCBPFY190002
+    order_number: 4
+    mod_number: 0
+    start_date: "2020-02-15"
+    end_date: "2021-02-14"
+    estimated_amount: 200.78
+    pricing_model: 2
+    iaa_status: step2
+    approved_apps:
+      - "Foo"
+      - "Bar"
+      - "Baz"
+    integrations:
+      - "https://rp1.serviceprovider.com/auth/saml/metadata"

--- a/spec/fixtures/iaa_statuses.yml
+++ b/spec/fixtures/iaa_statuses.yml
@@ -1,0 +1,8 @@
+# we need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed
+production:
+  test_step_1:
+    order: 123
+    partner_name: pending
+  test_step_2:
+    order: 456

--- a/spec/fixtures/integration_statuses.yml
+++ b/spec/fixtures/integration_statuses.yml
@@ -1,0 +1,8 @@
+# we need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed
+production:
+  test_step_1:
+    order: 123
+    partner_name: pending
+  test_step_2:
+    order: 456

--- a/spec/fixtures/integrations.yml
+++ b/spec/fixtures/integrations.yml
@@ -1,0 +1,9 @@
+# We need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed. This also depends on the
+# values in config/ for associated records.
+production:
+  "new_issuer":
+    partner_account: DHS-CBP
+    name: "Test Agency App"
+    dashboard_identifier: 123456
+    integration_status: live

--- a/spec/fixtures/partner_account_statuses.yml
+++ b/spec/fixtures/partner_account_statuses.yml
@@ -1,0 +1,8 @@
+# we need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed
+production:
+  test_step_1:
+    order: 123
+    partner_name: pending
+  test_step_2:
+    order: 456

--- a/spec/fixtures/partner_accounts.yml
+++ b/spec/fixtures/partner_accounts.yml
@@ -1,0 +1,13 @@
+# We need to avoid collisions with the values in config/ since the test database
+# is seeded with default values when we run db:seed. This also depends on the
+# values in config/ for associated records.
+production:
+  DHS-FOO:
+    name: "U.S. Friendly Officer Organization"
+    agency: DHS
+    partner_account_status: active
+    crm_id: 123456
+    became_partner: "2018-09-20"
+    contacts:
+      - "first.person@cbp.dhs.gov"
+      - "second.person@cbp.dhs.gov"

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe AgencySeeder do
   let(:deploy_env) { 'int' }
 
   describe '#run' do
-    before { Agency.delete_all }
+    before do
+      Agreements::IntegrationUsage.delete_all
+      Agreements::Integration.delete_all
+      Agreements::IaaOrder.delete_all
+      Agreements::IaaGtc.delete_all
+      Agreements::PartnerAccount.delete_all
+      Agency.delete_all
+    end
 
     subject(:run) { instance.run }
 

--- a/spec/services/agreements/iaa_gtc_seeder_spec.rb
+++ b/spec/services/agreements/iaa_gtc_seeder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::IaaGtcSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::IaaGtc.count }.by(1)
+    end
+    it 'updates a record if one exist' do
+      gtc = create(:iaa_gtc, gtc_number: 'LGCBPFY180002', estimated_amount: 100)
+
+      expect { seeder.run }.to change { gtc.reload.estimated_amount }.from(100).to(200)
+    end
+  end
+end

--- a/spec/services/agreements/iaa_order_seeder_spec.rb
+++ b/spec/services/agreements/iaa_order_seeder_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::IaaOrderSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::IaaOrder.count }.by(1)
+    end
+    it 'updates a record if one exist' do
+      gtc = Agreements::IaaGtc.find_by!(gtc_number: 'LGCBPFY190002')
+      order = create(:iaa_order, iaa_gtc: gtc, order_number: 4, estimated_amount: 100)
+
+    expect { seeder.run }.to change { order.reload.estimated_amount }.from(100).to(200.78)
+    end
+  end
+end

--- a/spec/services/agreements/iaa_status_seeder_spec.rb
+++ b/spec/services/agreements/iaa_status_seeder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::IaaStatusSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::IaaStatus.count }.by(2)
+    end
+    it 'updates a record if one exist' do
+      status = create(:iaa_status, name: 'test_step_1', order: 124)
+
+      expect { seeder.run }.to change { status.reload.order }.from(124).to(123)
+    end
+  end
+end

--- a/spec/services/agreements/integration_seeder_spec.rb
+++ b/spec/services/agreements/integration_seeder_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::IntegrationSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    before { create(:service_provider, issuer: 'new_issuer') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::Integration.count }.by(1)
+    end
+    it 'updates a record if one exist' do
+      integration = create(:integration, issuer: 'new_issuer', name: 'Old Name')
+
+      expect { seeder.run }.to \
+        change { integration.reload.name }.
+        from('Old Name').
+        to('Test Agency App')
+    end
+  end
+end

--- a/spec/services/agreements/integration_status_seeder_spec.rb
+++ b/spec/services/agreements/integration_status_seeder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::IntegrationStatusSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::IntegrationStatus.count }.by(2)
+    end
+    it 'updates a record if one exist' do
+      status = create(:integration_status, name: 'test_step_1', order: 124)
+
+      expect { seeder.run }.to change { status.reload.order }.from(124).to(123)
+    end
+  end
+end

--- a/spec/services/agreements/partner_account_seeder_spec.rb
+++ b/spec/services/agreements/partner_account_seeder_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::PartnerAccountSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::PartnerAccount.count }.by(1)
+    end
+    it 'updates a record if one exist' do
+      partner_account = create(
+        :partner_account,
+        requesting_agency: 'DHS-FOO',
+        agency: Agency.find_by(abbreviation: 'DHS'),
+        partner_account_status: Agreements::PartnerAccountStatus.find_by(name: 'active'),
+        crm_id: 123457,
+        became_partner: '2018-09-20',
+      )
+
+      expect { seeder.run }.to change { partner_account.reload.crm_id }.from(123457).to(123456)
+    end
+  end
+end

--- a/spec/services/agreements/partner_account_status_seeder_spec.rb
+++ b/spec/services/agreements/partner_account_status_seeder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Agreements::PartnerAccountStatusSeeder do
+  describe '.run' do
+    let(:seeder) { described_class.new(rails_env: 'production', yaml_path: 'spec/fixtures') }
+
+    it 'creates new records if none exits' do
+      expect { seeder.run }.to change { Agreements::PartnerAccountStatus.count }.by(2)
+    end
+    it 'updates a record if one exist' do
+      status = create(:partner_account_status, name: 'test_step_1', order: 124)
+
+      expect { seeder.run }.to change { status.reload.order }.from(124).to(123)
+    end
+  end
+end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -106,6 +106,8 @@ describe Reports::IaaBillingReport do
   let(:now) { Time.zone.parse('2020-06-15') }
 
   before do
+    Agreements::IntegrationUsage.delete_all
+    Agreements::Integration.delete_all
     ServiceProvider.delete_all
     Timecop.travel now
   end

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe ServiceProviderSeeder do
   let(:deploy_env) { 'int' }
 
   describe '#run' do
-    before { ServiceProvider.delete_all }
+    before do
+      Agreements::IntegrationUsage.delete_all
+      Agreements::Integration.delete_all
+      ServiceProvider.delete_all
+    end
 
     subject(:run) { instance.run }
 


### PR DESCRIPTION
Resolves LG-3974

Adds a collection of service objects (under the Agreements namespace) to
handle ingesting config YAML files and either creating or updating
records in the database. Leverages inheritance to avoid duplication
across the service objects and requires that a set of private methods be
defined in the child objects.

Due to the fact that we run db:seed in the test environment as well as
in development (and production) this required that a few tests have some
extra deletes added to avoid foreign key constraint violations.