### PR TITLE
Fix button block link styling from USWDS migration

### DIFF
--- a/app/views/idv/shared/_back_to_sp_link.html.erb
+++ b/app/views/idv/shared/_back_to_sp_link.html.erb
@@ -1,12 +1,5 @@
 <% if decorated_session.sp_name %>
-  <hr>
-    <div class="margin-bottom-2 margin-top-2">
-      <div class="right">
-        <%= link_to image_tag(asset_url('carat-right.svg'), size: '10'),
-            return_to_sp_failure_to_proof_path, class: 'bold block usa-button usa-button--unstyled text-decoration-none' %>
-      </div>
-      <%= link_to t('idv.failure.help.get_help_html', sp_name: decorated_session.sp_name),
-          return_to_sp_failure_to_proof_path, class: 'block usa-button usa-button--unstyled text-decoration-none' %>
-    </div>
-  <hr/>
+  <%= render 'shared/block_link', url: return_to_sp_failure_to_proof_path do %>
+    <%= t('idv.failure.help.get_help_html', sp_name: decorated_session.sp_name) %>
+  <% end %>
 <% end %>

--- a/app/views/idv/shared/_reset_your_account.html.erb
+++ b/app/views/idv/shared/_reset_your_account.html.erb
@@ -1,10 +1,3 @@
-<hr>
-  <div class="margin-bottom-2 margin-top-2">
-    <div class="right">
-      <%= link_to image_tag(asset_url('carat-right.svg'), size: '10'),
-        return_to_sp_failure_to_proof_path, class: 'bold block usa-button usa-button--unstyled text-decoration-none' %>
-    </div>
-    <%= link_to t('two_factor_authentication.account_reset.reset_your_account'),
-      account_reset_request_path %>
-  </div>
-<hr/>
+<%= render 'shared/block_link', url: return_to_sp_failure_to_proof_path do %>
+  <%= t('two_factor_authentication.account_reset.reset_your_account') %>
+<% end %>

--- a/app/views/idv/shared/_reset_your_account.html.erb
+++ b/app/views/idv/shared/_reset_your_account.html.erb
@@ -1,3 +1,3 @@
-<%= render 'shared/block_link', url: return_to_sp_failure_to_proof_path do %>
+<%= render 'shared/block_link', url: account_reset_request_path do %>
   <%= t('two_factor_authentication.account_reset.reset_your_account') %>
 <% end %>

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -38,7 +38,7 @@
 <div class="block-center center col-10">
   <div class="col-12 margin-bottom-2">
     <%= link_to t('links.account.reactivate.with_key'), verify_personal_key_path,
-                class: 'usa-button usa-button--big block' %>
+                class: 'usa-button usa-button--big usa-button--full-width' %>
   </div>
 
   <%= form_tag reactivate_account_path, method: :put, class: 'col-12' do %>

--- a/app/views/shared/_block_link.html.erb
+++ b/app/views/shared/_block_link.html.erb
@@ -3,8 +3,9 @@ yields: Link text (required).
 locals:
 * url: URL of link.
 %>
+<% content = yield.presence or raise "no block content given" %>
 <%= tag.a href: url, class: 'usa-link block-link' do %>
-  <%= yield %>
+  <%= content %>
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewbox="0 0 5.2 8.91"

--- a/app/views/shared/_block_link.html.erb
+++ b/app/views/shared/_block_link.html.erb
@@ -1,0 +1,20 @@
+<%#
+yields: Link text (required).
+locals:
+* url: URL of link.
+%>
+<%= tag.a href: url, class: 'usa-link block-link' do %>
+  <%= yield %>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewbox="0 0 5.2 8.91"
+    focusable="false"
+    aria-hidden="true"
+    class="block-link__arrow"
+  >
+    <path
+      d="M5.11 4.66L1 8.82a.36.36 0 01-.21.09.31.31 0 01-.2-.09l-.5-.45a.29.29 0 01-.09-.2A.36.36 0 01.09 8L3.6 4.45.09 1A.36.36 0 010 .74a.31.31 0 01.09-.2L.54.09A.31.31 0 01.74 0 .36.36 0 011 .09l4.11 4.16a.31.31 0 01.09.2.31.31 0 01-.09.21z"
+      fill="currentColor"
+    />
+  </svg>
+<% end %>

--- a/spec/views/shared/_block_link.html.erb_spec.rb
+++ b/spec/views/shared/_block_link.html.erb_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe 'shared/_block_link.html.erb' do
+  it 'raises an error if no block given' do
+    expect { render 'shared/block_link', url: '/example' }.to raise_error('no block content given')
+  end
+
   it 'renders a link to the given URL with the given text' do
     render('shared/block_link', url: '/example') { 'Link Text' }
 

--- a/spec/views/shared/_block_link.html.erb_spec.rb
+++ b/spec/views/shared/_block_link.html.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'shared/_block_link.html.erb' do
+  it 'renders a link to the given URL with the given text' do
+    render('shared/block_link', url: '/example') { 'Link Text' }
+
+    expect(rendered).to have_selector('a[href="/example"]')
+    expect(rendered).to have_content('Link Text')
+  end
+end


### PR DESCRIPTION
Related: #4836

**Why**: Prior to #4836, there were a few instances of links which used the `block` class to extend the width of the link to occupy the full width of its container. Since the USWDS button applies its own `display: inline-block` which takes precedence over the `block` utility class, this caused these links to shrink unintentionally.

Solution:

- In the "Reactivate Account" screen, replace `block` with `usa-button--full-width` as an equivalent effect
- In IDV session errors screen, refactor links to replicate the equivalent `<BlockLink />` React component added for document capture step in #4751.

Discovered using full-project search patterns `block[^'"]+usa-button`, `usa-button[^'"]+block`, `f\.button([^%]|\n)+block`.

**Screenshots:**

Reactivate Account:

Before|After
---|---
![Screen Shot 2021-04-07 at 10 36 43 AM](https://user-images.githubusercontent.com/1779930/113884666-29a82380-978d-11eb-87b1-001d3c1d6357.png)|![Screen Shot 2021-04-07 at 10 36 27 AM](https://user-images.githubusercontent.com/1779930/113884679-2c0a7d80-978d-11eb-8f5b-97e5fa8c7555.png)

IDV Session Errors:

Before|After
---|---
![Screen Shot 2021-04-07 at 10 35 16 AM](https://user-images.githubusercontent.com/1779930/113884480-01202980-978d-11eb-978e-424b220e8c7e.png)|![Screen Shot 2021-04-07 at 10 24 43 AM](https://user-images.githubusercontent.com/1779930/113884489-02e9ed00-978d-11eb-88af-294604c9309c.png)

Note that the two links are usually mutually exclusive and not shown at the same time, depending if the user is verifying their identity from an SP or recovering from a password reset.
