### PR TITLE
Add code to test benchmarking salted backup codes (LG-4425)

### DIFF
--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -13,7 +13,7 @@ class BackupCodeBenchmarker
   def initialize(
     cost: '10000$8$1$',
     batch_size: 1000,
-    num_rows: 100_000, # number of BackupCodeCon
+    num_rows: 100_000, # number of rows to test backfilling
     num_per_user: BackupCodeGenerator::NUMBER_OF_CODES, # defaults to 10
     logger: Logger.new(STDOUT)
   )

--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -1,3 +1,5 @@
+# This is for benchmarking backup code conversion to salted hashes
+# DO NOT RUN IT IN PRODUCTION
 class BackupCodeBenchmarker
   # attribute_cost: "4000$8$4$"
   # scrypt_cost: "10000$8$1$"
@@ -9,7 +11,7 @@ class BackupCodeBenchmarker
   attr_reader :logger
 
   def initialize(
-    cost: "10000$8$1$",
+    cost: '10000$8$1$',
     batch_size: 1000,
     num_rows: 100_000, # number of BackupCodeCon
     num_per_user: BackupCodeGenerator::NUMBER_OF_CODES, # defaults to 10
@@ -38,7 +40,7 @@ class BackupCodeBenchmarker
       end
     end
 
-    logger.info "done creating backup codes"
+    logger.info 'done creating backup codes'
   end
 
   def run

--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -57,7 +57,11 @@ class BackupCodeBenchmarker
       BackupCodeConfiguration.find_in_batches(batch_size: batch_size) do |batch|
         Benchmark.realtime do
           batch.each_slice(num_per_user) do |slice|
-            convert_codes!(slice)
+            Benchmark.realtime do
+              convert_codes!(slice)
+            end.tap do |duration|
+              logger.info "duration=#{duration} batch_size=#{slice.size}"
+            end
           end
         end.tap do |duration|
           logger.info "duration=#{duration} batch_size=#{batch.size}"

--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -1,0 +1,105 @@
+class BackupCodeBenchmarker
+  # attribute_cost: "4000$8$4$"
+  # scrypt_cost: "10000$8$1$"
+
+  attr_reader :cost
+  attr_reader :batch_size
+  attr_reader :num_rows
+  attr_reader :num_per_user
+  attr_reader :logger
+
+  def initialize(
+    cost: "10000$8$1$",
+    batch_size: 1000,
+    num_rows: 100_000, # number of BackupCodeCon
+    num_per_user: BackupCodeGenerator::NUMBER_OF_CODES, # defaults to 10
+    logger: Logger.new(STDOUT)
+  )
+    @cost = cost
+    @batch_size = batch_size
+    @num_rows = num_rows
+    @num_per_user = num_per_user
+    @logger = logger
+  end
+
+  def prepare!
+    return if BackupCodeConfiguration.count >= num_rows
+
+    user = User.first!
+    num_to_create = num_rows - BackupCodeConfiguration.count
+
+    logger.info "creating #{num_to_create} backup code configurations"
+
+    num_to_create.times.each_slice(batch_size) do |slice|
+      slice.each do
+        code = SecureRandom.hex(6) # @see BackupCodeGenerator#backup_code
+
+        user.backup_code_configurations.create!(code: code)
+      end
+    end
+
+    logger.info "done creating backup codes"
+  end
+
+  def run
+    raise 'whoah buddy' if Identity::Hostdata.env == 'prod'
+
+    silence_active_record_logger do
+      prepare!
+      convert!
+    end
+  end
+
+  def convert!
+    Benchmark.realtime do
+      BackupCodeConfiguration.find_in_batches(batch_size: batch_size) do |batch|
+        Benchmark.realtime do
+          batch.each_slice(num_per_user) do |slice|
+            convert_codes!(slice)
+          end
+        end.tap do |duration|
+          logger.info "duration=#{duration} batch_size=#{batch.size}"
+        end
+      end
+    end.tap do |duration|
+      logger.info "duration=#{duration} batch_size=#{num_rows} (done)"
+    end
+  end
+
+  # @param [Array<BackupCodeConfiguration>] backup_code_configurations
+  def convert_codes!(backup_code_configurations)
+    salt = SecureRandom.hex(32)
+
+    backup_code_configurations.each do |backup_code_configuration|
+      code = backup_code_configuration.code
+
+      backup_code_configuration.code_cost = cost
+      backup_code_configuration.code_salt = salt
+      backup_code_configuration.salted_code_fingerprint = scrypt_password_digest(
+        password: code,
+        salt: salt,
+        cost: cost,
+      )
+      backup_code_configuration.save!
+    end
+  end
+
+  # Open Question: do we need Base64? This is going directly to a column, not to a JSON blob
+  # @see PasswordVerifier#scrypt_password_digest
+  def scrypt_password_digest(password:, salt:, cost:)
+    scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
+    scrypted = SCrypt::Engine.hash_secret password, scrypt_salt, 32
+    scrypt_password_digest = SCrypt::Password.new(scrypted).digest
+    # Base64.strict_encode64(scrypt_password_digest)
+  end
+
+  # @yield a block to run with a silenced AR logger
+  def silence_active_record_logger
+    ar_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = nil
+
+    yield
+  ensure
+    ActiveRecord::Base.logger = ar_logger
+  end
+end

--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -86,13 +86,11 @@ class BackupCodeBenchmarker
     end
   end
 
-  # Open Question: do we need Base64? This is going directly to a column, not to a JSON blob
   # @see PasswordVerifier#scrypt_password_digest
   def scrypt_password_digest(password:, salt:, cost:)
     scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
     scrypted = SCrypt::Engine.hash_secret password, scrypt_salt, 32
     scrypt_password_digest = SCrypt::Password.new(scrypted).digest
-    # Base64.strict_encode64(scrypt_password_digest)
   end
 
   # @yield a block to run with a silenced AR logger

--- a/app/services/backup_code_benchmarker.rb
+++ b/app/services/backup_code_benchmarker.rb
@@ -54,7 +54,7 @@ class BackupCodeBenchmarker
 
   def convert!
     Benchmark.realtime do
-      BackupCodeConfiguration.find_in_batches(batch_size: batch_size) do |batch|
+      BackupCodeConfiguration.limit(num_rows).find_in_batches(batch_size: batch_size) do |batch|
         Benchmark.realtime do
           batch.each_slice(num_per_user) do |slice|
             Benchmark.realtime do

--- a/db/migrate/20210401192727_add_salted_code_fingerprint_salt_cost_to_backup_code_configurations.rb
+++ b/db/migrate/20210401192727_add_salted_code_fingerprint_salt_cost_to_backup_code_configurations.rb
@@ -1,0 +1,7 @@
+class AddSaltedCodeFingerprintSaltCostToBackupCodeConfigurations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :backup_code_configurations, :salted_code_fingerprint, :string, limit: 255
+    add_column :backup_code_configurations, :code_salt, :string, limit: 255
+    add_column :backup_code_configurations, :code_cost, :string, limit: 20
+  end
+end

--- a/db/migrate/20210401192727_add_salted_code_fingerprint_salt_cost_to_backup_code_configurations.rb
+++ b/db/migrate/20210401192727_add_salted_code_fingerprint_salt_cost_to_backup_code_configurations.rb
@@ -1,7 +1,7 @@
 class AddSaltedCodeFingerprintSaltCostToBackupCodeConfigurations < ActiveRecord::Migration[6.1]
   def change
-    add_column :backup_code_configurations, :salted_code_fingerprint, :string, limit: 255
-    add_column :backup_code_configurations, :code_salt, :string, limit: 255
-    add_column :backup_code_configurations, :code_cost, :string, limit: 20
+    add_column :backup_code_configurations, :salted_code_fingerprint, :string
+    add_column :backup_code_configurations, :code_salt, :string
+    add_column :backup_code_configurations, :code_cost, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,9 +75,9 @@ ActiveRecord::Schema.define(version: 2021_04_01_192727) do
     t.datetime "used_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "salted_code_fingerprint", limit: 255
-    t.string "code_salt", limit: 255
-    t.string "code_cost", limit: 20
+    t.string "salted_code_fingerprint"
+    t.string "code_salt"
+    t.string "code_cost"
     t.index ["user_id", "code_fingerprint"], name: "index_bcc_on_user_id_code_fingerprint", unique: true
     t.index ["user_id", "created_at"], name: "index_backup_code_configurations_on_user_id_and_created_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_162528) do
+ActiveRecord::Schema.define(version: 2021_04_01_192727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,9 @@ ActiveRecord::Schema.define(version: 2021_03_29_162528) do
     t.datetime "used_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "salted_code_fingerprint", limit: 255
+    t.string "code_salt", limit: 255
+    t.string "code_cost", limit: 20
     t.index ["user_id", "code_fingerprint"], name: "index_bcc_on_user_id_code_fingerprint", unique: true
     t.index ["user_id", "created_at"], name: "index_backup_code_configurations_on_user_id_and_created_at"
   end

--- a/spec/services/backup_code_benchmarker_spec.rb
+++ b/spec/services/backup_code_benchmarker_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe BackupCodeBenchmarker do
     end
 
     it 'sets scrypted value' do
-      BackupCodeConfiguration.delete_all
-
       benchmarker.run
 
       expect(BackupCodeConfiguration.count).to eq(num_rows)

--- a/spec/services/backup_code_benchmarker_spec.rb
+++ b/spec/services/backup_code_benchmarker_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe BackupCodeBenchmarker do
             password: cfg.code,
             salt: cfg.code_salt,
             cost: cfg.code_cost,
-          )
+          ),
         )
       end
     end

