### PR TITLE
LG-4135: Remove old Acuant SDK initialization endpoint from CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -7,7 +7,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_permitted_cross_domain_policies = 'none'
 
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
-                 'us.acas.acuant.net', 'services.assureid.net']
+                 'us.acas.acuant.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   default_csp_config = {
     default_src: ["'self'"],


### PR DESCRIPTION
**Why**: As follow-up to #4812, remove old Acuant SDK initialization endpoint. As of Acuant Web SDK v11.4.2, the endpoint has changed to the acuant.net host already present in the CSP headers.

See:
- https://github.com/Acuant/JavascriptWebSDKV11/blob/master/SimpleHTMLApp/docs/MigrationDetail11.4.2.md
- #4812