### PR TITLE
Don't try to apply web or worker config overrides if web_or_worker_yaml is nil

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -162,7 +162,7 @@ module Deploy
       config = YAML.load_file(example_application_yaml_path).
         deep_merge(YAML.load_file(env_yaml_path))
 
-      if File.exist?(web_or_worker_yaml_path)
+      if web_or_worker_yml && File.exist?(web_or_worker_yaml_path)
         config.deep_merge(YAML.load_file(web_or_worker_yaml_path))
       else
         config


### PR DESCRIPTION


**Why**: If the `web_or_worker_yml` method returns `nil`, then we'll try to load configs from `$IDP_BASE/config/`. This doesn't work because a directory is not valid yaml.