### PR TITLE
Include flow_path in logged events to distinguish hybrid flow (LG-4399)

### DIFF
--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-/** @typedef {Record<string,string|number|boolean|null>} Payload */
+/** @typedef {Record<string,string|number|boolean|null|undefined>} Payload */
 
 /**
  * @typedef PageAction

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -98,12 +98,15 @@ const device = {
 
 /** @type {import('@18f/identity-document-capture/context/analytics').AddPageAction} */
 function addPageAction(action) {
+  const { flowPath } = appRoot.dataset;
+  const payload = { ...action.payload, flow_path: flowPath };
+
   const { newrelic } = /** @type {DocumentCaptureGlobal} */ (window);
   if (action.key && newrelic) {
-    newrelic.addPageAction(action.key, action.payload);
+    newrelic.addPageAction(action.key, payload);
   }
 
-  trackEvent(action.label, action.payload);
+  trackEvent(action.label, payload);
 }
 
 /** @type {import('@18f/identity-document-capture/context/analytics').NoticeError} */

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -53,6 +53,10 @@ module Flow
       obj.extra_view_variables
     end
 
+    def flow_path
+      'standard'
+    end
+
     private
 
     def wrap_send(handler)

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -182,6 +182,7 @@ module Flow
 
     def analytics_properties
       {
+        flow_path: @flow.flow_path,
         step: current_step,
         step_count: current_flow_step_counts[current_step_name],
       }

--- a/app/services/idv/flows/capture_doc_flow.rb
+++ b/app/services/idv/flows/capture_doc_flow.rb
@@ -16,6 +16,10 @@ module Idv
       def initialize(controller, session, _name)
         super(controller, STEPS, ACTIONS, session)
       end
+
+      def flow_path
+        'hybrid'
+      end
     end
   end
 end

--- a/app/views/idv/capture_doc/document_capture.html.erb
+++ b/app/views/idv/capture_doc/document_capture.html.erb
@@ -1,6 +1,7 @@
 <%= render(
   'idv/shared/document_capture',
   flow_session: flow_session,
+  flow_path: 'hybrid',
   sp_name: decorated_session.sp_name,
   failure_to_proof_url: return_to_sp_failure_to_proof_path,
   front_image_upload_url: front_image_upload_url,

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -1,6 +1,7 @@
 <%= render(
   'idv/shared/document_capture',
   flow_session: flow_session,
+  flow_path: 'standard',
   sp_name: decorated_session.sp_name,
   failure_to_proof_url: return_to_sp_failure_to_proof_path,
   front_image_upload_url: front_image_upload_url,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -25,6 +25,7 @@
     nil,
   status_poll_interval_ms: AppConfig.env.poll_rate_for_verify_in_seconds.to_i * 1000,
   sp_name: sp_name,
+  flow_path: flow_path,
   failure_to_proof_url: failure_to_proof_url,
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -99,7 +99,7 @@ describe Idv::CaptureDocController do
 
       it 'tracks analytics' do
         mock_next_step(:capture_complete)
-        result = { step: 'capture_complete', step_count: 1 }
+        result = { step: 'capture_complete', flow_path: 'hybrid', step_count: 1 }
 
         get :show, params: { step: 'capture_complete' }
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -62,7 +62,7 @@ describe Idv::DocAuthController do
     end
 
     it 'tracks analytics' do
-      result = { step: 'welcome', step_count: 1 }
+      result = { step: 'welcome', flow_path: 'standard', step_count: 1 }
 
       get :show, params: { step: 'welcome' }
 
@@ -108,7 +108,7 @@ describe Idv::DocAuthController do
       mock_next_step(:back_image)
       allow_any_instance_of(Flow::BaseFlow).to \
         receive(:flow_session).and_return(pii_from_doc: {})
-      result = { success: true, errors: {}, step: 'ssn', step_count: 1 }
+      result = { success: true, errors: {}, step: 'ssn', flow_path: 'standard', step_count: 1 }
 
       put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
 
@@ -152,6 +152,7 @@ describe Idv::DocAuthController do
           message: 'Doc Auth error: Javascript could not detect camera on mobile device.',
         },
         step: 'welcome',
+        flow_path: 'standard',
         step_count: 1,
       }
 
@@ -367,6 +368,7 @@ describe Idv::DocAuthController do
           success: false,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           step: 'verify_document_status',
+          flow_path: 'standard',
           step_count: 1,
         }
       )
@@ -376,6 +378,7 @@ describe Idv::DocAuthController do
           success: false,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           step: 'verify_document_status',
+          flow_path: 'standard',
           step_count: 1,
         }
       )

--- a/spec/controllers/idv/recovery_controller_spec.rb
+++ b/spec/controllers/idv/recovery_controller_spec.rb
@@ -111,7 +111,7 @@ describe Idv::RecoveryController do
       end
 
       it 'tracks analytics' do
-        result = { step: 'recover', step_count: 1 }
+        result = { step: 'recover', flow_path: 'standard', step_count: 1 }
 
         get :show, params: { step: 'recover' }
 

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -55,12 +55,14 @@ feature 'doc auth document capture step' do
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH + ' submitted',
         step: 'document_capture',
+        flow_path: 'standard',
         result: 'Passed',
         billed: true,
       )
       expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
         step: 'document_capture',
+        flow_path: 'standard',
         result: 'Passed',
         billed: true,
       )
@@ -87,6 +89,7 @@ feature 'doc auth document capture step' do
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH + ' submitted',
         step: 'document_capture',
+        flow_path: 'standard',
         result: 'Passed',
         billed: true,
         success: false,
@@ -94,6 +97,7 @@ feature 'doc auth document capture step' do
       expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
         step: 'document_capture',
+        flow_path: 'standard',
         result: 'Passed',
         billed: true,
         success: false,

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -41,6 +41,7 @@ feature 'doc capture document capture step' do
 
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH,
+        flow_path: 'hybrid',
         success: false,
       )
     end
@@ -55,6 +56,7 @@ feature 'doc capture document capture step' do
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH + ' visited',
         step: 'document_capture',
+        flow_path: 'hybrid',
       )
     end
   end
@@ -139,6 +141,14 @@ feature 'doc capture document capture step' do
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH + ' submitted',
         step: 'document_capture',
+        flow_path: 'hybrid',
+        result: 'Passed',
+        billed: true,
+      )
+      expect(fake_analytics).to have_logged_event(
+        'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
+        step: 'document_capture',
+        flow_path: 'hybrid',
         result: 'Passed',
         billed: true,
       )

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -41,7 +41,6 @@ feature 'doc capture document capture step' do
 
       expect(fake_analytics).to have_logged_event(
         Analytics::DOC_AUTH,
-        flow_path: 'hybrid',
         success: false,
       )
     end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe 'idv/shared/_document_capture.html.erb' do
 
   let(:flow_session) { {} }
   let(:sp_name) { nil }
+  let(:flow_path) { 'standard' }
   let(:failure_to_proof_url) { return_to_sp_failure_to_proof_path }
   let(:front_image_upload_url) { nil }
   let(:back_image_upload_url) { nil }
@@ -23,6 +24,7 @@ describe 'idv/shared/_document_capture.html.erb' do
     render partial: 'idv/shared/document_capture', locals: {
       flow_session: flow_session,
       sp_name: sp_name,
+      flow_path: flow_path,
       failure_to_proof_url: failure_to_proof_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,


### PR DESCRIPTION
We want to have a way to distinguish document capture events as to whether they occur in the standard, or normal, flow or the hybrid flow. This PR adds the `flow_path` entry to document capture events with either `standard` or `hybrid`.