### PR TITLE
Avoid Rack Timeouts from AWS SDK timeout (LG-4220)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v1.0.1'
 gem 'identity-logging', github: '18F/identity-logging', tag: 'v0.1.0'
 require File.join(__dir__, 'lib', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
-gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.11'
+gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.12'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'main'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,10 +87,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: 8e56cce97f706679709a0007fd2904723f1f3cbc
-  tag: v0.1.11
+  revision: ee4ad50a3275ef7ff3f4855f99117115c5960915
+  tag: v0.1.12
   specs:
-    identity-telephony (0.1.11)
+    identity-telephony (0.1.12)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -43,6 +43,8 @@ asset_host:
 async_wait_timeout_seconds: '60'
 available_locales: en es fr
 aws_http_timeout: '5'
+aws_http_retry_limit: '2'
+aws_http_retry_max_delay: '1'
 aws_logo_bucket:
 aws_region: 'us-west-2'
 aws_kms_multi_region_enabled: 'false'

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,7 @@
 Aws.config.update(
   region: AppConfig.env.aws_region,
-  http_open_timeout: AppConfig.env.aws_http_timeout.to_i,
-  http_read_timeout: AppConfig.env.aws_http_timeout.to_i,
+  http_open_timeout: AppConfig.env.aws_http_timeout.to_f,
+  http_read_timeout: AppConfig.env.aws_http_timeout.to_f,
+  retry_limit: AppConfig.env.aws_http_retry_limit.to_i,
+  retry_max_delay: AppConfig.env.aws_http_retry_max_delay.to_i,
 )


### PR DESCRIPTION
Pending changes in https://github.com/18F/identity-telephony/pull/41

We time out web requests at 15 seconds, but during AWS outages or periods of service degradation, the default AWS SDK timeout behavior will cause us to hit the Rack timeout. Services like Pinpoint, STS, and SES have error handling, but services like KMS are probably too central to be able to gracefully handle.

The AWS SDK has a bunch of options for configuring retries that aren't published in the documentation, but we can look at the source code: [retries](https://github.com/aws/aws-sdk-ruby/blob/a6c0e1d866becd4b8bd6d4785186bc7b42114c95/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb)

The defaults are:

- Base retry delay: 0.3 seconds
- Max retry delay: infinity
- Retry limit: 3
- Backoff calculation: 2^(retry count) * base delay

The SDK also offers some options for jitter and different retry modes.

The default maximum delay for 3 retries adds up to 2.1 seconds. If we reduce our retries to 2, the max delay will be at most 0.9 seconds. Our current max read timeout is 5 seconds, so we'd potentially be at 4 requests * 5 seconds + 2.1 seconds for a total of 22.1 seconds (assuming a single AWS call, but we typically have at least two just for KMS.

Reducing retries to 2 and the read timeout to 5 would give us a maximum of 15.9 seconds.

I think the next step is having different timeout behavior for different services since the response time varies a lot among all of them. KMS and STS are typically a few times faster than SES and Pinpoint.