### PR TITLE
send recovery information event when emails are added or removed

### DIFF
--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -50,5 +50,7 @@ class DeleteUserEmailForm
     PushNotification::HttpPush.deliver(identifier_recycled)
     email_changed = PushNotification::EmailChangedEvent.new(user: user, email: email)
     PushNotification::HttpPush.deliver(email_changed)
+    recovery_information_changed = PushNotification::RecoveryInformationChangedEvent.new(user: user)
+    PushNotification::HttpPush.deliver(recovery_information_changed)
   end
 end

--- a/app/services/push_notification/email_changed_event.rb
+++ b/app/services/push_notification/email_changed_event.rb
@@ -23,7 +23,7 @@ module PushNotification
     end
 
     def ==(other)
-      user == other.user && email == other.email
+      other.class == self.class && user == other.user && email == other.email
     end
   end
 end

--- a/app/services/push_notification/identifier_recycled_event.rb
+++ b/app/services/push_notification/identifier_recycled_event.rb
@@ -23,7 +23,7 @@ module PushNotification
     end
 
     def ==(other)
-      user == other.user && email == other.email
+      self.class == other.class && user == other.user && email == other.email
     end
   end
 end

--- a/app/services/push_notification/recovery_information_changed_event.rb
+++ b/app/services/push_notification/recovery_information_changed_event.rb
@@ -23,7 +23,7 @@ module PushNotification
     end
 
     def ==(other)
-      other.user == user
+      other.class == self.class && other.user == user
     end
   end
 end

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Users::EmailConfirmationsController do
+  describe '#create' do
+    describe 'Valid email confirmation tokens' do
+      it 'tracks a valid email confirmation token event' do
+        user = create(:user)
+        new_email = Faker::Internet.safe_email
+
+        expect(PushNotification::HttpPush).to receive(:deliver).once.
+          with(PushNotification::EmailChangedEvent.new(
+            user: user,
+            email: new_email,
+          )).ordered
+
+        expect(PushNotification::HttpPush).to receive(:deliver).once.
+            with(PushNotification::RecoveryInformationChangedEvent.new(
+              user: user,
+            )).ordered
+
+        add_email_form = AddUserEmailForm.new
+        add_email_form.submit(user, email: new_email)
+        email_record = add_email_form.email_address_record(new_email)
+
+        get :create, params: { confirmation_token: email_record.reload.confirmation_token }
+      end
+    end
+  end
+end

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -47,9 +47,16 @@ describe DeleteUserEmailForm do
           with(PushNotification::IdentifierRecycledEvent.new(
             user: user,
             email: email_address.email,
-          ))
+          )).ordered
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-            with(PushNotification::EmailChangedEvent.new(user: user, email: email_address.email))
+          with(PushNotification::EmailChangedEvent.new(
+            user: user,
+            email: email_address.email,
+          )).ordered
+        expect(PushNotification::HttpPush).to receive(:deliver).once.
+            with(PushNotification::RecoveryInformationChangedEvent.new(
+              user: user,
+            )).ordered
 
         submit
       end


### PR DESCRIPTION
Following a short discussion in https://github.com/18F/identity-dev-docs/pull/179#discussion_r614317429, this PR inlcudes `RecoveryInformationChangedEvent` pushes when an email is added or removed