### PR TITLE
LG-4387: Associate image metadata with logged vendor response

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -205,7 +205,7 @@ module Idv
       params.permit(:front_metadata, :back_metadata).
         to_h.
         transform_values do |str|
-          JSON.parse(str)
+          JSON.parse(str, symbolize_names: true)
         rescue JSON::ParserError
           nil
         end.

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -202,7 +202,7 @@ module Idv
     end
 
     def image_metadata
-      params.permit(:front_metadata, :back_metadata).
+      params.permit(:front_image_metadata, :back_image_metadata).
         to_h.
         transform_values do |str|
           JSON.parse(str, symbolize_names: true)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -197,8 +197,20 @@ module Idv
       update_funnel(client_response)
       track_event(
         Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
-        client_response.to_h,
+        client_response.to_h.merge(image_metadata),
       )
+    end
+
+    def image_metadata
+      params.permit(:front_metadata, :back_metadata).
+        to_h.
+        transform_values do |str|
+          JSON.parse(str)
+        rescue JSON::ParserError
+          nil
+        end.
+        compact.
+        symbolize_keys
     end
 
     def add_costs(response)

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -8,16 +8,22 @@ import ServiceProviderContext from '../context/service-provider';
 import withBackgroundEncryptedUpload from '../higher-order/with-background-encrypted-upload';
 
 /**
+ * @typedef {'front'|'back'} DocumentSide
+ */
+
+/**
  * @typedef DocumentsStepValue
  *
  * @prop {Blob|string|null|undefined} front Front image value.
  * @prop {Blob|string|null|undefined} back Back image value.
+ * @prop {string=} front_metadata Front image metadata.
+ * @prop {string=} back_metadata Back image metadata.
  */
 
 /**
  * Sides of document to present as file input.
  *
- * @type {Array<keyof DocumentsStepValue>}
+ * @type {DocumentSide[]}
  */
 const DOCUMENT_SIDES = ['front', 'back'];
 
