### PR TITLE
LG-4191: Allow session-associated user frontend logging

### DIFF
--- a/app/controllers/concerns/effective_user.rb
+++ b/app/controllers/concerns/effective_user.rb
@@ -6,4 +6,8 @@ module EffectiveUser
       current_user&.id,
     ].find(&:present?)
   end
+
+  def effective_user
+    User.find_by(id: effective_user_id) if effective_user_id
+  end
 end

--- a/app/controllers/concerns/effective_user.rb
+++ b/app/controllers/concerns/effective_user.rb
@@ -1,0 +1,9 @@
+module EffectiveUser
+  def effective_user_id
+    [
+      session[:ial2_recovery_user_id],
+      session[:doc_capture_user_id],
+      current_user&.id,
+    ].find(&:present?)
+  end
+end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -9,7 +9,7 @@ class FrontendLogController < ApplicationController
 
   def create
     event = "Frontend: #{log_params[:event]}"
-    analytics.track_event(event, log_params[:payload].to_h.merge(user_id: effective_user_id))
+    analytics.track_event(event, log_params[:payload].to_h)
 
     render json: { success: true }, status: :ok
   end
@@ -20,8 +20,12 @@ class FrontendLogController < ApplicationController
     params.permit(:event, payload: {})
   end
 
+  def analytics_user
+    effective_user || super
+  end
+
   def check_user_authenticated
-    return if effective_user_id
+    return if effective_user
 
     render json: { success: false }, status: :unauthorized
   end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -1,4 +1,6 @@
 class FrontendLogController < ApplicationController
+  include EffectiveUser
+
   respond_to :json
 
   skip_before_action :verify_authenticity_token
@@ -7,7 +9,7 @@ class FrontendLogController < ApplicationController
 
   def create
     event = "Frontend: #{log_params[:event]}"
-    analytics.track_event(event, log_params[:payload].to_h)
+    analytics.track_event(event, log_params[:payload].to_h.merge(user_id: effective_user_id))
 
     render json: { success: true }, status: :ok
   end
@@ -19,7 +21,7 @@ class FrontendLogController < ApplicationController
   end
 
   def check_user_authenticated
-    return if user_fully_authenticated?
+    return if effective_user_id
 
     render json: { success: false }, status: :unauthorized
   end

--- a/spec/controllers/concerns/effective_user_spec.rb
+++ b/spec/controllers/concerns/effective_user_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe EffectiveUser, type: :controller do
+  controller ApplicationController do
+    include EffectiveUser
+  end
+
+  let(:user) { build_stubbed(:user) }
+
+  describe '#effective_user_id' do
+    subject { controller.effective_user_id }
+
+    context 'logged out' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'logged out with ial2 recovery session user id' do
+      before do
+        session[:ial2_recovery_user_id] = user.id
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user.id
+      end
+    end
+
+    context 'logged out with doc capture session user id' do
+      before do
+        session[:doc_capture_user_id] = user.id
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user.id
+      end
+    end
+
+    context 'logged in' do
+      before do
+        stub_sign_in user
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user.id
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/effective_user_spec.rb
+++ b/spec/controllers/concerns/effective_user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe EffectiveUser, type: :controller do
     include EffectiveUser
   end
 
-  let(:user) { build_stubbed(:user) }
+  let(:user) { create(:user) }
 
   describe '#effective_user_id' do
     subject { controller.effective_user_id }
@@ -43,6 +43,56 @@ RSpec.describe EffectiveUser, type: :controller do
 
       it 'returns session user id' do
         expect(subject).to eq user.id
+      end
+    end
+  end
+
+  describe '#effective_user' do
+    subject { controller.effective_user }
+
+    context 'logged out' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'non-existent user' do
+      before do
+        session[:ial2_recovery_user_id] = -1
+      end
+
+      it 'returns session user id' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'logged out with ial2 recovery session user id' do
+      before do
+        session[:ial2_recovery_user_id] = user.id
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user
+      end
+    end
+
+    context 'logged out with doc capture session user id' do
+      before do
+        session[:doc_capture_user_id] = user.id
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user
+      end
+    end
+
+    context 'logged in' do
+      before do
+        stub_sign_in user
+      end
+
+      it 'returns session user id' do
+        expect(subject).to eq user
       end
     end
   end

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -18,7 +18,7 @@ describe FrontendLogController do
 
       it 'succeeds' do
         expect(@analytics).to receive(:track_event).
-          with("Frontend: #{event}", payload)
+          with("Frontend: #{event}", payload.merge(user_id: user.id))
 
         action
 
@@ -81,6 +81,25 @@ describe FrontendLogController do
 
         expect(response).to have_http_status(:unauthorized)
         expect(json[:success]).to eq(false)
+      end
+    end
+
+    context 'anonymous user with session-associated user id' do
+      let(:user_id) { user.id }
+
+      before do
+        session[:doc_capture_user_id] = user_id
+        stub_analytics
+      end
+
+      it 'succeeds' do
+        expect(@analytics).to receive(:track_event).
+          with("Frontend: #{event}", payload.merge(user_id: user_id))
+
+        action
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:success]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
**Why**: Frontend logging that occurs in the hybrid document capture step should succeed and should be associated with the user who initiated the proofing session.

**Implementation Notes:**

Inspiration is drawn from two similar existing implementations:

https://github.com/18F/identity-idp/blob/dfd2447aa4e2e73023d3547648556aff1571d390/app/services/flow/flow_state_machine.rb#L64-L70

https://github.com/18F/identity-idp/blob/dfd2447aa4e2e73023d3547648556aff1571d390/app/controllers/idv/session_errors_controller.rb#L34-L42

The idea with a separate concern is partly to try to isolate awareness of these "side" sessions, so that the otherwise-generic frontend logging controller doesn't need to be aware of IAL2 sub-sessions. I'm open to alternatives here to try to hook / override "effective" user.

It was also something where in drawing from above implementations, those could potentially be refactored to make use of this mixin. Or, if there's a desire to make this more application-wide, possibly including or adapting this behavior somewhere lower-level like `ApplicationController`.

