### PR TITLE
No longer autocorrecting the email field (Safari only) (LG-3842)

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,7 +14,10 @@
 <%= validated_form_for(@password_reset_email_form,
                        url: user_password_path,
                        html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
-  <%= f.input :email, required: true, input_html: { aria: { invalid: false, describedby: 'email-description' } } %>
+  <%= f.input :email,
+              required: true,
+              input_html: { autocorrect: 'off',
+                            aria: { invalid: false, describedby: 'email-description' } } %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <%= render 'shared/recaptcha' %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'margin-top-2' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,7 +24,9 @@
   <%= f.input :email,
               label: t('account.index.email'),
               required: true,
-              input_html: { class: 'margin-bottom-6', aria: { invalid: false } } %>
+              input_html: { class: 'margin-bottom-6',
+                            autocorrect: 'off',
+                            aria: { invalid: false } } %>
   <%= f.input :password,
               label: t('account.index.password'),
               required: true,

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -14,7 +14,10 @@
   <%= validated_form_for(@register_user_email_form,
       html: { autocomplete: 'off', role: 'form' },
       url: sign_up_register_path) do |f| %>
-    <%= f.input :email, label: t('forms.registration.labels.email'), required: true, input_html: { aria: { invalid: false } } %>
+    <%= f.input :email,
+                label: t('forms.registration.labels.email'),
+                required: true,
+                input_html: { autocorrect: "off", aria: { invalid: false } } %>
 
     <span class='email-invalid-alert-inline usa-error-message margin-top-neg-3 margin-bottom-3 display-none' role='alert'>
       <%= t('sign_up.email.invalid_email_alert_inline') %>

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -18,6 +18,12 @@ describe 'devise/sessions/new.html.erb' do
     expect(rendered).to match(/<form[^>]*autocomplete="off"/)
   end
 
+  it 'sets input autocorrect to off' do
+    render
+
+    expect(rendered).to have_xpath("//input[@autocorrect='off']")
+  end
+
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('titles.visitors.index'))
 


### PR DESCRIPTION
Previously, if a user navigated to secure.login.gov **in Safari**, and typed in `jane.doe@gsa.gov` the field would autocorrect to `Jane.doe@gsa.gov`. This PR preevents that on the sign in page, the create account page, and the forgot password page.
