### PR TITLE
Remove references to SimpleForm required markup

### DIFF
--- a/app/views/partials/backup_code/_entry_fields.html.erb
+++ b/app/views/partials/backup_code/_entry_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-bottom-4">
   <%= f.input attribute_name,
-              label: t('simple_form.required.html') + t('forms.two_factor.backup_code'),
+              label: t('forms.two_factor.backup_code'),
               input_html: { autocapitalize: 'none',
                             autocomplete: 'off',
                             class: 'caps backup-code',

--- a/app/views/partials/personal_key/_entry_fields.html.erb
+++ b/app/views/partials/personal_key/_entry_fields.html.erb
@@ -2,7 +2,7 @@
 
 <div class='margin-bottom-4'>
   <%= f.input attribute_name,
-              label: t('simple_form.required.html') + t('forms.two_factor.personal_key'),
+              label: t('forms.two_factor.personal_key'),
               input_html: { autocapitalize: 'none',
                             autocomplete: 'off',
                             class: 'personal-key caps',

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -6,7 +6,7 @@
 
 <%= form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'margin-top-4 tablet:margin-top-6') do %>
   <%= render @presenter.reauthn_hidden_field_partial %>
-  <%= label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'), class: 'block bold' %>
+  <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
   <div class="col-12 sm-col-5 margin-bottom-1 tablet:margin-bottom-0 sm-mr-20p inline-block">
     <%= text_field_tag :code, '',
                        value: @code,

--- a/config/locales/simple_form/en.yml
+++ b/config/locales/simple_form/en.yml
@@ -5,7 +5,7 @@ en:
       default_message: 'Please review the problems below:'
     'no': 'No'
     required:
-      html: <abbr title="required" class="red display-none">*</abbr>
-      mark: "*"
+      html: ''
+      mark: ''
       text: This field is required
     'yes': 'Yes'

--- a/config/locales/simple_form/es.yml
+++ b/config/locales/simple_form/es.yml
@@ -5,7 +5,7 @@ es:
       default_message: 'Por favor revise los siguientes problemas:'
     'no': 'No'
     required:
-      html: <abbr title="required" class="red display-none">*</abbr>
-      mark: "*"
+      html: ''
+      mark: ''
       text: Este campo es requerido
     'yes': Sí

--- a/config/locales/simple_form/fr.yml
+++ b/config/locales/simple_form/fr.yml
@@ -5,7 +5,7 @@ fr:
       default_message: 'Veuillez examiner les problèmes ci-dessous :'
     'no': Non
     required:
-      html: <abbr title="required" class="red display-none">*</abbr>
-      mark: "*"
+      html: ''
+      mark: ''
       text: Ce champ est requis
     'yes': Oui


### PR DESCRIPTION
**Why**:

- We hide it anyways, both visually and from assistive technology
- If it were to be visible, it would use non-standard red color instead of design system (facilitates LG-3877)

See: https://github.com/18F/identity-idp/pull/4854#discussion_r604217085