### PR TITLE
[LG-4250] Add Rake task to collect a report of UUIDs for partners

### DIFF
--- a/app/services/user_seeder.rb
+++ b/app/services/user_seeder.rb
@@ -3,14 +3,20 @@ class UserSeeder
     new(**opts).run
   end
 
-  def initialize(**options)
-    @csv_file = options[:csv_file]
+  # Instantiate a new instance of the service object
+  #
+  # @attr csv_file [String] the location of the CSV file with the dummy user data
+  # @attr email_domain [String] the domain to use for user emails
+  # @attr deploy_env [String] the deploy environment, defaults to
+  #   LoginGov::Hostdata but can be overriden for testing
+  def initialize(csv_file:, email_domain:, deploy_env: Identity::Hostdata.env)
+    @csv_file = csv_file
     file = File.read(csv_file)
     @csv = CSV.parse(file, headers: true)
     validate_csv_headers
-    @email_domain = options[:email_domain]
+    @email_domain = email_domain
     validate_email_domain
-    @deploy_env = options[:deploy_env] || Identity::Hostdata.env
+    @deploy_env = deploy_env
   rescue Errno::ENOENT
     raise ArgumentError.new("#{csv_file} does not exist")
   end

--- a/app/services/uuid_reporter.rb
+++ b/app/services/uuid_reporter.rb
@@ -1,0 +1,121 @@
+class UuidReporter
+  def self.run(**opts)
+    new(**opts).run
+  end
+
+  # Instantiate the service object
+  #
+  # @attr email_file [String] the location of the file with the list of emails
+  # @attr sp_file [String] the location of the file with the list of SP issuers
+  # @attr output [String] the location where the output CSV should be written
+  def initialize(email_file:, sp_file:, output:)
+    @emails = parse_file(email_file).map(&:downcase).uniq
+    validate_emails
+    @issuers = parse_file(sp_file).uniq
+    validate_issuers
+    @output = output
+    validate_output
+  end
+
+  # Take the lists of ServiceProvider issuers and emails and do the following:
+  #   1. Confirm that the user has an Identity with at least one of the SPs
+  #   2. Find the user's associated AgencyIdentity and uuid
+  #   3. Export a CSV file with email addresses and associated uuids
+  #
+  # @return [Integer] the number of uuids collected
+  def run
+    agency = find_agency
+    emails_to_user_ids = collect_user_ids
+    emails_to_uuids = collect_identities(agency, emails_to_user_ids)
+    save_csv(emails_to_uuids)
+
+    emails_to_uuids.length
+  end
+
+  private
+
+  attr_reader :emails, :issuers, :output
+
+  def parse_file(file)
+    File.readlines(file, chomp: true)
+  rescue Errno::ENOENT
+    raise ArgumentError.new("#{file} does not exist")
+  end
+
+  def validate_emails
+    return if emails.all? { |e| ValidateEmail.valid?(e) }
+
+    raise ArgumentError.new('All of the email addresses must be valid emails')
+  end
+
+  def validate_issuers
+    all_issuers_belong_to_an_sp?
+    all_issuers_belong_to_same_agency?
+  end
+
+  def all_issuers_belong_to_an_sp?
+    return if ServiceProvider.where(issuer: issuers).count == issuers.length 
+
+    raise ArgumentError.new('All of the issuers must correspond to a service provider')
+  end
+
+  def all_issuers_belong_to_same_agency?
+    agency_count = Agency.
+      joins(:service_providers).
+      where(service_providers: { issuer: issuers }).
+      distinct.
+      count
+
+    return if agency_count == 1
+
+    raise ArgumentError.new('All of the issuers must belong to the same agency')
+  end
+
+  def validate_output
+    return unless File.exist?(@output)
+
+    raise ArgumentError.new('Output file already exists')
+  end
+
+  def find_agency
+    Agency.
+      joins(:service_providers).
+      find_by(service_providers: { issuer: issuers.first })
+  end
+
+  def collect_user_ids
+    emails.each_with_object({}) do |email, hash|
+      user_id = EmailAddress.confirmed.find_with_email(email)&.user_id
+      hash[email] = user_id
+    end
+  end
+
+  def collect_identities(agency, emails_to_user_ids)
+    # This makes use of the composite indexes on both the identities table
+    # (user_id, service_provider) and the agency_identities table (user_id,
+    # agency_id) so it should not require a full scan of either table.
+    #
+    # Note that we use two separate queries since the inner joins don't take
+    # advantage of the composite indexes and are highly non-performant.
+    actual_user_ids = emails_to_user_ids.values.select(&:present?)
+    user_ids_with_identities = ServiceProviderIdentity.
+      where(user_id: actual_user_ids, service_provider: issuers).
+      pluck(:user_id)
+    agency_identities = AgencyIdentity.
+      select(:uuid, :user_id).
+      where(user_id: user_ids_with_identities, agency_id: agency.id)
+
+    uuid_hash = agency_identities.map { |record| [record.user_id, record.uuid] }.to_h
+    emails_to_user_ids.transform_values { |user_id| uuid_hash[user_id] }
+  end
+
+  def save_csv(emails_to_uuids)
+    CSV.open(output, 'w') do |csv|
+      csv << ['email_address', 'uuid']
+
+      emails_to_uuids.each do |email, uuid|
+        csv << [email, uuid]
+      end
+    end
+  end
+end

