### PR TITLE
Fix active, disabled, unstyled button background color

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -65,6 +65,18 @@
   display: inline;
   width: auto;
 
+  // Temporary: To be backported to design system. Unstyled buttons should not ever show the default
+  // opaque disabled background color. Typically a button would not be both disabled and active, but
+  // it is possible in some browsers when e.g. disabling a button in response to its own click.
+  &:disabled:hover,
+  &:disabled.usa-button--hover,
+  &:disabled:active,
+  &:disabled.usa-button--active,
+  &:disabled:focus,
+  &:disabled.usa-focus {
+    background-color: transparent;
+  }
+
   &:hover,
   &:active {
     // Temporary: These styles should be ported upstream to the design system, optionally as part of

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -68,12 +68,12 @@
   // Temporary: To be backported to design system. Unstyled buttons should not ever show the default
   // opaque disabled background color. Typically a button would not be both disabled and active, but
   // it is possible in some browsers when e.g. disabling a button in response to its own click.
-  &:disabled:hover,
-  &:disabled.usa-button--hover,
-  &:disabled:active,
-  &:disabled.usa-button--active,
-  &:disabled:focus,
-  &:disabled.usa-focus {
+  &.usa-button:disabled:hover,
+  &.usa-button:disabled.usa-button--hover,
+  &.usa-button:disabled:active,
+  &.usa-button:disabled.usa-button--active,
+  &.usa-button:disabled:focus,
+  &.usa-button:disabled.usa-focus {
     background-color: transparent;
   }
 


### PR DESCRIPTION
**Why**: When an unstyled button is used as the submit button in a form, it can cause an issue where clicking the button would make it both disabled and active. This is because our default form validation will disable all submit buttons when a form is submitted. Since this happens at the same time as the link activation, and since the USWDS default disabled button styles conflict with the unstyled link appearance, an undesirable background color can be shown.

Problematic base styles: https://github.com/uswds/uswds/blob/0f1f4d0/src/stylesheets/core/mixins/_button-disabled.scss#L7-L16

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/113626484-3a8f5280-9630-11eb-82a7-a5366b67480c.png)|![image](https://user-images.githubusercontent.com/1779930/113626418-28151900-9630-11eb-8b4e-6bcbb54a1929.png)
