### PR TITLE
Refactoring ApiImageUploadController (LG-4252)

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -8,7 +8,6 @@ module Idv
       image_upload_form_response = image_upload_form.submit
 
       presenter = ImageUploadResponsePresenter.new(
-        form: image_upload_form,
         form_response: image_upload_form_response,
         url_options: url_options,
       )

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -5,45 +5,11 @@ module Idv
     respond_to :json
 
     def create
-      image_form_response = image_form.submit
-      analytics.track_event(
-        Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
-        image_form_response.to_h,
-      )
-
-      client_response = nil
-      doc_pii_form_response = nil
-
-      if image_form_response.success?
-        client_response = doc_auth_client.post_images(
-          front_image: image_form.front.read,
-          back_image: image_form.back.read,
-          selfie_image: image_form.selfie&.read,
-          liveness_checking_enabled: liveness_checking_enabled?,
-        )
-
-        update_analytics(client_response)
-
-        if client_response.success?
-          doc_pii_form_response = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
-          analytics.track_event(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
-            doc_pii_form_response.to_h.merge(user_id: user_uuid),
-          )
-          store_pii(client_response) if client_response.success? && doc_pii_form_response.success?
-
-          # merge in the image_form_response to pick up the remaining_attempts
-          doc_pii_form_response = image_form_response.merge(doc_pii_form_response)
-        end
-      end
+      image_upload_form_response = image_upload_form.submit
 
       presenter = ImageUploadResponsePresenter.new(
-        form: image_form,
-        form_response: presenter_response(
-          image_form_response: image_form_response,
-          client_response: client_response,
-          doc_pii_form_response: doc_pii_form_response,
-        ),
+        form: image_upload_form,
+        form_response: image_upload_form_response,
         url_options: url_options,
       )
 
@@ -52,62 +18,13 @@ module Idv
 
     private
 
-    def image_form
-      @image_form ||= Idv::ApiImageUploadForm.new(
+    def image_upload_form
+      @image_upload_form ||= Idv::ApiImageUploadForm.new(
         params,
         liveness_checking_enabled: liveness_checking_enabled?,
+        issuer: sp_session[:issuer].to_s,
+        analytics: analytics,
       )
-    end
-
-    def store_pii(doc_response)
-      image_form.document_capture_session.store_result_from_response(doc_response)
-    end
-
-    def doc_auth_client
-      @doc_auth_client ||= DocAuthRouter.client
-    end
-
-    def update_analytics(client_response)
-      add_costs(client_response)
-      update_funnel(client_response)
-      analytics.track_event(
-        Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
-        client_response.to_h.merge(user_id: user_uuid),
-      )
-    end
-
-    def update_funnel(result)
-      user_id = image_form.document_capture_session.user.id
-      issuer = sp_session[:issuer]
-      steps = %i[front_image back_image]
-      steps << :selfie if liveness_checking_enabled?
-      steps.each do |step|
-        Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(step.to_s, :update, result.success?)
-      end
-    end
-
-    def add_costs(client_response)
-      Db::AddDocumentVerificationAndSelfieCosts.
-        new(user_id: image_form.document_capture_session.user.id,
-            issuer: sp_session[:issuer].to_s,
-            liveness_checking_enabled: liveness_checking_enabled?).
-        call(client_response)
-    end
-
-    def presenter_response(image_form_response:, client_response:, doc_pii_form_response:)
-      # image form wasn't valid
-      return image_form_response unless image_form_response.success?
-
-      # doc_pii_form exists, but wasn't valid
-      if doc_pii_form_response.present? && !doc_pii_form_response.success?
-        return doc_pii_form_response
-      end
-
-      client_response
-    end
-
-    def user_uuid
-      image_form.document_capture_session.user.uuid
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -31,6 +31,8 @@ module Idv
 
         if client_response.success?
           doc_pii_response = validate_pii_from_doc(client_response)
+        else
+          client_response = client_response.merge(form_response)
         end
       end
 
@@ -39,11 +41,6 @@ module Idv
         client_response: client_response,
         doc_pii_response: doc_pii_response,
       )
-    end
-
-    def remaining_attempts
-      return nil unless document_capture_session
-      Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end
 
     private
@@ -59,7 +56,7 @@ module Idv
     end
 
     def validate_form