--- a/config/service_providers.yml.old
+++ b/config/service_providers.yml.old
@@ -1,0 +1,395 @@
+test:
+  'http://localhost:3000':
+    acs_url: 'http://localhost:3000/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'http://localhost:3000/test/saml'
+    block_encryption: 'none'
+    cert: 'saml_test_sp'
+    agency: 'Test Government Agency'
+    agency_id: 1
+    uuid_priority: 10
+    friendly_name: 'Your friendly Government Agency'
+    logo: 'generic.svg'
+    return_to_sp_url: 'http://localhost:3000'
+    redirect_uris:
+      - 'x-example-app://idp_return'
+    attribute_bundle:
+      - email
+      - phone
+    allow_prompt_login: true
+
+  'https://rp1.serviceprovider.com/auth/saml/metadata':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 2
+    attribute_bundle:
+      - first_name
+      - last_name
+      - ssn
+      - zipcode
+    allow_prompt_login: true
+
+  'https://aal3.serviceprovider.com/auth/saml/metadata':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 2
+    aal: 3
+    attribute_bundle:
+      - first_name
+      - last_name
+      - ssn
+      - zipcode
+    allow_prompt_login: true
+
+  'test_saml_sp_not_requesting_signed_response_message':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP requesting signed response message'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 1
+    attribute_bundle:
+      - email
+    allow_prompt_login: true
+    block_encryption: 'none'
+    signed_response_message_requested: false
+
+  'test_saml_sp_requesting_signed_response_message':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP requesting signed response message'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 1
+    attribute_bundle:
+      - email
+    allow_prompt_login: true
+    block_encryption: 'none'
+    signed_response_message_requested: true
+
+  'https://rp2.serviceprovider.com/auth/saml/metadata':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    cert: 'saml_test_sp'
+    friendly_name: 'Test SP'
+    allow_prompt_login: true
+
+  'http://test.host':
+    acs_url: 'http://test.host/test/saml/decode_assertion'
+    block_encryption: 'aes256-cbc'
+    metadata_url: 'http://test.host/test/saml/metadata'
+    sp_initiated_login_url: 'http://test.host/test/saml'
+    friendly_name: 'Test SP'
+    allow_prompt_login: true
+    launch_date: '2020-03-01'
+    iaa: 'ABC123-2020'
+    iaa_start_date: '2020-01-01'
+    iaa_end_date: '2020-12-31'
+
+  'urn:gov:gsa:openidconnect:test':
+    redirect_uris:
+      - 'gov.gsa.openidconnect.test://result'
+      - 'gov.gsa.openidconnect.test://result/signout'
+    cert: 'saml_test_sp'
+    friendly_name: 'Example iOS App'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
+    logo: 'generic.svg'
+    ial: 2
+    push_notification_url: http://localhost/push_notifications
+    allow_prompt_login: true
+
+  'urn:gov:gsa:openidconnect:test_prompt_login_banned':
+    redirect_uris:
+      - 'gov.gsa.openidconnect.test://result'
+      - 'gov.gsa.openidconnect.test://result/signout'
+    cert: 'saml_test_sp'
+    friendly_name: 'Example app that disallows prompt=login'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
+    logo: 'generic.svg'
+    ial: 1
+    allow_prompt_login: false
+
+  'urn:gov:gsa:openidconnect:test:loa1':
+    redirect_uris:
+      - 'gov.gsa.openidconnect.test://result'
+      - 'gov.gsa.openidconnect.test://result/logout'
+    cert: 'saml_test_sp'
+    friendly_name: 'Example iOS App'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
+    logo: 'generic.svg'
+    allow_prompt_login: true
+
+  'urn:gov:gsa:openidconnect:sp:server':
+    agency_id: 2
+    redirect_uris:
+      - 'http://localhost:7654/auth/result'
+      - 'https://example.com'
+      - 'http://www.example.com/test/oidc'
+    cert: 'saml_test_sp'
+    friendly_name: 'Test SP'
+    assertion_consumer_logout_service_url: ''
+    ial: 2
+    allow_prompt_login: true
+
+  'urn:gov:gsa:openidconnect:sp:server_requiring_aal3':
+    agency_id: 2
+    redirect_uris:
+      - 'http://localhost:7654/auth/result'
+      - 'https://example.com'
+    cert: 'saml_test_sp'
+    friendly_name: 'Test SP'
+    assertion_consumer_logout_service_url: ''
+    ial: 2
+    aal: 3
+    allow_prompt_login: true
+
+  'test_sp_with_default_help_text':
+    agency_id: 2
+    cert: 'saml_test_sp'
+    friendly_name: 'Test SP with default help text'
+    ial: 2
+    help_text:
+      sign_in:
+        en: <b>First time here from %{sp_name}?</b><p>Your old %{sp_name} username
+          and password won’t work. Please <a href=%{sp_create_link}>create a login.gov
+          account</a> using the same email address you use for %{sp_name}. <p><a href="https://login.gov/help/">Learn
+          more</a>
+        es: <b>¿Ha venido de %{sp_name}?</b><p>Si tiene un perfil de %{sp_name}
+          existente, favor de usar la dirección de correo electrónico primaria o secundaria
+          que usó para %{sp_name} para <a href=%{sp_create_link}>crear un nueva cuenta
+          de login.gov</a> <p><a href="https://login.gov/help/">Obtenga más información.</a>
+        fr: <b>Êtes-vous venu(e) de %{sp_name}?</b><p> Si vous avez déjà un profil
+          %{sp_name}, veuillez utiliser l'adresse e-mail principale ou secondaire
+          que vous avez utilisée pour %{sp_name} pour <a href=%{sp_create_link}> créer
+          votre nouveau compte login.gov</a> <p><a href="https://login.gov/help/">En
+          savoir plus.</a>
+      sign_up:
+        en: Please create a login.gov account using the same email address you
+          use for %{sp_name} <p><a href="https://login.gov/help/">Learn more</a>
+        es: Por favor crea un login.gov cuenta usando la misma dirección de correo
+          electrónico que utiliza para %{sp_name}. <p><a href="https://login.gov/help/">Obtenga
+          más información.</a>
+        fr: Veuillez créer un compte login.gov avec la même adresse e-mail que
+          vous avez utilisée pour %{sp_name}. <p><a href="https://login.gov/help/">En
+          savoir plus.</a>
+      forgot_password:
+        en: Your old %{sp_name} username and password won’t work. Please
+          <a href=%{sp_create_link}>create a login.gov account</a> using the same
+          email address you use for %{sp_name}. <p><a href="https://login.gov/help/">Learn
+          more</a>
+        es: Si tiene un perfil de %{sp_name} existente, favor de usar
+          la dirección de correo electrónico primaria o secundaria que usó para %{sp_name}
+          para <a href=%{sp_create_link}>crear su nueva cuenta de login.gov</a>. <p><a
+          href="https://login.gov/help/">Obtenga más información.</a>
+        fr: Si vous avez déjà un profil %{sp_name}, veuillez utiliser
+          l'adresse e-mail principale ou secondaire que vous avez utilisée pour %{sp_name}
+          pour <a href=%{sp_create_link}> créer votre nouveau compte login.gov</a>
+          <p><a href="https://login.gov/help/">En savoir plus.</a>
+    allow_prompt_login: true
+
+  'test_sp_with_custom_help_text':
+    agency_id: 2
+    cert: 'saml_test_sp'
+    friendly_name: 'Test SP with custom help text'
+    ial: 2
+    help_text:
+      sign_in:
+        en: "custom sign in help text for %{sp_name}"
+        es: ""
+        fr: ""
+      sign_up:
+        en: ""
+        es: ""
+        fr: ""
+      forgot_password:
+        en: ""
+        es: ""
+        fr: ""
+    allow_prompt_login: true
+
+development:
+  'https://rp1.serviceprovider.com/auth/saml/metadata':
+    agency_id: 2
+    metadata_url: 'http://localhost:3000/test/saml/metadata'
+    acs_url: 'http://localhost:3000/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    sp_initiated_login_url: 'http://localhost:3000/test/saml'
+    cert: 'saml_test_sp'
+    fingerprint: '08:79:F5:B1:B8:CC:EC:8F:5C:2A:58:03:30:14:C9:E6:F1:67:78:F1:97:E8:3A:88:EB:8E:70:92:25:D2:2F:32'
+    logo: 'generic.svg'
+    agency: 'GSA'
+    friendly_name: 'Awesome test SP'
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
+    friendly_name: 'Test SAML SP'
+    acs_url: 'http://localhost:4567/consume'
+    sp_initiated_login_url: 'http://localhost:4567/test/saml'
+    assertion_consumer_logout_service_url: 'http://localhost:4567/slo_logout'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_sinatra_demo'
+    ial: 2
+    attribute_bundle:
+      - email
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
+    acs_url: 'http://localhost:3000/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/auth/saml/logout'
+    sp_initiated_login_url: 'http://localhost:3000/admin/sign_in'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_micropurchase'
+    agency: 'TTS Acquisition'
+    logo: '18f.svg'
+    friendly_name: 'Micro-purchase Dev'
+    return_to_sp_url: 'http://localhost:3000'
+    attribute_bundle:
+      - email
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
+    acs_url: 'http://localhost:3003/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'http://localhost:3003/auth/saml/logout'
+    sp_initiated_login_url: 'http://localhost:3003/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 10
+    friendly_name: '18F Test Service Provider'
+    logo: 'generic.svg'
+    return_to_sp_url: 'http://localhost:3003'
+    attribute_bundle:
+      - email
+    ial: 2
+
+  'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
+    friendly_name: 'Dashboard'
+    agency: 'GSA'
+    agency_id: 2
+    uuid_priority: 30
+    logo: '18f.svg'
+    cert: 'identity_dashboard_cert'
+    return_to_sp_url: 'http://localhost:3001'
+    redirect_uris:
+      - 'http://localhost:3001/auth/logindotgov/callback'
+      - 'http://localhost:3001'
+
+  'urn:gov:gsa:openidconnect:development':
+    redirect_uris:
+      - 'gov.gsa.openidconnect.development://result'
+    friendly_name: 'Example iOS App'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
+    logo: 'generic.svg'
+
+  'urn:gov:gsa:openidconnect:sp:sinatra':
+    agency_id: 1
+    ial: 2
+    push_notification_url: http://localhost:9292/api/push_notifications
+    redirect_uris:
+      - 'http://localhost:9292/'
+      - 'http://localhost:9292/auth/result'
+      - 'http://localhost:9292/logout'
+    cert: 'sp_sinatra_demo'
+    friendly_name: 'Example Sinatra App'
+
+  'urn:gov:gsa:openidconnect:sp:expressjs':
+    agency: 'GSA'
+    cert: 'sp_expressjs_demo'
+    friendly_name: 'Example OIDC Client (Express.js)'
+    logo: '18f.svg'
+    redirect_uris:
+      - 'http://localhost:9393/'
+      - 'http://localhost:9393/auth/login-gov/callback'
+
+  'urn:gov:gsa:openidconnect:sp:gin':
+    agency: 'GSA'
+    cert: 'sp_gin_demo'
+    friendly_name: 'Example OIDC Client (Gin)'
+    logo: '18f.svg'
+    redirect_uris:
+      - 'http://localhost:8080/'
+      - 'http://localhost:8080/auth/login-gov/callback'
+
+  'urn:gov:gsa:openidconnect:sp:phoenix':
+    agency: 'GSA'
+    cert: 'sp_phoenix_demo'
+    friendly_name: 'Example OIDC Client (Phoenix)'
+    logo: '18f.svg'
+    redirect_uris:
+      - 'http://localhost:4000/'
+      - 'http://localhost:4000/auth/result'
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:oyk_sml':
+    agency: 'GSA'
+    friendly_name: 'Ruby client test app'
+    cert: 'ruby_client'
+    logo: '18f.sv'
+    redirect_uris:
+      - 'http://localhost:4567/'
+    ial: 1
+    attribute_bundle:
+      - email
+    acs_url: 'http://localhost:4567/auth/saml/sso'
+
+# These are fake production service providers needed for the
+# ServiceProviderSeeder tests. They are not actually used in production.
+#
+# Production service providers come from identity-idp-config and shouldn't be
+# added here.
+#
+production:
+
+  'urn:gov:login:test-providers:fake-prod-sp':
+    friendly_name: 'Fake/Test stub SP for prod'
+    restrict_to_deploy_env: 'prod'
+
+  'urn:gov:login:test-providers:fake-staging-sp':
+    friendly_name: 'Fake/Test stub SP for staging'
+    restrict_to_deploy_env: 'staging'
+
+  'urn:gov:login:test-providers:fake-unrestricted-sp':
+    friendly_name: 'Fake/Test stub SP, env unrestricted'

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -20,4 +20,27 @@ namespace :partners do
       exit(-1)
     end
   end
