### PR TITLE
LG-4305: Log new event in case of lockout from proofing

### DIFF
--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -160,7 +160,10 @@ module Idv
 
     def max_attempts_reached
       if idv_attempter_throttled?
-        analytics.track_event(Analytics::IDV_USPS_ADDRESS_RATE_LIMIT_TRIGGERED)
+        analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :idv_resolution,
+        )
         flash_error
       end
     end

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -159,7 +159,10 @@ module Idv
     end
 
     def max_attempts_reached
-      flash_error if idv_attempter_throttled?
+      if idv_attempter_throttled?
+        analytics.track_event(Analytics::IDV_USPS_ADDRESS_RATE_LIMIT_TRIGGERED)
+        flash_error
+      end
     end
 
     def error_message

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -136,16 +136,12 @@ module Idv
       FormResponse.new(success: success, errors: result[:errors])
     end
 
-    def idv_throttle_params
-      [idv_session.current_user.id, :idv_resolution]
-    end
-
     def idv_attempter_increment
-      Throttler::Increment.call(*idv_throttle_params)
+      Throttler::Increment.call(idv_session.current_user.id, :idv_resolution, analytics: analytics)
     end
 
     def idv_attempter_throttled?
-      Throttler::IsThrottled.call(*idv_throttle_params)
+      Throttler::IsThrottled.call(idv_session.current_user.id, :idv_resolution)
     end
 
     def throttle_failure
@@ -159,13 +155,7 @@ module Idv
     end
 
     def max_attempts_reached
-      if idv_attempter_throttled?
-        analytics.track_event(
-          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
-          throttle_type: :idv_resolution,
-        )
-        flash_error
-      end
+      flash_error if idv_attempter_throttled?
     end
 
     def error_message

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -12,9 +12,10 @@ module Idv
 
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:)
+    def initialize(params, liveness_checking_enabled:, analytics:)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
+      @analytics = analytics
     end
 
     def submit
