### PR TITLE
Handle Pinpoint invalid phone number errors (LG-4362)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -59,7 +59,6 @@ plugins:
       - FIXME
       - HACK
       - BUG
-      - XXX
   pep8:
     enabled: true
   reek:


### PR DESCRIPTION
- Catches the error and adds some redacted logging so we can
  try to understand the data we were sending