### PR TITLE
Create a `certs` folder when symlinking SP certs

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -74,6 +74,7 @@ module Deploy
       end
 
       # Service provider public keys
+      FileUtils.mkdir_p(File.join(root, 'certs'))
       symlink_verbose(
         File.join(root, idp_config_checkout_name, 'certs/sp'),
         File.join(root, 'certs/sp'),


### PR DESCRIPTION
**Why**: Currently, the `certs` folder is created by the `idp_configs` resource. This resource adds the SAML and OIDC certs and keys to the filesystem. With the app artifacts change we no longer need this resource. Without it, this folder does not get created and the symlink fails.