### PR TITLE
Disable SMS for DZ

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -264,7 +264,8 @@ DO:
 DZ:
   country_code: '213'
   name: Algeria
-  supports_sms: true
+  # Temporarily disabled due to SMS fraud attack 2021-04-16
+  supports_sms: false
   supports_voice: false
 EC:
   country_code: '593'


### PR DESCRIPTION
Disabling SMS to Algeria to stop ongoing SMS fraud attack.

Incident issue: https://github.com/18F/identity-devops/issues/3419