### PR TITLE
Rename Identity class (LG-4229)

### DIFF
--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -47,7 +47,7 @@ module VerifySpAttributesConcern
     return false if sp_session_identity.deleted_at.present?
     last_estimated_consent = sp_session_identity.last_consented_at || sp_session_identity.created_at
     !last_estimated_consent ||
-      last_estimated_consent < Identity::CONSENT_EXPIRATION.ago ||
+      last_estimated_consent < ServiceProviderIdentity::CONSENT_EXPIRATION.ago ||
       verified_after_consent?(last_estimated_consent)
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -67,7 +67,7 @@ class OpenidConnectTokenForm
     return if code.blank? || code.include?("\x00")
 
     session_expiration = AppConfig.env.session_timeout_in_minutes.to_i.minutes.ago
-    @identity = Identity.where(session_uuid: code).
+    @identity = ServiceProviderIdentity.where(session_uuid: code).
                 where('updated_at >= ?', session_expiration).
                 order(updated_at: :desc).first
   end

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -237,7 +237,7 @@ class SecurityEventForm
   end
 
   def identity_from_identity
-    Identity.find_by(
+    ServiceProviderIdentity.find_by(
       uuid: event.dig('subject', 'sub'),
       service_provider: service_provider.issuer,
     )

--- a/app/models/null_identity.rb
+++ b/app/models/null_identity.rb
@@ -1,3 +1,4 @@
+# Null object pattern substitute for ServiceProviderIdentity
 class NullIdentity
   SERVICE_PROVIDER = 'null-identity-service-provider'.freeze
 

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -9,7 +9,8 @@ class ServiceProvider < ApplicationRecord
   # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :identities, inverse_of: :service_provider_record,
                         foreign_key: 'service_provider',
-                        primary_key: 'issuer'
+                        primary_key: 'issuer',
+                        class_name: 'ServiceProviderIdentity'
   # rubocop:enable Rails/HasManyOrHasOneDependent
 
   # Do not define validations in this model.

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -1,4 +1,7 @@
-class Identity < ApplicationRecord
+# Joins Users to ServiceProviders
+class ServiceProviderIdentity < ApplicationRecord
+  self.table_name = :identities
+
   include NonNullUuid
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,8 @@ class User < ApplicationRecord
 
   has_many :authorizations, dependent: :destroy
   # rubocop:disable Rails/HasManyOrHasOneDependent
-  has_many :identities # identities need to be orphaned to prevent UUID reuse
+  # identities need to be orphaned to prevent UUID reuse
+  has_many :identities, class_name: 'ServiceProviderIdentity'
   has_many :events # we are retaining events after delete
   has_many :devices # we are retaining devices after delete
   # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -27,7 +27,7 @@ class AccessTokenVerifier
   end
 
   def load_identity(access_token)
-    identity = Identity.where(access_token: access_token).take
+    identity = ServiceProviderIdentity.where(access_token: access_token).take
 
     if identity && Pii::SessionStore.new(identity.rails_session_id).ttl.positive?
       @identity = identity

--- a/app/services/agency_identity_linker.rb
+++ b/app/services/agency_identity_linker.rb
@@ -16,7 +16,7 @@ class AgencyIdentityLinker
                else
                  { uuid: uuid, service_provider: service_provider }
                end
-    Identity.where(criteria).take
+    ServiceProviderIdentity.where(criteria).take
   end
 
   private

--- a/app/services/data_requests/lookup_user_by_uuid.rb
+++ b/app/services/data_requests/lookup_user_by_uuid.rb
@@ -8,7 +8,7 @@ module DataRequests
 
     def call
       User.find_by(uuid: uuid) ||
-        Identity.find_by(uuid: uuid)&.user
+        ServiceProviderIdentity.find_by(uuid: uuid)&.user
     end
   end
 end

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -19,7 +19,7 @@ module PushNotification
     def deliver
       event.user.
         service_providers.
-        merge(Identity.not_deleted).
+        merge(ServiceProviderIdentity.not_deleted).
         with_push_notification_urls.each do |service_provider|
           deliver_one(service_provider)
         end

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -76,7 +76,7 @@ module PushNotification
     def agency_uuid(service_provider)
       AgencyIdentity.find_by(
         user_id: event.user.id,
-        agency_id: service_provider.agency_id
+        agency_id: service_provider.agency_id,
       )&.uuid ||
         ServiceProviderIdentity.find_by(
           user_id: event.user.id,

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -74,8 +74,14 @@ module PushNotification
     end
 
     def agency_uuid(service_provider)
-      AgencyIdentity.find_by(user_id: event.user.id, agency_id: service_provider.agency_id)&.uuid ||
-        Identity.find_by(user_id: event.user.id, service_provider: service_provider.issuer)&.uuid
+      AgencyIdentity.find_by(
+        user_id: event.user.id,
+        agency_id: service_provider.agency_id
+      )&.uuid ||
+        ServiceProviderIdentity.find_by(
+          user_id: event.user.id,
+          service_provider: service_provider.issuer,
+        )&.uuid
     end
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -15,7 +15,7 @@ describe AccountsController do
       it 'renders the profile and does not redirect out of the app' do
         stub_analytics
         user = create(:user, :signed_up)
-        user.identities << Identity.create(
+        user.identities << ServiceProviderIdentity.create(
           service_provider: 'http://localhost:3000',
           last_authenticated_at: Time.zone.now,
         )

--- a/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
+++ b/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe VerifySpAttributesConcern do
     end
 
     context 'when the last_consented_at is older than a year ago' do
-      let(:sp_session_identity) { build(:service_provider_identity, last_consented_at: 2.years.ago) }
+      let(:sp_session_identity) do
+        build(:service_provider_identity, last_consented_at: 2.years.ago)
+      end
 
       it 'is true' do
         expect(consent_has_expired?).to eq(true)

--- a/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
+++ b/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe VerifySpAttributesConcern do
   end
 
   describe '#consent_has_expired?' do
-    let(:sp_session_identity) { build(:identity, user: user) }
+    let(:sp_session_identity) { build(:service_provider_identity, user: user) }
     let(:user) { build(:user) }
 
     before do
@@ -30,7 +30,7 @@ RSpec.describe VerifySpAttributesConcern do
     end
 
     context 'when last_consented_at within one year' do
-      let(:sp_session_identity) { build(:identity, last_consented_at: 5.days.ago) }
+      let(:sp_session_identity) { build(:service_provider_identity, last_consented_at: 5.days.ago) }
 
       it 'is false' do
         expect(consent_has_expired?).to eq(false)
@@ -38,7 +38,7 @@ RSpec.describe VerifySpAttributesConcern do
     end
 
     context 'when the last_consented_at is older than a year ago' do
-      let(:sp_session_identity) { build(:identity, last_consented_at: 2.years.ago) }
+      let(:sp_session_identity) { build(:service_provider_identity, last_consented_at: 2.years.ago) }
 
       it 'is true' do
         expect(consent_has_expired?).to eq(true)
@@ -47,7 +47,7 @@ RSpec.describe VerifySpAttributesConcern do
 
     context 'when last_consented_at is nil but created_at is within a year' do
       let(:sp_session_identity) do
-        build(:identity, last_consented_at: nil, created_at: 4.days.ago)
+        build(:service_provider_identity, last_consented_at: nil, created_at: 4.days.ago)
       end
 
       it 'is false' do
@@ -57,7 +57,7 @@ RSpec.describe VerifySpAttributesConcern do
 
     context 'when last_consented_at is nil and created_at is older than a year' do
       let(:sp_session_identity) do
-        build(:identity, last_consented_at: nil, created_at: 4.years.ago)
+        build(:service_provider_identity, last_consented_at: nil, created_at: 4.years.ago)
       end
 
       it 'is true' do
@@ -67,7 +67,7 @@ RSpec.describe VerifySpAttributesConcern do
 
     context 'when the identity has been soft-deleted (consent has been revoked)' do
       let(:sp_session_identity) do
-        build(:identity,
+        build(:service_provider_identity,
               deleted_at: 1.day.ago,
               last_consented_at: 2.years.ago)
       end
@@ -79,7 +79,7 @@ RSpec.describe VerifySpAttributesConcern do
 
     context 'when there is an active profile' do
       let(:sp_session_identity) do
-        create(:identity, last_consented_at: 15.days.ago, user: user)
+        create(:service_provider_identity, last_consented_at: 15.days.ago, user: user)
       end
 
       before do
@@ -103,7 +103,7 @@ RSpec.describe VerifySpAttributesConcern do
   end
 
   describe '#consent_was_revoked?' do
-    let(:sp_session_identity) { build(:identity) }
+    let(:sp_session_identity) { build(:service_provider_identity) }
 
     before do
       allow(controller).to receive(:sp_session_identity).and_return(sp_session_identity)
@@ -125,7 +125,7 @@ RSpec.describe VerifySpAttributesConcern do
     end
 
     context 'when the sp_session_identity exists and has been deleted' do
-      let(:sp_session_identity) { build(:identity, deleted_at: 2.days.ago) }
+      let(:sp_session_identity) { build(:service_provider_identity, deleted_at: 2.days.ago) }
 
       it 'is false' do
         expect(consent_was_revoked?).to eq(true)

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OpenidConnect::LogoutController do
   let(:user) { build(:user) }
   let(:service_provider) { 'urn:gov:gsa:openidconnect:test' }
   let(:identity) do
-    create(:identity,
+    create(:service_provider_identity,
            service_provider: service_provider,
            user: user,
            access_token: SecureRandom.hex,

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe OpenidConnect::UserInfoController do
     context 'with a valid bearer token' do
       let(:authorization_header) { "Bearer #{access_token}" }
       let(:access_token) { SecureRandom.hex }
-      let(:identity) { build(:identity, user: create(:user)) }
+      let(:identity) { build(:service_provider_identity, user: create(:user)) }
 
       before do
         fake_verifier = instance_double(AccessTokenVerifier,

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -84,7 +84,7 @@ describe SignUp::CompletionsController do
 
     it 'renders show if the user has identities and no active session' do
       user = create(:user)
-      create(:identity, user: user)
+      create(:service_provider_identity, user: user)
       stub_sign_in(user)
       subject.session[:sp] = { issuer: 'awesome sp', ial2: false }
       get :show

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -72,13 +72,13 @@ describe Users::DeleteController do
 
     it 'does not delete identities to prevent uuid reuse' do
       user = stub_signed_in_user
-      user.identities << Identity.create(
+      user.identities << ServiceProviderIdentity.create(
         service_provider: 'foo',
         last_authenticated_at: Time.zone.now,
       )
-      expect(Identity.where(user_id: user.id).length).to eq(1)
+      expect(ServiceProviderIdentity.where(user_id: user.id).length).to eq(1)
       delete
-      expect(Identity.where(user_id: user.id).length).to eq(1)
+      expect(ServiceProviderIdentity.where(user_id: user.id).length).to eq(1)
     end
 
     it 'deletes profile information for ial2' do

--- a/spec/decorators/identity_decorator_spec.rb
+++ b/spec/decorators/identity_decorator_spec.rb
@@ -31,7 +31,9 @@ describe IdentityDecorator do
   describe '#failure_to_proof_url' do
     let(:user) { create(:user) }
     let(:service_provider) { 'https://rp1.serviceprovider.com/auth/saml/metadata' }
-    let(:identity) { create(:identity, :active, user: user, service_provider: service_provider) }
+    let(:identity) do
+      create(:service_provider_identity, :active, user: user, service_provider: service_provider)
+    end
 
     subject { IdentityDecorator.new(identity) }
 

--- a/spec/decorators/identity_decorator_spec.rb
+++ b/spec/decorators/identity_decorator_spec.rb
@@ -6,7 +6,9 @@ describe IdentityDecorator do
   describe '#return_to_sp_url' do
     let(:user) { create(:user) }
     let(:service_provider) { 'http://localhost:3000' }
-    let(:identity) { create(:identity, :active, user: user, service_provider: service_provider) }
+    let(:identity) do
+      create(:service_provider_identity, :active, user: user, service_provider: service_provider)
+    end
 
     subject { IdentityDecorator.new(identity) }
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -261,7 +261,10 @@ describe UserDecorator do
     let(:decorated_user) { user.decorate }
     let!(:event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
     let!(:identity) do
-      create(:service_provider_identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days)
+      create(:service_provider_identity,
+             :active,
+             user: user,
+             last_authenticated_at: Time.zone.now - 60.days)
     end
     let!(:another_event) do
       create(:event, user: user, event_type: :email_changed, created_at: Time.zone.now - 30.days)

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -104,7 +104,7 @@ describe UserDecorator do
       sp = create(:service_provider, issuer: 'http://sp.example.com')
       user = create(:user)
       user.identities << create(
-        :identity,
+        :service_provider_identity,
         service_provider: sp.issuer,
         session_uuid: SecureRandom.uuid,
       )

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -261,7 +261,7 @@ describe UserDecorator do
     let(:decorated_user) { user.decorate }
     let!(:event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
     let!(:identity) do
-      create(:identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days)
+      create(:service_provider_identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days)
     end
     let!(:another_event) do
       create(:event, user: user, event_type: :email_changed, created_at: Time.zone.now - 30.days)
@@ -343,8 +343,10 @@ describe UserDecorator do
 
   describe '#connected_apps' do
     let(:user) { create(:user) }
-    let(:app) { create(:identity, service_provider: 'aaa') }
-    let(:deleted_app) { create(:identity, service_provider: 'bbb', deleted_at: 5.days.ago) }
+    let(:app) { create(:service_provider_identity, service_provider: 'aaa') }
+    let(:deleted_app) do
+      create(:service_provider_identity, service_provider: 'bbb', deleted_at: 5.days.ago)
+    end
 
     let(:user_decorator) { user.decorate }
 

--- a/spec/factories/service_provider_identities.rb
+++ b/spec/factories/service_provider_identities.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :identity do
+  factory :service_provider_identity do
     uuid { SecureRandom.uuid }
     service_provider { 'https://serviceprovider.com' }
   end

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -4,7 +4,7 @@ describe 'Account connected applications' do
   let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
   let(:identity_with_link) do
     create(
-      :identity,
+      :service_provider_identity,
       :active,
       user: user,
       created_at: Time.zone.now - 80.days,
@@ -13,7 +13,7 @@ describe 'Account connected applications' do
   end
   let(:identity_without_link) do
     create(
-      :identity,
+      :service_provider_identity,
       :active,
       user: user,
       created_at: Time.zone.now - 50.days,

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -8,7 +8,7 @@ describe 'Account history' do
   end
   let(:identity_with_link) do
     create(
-      :identity,
+      :service_provider_identity,
       :active,
       user: user,
       last_authenticated_at: Time.zone.now - 80.days,
@@ -20,7 +20,7 @@ describe 'Account history' do
   end
   let(:identity_without_link) do
     create(
-      :identity,
+      :service_provider_identity,
       :active,
       user: user,
       last_authenticated_at: Time.zone.now - 50.days,

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OpenidConnectLogoutForm do
 
   let(:service_provider) { 'urn:gov:gsa:openidconnect:test' }
   let(:identity) do
-    create(:identity,
+    create(:service_provider_identity,
            service_provider: service_provider,
            user: build(:user),
            access_token: SecureRandom.hex,

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe OpenidConnectTokenForm do
 
       context 'code is nil' do
         before do
-          # Create an identity with a nil session uuid to make sure the form is not
-          # looking up an identity with a nil code and finding this one
-          create(:identity, session_uuid: nil)
+          # Create a service provider identity with a nil session uuid to make sure the form is not
+          # looking up a service provider identity with a nil code and finding this one
+          create(:service_provider_identity, session_uuid: nil)
         end
 
         let(:code) { nil }

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe SecurityEventForm do
       end
 
       context 'with a uuid for a different identity' do
-        let(:subject_sub) { create(:identity).uuid }
+        let(:subject_sub) { create(:service_provider_identity).uuid }
         it 'is invalid' do
           expect(valid?).to eq(false)
           expect(form.error_code).to eq('setData')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,8 +73,8 @@ describe User do
       user.uuid = nil
 
       expect { user.save }.
-        to raise_error(ActiveRecord::StatementInvalid,
-                       /null value in column "uuid" violates not-null constraint/)
+        to raise_error(ActiveRecord::NotNullViolation,
+                       /null value in column "uuid".*violates not-null constraint/)
     end
 
     it 'uses a DB index to enforce uniqueness' do
@@ -158,10 +158,10 @@ describe User do
   context 'when identities are present' do
     let(:user) { create(:user, :signed_up) }
     let(:active_identity) do
-      Identity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
+      ServiceProviderIdentity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
     end
     let(:inactive_identity) do
-      Identity.create(service_provider: 'entity_id2', session_uuid: nil)
+      ServiceProviderIdentity.create(service_provider: 'entity_id2', session_uuid: nil)
     end
 
     describe '#active_identities' do
@@ -177,12 +177,12 @@ describe User do
     let(:user) { create(:user, :signed_up) }
 
     before do
-      user.identities << Identity.create(
+      user.identities << ServiceProviderIdentity.create(
         service_provider: 'first',
         last_authenticated_at: Time.zone.now - 1.hour,
         session_uuid: SecureRandom.uuid,
       )
-      user.identities << Identity.create(
+      user.identities << ServiceProviderIdentity.create(
         service_provider: 'last',
         last_authenticated_at: Time.zone.now,
         session_uuid: SecureRandom.uuid,
@@ -211,12 +211,12 @@ describe User do
   describe 'deleting identities' do
     it 'does not delete identities when the user is destroyed preventing uuid reuse' do
       user = create(:user, :signed_up)
-      user.identities << Identity.create(
+      user.identities << ServiceProviderIdentity.create(
         service_provider: 'entity_id', session_uuid: SecureRandom.uuid,
       )
       user_id = user.id
       user.destroy!
-      expect(Identity.where(user_id: user_id).length).to eq 1
+      expect(ServiceProviderIdentity.where(user_id: user_id).length).to eq 1
     end
   end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   let(:service_provider) { create(:service_provider, ial: service_provider_ial) }
   let(:profile) { build(:profile, :active, :verified) }
   let(:identity) do
-    build(:identity,
+    build(:service_provider_identity,
           rails_session_id: rails_session_id,
           user: create(:user, profiles: [profile]),
           service_provider: service_provider.issuer,
@@ -45,7 +45,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
       context 'when the identity has piv/cac associated' do
         let(:identity) do
-          build(:identity,
+          build(:service_provider_identity,
                 rails_session_id: rails_session_id,
                 user: create(:user, :with_piv_or_cac),
                 scope: scope)

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AccessTokenVerifier do
   subject(:verifier) { AccessTokenVerifier.new(http_authorization_header) }
   let(:http_authorization_header) { "Bearer #{access_token}" }
 
-  let(:identity) { build(:identity, access_token: SecureRandom.urlsafe_base64) }
+  let(:identity) { build(:service_provider_identity, access_token: SecureRandom.urlsafe_base64) }
 
   describe '#submit' do
     let(:result) { verifier.submit }

--- a/spec/services/agency_identity_linker_spec.rb
+++ b/spec/services/agency_identity_linker_spec.rb
@@ -89,11 +89,11 @@ describe AgencyIdentityLinker do
   end
 
   def init_env(user)
-    Identity.where(user_id: user.id).delete_all
+    ServiceProviderIdentity.where(user_id: user.id).delete_all
     AgencyIdentity.where(user_id: user.id).delete_all
   end
 
   def create_identity(user, service_provider, uuid)
-    Identity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
+    ServiceProviderIdentity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
   end
 end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -8,7 +8,7 @@ describe AttributeAsserter do
   let(:user_session) { {} }
   let(:identity) do
     build(
-      :identity,
+      :service_provider_identity,
       service_provider: service_provider.issuer,
       session_uuid: SecureRandom.uuid,
     )

--- a/spec/services/data_requests/create_user_report_spec.rb
+++ b/spec/services/data_requests/create_user_report_spec.rb
@@ -17,7 +17,7 @@ describe DataRequests::CreateUserReport do
   context 'with a requesting SP issuer provided' do
     it 'includes the UUID for a SP if one exists' do
       user = create(:user)
-      identity = create(:identity, user: user, service_provider: 'test123')
+      identity = create(:service_provider_identity, user: user, service_provider: 'test123')
 
       result = described_class.new(user, 'test123').call
 

--- a/spec/services/data_requests/lookup_user_by_uuid_spec.rb
+++ b/spec/services/data_requests/lookup_user_by_uuid_spec.rb
@@ -13,7 +13,7 @@ describe DataRequests::LookupUserByUuid do
 
     context 'when an identity exists with the UUID' do
       it 'returns the user for the identity' do
-        identity = create(:identity)
+        identity = create(:service_provider_identity)
         uuid = identity.uuid
 
         expect(described_class.new(uuid).call).to eq(identity.user)

--- a/spec/services/db/identity/sp_active_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_active_user_counts_spec.rb
@@ -17,11 +17,11 @@ describe Db::Identity::SpActiveUserCounts do
     now = Time.zone.now
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app1')
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, app_id: 'app2')
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
                     last_ial1_authenticated_at: now)
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
                     last_ial1_authenticated_at: now)
-    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
                     last_ial1_authenticated_at: now)
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 2, total_ial2_active: 0 }.to_json
     result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 1,
@@ -37,11 +37,11 @@ describe Db::Identity::SpActiveUserCounts do
     now = Time.zone.now
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app1')
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, app_id: 'app2')
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
                     last_ial2_authenticated_at: now)
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
                     last_ial2_authenticated_at: now)
-    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
                     last_ial2_authenticated_at: now)
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 0, total_ial2_active: 2 }.to_json
     result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 0,
@@ -57,13 +57,13 @@ describe Db::Identity::SpActiveUserCounts do
     now = Time.zone.now
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app1')
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, app_id: 'app2')
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
                     last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
                     last_ial1_authenticated_at: now)
-    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
                     last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
-    Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4',
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4',
                     last_ial2_authenticated_at: now)
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 2, total_ial2_active: 1 }.to_json
     result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 1,

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -17,8 +17,10 @@ describe Db::Identity::SpUserCounts do
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, app_id: app_id2)
     ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+                                   verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4',
+                                   verified_at: Time.zone.now)
     result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, app_id: app_id }.to_json
     result2 = { issuer: issuer2, total: 1, ial1_total: 0, ial2_total: 1, app_id: app_id2 }.to_json
 

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -15,10 +15,10 @@ describe Db::Identity::SpUserCounts do
   it 'returns the total user counts per sp broken down by ial1 and ial2' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, app_id: app_id2)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
     result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, app_id: app_id }.to_json
     result2 = { issuer: issuer2, total: 1, ial1_total: 0, ial2_total: 1, app_id: app_id2 }.to_json
 

--- a/spec/services/db/identity/sp_user_quotas_spec.rb
+++ b/spec/services/db/identity/sp_user_quotas_spec.rb
@@ -19,8 +19,10 @@ describe Db::Identity::SpUserQuotas do
                            app_id: app_id2)
     ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+                                   verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4',
+                                   verified_at: Time.zone.now)
     result = { issuer: issuer, app_id: app_id, ial2_total: 1, percent_ial2_quota: 0 }.to_json
     result2 = { issuer: issuer2, app_id: app_id2, ial2_total: 1, percent_ial2_quota: 100 }.to_json
 

--- a/spec/services/db/identity/sp_user_quotas_spec.rb
+++ b/spec/services/db/identity/sp_user_quotas_spec.rb
@@ -17,10 +17,10 @@ describe Db::Identity::SpUserQuotas do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial2_quota: 1,
                            app_id: app_id2)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
     result = { issuer: issuer, app_id: app_id, ial2_total: 1, percent_ial2_quota: 0 }.to_json
     result2 = { issuer: issuer2, app_id: app_id2, ial2_total: 1, percent_ial2_quota: 100 }.to_json
 

--- a/spec/services/deleted_accounts_report_spec.rb
+++ b/spec/services/deleted_accounts_report_spec.rb
@@ -19,7 +19,7 @@ describe DeletedAccountsReport do
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
       expect(User.count).to eq(1)
-      expect(Identity.count).to eq(1)
+      expect(ServiceProviderIdentity.count).to eq(1)
       expect(rows.count).to eq(0)
     end
 
@@ -33,7 +33,7 @@ describe DeletedAccountsReport do
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
       expect(User.count).to eq(0)
-      expect(Identity.count).to eq(1)
+      expect(ServiceProviderIdentity.count).to eq(1)
       expect(rows.count).to eq(1)
     end
 
@@ -47,7 +47,7 @@ describe DeletedAccountsReport do
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
       expect(User.count).to eq(0)
-      expect(Identity.count).to eq(1)
+      expect(ServiceProviderIdentity.count).to eq(1)
       expect(rows.count).to eq(0)
     end
 
@@ -61,7 +61,7 @@ describe DeletedAccountsReport do
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
       expect(User.count).to eq(0)
-      expect(Identity.count).to eq(1)
+      expect(ServiceProviderIdentity.count).to eq(1)
       expect(rows.count).to eq(0)
     end
   end

--- a/spec/services/deleted_accounts_report_spec.rb
+++ b/spec/services/deleted_accounts_report_spec.rb
@@ -12,8 +12,10 @@ describe DeletedAccountsReport do
 
     it 'prints the report with zero records when no users are deleted' do
       user = create(:user)
-      create(:identity, service_provider: service_provider, user: user,
-                        last_authenticated_at: Time.zone.now)
+      create(:service_provider_identity,
+             service_provider: service_provider,
+             user: user,
+             last_authenticated_at: Time.zone.now)
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
       expect(User.count).to eq(1)
@@ -23,8 +25,10 @@ describe DeletedAccountsReport do
 
     it 'prints the report with one record' do
       user = create(:user)
-      create(:identity, service_provider: service_provider, user: user,
-                        last_authenticated_at: Time.zone.now)
+      create(:service_provider_identity,
+             service_provider: service_provider,
+             user: user,
+             last_authenticated_at: Time.zone.now)
       user.destroy!
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
@@ -35,8 +39,10 @@ describe DeletedAccountsReport do
 
     it 'prints the report with zero records when the last auth date is beyond days ago' do
       user = create(:user)
-      create(:identity, service_provider: service_provider, user: user,
-                        last_authenticated_at: days_ago + 1)
+      create(:service_provider_identity,
+             service_provider: service_provider,
+             user: user,
+             last_authenticated_at: days_ago + 1)
       user.destroy!
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 
@@ -47,7 +53,10 @@ describe DeletedAccountsReport do
 
     it 'prints the report with zero records when it is not the correct sp' do
       user = create(:user)
-      create(:identity, service_provider: 'foo', user: user, last_authenticated_at: Time.zone.now)
+      create(:service_provider_identity,
+             service_provider: 'foo',
+             user: user,
+             last_authenticated_at: Time.zone.now)
       user.destroy!
       rows = DeletedAccountsReport.call(service_provider, days_ago)
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IdTokenBuilder do
   let(:code) { SecureRandom.hex }
 
   let(:identity) do
-    build(:identity,
+    build(:service_provider_identity,
           nonce: SecureRandom.hex,
           uuid: SecureRandom.uuid,
           ial: 2,

--- a/spec/services/reports/deleted_user_accounts_report_spec.rb
+++ b/spec/services/reports/deleted_user_accounts_report_spec.rb
@@ -17,10 +17,11 @@ describe Reports::DeletedUserAccountsReport do
   end
 
   it 'sends out a report to the email listed with one deleted user account' do
-    create(:identity, service_provider: issuer,
-                      user: user,
-                      uuid: uuid,
-                      last_authenticated_at: last_authenticated_at)
+    create(:service_provider_identity,
+           service_provider: issuer,
+           user: user,
+           uuid: uuid,
+           last_authenticated_at: last_authenticated_at)
     user.destroy!
 
     allow(AppConfig.env).to receive(:deleted_user_accounts_report_configs).and_return(

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -147,11 +147,11 @@ describe Reports::IaaBillingReport do
                            iaa_start_date: iaa_start_date2, iaa_end_date: iaa_end_date2)
     ServiceProvider.create(issuer: issuer3, friendly_name: issuer3, ial: 2, iaa: iaa2,
                            iaa_start_date: iaa_start_date2, iaa_end_date: iaa_end_date2)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'a',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'a',
                     last_ial2_authenticated_at: now - 1.hour)
-    Identity.create(user_id: 2, service_provider: issuer2, uuid: 'b',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer2, uuid: 'b',
                     last_ial2_authenticated_at: last_month)
-    Identity.create(user_id: 3, service_provider: issuer3, uuid: 'c',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer3, uuid: 'c',
                     last_ial2_authenticated_at: now - 1.hour)
     create(:profile, :active, :verified, user_id: 1)
     create(:profile, :active, :verified, user_id: 2)

--- a/spec/services/reports/sp_active_users_over_period_of_performance_report_spec.rb
+++ b/spec/services/reports/sp_active_users_over_period_of_performance_report_spec.rb
@@ -14,13 +14,13 @@ describe Reports::SpActiveUsersOverPeriodOfPerformanceReport do
   it 'returns total active user counts per sp broken down by ial1 and ial2' do
     now = Time.zone.now
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
                     last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
                     last_ial1_authenticated_at: now)
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
                     last_ial2_authenticated_at: now)
