### PR TITLE
LG-3752: Handle failed uploads in document capture async upload

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -11,6 +11,7 @@ import SubmissionStatus from './submission-status';
 import DesktopDocumentDisclosure from './desktop-document-disclosure';
 import useI18n from '../hooks/use-i18n';
 import { RetrySubmissionError } from './submission-complete';
+import { BackgroundEncryptedUploadError } from '../higher-order/with-background-encrypted-upload';
 import SuspenseErrorBoundary from './suspense-error-boundary';
 import SubmissionInterstitial from './submission-interstitial';
 import PromptOnNavigate from './prompt-on-navigate';
@@ -75,6 +76,17 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
       field: error.field,
       error,
     }));
+  } else if (submissionError instanceof BackgroundEncryptedUploadError) {
+    initialActiveErrors = [{ field: submissionError.baseField, error: submissionError }];
+  }
+
+  let initialValues;
+  if (submissionError && formValues) {
+    initialValues = formValues;
+
+    if (submissionError instanceof BackgroundEncryptedUploadError) {
+      initialValues = except(initialValues, ...submissionError.fields);
+    }
   }
 
   /** @type {FormStep[]} */
@@ -131,7 +143,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
       )}
       <FormSteps
         steps={steps}
-        initialValues={submissionError && formValues ? formValues : undefined}
+        initialValues={initialValues}
         initialActiveErrors={initialActiveErrors}
         onComplete={submitForm}
         onStepChange={onStepChange}

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -132,6 +132,17 @@ const FileInput = forwardRef((props, ref) => {
         setOwnErrorMessage(nextOwnErrorMessage);
         onError(nextOwnErrorMessage);
       }
+
+      // This is not a controlled component in the sense that the value is reflected onto the input
+      // element. Clear the value being set, so that the browser doesn't suppress a change event
+      // based on what it assumes the current value to be, as it might not be the same as the
+      // component's `value`, especially when the value is modified externally.
+      //
+      // "In React, an <input type="file" /> is always an uncontrolled component because its value
+      // can only be set by a user, and not programmatically."
+      //
+      // See: https://reactjs.org/docs/uncontrolled-components.html#the-file-input-tag
+      event.target.value = '';
     } else {
       onChange(null);
     }

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -1,4 +1,12 @@
-import { useContext, useState, useMemo, forwardRef } from 'react';
+import {
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+  forwardRef,
+  useRef,
+  useImperativeHandle,
+} from 'react';
 import FileImage from './file-image';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
@@ -103,6 +111,8 @@ const FileInput = forwardRef((props, ref) => {
     onChange = () => {},
     onError = () => {},
   } = props;
+  const isResettingValue = useRef(false);
+  const inputRef = useRef(/** @type {HTMLInputElement?} */ (null));
   const { t, formatHTML } = useI18n();
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
@@ -113,6 +123,22 @@ const FileInput = forwardRef((props, ref) => {
   ]);
   const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {string?} */ (null));
   useMemo(() => setOwnErrorMessage(null), [value]);
