### PR TITLE
Log an event when a user elects to return to an SP

### DIFF
--- a/app/controllers/return_to_sp_controller.rb
+++ b/app/controllers/return_to_sp_controller.rb
@@ -1,0 +1,44 @@
+class ReturnToSpController < ApplicationController
+  before_action :validate_sp_exists
+
+  def cancel
+    redirect_url = sp_return_url_resolver.return_to_sp_url
+    analytics.track_event(Analytics::RETURN_TO_SP_CANCEL, redirect_url: redirect_url)
+    redirect_to redirect_url
+  end
+
+  def failure_to_proof
+    redirect_url = sp_return_url_resolver.failure_to_proof_url
+    analytics.track_event(Analytics::RETURN_TO_SP_FAILURE_TO_PROOF, redirect_url: redirect_url)
+    redirect_to redirect_url
+  end
+
+  private
+
+  def sp_return_url_resolver
+    @sp_return_url_resolver ||= SpReturnUrlResolver.new(
+      service_provider: current_sp,
+      oidc_state: sp_request_params[:state],
+      oidc_redirect_uri: sp_request_params[:redirect_uri],
+    )
+  end
+
+  def sp_request_params
+    @request_params ||= begin
+      if sp_request_url.present?
+        UriService.params(sp_request_url)
+      else
+        {}
+      end
+    end
+  end
+
+  def sp_request_url
+    sp_session[:request_url] || service_provider_request.url
+  end
+
+
+  def validate_sp_exists
+    redirect_to account_url if current_sp.nil?
+  end
+end

--- a/app/controllers/return_to_sp_controller.rb
+++ b/app/controllers/return_to_sp_controller.rb
@@ -34,7 +34,7 @@ class ReturnToSpController < ApplicationController
   end
 
   def sp_request_url
-    sp_session[:request_url] || service_provider_request.url
+    sp_session[:request_url] || service_provider_request&.url
   end
 
   def validate_sp_exists

--- a/app/controllers/return_to_sp_controller.rb
+++ b/app/controllers/return_to_sp_controller.rb
@@ -37,7 +37,6 @@ class ReturnToSpController < ApplicationController
     sp_session[:request_url] || service_provider_request.url
   end
 
-
   def validate_sp_exists
     redirect_to account_url if current_sp.nil?
   end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -12,7 +12,6 @@ class ServiceProviderSessionDecorator
   end
 
   delegate :redirect_uris, to: :sp, prefix: true
-  delegate :failure_to_proof_url, to: :sp_return_url_resolver
 
   def remember_device_default
     sp_aal < 2
@@ -81,10 +80,6 @@ class ServiceProviderSessionDecorator
     sp.friendly_name || sp.agency&.name
   end
 
-  def sp_return_url
-    @sp_request_url ||= sp_return_url_resolver.return_to_sp_url
-  end
-
   def cancel_link_url
     view_context.new_user_session_url(request_id: sp_session[:request_id])
   end
@@ -129,14 +124,6 @@ class ServiceProviderSessionDecorator
 
   def sp_ial
     sp.ial || 1
-  end
-
-  def sp_return_url_resolver
-    @sp_return_url_resolver ||= SpReturnUrlResolver.new(
-      service_provider: sp,
-      oidc_state: request_params[:state],
-      oidc_redirect_uri: request_params[:redirect_uri],
-    )
   end
 
   def request_url

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -31,8 +31,6 @@ class SessionDecorator
     AppConfig.env.remember_device_expiration_hours_aal_1.to_i.hours
   end
 
-  def failure_to_proof_url; end
-
   def remember_device_default
     true
   end
@@ -44,8 +42,6 @@ class SessionDecorator
   def sp_logo_url; end
 
   def sp_redirect_uris; end
-
-  def sp_return_url; end
 
   def requested_attributes; end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -184,6 +184,8 @@ class Analytics
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
+  RETURN_TO_SP_CANCEL = 'Return to SP: Cancelled'.freeze
+  RETURN_TO_SP_FAILURE_TO_PROOF = 'Return to SP: Failed to proof'.freeze
   SECURITY_EVENT_RECEIVED = 'RISC: Security event received'.freeze
   SP_REVOKE_CONSENT_REVOKED = 'SP Revoke Consent: Revoked'.freeze
   SP_REVOKE_CONSENT_VISITED = 'SP Revoke Consent: Visited'.freeze

