### PR TITLE
Remove unreachable TOTP / PIVCAC enable partials

### DIFF
--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -55,40 +55,6 @@ class AccountShow
     decrypted_pii.present? || decorated_user.identity_verified?
   end
 
-  def totp_partial
-    if TwoFactorAuthentication::AuthAppPolicy.new(decorated_user.user).enabled?
-      disable_totp_partial
-    else
-      enable_totp_partial
-    end
-  end
-
-  def disable_totp_partial
-    return 'shared/null' unless MfaPolicy.new(decorated_user.user).multiple_factors_enabled?
-    'accounts/actions/disable_totp'
-  end
-
-  def enable_totp_partial
-    'accounts/actions/enable_totp'
-  end
-
-  def piv_cac_partial
-    if TwoFactorAuthentication::PivCacPolicy.new(decorated_user.user).enabled?
-      disable_piv_cac_partial
-    else
-      enable_piv_cac_partial
-    end
-  end
-
-  def disable_piv_cac_partial
-    return 'shared/null' unless MfaPolicy.new(decorated_user.user).multiple_factors_enabled?
-    'accounts/actions/disable_piv_cac'
-  end
-
-  def enable_piv_cac_partial
-    'accounts/actions/enable_piv_cac'
-  end
-
   def show_manage_personal_key_partial?
     if TwoFactorAuthentication::PersonalKeyPolicy.new(decorated_user.user).visible? &&
        decorated_user.password_reset_profile.blank?

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -23,7 +23,7 @@
           </div>
         </div>
         <div class="grid-col-4 right-align">
-          <%= render @view_model.totp_partial, id: auth_app_configuration.id %>
+          <%= render 'accounts/actions/disable_totp', id: auth_app_configuration.id %>
         </div>
       </div>
     <% end %>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -23,7 +23,7 @@
           </div>
         </div>
         <div class="grid-col-4 right-align">
-          <%= render @view_model.piv_cac_partial, id: piv_cac_configuration.id %>
+          <%= render 'accounts/actions/disable_piv_cac', id: piv_cac_configuration.id %>
         </div>
       </div>
     <% end %>

--- a/app/views/accounts/actions/_enable_piv_cac.html.erb
+++ b/app/views/accounts/actions/_enable_piv_cac.html.erb
@@ -1,6 +1,0 @@
-<%= link_to setup_piv_cac_url, class: 'btn btn-account-action rounded-lg bg-light-blue add-piv' do %>
-  <span class="usa-sr-only">
-    <%= t('account.index.piv_cac_card') %>
-  </span>
-  <%= prefix_with_plus(t('forms.buttons.enable')) %>
-<% end %>

--- a/app/views/accounts/actions/_enable_totp.html.erb
+++ b/app/views/accounts/actions/_enable_totp.html.erb
@@ -1,3 +1,0 @@
-<%= link_to authenticator_setup_url, class: 'btn btn-account-action rounded-lg bg-light-blue add-auth-app' do %>
-  <%= prefix_with_plus(t('forms.buttons.enable')) %>
-<% end %>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -44,7 +44,6 @@ en:
       phone: Phone numbers
       phone_add: Add phone
       piv_cac_add: Add ID
-      piv_cac_card: PIV/CAC Cards
       piv_cac_confirm_delete: Yes, remove card
       piv_cac_disabled: not enabled
       piv_cac_enabled: enabled

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -45,7 +45,6 @@ es:
       phone: Teléfono
       phone_add: Añadir teléfono
       piv_cac_add: Agregar ID
-      piv_cac_card: Tarjetas PIV/CAC
       piv_cac_confirm_delete: Sí, retire la tarjeta
       piv_cac_disabled: desactivada
       piv_cac_enabled: activada

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -45,7 +45,6 @@ fr:
       phone: Numéro de téléphone
       phone_add: Ajouter un téléphone
       piv_cac_add: Ajouter un identifiant
-      piv_cac_card: Cartes PIV/CAC
       piv_cac_confirm_delete: Oui, retirer la carte
       piv_cac_disabled: désactivée
       piv_cac_enabled: activée

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -41,7 +41,6 @@ en:
       delete: Delete
       disable: Delete
       edit: Edit
-      enable: Add
       manage: Manage
       resend_confirmation: Resend confirmation instructions
       send_security_code: Send code

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -46,7 +46,6 @@ es:
       delete: Borrar
       disable: Borrar
       edit: Editar
-      enable: Permitir
       manage: Administrar
       resend_confirmation: Reenviar instrucciones de confirmación
       send_security_code: Enviar código

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -45,7 +45,6 @@ fr:
       delete: Effacer
       disable: Effacer
       edit: Modifier
-      enable: Activer
       manage: Administrer
       resend_confirmation: Envoyer les instructions de confirmation de nouveau
       send_security_code: Envoyer le code

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -48,7 +48,7 @@ describe 'Remembering a TOTP device' do
       page.find('.remove-auth-app').click # Delete
       click_on t('account.index.totp_confirm_delete')
       Timecop.travel 5.seconds.from_now # Travel past the revoked at date from disabling the device
-      click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+      click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
       fill_in :code, with: totp_secret_from_page
       check :remember_device
       click_submit_default

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -19,7 +19,7 @@ feature 'PIV/CAC Management' do
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
-      click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+      click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
 
       expect(page.response_headers['Content-Security-Policy']).
         to(include("form-action https://*.pivcac.test.example.com 'self';"))
@@ -48,12 +48,12 @@ feature 'PIV/CAC Management' do
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      expect(page).to have_link(t('forms.buttons.enable'), href: setup_piv_cac_url)
+      expect(page).to have_link(t('account.index.piv_cac_add'), href: setup_piv_cac_url)
       visit account_two_factor_authentication_path
 
       ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: 'bar', name: 'key2')
       visit account_two_factor_authentication_path