+  useImperativeHandle(ref, () => inputRef.current);
+  useEffect(() => {
+    // This is not a controlled component in the sense that the value is reflected onto the input
+    // element. Clear any DOM value that happens to be set, so that the browser doesn't suppress a
+    // change event based on what it assumes the current value to be.
+    //
+    // "In React, an <input type="file" /> is always an uncontrolled component because its value can
+    // only be set by a user, and not programmatically."
+    //
+    // See: https://reactjs.org/docs/uncontrolled-components.html#the-file-input-tag
+    if (inputRef.current && inputRef.current.files?.length) {
+      isResettingValue.current = true;
+      inputRef.current.value = '';
+      isResettingValue.current = false;
+    }
+  }, [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
 
@@ -123,6 +149,18 @@ const FileInput = forwardRef((props, ref) => {
    * @param {import('react').ChangeEvent<HTMLInputElement>} event Change event.
    */
   function onChangeIfValid(event) {
+    // It should not be expected to need to consider the value reset, since the HTML specification
+    // dictates that programmatic updates to values are excluded from event emissions. Alas, IE11
+    // _does_ emit a change event when assigning or resetting the value of a file input.
+    //
+    // "These events are not fired in response to changes made to the values of form controls by
+    // scripts."
+    //
+    // See: https://html.spec.whatwg.org/multipage/input.html
+    if (isResettingValue.current) {
+      return;
+    }
+
     const file = /** @type {FileList} */ (event.target.files)[0];
     if (file) {
       if (isValidForAccepts(file.type, accept)) {
@@ -132,17 +170,6 @@ const FileInput = forwardRef((props, ref) => {
         setOwnErrorMessage(nextOwnErrorMessage);
         onError(nextOwnErrorMessage);
       }
-
-      // This is not a controlled component in the sense that the value is reflected onto the input
-      // element. Clear the value being set, so that the browser doesn't suppress a change event
-      // based on what it assumes the current value to be, as it might not be the same as the
-      // component's `value`, especially when the value is modified externally.
-      //
-      // "In React, an <input type="file" /> is always an uncontrolled component because its value
-      // can only be set by a user, and not programmatically."
-      //
-      // See: https://reactjs.org/docs/uncontrolled-components.html#the-file-input-tag
-      event.target.value = '';
     } else {
       onChange(null);
     }
@@ -243,7 +270,7 @@ const FileInput = forwardRef((props, ref) => {
           )}
           <div className="usa-file-input__box" />
           <input
-            ref={ref}
+            ref={inputRef}
             id={inputId}
             className="usa-file-input__input"
             type="file"

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -1,4 +1,5 @@
 import { UploadFormEntryError } from '../services/upload';
+import { BackgroundEncryptedUploadError } from '../higher-order/with-background-encrypted-upload';
 import useI18n from '../hooks/use-i18n';
 
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -13,11 +14,6 @@ import useI18n from '../hooks/use-i18n';
  * An error representing a state where a required form value is missing.
  */
 export class RequiredValueMissingError extends Error {}
-
-/**
- * An error representing a failure to complete encrypted upload of image.
- */
-export class BackgroundEncryptedUploadError extends Error {}
 
 /**
  * @param {FormErrorMessageProps} props Props object.

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -30,7 +30,7 @@ function FormErrorMessage({ error }) {
   }
 
   if (error instanceof BackgroundEncryptedUploadError) {
-    return <>{t('errors.doc_auth.acuant_network_error')}</>;
+    return <>{t('errors.doc_auth.upload_error')}</>;
   }
 
   return null;

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -15,6 +15,11 @@ import useI18n from '../hooks/use-i18n';
 export class RequiredValueMissingError extends Error {}
 
 /**
+ * An error representing a failure to complete encrypted upload of image.
+ */
+export class BackgroundEncryptedUploadError extends Error {}
+
+/**
  * @param {FormErrorMessageProps} props Props object.
  */
 function FormErrorMessage({ error }) {
@@ -26,6 +31,10 @@ function FormErrorMessage({ error }) {
 
   if (error instanceof UploadFormEntryError) {
     return <>{error.message}</>;
+  }
+
+  if (error instanceof BackgroundEncryptedUploadError) {
+    return <>{t('errors.doc_auth.acuant_network_error')}</>;
   }
 
   return null;

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -8,6 +8,7 @@ import useI18n from '../hooks/use-i18n';
 import useHistoryParam from '../hooks/use-history-param';
 import useForceRender from '../hooks/use-force-render';
 import useDidUpdateEffect from '../hooks/use-did-update-effect';
+import useIfStillMounted from '../hooks/use-if-still-mounted';
 
 /**
  * @typedef FormStepError
@@ -118,6 +119,7 @@ function FormSteps({
   const fields = useRef(/** @type {Record<string,FieldsRefEntry>} */ ({}));
   const didSubmitWithErrors = useRef(false);
   const forceRender = useForceRender();
+  const ifStillMounted = useIfStillMounted();
   useEffect(() => {
     if (activeErrors.length && didSubmitWithErrors.current) {
       getFieldActiveErrorFieldElement(activeErrors, fields.current)?.focus();
@@ -226,15 +228,15 @@ function FormSteps({
         key={name}
         value={values}
         errors={activeErrors}
-        onChange={(nextValuesPatch) => {
+        onChange={ifStillMounted((nextValuesPatch) => {
           setActiveErrors((prevActiveErrors) =>
             prevActiveErrors.filter(({ field }) => !(field in nextValuesPatch)),
           );
           setValues((prevValues) => ({ ...prevValues, ...nextValuesPatch }));
-        }}
-        onError={(field, error) => {
+        })}
+        onError={ifStillMounted((field, error) => {
           setActiveErrors((prevActiveErrors) => prevActiveErrors.concat({ field, error }));
-        }}
+        })}
         registerField={(field, options = {}) => {
           if (!fields.current[field]) {
             fields.current[field] = {

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -27,15 +27,15 @@ import useDidUpdateEffect from '../hooks/use-did-update-effect';
 /**
  * @typedef FormStepComponentProps
  *
- * @prop {(nextValues:Partial<V>)=>void} onChange Values change callback, merged with
- * existing values.
+ * @prop {(nextValues:Partial<V>)=>void} onChange Update values, merging with existing values.
+ * @prop {(field:string, error:Error)=>void} onError Trigger a field error.
  * @prop {Partial<V>} value Current values.
  * @prop {FormStepError<V>[]} errors Current active errors.
  * @prop {(
  *   field:string,
  *   options?:Partial<FormStepRegisterFieldOptions>
- * )=>undefined|import('react').RefCallback<HTMLElement>} registerField Registers field
- * by given name, returning ref assignment function.
+ * )=>undefined|import('react').RefCallback<HTMLElement>} registerField Registers field by given
+ * name, returning ref assignment function.
  *
  * @template V
  */
@@ -231,6 +231,9 @@ function FormSteps({
             prevActiveErrors.filter(({ field }) => !(field in nextValuesPatch)),
           );
           setValues((prevValues) => ({ ...prevValues, ...nextValuesPatch }));
+        }}
+        onError={(field, error) => {
+          setActiveErrors((prevActiveErrors) => prevActiveErrors.concat({ field, error }));
         }}
         registerField={(field, options = {}) => {
           if (!fields.current[field]) {

--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -15,14 +15,20 @@ import { createContext } from 'react';
  */
 
 /**
+ * @typedef {(error: Error)=>void} NoticeError
+ */
+
+/**
  * @typedef AnalyticsContext
  *
  * @prop {AddPageAction} addPageAction Log an action with optional payload.
+ * @prop {NoticeError} noticeError Log an error without affecting application behavior.
  */
 
 const AnalyticsContext = createContext(
   /** @type {AnalyticsContext} */ ({
     addPageAction: () => {},
+    noticeError: () => {},
   }),
 );
 

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -119,6 +119,7 @@ const withBackgroundEncryptedUpload = (Component) =>
                 payload: {
                   success: response.ok,
                   trace_id: traceId,
+                  status_code: response.status,
                 },
               });
 

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -93,6 +93,8 @@ const withBackgroundEncryptedUpload = (Component) =>
                 },
               });
               noticeError(error);
+
+              // Rethrow error to skip upload and proceed from next `catch` block.
               throw error;
             })
             .then((encryptedValue) => {

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -16,6 +16,7 @@ import { isCameraCapableMobile } from '@18f/identity-device';
  * @typedef NewRelicAgent
  *
  * @prop {(name:string,attributes:object)=>void} addPageAction Log page action to New Relic.
+ * @prop {(error:Error)=>void} noticeError Log an error without affecting application behavior.
  */
 
 /**
@@ -109,6 +110,10 @@ function addPageAction(action) {
   });
 }
 
+/** @type {import('@18f/identity-document-capture/context/analytics').NoticeError} */
+const noticeError = (error) =>
+  /** @type {DocumentCaptureGlobal} */ (window).newrelic?.noticeError(error);
+
 loadPolyfills(['fetch', 'crypto']).then(async () => {
   const backgroundUploadURLs = getBackgroundUploadURLs();
   const isAsyncForm = Object.keys(backgroundUploadURLs).length > 0;
@@ -159,7 +164,7 @@ loadPolyfills(['fetch', 'crypto']).then(async () => {
         >
           <I18nContext.Provider value={i18n.strings}>
             <ServiceProviderContext.Provider value={getServiceProvider()}>
-              <AnalyticsContext.Provider value={{ addPageAction }}>
+              <AnalyticsContext.Provider value={{ addPageAction, noticeError }}>
                 <AssetContext.Provider value={assets}>
                   <DocumentCapture isAsyncForm={isAsyncForm} onStepChange={keepAlive} />
                 </AssetContext.Provider>

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -56,6 +56,7 @@
 - errors.doc_auth.invalid_file_input_type
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_glare
+- errors.doc_auth.upload_error
 - errors.file_input.invalid_type
 - forms.buttons.continue
 - forms.buttons.submit.default

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -63,6 +63,7 @@ en:
         Try taking a new picture.
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
+      upload_error: Sorry, something went wrong on our end. Please try again.
     file_input:
       invalid_type: This file type is not accepted, please try again.
     invalid_authenticity_token: Oops, something went wrong. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -64,6 +64,8 @@ es:
         Intente tomar una nueva foto.
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
+      upload_error: Lo siento, algo salió mal por nuestra parte. Por favor, inténtelo
+        de nuevo.
     file_input:
       invalid_type: Este tipo de archivo no es aceptado, inténtalo de nuevo.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -66,6 +66,7 @@ fr:
       send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
         votre ordinateur.
+      upload_error: Désolé, quelque chose a mal tourné de notre côté. Veuillez réessayer.
     file_input:
       invalid_type: Ce type de fichier n'est pas accepté, veuillez réessayer.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -532,7 +532,8 @@ describe('document-capture/components/document-capture', () => {
         submit();
         expect(upload).not.to.have.been.called();
         completeUploadAsSuccess();
-        await new Promise((resolve) => upload.callsFake(resolve));
+        await new Promise((resolve) => onSubmit.callsFake(resolve));
+        expect(upload).to.have.been.calledOnce();
       });
     });
 

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -475,4 +475,90 @@ describe('document-capture/components/document-capture', () => {
 
     expect(onStepChange.callCount).to.equal(1);
   });
+
+  describe('pending promise values', () => {
+    let completeUploadAsSuccess;
+    let completeUploadAsFailure;
+    let renderResult;
+    let upload;
+    let submit;
+
+    beforeEach(async () => {
+      sandbox.stub(window, 'fetch');
+      window.fetch.withArgs('about:blank#front').returns(
+        new Promise((resolve, reject) => {
+          completeUploadAsSuccess = () => resolve({ ok: true, headers: new window.Headers() });
+          completeUploadAsFailure = () => reject(new Error());
+        }),
+      );
+      window.fetch
+        .withArgs('about:blank#back')
+        .resolves({ ok: true, headers: new window.Headers() });
+      upload = sinon.stub().resolves({ success: true, isPending: false });
+      const key = await window.crypto.subtle.generateKey(
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt'],
+      );
+      renderResult = render(
+        <UploadContextProvider
+          endpoint="about:blank#upload"
+          backgroundUploadURLs={{
+            front: 'about:blank#front',
+            back: 'about:blank#back',
+          }}
+          backgroundUploadEncryptKey={key}
+          upload={upload}
+        >
+          <ServiceProviderContext.Provider value={{ isLivenessRequired: false }}>
+            <AcuantContextProvider sdkSrc="about:blank">
+              <DocumentCapture />
+            </AcuantContextProvider>
+          </ServiceProviderContext.Provider>
+        </UploadContextProvider>,
+      );
+      const { getByLabelText, getByText } = renderResult;
+
+      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+      submit = () => userEvent.click(getByText('forms.buttons.submit.default'));
+    });
+
+    context('success', () => {
+      it('calls to upload once pending values resolve', async () => {
+        submit();
+        expect(upload).not.to.have.been.called();
+        completeUploadAsSuccess();
+        await new Promise((resolve) => upload.callsFake(resolve));
+      });
+    });
+
+    context('failure', () => {
+      it('shows an error screen once pending values reject', async () => {
+        submit();
+        expect(upload).not.to.have.been.called();
+        completeUploadAsFailure();
+        const { findAllByRole, getByLabelText } = renderResult;
+
+        const alerts = await findAllByRole('alert');
+        expect(alerts).to.have.lengthOf(2);
+        expect(alerts[0].textContent).to.equal('errors.doc_auth.acuant_network_error');
+        expect(alerts[1].textContent).to.equal('errors.doc_auth.acuant_network_error');
+
+        const input = await getByLabelText('doc_auth.headings.document_capture_front');
+        expect(input.closest('.usa-file-input--has-value')).to.be.null();
+
+        expect(console).to.have.loggedError(/PromiseRejectionHandledWarning/);
+        expect(console).to.have.loggedError(/^Error: Uncaught/);
+        expect(console).to.have.loggedError(
+          /React will try to recreate this component tree from scratch using the error boundary you provided/,
+        );
+
+        expect(upload).not.to.have.been.called();
+      });
+    });
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -546,7 +546,7 @@ describe('document-capture/components/document-capture', () => {
         const alerts = await findAllByRole('alert');
         expect(alerts).to.have.lengthOf(2);
         expect(alerts[0].textContent).to.equal('errors.doc_auth.acuant_network_error');
-        expect(alerts[1].textContent).to.equal('errors.doc_auth.acuant_network_error');
+        expect(alerts[1].textContent).to.equal('errors.doc_auth.upload_error');
 
         const input = await getByLabelText('doc_auth.headings.document_capture_front');
         expect(input.closest('.usa-file-input--has-value')).to.be.null();

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -175,6 +175,19 @@ describe('document-capture/components/file-input', () => {
     );
   });
 
+  it('always emits a change event, regardless what the browser assumes is the current value', () => {
+    const onChange = sinon.spy();
+    const { rerender, getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
+
+    const input = getByLabelText('File');
+    userEvent.upload(input, file);
+
+    rerender(<FileInput label="File" value={null} onChange={onChange} />);
+    userEvent.upload(input, file);
+
+    expect(onChange).to.have.been.calledTwice();
+  });
+
   it('renders a value preview for a data URL', async () => {
     const { container, findByRole, getByLabelText } = render(
       <FileInput

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -2,10 +2,10 @@ import { useEffect } from 'react';
 import sinon from 'sinon';
 import { UploadContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import withBackgroundEncryptedUpload, {
+  BackgroundEncryptedUploadError,
   blobToArrayBuffer,
   encrypt,
 } from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
-import { BackgroundEncryptedUploadError } from '@18f/identity-document-capture/components/form-error-message';
 import { useSandbox } from '../../../support/sinon';
 import { render } from '../../../support/document-capture';
 
@@ -200,7 +200,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           expect(patch.baz).to.equal('quux');
           expect(patch.foo_image_url).to.be.an.instanceOf(Promise);
           await patch.foo_image_url.catch((error) => {
-            expect(error.message).to.equal('Failed to upload image');
+            expect(error).to.be.instanceOf(BackgroundEncryptedUploadError);
           });
         });
 
@@ -208,7 +208,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           const { onChange, onError } = await renderWithResponse(response);
 
           const patch = onChange.getCall(0).args[0];
-          await patch.foo_image_url;
+          await patch.foo_image_url.catch(() => {});
           expect(onError).to.have.been.calledOnceWith(
             'foo',
             sinon.match.instanceOf(BackgroundEncryptedUploadError),

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -178,7 +178,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           expect(addPageAction).to.have.been.calledWith({
             key: 'documentCapture.asyncUpload',
             label: 'IdV: document capture async upload submitted',
-            payload: { success: true, trace_id: null },
+            payload: { success: true, trace_id: null, status_code: 200 },
           });
         });
       });
@@ -261,7 +261,11 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           expect(addPageAction).to.have.been.calledWith({
             key: 'documentCapture.asyncUpload',
             label: 'IdV: document capture async upload submitted',
-            payload: { success: false, trace_id: '1-67891233-abcdef012345678912345678' },
+            payload: {
+              success: false,
+              trace_id: '1-67891233-abcdef012345678912345678',
+              status_code: 403,
+            },
           });
         });
       });

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -187,10 +187,20 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
         /** @type {Response} */
         const response = {
           ok: false,
-          status: 400,
+          status: 403,
           headers: new window.Headers({
             'X-Amzn-Trace-Id': '1-67891233-abcdef012345678912345678',
           }),
+          text: Promise.resolve(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+              '<Error>' +
+              '<Code>InvalidAccessKeyId</Code>' +
+              '<Message>The AWS Access Key Id you provided does not exist in our records.</Message>' +
+              '<AWSAccessKeyId>...</AWSAccessKeyId>' +
+              '<RequestId>...</RequestId>' +
+              '<HostId>...</HostId>' +
+              '</Error>',
+          ),
         };
 
         it('throws on failed background upload', async () => {

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -235,6 +235,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
             payload: { success: false },
           });
           expect(noticeError).to.have.been.calledWith(error);
+          expect(window.fetch).not.to.have.been.called();
         });
 
         it('calls onError', async () => {


### PR DESCRIPTION
**Why**: Currently, if encryption or async upload fails at the document capture step, we don't inform the user, so from their perspective it likely seem as if the upload was successful. With these changes, we'll show an error message indicating that there was an issue. This integrates into the existing FormSteps field error handling behavior which will prevent users from continuing until they change the value.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/110162737-20f2b500-7dbd-11eb-9be7-e96506ce72a3.png)
