### PR TITLE
Use configurable paths for geolite db and pwned passwords

### DIFF
--- a/app/services/pwned_passwords/lookup_password.rb
+++ b/app/services/pwned_passwords/lookup_password.rb
@@ -1,6 +1,6 @@
 module PwnedPasswords
   class LookupPassword
-    PWNED_PASSWORD_FILE = Rails.root.join('pwned_passwords', 'pwned_passwords.txt')
+    PWNED_PASSWORD_FILE = Rails.root.join(AppConfig.env.pwned_passwords_file_path).freeze
 
     def self.call(password)
       BinarySearchSortedHashFile.new(PWNED_PASSWORD_FILE).call(password)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -52,6 +52,7 @@ email_from: no-reply@login.gov
 email_from_display_name: Login.gov
 enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'
+geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 gpo_designated_receiver_pii: '{}'
 ial2_recovery_request_valid_for_minutes: '15'
 identity_pki_local_dev: 'false'
@@ -112,6 +113,7 @@ poll_rate_for_verify_in_seconds: '3'
 proofer_mock_fallback: 'true'
 proofing_send_partial_dob: 'false'
 push_notifications_enabled:
+pwned_passwords_file_path: 'pwned_passwords/pwned_passwords.txt'
 rack_timeout_service_timeout_seconds: '15'
 reauthn_window: '120'
 recaptcha_enabled_percent: '0'

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -9,7 +9,7 @@ module Geocoder
   end
 end
 
-GEO_DATA_FILEPATH = Rails.root.join('geo_data', 'GeoLite2-City.mmdb').freeze
+GEO_DATA_FILEPATH = Rails.root.join(AppConfig.env.geo_data_file_path).freeze
 
 if !Rails.env.production? && !File.exist?(GEO_DATA_FILEPATH)
   Geocoder.configure(ip_lookup: :test)

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -31,11 +31,11 @@ module Deploy
       deep_merge_s3_data_with_example_application_yml
       set_proper_file_permissions_for_application_yml
 
-      secrets_s3.download_file(
+      download_from_secrets_s3_unless_exists(
         s3_path: '/common/GeoIP2-City.mmdb',
         local_path: geolocation_db_path,
       )
-      secrets_s3.download_file(
+      download_from_secrets_s3_unless_exists(
         s3_path: '/common/pwned-passwords.txt',
         local_path: pwned_passwords_path,
       )
@@ -110,6 +110,14 @@ module Deploy
     def download_from_s3_and_update_permissions(src, dest)
       download_file(src, dest)
       update_file_permissions(dest)
+    end
+
+    def download_from_secrets_s3_unless_exists(s3_path:, local_path:)
+      return if File.exist?(local_path)
+      secrets_s3.download_file(
+        s3_path: s3_path,
+        local_path: local_path,
+      )
     end
 
     def app_secrets_s3

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -115,6 +115,13 @@ describe Deploy::Activate do
       expect(File.read(pwned_passwords_path)).to eq(pwned_passwords_content)
     end
 
+    it 'does not re-downlaod passowrds and configs if they already exist' do
+      FileUtils.mkdir_p(File.dirname(geolite_path))
+      File.write(geolite_path, 'existing geolite tests')
+
+      expect { subject.run }.to_not(change { File.read(geolite_path) })
+    end
+
     it 'uses a default logger with a progname' do
       subject = Deploy::Activate.new(s3_client: s3_client)
 


### PR DESCRIPTION
**Why**: So we don't have to depend on chef to put them on the right magical path

This commit also includes a bonus fix to prevent us from download the files if they already exist.