### PR TITLE
LG-4419 Email Changed RISC event

### DIFF
--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -68,7 +68,6 @@ class AddUserEmailForm
   end
 
   def notify_subscribers
-    return unless IdentityConfig.store.push_notifications_enabled
     event = PushNotification::EmailChangedEvent.new(user: existing_user, email: email_address.email)
     PushNotification::HttpPush.deliver(event)
   end

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -53,6 +53,7 @@ class AddUserEmailForm
     @success = true
     email_address.save!
     SendAddEmailConfirmation.new(user).call(email_address)
+    notify_subscribers
   end
 
   def extra_analytics_attributes
@@ -64,5 +65,11 @@ class AddUserEmailForm
 
   def existing_user
     @_user ||= User.find_with_email(email) || AnonymousUser.new
+  end
+
+  def notify_subscribers
+    return unless IdentityConfig.store.push_notifications_enabled
+    event = PushNotification::EmailChangedEvent.new(user: existing_user, email: email_address.email)
+    PushNotification::HttpPush.deliver(event)
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -45,10 +45,10 @@ class DeleteUserEmailForm
   end
 
   def notify_subscribers
-    identifier_recycled = PushNotification::IdentifierRecycledEvent.new(user: user,
-                                                                        email: email_address)
+    email = email_address.email
+    identifier_recycled = PushNotification::IdentifierRecycledEvent.new(user: user, email: email)
     PushNotification::HttpPush.deliver(identifier_recycled)
-    email_changed = PushNotification::EmailChangedEvent.new(user: user, email: email_address.email)
+    email_changed = PushNotification::EmailChangedEvent.new(user: user, email: email)
     PushNotification::HttpPush.deliver(email_changed)
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -45,9 +45,10 @@ class DeleteUserEmailForm
   end
 
   def notify_subscribers
-    event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address)
-    PushNotification::HttpPush.deliver(event)
-    event = PushNotification::EmailChangedEvent.new(user: user, email: email_address.email)
-    PushNotification::HttpPush.deliver(event)
+    identifier_recycled = PushNotification::IdentifierRecycledEvent.new(user: user,
+                                                                        email: email_address)
+    PushNotification::HttpPush.deliver(identifier_recycled)
+    email_changed = PushNotification::EmailChangedEvent.new(user: user, email: email_address.email)
+    PushNotification::HttpPush.deliver(email_changed)
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -47,5 +47,7 @@ class DeleteUserEmailForm
   def notify_subscribers
     event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address)
     PushNotification::HttpPush.deliver(event)
+    event = PushNotification::EmailChangedEvent.new(user: user, email: email_address.email)
+    PushNotification::HttpPush.deliver(event)
   end
 end

--- a/app/services/push_notification/email_changed_event.rb
+++ b/app/services/push_notification/email_changed_event.rb
@@ -21,5 +21,9 @@ module PushNotification
         },
       }
     end
+
+    def ==(other)
+      user == other.user && email == other.email
+    end
   end
 end

--- a/app/services/push_notification/email_changed_event.rb
+++ b/app/services/push_notification/email_changed_event.rb
@@ -17,7 +17,7 @@ module PushNotification
       {
         subject: {
           subject_type: 'email',
-          email: email,
+          email: email.email,
         },
       }
     end

--- a/app/services/push_notification/email_changed_event.rb
+++ b/app/services/push_notification/email_changed_event.rb
@@ -1,0 +1,25 @@
+module PushNotification
+  class EmailChangedEvent
+    EVENT_TYPE = 'https://schemas.openid.net/secevent/risc/event-type/identifier-changed'.freeze
+
+    attr_reader :user, :email
+
+    def initialize(user:, email:)
+      @user = user
+      @email = email
+    end
+
+    def event_type
+      EVENT_TYPE
+    end
+
+    def payload(*)
+      {
+        subject: {
+          subject_type: 'email',
+          email: email,
+        },
+      }
+    end
+  end
+end

--- a/app/services/push_notification/email_changed_event.rb
+++ b/app/services/push_notification/email_changed_event.rb
@@ -17,7 +17,7 @@ module PushNotification
       {
         subject: {
           subject_type: 'email',
-          email: email.email,
+          email: email,
         },
       }
     end

--- a/app/services/push_notification/identifier_recycled_event.rb
+++ b/app/services/push_notification/identifier_recycled_event.rb
@@ -21,5 +21,9 @@ module PushNotification
         },
       }
     end
+
+    def ==(other)
+      user == other.user && email == other.email
+    end
   end
 end

--- a/app/services/push_notification/identifier_recycled_event.rb
+++ b/app/services/push_notification/identifier_recycled_event.rb
@@ -17,7 +17,7 @@ module PushNotification
       {
         subject: {
           subject_type: 'email',
-          email: email,
+          email: email.email,
         },
       }
     end