-      response = FormResponse.new(
+      response = Idv::DocAuthFormResponse.new(
         success: valid?,
         errors: errors.messages,
         extra: {
@@ -99,6 +96,11 @@ module Idv
 
       # merge in the image_form_response to pick up the remaining_attempts
       response.merge(form_response)
+    end
+
+    def remaining_attempts
+      return nil unless document_capture_session
+      Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end
 
     def determine_response(form_response:, client_response:, doc_pii_response:)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -147,9 +147,6 @@ module Idv
     end
 
     def self.human_attribute_name(attr, options = {})
-      # i18n-tasks-use t('doc_auth.headings.document_capture_front')
-      # i18n-tasks-use t('doc_auth.headings.document_capture_back')
-      # i18n-tasks-use t('doc_auth.headings.document_capture_selfie')
       I18n.t("doc_auth.headings.document_capture_#{attr}", options)
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -5,34 +5,112 @@ module Idv
 
     validates_presence_of :front
     validates_presence_of :back
-    validates_presence_of :document_capture_session
     validates_presence_of :selfie, if: :liveness_checking_enabled?
+    validates_presence_of :document_capture_session
 
     validate :validate_images
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:)
+    def initialize(params, liveness_checking_enabled:, issuer:, analytics: nil)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
+      @issuer = issuer
+      @analytics = analytics
       @readable = {}
     end
 
     def submit
       throttled_else_increment
+      @form_response = validate_form
 
-      FormResponse.new(
-        success: valid?,
-        errors: errors.messages,
-        extra: {
-          remaining_attempts: remaining_attempts,
-          user_id: document_capture_session&.user&.uuid,
-        },
+      client_response = nil
+      doc_pii_response = nil
+
+      if form_response.success?
+        client_response = post_images_to_client
+
+        if client_response.success?
+          doc_pii_response = validate_pii_from_doc(client_response)
+        end
+      end
+
+      return determine_response(
+        form_response: form_response,
+        client_response: client_response,
+        doc_pii_response: doc_pii_response,
       )
     end
 
     def remaining_attempts
       return nil unless document_capture_session
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
+    end
+
+    private
+
+    attr_reader :params, :analytics, :issuer, :form_response
+
+    def throttled_else_increment
+      return unless document_capture_session
+      @throttled = Throttler::IsThrottledElseIncrement.call(
+        document_capture_session.user_id,
+        :idv_acuant,
+      )
+    end
+
+    def validate_form
+      response = FormResponse.new(
+        success: valid?,
+        errors: errors.messages,
+        extra: {
+          remaining_attempts: remaining_attempts,
+          user_id: user_uuid,
+        },
+      )
+
+      track_event(
+        Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+        response.to_h,
+      )
+
+      response
+    end
+
+    def post_images_to_client
+      response = doc_auth_client.post_images(
+        front_image: front.read,
+        back_image: back.read,
+        selfie_image: selfie&.read,
+        liveness_checking_enabled: liveness_checking_enabled?,
+      )
+
+      update_analytics(response)
+
+      response
+    end
+
+    def validate_pii_from_doc(client_response)
+      response = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
+      track_event(
+        Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+        response.to_h.merge(user_id: user_uuid),
+      )
+      store_pii(client_response) if client_response.success? && response.success?
+
+      # merge in the image_form_response to pick up the remaining_attempts
+      response.merge(form_response)
+    end
+
+    def determine_response(form_response:, client_response:, doc_pii_response:)
+      # image validation failed
+      return form_response unless form_response.success?
+
+      # doc_pii validation failed
+      if doc_pii_response.present? && !doc_pii_response.success?
+        return doc_pii_response
+      end
+
+      client_response
     end
 
     def liveness_checking_enabled?
@@ -51,14 +129,21 @@ module Idv
       as_readable(:selfie)
     end
 
-    def document_capture_session_uuid
-      params[:document_capture_session_uuid]
-    end
-
     def document_capture_session
       @document_capture_session ||= DocumentCaptureSession.find_by(
         uuid: document_capture_session_uuid,
       )
+    end
+
+    def validate_images
+      errors.add(:front, t('doc_auth.errors.not_a_file')) if front.is_a? URI::InvalidURIError
+      errors.add(:back, t('doc_auth.errors.not_a_file')) if back.is_a? URI::InvalidURIError
+      errors.add(:selfie, t('doc_auth.errors.not_a_file')) if selfie.is_a? URI::InvalidURIError
+    end
+
+    def throttle_if_rate_limited
+      return unless @throttled
+      errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 
     def self.human_attribute_name(attr, options = {})
@@ -68,27 +153,12 @@ module Idv
       I18n.t("doc_auth.headings.document_capture_#{attr}", options)
     end
 
-    private
-
-    attr_reader :params
-
-    def throttle_if_rate_limited
-      return unless @throttled
-      errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
+    def document_capture_session_uuid
+      params[:document_capture_session_uuid]
     end
 
-    def throttled_else_increment
-      return unless document_capture_session
-      @throttled = Throttler::IsThrottledElseIncrement.call(
-        document_capture_session.user_id,
-        :idv_acuant,
-      )
-    end
-
-    def validate_images
-      errors.add(:front, t('doc_auth.errors.not_a_file')) if front.is_a? URI::InvalidURIError
-      errors.add(:back, t('doc_auth.errors.not_a_file')) if back.is_a? URI::InvalidURIError
-      errors.add(:selfie, t('doc_auth.errors.not_a_file')) if selfie.is_a? URI::InvalidURIError
+    def doc_auth_client
+      @doc_auth_client ||= DocAuthRouter.client
     end
 
     def as_readable(image_key)
@@ -103,6 +173,53 @@ module Idv
       rescue URI::InvalidURIError => error
         error
       end
+    end
+
+    def track_event(event, attributes = {})
+      if analytics.present?
+        analytics.track_event(
+          event,
+          attributes,
+        )
+      end
+    end
+
+    def update_analytics(client_response)
+      add_costs(client_response)
+      update_funnel(client_response)
+      track_event(
+        Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+        client_response.to_h.merge(user_id: user_uuid),
+      )
+    end
+
+    def add_costs(response)
+      Db::AddDocumentVerificationAndSelfieCosts.
+        new(user_id: user_id,
+            issuer: issuer,
+            liveness_checking_enabled: liveness_checking_enabled?).
+        call(response)
+    end
+
+    def update_funnel(client_response)
+      steps = %i[front_image back_image]
+      steps << :selfie if liveness_checking_enabled?
+      steps.each do |step|
+        Funnel::DocAuth::RegisterStep.new(user_id, issuer).
+          call(step.to_s, :update, client_response.success?)
+      end
+    end
+
+    def store_pii(client_response)
+      document_capture_session.store_result_from_response(client_response)
+    end
+
+    def user_id
+      document_capture_session&.user&.id
+    end
+
+    def user_uuid
+      document_capture_session&.user&.uuid
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -108,9 +108,7 @@ module Idv
       return form_response unless form_response.success?
 
       # doc_pii validation failed
-      if doc_pii_response.present? && !doc_pii_response.success?
-        return doc_pii_response
-      end
+      return doc_pii_response if (doc_pii_response.present? && !doc_pii_response.success?)
 
       client_response
     end

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -14,7 +14,7 @@ module Idv
     end
 
     def submit
-      FormResponse.new(
+      Idv::DocAuthFormResponse.new(
         success: valid?,
         errors: errors.messages,
       )

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -1,8 +1,7 @@
 class ImageUploadResponsePresenter
   include Rails.application.routes.url_helpers
 
-  def initialize(form:, form_response:, url_options: )
-    @form = form
+  def initialize(form_response:, url_options: )
     @form_response = form_response
     @url_options = url_options
   end
@@ -18,7 +17,7 @@ class ImageUploadResponsePresenter
   end
 
   def remaining_attempts
-    @form.remaining_attempts
+    @form_response.to_h[:remaining_attempts]
   end
 
   def status

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -10,7 +10,6 @@ module Idv
       def form_submit
         response = form.submit
         presenter = ImageUploadResponsePresenter.new(
-          form: form,
           form_response: response,
           url_options: url_options,
         )

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -25,7 +25,6 @@ module Idv
         end
 
         presenter = ImageUploadResponsePresenter.new(
-          form: form,
           form_response: form_response,
           url_options: url_options,
         )

--- a/app/services/idv/doc_auth_form_response.rb
+++ b/app/services/idv/doc_auth_form_response.rb
@@ -1,0 +1,9 @@
+module Idv
+  # A custom form response with additional noop methods to allow merging with DocAuth responses
+  class DocAuthFormResponse < ::FormResponse
+    def exception; end
+    def pii_from_doc
+      {}
+    end
+  end
+end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Idv::ApiImageUploadForm do
         document_capture_session_uuid: document_capture_session_uuid,
       },
       liveness_checking_enabled: liveness_checking_enabled?,
+      issuer: 'test_issuer',
     )
   end
 
@@ -82,9 +83,13 @@ RSpec.describe Idv::ApiImageUploadForm do
   end
 
   describe '#submit' do
-    it 'includes remaining_attempts' do
-      response = form.submit
-      expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+    context 'form is missing a required param' do
+      let(:front_image) { nil }
+
+      it 'includes remaining_attempts' do
+        response = form.submit
+        expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+      end
     end
   end
 end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       },
       liveness_checking_enabled: liveness_checking_enabled?,
       issuer: 'test_issuer',
-      analytics: FakeAnalytics.new
+      analytics: FakeAnalytics.new,
     )
   end
 