--- a/app/views/devise/sessions/_return_to_service_provider.html.erb
+++ b/app/views/devise/sessions/_return_to_service_provider.html.erb
@@ -2,7 +2,7 @@
   <%= link_to(
     "‹ #{t('links.back_to_sp',
     sp: decorated_session.sp_name)}",
-    decorated_session.sp_return_url,
+    return_to_sp_cancel_path,
     class: 'inline-block text-bottom',
   ) %>
 </div>

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -18,7 +18,7 @@
 <% if decorated_session.sp_name %>
   <div class='margin-top-2'>
     <%= link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
-      decorated_session.failure_to_proof_url %>
+      return_to_sp_failure_to_proof_path %>
   </div>
 <% else %>
   <div class='margin-top-2'>

--- a/app/views/idv/capture_doc/document_capture.html.erb
+++ b/app/views/idv/capture_doc/document_capture.html.erb
@@ -2,7 +2,7 @@
   'idv/shared/document_capture',
   flow_session: flow_session,
   sp_name: decorated_session.sp_name,
-  failure_to_proof_url: decorated_session.failure_to_proof_url,
+  failure_to_proof_url: return_to_sp_failure_to_proof_path,
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -16,7 +16,7 @@
   <div class="center">
     <% if decorated_session.sp_name.present? %>
       <%= link_to(t('idv.buttons.continue_plain'),
-                  decorated_session.sp_return_url,
+                  return_to_sp_cancel_path,
                   class: 'btn btn-primary btn-wide') %>
     <% else %>
       <%= link_to(t('idv.buttons.continue_plain'),

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -2,7 +2,7 @@
   'idv/shared/document_capture',
   flow_session: flow_session,
   sp_name: decorated_session.sp_name,
-  failure_to_proof_url: decorated_session.failure_to_proof_url,
+  failure_to_proof_url: return_to_sp_failure_to_proof_path,
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -26,7 +26,7 @@
   <p>
     <%= t(
             'doc_auth.info.no_other_id_help_bold_html',
-            failure_to_proof_url: decorated_session.failure_to_proof_url,
+            failure_to_proof_url: return_to_sp_failure_to_proof_path,
             sp_name: decorated_session.sp_name,
         ) %>
   </p>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -30,7 +30,7 @@
   <p>
     <%= t(
       'doc_auth.info.no_other_id_help_bold_html',
-      failure_to_proof_url: decorated_session.failure_to_proof_url,
+      failure_to_proof_url: return_to_sp_failure_to_proof_path,
       sp_name: decorated_session.sp_name,
     ) %>
   </p>

--- a/app/views/idv/fail.html.erb
+++ b/app/views/idv/fail.html.erb
@@ -9,6 +9,6 @@
 <% if decorated_session.sp_name %>
   <div class='margin-top-2'>
     <%= t('idv.failure.help.get_help_html',
-          sp_name: link_to(decorated_session.sp_name, decorated_session.failure_to_proof_url)) %>
+          sp_name: link_to(decorated_session.sp_name, return_to_sp_failure_to_proof_path)) %>
   </div>
 <% end %>

--- a/app/views/idv/shared/_back_to_sp_link.html.erb
+++ b/app/views/idv/shared/_back_to_sp_link.html.erb
@@ -3,10 +3,10 @@
     <div class="margin-bottom-2 margin-top-2">
       <div class="right">
         <%= link_to image_tag(asset_url('carat-right.svg'), size: '10'),
-            decorated_session.failure_to_proof_url, class: 'bold block btn-link text-decoration-none' %>
+            return_to_sp_failure_to_proof_path, class: 'bold block btn-link text-decoration-none' %>
       </div>
       <%= link_to t('idv.failure.help.get_help_html', sp_name: decorated_session.sp_name),
-          decorated_session.failure_to_proof_url, class: 'block btn-link text-decoration-none' %>
+          return_to_sp_failure_to_proof_path, class: 'block btn-link text-decoration-none' %>
     </div>
   <hr/>
 <% end %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -61,7 +61,7 @@
       <p>
         <%= t(
                 'doc_auth.info.no_other_id_help_bold_html',
-                failure_to_proof_url: decorated_session.failure_to_proof_url,
+                failure_to_proof_url: failure_to_proof_url,
                 sp_name: sp_name,
             ) %>
       </p>