+
+  desc 'Retrieve a list of agency UUIDs given a list of emails and SPs'
+  task get_agency_uuids: :environment do
+    options = {
+      email_file: ENV['EMAIL_FILE'],
+      sp_file: ENV['SP_FILE'],
+      output: ENV['OUTPUT'],
+    }
+
+    if options.values.any?(&:nil?)
+      puts 'You must define the environment variables EMAIL_FILE, SP_FILE, and OUTPUT'
+      exit(-1)
+    end
+
+    begin
+      count = UuidReporter.run(**options)
+      puts "#{count} users reported"
+      puts 'Complete!'
+    rescue ArgumentError, StandardError => e
+      puts "ERROR: #{e.message}"
+      exit(-1)
+    end
+  end
 end

--- a/spec/fixtures/invalid_uuid_report_emails.txt
+++ b/spec/fixtures/invalid_uuid_report_emails.txt
@@ -1,0 +1,2 @@
+user1@example.com
+not_a_valid_email

--- a/spec/fixtures/valid_uuid_report_emails.txt
+++ b/spec/fixtures/valid_uuid_report_emails.txt
@@ -1,0 +1,4 @@
+user1@example.com
+user2@example.com
+user3@example.com
+user4@example.com

--- a/spec/fixtures/valid_uuid_report_sps.txt
+++ b/spec/fixtures/valid_uuid_report_sps.txt
@@ -1,0 +1,2 @@
+spissuer1
+spissuer2

