### PR TITLE
Change worker log location

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -149,7 +149,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     if Rails.env.test?
       Rails.logger
     else
-      ActiveSupport::Logger.new(Rails.root.join('log', "#{Rails.env}.log"))
+      ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
     end
   end
 

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -62,7 +62,6 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
 
     json = default_attributes(event, job).merge(
       enqueued_at: job.enqueued_at,
-      queued_duration_ms: queued_duration(job),
     )
 
     if ex


### PR DESCRIPTION
All worker logs should go to their own file in `logs/workers.log`