### PR TITLE
Fix account reset double submit 500 error

### DIFF
--- a/app/services/db/deleted_user/create.rb
+++ b/app/services/db/deleted_user/create.rb
@@ -8,6 +8,8 @@ module Db
                               uuid: user.uuid,
                               user_created_at: user.created_at,
                               deleted_at: Time.zone.now)
+      rescue ActiveRecord::RecordNotUnique
+        ::DeletedUser.where(user_id: user_id)&.first
       end
     end
   end

--- a/spec/services/db/deleted_user/create_spec.rb
+++ b/spec/services/db/deleted_user/create_spec.rb
@@ -16,4 +16,11 @@ describe Db::DeletedUser::Create do
     deleted_user = DeletedUser.first
     expect(deleted_user.user_id).to eq(user.id)
   end
+
+  it 'fails gracefully if we try to insert the same user twice and returns the deleted user' do
+    user = create(:user)
+    deleted_user1 = subject.call(user.id)
+    deleted_user2 = subject.call(user.id)
+    expect(deleted_user1).to eq(deleted_user2)
+  end
 end


### PR DESCRIPTION
**Why**: When a user deletes their account we store off some minimal information about the user (user_id, uuid) in deleted_user.  A double submit is creating a unique key violation.  We will eventually implement soft-deletes.