### PR TITLE
LG-4308: Update messaging for "Return to SP" link in document capture

### DIFF
--- a/app/assets/stylesheets/components/_block-link.scss
+++ b/app/assets/stylesheets/components/_block-link.scss
@@ -1,0 +1,24 @@
+.block-link {
+  @include u-position('relative');
+  @include u-display('block');
+  @include u-margin-y(3);
+  @include u-padding-y(2);
+  @include u-padding-right(5);
+  @include u-border-y(1px, 'primary-light');
+  @include u-text('no-underline');
+
+  & + & {
+    @include u-margin-top(neg-3);
+    @include u-border-top(0);
+  }
+}
+
+.block-link__arrow {
+  @include u-display('block');
+  @include u-position('absolute');
+  @include u-right(2);
+  @include u-top(50%);
+  height: 12px;
+  transform: translateY(-50%);
+  width: 7px;
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -2,6 +2,7 @@
 @import 'abbr';
 @import 'background';
 @import 'banner';
+@import 'block-link';
 @import 'border';
 @import 'btn';
 @import 'card';

--- a/app/javascript/packages/document-capture/components/block-link.jsx
+++ b/app/javascript/packages/document-capture/components/block-link.jsx
@@ -1,0 +1,33 @@
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef BlockLinkProps
+ *
+ * @prop {string} url Link destination.
+ * @prop {ReactNode} children Child elements.
+ */
+
+/**
+ * @param {BlockLinkProps} props
+ */
+function BlockLink({ url, children }) {
+  return (
+    <a href={url} className="usa-link block-link">
+      {children}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 5.2 8.91"
+        focusable="false"
+        aria-hidden="true"
+        className="block-link__arrow"
+      >
+        <path
+          d="M5.11 4.66L1 8.82a.36.36 0 01-.21.09.31.31 0 01-.2-.09l-.5-.45a.29.29 0 01-.09-.2A.36.36 0 01.09 8L3.6 4.45.09 1A.36.36 0 010 .74a.31.31 0 01.09-.2L.54.09A.31.31 0 01.74 0 .36.36 0 011 .09l4.11 4.16a.31.31 0 01.09.2.31.31 0 01-.09.21z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+  );
+}
+
+export default BlockLink;

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import BlockLink from './block-link';
 import AcuantCapture from './acuant-capture';
 import FormErrorMessage from './form-error-message';
 import useI18n from '../hooks/use-i18n';
@@ -52,22 +53,6 @@ function DocumentsStep({
           </p>
         </>
       )}
-      {serviceProvider.name && isMobile && (
-        <p>
-          {formatHTML(
-            t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
-            {
-              strong: 'strong',
-              a: ({ children }) =>
-                serviceProvider.failureToProofURL ? (
-                  <a href={serviceProvider.failureToProofURL}>{children}</a>
-                ) : (
-                  <>{children}</>
-                ),
-            },
-          )}
-        </p>
-      )}
       <p className="margin-bottom-0">{t('doc_auth.tips.document_capture_header_text')}</p>
       <ul>
         <li>{t('doc_auth.tips.document_capture_id_text1')}</li>
@@ -75,6 +60,13 @@ function DocumentsStep({
         <li>{t('doc_auth.tips.document_capture_id_text3')}</li>
         {!isMobile && <li>{t('doc_auth.tips.document_capture_id_text4')}</li>}
       </ul>
+      {serviceProvider.name && (
+        <BlockLink url={serviceProvider.failureToProofURL}>
+          {formatHTML(t('doc_auth.info.get_help_at_sp_html', { sp_name: serviceProvider.name }), {
+            strong: 'strong',
+          })}
+        </BlockLink>
+      )}
       {DOCUMENT_SIDES.map((side) => {
         const error = errors.find(({ field }) => field === side)?.error;
 

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -250,7 +250,12 @@ function FormSteps({
           return fields.current[field].refCallback;
         }}
       />
-      <Button type="submit" isPrimary className="margin-y-5" isVisuallyDisabled={!canContinue}>
+      <Button
+        type="submit"
+        isPrimary
+        className="display-block margin-y-5"
+        isVisuallyDisabled={!canContinue}
+      >
         {isLastStep ? t('forms.buttons.submit.default') : t('forms.buttons.continue')}
       </Button>
       {Footer && <Footer />}

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -3,6 +3,7 @@ import { hasMediaAccess } from '@18f/identity-device';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
+import BlockLink from './block-link';
 import SelfieCapture from './selfie-capture';
 import FormErrorMessage from './form-error-message';
 import ServiceProviderContext from '../context/service-provider';
@@ -59,22 +60,6 @@ function ReviewIssuesStep({
           strong: 'strong',
         })}
       </p>
-      {serviceProvider.name && (
-        <p>
-          {formatHTML(
-            t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
-            {
-              strong: ({ children }) => <>{children}</>,
-              a: ({ children }) =>
-                serviceProvider.failureToProofURL ? (
-                  <a href={serviceProvider.failureToProofURL}>{children}</a>
-                ) : (
-                  <>{children}</>
-                ),
-            },
-          )}
-        </p>
-      )}
       <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_id_header_text')}</p>
       <ul>
         <li>{t('doc_auth.tips.review_issues_id_text1')}</li>
@@ -141,6 +126,13 @@ function ReviewIssuesStep({
             />
           )}
         </>
+      )}
+      {serviceProvider.name && (
+        <BlockLink url={serviceProvider.failureToProofURL}>
+          {formatHTML(t('doc_auth.info.get_help_at_sp_html', { sp_name: serviceProvider.name }), {
+            strong: 'strong',
+          })}
+        </BlockLink>
       )}
     </>
   );

--- a/app/javascript/packages/document-capture/context/service-provider.js
+++ b/app/javascript/packages/document-capture/context/service-provider.js
@@ -4,14 +4,14 @@ import { createContext } from 'react';
  * @typedef ServiceProviderContext
  *
  * @prop {string?} name Service provider name.
- * @prop {string?} failureToProofURL URL to redirect user on failure to proof.
+ * @prop {string} failureToProofURL URL to redirect user on failure to proof.
  * @prop {boolean} isLivenessRequired Whether liveness capture should be expected from the user.
  */
 
 const ServiceProviderContext = createContext(
   /** @type {ServiceProviderContext} */ ({
     name: null,
-    failureToProofURL: null,
+    failureToProofURL: '',
     isLivenessRequired: true,
   }),
 );

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -62,8 +62,7 @@ const keepAliveEndpoint = /** @type {string} */ (appRoot.getAttribute('data-keep
  * ).ServiceProviderContext}
  */
 function getServiceProvider() {
-  const name = appRoot.getAttribute('data-sp-name');
-  const failureToProofURL = appRoot.getAttribute('data-failure-to-proof-url');
+  const { spName: name = null, failureToProofUrl: failureToProofURL = '' } = appRoot.dataset;
   const isLivenessRequired = appRoot.hasAttribute('data-liveness-required');
 
   return { name, failureToProofURL, isLivenessRequired };

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -21,6 +21,7 @@
 - doc_auth.info.capture_status_tap_to_capture
 - doc_auth.info.document_capture_intro_acknowledgment
 - doc_auth.info.document_capture_upload_image
+- doc_auth.info.get_help_at_sp_html
 - doc_auth.info.image_updated
 - doc_auth.info.id_worn_html
 - doc_auth.info.interstitial_eta

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -26,7 +26,6 @@
 - doc_auth.info.id_worn_html
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks
-- doc_auth.info.no_other_id_help_bold_html
 - doc_auth.instructions.document_capture_selfie_consent_banner
 - doc_auth.instructions.document_capture_selfie_consent_blocked
 - doc_auth.instructions.document_capture_selfie_consent_blocked_action

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -113,6 +113,7 @@ en:
         your identity.
       document_capture_upload_image: We only use your ID to verify your identity,
         and we will not save any images.
+      get_help_at_sp_html: "<strong>Having trouble?</strong> Get help at %{sp_name}"
       id_worn_html: "<strong>Is your ID worn or damaged?</strong> Use another state-issued
         ID if you have one."
       image_updated: Image updated

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -120,6 +120,8 @@ es:
         que subes. Solo verificamos su identidad.
       document_capture_upload_image: Solo utilizamos su ID para verificar su identidad
         y no guardaremos ninguna imagen.
+      get_help_at_sp_html: "<strong>¿Tienes algún problema?</strong> Obtén ayuda en
+        %{sp_name}"
       id_worn_html: "<strong>¿Su documento de identidad está desgastado o dañado?</strong>
         Utilice otro documento de identidad expedido por el estado, si lo tiene."
       image_updated: Imagen actualizada

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -131,6 +131,8 @@ fr:
         images que vous téléchargez. Nous vérifions uniquement votre identité.
       document_capture_upload_image: Nous n'utilisons votre identifiant que pour vérifier
         votre identité, et nous n'enregistrerons aucune image.
+      get_help_at_sp_html: "<strong>Vous avez des problèmes?</strong> Obtenez de l'aide
+        à %{sp_name}"
       id_worn_html: "<strong>Votre carte d'identité est-elle usée ou endommagée?</strong>
         Utilisez une autre carte d'identité délivrée par l'État si vous en avez une."
       image_updated: Image mise à jour

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -115,9 +115,8 @@ describe('document-capture/components/review-issues-step', () => {
       const { getByText } = render(
         <I18nContext.Provider
           value={{
-            'doc_auth.info.no_other_id_help_bold_html':
-              'If you do not have another state-issued ID, ' +
-              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
+            'doc_auth.info.get_help_at_sp_html':
+              '<strong>Having trouble?</strong> Get help at %{sp_name}',
           }}
         >
           <ServiceProviderContext.Provider
@@ -132,43 +131,9 @@ describe('document-capture/components/review-issues-step', () => {
         </I18nContext.Provider>,
       );
 
-      const help = getByText(
-        (_content, element) =>
-          element.innerHTML ===
-          'If you do not have another state-issued ID, ' +
-            '<a href="https://example.com">get help at Example App.</a>',
-      );
+      const help = getByText('Having trouble?').closest('a');
 
-      expect(help).to.be.ok();
-    });
-
-    it('renders with name', () => {
-      const { getByText } = render(
-        <I18nContext.Provider
-          value={{
-            'doc_auth.info.no_other_id_help_bold_html':
-              'If you do not have another state-issued ID, ' +
-              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
-          }}
-        >
-          <ServiceProviderContext.Provider
-            value={{
-              name: 'Example App',
-              failureToProofURL: null,
-              isLivenessRequired: false,
-            }}
-          >
-            <ReviewIssuesStep />
-          </ServiceProviderContext.Provider>
-        </I18nContext.Provider>,
-      );
-
-      const help = getByText(
-        (_content, element) =>
-          element.innerHTML ===
-          'If you do not have another state-issued ID, get help at Example App.',
-      );
-
+      expect(help.href).to.equal('https://example.com/');
       expect(help).to.be.ok();
     });
 


### PR DESCRIPTION
**Why**: As an end-user, I want to know if there are any fallback options in case I am unable to take a snapshot of my state-issued ID that is acceptable to login so that I am not frustrated by having to repeatedly try and fail.

**Screenshot:**

_Documents Step:_

&nbsp;|Before|After
---|---|---
Desktop|![image](https://user-images.githubusercontent.com/1779930/110018122-fb01dd80-7cf4-11eb-9c1f-c9a64daaee19.png)|![desktop](https://user-images.githubusercontent.com/1779930/110015146-8ed1aa80-7cf1-11eb-9c81-bbe4b203c261.png)
Mobile|![image](https://user-images.githubusercontent.com/1779930/110018251-1c62c980-7cf5-11eb-8871-1a637403b9da.png)|![mobile](https://user-images.githubusercontent.com/1779930/110015246-a5780180-7cf1-11eb-8e9c-789a3f6b27b8.png)

_Review Step:_

&nbsp;|Before|After
---|---|---
Desktop|![image](https://user-images.githubusercontent.com/1779930/110018195-0e14ad80-7cf5-11eb-83ef-d9a687203e75.png)|![desktop](https://user-images.githubusercontent.com/1779930/110015650-1c14ff00-7cf2-11eb-86e0-f98525c9097e.png)
Mobile|![image](https://user-images.githubusercontent.com/1779930/110018315-2be21280-7cf5-11eb-82dd-71398bfc064d.png)|![mobile](https://user-images.githubusercontent.com/1779930/110015317-b9bbfe80-7cf1-11eb-90d2-d0ee36b32241.png)
