### PR TITLE
Format phone numbers consistently in OIDC and SAML

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -36,7 +36,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ial2_attributes
-    phone = stringify_attr(ial2_data.phone)
+    phone = Phonelib.parse(ial2_data.phone).e164 if ial2_data.phone.present?
 
     {
       given_name: stringify_attr(ial2_data.first_name),

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -36,8 +36,6 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ial2_attributes
-    phone = Phonelib.parse(ial2_data.phone).e164 if ial2_data.phone.present?
-
     {
       given_name: stringify_attr(ial2_data.first_name),
       family_name: stringify_attr(ial2_data.last_name),
@@ -55,6 +53,18 @@ class OpenidConnectUserInfoPresenter
       x509_issuer: stringify_attr(x509_data.issuer),
       x509_presented: x509_data.presented,
     }
+  end
+
+  def phone
+    return if ial2_data.phone.blank?
+
+    opt_out_list = JSON.parse(AppConfig.env.phone_format_e164_opt_out_list || '[]')
+
+    if opt_out_list.include?(identity.service_provider)
+      ial2_data.phone
+    else
+      Phonelib.parse(ial2_data.phone).e164
+    end
   end
 
   def address

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -67,10 +67,14 @@ class AttributeAsserter
   end
 
   def add_bundle(attrs)
+    phone_format_opt_out = JSON.parse(AppConfig.env.phone_format_e164_opt_out_list || '[]')
+
     bundle.each do |attr|
       next unless VALID_ATTRIBUTES.include? attr
       getter = ascii? ? attribute_getter_function_ascii(attr) : attribute_getter_function(attr)
-      getter = wrap_with_phone_formatter(getter) if attr == :phone
+      if attr == :phone && !phone_format_opt_out.include?(service_provider.issuer)
+        getter = wrap_with_phone_formatter(getter)
+      end
       attrs[attr] = { getter: getter }
     end
     add_verified_at(attrs)

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -70,9 +70,22 @@ class AttributeAsserter
     bundle.each do |attr|
       next unless VALID_ATTRIBUTES.include? attr
       getter = ascii? ? attribute_getter_function_ascii(attr) : attribute_getter_function(attr)
+      getter = wrap_with_phone_formatter(getter) if attr == :phone
       attrs[attr] = { getter: getter }
     end
     add_verified_at(attrs)
+  end
+
+  def wrap_with_phone_formatter(getter)
+    proc do |principal|
+      result = getter.call(principal)
+
+      if result.present?
+        Phonelib.parse(result).e164
+      else
+        result
+      end
+    end
   end
 
   def add_verified_at(attrs)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -97,6 +97,7 @@ otps_per_ip_track_only_mode: 'true'
 outbound_connection_check_url: 'https://checkip.amazonaws.com'
 password_max_attempts: '3'
 personal_key_retired: 'true'
+phone_format_e164_opt_out_list: '[]'
 pii_lock_timeout_in_minutes: '30'
 pinpoint_sms_application_id:
 pinpoint_sms_credential_role_arn:

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
   subject(:presenter) { OpenidConnectUserInfoPresenter.new(identity) }
 
+  let(:phone_format_e164_opt_out_list) { '[]' }
+  before do
+    allow(AppConfig.env).to receive(:phone_format_e164_opt_out_list).
+      and_return(phone_format_e164_opt_out_list)
+  end
+
   describe '#user_info' do
     subject(:user_info) { presenter.user_info }
 
@@ -88,7 +94,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           city: 'Washington',
           state: 'DC',
           zipcode: '12345',
-          phone: '+1 (703) 555-5555',
+          phone: '1 (703) 555-5555',
           ssn: '666661234',
         }
       end
@@ -124,6 +130,14 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             json = user_info.as_json
 
             expect(json['given_name']).to eq('John')
+          end
+
+          context 'when the service provider is in the e164 opt-out list' do
+            let(:phone_format_e164_opt_out_list) { [service_provider.issuer].to_json }
+
+            it 'leaves the phone format as-is' do
+              expect(user_info[:phone]).to eq('1 (703) 555-5555')
+            end
           end
         end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:given_name]).to eq('John')
               expect(user_info[:family_name]).to eq('Smith')
               expect(user_info[:birthdate]).to eq('1970-01-01')
-              expect(user_info[:phone]).to eq('+1 (703) 555-5555')
+              expect(user_info[:phone]).to eq('+17035555555')
               expect(user_info[:phone_verified]).to eq(true)
               expect(user_info[:address]).to eq(
                 formatted: "123 Fake St Apt 456\nWashington, DC 12345",
@@ -137,7 +137,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:given_name]).to eq(nil)
               expect(user_info[:family_name]).to eq(nil)
               expect(user_info[:birthdate]).to eq(nil)
-              expect(user_info[:phone]).to eq('+1 (703) 555-5555')
+              expect(user_info[:phone]).to eq('+17035555555')
               expect(user_info[:phone_verified]).to eq(true)
               expect(user_info[:address]).to eq(nil)
               expect(user_info[:verified_at]).to eq(nil)

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -54,6 +54,11 @@ describe AttributeAsserter do
       phone: '1 (888) 867-5309',
     )
   end
+  let(:phone_format_e164_opt_out_list) { '[]' }
+  before do
+    allow(AppConfig.env).to receive(:phone_format_e164_opt_out_list).
+      and_return(phone_format_e164_opt_out_list)
+  end
 
   describe '#build' do
     context 'verified user and IAL2 request' do
@@ -87,6 +92,14 @@ describe AttributeAsserter do
 
         it 'formats the phone number as e164' do
           expect(user.asserted_attributes[:phone][:getter].call(user)).to eq '+18888675309'
+        end
+
+        context 'when the service provider is in the e164 opt-out list' do
+          let(:phone_format_e164_opt_out_list) { [service_provider.issuer].to_json }
+
+          it 'leaves the phone format as-is' do
+            expect(user.asserted_attributes[:phone][:getter].call(user)).to eq '1 (888) 867-5309'
+          end
         end
 
         it 'gets UUID (MBUN) from Service Provider' do

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -48,7 +48,12 @@ describe AttributeAsserter do
   let(:ial1_aal3_authn_request) do
     SamlIdp::Request.from_deflated_request(raw_ial1_aal3_authn_request)
   end
-  let(:decrypted_pii) { Pii::Attributes.new_from_hash(first_name: 'Jåné') }
+  let(:decrypted_pii) do
+    Pii::Attributes.new_from_hash(
+      first_name: 'Jåné',
+      phone: '1 (888) 867-5309',
+    )
+  end
 
   describe '#build' do
     context 'verified user and IAL2 request' do
@@ -78,6 +83,10 @@ describe AttributeAsserter do
 
         it 'creates getter function' do
           expect(user.asserted_attributes[:first_name][:getter].call(user)).to eq 'Jåné'
+        end
+
+        it 'formats the phone number as e164' do
+          expect(user.asserted_attributes[:phone][:getter].call(user)).to eq '+18888675309'
         end
 
         it 'gets UUID (MBUN) from Service Provider' do

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -200,7 +200,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)
     expect(current_url).to eq @saml_authn_request
-    expect(xmldoc.phone_number.children.children.to_s).to eq(profile_phone)
+    expect(xmldoc.phone_number.children.children.to_s).to eq(Phonelib.parse(profile_phone).e164)
   end
 
   def client_private_key


### PR DESCRIPTION
We got reports that our phone numbers were coming back in multiple formats in the API, this ensures that we format consistently on the way out