### PR TITLE
LG-4359 Cannot redirect to nil! error during signup

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else
-        redirect_to sp_session_request_url_without_prompt_login
+        redirect_to sp_session_request_url_without_prompt_login || account_url
       end
     end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else
-        redirect_to sp_session_request_url_without_prompt_login || account_url
+        redirect_to(sp_session_request_url_without_prompt_login || account_url)
       end
     end
 

--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -2,17 +2,26 @@ module Users
   class AuthorizationConfirmationController < ApplicationController
     include AuthorizationCountConcern
 
+    before_action :ensure_sp_in_session_with_request_url, only: :show
     before_action :bump_auth_count
     before_action :confirm_two_factor_authenticated
 
     def show
       analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION)
-      @sp = ServiceProvider.find_by(issuer: sp_session[:issuer]) if sp_session
+      @sp = ServiceProvider.find_by(issuer: sp_session[:issuer])
     end
 
     def update
       sign_out :user
       redirect_to new_user_session_url(request_id: sp_session[:request_id])
+    end
+
+    private
+
+    def ensure_sp_in_session_with_request_url
+      return if sp_session&.dig(:request_url)
+
+      redirect_to account_url
     end
   end
 end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -140,6 +140,17 @@ describe SignUp::CompletionsController do
           patch :update
         end
       end
+
+      it 'redirects to account page if the session request_url is removed' do
+        stub_sign_in
+        subject.session[:sp] = {
+          ial2: false,
+          issuer: 'foo',
+        }
+
+        patch :update
+        expect(response).to redirect_to account_path
+      end
     end
 
     context 'IAL2' do

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -69,5 +69,12 @@ feature 'SAML Authorization Confirmation' do
 
       expect(current_path).to eq(new_user_session_path)
     end
+
+    it 'redirects to the account page with no sp in session' do
+      sign_in_user(user1)
+      visit user_authorization_confirmation_path
+
+      expect(current_path).to eq(account_path)
+    end
   end
 end


### PR DESCRIPTION
**Why**: There is a race condition (0.04% frequency) where one request overwrites session and deletes the request_url from the sp while the other request consents to the terms but the session has no way back to the sp.  In that situation redirect back to the accounts page or the root if the session is no longer valid.