### PR TITLE
Read the app configs from S3 when we start the app

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -23,8 +23,8 @@ Dir.chdir APP_ROOT do
            |___/          |___/
   ]
 
-  puts "== Copying application.yml =="
-  run "test -r config/application.yml || cp -v config/application.yml.default config/application.yml"
+  puts '== Setting up config overrides =='
+  File.write('config/application.yml', 'development:') unless File.exists?('config/application.yml')
 
   puts "== Linking service_providers.yml =="
   run "test -r config/service_providers.yml || ln -sv service_providers.localdev.yml config/service_providers.yml"

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,11 @@ APP_NAME = 'login.gov'.freeze
 module Upaya
   class Application < Rails::Application
     configuration = AppConfigReader.new.read_configuration
+
+    # Write a copy of the current config for inspection on the instance
+    File.write(Rails.root.join('tmp', 'application.yml'), configuration)
+    FileUtils.chmod(0o640, Rails.root.join('tmp', 'application.yml'))
+
     AppConfig.setup(configuration)
 
     config.load_defaults '6.1'

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Upaya
     configuration = AppConfigReader.new.read_configuration
 
     # Write a copy of the current config for inspection on the instance
-    File.write(Rails.root.join('tmp', 'application.yml'), configuration)
+    File.write(Rails.root.join('tmp', 'application.yml'), configuration.to_yaml)
     FileUtils.chmod(0o640, Rails.root.join('tmp', 'application.yml'))
 
     AppConfig.setup(configuration)

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,12 +18,9 @@ APP_NAME = 'login.gov'.freeze
 
 module Upaya
   class Application < Rails::Application
-    configuration = AppConfigReader.new.read_configuration
-
-    # Write a copy of the current config for inspection on the instance
-    FileUtils.mkdir_p(Rails.root.join('tmp'))
-    File.write(Rails.root.join('tmp', 'application.yml'), configuration.to_yaml)
-    FileUtils.chmod(0o640, Rails.root.join('tmp', 'application.yml'))
+    configuration = AppConfigReader.new.read_configuration(
+      write_copy_to: Rails.root.join('tmp', 'application.yml'),
+    )
 
     AppConfig.setup(configuration)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
 require 'identity/logging/railtie'
 
+require_relative '../lib/app_config_reader'
 require_relative '../lib/app_config'
 require_relative '../lib/fingerprinter'
 
@@ -17,7 +18,8 @@ APP_NAME = 'login.gov'.freeze
 
 module Upaya
   class Application < Rails::Application
-    AppConfig.setup(YAML.safe_load(File.read(Rails.root.join('config', 'application.yml'))))
+    configuration = AppConfigReader.new.read_configuration
+    AppConfig.setup(configuration)
 
     config.load_defaults '6.1'
     config.active_record.belongs_to_required_by_default = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module Upaya
     configuration = AppConfigReader.new.read_configuration
 
     # Write a copy of the current config for inspection on the instance
+    FileUtils.mkdir_p(Rails.root.join('tmp'))
     File.write(Rails.root.join('tmp', 'application.yml'), configuration.to_yaml)
     FileUtils.chmod(0o640, Rails.root.join('tmp', 'application.yml'))
 

--- a/lib/app_config.rb
+++ b/lib/app_config.rb
@@ -5,8 +5,8 @@ class AppConfig
     attr_reader :env
   end
 
-  def self.setup(path, env = Rails.env)
-    @env ||= Environment.new(path, env)
+  def self.setup(configuration, env = Rails.env)
+    @env ||= Environment.new(configuration, env)
   end
 
   def self.require_keys(keys)

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -18,7 +18,7 @@ class AppConfigReader
       read_role_configuration,
     )
 
-    if write_copy_to
+    if write_copy_to && !File.exists?(write_copy_to)
       FileUtils.mkdir_p(File.dirname(write_copy_to))
       File.write(write_copy_to, configuration.to_yaml)
       FileUtils.chmod(0o640, write_copy_to)

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -4,7 +4,7 @@ class AppConfigReader
   def initialize(
     root_path: Rails.root,
     s3_client: nil,
-    logger: Logger.new(STDOUT),
+    logger: Logger.new(STDOUT)
   )
     @root_path = root_path
     @logger = logger

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -55,6 +55,6 @@ class AppConfigReader
   end
 
   def app_secrets_s3
