### PR TITLE
log specific error when piv/cac second factor fails

### DIFF
--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -11,10 +11,11 @@ class UserPivCacVerificationForm
 
   def submit
     success = valid? && valid_submission?
+    errors = error_type ? { type: error_type } : {}
 
     FormResponse.new(
       success: success,
-      errors: {},
+      errors: errors,
       extra: extra_analytics_attributes.merge(error_type ? { key_id: key_id } : {}),
     )
   end

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -179,7 +179,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
 
         submit_attributes = {
           success: false,
-          errors: {},
+          errors: { type: 'user.piv_cac_mismatch' },
           context: 'authentication',
           multi_factor_auth_method: 'piv_cac',
           key_id: nil,

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -29,7 +29,7 @@ describe UserPivCacVerificationForm do
           result = instance_double(FormResponse)
 
           expect(FormResponse).to receive(:new).
-            with(success: false, errors: {},
+            with(success: false, errors: { type: 'user.no_piv_cac_associated' },
                  extra: { multi_factor_auth_method: 'piv_cac',
                           piv_cac_configuration_id: nil,
                           key_id: nil }).and_return(result)
@@ -45,7 +45,7 @@ describe UserPivCacVerificationForm do
           result = instance_double(FormResponse)
 
           expect(FormResponse).to receive(:new).
-            with(success: false, errors: {},
+            with(success: false, errors: { type: 'user.piv_cac_mismatch'},
                  extra: { multi_factor_auth_method: 'piv_cac',
                           piv_cac_configuration_id: nil,
                           key_id: nil }).and_return(result)
@@ -77,7 +77,7 @@ describe UserPivCacVerificationForm do
             result = instance_double(FormResponse)
 
             expect(FormResponse).to receive(:new).
-              with(success: false, errors: {},
+              with(success: false, errors: { type: 'token.invalid' },
                    extra: { multi_factor_auth_method: 'piv_cac',
                             piv_cac_configuration_id: nil,
                             key_id: nil }).and_return(result)
@@ -99,7 +99,7 @@ describe UserPivCacVerificationForm do
         result = instance_double(FormResponse)
 
         expect(FormResponse).to receive(:new).
-          with(success: false, errors: {},
+          with(success: false, errors: { type: 'token.bad' },
                extra: { multi_factor_auth_method: 'piv_cac',
                         piv_cac_configuration_id: nil,
                         key_id: nil }).and_return(result)


### PR DESCRIPTION
so we can see what errors are happening on PIV/CACs used as a second factor, copied from what we do with the "Sign in with your Government Employee ID" event here: https://github.com/18F/identity-idp/blob/f12de9574723a4f31a2d392c8269c5b9908b62e7/app/forms/user_piv_cac_login_form.rb#L13-L14

Instead of:

```
{:success=>false,
 :errors=>{},
 :multi_factor_auth_method=>"piv_cac",
 :piv_cac_configuration_id=>nil,
 :key_id=>nil,
 :context=>"authentication"}
```

We'll have

```diff
 {:success=>false,
+ :errors=>{:type=>"certificate.invalid"},
  :multi_factor_auth_method=>"piv_cac",
  :piv_cac_configuration_id=>nil,
  :key_id=>nil,
  :context=>"authentication"}
```