--- a/spec/services/backup_code_benchmarker_spec.rb
+++ b/spec/services/backup_code_benchmarker_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe BackupCodeBenchmarker do
 
   let(:num_rows) { 4 }
   let(:num_per_user) { 2 }
+  let(:user) { build(:user) }
   subject(:benchmarker) do
     BackupCodeBenchmarker.new(
       cost: '4000$8$4$',
@@ -28,7 +29,6 @@ RSpec.describe BackupCodeBenchmarker do
 
     context 'when enough backup code configurations already exist' do
       let(:num_rows) { 2 }
-      let(:user) { build(:user) }
 
       before do
         num_rows.times { create(:backup_code_configuration, user: user) }
@@ -55,6 +55,13 @@ RSpec.describe BackupCodeBenchmarker do
           ),
         )
       end
+    end
+
+    it 'does not update beyond num_rows' do
+      (num_rows + 1).times { create(:backup_code_configuration, user: user) }
+
+      expect { benchmarker.run }.
+        to_not(change { BackupCodeConfiguration.last.salted_code_fingerprint })
     end
   end
 end

--- a/spec/services/backup_code_benchmarker_spec.rb
+++ b/spec/services/backup_code_benchmarker_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe BackupCodeBenchmarker do
+  let(:logger) { Logger.new('/dev/null') }
+
+  let(:num_rows) { 4 }
+  let(:num_per_user) { 2 }
+  subject(:benchmarker) do
+    BackupCodeBenchmarker.new(
+      cost: '4000$8$4$',
+      logger: logger,
+      num_rows: num_rows,
+      num_per_user: num_per_user,
+      batch_size: 10,
+    )
+  end
+
+  describe '#run' do
+    context 'in production' do
+      before do
+        expect(Identity::Hostdata).to receive(:env).and_return('prod')
+      end
+
+      it 'bails and does not run' do
+        expect { benchmarker.run }.to raise_error('do not run in prod')
+      end
+    end
+
+    context 'when enough backup code configurations already exist' do
+      let(:num_rows) { 2 }
+      let(:user) { build(:user) }
+
+      before do
+        num_rows.times { create(:backup_code_configuration, user: user) }
+      end
+
+      it 'does not create any new ones' do
+        expect { benchmarker.run }.to_not(change { BackupCodeConfiguration.count })
+      end
+    end
+
+    it 'sets scrypted value' do
+      BackupCodeConfiguration.delete_all
+
+      benchmarker.run
+
+      expect(BackupCodeConfiguration.count).to eq(num_rows)
+
+      BackupCodeConfiguration.all.each do |cfg|
+        expect(cfg.salted_code_fingerprint).to eq(
+          benchmarker.scrypt_password_digest(
+            password: cfg.code,
+            salt: cfg.code_salt,
+            cost: cfg.code_cost,
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/services/backup_code_benchmarker_spec.rb
+++ b/spec/services/backup_code_benchmarker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BackupCodeBenchmarker do
   let(:user) { build(:user) }
   subject(:benchmarker) do
     BackupCodeBenchmarker.new(
-      cost: '4000$8$4$',
+      cost: '10$8$4$',
       logger: logger,
       num_rows: num_rows,
       num_per_user: num_per_user,


### PR DESCRIPTION
My plan: get some information on which cost we want to use, and then deploy this to my personal env to test

To run, do this in the Rails console:

```ruby
BackupCodeBenchmarker.new(num_rows: 1000, batch_size: 10).run
```

Sample output:

```
I, [2021-04-01T13:32:50.828821 #95802]  INFO -- : duration=2.510444000014104 batch_size=10
I, [2021-04-01T13:32:53.434113 #95802]  INFO -- : duration=2.6033740000566468 batch_size=10
I, [2021-04-01T13:32:55.786748 #95802]  INFO -- : duration=2.3510239999741316 batch_size=10
I, [2021-04-01T13:32:58.154022 #95802]  INFO -- : duration=2.3660519999684766 batch_size=10
I, [2021-04-01T13:33:00.629123 #95802]  INFO -- : duration=2.4735469999723136 batch_size=10
I, [2021-04-01T13:33:03.042509 #95802]  INFO -- : duration=2.4109069999540225 batch_size=10
I, [2021-04-01T13:33:05.537544 #95802]  INFO -- : duration=2.4928170000202954 batch_size=10
I, [2021-04-01T13:33:08.356079 #95802]  INFO -- : duration=2.817155000055209 batch_size=10
```