### PR TITLE
Configuration type checks for uri configs

### DIFF
--- a/app/controllers/concerns/piv_cac_concern.rb
+++ b/app/controllers/concerns/piv_cac_concern.rb
@@ -41,7 +41,7 @@ module PivCacConcern
     # for the SP and for the PIV/CAC service need appear in the CSP form-action
     # Returns fully formed CSP array w/"'self'" and redirect_uris
     piv_cac_uri = if Rails.env.development?
-                    AppConfig.env.piv_cac_service_url
+                    IdentityConfig.store.piv_cac_service_url
                   else
                     "https://*.pivcac.#{Identity::Hostdata.env}.#{Identity::Hostdata.domain}"
                   end

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -22,7 +22,7 @@ class ResolutionProofingJob < ApplicationJob
           private_key: AppConfig.env.aamva_private_key,
           public_key: AppConfig.env.aamva_public_key,
           verification_request_timeout: AppConfig.env.aamva_verification_request_timeout,
-          verification_url: AppConfig.env.aamva_verification_url,
+          verification_url: IdentityConfig.store.aamva_verification_url,
         },
         lexisnexis_config: {
           instant_verify_workflow: AppConfig.env.lexisnexis_instant_verify_workflow,

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -183,7 +183,7 @@ module DocAuthRouter
           assure_id_url: IdentityConfig.store.acuant_assure_id_url,
           assure_id_username: AppConfig.env.acuant_assure_id_username,
           facial_match_url: IdentityConfig.store.acuant_facial_match_url,
-          passlive_url: AppConfig.env.acuant_passlive_url,
+          passlive_url: IdentityConfig.store.acuant_passlive_url,
           timeout: AppConfig.env.acuant_timeout,
           exception_notifier: method(:notify_exception),
         ),

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -182,7 +182,7 @@ module DocAuthRouter
           assure_id_subscription_id: AppConfig.env.acuant_assure_id_subscription_id,
           assure_id_url: IdentityConfig.store.acuant_assure_id_url,
           assure_id_username: AppConfig.env.acuant_assure_id_username,
-          facial_match_url: AppConfig.env.acuant_facial_match_url,
+          facial_match_url: IdentityConfig.store.acuant_facial_match_url,
           passlive_url: AppConfig.env.acuant_passlive_url,
           timeout: AppConfig.env.acuant_timeout,
           exception_notifier: method(:notify_exception),

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -180,7 +180,7 @@ module DocAuthRouter
         IdentityDocAuth::Acuant::AcuantClient.new(
           assure_id_password: AppConfig.env.acuant_assure_id_password,
           assure_id_subscription_id: AppConfig.env.acuant_assure_id_subscription_id,
-          assure_id_url: AppConfig.env.acuant_assure_id_url,
+          assure_id_url: IdentityConfig.store.acuant_assure_id_url,
           assure_id_username: AppConfig.env.acuant_assure_id_username,
           facial_match_url: AppConfig.env.acuant_facial_match_url,
           passlive_url: AppConfig.env.acuant_passlive_url,

--- a/app/services/outbound_health_checker.rb
+++ b/app/services/outbound_health_checker.rb
@@ -11,13 +11,13 @@ module OutboundHealthChecker
   end
 
   def outbound_response
-    if AppConfig.env.outbound_connection_check_url.blank?
+    if IdentityConfig.store.outbound_connection_check_url.blank?
       raise 'missing outbound_connection_check_url'
     end
 
-    response = faraday.head(AppConfig.env.outbound_connection_check_url)
+    response = faraday.head(IdentityConfig.store.outbound_connection_check_url)
 
-    { url: AppConfig.env.outbound_connection_check_url, status: response.status }
+    { url: IdentityConfig.store.outbound_connection_check_url, status: response.status }
   end
 
   # @api private

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -16,7 +16,7 @@ module PivCacService
       uri = if FeatureManagement.development_and_identity_pki_disabled?
               URI(test_piv_cac_entry_url)
             else
-              URI(randomize_uri(AppConfig.env.piv_cac_service_url))
+              URI(randomize_uri(IdentityConfig.store.piv_cac_service_url))
             end
       # add the nonce and redirect uri
       uri.query = { nonce: nonce, redirect_uri: redirect_uri }.to_query

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -24,7 +24,7 @@ module PivCacService
     end
 
     def piv_cac_verify_token_link
-      AppConfig.env.piv_cac_verify_token_url
+      IdentityConfig.store.piv_cac_verify_token_url
     end
 
     def url_options

--- a/app/services/usps_in_person_proofer.rb
+++ b/app/services/usps_in_person_proofer.rb
@@ -180,7 +180,7 @@ class UspsInPersonProofer
   end
 
   def root_url
-    AppConfig.env.usps_ipp_root_url
+    IdentityConfig.store.usps_ipp_root_url
   end
 
   def sponsor_id

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.doc_auth.verify') %>
 <% content_for :meta_tags do %>
-  <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: AppConfig.env.acuant_sdk_initialization_endpoint %>
+  <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: IdentityConfig.store.acuant_sdk_initialization_endpoint %>
   <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: AppConfig.env.acuant_sdk_initialization_creds %>
 <% end %>
 <% SecureHeaders.append_content_security_policy_directives(

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -108,7 +108,7 @@
                                               ),
                                               app: link_to(
                                                 APP_NAME,
-                                                AppConfig.env.mailer_domain_name,
+                                                IdentityConfig.store.mailer_domain_name,
                                                 style: 'text-decoration: none;',
                                               ),
                                             )).html_safe %>