-      expect(page).to_not have_link(t('forms.buttons.enable'), href: setup_piv_cac_url)
+      expect(page).to_not have_link(t('account.index.piv_cac_add'), href: setup_piv_cac_url)
 
       visit setup_piv_cac_path
       expect(current_path).to eq account_two_factor_authentication_path
@@ -64,7 +64,7 @@ feature 'PIV/CAC Management' do
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
-      click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+      click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
 
       nonce = piv_cac_nonce_from_form_action
 
@@ -76,7 +76,7 @@ feature 'PIV/CAC Management' do
       expect(current_path).to eq account_path
 
       visit account_two_factor_authentication_path
-      click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+      click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
       user.reload
       fill_in 'name', with: user.piv_cac_configurations.first.name
       click_button t('forms.piv_cac_setup.submit')
@@ -89,7 +89,7 @@ feature 'PIV/CAC Management' do
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
-      click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+      click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
 
       nonce = piv_cac_nonce_from_form_action
       visit_piv_cac_service(setup_piv_cac_url,
@@ -109,7 +109,7 @@ feature 'PIV/CAC Management' do
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
-      click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+      click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
 
       nonce = piv_cac_nonce_from_form_action
       visit_piv_cac_service(setup_piv_cac_url,
@@ -148,7 +148,7 @@ feature 'PIV/CAC Management' do
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
-      expect(page).to have_link(t('forms.buttons.enable'), href: setup_piv_cac_url)
+      expect(page).to have_link(t('account.index.piv_cac_add'), href: setup_piv_cac_url)
     end
 
     scenario 'allows disassociation of the piv/cac' do
@@ -165,7 +165,7 @@ feature 'PIV/CAC Management' do
 
       expect(current_path).to eq account_two_factor_authentication_path
 
-      expect(page).to have_link(t('forms.buttons.enable'), href: setup_piv_cac_url)
+      expect(page).to have_link(t('account.index.piv_cac_add'), href: setup_piv_cac_url)
 
       user.reload
       expect(user.piv_cac_configurations.first&.x509_dn_uuid).to be_nil

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -39,7 +39,7 @@ describe 'totp management' do
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+      click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
       secret = find('#qr-code').text
       fill_in 'code', with: generate_totp_code(secret)
@@ -53,14 +53,14 @@ describe 'totp management' do
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+      click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
       secret = find('#qr-code').text
       fill_in 'name', with: 'foo'
       fill_in 'code', with: generate_totp_code(secret)
       click_button 'Submit'
 
-      click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+      click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
       secret = find('#qr-code').text
       fill_in 'name', with: 'foo'
@@ -75,7 +75,7 @@ describe 'totp management' do
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+      click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
       secret = find('#qr-code').text
       fill_in 'name', with: 'foo'
@@ -84,7 +84,7 @@ describe 'totp management' do
 
       # simulate user delay. totp has a 30 second time step
       Timecop.travel 30.seconds.from_now do
-        click_link "+ #{t('forms.buttons.enable')}", href: authenticator_setup_url
+        click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
         secret = find('#qr-code').text
         fill_in 'name', with: 'bar'
@@ -94,7 +94,7 @@ describe 'totp management' do
         expect(page).to have_current_path(account_two_factor_authentication_path)
         expect(user.auth_app_configurations.count).to eq(2)
         expect(page).
-          to_not have_link("+ #{t('forms.buttons.enable')}", href: authenticator_setup_url)
+          to_not have_link("+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url)
       end
     end
   end

--- a/spec/view_models/account_show_spec.rb
+++ b/spec/view_models/account_show_spec.rb
@@ -27,43 +27,6 @@ describe AccountShow do
     end
   end
 
-  describe '#totp_partial' do
-    context 'user has enabled an authenticator app' do
-      it 'returns the disable_totp partial' do
-        user = User.new
-        allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy,
-        ).to receive(:enabled?).and_return(true)
-        allow_any_instance_of(
-          MfaPolicy,
-        ).to receive(:multiple_factors_enabled?).and_return(true)
-
-        profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
-          locked_for_session: false
-        )
-
-        expect(profile_index.totp_partial).to eq 'accounts/actions/disable_totp'
-      end
-    end
-
-    context 'user does not have an authenticator app enabled' do
-      it 'returns the enable_totp partial' do
-        user = User.new
-        allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy,
-        ).to receive(:enabled?).and_return(false)
-
-        profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
-          locked_for_session: false
-        )
-
-        expect(profile_index.totp_partial).to eq 'accounts/actions/enable_totp'
-      end
-    end
-  end
-
   describe '#header_personalization' do
     context 'AccountShow instance has decrypted_pii' do
       it "returns the user's first name" do

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -18,7 +18,7 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
     it 'contains link to enable TOTP' do
       render
 
-      expect(rendered).to have_link(t('forms.buttons.enable'), href: authenticator_setup_url)
+      expect(rendered).to have_link(t('account.index.auth_app_add'), href: authenticator_setup_url)
       expect(rendered).not_to have_xpath("//input[@value='Disable']")
     end
   end
@@ -38,7 +38,10 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
       render
 
       expect(rendered).to have_link(t('forms.buttons.disable', href: auth_app_delete_path))
-      expect(rendered).not_to have_link(t('forms.buttons.enable'), href: authenticator_start_path)
+      expect(rendered).not_to have_link(
+        t('account.index.auth_app_add'),
+        href: authenticator_start_path,
+      )
     end
   end
 


### PR DESCRIPTION
**Why**: The logic which renders the `totp_partial` and `piv_cac_partial` occurs within a loop of current TOTP and PIV/CAC configurations, and as such could never render anything other than the "disable" (delete) configuration case.