### PR TITLE
Log AWS SDK calls (LG-4315)

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,7 +1,13 @@
+pattern =
+  ':client_class :http_response_status_code :time :retries :operation [:error_class :error_message]'
+log_formatter = Aws::Log::Formatter.new(pattern)
+
 Aws.config.update(
   region: AppConfig.env.aws_region,
   http_open_timeout: AppConfig.env.aws_http_timeout.to_f,
   http_read_timeout: AppConfig.env.aws_http_timeout.to_f,
   retry_limit: AppConfig.env.aws_http_retry_limit.to_i,
   retry_max_delay: AppConfig.env.aws_http_retry_max_delay.to_i,
+  logger: ActiveSupport::Logger.new(Rails.root.join('log', 'production.log')),
+  log_formatter: log_formatter,
 )


### PR DESCRIPTION
Related to #4740 

Configures AWS SDK to log to the `production.log` file in the format of `Aws::SES::Client 200 0.423279 0 send_raw_email []`. The `[]` is to help Cloudwatch ingest errors as a single field.

Ideally we'd do JSON so Cloudwatch could automatically parse logs from the AWS SDK, but it doesn't appear to be possible.