### PR TITLE
LG-4265: Bump gems for improved LexisNexis logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,5 +120,5 @@ end
 
 group :production do
   gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.6.0'
-  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.7.0'
+  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.8.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,10 +30,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: 849ead99e7bfc7ad510eea2dd3a8d295447db153
-  ref: 849ead99e7bfc7ad510eea2dd3a8d295447db153
+  revision: d2d0b4faafdd0bca20c3ebee5aa373499d1d2d1e
+  ref: d2d0b4faafdd0bca20c3ebee5aa373499d1d2d1e
   specs:
-    identity-idp-functions (0.12.0)
+    identity-idp-functions (0.13.0)
       aamva (>= 3.5.0)
       aws-sdk-s3 (>= 1.73)
       aws-sdk-ssm (>= 1.55)
@@ -41,10 +41,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git
-  revision: 415a0e970b6ff1ab3262fb4874164c4dfd156120
-  tag: v2.7.0
+  revision: f67a52d691a773db03bf5dc054f82a1427bb8433
+  tag: v2.8.0
   specs:
-    lexisnexis (2.7.0)
+    lexisnexis (2.8.0)
       activesupport
       dotenv
       faraday

--- a/lib/lambda_jobs/git_ref.rb
+++ b/lib/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = '849ead99e7bfc7ad510eea2dd3a8d295447db153'
+  GIT_REF = 'd2d0b4faafdd0bca20c3ebee5aa373499d1d2d1e'
 end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -215,7 +215,13 @@ describe Idv::PhoneController do
         result = {
           success: true,
           errors: {},
-          vendor: { messages: [], context: context, exception: nil, timed_out: false },
+          vendor: {
+            messages: [],
+            context: context,
+            exception: nil,
+            timed_out: false,
+            transaction_id: 'address-mock-transaction-id-123',
+          },
         }
 
         expect(@analytics).to receive(:track_event).ordered.with(
@@ -259,7 +265,13 @@ describe Idv::PhoneController do
           errors: {
             phone: ['The phone number could not be verified.'],
           },
-          vendor: { messages: [], context: context, exception: nil, timed_out: false },
+          vendor: {
+            messages: [],
+            context: context,
+            exception: nil,
+            timed_out: false,
+            transaction_id: 'address-mock-transaction-id-123',
+          },
         }
 
         expect(@analytics).to receive(:track_event).ordered.with(

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -33,7 +33,15 @@ describe Idv::PhoneStep do
   describe '#submit' do
     it 'succeeds with good params' do
       context = { stages: [{ address: 'AddressMock' }] }
-      extra = { vendor: { messages: [], context: context, exception: nil, timed_out: false } }
+      extra = {
+        vendor: {
+          messages: [],
+          context: context,
+          exception: nil,
+          timed_out: false,
+          transaction_id: 'address-mock-transaction-id-123',
+        },
+      }
 
       subject.submit(phone: good_phone)
 
@@ -51,7 +59,15 @@ describe Idv::PhoneStep do
 
     it 'fails with bad params' do
       context = { stages: [{ address: 'AddressMock' }] }
-      extra = { vendor: { messages: [], context: context, exception: nil, timed_out: false } }
+      extra = {
+        vendor: {
+          messages: [],
+          context: context,
+          exception: nil,
+          timed_out: false,
+          transaction_id: 'address-mock-transaction-id-123',
+        },
+      }
 
       subject.submit(phone: bad_phone)
       expect(subject.async_state.done?).to eq true


### PR DESCRIPTION
**Why**:

- Log failing error messages as structured data
- Include ConversationId in both success and failure logging

See:

- https://github.com/18F/identity-idp-functions/pull/62
- https://github.com/18F/identity-lexisnexis-api-client-gem/pull/24