@@ -86,6 +87,7 @@ module Idv
       @throttled = Throttler::IsThrottledElseIncrement.call(
         document_capture_session.user_id,
         :idv_acuant,
+        analytics: @analytics,
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -48,6 +48,7 @@ module Idv
       @throttled = Throttler::IsThrottledElseIncrement.call(
         document_capture_session.user_id,
         :idv_acuant,
+        analytics: @analytics,
       )
     end
 
@@ -153,7 +154,6 @@ module Idv
 
     def throttle_if_rate_limited
       return unless @throttled
-      track_event(Analytics::THROTTLER_RATE_LIMIT_TRIGGERED, throttle_type: :idv_acuant)
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -153,7 +153,7 @@ module Idv
 
     def throttle_if_rate_limited
       return unless @throttled
-      track_event(Analytics::IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED)
+      track_event(Analytics::THROTTLER_RATE_LIMIT_TRIGGERED, throttle_type: :idv_acuant)
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -153,6 +153,7 @@ module Idv
 
     def throttle_if_rate_limited
       return unless @throttled
+      track_event(Analytics::IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED)
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -201,7 +201,7 @@ class Analytics
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'.freeze
-  THROTTLER_RATE_LIMIT_TRIGGERED = 'Throtter Rate Limit Triggered'.freeze
+  THROTTLER_RATE_LIMIT_TRIGGERED = 'Throttler Rate Limit Triggered'.freeze
   TOTP_SETUP_VISIT = 'TOTP Setup Visited'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze
   OTP_PHONE_VALIDATION_FAILED = 'Twilio Phone Validation Failed'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -97,7 +97,6 @@ class Analytics
   IAL2_RECOVERY = 'IAL2 Recovery'.freeze # visited or submitted is appended
   IAL2_RECOVERY_REQUEST = 'IAL2 Recovery Request'.freeze
   IAL2_RECOVERY_REQUEST_VISITED = 'IAL2 Recovery Request Visited'.freeze
-  IAL2_RECOVERY_REQUEST_RATE_LIMIT_TRIGGERED = 'IAL2 Recovery Request Rate Limited'.freeze
   IDV_ADDRESS_VISIT = 'IdV: address visited'.freeze
   IDV_ADDRESS_SUBMITTED = 'IdV: address submitted'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
@@ -105,9 +104,7 @@ class Analytics
   IDV_BASIC_INFO_SUBMITTED_VENDOR = 'IdV: basic info vendor submitted'.freeze
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
-  IDV_CAPTURE_DOC_LINK_SENT_RATE_LIMIT_TRIGGERED = 'IdV: capture doc link sent rate limited'.freeze
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
-  IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED = 'IdV: doc auth rate limited'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
@@ -134,7 +131,6 @@ class Analytics
   IDV_USPS_ADDRESS_LETTER_REQUESTED = 'IdV: USPS address letter requested'.freeze
   IDV_USPS_ADDRESS_SUBMITTED = 'IdV: USPS address submitted'.freeze
   IDV_USPS_ADDRESS_VISITED = 'IdV: USPS address visited'.freeze
-  IDV_USPS_ADDRESS_RATE_LIMIT_TRIGGERED = 'IdV: USPS address rate limited'.freeze
   IDV_VERIFICATION_ATTEMPT_CANCELLED = 'IdV: verification attempt cancelled'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   IN_PERSON_PROOFING = 'In Person Proofing'.freeze # visited or submitted is appended
@@ -205,6 +201,7 @@ class Analytics
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'.freeze
+  THROTTLER_RATE_LIMIT_TRIGGERED = 'Throtter Rate Limit Triggered'.freeze
   TOTP_SETUP_VISIT = 'TOTP Setup Visited'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze
   OTP_PHONE_VALIDATION_FAILED = 'Twilio Phone Validation Failed'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -97,6 +97,7 @@ class Analytics
   IAL2_RECOVERY = 'IAL2 Recovery'.freeze # visited or submitted is appended
   IAL2_RECOVERY_REQUEST = 'IAL2 Recovery Request'.freeze
   IAL2_RECOVERY_REQUEST_VISITED = 'IAL2 Recovery Request Visited'.freeze
+  IAL2_RECOVERY_REQUEST_RATE_LIMIT_TRIGGERED = 'IAL2 Recovery Request Rate Limited'.freeze
   IDV_ADDRESS_VISIT = 'IdV: address visited'.freeze
   IDV_ADDRESS_SUBMITTED = 'IdV: address submitted'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
@@ -104,7 +105,9 @@ class Analytics
   IDV_BASIC_INFO_SUBMITTED_VENDOR = 'IdV: basic info vendor submitted'.freeze
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
+  IDV_CAPTURE_DOC_LINK_SENT_RATE_LIMIT_TRIGGERED = 'IdV: capture doc link sent rate limited'.freeze
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
+  IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED = 'IdV: doc auth rate limited'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
@@ -131,6 +134,7 @@ class Analytics
   IDV_USPS_ADDRESS_LETTER_REQUESTED = 'IdV: USPS address letter requested'.freeze
   IDV_USPS_ADDRESS_SUBMITTED = 'IdV: USPS address submitted'.freeze
   IDV_USPS_ADDRESS_VISITED = 'IdV: USPS address visited'.freeze
+  IDV_USPS_ADDRESS_RATE_LIMIT_TRIGGERED = 'IdV: USPS address rate limited'.freeze
   IDV_VERIFICATION_ATTEMPT_CANCELLED = 'IdV: verification attempt cancelled'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   IN_PERSON_PROOFING = 'In Person Proofing'.freeze # visited or submitted is appended

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -25,6 +25,7 @@ module Idv
         @form ||= Idv::ApiDocumentVerificationForm.new(
           params,
           liveness_checking_enabled: liveness_checking_enabled?,
+          analytics: @flow.analytics,
         )
       end
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -55,6 +55,7 @@ module Idv
       end
 
       def throttled_response
+        analytics.track_event(Analytics::IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED)
         redirect_to throttled_url
         IdentityDocAuth::Response.new(
           success: false,

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -7,16 +7,12 @@ module Idv
 
       private
 
-      def idv_throttle_params
-        [current_user.id, :idv_resolution]
-      end
-
       def attempter_increment
-        Throttler::Increment.call(*idv_throttle_params)
+        Throttler::Increment.call(current_user.id, :idv_resolution, analytics: @flow.analytics)
       end
 
       def attempter_throttled?
-        Throttler::IsThrottled.call(*idv_throttle_params)
+        Throttler::IsThrottled.call(current_user.id, :idv_resolution)
       end
 
       def idv_failure(result)
@@ -55,7 +51,6 @@ module Idv
       end
 
       def throttled_response
-        analytics.track_event(Analytics::THROTTLER_RATE_LIMIT_TRIGGERED, throttle_type: :idv_acuant)
         redirect_to throttled_url
         IdentityDocAuth::Response.new(
           success: false,
@@ -69,7 +64,7 @@ module Idv
       end
 
       def throttled_else_increment
-        Throttler::IsThrottledElseIncrement.call(user_id, :idv_acuant)
+        Throttler::IsThrottledElseIncrement.call(user_id, :idv_acuant, analytics: @flow.analytics)
       end
 
       def user_id

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -55,7 +55,7 @@ module Idv
       end
 
       def throttled_response
-        analytics.track_event(Analytics::IDV_DOC_AUTH_RATE_LIMIT_TRIGGERED)
+        analytics.track_event(Analytics::THROTTLER_RATE_LIMIT_TRIGGERED, throttle_type: :idv_acuant)
         redirect_to throttled_url
         IdentityDocAuth::Response.new(
           success: false,

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -59,10 +59,6 @@ module Idv
       def idv_failure(result)
         attempter_increment if result.extra.dig(:proofing_results, :exception).blank?
         if attempter_throttled?
-          @flow.analytics.track_event(
-            Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
-            throttle_type: :idv_resolution,
-          )
           redirect_to idv_session_errors_recovery_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           redirect_to idv_session_errors_recovery_exception_url

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -59,6 +59,7 @@ module Idv
       def idv_failure(result)
         attempter_increment if result.extra.dig(:proofing_results, :exception).blank?
         if attempter_throttled?
+          @flow.analytics.track_event(Analytics::IAL2_RECOVERY_REQUEST_RATE_LIMIT_TRIGGERED)
           redirect_to idv_session_errors_recovery_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           redirect_to idv_session_errors_recovery_exception_url

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -59,7 +59,10 @@ module Idv
       def idv_failure(result)
         attempter_increment if result.extra.dig(:proofing_results, :exception).blank?
         if attempter_throttled?
-          @flow.analytics.track_event(Analytics::IAL2_RECOVERY_REQUEST_RATE_LIMIT_TRIGGERED)
+          @flow.analytics.track_event(
+            Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+            throttle_type: :idv_resolution,
+          )
           redirect_to idv_session_errors_recovery_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           redirect_to idv_session_errors_recovery_exception_url

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -10,7 +10,10 @@ module Idv
       private
 
       def throttled_failure
-        analytics.track_event(Analytics::IDV_CAPTURE_DOC_LINK_SENT_RATE_LIMIT_TRIGGERED)
+        analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :idv_send_link,
+        )
         failure(I18n.t('errors.doc_auth.send_link_throttle'))
       end
 

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -2,12 +2,17 @@ module Idv
   module Steps
     class SendLinkStep < DocAuthBaseStep
       def call
-        return failure(I18n.t('errors.doc_auth.send_link_throttle')) if throttled_else_increment
+        return throttled_failure if throttled_else_increment
         telephony_result = send_link
         return failure(telephony_result.error.friendly_message) unless telephony_result.success?
       end
 
       private
+
+      def throttled_failure
+        analytics.track_event(Analytics::IDV_CAPTURE_DOC_LINK_SENT_RATE_LIMIT_TRIGGERED)
+        failure(I18n.t('errors.doc_auth.send_link_throttle'))
+      end
 
       def send_link
         session_uuid = flow_session[:document_capture_session_uuid]

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -2,20 +2,12 @@ module Idv
   module Steps
     class SendLinkStep < DocAuthBaseStep
       def call
-        return throttled_failure if throttled_else_increment
+        return failure(I18n.t('errors.doc_auth.send_link_throttle')) if throttled_else_increment
         telephony_result = send_link
         return failure(telephony_result.error.friendly_message) unless telephony_result.success?
       end
 
       private
-
-      def throttled_failure
-        analytics.track_event(
-          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
-          throttle_type: :idv_send_link,
-        )
-        failure(I18n.t('errors.doc_auth.send_link_throttle'))
-      end
 
       def send_link
         session_uuid = flow_session[:document_capture_session_uuid]
@@ -51,7 +43,11 @@ module Idv
       end
 
       def throttled_else_increment
-        Throttler::IsThrottledElseIncrement.call(user_id, :idv_send_link)
+        Throttler::IsThrottledElseIncrement.call(
+          user_id,
+          :idv_send_link,
+          analytics: @flow.analytics,
+        )
       end
     end
   end

--- a/app/services/throttler/increment.rb
+++ b/app/services/throttler/increment.rb
@@ -1,9 +1,13 @@
 module Throttler
   class Increment
-    def self.call(user_id, throttle_type)
+    def self.call(user_id, throttle_type, analytics: nil)
       throttle = Throttler::FindOrCreate.call(user_id, throttle_type)
       return throttle if throttle.maxed?
-      throttle.update(attempts: throttle.attempts + 1, attempted_at: Time.zone.now)
+      Update.call(
+        throttle: throttle,
+        attributes: { attempts: throttle.attempts + 1, attempted_at: Time.zone.now },
+        analytics: analytics,
+      )
       throttle
     end
   end

--- a/app/services/throttler/is_throttled_else_increment.rb
+++ b/app/services/throttler/is_throttled_else_increment.rb
@@ -1,9 +1,13 @@
 module Throttler
   class IsThrottledElseIncrement
-    def self.call(user_id, throttle_type)
+    def self.call(user_id, throttle_type, analytics: nil)
       throttle = FindOrCreate.call(user_id, throttle_type)
       return throttle if throttle.throttled?
-      throttle.update(attempts: throttle.attempts + 1, attempted_at: Time.zone.now)
+      Update.call(
+        throttle: throttle,
+        attributes: { attempts: throttle.attempts + 1, attempted_at: Time.zone.now },
+        analytics: analytics,
+      )
       false
     end
   end

--- a/app/services/throttler/reset.rb
+++ b/app/services/throttler/reset.rb
@@ -2,7 +2,7 @@ module Throttler
   class Reset
     def self.call(user_id, throttle_type)
       throttle = Throttle.find_or_create_by(user_id: user_id, throttle_type: throttle_type)
-      throttle.update(attempts: 0)
+      Update.call(throttle: throttle, attributes: { attempts: 0 })
       throttle
     end
   end

--- a/app/services/throttler/update.rb
+++ b/app/services/throttler/update.rb
@@ -1,0 +1,13 @@
+module Throttler
+  class Update
+    def self.call(throttle:, attributes:, analytics: nil)
+      was_throttled = throttle.throttled?
+      throttle.update(attributes)
+      analytics.track_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: throttle.throttle_type,
+      ) if analytics.present? && !was_throttled && throttle.throttled?
+      throttle
+    end
+  end
+end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -115,6 +115,7 @@ feature 'doc auth document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       allow(AppConfig.env).to receive(:acuant_max_attempts).and_return(max_attempts)
       max_attempts.times do
         attach_and_submit_images
@@ -127,6 +128,10 @@ feature 'doc auth document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: 'idv_acuant',
+      )
 
       Timecop.travel(AppConfig.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
         sign_in_and_2fa_user(user)
@@ -189,6 +194,7 @@ feature 'doc auth document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       allow(AppConfig.env).to receive(:acuant_max_attempts).and_return(max_attempts)
       max_attempts.times do
         attach_and_submit_images
@@ -201,6 +207,10 @@ feature 'doc auth document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: 'idv_acuant',
+      )
 
       Timecop.travel(AppConfig.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
         sign_in_and_2fa_user(user)

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -152,6 +152,7 @@ feature 'doc capture document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_front_image,
         response: IdentityDocAuth::Response.new(
@@ -168,6 +169,10 @@ feature 'doc capture document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: 'idv_acuant',
+      )
 
       IdentityDocAuth::Mock::DocAuthMockClient.reset!
 
@@ -234,6 +239,7 @@ feature 'doc capture document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_front_image,
         response: IdentityDocAuth::Response.new(
@@ -250,6 +256,10 @@ feature 'doc capture document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: 'idv_acuant',
+      )
 
       IdentityDocAuth::Mock::DocAuthMockClient.reset!
 

--- a/spec/forms/idv/api_document_verification_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
         document_capture_session_uuid: document_capture_session_uuid,
       },
       liveness_checking_enabled: liveness_checking_enabled?,
+      analytics: FakeAnalytics.new,
     )
   end
 

