### PR TITLE
Remove USPS references from IDV session

### DIFF
--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -27,7 +27,7 @@ module Idv
     def next_step
       if session[:sp] && !pending_profile?
         sign_up_completed_url
-      elsif pending_profile? && %w[gpo usps].include?(idv_session.address_verification_mechanism)
+      elsif pending_profile? && idv_session.address_verification_mechanism == 'gpo'
         idv_come_back_later_url
       else
         after_sign_in_path_for(current_user)

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -53,8 +53,7 @@ module Idv
     private
 
     def flash_message_content
-      # NOTE: remove usps after next deploy
-      if %w[gpo usps].include?(idv_session.address_verification_mechanism)
+      if idv_session.address_verification_mechanism == 'gpo'
         t('idv.messages.mail_sent')
       else
         phone_of_record_msg = ActionController::Base.helpers.content_tag(

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,18 +1,15 @@
 module Idv
   class Session
-    # NOTE: remove _usps_ attributes after next deploy
     VALID_SESSION_ATTRIBUTES = %i[
       address_verification_mechanism
       applicant
       idv_phone_step_document_capture_session_uuid
-      idv_usps_document_capture_session_uuid
       idv_gpo_document_capture_session_uuid
       vendor_phone_confirmation
       user_phone_confirmation
       pii
       previous_phone_step_params
       previous_profile_step_params
-      previous_usps_step_params
       previous_gpo_step_params
       profile_confirmation
       profile_id
@@ -29,24 +26,6 @@ module Idv
       @current_user = current_user
       @issuer = issuer
       set_idv_session
-    end
-
-    def idv_gpo_document_capture_session_uuid(value = nil)
-      if value
-        session[:idv_gpo_document_capture_session_uuid] = value
-      else
-        session[:idv_gpo_document_capture_session_uuid] ||
-          session[:idv_usps_document_capture_session_uuid]
-      end
-    end
-
-    def previous_gpo_step_params(value = nil)
-      if value
-        session[:previous_gpo_step_params] = value
-      else
-        session[:previous_gpo_step_params] ||
-          session[:previous_usps_step_params]
-      end
     end
 
     def method_missing(method_sym, *arguments, &block)
@@ -99,7 +78,7 @@ module Idv
 
     def complete_session
       complete_profile if phone_confirmed?
-      create_gpo_entry if %w[usps gpo].include?(address_verification_mechanism)
+      create_gpo_entry if address_verification_mechanism == 'gpo'
     end
 
     def complete_profile
@@ -121,7 +100,7 @@ module Idv
     end
 
     def address_mechanism_chosen?
-      vendor_phone_confirmation == true || %w[gpo usps].include?(address_verification_mechanism)
+      vendor_phone_confirmation == true || address_verification_mechanism == 'gpo'
     end
 
     def user_phone_confirmation_session

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -120,12 +120,6 @@ describe Idv::Session do
       end
     end
 
-    it 'returns true if the user has selected gpo address verification (legacy value)' do
-      subject.address_verification_mechanism = 'usps'
-
-      expect(subject.address_mechanism_chosen?).to eq(true)
-    end
-
     it 'returns true if the user has selected gpo address verification' do
       subject.address_verification_mechanism = 'gpo'
 


### PR DESCRIPTION
This is a small change to remove some backwards-compatible code added in #4837

It needs to be merged *after* that code has been deployed.

**View the [incremental diff](https://github.com/18F/identity-idp/compare/margolis-rename-usps-gpo...margolis-remove-usps-session)**, it's really just one commit
