### PR TITLE
[LG-4249] Add null constraint to agencies.abbreviation

### DIFF
--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -4,5 +4,5 @@ class Agency < ApplicationRecord
   has_many :service_providers, inverse_of: :agency
   # rubocop:enable Rails/HasManyOrHasOneDependent
   validates :name, presence: true
-  validates :abbreviation, uniqueness: { case_sensitive: false, allow_nil: true }
+  validates :abbreviation, uniqueness: { case_sensitive: false }
 end

--- a/db/migrate/20210303161124_add_null_constraint_to_agencies_abbreviation.rb
+++ b/db/migrate/20210303161124_add_null_constraint_to_agencies_abbreviation.rb
@@ -1,0 +1,14 @@
+class AddNullConstraintToAgenciesAbbreviation < ActiveRecord::Migration[6.1]
+  def up
+    # following guidance from strong_migration
+    safety_assured do
+      execute 'ALTER TABLE "agencies" ADD CONSTRAINT "agencies_abbreviation_null" CHECK ("abbreviation" IS NOT NULL) NOT VALID'
+    end
+  end
+
+  def down
+    safety_assured do
+      execute 'ALTER TABLE "agencies" DROP CONSTRAINT "agencies_abbreviation_null"'
+    end
+  end
+end

--- a/db/migrate/20210303182041_validate_add_null_constraint_to_agencies_abbreviation.rb
+++ b/db/migrate/20210303182041_validate_add_null_constraint_to_agencies_abbreviation.rb
@@ -1,0 +1,30 @@
+class ValidateAddNullConstraintToAgenciesAbbreviation < ActiveRecord::Migration[6.1]
+  def up
+    # just in case, copy over the name to abbreviation in case an environment is
+    # missing the abbreviations. This will be overriden by the contents of the
+    # YAML file when db:seed is run, but allows us to set the null constraint
+    # safely. I'm using SQL just so we're not dependent on the Model class.
+    safety_assured do
+      execute 'UPDATE agencies SET abbreviation = name WHERE abbreviation IS NULL'
+    end
+
+    # following guidance from strong_migration
+    safety_assured do
+      execute 'ALTER TABLE "agencies" VALIDATE CONSTRAINT "agencies_abbreviation_null"'
+    end
+
+    change_column_null :agencies, :abbreviation, false
+
+    safety_assured do
+      execute 'ALTER TABLE "agencies" DROP CONSTRAINT "agencies_abbreviation_null"'
+    end
+  end
+
+  def down
+    safety_assured do
+      execute 'ALTER TABLE "agencies" ADD CONSTRAINT "agencies_abbreviation_null" CHECK ("abbreviation" IS NOT NULL) NOT VALID'
+    end
+
+    change_column_null :agencies, :abbreviation, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_03_033634) do
+ActiveRecord::Schema.define(version: 2021_03_03_182041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2021_03_03_033634) do
 
   create_table "agencies", force: :cascade do |t|
     t.string "name", null: false
-    t.string "abbreviation"
+    t.string "abbreviation", null: false
     t.index ["abbreviation"], name: "index_agencies_on_abbreviation", unique: true
     t.index ["name"], name: "index_agencies_on_name", unique: true
   end

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -13,5 +13,12 @@ FactoryBot.define do
              industry: Faker::Company.industry,
              tag: SecureRandom.hex)
     end
+    abbreviation do
+      name.
+        split(' ').
+        map { |w| w.chars.first.upcase }.
+        select { |c| /\w/.match?(c) }.
+        join
+    end
   end
 end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -8,6 +8,6 @@ describe Agency do
     let(:agency) { build_stubbed(:agency) }
 
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_uniqueness_of(:abbreviation).case_insensitive.allow_nil }
+    it { is_expected.to validate_uniqueness_of(:abbreviation).case_insensitive }
   end
 end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AgencySeeder do
     end
 
     it 'updates existing agencies based on the current value of the yml file' do
-      Agency.create(id: 1, name: 'FOO')
+      create(:agency, id: 1, name: 'FOO')
 
       expect(Agency.find_by(id: 1).name).to eq('FOO')
       run


### PR DESCRIPTION
Resolves LG-4249

Follows guidance from the strong_migration gem in terms of adding a
separate constraint instead of just running change_column_null. Also
updates the Agency factory to generate an abbreviation.