--- a/app/views/user_mailer/account_does_not_exist.html.erb
+++ b/app/views/user_mailer/account_does_not_exist.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.account_does_not_exist.intro_html', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.account_does_not_exist.intro_html', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="button expanded large radius">

--- a/app/views/user_mailer/account_reset_cancel.html.erb
+++ b/app/views/user_mailer/account_reset_cancel.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.account_reset_cancel.intro', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.account_reset_cancel.intro', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="spacer">

--- a/app/views/user_mailer/account_reset_complete.html.erb
+++ b/app/views/user_mailer/account_reset_complete.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.account_reset_complete.intro', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.account_reset_complete.intro', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="spacer">

--- a/app/views/user_mailer/account_reset_granted.html.erb
+++ b/app/views/user_mailer/account_reset_granted.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.account_reset_granted.intro_html', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.account_reset_granted.intro_html', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="button expanded large">

--- a/app/views/user_mailer/account_reset_request.html.erb
+++ b/app/views/user_mailer/account_reset_request.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.account_reset_request.intro_html', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.account_reset_request.intro_html', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <p class="lead">

--- a/app/views/user_mailer/add_email_associated_with_another_account.html.erb
+++ b/app/views/user_mailer/add_email_associated_with_another_account.html.erb
@@ -1,6 +1,6 @@
 <p class="lead">
   <%= t('user_mailer.add_email_associated_with_another_account.intro_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="button expanded large radius">
@@ -50,12 +50,12 @@
 
 <p>
   <%= t('user_mailer.add_email_associated_with_another_account.reset_password_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <p>
   <%= t('user_mailer.add_email_associated_with_another_account.help_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
         contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url)) %>
 </p>

--- a/app/views/user_mailer/email_added.html.erb
+++ b/app/views/user_mailer/email_added.html.erb
@@ -22,7 +22,7 @@
 
 <p>
   <%= t('user_mailer.email_added.help',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
         contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url)) %>
 </p>

--- a/app/views/user_mailer/email_deleted.html.erb
+++ b/app/views/user_mailer/email_deleted.html.erb
@@ -18,7 +18,7 @@
 <p>
   <%=
     t('.help_html',
-       app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+       app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
        help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
        contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))
   %>

--- a/app/views/user_mailer/new_device_sign_in.html.erb
+++ b/app/views/user_mailer/new_device_sign_in.html.erb
@@ -24,7 +24,7 @@
 
 <p>
   <%= t('user_mailer.new_device_sign_in.help_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
         disavowal_link: link_to(t('.disavowal_link'),
           event_disavowal_url(disavowal_token: @disavowal_token)),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),