@@ -81,7 +87,12 @@ function DocumentsStep({
             /* i18n-tasks-use t('doc_auth.headings.front') */
             bannerText={t(`doc_auth.headings.${side}`)}
             value={value[side]}
-            onChange={(nextValue) => onChange({ [side]: nextValue })}
+            onChange={(nextValue, metadata) =>
+              onChange({
+                [side]: nextValue,
+                [`${side}_metadata`]: JSON.stringify(metadata),
+              })
+            }
             errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
             name={side}
           />

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -16,8 +16,8 @@ import withBackgroundEncryptedUpload from '../higher-order/with-background-encry
  *
  * @prop {Blob|string|null|undefined} front Front image value.
  * @prop {Blob|string|null|undefined} back Back image value.
- * @prop {string=} front_metadata Front image metadata.
- * @prop {string=} back_metadata Back image metadata.
+ * @prop {string=} front_image_metadata Front image metadata.
+ * @prop {string=} back_image_metadata Back image metadata.
  */
 
 /**
@@ -90,7 +90,7 @@ function DocumentsStep({
             onChange={(nextValue, metadata) =>
               onChange({
                 [side]: nextValue,
-                [`${side}_metadata`]: JSON.stringify(metadata),
+                [`${side}_image_metadata`]: JSON.stringify(metadata),
               })
             }
             errorMessage={error ? <FormErrorMessage error={error} /> : undefined}

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -20,8 +20,8 @@ import './review-issues-step.scss';
  * @prop {Blob|string|null|undefined} front Front image value.
  * @prop {Blob|string|null|undefined} back Back image value.
  * @prop {Blob|string|null|undefined} selfie Back image value.
- * @prop {string=} front_metadata Front image metadata.
- * @prop {string=} back_metadata Back image metadata.
+ * @prop {string=} front_image_metadata Front image metadata.
+ * @prop {string=} back_image_metadata Back image metadata.
  */
 
 /**
@@ -90,7 +90,7 @@ function ReviewIssuesStep({
             bannerText={t(`doc_auth.headings.${side}`)}
             value={value[side]}
             onChange={(nextValue, metadata) =>
-              onChange({ [side]: nextValue, [`${side}_metadata`]: JSON.stringify(metadata) })
+              onChange({ [side]: nextValue, [`${side}_image_metadata`]: JSON.stringify(metadata) })
             }
             className="document-capture-review-issues-step__input"
             errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -11,15 +11,23 @@ import withBackgroundEncryptedUpload from '../higher-order/with-background-encry
 import './review-issues-step.scss';
 
 /**
+ * @typedef {'front'|'back'} DocumentSide
+ */
+
+/**
  * @typedef ReviewIssuesStepValue
  *
  * @prop {Blob|string|null|undefined} front Front image value.
  * @prop {Blob|string|null|undefined} back Back image value.
  * @prop {Blob|string|null|undefined} selfie Back image value.
+ * @prop {string=} front_metadata Front image metadata.
+ * @prop {string=} back_metadata Back image metadata.
  */
 
 /**
  * Sides of document to present as file input.
+ *
+ * @type {DocumentSide[]}
  */
 const DOCUMENT_SIDES = ['front', 'back'];
 
@@ -81,7 +89,9 @@ function ReviewIssuesStep({
             /* i18n-tasks-use t('doc_auth.headings.front') */
             bannerText={t(`doc_auth.headings.${side}`)}
             value={value[side]}
-            onChange={(nextValue) => onChange({ [side]: nextValue })}
+            onChange={(nextValue, metadata) =>
+              onChange({ [side]: nextValue, [`${side}_metadata`]: JSON.stringify(metadata) })
+            }
             className="document-capture-review-issues-step__input"
             errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}
             name={side}

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Idv::ApiImageUploadForm do
     Idv::ApiImageUploadForm.new(
       ActionController::Parameters.new(
         front: front_image,
-        front_metadata: front_image_metadata,
+        front_image_metadata: front_image_metadata,
         back: back_image,
-        back_metadata: back_image_metadata,
+        back_image_metadata: back_image_metadata,
         selfie: selfie_image,
         document_capture_session_uuid: document_capture_session_uuid,
       ),
@@ -106,8 +106,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
-          back_metadata: JSON.parse(back_image_metadata, symbolize_names: true),
+          front_image_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
+          back_image_metadata: JSON.parse(back_image_metadata, symbolize_names: true),
         )
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
+          front_image_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
         )
       end
     end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_metadata: JSON.parse(front_image_metadata),
-          back_metadata: JSON.parse(back_image_metadata),
+          front_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
+          back_metadata: JSON.parse(back_image_metadata, symbolize_names: true),
         )
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_metadata: JSON.parse(front_image_metadata),
+          front_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
         )
       end
     end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -3,24 +3,33 @@ require 'rails_helper'
 RSpec.describe Idv::ApiImageUploadForm do
   subject(:form) do
     Idv::ApiImageUploadForm.new(
-      {
+      ActionController::Parameters.new(
         front: front_image,
+        front_metadata: front_image_metadata,
         back: back_image,
+        back_metadata: back_image_metadata,
         selfie: selfie_image,
         document_capture_session_uuid: document_capture_session_uuid,
-      },
+      ),
       liveness_checking_enabled: liveness_checking_enabled?,
       issuer: 'test_issuer',
-      analytics: FakeAnalytics.new,
+      analytics: fake_analytics,
     )
   end
 
   let(:front_image) { DocAuthImageFixtures.document_front_image_multipart }
   let(:back_image) { DocAuthImageFixtures.document_back_image_multipart }
+  let(:front_image_metadata) do
+    { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }.to_json
+  end
+  let(:back_image_metadata) do
+    { width: 20, height: 20, mimeType: 'image/png', source: 'upload' }.to_json
+  end
   let(:selfie_image) { DocAuthImageFixtures.selfie_image_multipart }
   let!(:document_capture_session) { DocumentCaptureSession.create! }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:liveness_checking_enabled?) { true }
+  let(:fake_analytics) { FakeAnalytics.new }
 
   describe '#valid?' do
     context 'with all valid images' do
@@ -84,6 +93,45 @@ RSpec.describe Idv::ApiImageUploadForm do
   end
 
   describe '#submit' do
+    context 'valid form' do
+      it 'logs analytics' do
+        form.submit
+
+        expect(fake_analytics).to have_logged_event(
+          Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+          success: true,
+          errors: {},
+          exception: nil,
+          result: 'Passed',
+          billed: true,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
+          user_id: nil,
+          front_metadata: JSON.parse(front_image_metadata),
+          back_metadata: JSON.parse(back_image_metadata),
+        )
+      end
+    end
+
+    context 'invalid metadata shape' do
+      let(:back_image_metadata) { '{' }
+
+      it 'logs analytics excluding invalid metadata' do
+        form.submit
+
+        expect(fake_analytics).to have_logged_event(
+          Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+          success: true,
+          errors: {},
+          exception: nil,
+          result: 'Passed',
+          billed: true,
+          remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
+          user_id: nil,
+          front_metadata: JSON.parse(front_image_metadata),
+        )
+      end
+    end
+
     context 'form is missing a required param' do
       let(:front_image) { nil }
 

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -361,10 +361,10 @@ describe('document-capture/components/document-capture', () => {
           expect(payload).to.have.keys([
             'front_image_iv',
             'front_image_url',
-            'front_metadata',
+            'front_image_metadata',
             'back_image_iv',
             'back_image_url',
-            'back_metadata',
+            'back_image_metadata',
             'selfie_image_iv',
             'selfie_image_url',
           ]);

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -334,8 +334,11 @@ describe('document-capture/components/document-capture', () => {
           }),
       });
 
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
+    const backImage = getByLabelText('doc_auth.headings.document_capture_back');
+    userEvent.upload(frontImage, validUpload);
+    userEvent.upload(backImage, validUpload);
+    await waitFor(() => frontImage.src && backImage.src);
 
     userEvent.click(getByText('forms.buttons.submit.default'));
     await waitFor(() => window.location.hash === '#teapot');
