### PR TITLE
LG-4316: Add lockout information to two-factor options screen

### DIFF
--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -10,6 +10,12 @@
 
 <p class="mt-tiny"><%== @presenter.intro %></p>
 
+<div class="usa-alert usa-alert--info" >
+  <div class="usa-alert__body">
+    <p class="usa-alert__text"><%=t('two_factor_authentication.lockout_information')%></p>
+  </div>
+</div>
+
 <%= validated_form_for @two_factor_options_form,
                        html: { autocomplete: 'off', role: 'form' },
                        method: :patch,

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -10,11 +10,7 @@
 
 <p class="mt-tiny"><%== @presenter.intro %></p>
 
-<div class="usa-alert usa-alert--info" >
-  <div class="usa-alert__body">
-    <p class="usa-alert__text"><%=t('two_factor_authentication.lockout_information')%></p>
-  </div>
-</div>
+<%= render('shared/alert') { t('two_factor_authentication.lockout_information') } %>
 
 <%= validated_form_for @two_factor_options_form,
                        html: { autocomplete: 'off', role: 'form' },

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -29,7 +29,7 @@ en:
       phone: Phone
       piv_cac: PIV/CAC
       webauthn: Security key
-    header_text: Enter your security code
+    header_text: Enter your security code 
     important_alert_icon: important alert icon
     invalid_backup_code: That backup code is invalid.
     invalid_otp: That security code is invalid. You can try entering it again or request
@@ -63,6 +63,7 @@ en:
       webauthn_info_html: Use your security key to access your account.
     login_options_link_text: Choose another authentication method
     login_options_title: Select your authentication method
+    lockout_information: Keep this informations safe. You will be locked out and have to create a new account if you lose your authentication method.
     max_backup_code_login_attempts_reached: For your security, your account is temporarily
       locked because you have entered the backup code incorrectly too many times.
     max_generic_login_attempts_reached: For your security, your account is temporarily

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -29,7 +29,7 @@ en:
       phone: Phone
       piv_cac: PIV/CAC
       webauthn: Security key
-    header_text: Enter your security code 
+    header_text: Enter your security code
     important_alert_icon: important alert icon
     invalid_backup_code: That backup code is invalid.
     invalid_otp: That security code is invalid. You can try entering it again or request
@@ -38,6 +38,8 @@ en:
     invalid_piv_cac: That PIV/CAC didn’t work. Make sure it’s the right PIV/CAC for
       this account. If it is, there may be a problem with your PIV/CAC, PIN, or something
       went wrong on our end. Try again or choose another authentication method.
+    lockout_information: Keep this informations safe. You will be locked out and have
+      to create a new account if you lose your authentication method.
     login_intro: You set these up when you created your account
     login_options:
       auth_app: Authentication app
@@ -63,7 +65,6 @@ en:
       webauthn_info_html: Use your security key to access your account.
     login_options_link_text: Choose another authentication method
     login_options_title: Select your authentication method
-    lockout_information: Keep this informations safe. You will be locked out and have to create a new account if you lose your authentication method.
     max_backup_code_login_attempts_reached: For your security, your account is temporarily
       locked because you have entered the backup code incorrectly too many times.
     max_generic_login_attempts_reached: For your security, your account is temporarily

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -38,7 +38,7 @@ en:
     invalid_piv_cac: That PIV/CAC didn’t work. Make sure it’s the right PIV/CAC for
       this account. If it is, there may be a problem with your PIV/CAC, PIN, or something
       went wrong on our end. Try again or choose another authentication method.
-    lockout_information: Keep this informations safe. You will be locked out and have
+    lockout_information: Keep this information safe. You will be locked out and have
       to create a new account if you lose your authentication method.
     login_intro: You set these up when you created your account
     login_options:

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -39,6 +39,8 @@ es:
     invalid_piv_cac: Ese PIV/CAC no funcionó. Asegúrese de que sea el PIV/CAC correcto
       para esta cuenta. Si es así, puede haber un problema con su PIV/CAC, PIN o algo
       salió mal de nuestra parte. Intente nuevamente o elija otro método de autenticación.
+    lockout_information: Mantenga esta información de forma segura. En caso de perder
+      el método de autenticación, la cuenta se bloqueará y tendrá que crear una nueva.
     login_intro: Usted configuró esto cuando creó su cuenta
     login_options:
       auth_app: Aplicación de autenticación
@@ -68,7 +70,6 @@ es:
       webauthn_info_html: Use su llave de seguridad para acceder a su cuenta.
     login_options_link_text: Elige otra opción de seguridad
     login_options_title: Seleccione su opción de seguridad
-    lockout_information: Mantenga esta información de forma segura. En caso de perder el método de autenticación, la cuenta se bloqueará y tendrá que crear una nueva.
     max_backup_code_login_attempts_reached: Para su seguridad, su cuenta está bloqueada
       temporalmente porque ha ingresado el código de respaldo incorrectamente muchas
       veces.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -68,6 +68,7 @@ es:
       webauthn_info_html: Use su llave de seguridad para acceder a su cuenta.
     login_options_link_text: Elige otra opción de seguridad
     login_options_title: Seleccione su opción de seguridad
+    lockout_information: Mantenga esta información de forma segura. En caso de perder el método de autenticación, la cuenta se bloqueará y tendrá que crear una nueva.
     max_backup_code_login_attempts_reached: Para su seguridad, su cuenta está bloqueada
       temporalmente porque ha ingresado el código de respaldo incorrectamente muchas
       veces.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -40,6 +40,8 @@ fr:
       PIV/CAC pour ce compte. Si c'est le cas, votre PIV/CAC, votre NIP ou un problème
       survenu de notre côté pourrait bien poser problème. Réessayez ou choisissez
       une autre méthode d'authentification.
+    lockout_information: Conservez ces informations en toute sécurité. Vous serez
+      bloqué et devrez créer un nouveau compte si vous perdez votre méthode d'authentification.
     login_intro: Vous les avez configurés lorsque vous avez crée votre compte
     login_options:
       auth_app: Application d'authentification
@@ -68,7 +70,6 @@ fr:
       webauthn_info_html: Utilisez votre clé de sécurité pour accéder à votre compte.
     login_options_link_text: Choisissez une autre option de sécurité
     login_options_title: Sélectionnez votre option de sécurité
-    lockout_information: Conservez ces informations en toute sécurité. Vous serez bloqué et devrez créer un nouveau compte si vous perdez votre méthode d'authentification.
     max_backup_code_login_attempts_reached: Pour votre sécurité, votre compte est
       temporairement verrouillé car vous avez saisi trop de fois le code de sauvegarde.
     max_generic_login_attempts_reached: Pour votre sécurité, votre compte est temporairement

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -68,6 +68,7 @@ fr:
       webauthn_info_html: Utilisez votre clé de sécurité pour accéder à votre compte.
     login_options_link_text: Choisissez une autre option de sécurité
     login_options_title: Sélectionnez votre option de sécurité
+    lockout_information: Conservez ces informations en toute sécurité. Vous serez bloqué et devrez créer un nouveau compte si vous perdez votre méthode d'authentification.
     max_backup_code_login_attempts_reached: Pour votre sécurité, votre compte est
       temporairement verrouillé car vous avez saisi trop de fois le code de sauvegarde.
     max_generic_login_attempts_reached: Pour votre sécurité, votre compte est temporairement


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17969963/113437276-5ab2dd80-93b4-11eb-9938-97f97edde066.png)

This PR adds an information box to inform users to keep their authentication method safe.