### PR TITLE
Split Yarn lockfile sync build error from optimized assets check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
       - run:
           name: Run Lints
           command: |
+            make lint_yarn_lockfile
             yarn run lint
             yarn run typecheck
             bundle exec rubocop

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ lint:
 lint_erb:
 	bundle exec erblint app/views
 
+lint_yarn_lockfile:
+	(git diff --name-only | grep yarn.lock) && (echo "Error: Sync Yarn lockfile using 'yarn install'"; exit 1)
+
 lintfix:
 	@echo "--- rubocop fix ---"
 	bundle exec rubocop -R -a
@@ -79,7 +82,7 @@ optimize_svg:
 optimize_assets: optimize_svg
 
 lint_optimized_assets: optimize_assets
-	git diff --quiet || (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
+	(git diff --name-only | grep "\.svg$") && (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
 
 update_country_dialing_codes:
 	bundle exec ./scripts/pinpoint-supported-countries > config/country_dialing_codes.yml

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint_erb:
 	bundle exec erblint app/views
 
 lint_yarn_lockfile:
-	(git diff --name-only | grep yarn.lock) && (echo "Error: Sync Yarn lockfile using 'yarn install'"; exit 1)
+	(! git diff --name-only | grep yarn.lock) || (echo "Error: Sync Yarn lockfile using 'yarn install'"; exit 1)
 
 lintfix:
 	@echo "--- rubocop fix ---"
@@ -82,7 +82,7 @@ optimize_svg:
 optimize_assets: optimize_svg
 
 lint_optimized_assets: optimize_assets
-	(git diff --name-only | grep "\.svg$") && (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
+	(! git diff --name-only | grep "\.svg$") || (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
 
 update_country_dialing_codes:
 	bundle exec ./scripts/pinpoint-supported-countries > config/country_dialing_codes.yml

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ optimize_svg:
 optimize_assets: optimize_svg
 
 lint_optimized_assets: optimize_assets
-	(! git diff --name-only | grep "\.svg$") || (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
+	(! git diff --name-only | grep "\.svg$$") || (echo "Error: Optimize assets using 'make optimize_assets'"; exit 1)
 
 update_country_dialing_codes:
 	bundle exec ./scripts/pinpoint-supported-countries > config/country_dialing_codes.yml


### PR DESCRIPTION
**Why**: An out-of-sync yarn.lock will currently be caught as a failure by the CircleCI build, but the associated error message mentions "Optimize assets using 'make optimize_assets'". This is because it's only incidentally caught due to the fact that optimize assets lint relies on changes existing in the working directory after running the optimization, regardless if those changes are for SVG files.

With these changes, we test for the specific changes we might expect, and tailor the error message accordingly.