--- a/app/views/user_mailer/password_changed.html.erb
+++ b/app/views/user_mailer/password_changed.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.password_changed.intro_html', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.password_changed.intro_html', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="spacer">
@@ -22,7 +22,7 @@
 
 <p>
   <%= t('user_mailer.password_changed.help_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
         disavowal_link: link_to(t('.disavowal_link'),
           event_disavowal_url(disavowal_token: @disavowal_token)),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),

--- a/app/views/user_mailer/phone_added.html.erb
+++ b/app/views/user_mailer/phone_added.html.erb
@@ -1,5 +1,5 @@
 <p class='lead'>
-  <%= raw t('.intro', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= raw t('.intro', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class='spacer'>

--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <p class="lead">
   <%= t('user_mailer.reset_password_instructions.header',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="button expanded large radius">

--- a/app/views/user_mailer/signup_with_your_email.html.erb
+++ b/app/views/user_mailer/signup_with_your_email.html.erb
@@ -1,5 +1,5 @@
 <p class="lead">
-  <%= t('user_mailer.signup_with_your_email.intro_html', app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+  <%= t('user_mailer.signup_with_your_email.intro_html', app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <table class="button expanded large radius">
@@ -50,12 +50,12 @@
 
 <p>
   <%= t('user_mailer.signup_with_your_email.reset_password_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray')) %>
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
 </p>
 
 <p>
   <%= t('user_mailer.signup_with_your_email.help_html',
-        app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+        app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
         contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url)) %>
 </p>

--- a/app/views/user_mailer/sps_over_quota_limit.html.erb
+++ b/app/views/user_mailer/sps_over_quota_limit.html.erb
@@ -18,7 +18,7 @@
 <p>
   <%=
     t('.help',
-      app: link_to(APP_NAME, AppConfig.env.mailer_domain_name, class: 'gray'),
+      app: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray'),
       help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
       contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))
   %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -107,6 +107,7 @@ pii_lock_timeout_in_minutes: '30'
 pinpoint_sms_configs: '[]'
 pinpoint_voice_configs: '[]'
 piv_cac_service_url: https://localhost:8443/
+piv_cac_verify_token_url: https://localhost:8443/
 poll_rate_for_verify_in_seconds: '3'
 proofer_mock_fallback: 'true'
 proofing_send_partial_dob: 'false'
@@ -214,7 +215,6 @@ development:
   participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
-  piv_cac_verify_token_url: https://localhost:8443/
   rack_mini_profiler: 'off'
   recurring_jobs_disabled_names: "[]"
   redis_throttle_url: redis://localhost:6379/1
@@ -422,7 +422,6 @@ test:
   participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
-  piv_cac_verify_token_url: https://localhost:8443/
   poll_rate_for_verify_in_seconds: '1'
   rack_mini_profiler:
   recurring_jobs_disabled_names: '["disabled job"]'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -29,6 +29,7 @@ acuant_assure_id_url: ''
 acuant_assure_id_username: ''
 acuant_attempt_window_in_minutes: '360'
 acuant_facial_match_license_key: ''
+acuant_facial_match_url: ''
 # These are dummy creds used to initialize the acuant SDK
 acuant_sdk_initialization_creds: 'aWRzY2FuZ293ZWJAYWN1YW50Y29ycC5jb206NVZLcm81Z0JEc1hrdFh2NA=='
 acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
@@ -154,7 +155,6 @@ development:
   aamva_private_key: 123abc
   aamva_public_key: 123abc
   account_reset_auth_token: abc123
-  acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
   address_proof_result_lambda_token: 123ABC
@@ -259,7 +259,6 @@ production:
   aamva_public_key:
   aamva_verification_url:
   account_reset_auth_token:
-  acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
   address_proof_result_lambda_token:

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -30,6 +30,7 @@ acuant_assure_id_username: ''
 acuant_attempt_window_in_minutes: '360'
 acuant_facial_match_license_key: ''
 acuant_facial_match_url: ''
+acuant_passlive_url: ''
 # These are dummy creds used to initialize the acuant SDK
 acuant_sdk_initialization_creds: 'aWRzY2FuZ293ZWJAYWN1YW50Y29ycC5jb206NVZLcm81Z0JEc1hrdFh2NA=='
 acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
@@ -156,7 +157,6 @@ development:
   aamva_public_key: 123abc
   account_reset_auth_token: abc123
   acuant_max_attempts: '20'
-  acuant_passlive_url: ''
   address_proof_result_lambda_token: 123ABC
   attribute_cost: 4000$8$4$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
@@ -260,7 +260,6 @@ production:
   aamva_verification_url:
   account_reset_auth_token:
   acuant_max_attempts: '20'
-  acuant_passlive_url: ''
   address_proof_result_lambda_token:
   attribute_cost: 4000$8$4$
   attribute_encryption_key:

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -119,6 +119,7 @@ recaptcha_enabled_percent: '0'
 recaptcha_secret_key: key2
 recaptcha_site_key: key1
 recovery_code_length: '4'
+redis_throttle_url: redis://localhost:6379/1
 reg_confirmed_email_window_in_minutes: '60'
 remember_device_expiration_hours_aal_1: '720'
 remember_device_expiration_hours_aal_2: '12'
@@ -217,7 +218,6 @@ development:
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   rack_mini_profiler: 'off'
   recurring_jobs_disabled_names: "[]"
-  redis_throttle_url: redis://localhost:6379/1
   redis_url: redis://localhost:6379/0
   reg_confirmed_email_max_attempts: '20'
   reg_unconfirmed_email_max_attempts: '20'
@@ -425,7 +425,6 @@ test:
   poll_rate_for_verify_in_seconds: '1'
   rack_mini_profiler:
   recurring_jobs_disabled_names: '["disabled job"]'
-  redis_throttle_url: redis://localhost:6379/1
   redis_url: redis://localhost:6379/0
   reg_confirmed_email_max_attempts: '3'
   reg_unconfirmed_email_max_attempts: '4'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -106,6 +106,7 @@ phone_format_e164_opt_out_list: '[]'
 pii_lock_timeout_in_minutes: '30'
 pinpoint_sms_configs: '[]'
 pinpoint_voice_configs: '[]'
+piv_cac_service_url: https://localhost:8443/
 poll_rate_for_verify_in_seconds: '3'
 proofer_mock_fallback: 'true'
 proofing_send_partial_dob: 'false'
@@ -212,7 +213,6 @@ development:
   otp_delivery_blocklist_maxretry: '10'
   participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   piv_cac_verify_token_url: https://localhost:8443/
   rack_mini_profiler: 'off'
@@ -421,7 +421,6 @@ test:
   otps_per_ip_track_only_mode: 'false'
   participate_in_dap: 'false'
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   piv_cac_verify_token_url: https://localhost:8443/
   poll_rate_for_verify_in_seconds: '1'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -18,6 +18,7 @@
 aal_authn_context_enabled: 'false'
 aamva_cert_enabled: 'true'
 aamva_sp_banlist_issuers: '[]'
+aamva_verification_url: https://example.org:12345/verification/url
 account_reset_token_valid_for_days: '1'
 account_reset_wait_period_days: '1'
 acuant_maintenance_window_start: '2020-09-19T03:00:00Z' # 9/18 11pm Eastern
@@ -151,7 +152,6 @@ development:
   aal_authn_context_enabled: 'true'
   aamva_private_key: 123abc
   aamva_public_key: 123abc
-  aamva_verification_url: https://example.org:12345/verification/url
   account_reset_auth_token: abc123
   acuant_assure_id_url: ''
   acuant_facial_match_url: ''
@@ -359,7 +359,6 @@ test:
   aal_authn_context_enabled: 'true'
   aamva_private_key: 123abc
   aamva_public_key: 123abc
-  aamva_verification_url: https://example.org:12345/verification/url
   account_reset_auth_token: test
   acuant_maintenance_window_start: ''
   acuant_maintenance_window_finish: ''

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -120,6 +120,7 @@ recaptcha_secret_key: key2
 recaptcha_site_key: key1
 recovery_code_length: '4'
 redis_throttle_url: redis://localhost:6379/1
+redis_url: redis://localhost:6379/0
 reg_confirmed_email_window_in_minutes: '60'
 remember_device_expiration_hours_aal_1: '720'
 remember_device_expiration_hours_aal_2: '12'
@@ -218,7 +219,6 @@ development:
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   rack_mini_profiler: 'off'
   recurring_jobs_disabled_names: "[]"
-  redis_url: redis://localhost:6379/0
   reg_confirmed_email_max_attempts: '20'
   reg_unconfirmed_email_max_attempts: '20'
   reg_unconfirmed_email_window_in_minutes: '60'
@@ -425,7 +425,6 @@ test:
   poll_rate_for_verify_in_seconds: '1'
   rack_mini_profiler:
   recurring_jobs_disabled_names: '["disabled job"]'
-  redis_url: redis://localhost:6379/0
   reg_confirmed_email_max_attempts: '3'
   reg_unconfirmed_email_max_attempts: '4'
   reg_unconfirmed_email_window_in_minutes: '70'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -25,6 +25,7 @@ acuant_maintenance_window_start: '2020-09-19T03:00:00Z' # 9/18 11pm Eastern
 acuant_maintenance_window_finish: '2020-09-19T05:00:00Z' # 9/19 1am Eastern
 acuant_assure_id_password: ''
 acuant_assure_id_subscription_id: ''
+acuant_assure_id_url: ''
 acuant_assure_id_username: ''
 acuant_attempt_window_in_minutes: '360'
 acuant_facial_match_license_key: ''
@@ -153,7 +154,6 @@ development:
   aamva_private_key: 123abc
   aamva_public_key: 123abc
   account_reset_auth_token: abc123
-  acuant_assure_id_url: ''
   acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
@@ -259,7 +259,6 @@ production:
   aamva_public_key:
   aamva_verification_url:
   account_reset_auth_token:
-  acuant_assure_id_url: ''
   acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
     host: AppConfig.env.domain_name,
     protocol: ENV['HTTPS'] == 'on' ? 'https' : 'http',
   }
-  config.action_mailer.asset_host = AppConfig.env.mailer_domain_name
+  config.action_mailer.asset_host = IdentityConfig.store.mailer_domain_name
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
     host: AppConfig.env.domain_name,
     protocol: 'https',
   }