--- a/spec/services/throttler/update_spec.rb
+++ b/spec/services/throttler/update_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe Throttler::Update do
+  let(:user_id) { 1 }
+  let(:throttle_type) { :idv_acuant }
+  let(:subject) { described_class }
+  let(:throttle) do
+    Throttle.create(
+      user_id: user_id,
+      throttle_type: throttle_type,
+      attempts: 1,
+      attempted_at: Time.zone.now,
+    )
+  end
+  let(:analytics) { FakeAnalytics.new }
+
+  it 'updates' do
+    subject.call(throttle: throttle, attributes: { attempts: 2 }, analytics: analytics)
+
+    expect(throttle.saved_change_to_attribute?(:attempts)).to be_truthy
+  end
+
+  it 'logs if model flips to throttled' do
+    max_attempts, _attempt_window_in_minutes = Throttle.config_values(throttle_type)
+    subject.call(
+      throttle: throttle,
+      attributes: { attempts: max_attempts + 1 },
+      analytics: analytics,
+    )
+
+    expect(analytics).to have_logged_event(
+      Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+      throttle_type: throttle_type.to_s,
+    )
+  end
+end


### PR DESCRIPTION
**Why**: As a login.gov developer, i want to see an event in the event log that indicates that a user was locked out for 6 hours from proofing along with the relevant data points that directly resulted in that lockout, so that I can troubleshoot any issues reported by end users and pinpoint exactly what caused the lock out.