### PR TITLE
Ensure non-nil fingerprint for SAML logout

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -35,8 +35,9 @@ class SamlIdpController < ApplicationController
     decode_request(raw_saml_request)
 
     # Plumb the fingerprint through to the internal service_provider representation
-    if saml_request && matching_cert
-      saml_request.service_provider.fingerprint = Fingerprinter.fingerprint_cert(matching_cert)
+    if saml_request&.service_provider
+      saml_request.service_provider.fingerprint =
+         Fingerprinter.fingerprint_cert(matching_cert || current_service_provider.ssl_certs.first)
     end
 
     track_logout_event

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -43,6 +43,32 @@ describe SamlIdpController do
 
       delete :logout, params: { SAMLRequest: 'foo' }
     end
+
+    let(:service_provider) do
+      create(:service_provider,
+             cert: nil, # override singular cert
+             certs: ['saml_test_sp'],
+             active: true)
+    end
+
+    let(:wrong_cert_settings) do
+      sp1_saml_settings.tap do |settings|
+        settings.issuer = service_provider.issuer
+        settings.certificate = File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt'))
+        settings.private_key = OpenSSL::PKey::RSA.new(
+          File.read(Rails.root + 'keys/saml_test_sp2.key'),
+        ).to_pem
+      end
+    end
+
+    it 'rejects requests from a wrong cert' do
+      request_url = OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings)
+      saml_request = UriService.params(request_url)[:SAMLRequest]
+
+      delete :logout, params: { SAMLRequest: saml_request }
+
+      expect(response).to be_bad_request
+    end
   end
 
   describe '/api/saml/metadata' do

--- a/spec/support/fake_saml_logout_request.rb
+++ b/spec/support/fake_saml_logout_request.rb
@@ -1,4 +1,6 @@
 class FakeSamlLogoutRequest
+  attr_accessor :fingerprint
+
   def service_provider
     self
   end


### PR DESCRIPTION
Re: [Error in NewRelic](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=1800000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiYzEzZmU3NDQtOTdkMi0xMWViLWExOGItMDI0MmFjMTEwMDA4XzBfMTY5NTUiLCJmaWx0ZXJzIjpbeyJrZXkiOiJlcnJvci5leHBlY3RlZCIsInZhbHVlIjoibm90IHRydWUifSx7ImtleSI6ImVycm9yLmNsYXNzIiwidmFsdWUiOiJOb01ldGhvZEVycm9yIiwibGlrZSI6ZmFsc2V9XSwibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3IiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1UQTBOREV3TURZMSJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1UQTBOREV3TURZMSIsInNlbGVjdGVkTmVyZGxldCI6eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXcifX0)

Love it when our tests stub out everything....