-  config.action_mailer.asset_host = AppConfig.env.asset_host || AppConfig.env.mailer_domain_name
+  config.action_mailer.asset_host = AppConfig.env.asset_host ||
+                                    IdentityConfig.store.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = if AppConfig.env.disable_email_sending == 'true'
                                            :test

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: AppConfig.env.domain_name }
-  config.action_mailer.asset_host = AppConfig.env.mailer_domain_name
+  config.action_mailer.asset_host = IdentityConfig.store.mailer_domain_name
 
   config.assets.debug = false
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -26,7 +26,7 @@ module Rack
 
     cache = Readthis::Cache.new(
       expires_in: 2.weeks.to_i,
-      redis: { url: AppConfig.env.redis_throttle_url, driver: :hiredis },
+      redis: { url: IdentityConfig.store.redis_throttle_url, driver: :hiredis },
     )
 
     Rack::Attack.cache.store = cache

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -3,6 +3,6 @@ ttl = env.service_provider_request_ttl_hours || ServiceProviderRequestProxy::DEF
 REDIS_POOL = ConnectionPool.new(size: 10) do
   Readthis::Cache.new(
     expires_in: ttl.to_i.hours.to_i,
-    redis: { url: env.redis_url, driver: :hiredis },
+    redis: { url: IdentityConfig.store.redis_url, driver: :hiredis },
   )
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -13,7 +13,7 @@ options = {
     ttl: AppConfig.env.session_timeout_in_minutes.to_i.minutes,
 
     key_prefix: "#{AppConfig.env.domain_name}:session:",
-    url: AppConfig.env.redis_url,
+    url: IdentityConfig.store.redis_url,
   },
   on_session_load_error: SessionEncryptorErrorHandler,
   serializer: SessionEncryptor.new,

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -12,7 +12,7 @@ class FeatureManagement
   def self.identity_pki_disabled?
     env = AppConfig.env
     env.identity_pki_disabled == 'true' ||
