### PR TITLE
Refactor the return to SP url code into a service

### DIFF
--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -7,10 +7,6 @@ class SessionDecorator
     'shared/null'
   end
 
-  def return_to_sp_from_start_page_partial
-    'shared/null'
-  end
-
   def nav_partial
     'shared/nav_lite'
   end

--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -1,0 +1,46 @@
+class SpReturnUrlResolver
+  attr_reader :sp, :sp_request_url, :view_context
+
+  def initialize(sp:, sp_request_url:)
+    @sp = sp
+    @sp_request_url = sp_request_url
+  end
+
+  def return_to_sp_url
+    if oidc_redirect_uri_present?
+      oidc_access_denied_redirect_url
+    elsif sp.return_to_sp_url.present?
+      sp.return_to_sp_url
+    else
+      inferred_redirect_url
+    end
+  end
+
+  def failure_to_proof_url
+    return sp.failure_to_proof_url unless sp.failure_to_proof_url.blank?
+    return_to_sp_url
+  end
+
+  private
+
+  def inferred_redirect_url
+    configured_url = sp.redirect_uris&.first || sp.acs_url
+    URI.join(configured_url, '/').to_s
+  end
+
+  def oidc_access_denied_redirect_url
+    UriService.add_params(
+      sp_request_url_pararms[:redirect_uri],
+      error: 'access_denied',
+      state: sp_request_url_pararms[:state],
+    )
+  end
+
+  def oidc_redirect_uri_present?
+    sp_request_url.present? && sp_request_url_pararms[:redirect_uri].present?
+  end
+
+  def sp_request_url_pararms
+    @sp_request_url_pararms ||= UriService.params(sp_request_url)
+  end
+end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceProviderSessionDecorator do
       sp: sp,
       view_context: view_context,
       sp_session: {},
-      service_provider_request: ServiceProviderRequestProxy.new,
+      service_provider_request: ServiceProviderRequest.new,
     )
   end
   let(:sp) { build_stubbed(:service_provider) }

--- a/spec/services/sp_return_url_resolver_spec.rb
+++ b/spec/services/sp_return_url_resolver_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe SpReturnUrlResolver do
+  describe '#return_sp_url' do
+    context 'for an SP with a redirect URI in the request URL' do
+      it 'returns the redirect URI with error params and state' do
+        redirect_uri = 'https://sp.gov/result'
+        sp = build(
+          :service_provider, redirect_uris: [redirect_uri], return_to_sp_url: 'https://sp.gov',
+        )
+        state = '1234abcd'
+        sp_request_url = UriService.add_params(
+          'https://example.com/authorize', redirect_uri: redirect_uri, state: state,
+        )
+
+        resolver = described_class.new(sp: sp, sp_request_url: sp_request_url)
+        return_to_sp_url = resolver.return_to_sp_url
+        return_to_sp_url_without_params = return_to_sp_url.split('?').first
+        return_to_sp_url_params = UriService.params(return_to_sp_url)
+
+        expect(return_to_sp_url_without_params).to eq(redirect_uri)
+        expect(return_to_sp_url_params).to eq('state' => state, 'error' => 'access_denied')
+      end
+    end
+
+    context 'for an SP without a redirect URI in the request URL' do
+      it 'returns the return URL specified in the config' do
+        configured_return_to_sp_url = 'https://sp.gov/return_to_sp'
+        sp = build(:service_provider, return_to_sp_url: configured_return_to_sp_url)
+
+        resolver = described_class.new(sp: sp, sp_request_url: nil)
+        return_to_sp_url = resolver.return_to_sp_url
+
+        expect(return_to_sp_url).to eq(configured_return_to_sp_url)
+      end
+    end
+
+    context 'for an SP without a redirect URI or return URL in the config' do
+      it 'returns the ACS URL without a path for a SAML SP' do
+        acs_url = 'https://sp.gov/acs_url'
+        sp = build(:service_provider, redirect_uris: [], return_to_sp_url: nil, acs_url: acs_url)
+
+        resolver = described_class.new(sp: sp, sp_request_url: nil)
+        return_to_sp_url = resolver.return_to_sp_url
+
+        expect(return_to_sp_url).to eq('https://sp.gov/')
+      end
+
+      it 'returns the first redirect URI without a path for an OIDC SP' do
+        redirect_uri = 'https://sp.gov/resut'
+        sp = build(:service_provider, redirect_uris: [redirect_uri], return_to_sp_url: nil)
+
+        resolver = described_class.new(sp: sp, sp_request_url: nil)
+        return_to_sp_url = resolver.return_to_sp_url
+
+        expect(return_to_sp_url).to eq('https://sp.gov/')
+      end
+    end
+  end
+
+  describe '#failure_to_proof_url' do
+    it 'return the failure to proof url if one is registered' do
+      configured_failure_to_proof_url = 'https://sp.gov/failure_to_proof'
+      configured_return_to_sp_url = 'https://sp.gov/return_to_sp'
+      sp = build(
+        :service_provider,
+        return_to_sp_url: configured_return_to_sp_url,
+        failure_to_proof_url: configured_failure_to_proof_url,
+      )
+
+      resolver = described_class.new(sp: sp, sp_request_url: nil)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(failure_to_proof_url).to eq(configured_failure_to_proof_url)
+    end
+
+    it 'returns the return to sp url if no failure to proof url is registered' do
+      configured_return_to_sp_url = 'https://sp.gov/return_to_sp'
+      sp = build(
+        :service_provider,
+        return_to_sp_url: configured_return_to_sp_url,
+        failure_to_proof_url: nil,
+      )
+
+      resolver = described_class.new(sp: sp, sp_request_url: nil)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(failure_to_proof_url).to eq(configured_return_to_sp_url)
+    end
+
+    it 'returns the returns to sp url if the failure to proof url is an empty string' do
+      configured_return_to_sp_url = 'https://sp.gov/return_to_sp'
+      sp = build(
+        :service_provider,
+        return_to_sp_url: configured_return_to_sp_url,
+        failure_to_proof_url: '',
+      )
+
+      resolver = described_class.new(sp: sp, sp_request_url: nil)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(failure_to_proof_url).to eq(configured_return_to_sp_url)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To make the adding the return to SP event easier by moving the complexity for generating the URL into a service.