### PR TITLE
Make throttle configs required and remove hardcoded defaults

### DIFF
--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -13,28 +13,28 @@ class Throttle < ApplicationRecord
 
   THROTTLE_CONFIG = {
     idv_acuant: {
-      max_attempts: (AppConfig.env.acuant_max_attempts || 3).to_i,
-      attempt_window: (AppConfig.env.acuant_attempt_window_in_minutes || 360).to_i,
+      max_attempts: AppConfig.env.acuant_max_attempts.to_i,
+      attempt_window: AppConfig.env.acuant_attempt_window_in_minutes.to_i,
     },
     reg_unconfirmed_email: {
-      max_attempts: (AppConfig.env.reg_unconfirmed_email_max_attempts || 20).to_i,
-      attempt_window: (AppConfig.env.reg_unconfirmed_email_window_in_minutes || 60).to_i,
+      max_attempts: AppConfig.env.reg_unconfirmed_email_max_attempts.to_i,
+      attempt_window: AppConfig.env.reg_unconfirmed_email_window_in_minutes.to_i,
     },
     reg_confirmed_email: {
-      max_attempts: (AppConfig.env.reg_confirmed_email_max_attempts || 20).to_i,
-      attempt_window: (AppConfig.env.reg_confirmed_email_window_in_minutes || 60).to_i,
+      max_attempts: AppConfig.env.reg_confirmed_email_max_attempts.to_i,
+      attempt_window: AppConfig.env.reg_confirmed_email_window_in_minutes.to_i,
     },
     reset_password_email: {
-      max_attempts: (AppConfig.env.reset_password_email_max_attempts || 20).to_i,
-      attempt_window: (AppConfig.env.reset_password_email_window_in_minutes || 60).to_i,
+      max_attempts: AppConfig.env.reset_password_email_max_attempts.to_i,
+      attempt_window: AppConfig.env.reset_password_email_window_in_minutes.to_i,
     },
     idv_resolution: {
-      max_attempts: (AppConfig.env.idv_max_attempts || 5).to_i,
-      attempt_window: (AppConfig.env.idv_attempt_window_in_hours || 6).to_i * 60,
+      max_attempts: AppConfig.env.idv_max_attempts.to_i,
+      attempt_window: AppConfig.env.idv_attempt_window_in_hours.to_i * 60,
     },
     idv_send_link: {
-      max_attempts: (AppConfig.env.idv_send_link_max_attempts || 5).to_i,
-      attempt_window: (AppConfig.env.idv_send_link_attempt_window_in_minutes || 10).to_i,
+      max_attempts: AppConfig.env.idv_send_link_max_attempts.to_i,
+      attempt_window: AppConfig.env.idv_send_link_attempt_window_in_minutes.to_i,
     },
   }.freeze
 

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,6 +1,8 @@
 require Rails.root.join('lib', 'config_validator.rb')
 
 AppConfig.require_keys(%w[
+                         acuant_max_attempts
+                         acuant_attempt_window_in_minutes
                          async_wait_timeout_seconds
                          attribute_encryption_key
                          database_statement_timeout
@@ -15,6 +17,10 @@ AppConfig.require_keys(%w[
                          enable_usps_verification
                          exception_recipients
                          hmac_fingerprinter_key
+                         idv_attempt_window_in_hours
+                         idv_max_attempts
+                         idv_send_link_attempt_window_in_minutes
+                         idv_send_link_max_attempts
                          issuers_with_email_nameid_format
                          logins_per_ip_limit
                          logins_per_ip_period
@@ -37,11 +43,17 @@ AppConfig.require_keys(%w[
                          recovery_code_length
                          recurring_jobs_disabled_names
                          redis_url
+                         reg_confirmed_email_max_attempts
+                         reg_confirmed_email_window_in_minutes
+                         reg_unconfirmed_email_max_attempts
+                         reg_unconfirmed_email_window_in_minutes
                          requests_per_ip_limit
                          requests_per_ip_period
                          requests_per_ip_track_only_mode
                          remember_device_expiration_hours_aal_1
                          remember_device_expiration_hours_aal_2
+                         reset_password_email_max_attempts
+                         reset_password_email_window_in_minutes
                          saml_endpoint_configs
                          s3_report_bucket_prefix
                          s3_reports_enabled


### PR DESCRIPTION
**Why**: The app config defaults are the preferred way for setting configs.