### PR TITLE
Add ESLint configuration to forbid development-only logging and test exclusivity

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "indent": "off",
     "max-classes-per-file": "off",
     "newline-per-chained-call": "off",
+    "no-console": "error",
     "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -37,10 +37,6 @@
         "message": "Use CustomEvent constructor with polyfill for Internet Explorer"
       },
       {
-        "selector": "ArrayExpression > SpreadElement",
-        "message": "Don't use array spread, issue with IE 11 (use Array.from instead)"
-      },
-      {
         "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
         "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
       },
@@ -80,8 +76,7 @@
     {
       "files": "spec/javascripts/**/*",
       "rules": {
-        "react/jsx-props-no-spreading": "off",
-        "no-restricted-syntax": "off"
+        "react/jsx-props-no-spreading": "off"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,10 @@
       {
         "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
         "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
+      },
+      {
+        "selector": "CallExpression[callee.object.name=/^(it|describe|context)$/][callee.property.name='only']",
+        "message": "Test exclusivity should not be committed"
       }
     ],
     "no-unused-expressions": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,7 @@
         "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
       },
       {
-        "selector": "CallExpression[callee.object.name=/^(it|describe|context)$/][callee.property.name='only']",
+        "selector": "CallExpression[callee.object.name=/^(it|describe|context)$/][callee.property.name='only'] > MemberExpression",
         "message": "Test exclusivity should not be committed"
       }
     ],


### PR DESCRIPTION
> Prevent console logging

**Why**: Console logging may be useful for development debugging, but should be removed prior to commit.

As with any other rule, we can use inline configuration (`// eslint-disable-line`) for exceptional cases.

See: https://eslint.org/docs/rules/no-console

> Prevent test exclusivity

**Why**: Test exclusivity (`.only`) can be useful for development debugging, but should be removed prior to merging, as otherwise it will prevent other tests from being run.

There's a [popular ESLint plugin](https://github.com/lo1tuma/eslint-plugin-mocha) which provides similar functionality via its `mocha/no-exclusive-tests`. The implementation here is custom, to avoid introducing additional dependencies. I don't feel strongly about this, and would be open to using this plugin instead.

See: https://astexplorer.net/#/gist/d48c4b65dc8c0e81ee29558bbcc8944c/cfb7f8714c4eadb8bc808eaab087ae3fb931898b

---

Nothing specific had prompted this, but I've personally encountered a few scenarios where I'd been close to accidentally committing a `.only`, which can be pretty bad since it causes the appearance of a passed test, when in-fact only one or a few tests are actually being run.