### PR TITLE
Refactor account action button as independent from BassCSS

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -96,18 +96,23 @@
   cursor: not-allowed;
 }
 
-.btn-account-action {
+.account-action-button {
+  @include u-radius('lg');
+  background-color: color('primary-lighter');
   border: 0;
   color: $blue;
+  display: inline-block;
   font-size: .8125rem;
   font-weight: normal;
+  line-height: 1.375rem;
   margin-bottom: -3px;
   margin-top: -3px;
   padding: .5rem;
   padding-bottom: .125rem;
   padding-top: .125rem;
 
-  a {
+  &,
+  &:hover {
     text-decoration: none;
   }
 }

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -8,7 +8,7 @@
         <%= link_to(
           prefix_with_plus(t('account.index.auth_app_add')),
           authenticator_setup_url,
-          class: 'btn btn-account-action rounded-lg bg-light-blue',
+          class: 'account-action-button',
         ) %>
       </div>
     <% end %>

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -8,7 +8,7 @@
         <%= link_to(
           prefix_with_plus(t('account.index.email_add')),
           add_email_path,
-          class: 'btn btn-account-action rounded-lg bg-light-blue',
+          class: 'account-action-button',
         ) %>
       <% end %>
     </div>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -8,7 +8,7 @@
         <%= link_to(
           prefix_with_plus(t('account.index.phone_add')),
           add_phone_path,
-          class: 'btn btn-account-action rounded-lg bg-light-blue',
+          class: 'account-action-button',
         ) %>
       <% end %>
     </div>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -8,7 +8,7 @@
         <%= link_to(
           prefix_with_plus(t('account.index.piv_cac_add')),
           setup_piv_cac_url,
-          class: 'btn btn-account-action rounded-lg bg-light-blue',
+          class: 'account-action-button',
         ) %>
       </div>
     <% end %>

--- a/app/views/accounts/_webauthn.html.erb
+++ b/app/views/accounts/_webauthn.html.erb
@@ -7,7 +7,7 @@
       <%= link_to(
         prefix_with_plus(t('account.index.webauthn_add')),
         webauthn_setup_path,
-        class: 'btn btn-account-action rounded-lg bg-light-blue',
+        class: 'account-action-button',
       ) %>
     </div>
   </div>

--- a/app/views/accounts/actions/_generate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_generate_backup_codes.html.erb
@@ -1,3 +1,3 @@
 <%= link_to prefix_with_plus(t('forms.backup_code.generate')),
             backup_code_create_path,
-            class: 'btn btn-account-action rounded-lg bg-light-blue' %>
+            class: 'account-action-button' %>

--- a/app/views/accounts/actions/_regenerate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_regenerate_backup_codes.html.erb
@@ -1,3 +1,3 @@
-<%= link_to backup_code_regenerate_path, class: 'btn btn-account-action rounded-lg bg-light-blue' do %>
+<%= link_to backup_code_regenerate_path, class: 'account-action-button' do %>
   <%= prefix_with_plus(t('forms.backup_code.regenerate')) %>
 <% end %>


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4836#discussion_r601813531

**Why**: As part of LG-3865, will be eliminating BassCSS buttons as a dependency. Account action buttons currently inherit styles from BassCSS, and there is not a standalone design system alternative.

It's expected that account action buttons should appear visually identical before and after these changes.