--- a/app/views/idv/shared/_reset_your_account.html.erb
+++ b/app/views/idv/shared/_reset_your_account.html.erb
@@ -2,7 +2,7 @@
   <div class="margin-bottom-2 margin-top-2">
     <div class="right">
       <%= link_to image_tag(asset_url('carat-right.svg'), size: '10'),
-        decorated_session.failure_to_proof_url, class: 'bold block btn-link text-decoration-none' %>
+        return_to_sp_failure_to_proof_path, class: 'bold block btn-link text-decoration-none' %>
     </div>
     <%= link_to t('two_factor_authentication.account_reset.reset_your_account'),
       account_reset_request_path %>

--- a/app/views/shared/_cancel.html.erb
+++ b/app/views/shared/_cancel.html.erb
@@ -2,6 +2,6 @@
   <% if user_signing_up? %>
     <%= link_to cancel_link_text, sign_up_cancel_path, method: :get, class: 'btn btn-link' %>
   <% else %>
-    <%= link_to cancel_link_text, link || decorated_session&.sp_return_url || profile_path %>
+    <%= link_to cancel_link_text, link || return_to_sp_cancel_path %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,9 @@ Rails.application.routes.draw do
     get '/sign_up/cancel/' => 'sign_up/cancellations#new', as: :sign_up_cancel
     delete '/sign_up/cancel' => 'sign_up/cancellations#destroy'
 
+    get '/return_to_sp/cancel' => 'return_to_sp#cancel'
+    get '/return_to_sp/failure_to_proof' => 'return_to_sp#failure_to_proof'
+
     match '/sign_out' => 'sign_out#destroy', via: %i[get post delete]
 
     delete '/users' => 'users#destroy', as: :destroy_user

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -208,18 +208,14 @@ describe IdvController do
       context 'when there is an SP in the session' do
         render_views
 
-        let(:service_provider) do
-          create(:service_provider, failure_to_proof_url: 'https://foo.bar')
-        end
-
         before do
-          session[:sp] = { issuer: service_provider.issuer }
+          session[:sp] = { issuer: create(:service_provider).issuer }
         end
 
-        it "includes a link back to the SP's failure to proof URL" do
+        it 'includes a link back to the failure to proof URL' do
           get :fail
 
-          expect(response.body).to include('https://foo.bar')
+          expect(response.body).to include(return_to_sp_failure_to_proof_path)
         end
       end
     end

