### PR TITLE
Fix IDV address 500 error if no document data in session

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -3,9 +3,9 @@ module Idv
     include IdvSession
 
     before_action :confirm_two_factor_authenticated
+    before_action :confirm_pii_from_doc
 
     def new
-      @pii = user_session['idv/doc_auth']['pii_from_doc']
       analytics.track_event(Analytics::IDV_ADDRESS_VISIT)
     end
 
@@ -20,6 +20,12 @@ module Idv
     end
 
     private
+
+    def confirm_pii_from_doc
+      @pii = user_session.dig('idv/doc_auth','pii_from_doc')
+      return if @pii.present?
+      redirect_to idv_doc_auth_url
+    end
 
     def idv_form
       Idv::AddressForm.new(

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -22,7 +22,7 @@ module Idv
     private
 
     def confirm_pii_from_doc
-      @pii = user_session.dig('idv/doc_auth','pii_from_doc')
+      @pii = user_session.dig('idv/doc_auth', 'pii_from_doc')
       return if @pii.present?
       redirect_to idv_doc_auth_url
     end

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -33,4 +33,10 @@ feature 'doc auth verify step' do
 
     expect(page).to have_current_path(idv_doc_auth_verify_step)
   end
+
+  it 'sends the user to doc auth if there is no pii from the document' do
+    visit sign_out_url
+    sign_in_and_2fa_user
+    visit idv_address_path
+  end
 end

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -34,9 +34,11 @@ feature 'doc auth verify step' do
     expect(page).to have_current_path(idv_doc_auth_verify_step)
   end
 
-  it 'sends the user to doc auth if there is no pii from the document' do
+  it 'sends the user to start doc auth if there is no pii from the document in session' do
     visit sign_out_url
     sign_in_and_2fa_user
     visit idv_address_path
+
+    expect(page).to have_current_path(idv_doc_auth_welcome_step)
   end
 end


### PR DESCRIPTION
**Why**: A prerequisite for the change address screen is that the PII from the document used for verification is in session.  If it's not there just route the user to the appropriate step in doc auth.