### PR TITLE
Add line break to async upload error message

### DIFF
--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -13,10 +13,13 @@ import useI18n from '../hooks/use-i18n';
 /**
  * Given an array, returns a copy of the array with joiner entry inserted between each item.
  *
- * @param {array} arr Original array.
- * @param {any} joiner Joiner item to insert.
+ * @template I
+ * @template J
  *
- * @return {array} Interspersed array.
+ * @param {Array<I>} arr Original array.
+ * @param {J} joiner Joiner item to insert.
+ *
+ * @return {Array<I|J>} Interspersed array.
  */
 export const intersperse = (arr, joiner) => arr.flatMap((item) => [item, joiner]).slice(0, -1);
 

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -30,7 +30,13 @@ function FormErrorMessage({ error }) {
   }
 
   if (error instanceof BackgroundEncryptedUploadError) {
-    return <>{t('errors.doc_auth.upload_error')}</>;
+    return (
+      <>
+        {t('errors.doc_auth.upload_error')}
+        <br />
+        {t('errors.messages.try_again')}
+      </>
+    );
   }
 
   return null;

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -11,6 +11,16 @@ import useI18n from '../hooks/use-i18n';
  */
 
 /**
+ * Given an array, returns a copy of the array with joiner entry inserted between each item.
+ *
+ * @param {array} arr Original array.
+ * @param {any} joiner Joiner item to insert.
+ *
+ * @return {array} Interspersed array.
+ */
+export const intersperse = (arr, joiner) => arr.flatMap((item) => [item, joiner]).slice(0, -1);
+
+/**
  * An error representing a state where a required form value is missing.
  */
 export class RequiredValueMissingError extends Error {}
@@ -32,9 +42,8 @@ function FormErrorMessage({ error }) {
   if (error instanceof BackgroundEncryptedUploadError) {
     return (
       <>
-        {t('errors.doc_auth.upload_error')}
-        <br />
-        {t('errors.messages.try_again')}
+        {t('errors.doc_auth.upload_error')}{' '}
+        {intersperse(t('errors.messages.try_again').split(' '), <>&nbsp;</>)}
       </>
     );
   }

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -58,6 +58,7 @@
 - errors.doc_auth.photo_glare
 - errors.doc_auth.upload_error
 - errors.file_input.invalid_type
+- errors.messages.try_again
 - forms.buttons.continue
 - forms.buttons.submit.default
 - forms.file_input.file_updated

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -63,7 +63,7 @@ en:
         Try taking a new picture.
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
-      upload_error: Sorry, something went wrong on our end. Please try again.
+      upload_error: Sorry, something went wrong on our end.
     file_input:
       invalid_type: This file type is not accepted, please try again.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
@@ -102,6 +102,7 @@ en:
         the phone call option below, or use your personal key.
       pwned_password: The password you entered is not safe. It's in a list of known
         passwords exposed in data breaches.
+      try_again: Please try again.
       unauthorized_authn_context: Unauthorized authentication context
       unauthorized_nameid_format: Unauthorized nameID format
       unauthorized_service_provider: Unauthorized Service Provider

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -64,8 +64,7 @@ es:
         Intente tomar una nueva foto.
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
-      upload_error: Lo siento, algo salió mal por nuestra parte. Por favor, inténtelo
-        de nuevo.
+      upload_error: Lo siento, algo salió mal por nuestra parte.
     file_input:
       invalid_type: Este tipo de archivo no es aceptado, inténtalo de nuevo.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
@@ -105,6 +104,7 @@ es:
         la opción de llamada telefónica a continuación o use su clave personal.
       pwned_password: La contraseña que ingresaste no es segura. Está en una lista
         de contraseñas conocidas expuestas en violaciones de datos.
+      try_again: Por favor, inténtelo de nuevo.
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_nameid_format: Formato de ID de nombre no autorizado
       unauthorized_service_provider: Proveedor de servicio no autorizado

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -66,7 +66,7 @@ fr:
       send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
         votre ordinateur.
-      upload_error: Désolé, quelque chose a mal tourné de notre côté. Veuillez réessayer.
+      upload_error: Désolé, quelque chose a mal tourné de notre côté.
     file_input:
       invalid_type: Ce type de fichier n'est pas accepté, veuillez réessayer.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
@@ -111,6 +111,7 @@ fr:
         ou utilisez votre clé personnelle.
       pwned_password: Le mot de passe que vous avez entré n'est pas sécurisé. C'est
         dans une liste de mots de passe connus exposés dans les violations de données.
+      try_again: Veuillez réessayer.
       unauthorized_authn_context: Contexte d'authentification non autorisé
       unauthorized_nameid_format: Format non autorisé du nom d'identification
       unauthorized_service_provider: Fournisseur de service non autorisé

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -547,7 +547,9 @@ describe('document-capture/components/document-capture', () => {
         const alerts = await findAllByRole('alert');
         expect(alerts).to.have.lengthOf(2);
         expect(alerts[0].textContent).to.equal('errors.doc_auth.acuant_network_error');
-        expect(alerts[1].textContent).to.equal('errors.doc_auth.upload_error');
+        expect(alerts[1].innerHTML).to.equal(
+          'errors.doc_auth.upload_error<br>errors.messages.try_again',
+        );
 
         const input = await getByLabelText('doc_auth.headings.document_capture_front');
         expect(input.closest('.usa-file-input--has-value')).to.be.null();

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -547,8 +547,8 @@ describe('document-capture/components/document-capture', () => {
         const alerts = await findAllByRole('alert');
         expect(alerts).to.have.lengthOf(2);
         expect(alerts[0].textContent).to.equal('errors.doc_auth.acuant_network_error');
-        expect(alerts[1].innerHTML).to.equal(
-          'errors.doc_auth.upload_error<br>errors.messages.try_again',
+        expect(alerts[1].textContent).to.equal(
+          'errors.doc_auth.upload_error errors.messages.try_again',
         );
 
         const input = await getByLabelText('doc_auth.headings.document_capture_front');

--- a/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
@@ -1,10 +1,22 @@
 import FormErrorMessage, {
   RequiredValueMissingError,
+  intersperse,
 } from '@18f/identity-document-capture/components/form-error-message';
 import { UploadFormEntryError } from '@18f/identity-document-capture/services/upload';
 import { render } from '../../../support/document-capture';
 
 describe('document-capture/components/form-error-message', () => {
+  describe('intersperse', () => {
+    it('returns an interspersed array', () => {
+      const original = ['a', 'b', 'c'];
+      const result = intersperse(original, true);
+
+      const expected = ['a', true, 'b', true, 'c'];
+      expect(expected).to.not.equal(original);
+      expect(result).to.deep.equal(expected);
+    });
+  });
+
   it('returns formatted RequiredValueMissingError', () => {
     const { getByText } = render(<FormErrorMessage error={new RequiredValueMissingError()} />);
 


### PR DESCRIPTION
**Why**: Per design acceptance feedback

**Screenshot:**

Before|After
---|---
![Screen Shot 2021-03-09 at 11 00 06 AM](https://user-images.githubusercontent.com/1779930/110500279-08d5ab00-80c7-11eb-8bed-d36cdc1e96eb.png)|![Screen Shot 2021-03-09 at 10 59 47 AM](https://user-images.githubusercontent.com/1779930/110500274-07a47e00-80c7-11eb-8aed-cba6a4c625c7.png)


**Implementation Notes:** It could have been possible to implement this within the existing string, but it was implemented as two separate strings since (a) it may be desirable to avoid use-case-specific, highly-formatted strings and (b) there may be an option for reuse of the text "Please try again".