### PR TITLE
LG-4305: Remove unused IdvSession#confirm_idv_attempts_allowed

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -9,12 +9,6 @@ module IdvSession
     redirect_to idv_doc_auth_url if idv_session.applicant.blank?
   end
 
-  def confirm_idv_attempts_allowed
-    return unless idv_attempter_throttled?
-    analytics.track_event(Analytics::IDV_MAX_ATTEMPTS_EXCEEDED, request_path: request.path)
-    redirect_to failure_url(:fail)
-  end
-
   def confirm_idv_needed
     if current_user.active_profile.blank? ||
        decorated_session.requested_more_recent_verification? || liveness_upgrade_required?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -108,7 +108,6 @@ class Analytics
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
-  IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze
   IDV_FORGOT_PASSWORD_CONFIRMED = 'IdV: forgot password confirmed'.freeze

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -67,7 +67,6 @@ describe Idv::ReviewController do
       end
       idv_session.applicant = user_attrs
       allow(subject).to receive(:idv_session).and_return(idv_session)
-      allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     end
 
     context 'user has missed address step' do
@@ -154,7 +153,6 @@ describe Idv::ReviewController do
         post 'show' => 'idv/review#show'
       end
       allow(subject).to receive(:confirm_idv_steps_complete).and_return(true)
-      allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
       idv_session.applicant = user_attrs.merge(phone_confirmed_at: Time.zone.now)
       allow(subject).to receive(:idv_session).and_return(idv_session)
     end
@@ -190,7 +188,6 @@ describe Idv::ReviewController do
     before do
       stub_sign_in(user)
       allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-      allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     end
 
     context 'user has completed all steps' do
@@ -265,7 +262,6 @@ describe Idv::ReviewController do
     before do
       stub_sign_in(user)
       allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-      allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     end
 
     context 'user fails to supply correct password' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -40,7 +40,6 @@ module ControllerHelper
     idv_session.applicant = { first_name: 'Some', last_name: 'One' }.with_indifferent_access
     idv_session.profile_confirmation = true
     allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-    allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)
     allow(subject).to receive(:user_session).and_return(user_session)
   end


### PR DESCRIPTION
**Why**:

- It's not referenced anywhere
- As part of LG-4305 ("Log new event in case of lockout from proofing"), avoid confusion from duplicate or irrelevant events