### PR TITLE
Add has_many :identities association to ServiceProvider

### DIFF
--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -26,6 +26,7 @@ class NullServiceProvider
     iaa_start_date
     ial2_quota
     id
+    identities
     launch_date
     logo
     metadata_url
@@ -69,6 +70,10 @@ class NullServiceProvider
   end
 
   def redirect_uris
+    []
+  end
+
+  def identities
     []
   end
 

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -6,6 +6,12 @@ class ServiceProvider < ApplicationRecord
 
   belongs_to :agency
 
+  # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :identities, inverse_of: :service_provider_record,
+                        foreign_key: 'service_provider',
+                        primary_key: 'issuer'
+  # rubocop:enable Rails/HasManyOrHasOneDependent
+
   # Do not define validations in this model.
   # See https://github.com/18F/identity_validations
   include IdentityValidations::ServiceProviderValidation

--- a/spec/models/null_service_provider_spec.rb
+++ b/spec/models/null_service_provider_spec.rb
@@ -76,12 +76,20 @@ describe NullServiceProvider do
     end
   end
 
+  describe '#identities' do
+    it 'returns empty array' do
+      expect(subject.identities).to eq([])
+    end
+  end
+
   context 'matching methods on ServiceProvider' do
     it 'has all the methods that ServiceProvider has' do
       sp_methods = ServiceProvider.instance_methods(false)
       ignored_methods = %i[
         autosave_associated_records_for_agency
+        autosave_associated_records_for_identities
         belongs_to_counter_cache_after_update
+        validate_associated_records_for_identities
       ]
       null_sp_methods = NullServiceProvider.instance_methods
 

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -136,6 +136,18 @@ describe ServiceProvider do
     end
   end
 
+  describe 'associations' do
+    subject { service_provider }
+
+    it { is_expected.to belong_to(:agency) }
+    it do
+      is_expected.to have_many(:identities).
+        inverse_of(:service_provider_record).
+        with_foreign_key('service_provider').
+        with_primary_key('issuer')
+    end
+  end
+
   describe '#issuer' do
     it 'returns the constructor value' do
       expect(service_provider.issuer).to eq 'http://localhost:3000'


### PR DESCRIPTION
This is the inverse of the existing :service_provider_record association
on Identity but will allow for query composition using ActiveRecord.