--- a/spec/controllers/return_to_sp_controller_spec.rb
+++ b/spec/controllers/return_to_sp_controller_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+describe ReturnToSpController do
+  let(:current_sp) { build(:service_provider) }
+
+  before do
+    allow(subject).to receive(:current_sp).and_return(current_sp)
+    stub_analytics
+    allow(@analytics).to receive(:track_event)
+  end
+
+  describe '#cancel' do
+    context 'when there is no SP' do
+      let(:current_sp) { nil }
+
+      it 'redirects to the account' do
+        get 'cancel'
+
+        expect(response).to redirect_to account_url
+      end
+    end
+
+    context 'when there is an SP request in the session' do
+      it 'redirects to the redirect URI in the request url' do
+        redirect_uri = 'https://sp.gov/result'
+        state = '123abc'
+        sp_request_url = UriService.add_params(
+          'https://example.gov/authorize', state: state, redirect_uri: redirect_uri
+        )
+        session[:sp] = { request_url: sp_request_url }
+
+        get 'cancel'
+
+        expected_redirect_uri = SpReturnUrlResolver.new(
+          service_provider: current_sp, oidc_state: state, oidc_redirect_uri: redirect_uri,
+        ).return_to_sp_url
+        expect(response).to redirect_to(expected_redirect_uri)
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::RETURN_TO_SP_CANCEL,
+          redirect_url: expected_redirect_uri,
+        )
+      end
+    end
+
+    context 'when there is a SP request url for the request id param' do
+      it 'redirects to the redirect URI in the request url' do
+        redirect_uri = 'https://sp.gov/result'
+        state = '123abc'
+        sp_request_url = UriService.add_params(
+          'https://example.gov/authorize', state: state, redirect_uri: redirect_uri
+        )
+        sp_request = ServiceProviderRequest.new(url: sp_request_url)
+        allow(subject).to receive(:service_provider_request).and_return(sp_request)
+
+        get 'cancel'
+
+        expected_redirect_uri = SpReturnUrlResolver.new(
+          service_provider: current_sp, oidc_state: state, oidc_redirect_uri: redirect_uri,
+        ).return_to_sp_url
+        expect(response).to redirect_to(expected_redirect_uri)
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::RETURN_TO_SP_CANCEL,
+          redirect_url: expected_redirect_uri,
+        )
+      end
+    end
+
+    context 'when there is an SP in the session without a request url' do
+      it 'redirects to the configured request url' do
+        current_sp.return_to_sp_url = 'https://sp.gov/return_to_sp'
+
+        get 'cancel'
+
+        expect(response).to redirect_to('https://sp.gov/return_to_sp')
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::RETURN_TO_SP_CANCEL,
+          redirect_url: 'https://sp.gov/return_to_sp',
+        )
+      end
+    end
+  end
+
+  describe '#failure_to_proof' do
+    context 'when there is no SP' do
+      let(:current_sp) { nil }
+
+      it 'redirects to the account' do
+        get 'failure_to_proof'
+
+        expect(response).to redirect_to account_url
+      end
+    end
+
+    context 'when there is an SP in the session' do
+      it 'redirects to the SP' do
+        current_sp.failure_to_proof_url = 'https://sp.gov/failure_to_proof'
+
+        get 'failure_to_proof'
+
+        expect(response).to redirect_to('https://sp.gov/failure_to_proof')
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::RETURN_TO_SP_FAILURE_TO_PROOF,
+          redirect_url: 'https://sp.gov/failure_to_proof',
+        )
+      end
+    end
+  end
+end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -203,36 +203,6 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#failure_to_proof_url' do
-    it 'returns the failure_to_proof_url if present on the sp' do
-      url = 'https://www.example.com/fail'
-      allow_any_instance_of(ServiceProvider).to receive(:failure_to_proof_url).and_return(url)
-      expect(subject.failure_to_proof_url).to eq url
-    end
-
-    it 'returns the return_to_sp_url if the failure_to_proof_url is nil on the sp' do
-      url = 'https://www.example.com/'
-      allow_any_instance_of(ServiceProvider).to receive(:failure_to_proof_url).and_return(nil)
-      allow_any_instance_of(ServiceProvider).to receive(:return_to_sp_url).and_return(url)
-      expect(subject.failure_to_proof_url).to eq url
-    end
-
-    it 'returns the return_to_sp_url if the failure_to_proof_url is an blank string on the sp' do
-      url = 'https://www.example.com/'
-      allow_any_instance_of(ServiceProvider).to receive(:failure_to_proof_url).and_return('  ')
-      allow_any_instance_of(ServiceProvider).to receive(:return_to_sp_url).and_return(url)
-      expect(subject.failure_to_proof_url).to eq url
-    end
-  end
-
-  describe '#sp_return_url' do
-    it 'does not raise an error if request_url is nil' do
-      allow(subject).to receive(:request_url).and_return(nil)
-      allow(sp).to receive(:redirect_uris).and_return(['foo'])
-      subject.sp_return_url
-    end
-  end
-
   describe '#mfa_expiration_interval' do
     context 'with an AAL2 sp' do
       before do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -449,15 +449,13 @@ describe 'OpenID Connect' do
       email = 'test@test.com'
 
       perform_in_browser(:one) do
