### PR TITLE
LG-4271: properly log the step name of optional steps

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -124,7 +124,8 @@ module Flow
       result = optional_show_step.new(@flow).base_call
 
       if @analytics_id
-        optional_properties = result.to_h.merge(step: optional_show_step)
+        optional_show_step_name = optional_show_step.to_s.split('::').last.underscore
+        optional_properties = result.to_h.merge(step: optional_show_step_name)
 
         analytics.track_event(analytics_optional_step, optional_properties)
         # keeping the old event names for backward compatibility

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -117,14 +117,14 @@ module Flow
       render template: "#{@view || @name}/#{step}", locals: local_params
     end
 
-    def call_optional_show_step(step)
+    def call_optional_show_step(optional_step)
       return unless @flow.class.const_defined?('OPTIONAL_SHOW_STEPS')
-      optional_show_step = @flow.class::OPTIONAL_SHOW_STEPS.with_indifferent_access[step]
+      optional_show_step = @flow.class::OPTIONAL_SHOW_STEPS.with_indifferent_access[optional_step]
       return unless optional_show_step
       result = optional_show_step.new(@flow).base_call
 
       if @analytics_id
-        optional_show_step_name = optional_show_step.to_s.split('::').last.underscore
+        optional_show_step_name = optional_show_step.to_s.demodulize.underscore
         optional_properties = result.to_h.merge(step: optional_show_step_name)
 
         analytics.track_event(analytics_optional_step, optional_properties)
@@ -132,7 +132,7 @@ module Flow
         analytics.track_event(old_analytics_optional_step, optional_properties)
       end
 
-      if next_step.to_s != step
+      if next_step.to_s != optional_step
         if next_step_is_url
           redirect_to next_step
         else

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -76,7 +76,7 @@ describe Idv::DocAuthController do
 
     it 'tracks analytics for the optional step' do
       mock_next_step(:verify_wait)
-      result = { errors: {}, step: Idv::Steps::VerifyWaitStepShow, success: true }
+      result = { errors: {}, step: 'verify_wait_step_show', success: true }
 
       get :show, params: { step: 'verify_wait' }
 


### PR DESCRIPTION
The optional step processing of the FlowStateMachine was meaning to log the `step` but was assigning to it the Class of the step, not the name of the step. When this got serialized via `to_json` the result was `step: {}` - it silently failed.

This PR takes the step class and reduces it to the step name, e.g., `Idv::Steps::VerifyWaitStepShow` becomes `"verify_wait_step_show"`