### PR TITLE
Use unicode escape sequence for non-breaking space in document capture error

### DIFF
--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -11,17 +11,12 @@ import useI18n from '../hooks/use-i18n';
  */
 
 /**
- * Given an array, returns a copy of the array with joiner entry inserted between each item.
+ * Non-breaking space (`&nbsp;`) represented as unicode escape sequence, which React will more
+ * happily tolerate than an HTML entity.
  *
- * @template I
- * @template J
- *
- * @param {Array<I>} arr Original array.
- * @param {J} joiner Joiner item to insert.
- *
- * @return {Array<I|J>} Interspersed array.
+ * @type {string}
  */
-export const intersperse = (arr, joiner) => arr.flatMap((item) => [item, joiner]).slice(0, -1);
+const NBSP_UNICODE = '\u00A0';
 
 /**
  * An error representing a state where a required form value is missing.
@@ -46,7 +41,7 @@ function FormErrorMessage({ error }) {
     return (
       <>
         {t('errors.doc_auth.upload_error')}{' '}
-        {intersperse(t('errors.messages.try_again').split(' '), <>&nbsp;</>)}
+        {t('errors.messages.try_again').split(' ').join(NBSP_UNICODE)}
       </>
     );
   }

--- a/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
@@ -1,22 +1,12 @@
+import { I18nContext } from '@18f/identity-document-capture';
 import FormErrorMessage, {
   RequiredValueMissingError,
-  intersperse,
 } from '@18f/identity-document-capture/components/form-error-message';
 import { UploadFormEntryError } from '@18f/identity-document-capture/services/upload';
+import { BackgroundEncryptedUploadError } from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
 import { render } from '../../../support/document-capture';
 
 describe('document-capture/components/form-error-message', () => {
-  describe('intersperse', () => {
-    it('returns an interspersed array', () => {
-      const original = ['a', 'b', 'c'];
-      const result = intersperse(original, true);
-
-      const expected = ['a', true, 'b', true, 'c'];
-      expect(expected).to.not.equal(original);
-      expect(result).to.deep.equal(expected);
-    });
-  });
-
   it('returns formatted RequiredValueMissingError', () => {
     const { getByText } = render(<FormErrorMessage error={new RequiredValueMissingError()} />);
 
@@ -29,6 +19,27 @@ describe('document-capture/components/form-error-message', () => {
     );
 
     expect(getByText('Field is required')).to.be.ok();
+  });
+
+  it('returns formatted BackgroundEncryptedUploadError', () => {
+    const { getByText } = render(
+      <I18nContext.Provider
+        value={{
+          'errors.doc_auth.upload_error': 'Sorry, something went wrong on our end.',
+          'errors.messages.try_again': 'Please try again.',
+        }}
+      >
+        <FormErrorMessage error={new BackgroundEncryptedUploadError()} />
+      </I18nContext.Provider>,
+    );
+
+    const message = getByText('Sorry, something went wrong on our end. Please try again.');
+    expect(message).to.be.ok();
+    expect(message.innerHTML.split('&nbsp;')).to.deep.equal([
+      'Sorry, something went wrong on our end. Please',
+      'try',
+      'again.',
+    ]);
   });
 
   it('returns null if error is of an unknown type', () => {


### PR DESCRIPTION
Previously: #4773

**Why**:

- Simpler implementation, avoiding need for "intersperse" function
- Resolves React warning

>"Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information."

While we did have some test coverage for this error message, because strings are not translated by default in tests, the split/join behavior was not being exercised.

https://github.com/18F/identity-idp/blob/2f03042c2a17b53af0a6723b1e2c8a8ee01a7283/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx#L550-L552