-        state = SecureRandom.hex
-
         visit openid_connect_authorize_path(
           client_id: client_id,
           response_type: 'code',
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           scope: 'openid email',
           redirect_uri: 'gov.gsa.openidconnect.test://result',
-          state: state,
+          state: SecureRandom.hex,
           nonce: SecureRandom.hex,
           prompt: 'select_account',
           code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
@@ -471,11 +469,8 @@ describe 'OpenID Connect' do
 
         expect(page).to have_content(sp_content)
 
-        cancel_callback_url =
-          "gov.gsa.openidconnect.test://result?error=access_denied&state=#{state}"
-
         expect(page).to have_link(
-          t('links.back_to_sp', sp: 'Example iOS App'), href: cancel_callback_url
+          t('links.back_to_sp', sp: 'Example iOS App'), href: return_to_sp_cancel_path
         )
 
         sign_up_user_from_sp_without_confirming_email(email)
@@ -529,14 +524,10 @@ describe 'OpenID Connect' do
 
   context 'going back to the SP' do
     it 'links back to the SP from the sign in page' do
-      state = SecureRandom.hex
-
-      visit_idp_from_ial1_oidc_sp(prompt: 'select_account', state: state)
-
-      cancel_callback_url = "http://localhost:7654/auth/result?error=access_denied&state=#{state}"
+      visit_idp_from_ial1_oidc_sp(prompt: 'select_account')
 
       expect(page).to have_link(
-        "‹ #{t('links.back_to_sp', sp: 'Test SP')}", href: cancel_callback_url
+        "‹ #{t('links.back_to_sp', sp: 'Test SP')}", href: return_to_sp_cancel_path
       )
     end
   end

--- a/spec/features/openid_connect/redirect_uri_validation_spec.rb
+++ b/spec/features/openid_connect/redirect_uri_validation_spec.rb
@@ -67,13 +67,13 @@ describe 'redirect_uri validation' do
       visit new_user_session_path(request_id: '123', redirect_uri: 'evil.com')
       sp_redirect_uri = "http://localhost:7654/auth/result?error=access_denied&state=#{state}"
 
-      expect(page).
-        to have_link(t('links.back_to_sp', sp: 'Test SP'), href: sp_redirect_uri)
+      click_on t('links.back_to_sp', sp: 'Test SP')
+      expect(current_url).to eq(sp_redirect_uri)
 
       visit new_user_session_path(request_id: '123', redirect_uri: 'evil.com')
 
-      expect(page).
-        to have_link(t('links.back_to_sp', sp: 'Test SP'), href: sp_redirect_uri)
+      click_on t('links.back_to_sp', sp: 'Test SP')
+      expect(current_url).to eq(sp_redirect_uri)
     end
   end
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -71,10 +71,8 @@ feature 'IAL1 Single Sign On' do
 
       visit saml_authn_request
 
-      cancel_callback_url = 'http://localhost:3000'
-
       expect(page).to have_link(
-        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: cancel_callback_url
+        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: return_to_sp_cancel_path
       )
     end
 

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -68,10 +68,8 @@ feature 'IAL2 Single Sign On' do
 
       visit saml_authn_request
 
-      cancel_callback_url = 'http://localhost:3000'
-
       expect(page).to have_link(
-        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: cancel_callback_url
+        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: return_to_sp_cancel_path
       )
     end
   end

--- a/spec/features/saml/redirect_uri_validation_spec.rb
+++ b/spec/features/saml/redirect_uri_validation_spec.rb
@@ -14,7 +14,7 @@ describe 'redirect_uri validation' do
       sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
 
       expect(page).
-        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: sp.return_to_sp_url
+        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: return_to_sp_cancel_path
 
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -17,7 +17,7 @@ feature 'saml api' do
 
     it 'returns the user to the acs url after authentication' do
       expect(page).
-        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: sp.return_to_sp_url
+        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: return_to_sp_cancel_path
 
       sign_in_via_branded_page(user)
       click_agree_and_continue
@@ -36,7 +36,7 @@ feature 'saml api' do
 
     it 'returns the user to the account page after authentication' do
       expect(page).
-        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: sp.return_to_sp_url
+        to have_link t('links.back_to_sp', sp: sp.friendly_name), href: return_to_sp_cancel_path
 
       sign_in_via_branded_page(user)
       click_agree_and_continue

--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -39,3 +39,13 @@ Geocoder::Lookup::Test.add_stub(
     },
   ]
 )
+
+Geocoder::Lookup::Test.add_stub(
+  '0.0.0.0', [
+    {
+      'city' => '',
+      'country' => 'United States',
+      'state_code' => '',
+    },
+  ]
+)

--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -39,13 +39,3 @@ Geocoder::Lookup::Test.add_stub(
     },
   ]
 )
-
-Geocoder::Lookup::Test.add_stub(
-  '0.0.0.0', [
-    {
-      'city' => '',
-      'country' => 'United States',
-      'state_code' => '',
-    },
-  ]
-)

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -21,10 +21,7 @@ shared_examples 'cancel at idv step' do |step, sp|
 
   context 'with an sp', if: sp do
     it 'shows the user a cancellation message with the option to cancel and reset idv' do
