### PR TITLE
LG-4282 Prevent double click on completions screen

### DIFF
--- a/app/views/sign_up/completions/_show_sp.html.erb
+++ b/app/views/sign_up/completions/_show_sp.html.erb
@@ -13,8 +13,8 @@
 </p>
 <p>
   <div class="center">
-    <%= button_to t('sign_up.agree_and_continue'),
-                  sign_up_completed_path,
-                  class: 'btn btn-primary btn-wide' %>
+    <%= validated_form_for(:idv_form, url: sign_up_completed_path) do %>
+      <%= submit_tag t('sign_up.agree_and_continue'), class: 'btn btn-primary btn-wide' %>
+    <% end %>
   </div>
 </p>


### PR DESCRIPTION
**How**: Using `validated_form_for` automatically leverages the js code that was added to prevent double submit