### PR TITLE
Remove Hakiri badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Login.gov Identity Provider (IdP)
 [![Build Status](https://circleci.com/gh/18F/identity-idp.svg?style=svg)](https://circleci.com/gh/18F/identity-idp)
 [![Code Climate](https://api.codeclimate.com/v1/badges/e78d453f7cbcac64a664/maintainability)](https://codeclimate.com/github/18F/identity-idp/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e78d453f7cbcac64a664/test_coverage)](https://codeclimate.com/github/18F/identity-idp/test_coverage)
-[![security](https://hakiri.io/github/18F/identity-idp/main.svg)](https://hakiri.io/github/18F/identity-idp/main)
 
 Login.gov is the public's one account for government. Use one account and password for secure, private access to participating government agencies.
 


### PR DESCRIPTION
**Why**:

- It's a broken link and image, presumably from master to main migration
- Precedent: https://github.com/18F/identity-dashboard/pull/398#discussion_r593435574
- We use Snyk for security scanning (see checks on this pull request)