### PR TITLE
RISC event for password reset

### DIFF
--- a/app/services/push_notification/recovery_activated_event.rb
+++ b/app/services/push_notification/recovery_activated_event.rb
@@ -1,0 +1,30 @@
+module PushNotification
+  class RecoveryActivatedEvent
+    EVENT_TYPE = 'https://schemas.openid.net/secevent/risc/event-type/recovery-activated'.freeze
+
+    attr_reader :user
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def event_type
+      EVENT_TYPE
+    end
+
+    def payload(iss_sub:)
+      {
+        subject: {
+          subject_type: 'iss-sub',
+          iss: Rails.application.routes.url_helpers.root_url,
+          sub: iss_sub,
+        },
+      }
+    end
+
+    # Used by specs for argument matching
+    def ==(other)
+      user == other.user
+    end
+  end
+end

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -23,6 +23,9 @@ RequestPasswordReset = RedactedStruct.new(:email, :request_id, :analytics, keywo
     else
       token = user.set_reset_password_token
       UserMailer.reset_password_instructions(user, email, token: token).deliver_now
+
+      event = PushNotification::RecoveryActivatedEvent.new(user: user)
+      PushNotification::HttpPush.deliver(event)
     end
   end
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -12,6 +12,10 @@ feature 'Password Recovery' do
       visit root_path
       click_link t('links.passwords.forgot')
       fill_in 'Email', with: user.email
+
+      expect(PushNotification::HttpPush).to receive(:deliver).
+        with(PushNotification::RecoveryActivatedEvent.new(user: user))
+
       click_button t('forms.buttons.continue')
 
       expect(current_path).to eq forgot_password_path

--- a/spec/services/push_notification/recovery_activated_event_spec.rb
+++ b/spec/services/push_notification/recovery_activated_event_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PushNotification::RecoveryActivatedEvent do
+  include Rails.application.routes.url_helpers
+
+  subject(:event) do
+    PushNotification::RecoveryActivatedEvent.new(user: user)
+  end
+
+  let(:user) { build(:user) }
+
+  describe '#event_type' do
+    it 'is the RISC event type' do
+      expect(event.event_type).to eq(PushNotification::RecoveryActivatedEvent::EVENT_TYPE)
+    end
+  end
+
+  describe '#payload' do
+    let(:iss_sub) { SecureRandom.uuid }
+
+    subject(:payload) { event.payload(iss_sub: iss_sub) }
+
+    it 'is a subject with the provided iss_sub ' do
+      expect(payload).to eq(
+        subject: {
+          subject_type: 'iss-sub',
+          sub: iss_sub,
+          iss: root_url,
+        },
+      )
+    end
+  end
+end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
-describe RequestPasswordReset do
+RSpec.describe RequestPasswordReset do
   describe '#perform' do
+    let(:user) { create(:user) }
+    let(:email) { user.email_addresses.first.email }
+
     context 'when the user is not found' do
       it 'sends the account registration email' do
         email = 'nonexistent@example.com'
@@ -27,50 +30,48 @@ describe RequestPasswordReset do
 
     context 'when the user is found and confirmed' do
       it 'sends password reset instructions' do
-        user = create(:user)
-        email_address = user.email_addresses.first
-        email = email_address.email
+        allow(UserMailer).to receive(:reset_password_instructions).
+          and_wrap_original do |impl, user, email, options|
+            token = options.fetch(:token)
+            expect(token).to be_present
+            expect(Devise.token_generator.digest(User, :reset_password_token, token)).
+              to eq(user.reset_password_token)
 
-        allow(EmailAddress).to receive(:find_with_email).with(email).and_return(email_address)
+            impl.call(user, email, **options)
+          end
 
-        expect(user).to receive(:set_reset_password_token).and_return('asdf1234')
-
-        mail = double
-        expect(mail).to receive(:deliver_now)
-        expect(UserMailer).to receive(:reset_password_instructions).
-          with(user, email, token: 'asdf1234').
-          and_return(mail)
-
-        RequestPasswordReset.new(email: email).perform
+        expect { RequestPasswordReset.new(email: email).perform }.
+          to(change { user.reload.reset_password_token })
       end
     end
 
     context 'when the user is found, not privileged, and not yet confirmed' do
       it 'sends password reset instructions' do
-        user = create(:user, :unconfirmed)
-        email_address = user.email_addresses.first
-        email = email_address.email
+        allow(UserMailer).to receive(:reset_password_instructions).
+          and_wrap_original do |impl, user, email, options|
+            token = options.fetch(:token)
+            expect(token).to be_present
+            expect(Devise.token_generator.digest(User, :reset_password_token, token)).
+              to eq(user.reset_password_token)
 
-        allow(EmailAddress).to receive(:find_with_email).with(email).and_return(email_address)
+            impl.call(user, email, **options)
+          end
 
-        expect(user).to receive(:set_reset_password_token).and_return('asdf1234')
-
-        mail = double
-        expect(mail).to receive(:deliver_now)
-        expect(UserMailer).to receive(:reset_password_instructions).
-          with(user, email, token: 'asdf1234').
-          and_return(mail)
-
-        RequestPasswordReset.new(email: email).perform
+        expect { RequestPasswordReset.new(email: email).perform }.
+          to(change { user.reload.reset_password_token })
       end
     end
 
     context 'when the user is found and confirmed, but the email address is not' do
-      it 'sends the account registration email' do
-        user = create(:user, :with_multiple_emails)
-        unconfirmed_email_address = user.reload.email_addresses.last
-        unconfirmed_email_address.update!(confirmed_at: nil)
+      let(:user) { create(:user, :with_multiple_emails) }
 
+      let(:unconfirmed_email_address) do
+        user.reload.email_addresses.last.tap do |email_address|
+          email_address.update!(confirmed_at: nil)
+        end
+      end
+
+      it 'sends the account registration email' do
         send_sign_up_email_confirmation = instance_double(SendSignUpEmailConfirmation)
         expect(send_sign_up_email_confirmation).to receive(:call).with(
           hash_including(
@@ -112,19 +113,17 @@ describe RequestPasswordReset do
 
     context 'when the user requests password resets above the allowable threshold' do
       it 'throttles the email sending and logs a throttle event' do
-        user = create(:user)
-        email_address = user.email_addresses.first
-        email = email_address.email
         max_attempts = AppConfig.env.reset_password_email_max_attempts.to_i
 
-        allow(EmailAddress).to receive(:find_with_email).with(email).and_return(email_address)
-        expect(user).to receive(:set_reset_password_token).and_return('asdf1234').
-          exactly(max_attempts).times
-
         analytics = FakeAnalytics.new
-        (max_attempts + 1).times do
-          RequestPasswordReset.new(email: email, analytics: analytics).perform
+        max_attempts.times do
+          expect { RequestPasswordReset.new(email: email, analytics: analytics).perform }.
+            to(change { user.reload.reset_password_token })
         end
+
+        # extra time, throttled
+        expect { RequestPasswordReset.new(email: email, analytics: analytics).perform }.
+          to_not(change { user.reload.reset_password_token })
 
         expect(analytics).to have_logged_event(
           Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,


### PR DESCRIPTION
Sends a RISC event when somebody attempts a password reset for an account.

From the specs: https://openid.net/specs/openid-risc-event-types-1_0-ID1.html#recovery-activated

> Recovery Activated signals that the account identified by the subject activated a recovery flow.

We could choose to send this event after they click the link in their email, but I think the more valuable information is when somebody starts the flow