@@ -99,7 +99,9 @@ RSpec.describe Idv::ApiImageUploadForm do
     end
 
     context 'posting images to client fails' do
-      let(:failed_response) { IdentityDocAuth::Response.new(success: false, errors: { front: 'glare' }) }
+      let(:failed_response) do
+        IdentityDocAuth::Response.new(success: false, errors: { front: 'glare' })
+      end
       before do
         allow(subject).to receive(:post_images_to_client).and_return(failed_response)
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       },
       liveness_checking_enabled: liveness_checking_enabled?,
       issuer: 'test_issuer',
+      analytics: FakeAnalytics.new
     )
   end
 
@@ -86,9 +87,58 @@ RSpec.describe Idv::ApiImageUploadForm do
     context 'form is missing a required param' do
       let(:front_image) { nil }
 
+      it 'is not successful' do
+        response = form.submit
+        expect(response.success?).to eq(false)
+      end
+
       it 'includes remaining_attempts' do
         response = form.submit
         expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+      end
+    end
+
+    context 'posting images to client fails' do
+      let(:failed_response) { IdentityDocAuth::Response.new(success: false, errors: { front: 'glare' }) }
+      before do
+        allow(subject).to receive(:post_images_to_client).and_return(failed_response)
+      end
+
+      it 'is not successful' do
+        response = form.submit
+        expect(response.success?).to eq(false)
+      end
+
+      it 'includes remaining_attempts' do
+        response = form.submit
+        expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+      end
+
+      it 'includes client response errors' do
+        response = form.submit
+        expect(response.errors[:front]).to eq('glare')
+      end
+    end
+
+    context 'PII validation from client response fails' do
+      let(:failed_response) { FormResponse.new(success: false, errors: { doc_pii: 'bad' }) }
+      before do
+        allow_any_instance_of(Idv::DocPiiForm).to receive(:submit).and_return(failed_response)
+      end
+
+      it 'is not successful' do
+        response = form.submit
+        expect(response.success?).to eq(false)
+      end
+
+      it 'includes remaining_attempts' do
+        response = form.submit
+        expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+      end
+
+      it 'includes doc_pii errors' do
+        response = form.submit
+        expect(response.errors[:doc_pii]).to eq('bad')
       end
     end
   end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -3,16 +3,10 @@ require 'rails_helper'
 describe ImageUploadResponsePresenter do
   include Rails.application.routes.url_helpers
 