@@ -358,8 +361,10 @@ describe('document-capture/components/document-capture', () => {
           expect(payload).to.have.keys([
             'front_image_iv',
             'front_image_url',
+            'front_metadata',
             'back_image_iv',
             'back_image_url',
+            'back_metadata',
             'selfie_image_iv',
             'selfie_image_url',
           ]);

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -25,7 +25,7 @@ describe('document-capture/components/documents-step', () => {
     await new Promise((resolve) => onChange.callsFake(resolve));
     expect(onChange).to.have.been.calledWith({
       front: file,
-      front_metadata: sinon.match(/^\{.+\}$/),
+      front_image_metadata: sinon.match(/^\{.+\}$/),
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import DocumentsStep from '@18f/identity-document-capture/components/documents-step';
 import { render } from '../../../support/document-capture';
+import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/documents-step', () => {
   it('renders with front and back inputs', () => {
@@ -15,13 +16,17 @@ describe('document-capture/components/documents-step', () => {
     expect(back).to.be.ok();
   });
 
-  it('calls onChange callback with uploaded image', () => {
+  it('calls onChange callback with uploaded image', async () => {
     const onChange = sinon.stub();
     const { getByLabelText } = render(<DocumentsStep onChange={onChange} />);
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file = await getFixtureFile('doc_auth_images/id-back.jpg');
 
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file);
-    expect(onChange.getCall(0).args[0]).to.deep.equal({ front: file });
+    await new Promise((resolve) => onChange.callsFake(resolve));
+    expect(onChange).to.have.been.calledWith({
+      front: file,
+      front_metadata: sinon.match(/^\{.+\}$/),
+    });
   });
 
   it('renders device-specific instructions', () => {

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -77,7 +77,7 @@ describe('document-capture/components/review-issues-step', () => {
     await new Promise((resolve) => onChange.callsFake(resolve));
     expect(onChange).to.have.been.calledWith({
       front: file,
-      front_metadata: sinon.match(/^\{.+\}$/),
+      front_image_metadata: sinon.match(/^\{.+\}$/),
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -10,6 +10,7 @@ import ReviewIssuesStep, {
 } from '@18f/identity-document-capture/components/review-issues-step';
 import { render } from '../../../support/document-capture';
 import { useSandbox } from '../../../support/sinon';
+import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/review-issues-step', () => {
   const sandbox = useSandbox();
@@ -67,17 +68,21 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByLabelText('doc_auth.headings.document_capture_selfie')).to.be.ok();
   });
 
-  it('calls onChange callback with uploaded image', () => {
+  it('calls onChange callback with uploaded image', async () => {
     const onChange = sinon.stub();
     const { getByLabelText } = render(<ReviewIssuesStep onChange={onChange} />);
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file = await getFixtureFile('doc_auth_images/id-back.jpg');
 
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file);
-    expect(onChange.getCall(0).args[0]).to.deep.equal({ front: file });
+    await new Promise((resolve) => onChange.callsFake(resolve));
+    expect(onChange).to.have.been.calledWith({
+      front: file,
+      front_metadata: sinon.match(/^\{.+\}$/),
+    });
   });
 
   it('performs background encrypted uploads', async () => {
-    const onChange = sandbox.spy();
+    const onChange = sandbox.stub();
     sandbox.stub(window, 'fetch').callsFake(() =>
       Promise.resolve({
         ok: true,
@@ -102,9 +107,10 @@ describe('document-capture/components/review-issues-step', () => {
       </UploadContextProvider>,
     );
 
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file = await getFixtureFile('doc_auth_images/id-back.jpg');
 
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), file);
+    await new Promise((resolve) => onChange.callsFake(resolve));
     const patch = onChange.getCall(0).args[0];
     expect(await patch.back_image_url).to.equal('about:blank#back');
     expect(window.fetch.getCall(0).args[0]).to.equal('about:blank#back');


### PR DESCRIPTION
**Why**: So that we can better associate front-end image metrics with the final submission result