-      !env.piv_cac_service_url ||
+      !IdentityConfig.store.piv_cac_service_url ||
       !env.piv_cac_verify_token_url
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -13,7 +13,7 @@ class FeatureManagement
     env = AppConfig.env
     env.identity_pki_disabled == 'true' ||
       !IdentityConfig.store.piv_cac_service_url ||
-      !env.piv_cac_verify_token_url
+      !IdentityConfig.store.piv_cac_verify_token_url
   end
 
   def self.development_and_identity_pki_disabled?

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -57,6 +57,7 @@ class IdentityConfig
     config.add(:hmac_fingerprinter_key_queue, type: :json)
     config.add(:issuers_with_email_nameid_format, type: :comma_separated_string_list)
     config.add(:no_sp_campaigns_whitelist, type: :json)
+    config.add(:mailer_domain_name)
     config.add(:nonessential_email_banlist, type: :json)
     config.add(:recurring_jobs_disabled_names, type: :json)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -61,6 +61,7 @@ class IdentityConfig
     config.add(:nonessential_email_banlist, type: :json)
     config.add(:outbound_connection_check_url)
     config.add(:piv_cac_service_url)
+    config.add(:piv_cac_verify_token_url)
     config.add(:recurring_jobs_disabled_names, type: :json)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -68,7 +68,8 @@ class IdentityConfig
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sps_over_quota_limit_notify_email_list, type: :json)
-    final_env = config.add(:valid_authn_contexts, type: :json)
+    config.add(:valid_authn_contexts, type: :json)
+    final_env = config.add(:usps_ipp_root_url)
 
     @store = RedactedStruct.new('IdentityConfig', *final_env.keys, keyword_init: true).
       new(**final_env)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -48,6 +48,7 @@ class IdentityConfig
     config.add(:aamva_verification_url)
     config.add(:acuant_assure_id_url)
     config.add(:acuant_facial_match_url)