-    @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3(s3_client: s3_client, logger: logger)
+    @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3
   end
 end

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -1,0 +1,60 @@
+class AppConfigReader
+  attr_accessor :root_path
+
+  def initialize(
+    root_path: Rails.root
+  )
+    @root_path = root_path
+  end
+
+  def read_configuration
+    read_default_configuration.deep_merge(
+      read_override_configuration,
+    ).deep_merge(
+      read_role_configuration,
+    )
+  end
+
+  private
+
+  def read_default_configuration
+    YAML.safe_load(File.read(File.join(root_path, 'config', 'application.yml.default')))
+  end
+
+  def read_override_configuration
+    local_config_filepath = File.join(root_path, 'config', 'application.yml')
+    raw_configs = if Identity::Hostdata.in_datacenter?
+                    app_secrets_s3.read_file('/%<env>s/idp/v1/application.yml')
+                  elsif File.exists?(local_config_filepath)
+                    File.read(local_config_filepath)
+                  end
+    YAML.safe_load(raw_configs || '{}')
+  end
+
+  def read_role_configuration
+    return {} if role_configuration_filename.nil?
+    local_config_filepath = File.join(root_path, 'config', role_configuration_filename)
+    s3_config_filepath = "/%<env>s/idp/v1/#{role_configuration_filename}"
+
+    raw_configs = if Identity::Hostdata.in_datacenter?
+                    app_secrets_s3.read_file(s3_config_filepath)
+                  elsif File.exists?(local_config_filepath)
+                    File.read(local_config_filepath)
+                  end
+
+    YAML.safe_load(raw_configs || '{}')
+  end
+
+  def role_configuration_filename
+    case Identity::Hostdata.instance_role
+    when 'idp'
+      'web.yml'
+    when 'worker'
+      'worker.yml'
+    end
+  end
+
+  def app_secrets_s3
+    @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3(s3_client: s3_client, logger: logger)
+  end
+end

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -2,9 +2,13 @@ class AppConfigReader
   attr_accessor :root_path
 
   def initialize(
-    root_path: Rails.root
+    root_path: Rails.root,
+    s3_client: nil,
+    logger: Logger.new(STDOUT)
   )
     @root_path = root_path
+    @logger = logger
+    @s3_client = s3_client
   end
 
   def read_configuration
@@ -55,6 +59,6 @@ class AppConfigReader
   end
 
   def app_secrets_s3
-    @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3
+    @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3(logger: @logger, s3_client: @s3_client)
   end
 end

--- a/lib/app_config_reader.rb
+++ b/lib/app_config_reader.rb
@@ -4,19 +4,27 @@ class AppConfigReader
   def initialize(
     root_path: Rails.root,
     s3_client: nil,
-    logger: Logger.new(STDOUT)
+    logger: Logger.new(STDOUT),
   )
     @root_path = root_path
     @logger = logger
     @s3_client = s3_client
   end
 
-  def read_configuration
-    read_default_configuration.deep_merge(
+  def read_configuration(write_copy_to: nil)
+    configuration = read_default_configuration.deep_merge(
       read_override_configuration,
     ).deep_merge(
       read_role_configuration,
     )
+
+    if write_copy_to
+      FileUtils.mkdir_p(File.dirname(write_copy_to))
+      File.write(write_copy_to, configuration.to_yaml)
+      FileUtils.chmod(0o640, write_copy_to)
+    end
+
+    configuration
   end
 
   private

--- a/spec/lib/app_config_reader_spec.rb
+++ b/spec/lib/app_config_reader_spec.rb
@@ -2,15 +2,14 @@ require 'rails_helper'
 
 RSpec.describe AppConfigReader do
   DEFAULT_YAML = <<~HEREDOC
-    development:
-      config1: 'test'
-      config2: 'override me'
-    test:
-      config1: 'test but different'
+    config1: 'test'
+    config2: 'override me'
   HEREDOC
   OVERRIDE_YAML = <<~HEREDOC
-    development:
-      config2: 'overriden value'
+    config2: 'overriden value'
+  HEREDOC
+  ROLE_YAML = <<~HEREDOC
+    role_config: 'test'
   HEREDOC
 
   around(:each) do |ex|
@@ -21,14 +20,75 @@ RSpec.describe AppConfigReader do
     end
   end
 
-  subject(:reader) { AppConfigReader.new }
+  let(:logger) { Logger.new('/dev/null') }
+  let(:s3_client) { nil }
+  subject(:reader) { AppConfigReader.new(logger: logger, s3_client: s3_client) }
 
-  it 'merges the default and override configurations' do
-    configuration = reader.read_configuration
+  context 'in the datacenter' do
+    let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:s3_contents) do
+      {
+        'int/idp/v1/application.yml' => OVERRIDE_YAML,
+      }
+    end
 