-  let(:form) { Idv::ApiImageUploadForm.new({}, liveness_checking_enabled: false, issuer: 'test') }
-  let(:form_response) { FormResponse.new(success: true, errors: {}, extra: {}) }
-  let(:presenter) { described_class.new(form: form, form_response: form_response, url_options: {}) }
-
-  before do
-    allow(Throttler::RemainingCount).to receive(:call).and_return(3)
-    allow(DocumentCaptureSession).to receive(:find_by).and_return(
-      DocumentCaptureSession.create!(requested_at: Time.zone.now),
-    )
+  let(:form_response) do
+    FormResponse.new(success: true, errors: {}, extra: { remaining_attempts: 3 })
   end
+  let(:presenter) { described_class.new(form_response: form_response, url_options: {}) }
 
   describe '#success?' do
     context 'failure' do
@@ -135,7 +129,7 @@ describe ImageUploadResponsePresenter do
           errors: {
             front: t('doc_auth.errors.not_a_file'),
           },
-          extra: {},
+          extra: { remaining_attempts: 3 },
         )
       end
 

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ImageUploadResponsePresenter do
   include Rails.application.routes.url_helpers
 
-  let(:form) { Idv::ApiImageUploadForm.new({}, liveness_checking_enabled: false) }
+  let(:form) { Idv::ApiImageUploadForm.new({}, liveness_checking_enabled: false, issuer: 'test') }
   let(:form_response) { FormResponse.new(success: true, errors: {}, extra: {}) }
   let(:presenter) { described_class.new(form: form, form_response: form_response, url_options: {}) }
 


### PR DESCRIPTION
The `ApiImageUploadController` had a ton of logic in it and was difficult to follow. This PR attempts to move that logic into one form that does all the work and determines the correct response.

Bonus refactoring to remove the `ImageUploadResponsePresenter`'s dependency on the form itself - it now only requires the form's response.