-    Identity.create(user_id: 4, service_provider: issuer, uuid: 'foo4',
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer, uuid: 'foo4',
                     last_ial2_authenticated_at: now)
     result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json

--- a/spec/services/reports/sp_active_users_report_spec.rb
+++ b/spec/services/reports/sp_active_users_report_spec.rb
@@ -15,13 +15,13 @@ describe Reports::SpActiveUsersReport do
   it 'returns total active user counts per sp broken down by ial1 and ial2' do
     now = Time.zone.now
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app')
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
                     last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
                     last_ial1_authenticated_at: now)
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
                     last_ial2_authenticated_at: now)
-    Identity.create(user_id: 4, service_provider: issuer, uuid: 'foo4',
+    ServiceProviderIdentity.create(user_id: 4, service_provider: issuer, uuid: 'foo4',
                     last_ial2_authenticated_at: now)
     result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -12,9 +12,9 @@ describe Reports::SpUserCountsReport do
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, app_id: app_id }].to_json
 
     expect(subject.call).to eq(result)

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -14,7 +14,8 @@ describe Reports::SpUserCountsReport do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
     ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+                                   verified_at: Time.zone.now)
     result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, app_id: app_id }].to_json
 
     expect(subject.call).to eq(result)

--- a/spec/services/reports/sp_user_quotas_report_spec.rb
+++ b/spec/services/reports/sp_user_quotas_report_spec.rb
@@ -22,7 +22,8 @@ describe Reports::SpUserQuotasReport do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
     ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+                                   verified_at: Time.zone.now)
     results = [{ issuer: issuer, app_id: app_id, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
     Timecop.travel Date.new(year, month, day) do

--- a/spec/services/reports/sp_user_quotas_report_spec.rb
+++ b/spec/services/reports/sp_user_quotas_report_spec.rb
@@ -20,9 +20,9 @@ describe Reports::SpUserQuotasReport do
 
   def expect_report_to_run_correctly_for_fiscal_start_year_month_day(year, month, day)
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
-    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     results = [{ issuer: issuer, app_id: app_id, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
     Timecop.travel Date.new(year, month, day) do

--- a/spec/services/revoke_service_provider_consent_spec.rb
+++ b/spec/services/revoke_service_provider_consent_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RevokeServiceProviderConsent do
   subject(:service) { RevokeServiceProviderConsent.new(identity, now: now) }
 
   describe '#call' do
-    let!(:identity) { create(:identity, deleted_at: nil) }
+    let!(:identity) { create(:service_provider_identity, deleted_at: nil) }
 
     it 'sets the deleted_at' do
       expect { service.call }.

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -59,7 +59,7 @@ module ControllerHelper
   end
 
   def stub_identity(user, params)
-    Identity.new(params.merge(user: user)).save
+    ServiceProviderIdentity.new(params.merge(user: user)).save
   end
 end
 

--- a/spec/view_models/sign_up_completions_show_spec.rb
+++ b/spec/view_models/sign_up_completions_show_spec.rb
@@ -63,7 +63,7 @@ describe SignUpCompletionsShow do
     end
 
     let(:create_identity) do
-      create(:identity, user_id: @user.id)
+      create(:service_provider_identity, user_id: @user.id)
     end
 
     describe '#service_provider_partial' do

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -21,7 +21,7 @@ describe 'accounts/connected_accounts/show.html.erb' do
 
   context 'with a connected app that is a NullServiceProvider' do
     before do
-      user.identities << create(:identity, :active, service_provider: 'aaaaa')
+      user.identities << create(:service_provider_identity, :active, service_provider: 'aaaaa')
     end
 
     it 'renders' do

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -103,7 +103,7 @@ describe 'sign_up/completions/show.html.erb' do
         friendly_name: "SP app #{index}",
         agency: create(:agency, name: "Agency #{index}"),
       )
-      create(:identity, service_provider: sp.issuer, user: user)
+      create(:service_provider_identity, service_provider: sp.issuer, user: user)
     end
   end
 end


### PR DESCRIPTION
**Why**: This frees up the Identity:: namespace to be a
module so our gems can use it and match their "identity-"
project names.

- This just renames the class and leaves the underlying table the same `self.table_name = `
- The name `ServiceProviderIdentity` seemed like the simples thing that kind of explained how this is a join between users and service providers