+    config.add(:acuant_passlive_url)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -4,7 +4,6 @@ class IdentityConfig
   end
 
   CONVERTERS = {
-    uri: proc { |value| URI(value) },
     string: proc { |value| value.to_s },
     comma_separated_string_list: proc do |value|
       value.split(',')

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -45,6 +45,7 @@ class IdentityConfig
   def self.build_store(config_map)
     config = IdentityConfig.new(config_map)
     config.add(:aamva_sp_banlist_issuers, type: :json)
+    config.add(:aamva_verification_url)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -59,6 +59,7 @@ class IdentityConfig
     config.add(:no_sp_campaigns_whitelist, type: :json)
     config.add(:mailer_domain_name)
     config.add(:nonessential_email_banlist, type: :json)
+    config.add(:outbound_connection_check_url)
     config.add(:recurring_jobs_disabled_names, type: :json)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -60,6 +60,7 @@ class IdentityConfig
     config.add(:mailer_domain_name)
     config.add(:nonessential_email_banlist, type: :json)
     config.add(:outbound_connection_check_url)
+    config.add(:piv_cac_service_url)
     config.add(:recurring_jobs_disabled_names, type: :json)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -64,6 +64,7 @@ class IdentityConfig
     config.add(:piv_cac_verify_token_url)
     config.add(:recurring_jobs_disabled_names, type: :json)
     config.add(:redis_throttle_url)
+    config.add(:redis_url)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sps_over_quota_limit_notify_email_list, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -47,6 +47,7 @@ class IdentityConfig
     config.add(:aamva_sp_banlist_issuers, type: :json)
     config.add(:aamva_verification_url)
     config.add(:acuant_assure_id_url)
+    config.add(:acuant_facial_match_url)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -63,6 +63,7 @@ class IdentityConfig
     config.add(:piv_cac_service_url)
     config.add(:piv_cac_verify_token_url)
     config.add(:recurring_jobs_disabled_names, type: :json)
+    config.add(:redis_throttle_url)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sps_over_quota_limit_notify_email_list, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -49,6 +49,7 @@ class IdentityConfig
     config.add(:acuant_assure_id_url)
     config.add(:acuant_facial_match_url)
     config.add(:acuant_passlive_url)
+    config.add(:acuant_sdk_initialization_endpoint)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -46,6 +46,7 @@ class IdentityConfig
     config = IdentityConfig.new(config_map)
     config.add(:aamva_sp_banlist_issuers, type: :json)
     config.add(:aamva_verification_url)
+    config.add(:acuant_assure_id_url)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:aws_kms_regions, type: :json)
     config.add(:deleted_user_accounts_report_configs, type: :json)

