### PR TITLE
fix default application.yml content

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'pathname'
+require 'yaml'
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
@@ -24,8 +25,7 @@ Dir.chdir APP_ROOT do
   ]
 
   puts '== Setting up config overrides =='
-  require 'yaml'
-  default_application_yml = { development: { config_key: nil } }
+  default_application_yml = { 'development' => { 'config_key' => nil } }
   File.write('config/application.yml', default_application_yml.to_yaml) unless File.exists?('config/application.yml')
 
   puts "== Linking service_providers.yml =="

--- a/bin/setup
+++ b/bin/setup
@@ -24,7 +24,9 @@ Dir.chdir APP_ROOT do
   ]
 
   puts '== Setting up config overrides =='
-  File.write('config/application.yml', "development:\n  config_key:") unless File.exists?('config/application.yml')
+  require 'yaml'
+  default_application_yml = { development: { config_key: nil } }
+  File.write('config/application.yml', default_application_yml.to_yaml) unless File.exists?('config/application.yml')
 
   puts "== Linking service_providers.yml =="
   run "test -r config/service_providers.yml || ln -sv service_providers.localdev.yml config/service_providers.yml"

--- a/bin/setup
+++ b/bin/setup
@@ -24,7 +24,7 @@ Dir.chdir APP_ROOT do
   ]
 
   puts '== Setting up config overrides =='
-  File.write('config/application.yml', 'development:') unless File.exists?('config/application.yml')
+  File.write('config/application.yml', "development:\n  config_key:") unless File.exists?('config/application.yml')
 
   puts "== Linking service_providers.yml =="
   run "test -r config/service_providers.yml || ln -sv service_providers.localdev.yml config/service_providers.yml"


### PR DESCRIPTION
While setting up @jmdembe's local IDP environment, we ran into an error:

```
/Users/mitchellehenke/projects/identity-idp/config/application.rb:31:in `merge': no implicit
conversion of nil into Hash (TypeError)
```

The root issue is the setup script defaults to writing an override YAML with this content:

```
development:
```

which parses to `{ 'development' => nil }`

The deep_merge called in https://github.com/18F/identity-idp/blob/main/lib/app_config_reader.rb#L15-L16 caused everything under `application.yml.default`'s `development` key to be overwritten with `nil` 🙂 

This adds a fake key in the default so that the above now parses to ` { 'development' => { 'test_key' => nil } }` and avoids the destructive merge.