### PR TITLE
[WIP] Add a service for writing cloudwatch metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'saml_idp', @saml_gem
 gem 'ahoy_matey', '~> 3.0'
 gem 'american_date'
 gem 'autoprefixer-rails', '~> 10.0'
+gem 'aws-sdk-cloudwatch'
 gem 'aws-sdk-kms', '~> 1.4'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-ses', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
     awrence (1.1.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.411.0)
+    aws-sdk-cloudwatch (1.48.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-cloudwatchlogs (1.38.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
@@ -747,6 +750,7 @@ DEPENDENCIES
   ahoy_matey (~> 3.0)
   american_date
   autoprefixer-rails (~> 10.0)
+  aws-sdk-cloudwatch
   aws-sdk-cloudwatchlogs
   aws-sdk-kms (~> 1.4)
   aws-sdk-lambda

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,6 +53,13 @@ class ApplicationController < ActionController::Base
       Analytics.new(user: analytics_user, request: request, sp: current_sp&.issuer, ahoy: ahoy)
   end
 
+  def cloudwatch_metric_writer
+    @cloudwatch_metric_writer ||= CloudwatchMetricWriter.new(
+      current_sp: current_sp,
+      request_ial: sp_session_ial_1_or_2,
+    )
+  end
+
   def analytics_user
     effective_user || AnonymousUser.new
   end

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -45,6 +45,7 @@ module Idv
         new_phone_added: !configured_phones.include?(idv_session.applicant['phone']),
       }
       analytics.track_event(Analytics::IDV_FINAL, result)
+      cloudwatch_metric_writer.write_metric('ProofingCompleted')
       add_proofing_component
     end
 

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -4,6 +4,7 @@ module Idv
     before_action :redirect_if_mail_bounced
     before_action :redirect_if_pending_profile
     before_action :extend_timeout_using_meta_refresh_for_select_paths
+    before_action :track_proofing_started_metric
 
     include IdvSession # remove if we retire the non docauth LOA3 flow
     include Flow::FlowStateMachine
@@ -49,6 +50,13 @@ module Idv
 
     def flow_session
       user_session['idv/doc_auth']
+    end
+
+    def track_proofing_started_metric
+      return if current_session[:proofing_started_metric_written]
+
+      cloudwatch_metric_writer.write_metric('ProofingStarted')
+      current_session[:proofing_started_metric_written] = true
     end
   end
 end

--- a/app/services/cloudwatch_metric_writer.rb
+++ b/app/services/cloudwatch_metric_writer.rb
@@ -1,13 +1,19 @@
 class CloudwatchMetricWriter
   attr_reader :current_sp, :request_ial, :cloudwatch_client
 
-  def initialize(current_sp:, request_ial:, cloudwatch_client: build_cloudwatch_client)
+  def initialize(
+    current_sp:,
+    request_ial:,
+    cloudwatch_client: build_cloudwatch_client
+  )
     @current_sp = current_sp
     @request_ial = request_ial || 1
     @cloudwatch_client = cloudwatch_client
   end
 
   def write_metric(name, dimensions: [], value: 1, unit: 'Count')
+    return unless Identity::Hostdata.in_datacenter?
+
     cloudwatch_client.put_metric_data(
       namespace: "#{Identity::Hostdata.env || 'local'}/idp", # TODO: Drop 'local'
       metric_data: [

--- a/app/services/cloudwatch_metric_writer.rb
+++ b/app/services/cloudwatch_metric_writer.rb
@@ -37,10 +37,8 @@ class CloudwatchMetricWriter
         value: current_sp.issuer || 'NULL',
       },
       {
-      {
         name: 'RequestIAL',
         value: request_ial,
-      }
       },
       {
         name: 'DeployEnvironment',

--- a/app/services/cloudwatch_metric_writer.rb
+++ b/app/services/cloudwatch_metric_writer.rb
@@ -1,0 +1,56 @@
+class CloudwatchMetricWriter
+  attr_reader :current_sp, :request_ial, :cloudwatch_client
+
+  def initialize(current_sp:, request_ial:, cloudwatch_client: build_cloudwatch_client)
+    @current_sp = current_sp
+    @request_ial = request_ial || 1
+    @cloudwatch_client = cloudwatch_client
+  end
+
+  def write_metric(name, dimensions: {}, value: 1, unit: 'Count')
+    client.put_metric_data(
+      namespace: "IdentityIDP",
+      metric_data: [
+        {
+          metric_name: name,
+          dimensions: base_dimenstions.merge(dimensions),
+          timestamp: Time.now,
+          value: value,
+          statistic_values: {
+            sample_count: 1,
+            sum: value,
+            minimum: value,
+            maximum: value,
+          },
+          unit: unit,
+        },
+      ],
+    )
+  end
+
+  private
+
+  def base_dimenstions
+    [
+      {
+        name: 'ServiceProvider',
+        value: current_sp.issuer || 'NULL',
+      },
+      {
+      {
+        name: 'RequestIAL',
+        value: request_ial,
+      }
+      },
+      {
+        name: 'DeployEnvironment',
+        value: Identity::Hostdata.env,
+      },
+    ]
+  end
+
+  def build_cloudwatch_client
+    # TODO: Should we have some sort of stubbed or mocked client locally?
+    Aws::CloudWatch::Client.new
+  end
+end

--- a/app/services/cloudwatch_metric_writer.rb
+++ b/app/services/cloudwatch_metric_writer.rb
@@ -7,21 +7,15 @@ class CloudwatchMetricWriter
     @cloudwatch_client = cloudwatch_client
   end
 
-  def write_metric(name, dimensions: {}, value: 1, unit: 'Count')
-    client.put_metric_data(
-      namespace: "IdentityIDP",
+  def write_metric(name, dimensions: [], value: 1, unit: 'Count')
+    cloudwatch_client.put_metric_data(
+      namespace: "#{Identity::Hostdata.env || 'local'}/idp", # TODO: Drop 'local'
       metric_data: [
         {
           metric_name: name,
-          dimensions: base_dimenstions.merge(dimensions),
-          timestamp: Time.now,
+          dimensions: base_dimenstions + dimensions,
+          timestamp: Time.zone.now,
           value: value,
-          statistic_values: {
-            sample_count: 1,
-            sum: value,
-            minimum: value,
-            maximum: value,
-          },
           unit: unit,
         },
       ],
@@ -38,11 +32,7 @@ class CloudwatchMetricWriter
       },
       {
         name: 'RequestIAL',
-        value: request_ial,
-      },
-      {
-        name: 'DeployEnvironment',
-        value: Identity::Hostdata.env,
+        value: request_ial.to_s,
       },
     ]
   end

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -123,6 +123,13 @@ describe Idv::ConfirmationsController do
       expect(flash[:success]).to eq t('idv.messages.confirm')
     end
 
+    it 'tracks an proofing completed cloudwatch metric' do
+      expect(controller.cloudwatch_metric_writer).to receive(:write_metric).
+                                                     with('ProofingCompleted').
+                                                     once
+      get :show
+    end
+
     context 'user used 2FA phone as phone of record' do
       before do
         subject.idv_session.applicant['phone'] =

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -102,6 +102,15 @@ describe Idv::DocAuthController do
       )
     end
 
+    it 'writes a proofing started cloudwatch metrics on the first visit' do
+      expect(controller.cloudwatch_metric_writer).to receive(:write_metric).
+                                                       with('ProofingStarted').
+                                                       once
+
+      get :show, params: { step: 'welcome' }
+      get :show, params: { step: 'welcome' }
+    end
+
     it 'increments the analytics step counts on subsequent submissions' do
       get :show, params: { step: 'welcome' }
       get :show, params: { step: 'welcome' }

--- a/spec/services/cloudwatch_metric_writer_spec.rb
+++ b/spec/services/cloudwatch_metric_writer_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe CloudwatchMetricWriter do
   end
 
   before do
+    allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(true)
     allow(Identity::Hostdata).to receive(:env).and_return('int')
   end
 
@@ -89,6 +90,14 @@ RSpec.describe CloudwatchMetricWriter do
       )
 
       subject.write_metric('FunMetric', value: custom_value, unit: custom_unit)
+    end
+
+    it 'does not do anything outside a deployed environment' do
+      allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(false)
+
+      expect(cloudwatch_client).to_not receive(:put_metric_data)
+
+      subject.write_metric('FunMetric')
     end
   end
 end

--- a/spec/services/cloudwatch_metric_writer_spec.rb
+++ b/spec/services/cloudwatch_metric_writer_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe CloudwatchMetricWriter do
+  let(:cloudwatch_client) do
+    client = instance_double(Aws::CloudWatch::Client)
+    allow(client).to receive(:put_metric_data)
+    client
+  end
+  let(:current_sp) { NullServiceProvider.new(issuer: 'cloudwatch-test-sp') }
+  let(:request_ial) { 1 }
+
+  let(:expected_dimensions) do
+    [
+      {
+        name: 'ServiceProvider',
+        value: 'cloudwatch-test-sp',
+      },
+      {
+        name: 'RequestIAL',
+        value: '1',
+      },
+    ]
+  end
+
+  subject do
+    described_class.new(
+      current_sp: current_sp,
+      request_ial: request_ial,
+      cloudwatch_client: cloudwatch_client,
+    )
+  end
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+  end
+
+  describe '#write_metric' do
+    it 'writes a cloudwatch metric' do
+      expect(cloudwatch_client).to receive(:put_metric_data).with(
+        namespace: 'int/idp', # TODO: Drop 'local'
+        metric_data: [
+          {
+            metric_name: 'FunMetric',
+            dimensions: expected_dimensions,
+            timestamp: instance_of(ActiveSupport::TimeWithZone),
+            value: 1,
+            unit: 'Count',
+          },
+        ],
+      )
+
+      subject.write_metric('FunMetric')
+    end
+
+    it 'includes custom dimensions if they are provided' do
+      custom_dimensions = [{ name: 'Custom', value: '9000' }]
+
+      expect(cloudwatch_client).to receive(:put_metric_data).with(
+        namespace: 'int/idp', # TODO: Drop 'local'
+        metric_data: [
+          {
+            metric_name: 'FunMetric',
+            dimensions: expected_dimensions + custom_dimensions,
+            timestamp: instance_of(ActiveSupport::TimeWithZone),
+            value: 1,
+            unit: 'Count',
+          },
+        ],
+      )
+
+      subject.write_metric('FunMetric', dimensions: custom_dimensions )
+    end
+
+    it 'includes a custom value and units if they are provided' do
+      custom_value = 500
+      custom_unit = 'Terabytes/Second'
+
+      expect(cloudwatch_client).to receive(:put_metric_data).with(
+        namespace: 'int/idp', # TODO: Drop 'local'
+        metric_data: [
+          {
+            metric_name: 'FunMetric',
+            dimensions: expected_dimensions,
+            timestamp: instance_of(ActiveSupport::TimeWithZone),
+            value: custom_value,
+            unit: custom_unit,
+          },
+        ],
+      )
+
+      subject.write_metric('FunMetric', value: custom_value, unit: custom_unit)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that we can start creating metrics directly in CloudWatch from the IDP instead of leaning on insights queries