### PR TITLE
LG-4371: Messaging for users to keep their browser window/tab open

### DIFF
--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -23,15 +23,15 @@
   margin: 0 auto;
 }
 
-.js-fallback {
+// scss-lint:disable QualifyingElement
+html.no-js .js {
   display: none;
 }
 
-.no-js {
-  .js-fallback {
-    display: block;
-  }
+html.js .no-js {
+  display: none;
 }
+// scss-lint:enable QualifyingElement
 
 .scale-down {
   // trigger anti-aliasing in chrome

--- a/app/javascript/app/utils/index.js
+++ b/app/javascript/app/utils/index.js
@@ -4,9 +4,6 @@ import msFormatter from './ms-formatter';
 
 window.LoginGov = window.LoginGov || {};
 const { LoginGov } = window;
-const { documentElement } = window.document;
-
-documentElement.className = documentElement.className.replace(/no-js/, '');
 
 LoginGov.autoLogout = autoLogout;
 LoginGov.countdownTimer = countdownTimer;

--- a/app/javascript/packages/document-capture-polling/index.js
+++ b/app/javascript/packages/document-capture-polling/index.js
@@ -10,7 +10,6 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
  * @typedef DocumentCapturePollingElements
  *
  * @prop {HTMLFormElement} form
- * @prop {HTMLParagraphElement} instructions
  */
 
 /**
@@ -47,7 +46,6 @@ export class DocumentCapturePolling {
    */
   toggleFormVisible(isVisible) {
     this.elements.form.classList.toggle('display-none', !isVisible);
-    this.elements.instructions.classList.toggle('display-none', !isVisible);
   }
 
   onMaxPollAttempts() {

--- a/app/javascript/packs/doc-capture-polling.js
+++ b/app/javascript/packs/doc-capture-polling.js
@@ -9,9 +9,6 @@ loadPolyfills(['fetch', 'classlist']).then(() => {
       form: /** @type {HTMLFormElement} */ (document.querySelector(
         '.doc_capture_continue_button_form',
       )),
-      instructions: /** @type {HTMLParagraphElement} */ (document.querySelector(
-        '#doc_capture_continue_instructions',
-      )),
     },
   }).bind();
 });

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -7,6 +7,7 @@
 <% if flow_session[:error_message] %>
   <%= render 'shared/alert', {
     type: 'error',
+    class: 'margin-bottom-4',
     message: flow_session[:error_message],
   } %>
 <% end %>
@@ -31,7 +32,7 @@
 </div>
 
 <% if !is_cancelled %>
-  <div class="margin-top-2 margin-bottom-0">
+  <div class="margin-top-4 margin-bottom-0">
     <%=
       button_to(
         t('forms.buttons.continue'),

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -19,11 +19,13 @@
     <%= image_tag asset_url('idv/phone.png'), alt: t('image_description.camera_mobile_phone') %>
   </div>
   <div class='sm-col sm-col-9 padding-x-1 h2 margin-bottom-2 margin-top-0 margin-y-0'>
-    <p><%= t('doc_auth.info.link_sent').first %></p>
+    <p><%= t('doc_auth.info.link_sent') %></p>
     <% if !is_cancelled %>
-      <p id="doc_capture_continue_instructions" class="margin-bottom-0">
-        <%= t('doc_auth.info.link_sent').last %>
-      </p>
+      <%= render 'shared/alert', type: 'warning' do %>
+        <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>
+        <span class="no-js"><%= t('doc_auth.info.link_sent_complete_nojs') %></span>
+        <span class="js"><%= t('doc_auth.info.link_sent_complete_js') %></span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -31,7 +31,7 @@
   selfie_image_upload_url: selfie_image_upload_url,
   keep_alive_endpoint: sessions_keepalive_url,
 } %>
-<div class="js-fallback">
+<div class="no-js">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
   <h1 class="h3 margin-y-0">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -23,6 +23,9 @@
     <%= APP_NAME %><%= raw(" - #{yield(:title)}") if content_for?(:title) %>
   </title>
 
+  <%= nonced_javascript_tag do %>
+    document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+  <% end %>
   <%= preload_link_tag font_url('identity-style-guide/dist/assets/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2') %>
   <%= preload_link_tag font_url('identity-style-guide/dist/assets/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2') %>
   <%= preload_link_tag font_url('identity-style-guide/dist/assets/fonts/merriweather/Latin-Merriweather-Bold.woff2') %>

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.reactivate_account') %>
 
-<div class="js-fallback">
+<div class="no-js">
   <%= render 'shared/alert', {
     type: 'warning',
     class: 'margin-bottom-4',

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -121,10 +121,13 @@ en:
       interstitial_eta: This might take up to a minute. We’ll load the next step automatically
         when it’s done.
       interstitial_thanks: Thanks for your patience!
-      link_sent:
-      - Please check your phone and follow instructions to take a photo of your state
-        issued ID.
-      - When you are done click continue here to finish verifying your identity.
+      keep_window_open: Do not close this window.
+      link_sent: Please check your phone and follow instructions to take a photo of
+        your state issued ID.
+      link_sent_complete_js: The next step will load automatically once you verify
+        your ID using your phone.
+      link_sent_complete_nojs: When you are done, click Continue here to finish verifying
+        your identity.
       no_other_id_help_bold_html: "<strong>If you do not have a state-issued ID</strong>,
         <a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>"
       tag: Recommended

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -129,11 +129,13 @@ es:
       interstitial_eta: Esto puede tardar hasta un minuto. Cargaremos el siguiente
         paso automáticamente cuando esté terminado.
       interstitial_thanks: "¡Gracias por su paciencia!"
-      link_sent:
-      - Verifique su teléfono y siga las instrucciones para tomar una fotografía de
-        la identificación emitida por su estado.
-      - Cuando haya terminado, haga clic en continuar aquí para terminar de verificar
-        su identidad.
+      keep_window_open: No cierres esta ventana.
+      link_sent: Verifique su teléfono y siga las instrucciones para tomar una fotografía
+        de la identificación emitida por su estado.
+      link_sent_complete_js: El siguiente paso se cargará automáticamente una vez
+        que verifiques tu identidad a través de tu teléfono.
+      link_sent_complete_nojs: Cuando termines, haz clic en "Continuar" para completar
+        la verificación de tu identidad.
       no_other_id_help_bold_html: "<strong>Si no tiene un documento de identidad expedido
         por el estado</strong>, <a href=%{failure_to_proof_url}>obtenga ayuda en %{sp_name}.</a>"
       tag: Recomendado

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -140,10 +140,13 @@ fr:
       interstitial_eta: Cette opération peut prendre jusqu'à une minute. Nous chargerons
         automatiquement l'étape suivante lorsqu'elle sera terminée.
       interstitial_thanks: Merci de votre patience!
-      link_sent:
-      - Veuillez vérifier votre téléphone et suivre les instructions pour prendre
-        une photo de votre identité émise par l'État.
-      - Lorsque vous avez terminé, cliquez ici pour continuer à vérifier votre identité.
+      keep_window_open: Ne fermez pas cette fenêtre.
+      link_sent: Veuillez vérifier votre téléphone et suivre les instructions pour
+        prendre une photo de votre identité émise par l'État.
+      link_sent_complete_js: L'étape suivante se chargera automatiquement une fois
+        que vous aurez confirmé votre identifiant à l'aide de votre téléphone.
+      link_sent_complete_nojs: Quand vous aurez fini, cliquez sur « Continuer » ici
+        pour terminer la vérification de votre identité.
       no_other_id_help_bold_html: "<strong>Si vous n'avez pas de carte d'identité
         délivrée par l'État</strong>, <a href=%{failure_to_proof_url}>obtenez de l'aide
         à l'adresse %{sp_name}.</a>"

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -57,7 +57,7 @@ feature 'doc auth link sent step' do
 
     it 'does not show continue button or instruction text' do
       expect(page).to_not have_button(t('forms.buttons.continue'), visible: :all)
-      expect(page).to_not have_content(:all, t('doc_auth.info.link_sent').last)
+      expect(page).to_not have_content(:all, t('doc_auth.info.link_sent_complete_nojs'))
     end
   end
 
@@ -72,7 +72,8 @@ feature 'doc auth link sent step' do
     it 'automatically advances when the mobile flow is complete' do
       expect(page).to_not have_css 'meta[http-equiv="refresh"]', visible: false
       expect(page).to_not have_button(t('forms.buttons.continue'))
-      expect(page).to_not have_content(t('doc_auth.info.link_sent').last)
+      expect(page).to_not have_content(t('doc_auth.info.link_sent_complete_nojs'))
+      expect(page).to have_content(t('doc_auth.info.link_sent_complete_js'))
 
       mock_doc_captured(user.id)
 

--- a/spec/javascripts/packages/document-capture-polling/index-spec.js
+++ b/spec/javascripts/packages/document-capture-polling/index-spec.js
@@ -45,8 +45,7 @@ describe('DocumentCapturePolling', () => {
     subject.bind();
   });
 
-  it('hides form and instructions', () => {
-    expect(screen.getByText('Instructions').closest('.display-none')).to.be.ok();
+  it('hides form', () => {
     expect(screen.getByText('Submit').closest('.display-none')).to.be.ok();
   });
 


### PR DESCRIPTION
**Why**: As a user, I want to be reminded to keep my browser window/tab open while I am being redirected from my desktop to mobile phone to complete doc auth step so that I can continue the proofing flow when I am back on my desktop.

**Screenshots:**

&nbsp;|Before|After
---|---|---
JavaScript Enabled|<img width="1074" alt="Screen Shot 2021-03-17 at 5 49 59 PM" src="https://user-images.githubusercontent.com/1779930/111543407-657d3980-8749-11eb-9731-c67febac4682.png">|<img width="1118" alt="Screen Shot 2021-03-17 at 5 49 13 PM" src="https://user-images.githubusercontent.com/1779930/111543440-70d06500-8749-11eb-8cfb-53b7e36d8d51.png">
JavaScript Disabled|<img width="1118" alt="Screen Shot 2021-03-17 at 5 50 10 PM" src="https://user-images.githubusercontent.com/1779930/111543384-5a2a0e00-8749-11eb-9b78-093de5ddb7d1.png">|<img width="1118" alt="Screen Shot 2021-03-17 at 5 49 28 PM" src="https://user-images.githubusercontent.com/1779930/111543422-6910c080-8749-11eb-9572-64c625be9e30.png">


