### PR TITLE
Ignore more acuant errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'faraday'
 gem 'foundation_emails'
 gem 'hiredis'
 gem 'http_accept_language'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.4.0'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.4.1'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.3'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 164a507fd17ecffe4ef2289120d89156358b3a80
-  tag: v0.4.0
+  revision: 3b2c5997a62d7bf5f6114a55d41180f4bd1ae18e
+  tag: v0.4.1
   specs:
-    identity-doc-auth (0.4.0)
+    identity-doc-auth (0.4.1)
       activesupport
       faraday
 

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -26,8 +26,6 @@ module Idv
       def no_camera_redirect
         redirect_to idv_doc_auth_errors_no_camera_url
         msg = 'Doc Auth error: Javascript could not detect camera on mobile device.'
-
-        NewRelic::Agent.notice_error(StandardError.new(msg))
         failure(msg)
       end
     end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -161,8 +161,6 @@ describe Idv::DocAuthController do
         step_count: 1,
       }
 
-      expect(NewRelic::Agent).to receive(:notice_error)
-
       put :update, params: {
         step: 'welcome',
         ial2_consent_given: true,


### PR DESCRIPTION
Includes changes to ignore 440 error from https://github.com/18F/identity-doc-auth/pull/11

and disables reporting no camera to new relic since we already track it in cloudwatch