### PR TITLE
Gracefully handle bad SAML logout data

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -164,7 +164,7 @@ module SamlIdpAuthConcern
   def matching_cert
     return @matching_cert if defined?(@matching_cert)
 
-    @matching_cert = current_service_provider.ssl_certs.find do |ssl_cert|
+    matching_cert = current_service_provider.ssl_certs.find do |ssl_cert|
       fingerprint = Fingerprinter.fingerprint_cert(ssl_cert)
 
       saml_request = SamlIdp::Request.from_deflated_request(
@@ -177,7 +177,11 @@ module SamlIdpAuthConcern
         saml_request.service_provider.fingerprint = fingerprint
         saml_request.valid_signature?
       end
+    rescue OpenSSL::X509::CertificateError
+      false
     end
+
+    @matching_cert = matching_cert || current_service_provider.ssl_certs.first
   end
 
   def encryption_opts

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -36,8 +36,9 @@ class SamlIdpController < ApplicationController
 
     # Plumb the fingerprint through to the internal service_provider representation
     if saml_request&.service_provider
-      saml_request.service_provider.fingerprint =
-         Fingerprinter.fingerprint_cert(matching_cert || current_service_provider.ssl_certs.first)
+      saml_request.service_provider.fingerprint = matching_cert ?
+        Fingerprinter.fingerprint_cert(matching_cert) :
+        'some-non-nil-value'
     end
 
     track_logout_event
@@ -61,6 +62,12 @@ class SamlIdpController < ApplicationController
     return false unless saml_request
     decode_request(saml_request)
     valid_saml_request?
+  end
+
+  def valid_saml_request?
+    super
+  rescue OpenSSL::X509::CertificateError
+    false
   end
 
   def saml_metadata


### PR DESCRIPTION
I had some trouble building a request that generated the same error we saw in prod, so I went the route of stubbing something inside the IDP gem and then catching all the places