### PR TITLE
LG-4381: Log Acuant SDK load on frontend

### DIFF
--- a/app/javascript/packages/document-capture/context/acuant.jsx
+++ b/app/javascript/packages/document-capture/context/acuant.jsx
@@ -13,7 +13,7 @@ import AnalyticsContext from './analytics';
 /**
  * @typedef {1|2|400|401|403} AcuantInitializeCode Acuant initialization callback code.
  *
- * @see https://github.com/Acuant/JavascriptWebSDKV11/blob/11.4.4/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js#L1327-1353
+ * @see https://github.com/Acuant/JavascriptWebSDKV11/blob/11.4.4/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js#L1327-L1353
  */
 
 /**

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -141,34 +141,34 @@ loadPolyfills(['fetch', 'crypto']).then(async () => {
 
   render(
     <DeviceContext.Provider value={device}>
-      <AcuantContextProvider
-        credentials={getMetaContent('acuant-sdk-initialization-creds')}
-        endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
-      >
-        <UploadContextProvider
-          endpoint={/** @type {string} */ (appRoot.getAttribute('data-endpoint'))}
-          statusEndpoint={/** @type {string} */ (appRoot.getAttribute('data-status-endpoint'))}
-          statusPollInterval={
-            Number(appRoot.getAttribute('data-status-poll-interval-ms')) || undefined
-          }
-          method={isAsyncForm ? 'PUT' : 'POST'}
-          csrf={csrf}
-          isMockClient={isMockClient}
-          backgroundUploadURLs={backgroundUploadURLs}
-          backgroundUploadEncryptKey={backgroundUploadEncryptKey}
-          formData={formData}
+      <AnalyticsContext.Provider value={{ addPageAction, noticeError }}>
+        <AcuantContextProvider
+          credentials={getMetaContent('acuant-sdk-initialization-creds')}
+          endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
         >
-          <I18nContext.Provider value={i18n.strings}>
-            <ServiceProviderContext.Provider value={getServiceProvider()}>
-              <AnalyticsContext.Provider value={{ addPageAction, noticeError }}>
+          <UploadContextProvider
+            endpoint={/** @type {string} */ (appRoot.getAttribute('data-endpoint'))}
+            statusEndpoint={/** @type {string} */ (appRoot.getAttribute('data-status-endpoint'))}
+            statusPollInterval={
+              Number(appRoot.getAttribute('data-status-poll-interval-ms')) || undefined
+            }
+            method={isAsyncForm ? 'PUT' : 'POST'}
+            csrf={csrf}
+            isMockClient={isMockClient}
+            backgroundUploadURLs={backgroundUploadURLs}
+            backgroundUploadEncryptKey={backgroundUploadEncryptKey}
+            formData={formData}
+          >
+            <I18nContext.Provider value={i18n.strings}>
+              <ServiceProviderContext.Provider value={getServiceProvider()}>
                 <AssetContext.Provider value={assets}>
                   <DocumentCapture isAsyncForm={isAsyncForm} onStepChange={keepAlive} />
                 </AssetContext.Provider>
-              </AnalyticsContext.Provider>
-            </ServiceProviderContext.Provider>
-          </I18nContext.Provider>
-        </UploadContextProvider>
-      </AcuantContextProvider>
+              </ServiceProviderContext.Provider>
+            </I18nContext.Provider>
+          </UploadContextProvider>
+        </AcuantContextProvider>
+      </AnalyticsContext.Provider>
     </DeviceContext.Provider>,
     appRoot,
   );

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@testing-library/user-event": "^12.6.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/sinon": "^9.0.11",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "eslint": "^7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,18 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/sinon@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.11.tgz#7af202dda5253a847b511c929d8b6dda170562eb"
+  integrity sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
+  integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+
 "@types/testing-library__react-hooks@^3.4.0":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"


### PR DESCRIPTION
**Why**: To better understand issues that users may be having in completing the document capture step of the IAL2 flow, we should have insight into potential Acuant SDK load failures.

The details of the errors weren't known prior to starting the task. Documented here, they appear to be largely misconfiguration issues, ones which we likely won't often encounter. More interesting may be the sorts of errors that could be expected after Acuant SDK loads, and when the user attempts to start capture. This could be part of the discovery work involved in LG-4390.