### PR TITLE
LG-4301 Updated the idv_attempts default from 3 to 5

### DIFF
--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -29,7 +29,7 @@ class Throttle < ApplicationRecord
       attempt_window: (AppConfig.env.reset_password_email_window_in_minutes || 60).to_i,
     },
     idv_resolution: {
-      max_attempts: (AppConfig.env.idv_max_attempts || 3).to_i,
+      max_attempts: (AppConfig.env.idv_max_attempts || 5).to_i,
       attempt_window: (AppConfig.env.idv_attempt_window_in_hours || 6).to_i * 60,
     },
     idv_send_link: {

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -60,7 +60,7 @@ gpo_designated_receiver_pii: '{}'
 ial2_recovery_request_valid_for_minutes: '15'
 identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '6'
-idv_max_attempts: '3'
+idv_max_attempts: '5'
 idv_send_link_attempt_window_in_minutes: '10'
 idv_send_link_max_attempts: '5'
 in_person_proofing_enabled:

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -167,7 +167,7 @@ describe 'IdvStepConcern' do
     Throttle.create(
       throttle_type: 5,
       user_id: user.id,
-      attempts: 3,
+      attempts: 5,
       attempted_at: attempted_at,
     )
   end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -28,7 +28,7 @@ describe IdvController do
         :profile,
         user: user,
       )
-      Throttle.create(throttle_type: 5, user_id: user.id, attempts: 3, attempted_at: Time.zone.now)
+      Throttle.create(throttle_type: 5, user_id: user.id, attempts: 5, attempted_at: Time.zone.now)
 
       stub_sign_in(profile.user)
 
@@ -192,7 +192,7 @@ describe IdvController do
         Throttle.create(
           throttle_type: 5,
           user_id: user.id,
-          attempts: 3,
+          attempts: 5,
           attempted_at: Time.zone.now,
         )
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -178,7 +178,7 @@ feature 'idv phone step' do
       start_idv_from_sp
       complete_idv_steps_before_phone_step
 
-      2.times do
+      4.times do
         fill_out_phone_form_fail
         click_idv_continue
 


### PR DESCRIPTION
**Why**: To give users more opportunities to correct submitted information and a better chance of success