### PR TITLE
LG-4305: Log new event in case of lockout from proofing (2)

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -159,7 +159,13 @@ module Idv
     end
 
     def max_attempts_reached
-      flash_error if idv_attempter_throttled?
+      if idv_attempter_throttled?
+        analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :idv_resolution,
+        )
+        flash_error
+      end
     end
 
     def error_message

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -28,6 +28,10 @@ module Users
       )
 
       if throttled
+        analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :verify_gpo_key,
+        )
         render :throttled
       else
         result = @verify_account_form.submit

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -38,6 +38,7 @@ module Users
           flash[:success] = t('account.index.verification.success')
           redirect_to sign_up_completed_url
         else
+          flash[:error] = @verify_account_form.errors.first.message
           redirect_to verify_account_url
         end
       end

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -38,7 +38,7 @@ module Users
           flash[:success] = t('account.index.verification.success')
           redirect_to sign_up_completed_url
         else
-          render :index
+          redirect_to verify_account_url
         end
       end
     end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -65,7 +65,7 @@ module Users
     end
 
     def handle_failure(result)
-      flash.now[:error] = result.errors[:personal_key].last
+      flash[:error] = result.errors[:personal_key].last
       redirect_to verify_personal_key_url
     end
 

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -66,7 +66,7 @@ module Users
 
     def handle_failure(result)
       flash.now[:error] = result.errors[:personal_key].last
-      render :new
+      redirect_to verify_personal_key_url
     end
 
     def personal_key_form

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -27,6 +27,10 @@ module Users
       )
 
       if throttled
+        analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :verify_personal_key,
+        )
         render :throttled
       else
         result = personal_key_form.submit

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -14,7 +14,7 @@ module Users
       )
 
       if Throttler::IsThrottled.call(current_user.id, :verify_personal_key)
-        render :throttled
+        render_throttled
       else
         render :new
       end
@@ -27,11 +27,7 @@ module Users
       )
 
       if throttled
-        analytics.track_event(
-          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
-          throttle_type: :verify_personal_key,
-        )
-        render :throttled
+        render_throttled
       else
         result = personal_key_form.submit
 
@@ -45,6 +41,15 @@ module Users
     end
 
     private
+
+    def render_throttled
+      analytics.track_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :verify_personal_key,
+      )
+
+      render :throttled
+    end
 
     def init_account_reactivation
       return if reactivate_account_session.started?

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -12,9 +12,10 @@ module Idv
 
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:)
+    def initialize(params, liveness_checking_enabled:, analytics:)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
+      @analytics = analytics
     end
 
     def submit
@@ -78,6 +79,10 @@ module Idv
 
     def throttle_if_rate_limited
       return unless @throttled
+      @analytics.track_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_acuant,
+      )
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -153,6 +153,7 @@ module Idv
 
     def throttle_if_rate_limited
       return unless @throttled
+      track_event(Analytics::THROTTLER_RATE_LIMIT_TRIGGERED, throttle_type: :idv_acuant)
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -200,6 +200,7 @@ class Analytics
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'.freeze
+  THROTTLER_RATE_LIMIT_TRIGGERED = 'Throttler Rate Limit Triggered'.freeze
   TOTP_SETUP_VISIT = 'TOTP Setup Visited'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze
   OTP_PHONE_VALIDATION_FAILED = 'Twilio Phone Validation Failed'.freeze

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -25,6 +25,7 @@ module Idv
         @form ||= Idv::ApiDocumentVerificationForm.new(
           params,
           liveness_checking_enabled: liveness_checking_enabled?,
+          analytics: @flow.analytics,
         )
       end
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -22,6 +22,10 @@ module Idv
       def idv_failure(result)
         attempter_increment if result.extra.dig(:proofing_results, :exception).blank?
         if attempter_throttled?
+          @flow.analytics.track_event(
+            Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+            throttle_type: :idv_resolution,
+          )
           redirect_to idv_session_errors_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           redirect_to idv_session_errors_exception_url
@@ -55,6 +59,10 @@ module Idv
       end
 
       def throttled_response
