### PR TITLE
Add the precompiled assets folder to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ saml_*.key
 /kitchen/nodes/*.json
 /kitchen/data_bags/config/*.yml
 /kitchen/data_bags/config/databag_secrets.json
+/public/assets
 /public/packs
 /public/packs-test
 **/node_modules


### PR DESCRIPTION
**Why**: So that precompiled assets don't get accidentally checked in