### PR TITLE
Make sure e164 phone numbers include +1

### DIFF
--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -38,6 +38,7 @@ class PhoneNumberCapabilities
   end
 
   def parsed_phone
-    Phonelib.parse(phone)
+    blank_default_country = '' # override Phonelib.default_country so it doesn't default to US
+    Phonelib.parse(phone, blank_default_country)
   end
 end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -38,7 +38,6 @@ class PhoneNumberCapabilities
   end
 
   def parsed_phone
-    blank_default_country = '' # override Phonelib.default_country so it doesn't default to US
-    Phonelib.parse(phone, blank_default_country)
+    Phonelib.parse(phone)
   end
 end

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = 'US'

--- a/spec/config/initializers/phonelib_spec.rb
+++ b/spec/config/initializers/phonelib_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Phonelib do
+  describe '.default_country + #e164' do
+    it 'is set to US so that 10 digit phone numbers get the +1 in e164' do
+      expect(Phonelib.parse('888 867 5309').e164).to eq('+18888675309')
+    end
+  end
+end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           city: 'Washington',
           state: 'DC',
           zipcode: '  12345-1234',
-          phone: '1 (703) 555-5555',
+          phone: '(703) 555-5555',
           ssn: '666661234',
         }
       end
@@ -136,7 +136,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             let(:phone_format_e164_opt_out_list) { [service_provider.issuer].to_json }
 
             it 'leaves the phone format as-is' do
-              expect(user_info[:phone]).to eq('1 (703) 555-5555')
+              expect(user_info[:phone]).to eq('(703) 555-5555')
             end
           end
         end

--- a/spec/services/phone_number_capabilities_spec.rb
+++ b/spec/services/phone_number_capabilities_spec.rb
@@ -69,10 +69,10 @@ describe PhoneNumberCapabilities do
       expect(locality).to eq('Bermuda')
     end
 
-    context 'phonelib returns nil' do
-      it 'returns nil' do
+    context 'phonelib returns default country' do
+      it 'returns the default country' do
         locality = PhoneNumberCapabilities.new('703-555-1212').unsupported_location
-        expect(locality).to be_nil
+        expect(locality).to eq('United States')
       end
     end
   end


### PR DESCRIPTION
**How**: by setting Phonelib.default_country

--- 

```ruby
# before
Phonelib.parse('(888) 867-5309').e164
# => '+8888675309'

# after
Phonelib.default_country = 'US'
Phonelib.parse('(888) 867-5309').e164
# => '+18888675309'
```
