### PR TITLE
Add a rake task for reporting deployments to NewRelic

### DIFF
--- a/lib/tasks/newrelic.rake
+++ b/lib/tasks/newrelic.rake
@@ -1,0 +1,18 @@
+namespace :newrelic do
+  ##
+  # This task is essentially the same as running the following:
+  #
+  #     bundle exec newrelic deployment -r $(git rev-parse HEAD)
+  #
+  # The reason for the rake task is that our `newrelic.yml` file contains ERB
+  # blocks that expect the AppConfig to be setup and for identity-hostdata to be
+  # loaded. This rake task loads the rails environment before reporting the
+  # deployment so the NewRelic config is loaded correctly.
+  #
+  desc 'Report a new deployment to NewRelic'
+  task deployment: :environment do
+    require 'new_relic/cli/command'
+    revision = `git rev-parse HEAD`.chomp
+    NewRelic::Cli::Deployments.new(revision: `git rev-parse HEAD`).run
+  end
+end


### PR DESCRIPTION
**Why**: Our NewRelic config expects several tools to be part of the runtime in order to work. This means that `bundle exec newrelic deployment` breaks because it does not load the rails environment and thusly does not load `AppConfig` or `Identity::Hostdata`.

This change is the third of these solutions I investigated:

1. Add an ERB block to the NR config to setup AppConfig and load Hostdata
2. Completely rebuild the NR config to use env vars instead of our app's tooling (eventually we should pursue this as it is a better long-term solution)
3. Wrapping the deployment call in a rake task that loads the rails environment