### PR TITLE
LG-3993: Implement Web OTP API for autofilling OTPs on Android devices

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -70,14 +70,6 @@ textarea {
   }
 }
 
-// hide number field input spin box as per:
-// http://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box
-// and added .mfa class selector as per CodeClimate warning to:
-// 'Avoid qualifying attribute selectors with an element.'
-.mfa {
-  -moz-appearance: textfield;
-}
-
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;

--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -31,13 +31,6 @@ function formatForm() {
       delimiterLazyShow: true,
     });
   }
-
-  if (document.querySelector('.mfa')) {
-    new Cleave('.mfa', {
-      numericOnly: true,
-      blocks: [6],
-    });
-  }
 }
 
 document.addEventListener('DOMContentLoaded', formatForm);

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -36,7 +36,14 @@ class OneTimeCodeInput {
 
       input.value = code;
       form?.submit();
-    } catch {}
+    } catch {
+      // Thrown errors may be expected if:
+      // - the user submits the form and triggers the abort controller's signal. ('AbortError')
+      // - or, credential retrieval times out. ('InvalidStateError')
+      // Timeout errors occur in the real world, but they are not defined in the current version of
+      // of the specification. Ideally we would only allow expected errors and throw any others, but
+      // since this could unknowingly change in the future, we instead absorb all errors.
+    }
   }
 }
 

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -22,7 +22,7 @@ class OneTimeCodeInput {
    */
   async receive(transport) {
     const { input, form } = this.elements;
-    const controller = new AbortController();
+    const controller = new window.AbortController();
 
     if (form) {
       form.addEventListener('submit', () => controller.abort());

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -1,0 +1,41 @@
+class OneTimeCodeInput {
+  static isWebOTPSupported = 'OTPCredential' in window;
+
+  /**
+   * @param {HTMLInputElement} input
+   */
+  constructor(input) {
+    this.elements = { input };
+    this.options = { transport: /** @type {string=} */ (input.dataset.transport) };
+  }
+
+  bind() {
+    if (OneTimeCodeInput.isWebOTPSupported && this.options.transport) {
+      this.receive(this.options.transport);
+    }
+  }
+
+  /**
+   * @param {string} transport
+   */
+  async receive(transport) {
+    const controller = new AbortController();
+
+    const form = this.elements.input.closest('form');
+    if (form) {
+      form.addEventListener('submit', () => controller.abort());
+    }
+
+    let code;
+    try {
+      ({ code } = await /** @type {OTPCredentialsContainer} */ (navigator.credentials).get({
+        otp: { transport: [transport] },
+        signal: controller.signal,
+      }));
+    } catch {}
+
+    return code;
+  }
+}
+
+export default OneTimeCodeInput;

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -6,7 +6,9 @@ class OneTimeCodeInput {
    */
   constructor(input) {
     this.elements = { input };
-    this.options = { transport: /** @type {string=} */ (input.dataset.transport) };
+    this.options = {
+      transport: /** @type {OTPCredentialTransportType=} */ (input.dataset.transport),
+    };
   }
 
   bind() {
@@ -16,7 +18,7 @@ class OneTimeCodeInput {
   }
 
   /**
-   * @param {string} transport
+   * @param {OTPCredentialTransportType} transport
    */
   async receive(transport) {
     const controller = new AbortController();

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -5,7 +5,7 @@ class OneTimeCodeInput {
    * @param {HTMLInputElement} input
    */
   constructor(input) {
-    this.elements = { input };
+    this.elements = { input, form: input.closest('form') };
     this.options = {
       transport: /** @type {OTPCredentialTransportType=} */ (input.dataset.transport),
     };
@@ -21,22 +21,22 @@ class OneTimeCodeInput {
    * @param {OTPCredentialTransportType} transport
    */
   async receive(transport) {
+    const { input, form } = this.elements;
     const controller = new AbortController();
 
-    const form = this.elements.input.closest('form');
     if (form) {
       form.addEventListener('submit', () => controller.abort());
     }
 
-    let code;
     try {
-      ({ code } = await /** @type {OTPCredentialsContainer} */ (navigator.credentials).get({
+      const { code } = await /** @type {OTPCredentialsContainer} */ (navigator.credentials).get({
         otp: { transport: [transport] },
         signal: controller.signal,
-      }));
-    } catch {}
+      });
 
-    return code;
+      input.value = code;
+      form?.submit();
+    } catch {}
   }
 }
 

--- a/app/javascript/packages/one-time-code-input/package.json
+++ b/app/javascript/packages/one-time-code-input/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@18f/identity-one-time-code-input",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/app/javascript/packages/one-time-code-input/types.d.ts
+++ b/app/javascript/packages/one-time-code-input/types.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @see https://wicg.github.io/web-otp/#API
+ */
+interface OTPCredentialsContainer extends CredentialsContainer {
+  get(options?: OTPCredentialRequestOptions): Promise<OTPCredential>;
+}
+
+/**
+ * @see https://wicg.github.io/web-otp/#CredentialRequestOptions
+ */
+interface OTPCredentialRequestOptions extends CredentialRequestOptions {
+  otp: { transport: string[] };
+}
+
+/**
+ * @see https://wicg.github.io/web-otp/#OTPCredential
+ */
+interface OTPCredential extends Credential {
+  code: string;
+}

--- a/app/javascript/packages/one-time-code-input/types.d.ts
+++ b/app/javascript/packages/one-time-code-input/types.d.ts
@@ -9,7 +9,7 @@ interface OTPCredentialsContainer extends CredentialsContainer {
  * @see https://wicg.github.io/web-otp/#CredentialRequestOptions
  */
 interface OTPCredentialRequestOptions extends CredentialRequestOptions {
-  otp: { transport: string[] };
+  otp: { transport: OTPCredentialTransportType[] };
 }
 
 /**
@@ -17,4 +17,11 @@ interface OTPCredentialRequestOptions extends CredentialRequestOptions {
  */
 interface OTPCredential extends Credential {
   code: string;
+}
+
+/**
+ * @see https://wicg.github.io/web-otp/#enum-transport
+ */
+declare enum OTPCredentialTransportType {
+  SMS = 'sms',
 }

--- a/app/javascript/packs/one-time-code-input.js
+++ b/app/javascript/packs/one-time-code-input.js
@@ -1,38 +1,6 @@
-/**
- * @typedef {CredentialsContainer & {
- *  get(options?: OTPCredentialRequestOptions): Promise<OTPCredential>
- * }} OTPCredentialsContainer
- *
- * @see https://wicg.github.io/web-otp/#API
- */
-
-/**
- * @typedef {CredentialRequestOptions & {otp: { transport: string[] }}} OTPCredentialRequestOptions
- *
- * @see https://wicg.github.io/web-otp/#CredentialRequestOptions
- */
-
-/**
- * @typedef {Credential & {code: string}} OTPCredential
- *
- * @see https://wicg.github.io/web-otp/#OTPCredential
- */
+import OneTimeCodeInput from '@18f/identity-one-time-code-input';
 
 const input = document.querySelector('.one-time-code-input');
-
-if (input?.dataset.transport && window.OTPCredential) {
-  const controller = new AbortController();
-
-  const form = input.closest('form');
-  if (form) {
-    form.addEventListener('submit', () => controller.abort());
-  }
-
-  /** @type {OTPCredentialsContainer} */ (navigator.credentials)
-    .get({ otp: { transport: [input.dataset.transport] }, signal: controller.signal })
-    .then((credential) => {
-      input.value = credential.code;
-      form?.submit();
-    })
-    .catch(() => {});
+if (input) {
+  new OneTimeCodeInput(input).bind();
 }

--- a/app/javascript/packs/one-time-code-input.js
+++ b/app/javascript/packs/one-time-code-input.js
@@ -2,5 +2,5 @@ import OneTimeCodeInput from '@18f/identity-one-time-code-input';
 
 const input = document.querySelector('.one-time-code-input');
 if (input) {
-  new OneTimeCodeInput(input).bind();
+  new OneTimeCodeInput(/** @type {HTMLInputElement} */ (input)).bind();
 }

--- a/app/javascript/packs/one-time-code-input.js
+++ b/app/javascript/packs/one-time-code-input.js
@@ -1,0 +1,38 @@
+/**
+ * @typedef {CredentialsContainer & {
+ *  get(options?: OTPCredentialRequestOptions): Promise<OTPCredential>
+ * }} OTPCredentialsContainer
+ *
+ * @see https://wicg.github.io/web-otp/#API
+ */
+
+/**
+ * @typedef {CredentialRequestOptions & {otp: { transport: string[] }}} OTPCredentialRequestOptions
+ *
+ * @see https://wicg.github.io/web-otp/#CredentialRequestOptions
+ */
+
+/**
+ * @typedef {Credential & {code: string}} OTPCredential
+ *
+ * @see https://wicg.github.io/web-otp/#OTPCredential
+ */
+
+const input = document.querySelector('.one-time-code-input');
+
+if (input && window.OTPCredential) {
+  const controller = new AbortController();
+
+  const form = input.closest('form');
+  if (form) {
+    form.addEventListener('submit', () => controller.abort());
+  }
+
+  /** @type {OTPCredentialsContainer} */ (navigator.credentials)
+    .get({ otp: { transport: ['sms'] }, signal: controller.signal })
+    .then((credential) => {
+      input.value = credential.code;
+      form?.submit();
+    })
+    .catch(() => {});
+}

--- a/app/javascript/packs/one-time-code-input.js
+++ b/app/javascript/packs/one-time-code-input.js
@@ -20,7 +20,7 @@
 
 const input = document.querySelector('.one-time-code-input');
 
-if (input && window.OTPCredential) {
+if (input?.dataset.transport && window.OTPCredential) {
   const controller = new AbortController();
 
   const form = input.closest('form');
@@ -29,7 +29,7 @@ if (input && window.OTPCredential) {
   }
 
   /** @type {OTPCredentialsContainer} */ (navigator.credentials)
-    .get({ otp: { transport: ['sms'] }, signal: controller.signal })
+    .get({ otp: { transport: [input.dataset.transport] }, signal: controller.signal })
     .then((credential) => {
       input.value = credential.code;
       form?.submit();

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -11,17 +11,15 @@
 <%= form_tag(:idv_otp_verification, method: :put, role: 'form', class: 'margin-top-4') do %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
-      <%= text_field_tag :code, '',
-                         value: @code,
-                         required: true,
-                         aria: { invalid: false, describedby: 'code-instructs' },
-                         autofocus: true,
-                         pattern: '[0-9]*',
-                         class: 'col-12 field monospace mfa usa-input margin-bottom-5',
-                         maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
-                         autocomplete: 'one-time-code',
-                         type: 'tel' %>
+      <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
+      <%= render(
+        'shared/one_time_code_input',
+        name: :code,
+        value: @code,
+        required: true,
+        autofocus: true,
+        class: 'col-12 margin-bottom-5',
+      ) %>
       <%= submit_tag t('forms.buttons.submit.default'),
                      class: 'usa-button usa-button--big usa-button--full-width' %>
     </div>

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -24,3 +24,5 @@ classes << local_assigns[:class] if local_assigns[:class]
   **local_assigns,
   class: classes,
 ) %>
+
+<%= javascript_packs_tag_once 'one-time-code-input' %>

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -1,0 +1,26 @@
+<%#
+Renders a numeric OTP code input field. In addition to the locals described below, all additional
+local assigns will be applied directly to the text input as a hash of HTML attributes.
+
+locals:
+* name: Field name. Defaults to `:code`.
+* value: Field value. Defaults to `''`.
+%>
+<%
+name = local_assigns[:name] || :code
+classes = ['field monospace usa-input one-time-code-input']
+classes << local_assigns[:class] if local_assigns[:class]
+%>
+
+<%= text_field_tag(
+  name,
+  nil,
+  aria: { invalid: false },
+  pattern: '[0-9]*',
+  maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+  autocomplete: 'one-time-code',
+  inputmode: 'numeric',
+  type: 'text',
+  **local_assigns,
+  class: classes,
+) %>

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -7,9 +7,9 @@ locals:
 * value: Field value. Defaults to `''`.
 %>
 <%
-name = local_assigns[:name] || :code
+name = local_assigns.delete(:name) || :code
 classes = ['field monospace usa-input one-time-code-input']
-classes << local_assigns[:class] if local_assigns[:class]
+classes << local_assigns.delete(:class) if local_assigns[:class]
 %>
 
 <%= text_field_tag(

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -18,8 +18,8 @@ classes << local_assigns.delete(:class) if local_assigns[:class]
 <%= text_field_tag(
   name,
   nil,
-  aria: { invalid: false },
-  data: { transport: transport },
+  'aria-invalid': 'false',
+  'data-transport': transport,
   pattern: '[0-9]*',
   maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
   autocomplete: 'one-time-code',

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -4,11 +4,13 @@ local assigns will be applied directly to the text input as a hash of HTML attri
 
 locals:
 * name: Field name. Defaults to `:code`.
+* transport: WebOTP transport method. Defaults to 'sms'.
 * value: Field value. Defaults to `''`.
 * class: CSS classes to add (optional)
 %>
 <%
-name = local_assigns.delete(:name) || :code
+name = local_assigns.delete(:name) { :code }
+transport = local_assigns.delete(:transport) { 'sms' }
 classes = ['field monospace usa-input one-time-code-input']
 classes << local_assigns.delete(:class) if local_assigns[:class]
 %>
@@ -17,6 +19,7 @@ classes << local_assigns.delete(:class) if local_assigns[:class]
   name,
   nil,
   aria: { invalid: false },
+  data: { transport: transport },
   pattern: '[0-9]*',
   maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
   autocomplete: 'one-time-code',

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -5,6 +5,7 @@ local assigns will be applied directly to the text input as a hash of HTML attri
 locals:
 * name: Field name. Defaults to `:code`.
 * value: Field value. Defaults to `''`.
+* class: CSS classes to add (optional)
 %>
 <%
 name = local_assigns.delete(:name) || :code

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -12,17 +12,15 @@
   <%= render @presenter.reauthn_hidden_field_partial %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
-      <%= text_field_tag :code, '',
-                         value: @presenter.code_value,
-                         required: true,
-                         autofocus: true,
-                         pattern: '[0-9]*',
-                         class: 'field monospace mfa usa-input margin-bottom-5',
-                         aria: { invalid: false, describedby: 'code-instructs' },
-                         maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
-                         autocomplete: 'one-time-code',
-                         type: 'tel' %>
+      <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
+      <%= render(
+        'shared/one_time_code_input',
+        name: :code,
+        value: @presenter.code_value,
+        required: true,
+        autofocus: true,
+        class: 'margin-bottom-5',
+      ) %>
       <%= submit_tag t('forms.buttons.submit.default'),
                      class: 'usa-button usa-button--big usa-button--full-width' %>
     </div>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -6,18 +6,16 @@
 
 <%= form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'margin-top-4 tablet:margin-top-6') do %>
   <%= render @presenter.reauthn_hidden_field_partial %>
-  <%= label_tag 'code', t('forms.two_factor.code'), class: 'block bold' %>
+  <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
   <div class="col-12 sm-col-5 margin-bottom-1 tablet:margin-bottom-0 sm-mr-20p inline-block">
-    <%= text_field_tag :code, '',
-                       value: @code,
-                       required: true,
-                       aria: { invalid: false, describedby: 'code-instructs' },
-                       autofocus: true,
-                       pattern: '[0-9]*',
-                       class: 'col-12 field monospace mfa',
-                       type: 'tel',
-                       maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
-                       autocomplete: 'one-time-code' %>
+    <%= render(
+      'shared/one_time_code_input',
+      name: :code,
+      value: @code,
+      required: true,
+      autofocus: true,
+      class: 'col-12',
+    ) %>
   </div>
   <div class="border border-light-blue rounded-lg padding-y-1 margin-top-2 margin-bottom-6 tablet:margin-y-2 col-12 sm-col-7">
     <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -10,6 +10,7 @@
   <div class="col-12 sm-col-5 margin-bottom-1 tablet:margin-bottom-0 sm-mr-20p inline-block">
     <%= render(
       'shared/one_time_code_input',
+      transport: nil,
       name: :code,
       value: @code,
       required: true,

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -55,9 +55,15 @@
       <div class="sm-col-9 sm-ml-28p">
         <div class="clearfix margin-x-neg-1">
           <div class="col col-6 sm-col-7 padding-x-1">
-            <%= text_field_tag :code, '', required: true, aria: { invalid: false }, pattern: '[0-9]*', type: 'tel',
-                class: 'block col-12 field monospace mfa', maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
-                'aria-labelledby': 'totp-label' %>
+          <%= render(
+              'shared/one_time_code_input',
+              transport: nil,
+              name: :code,
+              value: @presenter.code_value,
+              required: true,
+              autofocus: true,
+              class: 'block col-12',
+            ) %>
           </div>
         </div>
       </div>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -55,10 +55,11 @@
       <div class="sm-col-9 sm-ml-28p">
         <div class="clearfix margin-x-neg-1">
           <div class="col col-6 sm-col-7 padding-x-1">
-          <%= render(
+            <%= render(
               'shared/one_time_code_input',
               transport: nil,
               name: :code,
+              'aria-labelledby': 'totp-label',
               required: true,
               class: 'block col-12',
             ) %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -59,9 +59,7 @@
               'shared/one_time_code_input',
               transport: nil,
               name: :code,
-              value: @presenter.code_value,
               required: true,
-              autofocus: true,
               class: 'block col-12',
             ) %>
           </div>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -21,7 +21,7 @@
       <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
       <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
       <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
-      <%= label_tag :code, t('forms.webauthn_setup.nickname'), class: 'block bold', for: 'nickname' %>
+      <%= label_tag 'code', t('forms.webauthn_setup.nickname'), class: 'block bold', for: 'nickname' %>
       <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
             class: 'block col-12 field monospace', size: 16, maxlength: 20 %>
      <div class='border border-light-blue rounded-lg padding-x-2 padding-y-1 margin-top-4'>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -21,7 +21,7 @@
       <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
       <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
       <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
-      <%= label_tag 'code', t('forms.webauthn_setup.nickname'), class: 'block bold', for: 'nickname' %>
+      <%= label_tag :code, t('forms.webauthn_setup.nickname'), class: 'block bold', for: 'nickname' %>
       <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
             class: 'block col-12 field monospace', size: 16, maxlength: 20 %>
      <div class='border border-light-blue rounded-lg padding-x-2 padding-y-1 margin-top-4'>

--- a/spec/javascripts/packages/one-time-code-input/index-spec.js
+++ b/spec/javascripts/packages/one-time-code-input/index-spec.js
@@ -1,0 +1,109 @@
+import OneTimeCodeInput from '@18f/identity-one-time-code-input';
+import { waitFor } from '@testing-library/dom';
+import { useSandbox } from '../../support/sinon';
+
+describe('OneTimeCodeInput', () => {
+  const sandbox = useSandbox();
+
+  function initialize({ transport = 'sms', inForm = false } = {}) {
+    const input = document.createElement('input');
+    if (transport) {
+      input.dataset.transport = transport;
+    }
+    if (inForm) {
+      const form = document.createElement('form');
+      form.appendChild(input);
+      document.body.appendChild(form);
+    } else {
+      document.body.appendChild(input);
+    }
+    const otcInput = new OneTimeCodeInput(document.body.querySelector('input'));
+    otcInput.bind();
+    return otcInput;
+  }
+
+  context('otp credential supported', () => {
+    let originalIsWebOTPSupported;
+    let originalCredentials;
+    const onSubmit = sandbox.stub().callsFake((event) => event.preventDefault());
+
+    beforeEach(() => {
+      originalIsWebOTPSupported = OneTimeCodeInput.isWebOTPSupported;
+      OneTimeCodeInput.isWebOTPSupported = true;
+      originalCredentials = navigator.credentials;
+      navigator.credentials = { get: sandbox.stub().resolves({ code: '123456' }) };
+      window.addEventListener('submit', onSubmit);
+    });
+
+    afterEach(() => {
+      OneTimeCodeInput.isWebOTPSupported = originalIsWebOTPSupported;
+      navigator.credentials = originalCredentials;
+      window.removeEventListener('submit', onSubmit);
+    });
+
+    context('in form', () => {
+      it('fills value and submits form', async () => {
+        const otcInput = initialize({ inForm: true });
+
+        await waitFor(() => expect(otcInput.elements.input.value).to.equal('123456'));
+        expect(navigator.credentials.get).to.have.been.calledWith({
+          otp: { transport: ['sms'] },
+          signal: sandbox.match.instanceOf(window.AbortSignal),
+        });
+        expect(onSubmit).to.have.been.calledOnce();
+      });
+
+      it('cancels credential receiver on submit', (done) => {
+        navigator.credentials.get = sandbox.stub().callsFake(() => new Promise(() => {}));
+        const otcInput = initialize({ inForm: true });
+        sandbox.stub(window.AbortController.prototype, 'abort').callsFake(done);
+
+        otcInput.elements.form.dispatchEvent(new window.CustomEvent('submit'));
+      });
+    });
+
+    context('not in form', () => {
+      it('fills value', async () => {
+        const otcInput = initialize();
+
+        await waitFor(() => expect(otcInput.elements.input.value).to.equal('123456'));
+        expect(navigator.credentials.get).to.have.been.calledWith({
+          otp: { transport: ['sms'] },
+          signal: sandbox.match.instanceOf(window.AbortSignal),
+        });
+        expect(onSubmit).not.to.have.been.called();
+      });
+    });
+
+    context('transport unset', () => {
+      it('is noop', () => {
+        initialize({ transport: null });
+
+        expect(navigator.credentials.get).not.to.have.been.called();
+      });
+    });
+  });
+
+  context('otp credential not supported', () => {
+    let originalIsWebOTPSupported;
+    let originalCredentials;
+
+    beforeEach(() => {
+      originalIsWebOTPSupported = OneTimeCodeInput.isWebOTPSupported;
+      OneTimeCodeInput.isWebOTPSupported = false;
+      originalCredentials = navigator.credentials;
+      navigator.credentials = { get: sandbox.stub() };
+    });
+
+    afterEach(() => {
+      OneTimeCodeInput.isWebOTPSupported = originalIsWebOTPSupported;
+      navigator.credentials = originalCredentials;
+    });
+
+    it('is noop', () => {
+      initialize();
+
+      expect(navigator.credentials.get).not.to.have.been.called();
+    });
+  });
+});

--- a/spec/views/shared/_one_time_code_input.html.erb_spec.rb
+++ b/spec/views/shared/_one_time_code_input.html.erb_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe 'shared/_one_time_code_input.html.erb' do
+  let(:params) { {} }
+
+  before do
+    render('shared/one_time_code_input', **params)
+  end
+
+  describe 'name' do
+    context 'no name given' do
+      it 'renders default name "code"' do
+        expect(rendered).to have_selector('[name="code"]')
+      end
+    end
+
+    context 'name given' do
+      let(:params) { { name: 'example' } }
+
+      it 'renders given name' do
+        expect(rendered).to have_selector('[name="example"]')
+      end
+    end
+  end
+
+  describe 'classes' do
+    context 'without custom classes given' do
+      it 'renders with default classes' do
+        expect(rendered).to have_selector('.one-time-code-input')
+      end
+    end
+
+    context 'with custom classes' do
+      let(:params) { { class: 'my-custom-class' } }
+
+      it 'renders with additional custom classes' do
+        expect(rendered).to have_selector('.one-time-code-input.my-custom-class')
+      end
+    end
+  end
+
+  describe 'transport' do
+    context 'omitted' do
+      it 'renders default sms transport' do
+        expect(rendered).to have_selector('[data-transport="sms"]')
+      end
+    end
+
+    context 'given' do
+      let(:params) { { transport: 'example' } }
+
+      it 'renders given transport' do
+        expect(rendered).to have_selector('[data-transport="example"]')
+      end
+    end
+
+    context 'explicitly nil' do
+      let(:params) { { transport: nil } }
+
+      it 'renders without transport' do
+        expect(rendered).not_to have_selector('[data-transport]')
+      end
+    end
+  end
+
+  describe 'aria attributes' do
+    let(:params) { { aria: { hidden: true } } }
+
+    it 'merges aria attributes' do
+      expect(rendered).to have_selector('[aria-invalid="false"][aria-hidden="true"]')
+    end
+  end
+
+  describe 'data attributes' do
+    let(:params) { { data: { foo: 'bar' } } }
+
+    it 'merges data attributes' do
+      expect(rendered).to have_selector('[data-transport][data-foo="bar"]')
+    end
+  end
+end

--- a/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
@@ -22,11 +22,11 @@ describe 'two_factor_authentication/totp_verification/show.html.erb' do
 
   it_behaves_like 'an otp form'
 
-  it 'uses type=tel (to allow leading zeroes)' do
+  it 'uses numeric input mode (to allow leading zeroes)' do
     render
 
     code_input = Nokogiri::HTML(rendered).at_css('input#code')
-    expect(code_input[:type]).to eq('tel')
+    expect(code_input[:inputmode]).to eq('numeric')
   end
 
   it 'shows the correct header' do

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "app/javascript/packs/document-capture.jsx",
     "app/javascript/packs/form-steps-wait.jsx",
     "app/javascript/packs/form-validation.js",
+    "app/javascript/packs/one-time-code-input.js",
     "app/javascript/packs/intl-tel-input.js",
     "app/javascript/packs/spinner-button.js",
     "app/javascript/packs/session-expire-session.js",


### PR DESCRIPTION
Related: https://github.com/18F/identity-telephony/pull/44

**Why**: As a user signing in on an Android device, I want login.gov to use the Web OTP API to request the OTP from my device, so that I don't have to leave the browser to get my OTP from my messages.

Related resources:

- WebOTP spec: https://wicg.github.io/web-otp/
- OTP form guidance: https://web.dev/sms-otp-form/
- Origin-bound one-time code message spec: https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message
- Apple developer blog on domain-bound codes: https://developer.apple.com/news/?id=z0i801mg

_(Currently draft because while I can get the prompt to appear locally, the auto-fill does not occur as expected, despite [identical demo code](https://codepen.io/aduth/pen/MWJGrWp) working as expected)_