### PR TITLE
LG-4396: Log frontend Acuant capture failure

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -31,12 +31,13 @@ import useI18n from '../hooks/use-i18n';
 
 /**
  * @typedef {(
- *   | null                    // Cropping failure. (SDK v11.4.3, L753)
- *   | undefined               // Cropping failure. (SDK v11.4.3, L960)
- *   | 'Camera not supported'  // Camera not supported. (SDK v11.4.3, L74, L798)
- *   | 'already started'       // Capture already started. (SDK v11.4.3, L565, L580)
- *   | 'Missing HTML elements' // Required page elements are not available. (SDK v11.4.3, L568)
- *   | MediaStreamError        // User or system denied camera access. (SDK v11.4.3, L544)
+ *   | null                     // Cropping failure (SDK v11.4.3, L753)
+ *   | undefined                // Cropping failure (SDK v11.4.3, L960)
+ *   | 'Camera not supported.'  // Camera not supported (SDK v11.4.3, L74, L798)
+ *   | 'already started.'       // Capture already started (SDK v11.4.3, L565)
+ *   | 'already started'        // Capture already started (SDK v11.4.3, L580)
+ *   | 'Missing HTML elements.' // Required page elements are not available (SDK v11.4.3, L568)
+ *   | MediaStreamError         // User or system denied camera access (SDK v11.4.3, L544)
  * )} AcuantCaptureFailureError
  */
 

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -30,6 +30,16 @@ import useI18n from '../hooks/use-i18n';
  */
 
 /**
+ * @typedef {(
+ *   | null                    // Cropping failure.
+ *   | 'Camera not supported'  // Camera not supported. (SDK v11.4.3, L74, L798)
+ *   | 'already started'       // Capture already started. (SDK v11.4.3, L565, L580)
+ *   | 'Missing HTML elements' // Required page elements are not available. (SDK v11.4.3, L568)
+ *   | MediaStreamError        // User or system denied camera access. (SDK v11.4.3, L544)
+ * )} AcuantCaptureFailureError
+ */
+
+/**
  * @typedef AcuantCameraUICallbacks
  *
  * @prop {(response: AcuantCaptureImage)=>void} onCaptured Document captured callback.
@@ -92,7 +102,7 @@ import useI18n from '../hooks/use-i18n';
  */
 
 /**
- * @typedef {(error?:Error)=>void} AcuantFailureCallback
+ * @typedef {(error:AcuantCaptureFailureError)=>void} AcuantFailureCallback
  */
 
 /**
@@ -122,7 +132,7 @@ function AcuantCaptureCanvas({
             if (response) {
               onImageCaptureSuccess(response);
             } else {
-              onImageCaptureFailure();
+              onImageCaptureFailure(response);
             }
           },
         },

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -31,7 +31,8 @@ import useI18n from '../hooks/use-i18n';
 
 /**
  * @typedef {(
- *   | null                    // Cropping failure.
+ *   | null                    // Cropping failure. (SDK v11.4.3, L753)
+ *   | undefined               // Cropping failure. (SDK v11.4.3, L960)
  *   | 'Camera not supported'  // Camera not supported. (SDK v11.4.3, L74, L798)
  *   | 'already started'       // Capture already started. (SDK v11.4.3, L565, L580)
  *   | 'Missing HTML elements' // Required page elements are not available. (SDK v11.4.3, L568)

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -90,7 +90,7 @@ import './acuant-capture.scss';
  * @prop {string=} className Optional additional class names.
  * @prop {boolean=} allowUpload Whether to allow file upload. Defaults to `true`.
  * @prop {ReactNode=} errorMessage Error to show.
- * @prop {string} analyticsPrefix Prefix to prepend to user action analytics labels.
+ * @prop {string} name Prefix to prepend to user action analytics labels.
  */
 
 /**
@@ -188,7 +188,7 @@ function AcuantCapture(
     className,
     allowUpload = true,
     errorMessage,
-    analyticsPrefix,
+    name,
   },
   ref,
 ) {
@@ -241,7 +241,7 @@ function AcuantCapture(
         };
 
         addPageAction({
-          label: `IdV: ${analyticsPrefix} added`,
+          label: `IdV: ${name} image added`,
           payload: analyticsPayload,
         });
       });
@@ -351,7 +351,7 @@ function AcuantCapture(
 
     addPageAction({
       key: 'documentCapture.acuantWebSDKResult',
-      label: `IdV: ${analyticsPrefix} added`,
+      label: `IdV: ${name} image added`,
       payload: analyticsPayload,
     });
 
@@ -368,7 +368,7 @@ function AcuantCapture(
               setOwnErrorMessage(t('errors.doc_auth.capture_failure'));
               setIsCapturingEnvironment(false);
               addPageAction({
-                label: `IdV: ${analyticsPrefix} capture failed`,
+                label: `IdV: ${name} image capture failed`,
                 payload: { error: getNormalizedAcuantCaptureFailureMessage(error) },
               });
             }}

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -368,8 +368,8 @@ function AcuantCapture(
               setOwnErrorMessage(t('errors.doc_auth.capture_failure'));
               setIsCapturingEnvironment(false);
               addPageAction({
-                label: `IdV: ${name} image capture failed`,
-                payload: { error: getNormalizedAcuantCaptureFailureMessage(error) },
+                label: 'IdV: Image capture failed',
+                payload: { field: name, error: getNormalizedAcuantCaptureFailureMessage(error) },
               });
             }}
           />

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -131,7 +131,7 @@ function getDocumentTypeLabel(documentType) {
  * @return {string}
  */
 export function getNormalizedAcuantCaptureFailureMessage(error) {
-  if (error instanceof window.MediaStreamError) {
+  if (error instanceof Error) {
     return 'User or system denied camera access';
   }
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -140,10 +140,11 @@ export function getNormalizedAcuantCaptureFailureMessage(error) {
   }
 
   switch (error) {
-    case 'Camera not supported':
+    case 'Camera not supported.':
       return 'Camera not supported';
-    case 'Missing HTML elements':
+    case 'Missing HTML elements.':
       return 'Required page elements are not available';
+    case 'already started.':
     case 'already started':
       return 'Capture already started';
     default:

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -126,6 +126,32 @@ function getDocumentTypeLabel(documentType) {
 }
 
 /**
+ * @param {import('./acuant-capture-canvas').AcuantCaptureFailureError} error
+ *
+ * @return {string}
+ */
+export function getNormalizedAcuantCaptureFailureMessage(error) {
+  if (error instanceof window.MediaStreamError) {
+    return 'User or system denied camera access';
+  }
+
+  if (!error) {
+    return 'Cropping failure';
+  }
+
+  switch (error) {
+    case 'Camera not supported':
+      return 'Camera not supported';
+    case 'Missing HTML elements':
+      return 'Required page elements are not available';
+    case 'already started':
+      return 'Capture already started';
+    default:
+      return 'Unknown error';
+  }
+}
+
+/**
  * @param {File} file Image file.
  *
  * @return {Promise<{width: number?, height: number?}>}
@@ -338,9 +364,13 @@ function AcuantCapture(
         <FullScreen onRequestClose={() => setIsCapturingEnvironment(false)}>
           <AcuantCaptureCanvas
             onImageCaptureSuccess={onAcuantImageCaptureSuccess}
-            onImageCaptureFailure={() => {
+            onImageCaptureFailure={(error) => {
               setOwnErrorMessage(t('errors.doc_auth.capture_failure'));
               setIsCapturingEnvironment(false);
+              addPageAction({
+                label: `IdV: ${analyticsPrefix} capture failed`,
+                payload: { error: getNormalizedAcuantCaptureFailureMessage(error) },
+              });
             }}
           />
         </FullScreen>

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -83,7 +83,7 @@ function DocumentsStep({
             value={value[side]}
             onChange={(nextValue) => onChange({ [side]: nextValue })}
             errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
-            analyticsPrefix={`${side} image`}
+            name={side}
           />
         );
       })}

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -84,7 +84,7 @@ function ReviewIssuesStep({
             onChange={(nextValue) => onChange({ [side]: nextValue })}
             className="document-capture-review-issues-step__input"
             errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}
-            analyticsPrefix={`${side} image`}
+            name={side}
           />
         );
       })}
@@ -109,7 +109,7 @@ function ReviewIssuesStep({
               allowUpload={false}
               className="document-capture-review-issues-step__input"
               errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
-              analyticsPrefix="selfie"
+              name="selfie"
             />
           ) : (
             <SelfieCapture

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -52,7 +52,7 @@ function SelfieStep({
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
           errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
-          analyticsPrefix="selfie"
+          name="selfie"
         />
       ) : (
         <SelfieCapture

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -46,6 +46,7 @@ describe('document-capture/components/acuant-capture', () => {
   describe('getNormalizedAcuantCaptureFailureMessage', () => {
     [
       null,
+      undefined,
       'Camera not supported',
       'already started',
       'Missing HTML elements',

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -195,8 +195,8 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(addPageAction).to.have.been.calledWith({
-        label: 'IdV: test image capture failed',
-        payload: { error: 'User or system denied camera access' },
+        label: 'IdV: Image capture failed',
+        payload: { field: 'test', error: 'User or system denied camera access' },
       });
     });
 

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -49,7 +49,7 @@ describe('document-capture/components/acuant-capture', () => {
       'Camera not supported',
       'already started',
       'Missing HTML elements',
-      new window.MediaStreamError(),
+      /** @type {MediaStreamError} */ (new Error()),
       'nonsense',
     ].forEach((error) => {
       it('returns a string', () => {
@@ -184,7 +184,7 @@ describe('document-capture/components/acuant-capture', () => {
       );
 
       initialize({
-        start: sinon.stub().callsArgWithAsync(1, new window.MediaStreamError()),
+        start: sinon.stub().callsArgWithAsync(1, new Error()),
       });
 
       const button = getByLabelText('Image');

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -178,7 +178,7 @@ describe('document-capture/components/acuant-capture', () => {
         <AnalyticsContext.Provider value={{ addPageAction }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
             <AcuantContextProvider sdkSrc="about:blank">
-              <AcuantCapture label="Image" analyticsPrefix="image" />
+              <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
         </AnalyticsContext.Provider>,
@@ -195,7 +195,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(addPageAction).to.have.been.calledWith({
-        label: 'IdV: image capture failed',
+        label: 'IdV: test image capture failed',
         payload: { error: 'User or system denied camera access' },
       });
     });
@@ -297,7 +297,7 @@ describe('document-capture/components/acuant-capture', () => {
         <AnalyticsContext.Provider value={{ addPageAction }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
             <AcuantContextProvider sdkSrc="about:blank">
-              <AcuantCapture label="Image" analyticsPrefix="image" />
+              <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
         </AnalyticsContext.Provider>,
@@ -318,7 +318,7 @@ describe('document-capture/components/acuant-capture', () => {
       const error = await findByText('errors.doc_auth.photo_glare');
       expect(addPageAction).to.have.been.calledWith({
         key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: image added',
+        label: 'IdV: test image added',
         payload: {
           documentType: 'id',
           mimeType: 'image/jpeg',
@@ -345,7 +345,7 @@ describe('document-capture/components/acuant-capture', () => {
         <AnalyticsContext.Provider value={{ addPageAction }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
             <AcuantContextProvider sdkSrc="about:blank">
-              <AcuantCapture label="Image" analyticsPrefix="image" />
+              <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
         </AnalyticsContext.Provider>,
@@ -366,7 +366,7 @@ describe('document-capture/components/acuant-capture', () => {
       const error = await findByText('errors.doc_auth.photo_blurry');
       expect(addPageAction).to.have.been.calledWith({
         key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: image added',
+        label: 'IdV: test image added',
         payload: {
           documentType: 'id',
           mimeType: 'image/jpeg',
@@ -426,7 +426,7 @@ describe('document-capture/components/acuant-capture', () => {
         <AnalyticsContext.Provider value={{ addPageAction }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
             <AcuantContextProvider sdkSrc="about:blank">
-              <AcuantCapture label="Image" analyticsPrefix="image" />
+              <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
         </AnalyticsContext.Provider>,
@@ -460,7 +460,7 @@ describe('document-capture/components/acuant-capture', () => {
       await waitForElementToBeRemoved(error);
       expect(addPageAction).to.have.been.calledWith({
         key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: image added',
+        label: 'IdV: test image added',
         payload: {
           documentType: 'id',
           mimeType: 'image/jpeg',
@@ -690,7 +690,7 @@ describe('document-capture/components/acuant-capture', () => {
     const { getByLabelText } = render(
       <AnalyticsContext.Provider value={{ addPageAction }}>
         <AcuantContextProvider sdkSrc="about:blank">
-          <AcuantCapture label="Image" analyticsPrefix="image" />
+          <AcuantCapture label="Image" name="test" />
         </AcuantContextProvider>
       </AnalyticsContext.Provider>,
     );
@@ -700,7 +700,7 @@ describe('document-capture/components/acuant-capture', () => {
 
     await new Promise((resolve) => addPageAction.callsFake(resolve));
     expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: image added',
+      label: 'IdV: test image added',
       payload: {
         height: sinon.match.number,
         mimeType: 'image/jpeg',

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -47,9 +47,10 @@ describe('document-capture/components/acuant-capture', () => {
     [
       null,
       undefined,
-      'Camera not supported',
+      'Camera not supported.',
+      'already started.',
       'already started',
-      'Missing HTML elements',
+      'Missing HTML elements.',
       /** @type {MediaStreamError} */ (new Error()),
       'nonsense',
     ].forEach((error) => {

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -26,6 +26,7 @@ Object.defineProperty(global.window.Image.prototype, 'src', {
     this.onload();
   },
 });
+global.window.MediaStreamError = class extends Error {}; // https://github.com/jsdom/jsdom/issues/2654
 global.navigator = window.navigator;
 global.document = window.document;
 global.Document = window.Document;

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -26,7 +26,6 @@ Object.defineProperty(global.window.Image.prototype, 'src', {
     this.onload();
   },
 });
-global.window.MediaStreamError = class extends Error {}; // https://github.com/jsdom/jsdom/issues/2654
 global.navigator = window.navigator;
 global.document = window.document;
 global.Document = window.Document;


### PR DESCRIPTION
**Why**: So that we have insight into the reasons that a capture fails:

- The cropping fails
- The camera is not supported
- The camera has already been started
- The page is misconfigured and missing HTML elements required by Acuant
- The user or system denies access to their camera