### PR TITLE
log when resolution and address proofing are throttled (LG-4430)

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -20,7 +20,14 @@ module IdvStepConcern
   end
 
   def confirm_step_allowed
-    redirect_to_fail_url if step_attempts_exceeded?
+    if step_attempts_exceeded?
+      analytics.track_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_resolution,
+        step_name: step_name,
+      )
+      redirect_to_fail_url
+    end
   end
 
   def redirect_to_fail_url

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -163,6 +163,7 @@ module Idv
         analytics.track_event(
           Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
           throttle_type: :idv_resolution,
+          step_name: :gpo,
         )
         flash_error
       end

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -12,6 +12,10 @@ class IdvController < ApplicationController
     elsif active_profile? && !liveness_upgrade_required?
       redirect_to idv_activated_url
     elsif idv_attempter_throttled?
+      analytics.track_event(
+        Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
+        throttle_type: :idv_resolution,
+      )
       redirect_to idv_fail_url
     elsif sp_over_quota_limit?
       flash[:error] = t('errors.doc_auth.quota_reached')

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -25,6 +25,7 @@ module Idv
           @flow.analytics.track_event(
             Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
             throttle_type: :idv_resolution,
+            step_name: self.class,
           )
           redirect_to idv_session_errors_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -109,6 +109,7 @@ feature 'doc auth verify step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
       throttle_type: :idv_resolution,
+      step_name: Idv::Steps::VerifyWaitStepShow,
     )
 
     Timecop.travel(AppConfig.env.idv_attempt_window_in_hours.to_i.hours.from_now) do
@@ -136,6 +137,7 @@ feature 'doc auth verify step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
       throttle_type: :idv_resolution,
+      step_name: Idv::Steps::VerifyWaitStepShow,
     )
   end
 


### PR DESCRIPTION
Adds a couple more throttle events, and some additional detail to be able to distinguish events using the same throttle key