--- a/lib/piv_cac/check_config.rb
+++ b/lib/piv_cac/check_config.rb
@@ -3,11 +3,11 @@ module PivCac
     def self.call
       return unless Rails.env.production?
 
-      url = URI.parse(AppConfig.env.piv_cac_verify_token_url)
+      url = URI.parse(IdentityConfig.store.piv_cac_verify_token_url)
       return if url.scheme == 'https'
 
       # rubocop:disable Layout/LineLength
-      message = "piv_cac_verify_token_url configured without SSL: #{AppConfig.env.piv_cac_verify_token_url}"
+      message = "piv_cac_verify_token_url configured without SSL: #{IdentityConfig.store.piv_cac_verify_token_url}"
       # rubocop:enable Layout/LineLength
       Rails.logger.error { "#{message} - EXITING" }
       NewRelic::Agent.notice_error("#{message} - EXITING")

--- a/spec/controllers/health/outbound_controller_spec.rb
+++ b/spec/controllers/health/outbound_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Health::OutboundController do
 
     context 'when the outbound connections are healthy' do
       before do
-        stub_request(:head, AppConfig.env.outbound_connection_check_url).
+        stub_request(:head, IdentityConfig.store.outbound_connection_check_url).
           to_return(status: 200)
       end
 
@@ -22,13 +22,16 @@ RSpec.describe Health::OutboundController do
         json = JSON.parse(response.body, symbolize_names: true)
 
         expect(json[:healthy]).to eq(true)
-        expect(json[:result]).to eq(status: 200, url: AppConfig.env.outbound_connection_check_url)
+        expect(json[:result]).to eq(
+          status: 200,
+          url: IdentityConfig.store.outbound_connection_check_url,
+        )
       end
     end
 
     context 'when the outbound connections are uhealthy' do
       before do
-        stub_request(:head, AppConfig.env.outbound_connection_check_url).to_timeout
+        stub_request(:head, IdentityConfig.store.outbound_connection_check_url).to_timeout
       end
 
       it 'is a 500' do

--- a/spec/services/outbound_health_checker_spec.rb
+++ b/spec/services/outbound_health_checker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OutboundHealthChecker do
 
     context 'bad config' do
       before do
-        expect(AppConfig.env).to receive(:outbound_connection_check_url).and_return('')
+        expect(IdentityConfig.store).to receive(:outbound_connection_check_url).and_return('')
       end
 
       it 'is not healthy' do
@@ -17,7 +17,7 @@ RSpec.describe OutboundHealthChecker do
 
     context 'successful connection to endpoint' do
       before do
-        stub_request(:head, AppConfig.env.outbound_connection_check_url).
+        stub_request(:head, IdentityConfig.store.outbound_connection_check_url).
           to_return(status: status)
       end
 
@@ -27,7 +27,7 @@ RSpec.describe OutboundHealthChecker do
         it 'is healthy' do
           expect(check).to be_healthy
           expect(check.result).to eq(
-            url: AppConfig.env.outbound_connection_check_url,
+            url: IdentityConfig.store.outbound_connection_check_url,
             status: status,
           )
         end
