### PR TITLE
[LG-4273] Update nameid-format:EmailAddress to match SAML spec

### DIFF
--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -24,7 +24,7 @@ module Saml
       ISSUERS_WITH_EMAIL_NAMEID_FORMAT = AppConfig.env.issuers_with_email_nameid_format.split(',').
                                          freeze
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'.freeze
-      NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'.freeze
+      NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 


### PR DESCRIPTION
Resolves LG-4273

See [the spec](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), section 8.3.2 (p. 78).