### PR TITLE
Update SMS OTP/TOTP app layouts to support USWDS buttons

### DIFF
--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -1,22 +1,27 @@
 .ico {
-  background-position: 1rem center;
-  background-repeat: no-repeat;
-  background-size: 1rem;
-  padding-left: 2.6rem;
+  &::before {
+    background-repeat: no-repeat;
+    background-size: 1rem;
+    content: '';
+    display: inline-block;
+    height: 1rem;
+    margin: -.125rem .5rem -.125rem 0;
+    width: 1rem;
+  }
 
-  &-copy {
+  &.ico-copy::before {
     background-image: url(image-path('ico-copy.svg'));
   }
 
-  &-download {
+  &.ico-download::before {
     background-image: url(image-path('ico-download.svg'));
   }
 
-  &-refresh {
+  &.ico-refresh::before {
     background-image: url(image-path('ico-refresh.svg'));
   }
 
-  &-print {
+  &.ico-print::before {
     background-image: url(image-path('ico-print.svg'));
   }
 }

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -28,10 +28,11 @@
   </div>
 <% end %>
 
-<%= button_to(t('links.two_factor_authentication.get_another_code'), idv_resend_otp_path,
+<%= button_to idv_resend_otp_path,
               method: :post,
-              class: 'usa-button usa-button--outline ico ico-refresh',
-              form_class: 'inline-block') %>
+              class: 'usa-button usa-button--outline ico ico-refresh' do %>
+  <%= t('links.two_factor_authentication.get_another_code') %>
+<% end %>
 
 <p class="margin-top-6">
   <%= @presenter.update_phone_link %>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -11,8 +11,7 @@
 <%= form_tag(:idv_otp_verification, method: :put, role: 'form', class: 'margin-top-4') do %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
-                    class: 'block bold' %>
+      <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
       <%= text_field_tag :code, '',
                          value: @code,
                          required: true,

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -9,22 +9,29 @@
 </p>
 
 <%= form_tag(:idv_otp_verification, method: :put, role: 'form', class: 'margin-top-4') do %>
-  <%= label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
-                class: 'block bold' %>
-  <div class="col-12 sm-col-5 margin-bottom-2 tablet:margin-bottom-0 sm-mr-20p inline-block">
-    <%= text_field_tag(:code, '', value: @code, required: true,
-                       aria: { invalid: false, describedby: 'code-instructs' }, autofocus: true,
-                       pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH, autocomplete: 'one-time-code', type: 'tel') %>
+  <div class="grid-row margin-bottom-5">
+    <div class="grid-col-12 tablet:grid-col-6">
+      <%= label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
+                    class: 'block bold' %>
+      <%= text_field_tag :code, '',
+                         value: @code,
+                         required: true,
+                         aria: { invalid: false, describedby: 'code-instructs' },
+                         autofocus: true,
+                         pattern: '[0-9]*',
+                         class: 'col-12 field monospace mfa usa-input margin-bottom-5',
+                         maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+                         autocomplete: 'one-time-code',
+                         type: 'tel' %>
+      <%= submit_tag t('forms.buttons.submit.default'),
+                     class: 'usa-button usa-button--big usa-button--full-width' %>
+    </div>
   </div>
-  <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary text-top sm-col-6 col-12' %>
-  <br/>
-  <br/>
 <% end %>
 
 <%= button_to(t('links.two_factor_authentication.get_another_code'), idv_resend_otp_path,
               method: :post,
-              class: 'usa-button usa-button--unstyled btn-border ico ico-refresh text-decoration-none',
+              class: 'usa-button usa-button--outline ico ico-refresh',
               form_class: 'inline-block') %>
 
 <p class="margin-top-6">

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -12,9 +12,7 @@
   <%= render @presenter.reauthn_hidden_field_partial %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= label_tag 'code',
-                    t('simple_form.required.html') + t('forms.two_factor.code'),
-                    class: 'block bold' %>
+      <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
       <%= text_field_tag :code, '',
                          value: @presenter.code_value,
                          required: true,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -10,33 +10,34 @@
 
 <%= form_tag(:login_otp, method: :post, role: 'form', class: 'margin-top-4') do %>
   <%= render @presenter.reauthn_hidden_field_partial %>
-  <%= label_tag 'code',
-                t('simple_form.required.html') + t('forms.two_factor.code'),
-                class: 'block bold' %>
-  <div class="col-12 sm-col-5 margin-bottom-2 tablet:margin-bottom-0 sm-mr-20p inline-block">
-    <%= text_field_tag(:code, '',
-                       value: @presenter.code_value,
-                       required: true,
-                       autofocus: true,
-                       pattern: '[0-9]*',
-                       class: 'col-12 field monospace mfa',
-                       aria: { invalid: false, describedby: 'code-instructs' },
-                       maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
-                       autocomplete: 'one-time-code', type: 'tel') %>
+  <div class="grid-row margin-bottom-5">
+    <div class="grid-col-12 tablet:grid-col-6">
+      <%= label_tag 'code',
+                    t('simple_form.required.html') + t('forms.two_factor.code'),
+                    class: 'block bold' %>
+      <%= text_field_tag :code, '',
+                         value: @presenter.code_value,
+                         required: true,
+                         autofocus: true,
+                         pattern: '[0-9]*',
+                         class: 'field monospace mfa usa-input margin-bottom-5',
+                         aria: { invalid: false, describedby: 'code-instructs' },
+                         maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+                         autocomplete: 'one-time-code',
+                         type: 'tel' %>
+      <%= submit_tag t('forms.buttons.submit.default'),
+                     class: 'usa-button usa-button--big usa-button--full-width' %>
+    </div>
   </div>
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
-  <%= submit_tag t('forms.buttons.submit.default'),
-                 class: 'btn btn-primary text-top sm-col-6 col-12' %>
-
-  <br/><br/>
   <div class="flex flex-row flex-align-center flex-wrap">
     <%= link_to(t('links.two_factor_authentication.get_another_code'),
                 otp_send_path(otp_delivery_selection_form: {
                   otp_delivery_preference: @presenter.otp_delivery_preference,
                   resend: true
                 }),
-                class: 'usa-button usa-button--unstyled btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
+                class: 'usa-button usa-button--outline ico ico-refresh flex-no-shrink margin-right-205',
                 form_class: 'inline-block') %>
 
     <span class="text-no-wrap flex-no-shrink flex flex-row flex-align-center">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -39,7 +39,7 @@
           <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px" id="qr-code">
             <%= @code %>
           </code>
-          <button class="clipboard margin-right-0 margin-top-2 tablet:margin-top-0 tablet:margin-left-2 usa-button usa-button--outline ico ico-copy"
+          <button class="clipboard margin-right-0 margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 usa-button usa-button--outline ico ico-copy"
                   type="button"
                   data-clipboard-text="<%= @code.upcase %>">
             <%= t('links.copy') %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -36,7 +36,7 @@
         </div>
         <%= t('instructions.mfa.authenticator.manual_entry') %>
         <div class="grid-row margin-top-2 flex-align-center">
-          <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px" id="qr-code">
+          <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
             <%= @code %>
           </code>
           <button class="clipboard margin-right-0 margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 usa-button usa-button--outline ico ico-copy"

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -34,12 +34,12 @@
         <div class="center">
           <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
         </div>
-        <div class="center">
-          <%= t('instructions.mfa.authenticator.manual_entry') %>
-        </div>
-        <div class="padding-x-2 padding-y-1 margin-top-1 border border-dashed border-navy">
-          <div class="inline fs-20p caps monospace" id="qr-code"><%= @code %></div>
-          <button class="clipboard margin-left-2 right mt-tiny btn btn-primary padding-0 w-60p bg-light-blue blue h6 regular border-box center"
+        <%= t('instructions.mfa.authenticator.manual_entry') %>
+        <div class="grid-row margin-top-2 flex-align-center">
+          <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px" id="qr-code">
+            <%= @code %>
+          </code>
+          <button class="clipboard margin-right-0 margin-top-2 tablet:margin-top-0 tablet:margin-left-2 usa-button usa-button--outline ico ico-copy"
                   type="button"
                   data-clipboard-text="<%= @code.upcase %>">
             <%= t('links.copy') %>
@@ -59,18 +59,16 @@
                 class: 'block col-12 field monospace mfa', maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
                 'aria-labelledby': 'totp-label' %>
           </div>
-          <div class="col col-6 sm-col-5 padding-x-1">
-            <%= submit_tag t('forms.buttons.submit.default'), class: 'col-12 btn btn-primary text-top' %>
-          </div>
-        </div>
-        <div class="border border-light-blue rounded-lg padding-x-2 padding-y-1 margin-top-4">
-          <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
-          <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'margin-y-2 margin-left-2 margin-right-1' %>
-          <%= label_tag 'remember_device', t('forms.messages.remember_device'), class: 'blue mt-1p' %>
         </div>
       </div>
     </li>
   </ul>
+  <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--big usa-button--wide' %>
+  <div class="margin-y-4 display-flex flex-align-center">
+    <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
+    <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked? %>
+    <%= label_tag 'remember_device', t('forms.messages.remember_device'), class: 'text-primary margin-0 margin-left-1' %>
+  </div>
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>


### PR DESCRIPTION
Related (extracted from): #4836

**Why**: In order to support design system buttons guidance as part of LG-3865, layouts for the SMS OTP entry and TOTP app setup should be revised.

**Notes:**

- This is based on layout revisions from Figma mockups attached to the work of LG-3907.
- This converts BassCSS buttons to USWDS buttons
- This doesn't yet include the outline button border reduction from https://github.com/18F/identity-style-guide/pull/205
- This doesn't include all layout revisions from the Figma mockups, but rather only those which largely affect button positioning

**Screenshots:**

_SMS OTP:_

&nbsp;|Before|After
---|---|---
Desktop|![desktop before](https://user-images.githubusercontent.com/1779930/112994273-11eef080-9138-11eb-95c1-fb7c4e592207.png)|![desktop ater](https://user-images.githubusercontent.com/1779930/112994305-1ca98580-9138-11eb-9317-c62276364f6a.png)
Mobile|![mobile before](https://user-images.githubusercontent.com/1779930/112994332-2337fd00-9138-11eb-8253-54ef59952465.png)|![mobile after](https://user-images.githubusercontent.com/1779930/112994354-27fcb100-9138-11eb-9059-fcaa7255cb10.png)

_TOTP App Setup:_

&nbsp;|Before|After
---|---|---
Desktop|![desktop before](https://user-images.githubusercontent.com/1779930/112994096-e4a24280-9137-11eb-8b66-083b0ad3f61f.png)|![desktop after](https://user-images.githubusercontent.com/1779930/112994127-ed931400-9137-11eb-83bc-28d661a7cb20.png)
Mobile|![mobile before](https://user-images.githubusercontent.com/1779930/112994181-fbe13000-9137-11eb-99a3-6c57e4afc759.png)|![mobile after](https://user-images.githubusercontent.com/1779930/112994234-06032e80-9138-11eb-84f5-e9a1e766d210.png)