### PR TITLE
LG-4323 Update the CaptureDocController analytic_id base string 

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -11,7 +11,7 @@ module Idv
       step_url: :idv_capture_doc_step_url,
       final_url: :root_url,
       flow: Idv::Flows::CaptureDocFlow,
-      analytics_id: Analytics::CAPTURE_DOC,
+      analytics_id: Analytics::DOC_AUTH,
     }.freeze
 
     private

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -81,7 +81,6 @@ class Analytics
   ADD_EMAIL_VISIT = 'Add Email: enter email visited'.freeze
   AUTHENTICATION_CONFIRMATION = 'Authentication Confirmation'.freeze
   CAC_PROOFING = 'CAC Proofing'.freeze # visited or submitted is appended
-  CAPTURE_DOC = 'Capture Doc'.freeze # visited or submitted is appended
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended
   DOC_AUTH_ASYNC = 'Doc Auth Async'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -104,7 +104,7 @@ describe Idv::CaptureDocController do
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).with(
-          Analytics::CAPTURE_DOC + ' visited', result
+          Analytics::DOC_AUTH + ' visited', result
         )
       end
 
@@ -115,11 +115,11 @@ describe Idv::CaptureDocController do
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::CAPTURE_DOC + ' visited',
+          Analytics::DOC_AUTH + ' visited',
           hash_including(step: 'capture_complete', step_count: 1),
         )
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::CAPTURE_DOC + ' visited',
+          Analytics::DOC_AUTH + ' visited',
           hash_including(step: 'capture_complete', step_count: 2),
         )
       end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -40,7 +40,7 @@ feature 'doc capture document capture step' do
       visit request_uri
 
       expect(fake_analytics).to have_logged_event(
-        Analytics::CAPTURE_DOC,
+        Analytics::DOC_AUTH,
         success: false,
       )
     end
@@ -53,7 +53,7 @@ feature 'doc capture document capture step' do
       complete_doc_capture_steps_before_first_step(user)
 
       expect(fake_analytics).to have_logged_event(
-        Analytics::CAPTURE_DOC + ' visited',
+        Analytics::DOC_AUTH + ' visited',
         step: 'document_capture',
       )
     end
@@ -137,7 +137,7 @@ feature 'doc capture document capture step' do
 
       expect(page).to have_current_path(next_step)
       expect(fake_analytics).to have_logged_event(
-        Analytics::CAPTURE_DOC + ' submitted',
+        Analytics::DOC_AUTH + ' submitted',
         step: 'document_capture',
         result: 'Passed',
         billed: true,


### PR DESCRIPTION
Update the CaptureDocController analytic_id base string to match the rest of Doc Auth and consolidate CloudWatch events.