### PR TITLE
make the addition of attempts_remaining more explicit (LG-4252)

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -55,10 +55,7 @@ module Idv
       response = Idv::DocAuthFormResponse.new(
         success: valid?,
         errors: errors.messages,
-        extra: {
-          remaining_attempts: remaining_attempts,
-          user_id: user_uuid,
-        },
+        extra: extra_attributes,
       )
 
       track_event(
@@ -76,7 +73,7 @@ module Idv
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
       )
-      response = response.merge(remaining_attempts_response)
+      response = response.merge(extra_attributes_response)
 
       update_analytics(response)
 
@@ -85,7 +82,7 @@ module Idv
 
     def validate_pii_from_doc(client_response)
       response = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
-      response = response.merge(remaining_attempts_response)
+      response = response.merge(extra_attributes_response)
 
       track_event(
         Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
@@ -96,16 +93,19 @@ module Idv
       response
     end
 
-    # A successful response providing remaining attempts and user_id to merge into other responses
-    def remaining_attempts_response
-      @remaining_attempts_response ||= Idv::DocAuthFormResponse.new(
+    def extra_attributes_response
+      @extra_attributes_response ||= Idv::DocAuthFormResponse.new(
         success: true,
-        errors: nil,
-        extra: {
-          remaining_attempts: remaining_attempts,
-          user_id: user_uuid,
-        },
+        errors: {},
+        extra: extra_attributes,
       )
+    end
+
+    def extra_attributes
+      @extra_attributes ||= {
+        remaining_attempts: remaining_attempts,
+        user_id: user_uuid,
+      }
     end
 
     def remaining_attempts

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -213,6 +213,7 @@ describe Idv::ImageUploadsController do
           exception: nil,
           result: 'Passed',
           user_id: user.uuid,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -220,6 +221,7 @@ describe Idv::ImageUploadsController do
           success: true,
           errors: {},
           user_id: user.uuid,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
         )
 
         action
@@ -272,6 +274,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               result: 'Passed',
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -281,6 +284,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.lexis_nexis.full_name_check')],
               },
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             action
@@ -309,6 +313,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               result: 'Passed',
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -318,6 +323,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')],
               },
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             action
@@ -346,6 +352,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               result: 'Passed',
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -355,6 +362,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks')],
               },
               user_id: user.uuid,
+              remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
             )
 
             action
@@ -404,6 +412,7 @@ describe Idv::ImageUploadsController do
             front: ['Too blurry', 'Wrong document'],
           },
           user_id: user.uuid,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
           exception: nil,
         )
 
@@ -449,6 +458,7 @@ describe Idv::ImageUploadsController do
           result: 'Caution',
           exception: nil,
           user_id: user.uuid,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1,
         )
 
         action

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -100,7 +100,11 @@ RSpec.describe Idv::ApiImageUploadForm do
 
     context 'posting images to client fails' do
       let(:failed_response) do
-        IdentityDocAuth::Response.new(success: false, errors: { front: 'glare' })
+        IdentityDocAuth::Response.new(
+          success: false,
+          errors: { front: 'glare' },
+          extra: { remaining_attempts: AppConfig.env.acuant_max_attempts.to_i - 1 },
+        )
       end
       before do
         allow(subject).to receive(:post_images_to_client).and_return(failed_response)


### PR DESCRIPTION
@aduth had noted in #4800 that having `form_response` as an instance variable seemed awkward and likely unnecessary. It was being used to merge that response into the client and doc_pii responses solely to get the remaining attempts copied into each of those. This PR leaves the form_response as it's own thing, and generates an empty, except for the extra vars we want, for the purposes of merging into the client and doc_pii responses. This makes the purpose of the merge much more evident and cleans the code even further.