-    expect(configuration['development']['config1']).to eq('test')
-    expect(configuration['development']['config2']).to eq('overriden value')
-    expect(configuration['test']['config1']).to eq('test but different')
+    before do
+      allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(true)
+      allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
+      allow(Identity::Hostdata).to receive(:env).and_return('int')
+
+      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        to_return(body: {
+          'region' => 'us-west-1',
+          'accountId' => '12345',
+        }.to_json)
+
+      s3_client.stub_responses(:get_object, proc do |context|
+          key = context.params[:key]
+          body = s3_contents[key]
+          if body.present?
+            { body: body }
+          else
+            raise Aws::S3::Errors::NoSuchKey.new(nil, nil)
+          end
+        end
+      )
+      allow(s3_client).to receive(:get_object).and_call_original
+    end
+
+    it 'merges the default and override yaml values' do
+      configuration = reader.read_configuration
+
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/application.yml'),
+      )
+      expect(configuration['config1']).to eq('test')
+      expect(configuration['config2']).to eq('overriden value')
+    end
+
+    it 'applies the role configs if they exist' do
+      s3_contents['int/idp/v1/web.yml'] = ROLE_YAML
+
+      configuration = reader.read_configuration
+
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/application.yml'),
+      )
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/web.yml'),
+      )
+      expect(configuration['config1']).to eq('test')
+      expect(configuration['config2']).to eq('overriden value')
+    end
+  end
+
+  context 'during local dev' do
+    it 'merges the default and override configurations' do
+      configuration = reader.read_configuration
+
+      expect(configuration['config1']).to eq('test')
+      expect(configuration['config2']).to eq('overriden value')
+    end
   end
 
   def set_tmp_dir_fixtures(root)

--- a/spec/lib/app_config_reader_spec.rb
+++ b/spec/lib/app_config_reader_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe AppConfigReader do
+  DEFAULT_YAML = <<~HEREDOC
+    development:
+      config1: 'test'
+      config2: 'override me'
+    test:
+      config1: 'test but different'
+  HEREDOC
+  OVERRIDE_YAML = <<~HEREDOC
+    development:
+      config2: 'overriden value'
+  HEREDOC
+
+  around(:each) do |ex|
+    Dir.mktmpdir do |root|
+      set_tmp_dir_fixtures(root)
+      reader.root_path = root
+      ex.run
+    end
+  end
+
+  subject(:reader) { AppConfigReader.new }
+
+  it 'merges the default and override configurations' do
+    configuration = reader.read_configuration
+
+    expect(configuration['development']['config1']).to eq('test')
+    expect(configuration['development']['config2']).to eq('overriden value')
+    expect(configuration['test']['config1']).to eq('test but different')
+  end
+
+  def set_tmp_dir_fixtures(root)
+    FileUtils.mkdir_p(File.join(root, 'config'))
+    File.write(File.join(root, 'config', 'application.yml.default'), DEFAULT_YAML)
+    File.write(File.join(root, 'config', 'application.yml'), OVERRIDE_YAML)
+  end
+end

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -18,8 +18,6 @@ describe Deploy::Activate do
   let(:set_up_files!) {}
   let(:instance_role) { 'idp' }
 
-  let(:result_yaml_path) { File.join(root, 'config', 'application.yml') }
-  let(:env_yaml_path) { File.join(root, 'config', 'application_s3_env.yml') }
   let(:geolite_path) { File.join(root, 'geo_data', 'GeoLite2-City.mmdb') }
   let(:pwned_passwords_path) { File.join(root, 'pwned_passwords', 'pwned_passwords.txt') }
 
@@ -61,123 +59,13 @@ describe Deploy::Activate do
 
     let(:s3_contents) do
       {
-        'int/idp/v1/application.yml' => application_yml,
         'common/GeoIP2-City.mmdb' => geolite_content,
         'common/pwned-passwords.txt' => pwned_passwords_content,
       }
     end
 
