### PR TITLE
Explicitly require Lambda function implementations for specs

### DIFF
--- a/spec/support/identity_idp_functions.rb
+++ b/spec/support/identity_idp_functions.rb
@@ -1,9 +1,6 @@
 require 'identity-idp-functions'
-require 'identity-idp-functions/proof_address'
 require 'identity-idp-functions/proof_address_mock'
-require 'identity-idp-functions/proof_document'
 require 'identity-idp-functions/proof_document_mock'
-require 'identity-idp-functions/proof_resolution'
 require 'identity-idp-functions/proof_resolution_mock'
 
 module IdentityIdpFunctions

--- a/spec/support/identity_idp_functions.rb
+++ b/spec/support/identity_idp_functions.rb
@@ -1,4 +1,10 @@
 require 'identity-idp-functions'
+require 'identity-idp-functions/proof_address'
+require 'identity-idp-functions/proof_address_mock'
+require 'identity-idp-functions/proof_document'
+require 'identity-idp-functions/proof_document_mock'
+require 'identity-idp-functions/proof_resolution'
+require 'identity-idp-functions/proof_resolution_mock'
 
 module IdentityIdpFunctions
   module LoggingHelper


### PR DESCRIPTION
**Why**: Avoid implicit dependencies on the implementations, which may be non-deterministic and produce intermittent test failures.

See: https://app.circleci.com/pipelines/github/18F/identity-idp/30173/workflows/71333084-f9ee-4c59-a141-18aaf301c38e/jobs/52548

Specifically, some test setups reference constants from these classes ([example](https://github.com/18F/identity-idp/blob/c530974a81a8eb1bf6a3e3f5b5d380b6873b1ea0/spec/services/idv/phone_step_spec.rb#L20-L28)). At runtime, we always require the implementation explicitly prior to using it ([source](https://github.com/18F/identity-idp/blob/master/app/services/idv/proofer.rb)).