### PR TITLE
LG-4304: Show confirmation prompt when closing or navigating away from "Link Sent" screen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   },
   "rules": {
     "@babel/no-unused-expressions": "error",
+    "class-methods-use-this": "off",
     "consistent-return": "off",
     "curly": ["error", "all"],
     "prettier/prettier": "error",

--- a/app/javascript/packages/document-capture-polling/index.js
+++ b/app/javascript/packages/document-capture-polling/index.js
@@ -10,6 +10,7 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
  * @typedef DocumentCapturePollingElements
  *
  * @prop {HTMLFormElement} form
+ * @prop {HTMLAnchorElement} backLink
  */
 
 /**
@@ -39,6 +40,10 @@ export class DocumentCapturePolling {
     this.toggleFormVisible(false);
     this.trackEvent('IdV: Link sent capture doc polling started');
     this.schedulePoll();
+    DocumentCapturePolling.bindPromptOnNavigate(true);
+    this.elements.backLink.addEventListener('click', () =>
+      DocumentCapturePolling.bindPromptOnNavigate(false),
+    );
   }
 
   /**
@@ -46,6 +51,18 @@ export class DocumentCapturePolling {
    */
   toggleFormVisible(isVisible) {
     this.elements.form.classList.toggle('display-none', !isVisible);
+  }
+
+  /**
+   * @param {boolean} shouldPrompt Whether to bind or unbind page unload behavior.
+   */
+  static bindPromptOnNavigate(shouldPrompt) {
+    window.onbeforeunload = shouldPrompt
+      ? (event) => {
+          event.preventDefault();
+          event.returnValue = '';
+        }
+      : null;
   }
 
   onMaxPollAttempts() {
@@ -57,6 +74,7 @@ export class DocumentCapturePolling {
    */
   async onComplete({ isCancelled }) {
     await this.trackEvent('IdV: Link sent capture doc polling complete', { isCancelled });
+    DocumentCapturePolling.bindPromptOnNavigate(false);
     this.elements.form.submit();
   }
 

--- a/app/javascript/packages/document-capture-polling/index.js
+++ b/app/javascript/packages/document-capture-polling/index.js
@@ -40,10 +40,8 @@ export class DocumentCapturePolling {
     this.toggleFormVisible(false);
     this.trackEvent('IdV: Link sent capture doc polling started');
     this.schedulePoll();
-    DocumentCapturePolling.bindPromptOnNavigate(true);
-    this.elements.backLink.addEventListener('click', () =>
-      DocumentCapturePolling.bindPromptOnNavigate(false),
-    );
+    this.bindPromptOnNavigate(true);
+    this.elements.backLink.addEventListener('click', () => this.bindPromptOnNavigate(false));
   }
 
   /**
@@ -56,7 +54,7 @@ export class DocumentCapturePolling {
   /**
    * @param {boolean} shouldPrompt Whether to bind or unbind page unload behavior.
    */
-  static bindPromptOnNavigate(shouldPrompt) {
+  bindPromptOnNavigate(shouldPrompt) {
     window.onbeforeunload = shouldPrompt
       ? (event) => {
           event.preventDefault();
@@ -74,7 +72,7 @@ export class DocumentCapturePolling {
    */
   async onComplete({ isCancelled }) {
     await this.trackEvent('IdV: Link sent capture doc polling complete', { isCancelled });
-    DocumentCapturePolling.bindPromptOnNavigate(false);
+    this.bindPromptOnNavigate(false);
     this.elements.form.submit();
   }
 

--- a/app/javascript/packs/doc-capture-polling.js
+++ b/app/javascript/packs/doc-capture-polling.js
@@ -6,9 +6,9 @@ loadPolyfills(['fetch', 'classlist']).then(() => {
   new DocumentCapturePolling({
     statusEndpoint: /** @type {string} */ (getPageData('docCaptureStatusEndpoint')),
     elements: {
-      backLink: /** @type {HTMLAnchorElement} */ (document.querySelector('.doc_capture_back_link')),
+      backLink: /** @type {HTMLAnchorElement} */ (document.querySelector('.link-sent-back-link')),
       form: /** @type {HTMLFormElement} */ (document.querySelector(
-        '.doc_capture_continue_button_form',
+        '.link-sent-continue-button-form',
       )),
     },
   }).bind();

--- a/app/javascript/packs/doc-capture-polling.js
+++ b/app/javascript/packs/doc-capture-polling.js
@@ -6,6 +6,7 @@ loadPolyfills(['fetch', 'classlist']).then(() => {
   new DocumentCapturePolling({
     statusEndpoint: /** @type {string} */ (getPageData('docCaptureStatusEndpoint')),
     elements: {
+      backLink: /** @type {HTMLAnchorElement} */ (document.querySelector('.doc_capture_back_link')),
       form: /** @type {HTMLFormElement} */ (document.querySelector(
         '.doc_capture_continue_button_form',
       )),

--- a/app/views/idv/doc_auth/_back.html.erb
+++ b/app/views/idv/doc_auth/_back.html.erb
@@ -14,6 +14,8 @@ text = '‹ ' + t('forms.buttons.back')
 step = local_assigns[:action] || local_assigns[:step]
 path = step ? idv_doc_auth_step_path(step: step) : go_back_path
 path ||= local_assigns[:fallback_path]
+classes = []
+classes << local_assigns[:class] if local_assigns[:class]
 %>
 <% if path %>
   <div class="margin-top-5 padding-top-2 border-top border-primary-light">
@@ -22,10 +24,10 @@ path ||= local_assigns[:fallback_path]
         text,
         path,
         method: :put,
-        class: 'btn btn-link'
+        class: [*classes, 'btn btn-link']
       ) %>
     <% else %>
-      <%= link_to(text, path) %>
+      <%= link_to(text, path, class: classes) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -50,4 +50,4 @@
   <% end %>
 <% end %>
 
-<%= render 'idv/doc_auth/back', action: 'cancel_link_sent' %>
+<%= render 'idv/doc_auth/back', action: 'cancel_link_sent', class: 'doc_capture_back_link' %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -39,7 +39,7 @@
         url_for,
         method: :put,
         class: 'btn btn-primary btn-wide sm-col-6 col-12',
-        form_class: 'doc_capture_continue_button_form'
+        form_class: 'link-sent-continue-button-form'
       )
     %>
   </div>
@@ -50,4 +50,4 @@
   <% end %>
 <% end %>
 
-<%= render 'idv/doc_auth/back', action: 'cancel_link_sent', class: 'doc_capture_back_link' %>
+<%= render 'idv/doc_auth/back', action: 'cancel_link_sent', class: 'link-sent-back-link' %>

--- a/spec/javascripts/packages/document-capture-polling/index-spec.js
+++ b/spec/javascripts/packages/document-capture-polling/index-spec.js
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/dom';
 import {
   DocumentCapturePolling,
@@ -26,18 +27,18 @@ describe('DocumentCapturePolling', () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <p id="doc_capture_continue_instructions">Instructions</p>
+      <a href="#" class="doc_capture_back_link">Back</a>
       <form class="doc_capture_continue_button_form"><button>Submit</button></form>
     `;
 
     subject = new DocumentCapturePolling({
       statusEndpoint: '/status',
       elements: {
+        backLink: /** @type {HTMLAnchorElement} */ (document.querySelector(
+          '.doc_capture_back_link',
+        )),
         form: /** @type {HTMLFormElement} */ (document.querySelector(
           '.doc_capture_continue_button_form',
-        )),
-        instructions: /** @type {HTMLParagraphElement} */ (document.querySelector(
-          '#doc_capture_continue_instructions',
         )),
       },
       trackEvent,
@@ -92,7 +93,7 @@ describe('DocumentCapturePolling', () => {
     expect(subject.elements.form.submit).to.have.been.called();
   });
 
-  it('polls until max, then showing instructions to submit', async () => {
+  it('polls until max, then showing form to submit', async () => {
     sandbox.stub(window, 'fetch').withArgs('/status').resolves({ status: 202 });
 
     for (let i = MAX_DOC_CAPTURE_POLL_ATTEMPTS; i; i--) {
@@ -101,7 +102,37 @@ describe('DocumentCapturePolling', () => {
       await flushPromises();
     }
 
-    expect(screen.getByText('Instructions').closest('.display-none')).to.not.be.ok();
     expect(screen.getByText('Submit').closest('.display-none')).to.not.be.ok();
+  });
+
+  describe('prompts', () => {
+    let event;
+    beforeEach(() => {
+      event = new window.CustomEvent('beforeunload', { cancelable: true });
+    });
+
+    it('prompts while polling', () => {
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).to.be.true();
+    });
+
+    it('does not prompt by navigating away via back link', () => {
+      userEvent.click(screen.getByText('Back'));
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).to.be.false();
+    });
+
+    it('does not prompt by navigating away via form submission', async () => {
+      sandbox.stub(subject.elements.form, 'submit');
+      sandbox.stub(window, 'fetch').withArgs('/status').resolves({ status: 200 });
+      subject.bind();
+      sandbox.clock.tick(DOC_CAPTURE_POLL_INTERVAL);
+      await flushPromises();
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).to.be.false();
+    });
   });
 });

--- a/spec/javascripts/packages/document-capture-polling/index-spec.js
+++ b/spec/javascripts/packages/document-capture-polling/index-spec.js
@@ -27,18 +27,16 @@ describe('DocumentCapturePolling', () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <a href="#" class="doc_capture_back_link">Back</a>
-      <form class="doc_capture_continue_button_form"><button>Submit</button></form>
+      <a href="#" class="link-sent-back-link">Back</a>
+      <form class="link-sent-continue-button-form"><button>Submit</button></form>
     `;
 
     subject = new DocumentCapturePolling({
       statusEndpoint: '/status',
       elements: {
-        backLink: /** @type {HTMLAnchorElement} */ (document.querySelector(
-          '.doc_capture_back_link',
-        )),
+        backLink: /** @type {HTMLAnchorElement} */ (document.querySelector('.link-sent-back-link')),
         form: /** @type {HTMLFormElement} */ (document.querySelector(
-          '.doc_capture_continue_button_form',
+          '.link-sent-continue-button-form',
         )),
       },
       trackEvent,

--- a/spec/views/idv/doc_auth/_back.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/_back.html.erb_spec.rb
@@ -1,40 +1,80 @@
 require 'rails_helper'
 
 describe 'idv/doc_auth/_back.html.erb' do
-  it 'renders with action' do
-    render 'idv/doc_auth/back', action: 'redo_ssn'
+  let(:action) { nil }
+  let(:step) { nil }
+  let(:classes) { nil }
+  let(:fallback_path) { nil }
 
-    expect(rendered).to have_selector("form[action='#{idv_doc_auth_step_path(step: 'redo_ssn')}']")
-    expect(rendered).to have_selector('input[name="_method"][value="put"]', visible: false)
-    expect(rendered).to have_selector("[type='submit'][value='#{'‹ ' + t('forms.buttons.back')}']")
+  subject do
+    render 'idv/doc_auth/back', {
+      action: action,
+      step: step,
+      class: classes,
+      fallback_path: fallback_path,
+    }
   end
 
-  it 'renders with step' do
-    render 'idv/doc_auth/back', step: 'verify'
+  shared_examples 'back link with class' do
+    let(:classes) { 'example-class' }
 
-    expect(rendered).to have_selector("a[href='#{idv_doc_auth_step_path(step: 'verify')}']")
-    expect(rendered).to have_content('‹ ' + t('forms.buttons.back'))
+    it 'renders with class' do
+      expect(subject).to have_css('.example-class')
+    end
   end
 
-  it 'renders with back path' do
-    allow(view).to receive(:go_back_path).and_return('/example')
+  context 'with action' do
+    let(:action) { 'redo_ssn' }
 
-    render 'idv/doc_auth/back'
+    it 'renders' do
+      expect(subject).to have_selector("form[action='#{idv_doc_auth_step_path(step: 'redo_ssn')}']")
+      expect(subject).to have_selector('input[name="_method"][value="put"]', visible: false)
+      expect(subject).to have_selector(
+        ".btn[type='submit'][value='#{'‹ ' + t('forms.buttons.back')}']",
+      )
+    end
 
-    expect(rendered).to have_selector('a[href="/example"]')
-    expect(rendered).to have_content('‹ ' + t('forms.buttons.back'))
+    it_behaves_like 'back link with class'
   end
 
-  it 'renders fallback path' do
-    render 'idv/doc_auth/back', fallback_path: '/example'
+  context 'with step' do
+    let(:step) { 'verify' }
 
-    expect(rendered).to have_selector('a[href="/example"]')
-    expect(rendered).to have_content('‹ ' + t('forms.buttons.back'))
+    it 'renders' do
+      expect(subject).to have_selector("a[href='#{idv_doc_auth_step_path(step: 'verify')}']")
+      expect(subject).to have_content('‹ ' + t('forms.buttons.back'))
+    end
+
+    it_behaves_like 'back link with class'
   end
 
-  it 'renders nothing if there is no back path' do
-    render 'idv/doc_auth/back'
+  context 'with back path' do
+    before do
+      allow(view).to receive(:go_back_path).and_return('/example')
+    end
 
-    expect(rendered).to be_empty
+    it 'renders with back path' do
+      expect(subject).to have_selector('a[href="/example"]')
+      expect(subject).to have_content('‹ ' + t('forms.buttons.back'))
+    end
+  end
+
+  context 'with fallback link' do
+    let(:fallback_path) { '/example' }
+
+    it 'renders' do
+      expect(subject).to have_selector('a[href="/example"]')
+      expect(subject).to have_content('‹ ' + t('forms.buttons.back'))
+    end
+
+    it_behaves_like 'back link with class'
+  end
+
+  context 'no back path' do
+    it 'renders nothing' do
+      render 'idv/doc_auth/back'
+
+      expect(subject).to be_empty
+    end
   end
 end


### PR DESCRIPTION
**Why**: As a user, I want to be reminded to keep my browser window/tab open if I try to close it either accidentally or on purpose while I have not yet completed the doc auth step on my mobile phone so that I have the option to change my mind and continue with the proofing flow.

It may make sense to wait to merge this until after corresponding content updates associated with LG-4303, to better inform the user why they should not close the page.