-    let(:application_yml) do
-      <<~YAML
-        production:
-          usps_confirmation_max_days: '5'
-      YAML
-    end
     let(:geolite_content) { 'geolite test' }
     let(:pwned_passwords_content ) { 'pwned passwords test' }
-
-    it 'downloads configs from s3' do
-      subject.run
-
-      expect(s3_client).to have_received(:get_object).with(
-        bucket: 'login-gov.app-secrets.12345-us-west-1',
-        key: 'int/idp/v1/application.yml',
-      )
-
-      expect(File.exist?(result_yaml_path)).to eq(true)
-      expect(File.read(result_yaml_path)).to include("usps_confirmation_max_days: '5'")
-    end
-
-    it 'merges the application.yml from s3 over the application.yml.default' do
-      subject.run
-
-      combined_application_yml = YAML.load_file(result_yaml_path)
-
-      # top-level key from application.yml.default
-      expect(combined_application_yml['recovery_code_length']).to eq('4')
-      # overridden production key from s3
-      expect(combined_application_yml['production']['usps_confirmation_max_days']).to eq('5')
-      # production key from application.yml.example, not overwritten
-      expect(combined_application_yml['production']['lockout_period_in_minutes']).to eq('10')
-    end
-
-    context 'on a web instance' do
-      let(:instance_role) { 'idp' }
-
-      context 'when web.yml exists in s3' do
-        before do
-          s3_contents['int/idp/v1/web.yml'] = <<~YAML
-            web_yaml_value: 'true'
-          YAML
-        end
-
-        it 'merges web.yml into application.yml' do
-          subject.run
-
-          expect(File.exist?("#{root}/config/web.yml")).to eq(true)
-
-          combined_application_yml = YAML.load_file(result_yaml_path)
-          expect(combined_application_yml['web_yaml_value']).to eq('true')
-        end
-      end
-
-      context 'when web.yml does not exist in s3' do
-        it 'warns and leaves application.yml as-is' do
-          expect(logger).to receive(:warn).with(/web.yml/)
-
-          expect { subject.run }.to_not raise_error
-
-          expect(File.exist?("#{root}/config/web.yml")).to eq(false)
-
-          combined_application_yml = YAML.load_file(result_yaml_path)
-          expect(combined_application_yml).to_not have_key('web_yaml_value')
-        end
-      end
-    end
-
-    context 'on a worker instance' do
-      let(:instance_role) { 'worker' }
-
-      context 'when worker.yml exists in s3' do
-        before do
-          s3_contents['int/idp/v1/worker.yml'] = <<~YAML
-            worker_yaml_value: 'true'
-          YAML
-        end
-
-        it 'merges worker.yml into application.yml' do
-          subject.run
-
-          expect(File.exist?("#{root}/config/worker.yml")).to eq(true)
-
-          combined_application_yml = YAML.load_file(result_yaml_path)
-          expect(combined_application_yml['worker_yaml_value']).to eq('true')
-        end
-      end
-
-      context 'when worker.yml does not exist in s3' do
-        it 'warns and leaves application.yml as-is' do
-          expect(logger).to receive(:warn).with(/worker.yml/)
-
-          expect { subject.run }.to_not raise_error
-
-          expect(File.exist?("#{root}/config/worker.yml")).to eq(false)
-
-          combined_application_yml = YAML.load_file(result_yaml_path)
-          expect(combined_application_yml).to_not have_key('worker_yaml_value')
-        end
-      end
-    end
-
-    it 'sets the correct permissions on the YAML files' do
-      subject.run
-
-      application_yml = File.new(result_yaml_path)
-      expect(application_yml.stat.mode.to_s(8)).to eq('100640')
-
-      application_env_yml = File.new(env_yaml_path)
-      expect(application_env_yml.stat.mode.to_s(8)).to eq('100640')
-    end
 
     it 'downloads the pwned passwords and geolite files from s3' do
       subject.run

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join('lib', 'deploy', 'activate.rb')
 
 describe Deploy::Activate do
   let(:root) { @root }
-  let(:example_application_yaml_path) { Rails.root.join('config', 'application.yml.default') }
 
   around(:each) do |ex|
     Identity::Hostdata.reset!
@@ -29,7 +28,6 @@ describe Deploy::Activate do
       logger: logger,
       s3_client: s3_client,
       root: root,
-      example_application_yaml_path: example_application_yaml_path,
     )
   end
 


### PR DESCRIPTION
**Why**: So that the IDP does not depend on special files being in the right place on the disk when it starts.