### PR TITLE
LG-4176: Fix errors with Internet Explorer async document capture encryption

### DIFF
--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -7,13 +7,13 @@ import AnalyticsContext from '../context/analytics';
  *
  * @param {Blob} blob Blob object.
  *
- * @return {Promise<DataView>}
+ * @return {Promise<ArrayBuffer>}
  */
 export function blobToDataView(blob) {
   return new Promise((resolve, reject) => {
     const reader = new window.FileReader();
     reader.onload = ({ target }) => {
-      resolve(new DataView(/** @type {ArrayBuffer} */ (target?.result)));
+      resolve(/** @type {ArrayBuffer} */ (target?.result));
     };
     reader.onerror = () => reject(reader.error);
     reader.readAsArrayBuffer(blob);
@@ -37,6 +37,9 @@ export async function encrypt(key, iv, value) {
     /** @type {AesGcmParams} */ ({
       name: 'AES-GCM',
       iv,
+      // Normally, it would not be expected to assign this value, since the property is optional and
+      // the default is 128. However, if not specified, Internet Explorer will throw an error.
+      tagLength: 128,
     }),
     key,
     data,

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -3,13 +3,13 @@ import UploadContext from '../context/upload';
 import AnalyticsContext from '../context/analytics';
 
 /**
- * Returns a promise resolving to an DataView representation of the given Blob object.
+ * Returns a promise resolving to an ArrayBuffer representation of the given Blob object.
  *
  * @param {Blob} blob Blob object.
  *
  * @return {Promise<ArrayBuffer>}
  */
-export function blobToDataView(blob) {
+export function blobToArrayBuffer(blob) {
   return new Promise((resolve, reject) => {
     const reader = new window.FileReader();
     reader.onload = ({ target }) => {
@@ -31,7 +31,7 @@ export function blobToDataView(blob) {
  */
 export async function encrypt(key, iv, value) {
   const data =
-    typeof value === 'string' ? new TextEncoder().encode(value) : await blobToDataView(value);
+    typeof value === 'string' ? new TextEncoder().encode(value) : await blobToArrayBuffer(value);
 
   return window.crypto.subtle.encrypt(
     /** @type {AesGcmParams} */ ({

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@peculiar/webcrypto": "^1.1.4",
+    "@peculiar/webcrypto": "^1.1.6",
     "@testing-library/dom": "^7.29.0",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^3.7.0",

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import sinon from 'sinon';
 import { UploadContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import withBackgroundEncryptedUpload, {
-  blobToDataView,
+  blobToArrayBuffer,
   encrypt,
 } from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
 import { useSandbox } from '../../../support/sinon';
@@ -33,13 +33,13 @@ function isArrayBufferEqual(a, b) {
 describe('document-capture/higher-order/with-background-encrypted-upload', () => {
   const sandbox = useSandbox();
 
-  describe('blobToDataView', () => {
+  describe('blobToArrayBuffer', () => {
     it('converts blob to data view', async () => {
       const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
       const expected = new Uint8Array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]).buffer;
 
-      const dataView = await blobToDataView(data);
-      expect(isArrayBufferEqual(dataView.buffer, expected)).to.be.true();
+      const actual = await blobToArrayBuffer(data);
+      expect(isArrayBufferEqual(actual, expected)).to.be.true();
     });
 
     it('rejects on filereader error', async () => {
@@ -50,7 +50,9 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
       });
 
       try {
-        await blobToDataView(new window.File(['Hello world'], 'demo.text', { type: 'text/plain' }));
+        await blobToArrayBuffer(
+          new window.File(['Hello world'], 'demo.text', { type: 'text/plain' }),
+        );
       } catch (actualError) {
         expect(actualError).to.equal(error);
       }

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -5,6 +5,7 @@ import sinonChai from 'sinon-chai';
 import { createDOM, useCleanDOM } from './support/dom';
 import { chaiConsoleSpy, useConsoleLogSpy } from './support/console';
 import { createObjectURLAsDataURL } from './support/file';
+import { useBrowserCompatibleEncrypt } from './support/crypto';
 
 chai.use(dirtyChai);
 chai.use(sinonChai);
@@ -34,3 +35,4 @@ global.self = window;
 
 useCleanDOM();
 useConsoleLogSpy();
+useBrowserCompatibleEncrypt();

--- a/spec/javascripts/support/crypto.js
+++ b/spec/javascripts/support/crypto.js
@@ -1,0 +1,33 @@
+import sinon from 'sinon';
+
+/**
+ * Test lifecycle hook which ensures that any call to `crypto.subtle.encrypt` using the AES-GCM
+ * algorithm should always include an explicit `tagLength`, despite specification allowing for its
+ * omission, due to browser-specific incompatibilities.
+ *
+ * This may be removed in the future if the upstream polyfill handles this incompatibility.
+ *
+ * @see https://github.com/vibornoff/webcrypto-shim/pull/44
+ */
+export function useBrowserCompatibleEncrypt() {
+  let originalEncrypt;
+
+  beforeEach(() => {
+    originalEncrypt = window.crypto.subtle.encrypt;
+    const stub = sinon.stub().callsFake(originalEncrypt);
+    stub
+      .withArgs(
+        sinon.match({
+          name: 'AES-GCM',
+          tagLength: undefined,
+        }),
+      )
+      .throws(new TypeError('Always pass numeric `tagLength`, even if default of `128`.'));
+
+    window.crypto.subtle.encrypt = stub;
+  });
+
+  afterEach(() => {
+    window.crypto.subtle.encrypt = originalEncrypt;
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,7 +997,7 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@peculiar/asn1-schema@^2.0.12", "@peculiar/asn1-schema@^2.0.26":
+"@peculiar/asn1-schema@^2.0.27":
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz#1ee3b2b869ff3200bcc8ec60e6c87bd5a6f03fe0"
   integrity sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==
@@ -1014,16 +1014,16 @@
   dependencies:
     tslib "^2.0.0"
 
-"@peculiar/webcrypto@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.4.tgz#cbbe2195e5e6f879780bdac9a66bcbaca75c483c"
-  integrity sha512-gEVxfbseFDV0Za3AmjTrRB+wigEMOejHDzoo571e8/YWD33Ejmk0XPF3+G+VaN8+5C5IWZx4CPvxQZ7mF2dvNA==
+"@peculiar/webcrypto@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz#484bb58be07149e19e873861b585b0d5e4f83b7b"
+  integrity sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==
   dependencies:
-    "@peculiar/asn1-schema" "^2.0.26"
+    "@peculiar/asn1-schema" "^2.0.27"
     "@peculiar/json-schema" "^1.1.12"
-    pvtsutils "^1.1.1"
-    tslib "^2.0.3"
-    webcrypto-core "^1.1.8"
+    pvtsutils "^1.1.2"
+    tslib "^2.1.0"
+    webcrypto-core "^1.2.0"
 
 "@rails/webpacker@^5.2.1":
   version "5.2.1"
@@ -7670,12 +7670,12 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pvtsutils@^1.0.11, pvtsutils@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.1.1.tgz#22c2d7689139d2c36d7ef3ac3d5e29bcd818d38a"
-  integrity sha512-Evbhe6L4Sxwu4SPLQ4LQZhgfWDQO3qa1lju9jM5cxsQp8vE10VipcSmo7hiJW48TmiHgVLgDtC2TL6/+ND+IVg==
+pvtsutils@^1.1.1, pvtsutils@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.1.2.tgz#483d72f4baa5e354466e68ff783ce8a9e2810030"
+  integrity sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==
   dependencies:
-    tslib "^2.0.3"
+    tslib "^2.1.0"
 
 pvutils@latest:
   version "1.0.17"
@@ -9172,10 +9172,10 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9478,16 +9478,16 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webcrypto-core@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.1.8.tgz#91720c07f4f2edd181111b436647ea5a282af0a9"
-  integrity sha512-hKnFXsqh0VloojNeTfrwFoRM4MnaWzH6vtXcaFcGjPEu+8HmBdQZnps3/2ikOFqS8bJN1RYr6mI2P/FJzyZnXg==
+webcrypto-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.2.0.tgz#44fda3f9315ed6effe9a1e47466e0935327733b5"
+  integrity sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==
   dependencies:
-    "@peculiar/asn1-schema" "^2.0.12"
+    "@peculiar/asn1-schema" "^2.0.27"
     "@peculiar/json-schema" "^1.1.12"
     asn1js "^2.0.26"
-    pvtsutils "^1.0.11"
-    tslib "^2.0.1"
+    pvtsutils "^1.1.2"
+    tslib "^2.1.0"
 
 webcrypto-shim@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
**Why**: Internet Explorer's implementation of crypto (even with polyfill) appears to be non-standard in a few ways, and as such cannot handle the arguments as currently provided. The proposed changes are effectively equivalent to the current implementation, but in a format that Internet Explorer will appear to tolerate.

Specifically:

- Pass ArrayBuffer instead of DataView for [data argument](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt)
   - Resolves error "Invalid argument"
- Provide default `tagLength` value for `AesGcmParams`, despite [spec defining as optional](https://developer.mozilla.org/en-US/docs/Web/API/AesGcmParams)
   - Resolves subsequent error "Unable to get property 'message' of undefined or null reference"

**Testing Instructions:**

Encryption only occurs in environments where [`doc_auth_enable_presigned_urls`](https://github.com/18F/identity-idp/blob/3b4086bce73ea5b3111fd31e5519da3ad1e38adc/config/application.yml.default#L53) is `'true'`.

We have a pretty good feature test to assure the original contents can be decrypted as expected with the revised implementation:

```
rspec spec/features/idv/doc_auth/document_capture_step_spec.rb:273
```

The errors only occur in Internet Explorer. A user can only reach this step if they are authenticating with a service provider which requires IAL2 non-strict. Therefore, testing requires running the sample OIDC provider alongside the IDP. A successful test is one where no errors are logged when selecting an image on the document capture step in Internet Explorer. Separately, we might want to have better error handling for failed encryption, possibly as part of LG-3752.