### PR TITLE
Remove redundant / unreachable backup code buttons helpers

### DIFF
--- a/app/presenters/backup_code_create_presenter.rb
+++ b/app/presenters/backup_code_create_presenter.rb
@@ -20,12 +20,4 @@ class BackupCodeCreatePresenter
   def continue_bttn_prologue
     t('forms.backup_code.are_you_sure_continue_prologue')
   end
-
-  def continue_bttn_title
-    t('forms.backup_code.are_you_sure_continue')
-  end
-
-  def continue_bttn_class
-    'usa-button usa-button--unstyled'
-  end
 end

--- a/app/presenters/backup_code_depleted_presenter.rb
+++ b/app/presenters/backup_code_depleted_presenter.rb
@@ -20,12 +20,4 @@ class BackupCodeDepletedPresenter
   def continue_bttn_prologue
     nil
   end
-
-  def continue_bttn_title
-    t('forms.buttons.continue')
-  end
-
-  def continue_bttn_class
-    'usa-button usa-button--big usa-button--wide'
-  end
 end

--- a/app/views/users/backup_code_setup/depleted.html.erb
+++ b/app/views/users/backup_code_setup/depleted.html.erb
@@ -10,7 +10,7 @@
 <%= form_tag(backup_code_setup_path, method: :patch, role: 'form') do %>
   <div class="clearfix margin-x-neg-1">
     <div class="col col-12 sm-col-8 padding-x-1">
-      <%= button_tag @presenter.continue_bttn_title, type: 'submit', class: @presenter.continue_bttn_class %>
+      <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>
     </div>
   </div>
 <% end %>

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -5,7 +5,7 @@
   <%= form_tag(backup_code_setup_path, method: :patch, role: 'form') do %>
     <div class="clearfix margin-x-neg-1">
       <div class="col col-12 sm-col-8 padding-x-1">
-        <%= button_tag @presenter.continue_bttn_title, type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>
+        <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>
       </div>
     </div>
   <% end %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -2,7 +2,6 @@
 en:
   forms:
     backup_code:
-      are_you_sure_continue: Continue
       are_you_sure_continue_prologue: If you don’t have access to any other authentication
         method,
       are_you_sure_desc: "<br><b>Backup codes are not very safe</b> because they can

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -2,7 +2,6 @@
 es:
   forms:
     backup_code:
-      are_you_sure_continue: Continuar
       are_you_sure_continue_prologue: Si no tienes acceso a ningún otro método de
         autenticación,
       are_you_sure_desc: "<br> <b> Los códigos de respaldo no son muy seguros </b>

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -2,7 +2,6 @@
 fr:
   forms:
     backup_code:
-      are_you_sure_continue: Continuer
       are_you_sure_continue_prologue: Si vous n'avez accès à aucune autre méthode
         d'authentification,
       are_you_sure_desc: "<br><b>Les codes de sauvegarde ne sont pas très sûrs</b>

--- a/spec/presenters/backup_code_create_presenter_spec.rb
+++ b/spec/presenters/backup_code_create_presenter_spec.rb
@@ -35,16 +35,4 @@ describe BackupCodeCreatePresenter do
         to eq t('forms.backup_code.are_you_sure_continue_prologue')
     end
   end
-
-  describe '#continue_bttn_title' do
-    it 'uses localization' do
-      expect(presenter.continue_bttn_title).to eq t('forms.backup_code.are_you_sure_continue')
-    end
-  end
-
-  describe '#continue_bttn_class' do
-    it 'displays as a link to continue' do
-      expect(presenter.continue_bttn_class).to eq 'usa-button usa-button--unstyled'
-    end
-  end
 end

--- a/spec/presenters/backup_code_depleted_presenter_spec.rb
+++ b/spec/presenters/backup_code_depleted_presenter_spec.rb
@@ -34,16 +34,4 @@ describe BackupCodeDepletedPresenter do
       expect(presenter.continue_bttn_prologue).to eq nil
     end
   end
-
-  describe '#continue_bttn_title' do
-    it 'uses localization' do
-      expect(presenter.continue_bttn_title).to eq t('forms.buttons.continue')
-    end
-  end
-
-  describe '#continue_bttn_class' do
-    it 'displays button to continue' do
-      expect(presenter.continue_bttn_class).to eq 'usa-button usa-button--big usa-button--wide'
-    end
-  end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -26,8 +26,7 @@ module Features
     def select_2fa_option(option, **find_options)
       find("label[for='two_factor_options_form_selection_#{option}']", **find_options).click
       click_on t('forms.buttons.continue')
-      click_button t('forms.backup_code.are_you_sure_continue') if
-        page.has_button?(t('forms.backup_code.are_you_sure_continue'))
+      click_button t('forms.buttons.continue') if page.has_button?(t('forms.buttons.continue'))
     end
 
     def select_phone_delivery_option(delivery_option)


### PR DESCRIPTION
Discovered as part of investigative work of #4869

**Why**: `continue_bttn_class` is only referenced on the depleted view, despite being a method defined on the BackupCodeCreatePresenter class. Since the create view itself hard-codes the same big, wide button as other backup code views, there is no variation of the classes between presenters and it can be removed.

Similarly, the text "Continue" is the same between the create and depleted views, despite using separate locale string keys. Instead, consolidate to the "forms.buttons.continue" and remove the helper method.

There's expected to be no visual or text changes as a result of these revisions.