-      failure_to_proof_url = 'https://www.example.com/failure'
       sp_name = 'Test SP'
-      allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
-        and_return(failure_to_proof_url)
       allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).
         and_return(sp_name)
 
@@ -39,7 +36,7 @@ shared_examples 'cancel at idv step' do |step, sp|
       expect(current_path).to eq(idv_cancel_path)
 
       expect(page).to have_link("‹ #{t('links.back_to_sp', sp: sp_name)}",
-                                href: failure_to_proof_url)
+                                href: return_to_sp_failure_to_proof_path)
 
       # After visiting /verify, expect to redirect to the jurisdiction step,
       # the first step in the IdV flow

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -92,7 +92,7 @@ describe 'devise/sessions/new.html.erb' do
       render
 
       expect(rendered).to have_link(
-        t('links.back_to_sp', sp: 'Awesome Application!'), href: @decorated_session.sp_return_url
+        t('links.back_to_sp', sp: 'Awesome Application!'), href: return_to_sp_cancel_path
       )
     end
 

--- a/spec/views/idv/come_back_later/show.html.erb_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.erb_spec.rb
@@ -1,22 +1,20 @@
 require 'rails_helper'
 
 describe 'idv/come_back_later/show.html.erb' do
-  let(:sp_return_url) { 'https://www.example.com' }
   let(:sp_name) { '🔒🌐💻' }
 
   before do
     @decorated_session = instance_double(ServiceProviderSessionDecorator)
-    allow(@decorated_session).to receive(:sp_return_url).and_return(sp_return_url)
     allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end
 
-  context 'with an SP with a return url' do
+  context 'with an SP' do
     it 'renders a return to SP button' do
       render
       expect(rendered).to have_link(
         t('idv.buttons.continue_plain'),
-        href: sp_return_url,
+        href: return_to_sp_cancel_path,
       )
     end
 
@@ -32,7 +30,6 @@ describe 'idv/come_back_later/show.html.erb' do
   end
 
   context 'without an SP' do
-    let(:sp_return_url) { nil }
     let(:sp_name) { nil }
 
     it 'renders a return to account button' do

--- a/spec/views/idv/doc_auth/upload.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/upload.html.erb_spec.rb
@@ -4,12 +4,10 @@ describe 'idv/doc_auth/upload.html.erb' do
   let(:flow_session) { {} }
   let(:user_fully_authenticated) { true }
   let(:sp_name) { nil }
-  let(:failure_to_proof_url) { 'https://example.com' }
 
   before do
     @decorated_session = instance_double(ServiceProviderSessionDecorator)
     allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
-    allow(@decorated_session).to receive(:failure_to_proof_url).and_return(failure_to_proof_url)
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
     allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
@@ -45,7 +43,7 @@ describe 'idv/doc_auth/upload.html.erb' do
 
       link_text = t(
         'doc_auth.info.no_other_id_help_bold_html',
-        failure_to_proof_url: @decorated_session.failure_to_proof_url,
+        failure_to_proof_url: return_to_sp_failure_to_proof_path,
         sp_name: @decorated_session.sp_name,
       )
 
@@ -61,7 +59,7 @@ describe 'idv/doc_auth/upload.html.erb' do
 
       link_text = t(
         'doc_auth.info.no_other_id_help_bold_html',
-        failure_to_proof_url: @decorated_session.failure_to_proof_url,
+        failure_to_proof_url: return_to_sp_failure_to_proof_path,
         sp_name: @decorated_session.sp_name,
       )
       expect(rendered).to include(link_text)

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe 'idv/shared/_document_capture.html.erb' do
 
   let(:flow_session) { {} }
   let(:sp_name) { nil }
-  let(:failure_to_proof_url) { 'https://example.com' }
+  let(:failure_to_proof_url) { return_to_sp_failure_to_proof_path }
   let(:front_image_upload_url) { nil }
   let(:back_image_upload_url) { nil }
   let(:selfie_image_upload_url) { nil }


### PR DESCRIPTION
**Why**: So that we can measure how many users are abandoning and leaving and how many users are returning to a service provider

**How**: By adding a controller that redirects the user to the SP. The changing the links to go through that controller. The controller logs an event before redirecting.