+        @flow.analytics.track_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :idv_acuant,
+        )
         redirect_to throttled_url
         IdentityDocAuth::Response.new(
           success: false,

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -59,6 +59,10 @@ module Idv
       def idv_failure(result)
         attempter_increment if result.extra.dig(:proofing_results, :exception).blank?
         if attempter_throttled?
+          @flow.analytics.track_event(
+            Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+            throttle_type: :idv_resolution,
+          )
           redirect_to idv_session_errors_recovery_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           redirect_to idv_session_errors_recovery_exception_url

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -8,7 +8,6 @@
 </p>
 <%= validated_form_for(@verify_account_form, url: verify_account_path,
                      html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
-  <%= f.error :base %>
   <%= f.input :otp, required: true, input_html: { aria: { invalid: false } },
     label: t('forms.verify_profile.name'), wrapper_html: { class: 'margin-bottom-4' }, wrapper: :inline_form do %>
     <%= f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10', value: @code %>

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Users::VerifyAccountController do
     context 'with an invalid form' do
       let(:submitted_otp) { 'the-wrong-otp' }
 
-      it 'renders the index page to show errors' do
+      it 'redirects to the index page to show errors' do
         expect(@analytics).to receive(:track_event).with(
           Analytics::ACCOUNT_VERIFICATION_SUBMITTED,
           success: false, errors: { otp: [t('errors.messages.confirmation_code_incorrect')]},
@@ -114,7 +114,7 @@ RSpec.describe Users::VerifyAccountController do
 
         action
 
-        expect(response).to render_template('users/verify_account/index')
+        expect(response).to redirect_to(verify_account_url)
       end
     end
 

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe Users::VerifyAccountController do
           success: false, errors: { otp: [t('errors.messages.confirmation_code_incorrect')]},
         ).exactly(max_attempts).times
 
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :verify_gpo_key,
+        ).once
+
         (max_attempts + 1).times do |i|
           post(
             :create,

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -109,6 +109,10 @@ describe Users::VerifyPersonalKeyController do
           Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED,
           { errors: { personal_key: ['bad_key'] }, success: false },
         ).once
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :verify_personal_key,
+        ).once
 
         post :create, params: { personal_key: bad_key }
         post :create, params: { personal_key: bad_key }

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -112,8 +112,8 @@ describe Users::VerifyPersonalKeyController do
         expect(flash[:error]).to eq(error_text)
       end
 
-      it 'renders the new template' do
-        expect(response).to render_template(:new)
+      it 'redirects to form' do
+        expect(response).to redirect_to(verify_personal_key_url)
       end
     end
 

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -115,6 +115,7 @@ feature 'doc auth document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       allow(AppConfig.env).to receive(:acuant_max_attempts).and_return(max_attempts)
       max_attempts.times do
         attach_and_submit_images
@@ -127,6 +128,10 @@ feature 'doc auth document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_acuant,
+      )
 
       Timecop.travel(AppConfig.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
         sign_in_and_2fa_user(user)
@@ -189,6 +194,7 @@ feature 'doc auth document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       allow(AppConfig.env).to receive(:acuant_max_attempts).and_return(max_attempts)
       max_attempts.times do
         attach_and_submit_images
@@ -201,6 +207,10 @@ feature 'doc auth document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_acuant,
+      )
 
       Timecop.travel(AppConfig.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
         sign_in_and_2fa_user(user)

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -152,6 +152,7 @@ feature 'doc capture document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_front_image,
         response: IdentityDocAuth::Response.new(
@@ -168,6 +169,10 @@ feature 'doc capture document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_acuant,
+      )
 
       IdentityDocAuth::Mock::DocAuthMockClient.reset!
 
@@ -234,6 +239,7 @@ feature 'doc capture document capture step' do
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_front_image,
         response: IdentityDocAuth::Response.new(
@@ -250,6 +256,10 @@ feature 'doc capture document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_session_errors_throttled_path)
+      expect(fake_analytics).to have_logged_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_acuant,
+      )
 
       IdentityDocAuth::Mock::DocAuthMockClient.reset!
 

--- a/spec/forms/idv/api_document_verification_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
         document_capture_session_uuid: document_capture_session_uuid,
       },
       liveness_checking_enabled: liveness_checking_enabled?,
+      analytics: analytics,
     )
   end
 
@@ -26,6 +27,7 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
   let(:selfie_image_iv) { 'selfie-iv' }
   let!(:document_capture_session) { DocumentCaptureSession.create! }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
+  let(:analytics) { FakeAnalytics.new }
   let(:liveness_checking_enabled?) { true }
 
   describe '#valid?' do
@@ -119,6 +121,10 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
         expect(form.valid?).to eq(false)
         expect(form.errors.attribute_names).to eq([:limit])
         expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.acuant_throttle')])
+        expect(analytics).to have_logged_event(
+          Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+          throttle_type: :idv_acuant,
+        )
       end
     end
   end


### PR DESCRIPTION
Originally: #4803

**Why**: As a login.gov developer, i want to see an event in the event log that indicates that a user was locked out for 6 hours from proofing along with the relevant data points that directly resulted in that lockout, so that I can troubleshoot any issues reported by end users and pinpoint exactly what caused the lock out.

Builds on (merges to) #4824

Cherry-picks from #4803