### PR TITLE
fix USPS test to not fail on first of month

### DIFF
--- a/app/services/reports/monthly_usps_letter_requests_report.rb
+++ b/app/services/reports/monthly_usps_letter_requests_report.rb
@@ -4,10 +4,7 @@ module Reports
   class MonthlyUspsLetterRequestsReport < BaseReport
     REPORT_NAME = 'monthly-usps-letter-requests-report'.freeze
 
-    def call(start_time: nil, end_time: nil)
-      start_time ||= first_of_this_month
-
-      end_time ||= end_of_today
+    def call(start_time: first_of_this_month, end_time: end_of_today)
 
       daily_results = transaction_with_timeout do
         ::LetterRequestsToUspsFtpLog.where(ftp_at: start_time..end_time)

--- a/app/services/reports/monthly_usps_letter_requests_report.rb
+++ b/app/services/reports/monthly_usps_letter_requests_report.rb
@@ -4,9 +4,13 @@ module Reports
   class MonthlyUspsLetterRequestsReport < BaseReport
     REPORT_NAME = 'monthly-usps-letter-requests-report'.freeze
 
-    def call
+    def call(start_time: nil, end_time: nil)
+      start_time ||= first_of_this_month
+
+      end_time ||= end_of_today
+
       daily_results = transaction_with_timeout do
-        ::LetterRequestsToUspsFtpLog.where(ftp_at: first_of_this_month..end_of_today)
+        ::LetterRequestsToUspsFtpLog.where(ftp_at: start_time..end_time)
       end
       totals = calculate_totals(daily_results)
       save_report(REPORT_NAME, {total_letter_requests: totals,

--- a/spec/features/reports/monthly_usps_letter_requests_report_spec.rb
+++ b/spec/features/reports/monthly_usps_letter_requests_report_spec.rb
@@ -20,7 +20,12 @@ feature 'Monthly usps letter requests report' do
     LetterRequestsToUspsFtpLog.create(ftp_at: now.yesterday, letter_requests_count: 3)
     LetterRequestsToUspsFtpLog.create(ftp_at: now, letter_requests_count: 4)
 
-    results_hash = JSON.parse(Reports::MonthlyUspsLetterRequestsReport.new.call)
+    results_hash = JSON.parse(
+      Reports::MonthlyUspsLetterRequestsReport.new.call(
+        start_time: now.yesterday,
+        end_time: now.tomorrow,
+      ),
+    )
     expect(results_hash['total_letter_requests']).to eq(7)
     expect(results_hash['daily_letter_requests'].count).to eq(2)
   end


### PR DESCRIPTION
The dynamic `Time.zone.now` and static end of month in the class causes some issues on the first of the month 🙂 