### PR TITLE
Update lexisnexis for DOB failure reason handling (LG-3706)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,5 +119,5 @@ end
 
 group :production do
   gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.6.0'
-  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.1.pre'
+  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.7.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,10 +41,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git
-  revision: dd16ec95e6dba972ab61e90f650e573ab071e83f
-  tag: v2.5.1.pre
+  revision: 415a0e970b6ff1ab3262fb4874164c4dfd156120
+  tag: v2.7.0
   specs:
-    lexisnexis (2.5.1.pre)
+    lexisnexis (2.7.0)
       activesupport
       dotenv
       faraday


### PR DESCRIPTION
Changes: https://github.com/18f/identity-lexisnexis-api-client-gem/compare/v2.5.1.pre...v2.7.0

This is another attempt to update how we handle partial DOB matches in LexisNexis. My goal is to deploy this behind a feature flag to staging again, it is still disabled in production