@@ -39,7 +39,7 @@ RSpec.describe OutboundHealthChecker do
         it 'is healthy' do
           expect(check).to be_healthy
           expect(check.result).to eq(
-            url: AppConfig.env.outbound_connection_check_url,
+            url: IdentityConfig.store.outbound_connection_check_url,
             status: status,
           )
         end
@@ -77,7 +77,7 @@ RSpec.describe OutboundHealthChecker do
 
     context 'timeout from endpoint' do
       before do
-        stub_request(:head, AppConfig.env.outbound_connection_check_url).to_timeout
+        stub_request(:head, IdentityConfig.store.outbound_connection_check_url).to_timeout
       end
 
       it 'is not healthy' do

--- a/spec/services/piv_cac/check_config_spec.rb
+++ b/spec/services/piv_cac/check_config_spec.rb
@@ -8,7 +8,7 @@ describe PivCac::CheckConfig do
 
   before do
     allow(Rails.env).to receive(:production?).and_return(is_production)
-    allow(AppConfig.env).to receive(:piv_cac_verify_token_url).and_return(url)
+    allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url).and_return(url)
   end
 
   context 'non-production environments' do

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -70,7 +70,7 @@ describe PivCacService do
         describe 'when configured with a user-facing endpoint' do
           before(:each) do
             allow(AppConfig.env).to receive(:identity_pki_disabled) { 'false' }
-            allow(AppConfig.env).to receive(:piv_cac_service_url) { base_url }
+            allow(IdentityConfig.store).to receive(:piv_cac_service_url) { base_url }
           end
 
           let(:nonce) { 'once' }

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -111,7 +111,9 @@ describe PivCacService do
         before(:each) do
           allow(AppConfig.env).to receive(:identity_pki_local_dev) { 'true' }
           allow(AppConfig.env).to receive(:identity_pki_disabled) { 'false' }
-          allow(AppConfig.env).to receive(:piv_cac_verify_token_url) { 'http://localhost:8443/' }
+          allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url) do
+            'http://localhost:8443/'
+          end
         end
 
         let!(:request) do
@@ -151,7 +153,9 @@ describe PivCacService do
       describe 'when configured to contact remote service' do
         before(:each) do
           allow(AppConfig.env).to receive(:identity_pki_disabled) { 'false' }
-          allow(AppConfig.env).to receive(:piv_cac_verify_token_url) { 'http://localhost:8443/' }
+          allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url) do
+            'http://localhost:8443/'
+          end
         end
 
         let!(:request) do
@@ -191,7 +195,9 @@ describe PivCacService do
       describe 'with bad json' do
         before(:each) do
           allow(AppConfig.env).to receive(:identity_pki_disabled) { 'false' }
-          allow(AppConfig.env).to receive(:piv_cac_verify_token_url) { 'http://localhost:8443/' }
+          allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url) do
+            'http://localhost:8443/'
+          end
         end
 
         let!(:request) do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -565,7 +565,7 @@ module Features
       allow(AppConfig.env).to receive(:identity_pki_disabled).and_return('false')
       allow(IdentityConfig.store).to receive(:piv_cac_service_url).
         and_return('http://piv.example.com/')
-      allow(AppConfig.env).to receive(:piv_cac_verify_token_url).and_return('http://piv.example.com/')
+      allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url).and_return('http://piv.example.com/')
       stub_request(:post, 'piv.example.com').to_return do |request|
         {
           status: 200,

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -563,7 +563,8 @@ module Features
 
     def stub_piv_cac_service
       allow(AppConfig.env).to receive(:identity_pki_disabled).and_return('false')
-      allow(AppConfig.env).to receive(:piv_cac_service_url).and_return('http://piv.example.com/')
+      allow(IdentityConfig.store).to receive(:piv_cac_service_url).
+        and_return('http://piv.example.com/')
       allow(AppConfig.env).to receive(:piv_cac_verify_token_url).and_return('http://piv.example.com/')
       stub_request(:post, 'piv.example.com').to_return do |request|
         {


### PR DESCRIPTION
Building on #4871, converts more configs to IdentityConfig

I thought we would have some config values that were always converted to `URI`, but it turns out none of them are in a way where we'd want to return them directly as a `URI` type.