### PR TITLE
Upgrade identity-style-guide to latest version (5.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clipboard": "^2.0.6",
     "domready": "^1.0.8",
     "focus-trap": "^6.2.3",
-    "identity-style-guide": "^3.0.0",
+    "identity-style-guide": "^5.0.1",
     "intl-tel-input": "^17.0.8",
     "libphonenumber-js": "^1.9.6",
     "postcss-clean": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4834,13 +4834,12 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-identity-style-guide@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-3.0.0.tgz#9f0d1331b3200dad63073c928dd195c1c50c9378"
-  integrity sha512-PFoNrTStU7uOFMXi8qEC1Yx+Vq4IZMxpK5+5mFRU5Ef6e/9S0U9wKaVzCv4+jK7Z4yUPlsMe8Xd/K9XWjnm6fQ==
+identity-style-guide@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-5.0.1.tgz#ada95337b503ed8ef46091696ba8a44a6061f0ac"
+  integrity sha512-eailVodxMJCw51dFFUXOwqNvvKgCHnZt6xXYn+9Cizx2YrbzFcOkGu/OIiOGes/jBINnq4upxyUZStkv9IhVFw==
   dependencies:
     uswds "^2.9.0"
-    zxcvbn "^4.4.2"
 
 ieee754@^1.1.4:
   version "1.1.13"


### PR DESCRIPTION
**Why**: Intermediate step between LG-4226 ("Update Button component in design system") and LG-3865 ("Remove BassCSS Module: Btn").

Diff: https://github.com/18F/identity-style-guide/compare/v3.0.0..v5.0.1

Notable changes:

- Buttons
  - Removals of success, dropdown, small, tiny are not impactful because they're not used in `identity-idp`
  - There's minimal usage of `usa-button` classes, mostly contained within document capture. Affected styling should be quite minimal (e.g. [line height](https://github.com/18F/identity-style-guide/compare/v3.0.0..v5.0.1#diff-5ff9b50fdcbf3839d9f7348070434e15394e2e8b565175e92566ddccbd8d0fd0R2), [fixed focus ring](https://github.com/18F/identity-style-guide/compare/v3.0.0..v5.0.1#diff-5ff9b50fdcbf3839d9f7348070434e15394e2e8b565175e92566ddccbd8d0fd0R4), [hover color](https://github.com/18F/identity-style-guide/compare/v3.0.0..v5.0.1#diff-91f56645fcc6ce1feb63b9906dc1121613f4d80ddffb6dad362e0d8eab32d9c9R201))
- Password strength
  - Unlike previously thought, we don't need to make any compensatory changes in this project, because everything was duplicated between `identity-style-guide` and this project, including styles
- Spinner button
  - We never used it