--- a/spec/services/uuid_reporter_spec.rb
+++ b/spec/services/uuid_reporter_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe UuidReporter do
+  let(:valid_email_fixture) { 'spec/fixtures/valid_uuid_report_emails.txt' }
+  let(:valid_sp_fixture) { 'spec/fixtures/valid_uuid_report_sps.txt' }
+  let(:valid_output) { 'tmp/uuids.csv' }
+
+  # DATA
+  let!(:agency) { create(:agency) }
+  let!(:sp1) { create(:service_provider, agency_id: agency.id, issuer: 'spissuer1') }
+  let!(:sp2) { create(:service_provider, agency_id: agency.id, issuer: 'spissuer2') }
+
+  describe '.new' do
+    it 'raises the appropriate error with missing email file' do
+      opts = {
+        email_file: 'does_not_exist.txt',
+        sp_file: valid_sp_fixture,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /does not exist/)
+    end
+    it 'raises the appropriate error when the email file contains an invalid email' do
+      opts = {
+        email_file: 'spec/fixtures/invalid_uuid_report_emails.txt',
+        sp_file: valid_sp_fixture,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /must be valid emails/)
+    end
+    it 'raises the appropriate error with missing sp file' do
+      opts = {
+        email_file: valid_email_fixture,
+        sp_file: 'does_not_exist.txt',
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /does not exist/)
+    end
+    it 'raises the appropriate error when the sp file contains an invalid issuer' do
+      sp2.delete # it's in the fixture
+
+      opts = {
+        email_file: valid_email_fixture,
+        sp_file: valid_sp_fixture,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /must correspond to a service provider/)
+    end
+    it 'raises the appropriate error when the sp file contains an SPs from multiple agencies' do
+      sp2.update!(agency: create(:agency))
+
+      opts = {
+        email_file: valid_email_fixture,
+        sp_file: valid_sp_fixture,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /must belong to the same agency/)
+    end
+    it 'raises the appropriate error when the output file exists' do
+      FileUtils.touch(valid_output)
+
+      opts = {
+        email_file: valid_email_fixture,
+        sp_file: valid_sp_fixture,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /Output file already exists/)
+
+      File.delete(valid_output)
+    end
+  end
+
+  describe '.run' do
+    context 'with valid inputs' do
+      let!(:user1) { create(:user, :signed_up, email: 'user1@example.com') }
+      let!(:user2) { create(:user, :signed_up, email: 'user2@example.com') }
+      let!(:user3) { create(:user, :signed_up, email: 'user3@example.com') }
+      let!(:uuid1) do
+        IdentityLinker.new(user1, sp1.issuer).link_identity
+        AgencyIdentity.find_by(user_id: user1.id, agency_id: agency.id).uuid
+      end
+      let!(:uuid2) do
+        IdentityLinker.new(user2, sp2.issuer).link_identity
+        AgencyIdentity.find_by(user_id: user2.id, agency_id: agency.id).uuid
+      end
+
+      let(:opts) do
+        {
+          email_file: valid_email_fixture,
+          sp_file: valid_sp_fixture,
+          output: valid_output,
+        }
+      end
+
+      before(:each) do
+        IdentityLinker.new(user3, create(:service_provider).issuer).link_identity
+      end
+
+      after(:each) { File.delete(valid_output) }
+
+      it 'generates the correct csv' do
+        expected = <<~CSV
+          email_address,uuid
+          user1@example.com,#{uuid1}
+          user2@example.com,#{uuid2}
+          user3@example.com,
+          user4@example.com,
+        CSV
+
+        described_class.run(**opts)
+
+        expect(File.read(valid_output)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,3 +42,5 @@ WebMock.disable_net_connect!(
 require 'zonebie'
 Zonebie.quiet = true
 require 'zonebie/rspec'
+
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing


### PR DESCRIPTION
Resolves LG-4250

Adds a partners:get_agency_uuids Rake task and a UuidReporter service
object to find and export a list of agency UUIDs given a list of emails
and a list of ServiceProvider issuers to check. If all of those SPs
belong to the same agency, a user is associated with a given email, and
that user has an Identity with at least one of the SPs, we include the
user's agency UUID in a CSV with their email, otherwise we leave the CSV
blank. Leverages composite indexes on the identities and
agency_identities tables.