### PR TITLE
Make local HTTPS development quality-of-life improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run:
 	foreman start -p $(PORT)
 
 run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt
-	rails s -b "ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt"
+	HTTPS=on rails s -b "ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt"
 
 .PHONY: setup all lint run test check brakeman
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,10 +23,12 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {
     host: AppConfig.env.domain_name,
-    protocol: 'http',
+    protocol: ENV['HTTPS'] == 'on' ? 'https' : 'http',
   }
   config.action_mailer.asset_host = AppConfig.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
+
+  routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'
 
   config.lograge.ignore_actions = ['Users::SessionsController#active']
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
     protocol: ENV['HTTPS'] == 'on' ? 'https' : 'http',
   }
   config.action_mailer.asset_host = AppConfig.env.mailer_domain_name
+  config.action_mailer.raise_delivery_errors = false
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
 
   routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'


### PR DESCRIPTION
1. Set development default URL protocol by env (start command)

**Why**: So that URL helpers generate correct URLs depending on whether server is running as HTTPS. Normally this falls back to the protocol of the request, but when URL helpers are called as class methods, the request instance doesn't exist. An alternative (albeit larger refactor) would be to provide the request/URL parameters wherever URL helpers are used.

I encountered this when testing #4726 on my phone over HTTPS, where async upload fails due to the fact that fake S3 URLs are generated with the HTTP protocol, regardless if the server is bound to HTTPS.

2. Avoid raising mail delivery errors in development

**Why**: If the MailCatcher process is not running (e.g. using `make run-https`), mail delivery currently throws by default. This makes it difficult to perform basic actions like login.

It's an open question as to whether we'd want to be alerted of these failures in local development, though it seems to me that the instances in which it would happen are limited to cases where we'd probably _expect_ it to happen (i.e. undeliverable = not running the mail catcher service). 