### PR TITLE
Include new Acuant SDK initialization endpoint in CSP connect directive

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -7,7 +7,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_permitted_cross_domain_policies = 'none'
 
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
-                 'services.assureid.net']
+                 'us.acas.acuant.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   default_csp_config = {
     default_src: ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -7,7 +7,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_permitted_cross_domain_policies = 'none'
 
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
-                 'us.acas.acuant.net']
+                 'us.acas.acuant.net', 'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   default_csp_config = {
     default_src: ["'self'"],


### PR DESCRIPTION
**Why**: Per [Acuant SDK migration guide](https://github.com/Acuant/JavascriptWebSDKV11/blob/master/SimpleHTMLApp/docs/MigrationDetail11.4.2.md) and `acuant_sdk_initialization_endpoint` configuration value updated in #4749, the new Acuant initialization endpoint host should be allowed in connect directive of CSP headers.

The old value should be removed, but we may want to keep it for an initial deploy.