### PR TITLE
Configuration type checks for comma separated list configs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module Upaya
     Rails.application.config.action_controller.urlsafe_csrf_tokens = false
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{yml}')]
-    config.i18n.available_locales = AppConfig.env.available_locales.try(:split, ' ') || %w[en]
+    config.i18n.available_locales = %w[en es fr]
     config.i18n.default_locale = :en
     config.action_controller.per_form_csrf_tokens = true
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -35,7 +35,6 @@ add_email_link_valid_for_hours: '24'
 allow_piv_cac_required: 'true'
 asset_host:
 async_wait_timeout_seconds: '60'
-available_locales: en es fr
 aws_http_timeout: '5'
 aws_http_retry_limit: '2'
 aws_http_retry_max_delay: '1'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -51,6 +51,7 @@ email_from: no-reply@login.gov
 email_from_display_name: Login.gov
 enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'
+exception_recipients: user1@example.com,user2@example.com
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 gpo_designated_receiver_pii: '{}'
 ial2_recovery_request_valid_for_minutes: '15'
@@ -189,7 +190,6 @@ development:
   enable_rate_limiting: 'false'
   enable_test_routes: 'true'
   enable_usps_verification: 'true'
-  exception_recipients: test1@test.com
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
@@ -294,7 +294,6 @@ production:
   enable_rate_limiting: 'true'
   enable_test_routes: 'false'
   enable_usps_verification: 'false'
-  exception_recipients: user1@example.com,user2@example.com
   expired_letters_auth_token:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,6 @@
 require 'exception_notification/rails'
 
-EXCEPTION_RECIPIENTS = AppConfig.env.exception_recipients.split(',').freeze
+EXCEPTION_RECIPIENTS = IdentityConfig.store.exception_recipients
 
 ExceptionNotification.configure do |config|
   config.add_notifier(

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -96,7 +96,7 @@ end
 # We need this to be called after the SecureHeaders::Railtie adds its own middleware at the top
 Rails.application.configure do |config|
   # I18n is not configured yet at this point
-  available_locales = AppConfig.env.available_locales.try(:split, ' ') || %w[en]
+  available_locales = %w[en es fr]
   worker_js = 'AcuantImageProcessingWorker.min.js'
 
   # example URLs:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -50,6 +50,7 @@ class IdentityConfig
     config.add(:deleted_user_accounts_report_configs, type: :json)
     config.add(:exception_recipients, type: :comma_separated_string_list)
     config.add(:hmac_fingerprinter_key_queue, type: :json)
+    config.add(:issuers_with_email_nameid_format, type: :comma_separated_string_list)
     config.add(:no_sp_campaigns_whitelist, type: :json)
     config.add(:nonessential_email_banlist, type: :json)
     config.add(:recurring_jobs_disabled_names, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -48,6 +48,7 @@ class IdentityConfig
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)
+    config.add(:exception_recipients, type: :comma_separated_string_list)
     config.add(:hmac_fingerprinter_key_queue, type: :json)
     config.add(:no_sp_campaigns_whitelist, type: :json)
     config.add(:nonessential_email_banlist, type: :json)

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -21,8 +21,7 @@ module Saml
       AAL3_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/3".freeze
       AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/3?hspd12=true".freeze
 
-      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = AppConfig.env.issuers_with_email_nameid_format.split(',').
-                                         freeze
+      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = IdentityConfig.store.issuers_with_email_nameid_format
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'.freeze
       NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
 


### PR DESCRIPTION
Follow up to #4847 that converts all of the comma separated list configs

I like deleting things so I also removed `available_locales` from configuration because it seems extremely unlikely that we'll need to configure that?