### PR TITLE
Move delivery feature flag check inside HttpPush#deliver

### DIFF
--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -42,7 +42,6 @@ module Users
     end
 
     def send_push_notifications
-      return unless IdentityConfig.store.push_notifications_enabled
       event = PushNotification::AccountPurgedEvent.new(user: current_user)
       PushNotification::HttpPush.deliver(event)
     end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -45,7 +45,6 @@ class DeleteUserEmailForm
   end
 
   def notify_subscribers
-    return unless IdentityConfig.store.push_notifications_enabled
     event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address)
     PushNotification::HttpPush.deliver(event)
   end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -46,8 +46,6 @@ module AccountReset
     end
 
     def send_push_notifications
-      return unless IdentityConfig.store.push_notifications_enabled
-
       event = PushNotification::AccountPurgedEvent.new(user: user)
       PushNotification::HttpPush.deliver(event)
     end

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -17,6 +17,8 @@ module PushNotification
     end
 
     def deliver
+      return unless IdentityConfig.store.push_notifications_enabled
+
       event.user.
         service_providers.
         merge(ServiceProviderIdentity.not_deleted).

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -2,13 +2,6 @@ require 'rails_helper'
 
 describe DeleteUserEmailForm do
   describe '#submit' do
-    let(:push_notifications_enabled) { true }
-
-    before do
-      allow(IdentityConfig.store).to receive(:push_notifications_enabled).
-        and_return(push_notifications_enabled)
-    end
-
     subject(:submit) { form.submit }
 
     context 'with only a single email address' do
@@ -53,16 +46,6 @@ describe DeleteUserEmailForm do
         expect(PushNotification::HttpPush).to receive(:deliver)
 
         submit
-      end
-
-      context 'when push notifications are disabled' do
-        let(:push_notifications_enabled) { false }
-
-        it 'does not notify subscribers' do
-          expect(PushNotification::HttpPush).to_not receive(:deliver)
-
-          submit
-        end
       end
     end
 

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe RequestPasswordReset do
     let(:user) { create(:user) }
     let(:email) { user.email_addresses.first.email }
 
-
     context 'when the user is not found' do
       it 'sends the account registration email' do
         email = 'nonexistent@example.com'

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe RequestPasswordReset do
     let(:user) { create(:user) }
     let(:email) { user.email_addresses.first.email }
 
-    let(:push_notifications_enabled) { true }
-    before do
-      allow(IdentityConfig.store).to receive(:push_notifications_enabled).
-        and_return(push_notifications_enabled)
-    end
 
     context 'when the user is not found' do
       it 'sends the account registration email' do
@@ -50,27 +45,11 @@ RSpec.describe RequestPasswordReset do
           to(change { user.reload.reset_password_token })
       end
 
+      it 'sends a recovery activated push event' do
+        expect(PushNotification::HttpPush).to receive(:deliver).
+          with(PushNotification::RecoveryActivatedEvent.new(user: user))
 
-
-      context 'when push notifications are enabled' do
-        let(:push_notifications_enabled) { true }
-
-        it 'does not send a push event' do
-          expect(PushNotification::HttpPush).to_not receive(:deliver)
-
-          RequestPasswordReset.new(email: email).perform
-        end
-      end
-
-      context 'when push notifications are disabled' do
-        let(:push_notifications_enabled) { false }
-
-        it 'sends a recovery activated push event' do
-          expect(PushNotification::HttpPush).to receive(:deliver).
-            with(PushNotification::RecoveryActivatedEvent.new(user: user))
-
-          RequestPasswordReset.new(email: email).perform
-        end
+        RequestPasswordReset.new(email: email).perform
       end
     end
 


### PR DESCRIPTION
I realized we have this feature flag sprinkled all around the codebase and I think we could just check in one point

The downside is a small bit of wasted object allocations that get thrown out if we early exit, but a small price to pay IMO