--- a/app/services/push_notification/identifier_recycled_event.rb
+++ b/app/services/push_notification/identifier_recycled_event.rb
@@ -17,7 +17,7 @@ module PushNotification
       {
         subject: {
           subject_type: 'email',
-          email: email.email,
+          email: email,
         },
       }
     end

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -7,13 +7,6 @@ RSpec.describe AddUserEmailForm do
   let(:user) { User.create(email: original_email) }
 
   describe '#submit' do
-    let(:push_notifications_enabled) { true }
-
-    before do
-      allow(IdentityConfig.store).to receive(:push_notifications_enabled).
-        and_return(push_notifications_enabled)
-    end
-
     let(:new_email) { 'new@example.com' }
 
     subject(:submit) { form.submit(user, email: new_email) }

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe AddUserEmailForm do
     end
 
     it 'notifies subscribers that the email was changed' do
-      expect(PushNotification::HttpPush).to receive(:deliver)
+      expect(PushNotification::HttpPush).to receive(:deliver).
+        with(PushNotification::EmailChangedEvent.new(user: user, email: new_email))
 
       submit
     end

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe AddUserEmailForm do
   subject(:form) { AddUserEmailForm.new }

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -19,7 +19,7 @@ describe DeleteUserEmailForm do
         expect(user.email_addresses.reload).to_not be_empty
       end
 
-      it 'does not notify subscribers that the identier or email was recycled' do
+      it 'does not notify subscribers that the identifier was recycled or email changed' do
         expect(PushNotification::HttpPush).to_not receive(:deliver)
 
         submit
@@ -42,7 +42,7 @@ describe DeleteUserEmailForm do
         expect(deleted_email).to be_empty
       end
 
-      it 'notifies subscribers that the identier was recycled' do
+      it 'notifies subscribers that the identifier was recycled and the email changed' do
         expect(PushNotification::HttpPush).to receive(:deliver).exactly(2).times.
           with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
 

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -43,8 +43,10 @@ describe DeleteUserEmailForm do
       end
 
       it 'notifies subscribers that the identifier was recycled and the email changed' do
-        expect(PushNotification::HttpPush).to receive(:deliver).exactly(2).times.
-          with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
+        expect(PushNotification::HttpPush).to receive(:deliver).once.
+          with(PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address.email))
+        expect(PushNotification::HttpPush).to receive(:deliver).once.
+            with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
 
         submit
       end

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -44,7 +44,8 @@ describe DeleteUserEmailForm do
 
       it 'notifies subscribers that the identifier was recycled and the email changed' do
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-          with(PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address.email))
+          with(PushNotification::IdentifierRecycledEvent.new(user: user,
+                                                             email: email_address.email))
         expect(PushNotification::HttpPush).to receive(:deliver).once.
             with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
 

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -43,7 +43,8 @@ describe DeleteUserEmailForm do
       end
 
       it 'notifies subscribers that the identier was recycled' do
-        expect(PushNotification::HttpPush).to receive(:deliver).exactly(2).times
+        expect(PushNotification::HttpPush).to receive(:deliver).exactly(2).times.
+          with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
 
         submit
       end

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -19,7 +19,7 @@ describe DeleteUserEmailForm do
         expect(user.email_addresses.reload).to_not be_empty
       end
 
-      it 'does not notify subscribers that the identier was recycled' do
+      it 'does not notify subscribers that the identier or email was recycled' do
         expect(PushNotification::HttpPush).to_not receive(:deliver)
 
         submit
@@ -43,7 +43,7 @@ describe DeleteUserEmailForm do
       end
 
       it 'notifies subscribers that the identier was recycled' do
-        expect(PushNotification::HttpPush).to receive(:deliver)
+        expect(PushNotification::HttpPush).to receive(:deliver).exactly(2).times
 
         submit
       end

--- a/spec/services/push_notification/email_changed_event_spec.rb
+++ b/spec/services/push_notification/email_changed_event_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe PushNotification::EmailChangedEvent do
   subject(:event) do

--- a/spec/services/push_notification/email_changed_event_spec.rb
+++ b/spec/services/push_notification/email_changed_event_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe PushNotification::IdentifierRecycledEvent do
+RSpec.describe PushNotification::EmailChangedEvent do
   subject(:event) do
-    PushNotification::IdentifierRecycledEvent.new(
+    PushNotification::EmailChangedEvent.new(
       user: user,
       email: email,
     )
@@ -13,7 +13,7 @@ RSpec.describe PushNotification::IdentifierRecycledEvent do
 
   describe '#event_type' do
     it 'is the RISC event type' do
-      expect(event.event_type).to eq(PushNotification::IdentifierRecycledEvent::EVENT_TYPE)
+      expect(event.event_type).to eq(PushNotification::EmailChangedEvent::EVENT_TYPE)
     end
   end
 


### PR DESCRIPTION
**Why**: Sends a RISC event when somebody adds or deletes an email.  From the specs: https://openid.net/specs/openid-risc-event-types-1_0-ID1.html#identifier-changed