### PR TITLE
Move the `domain_name` key under IdentityConfig

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    { locale: locale_url_param, host: AppConfig.env.domain_name }
+    { locale: locale_url_param, host: IdentityConfig.store.domain_name }
   end
 
   def sign_out(*args)

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -33,7 +33,7 @@ class WebauthnSetupForm
 
   # this gives us a hook to override the domain embedded in the attestation test object
   def self.domain_name
-    AppConfig.env.domain_name
+    IdentityConfig.store.domain_name
   end
 
   private

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -32,7 +32,7 @@ class WebauthnVerificationForm
 
   # this gives us a hook to override the domain embedded in the attestation test object
   def self.domain_name
-    AppConfig.env.domain_name
+    IdentityConfig.store.domain_name
   end
 
   private

--- a/app/helpers/go_back_helper.rb
+++ b/app/helpers/go_back_helper.rb
@@ -15,7 +15,7 @@ module GoBackHelper
   end
 
   def app_host
-    AppConfig.env.domain_name.split(':')[0]
+    IdentityConfig.store.domain_name.split(':')[0]
   end
 end
 

--- a/app/presenters/cancellation_presenter.rb
+++ b/app/presenters/cancellation_presenter.rb
@@ -41,7 +41,7 @@ class CancellationPresenter < FailurePresenter
     return if referer.blank?
     referer_uri = URI.parse(referer)
     return if referer_uri.scheme == 'javascript'
-    return unless referer_uri.host == IdentityConfig.store.split(':')[0]
+    return unless referer_uri.host == IdentityConfig.store.domain_name.split(':')[0]
     extract_path_and_query_from_uri(referer_uri)
   end
 

--- a/app/presenters/cancellation_presenter.rb
+++ b/app/presenters/cancellation_presenter.rb
@@ -41,7 +41,7 @@ class CancellationPresenter < FailurePresenter
     return if referer.blank?
     referer_uri = URI.parse(referer)
     return if referer_uri.scheme == 'javascript'
-    return unless referer_uri.host == AppConfig.env.domain_name.split(':')[0]
+    return unless referer_uri.host == IdentityConfig.store.split(':')[0]
     extract_path_and_query_from_uri(referer_uri)
   end
 

--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -45,7 +45,7 @@ class GpoConfirmationExporter
       format_date(now),
       format_date(due),
       service_provider.friendly_name || 'Login.gov',
-      "https://#{AppConfig.env.domain_name}",
+      "https://#{IdentityConfig.store.domain_name}",
     ]
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,7 @@ module Upaya
     config.i18n.default_locale = :en
     config.action_controller.per_form_csrf_tokens = true
 
-    routes.default_url_options[:host] = AppConfig.env.domain_name
+    routes.default_url_options[:host] = IdentityConfig.store.domain_name
 
     config.action_mailer.default_options = {
       from: Mail::Address.new.tap do |mail|
@@ -72,7 +72,7 @@ module Upaya
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins do |source, _env|
-          next if source == AppConfig.env.domain_name
+          next if source == IdentityConfig.store.domain_name
 
           ServiceProvider.pluck(:redirect_uris).flatten.compact.find do |uri|
             split_uri = uri.split('//')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   config.action_view.annotate_rendered_view_with_filenames = true
 
   config.action_mailer.default_url_options = {
-    host: AppConfig.env.domain_name,
+    host: IdentityConfig.store.domain_name,
     protocol: ENV['HTTPS'] == 'on' ? 'https' : 'http',
   }
   config.action_mailer.asset_host = IdentityConfig.store.mailer_domain_name

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.asset_host = proc do |_source, request|
     # we want precompiled assets to have domain-agnostic URLs
     # and request is nil during asset precompilation
-    (AppConfig.env.asset_host || AppConfig.env.domain_name) if request
+    (AppConfig.env.asset_host || IdentityConfig.store.domain_name) if request
   end
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = {
-    host: AppConfig.env.domain_name,
+    host: IdentityConfig.store.domain_name,
     protocol: 'https',
   }
   config.action_mailer.asset_host = AppConfig.env.asset_host ||

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   config.action_mailer.delivery_method = :test
-  config.action_mailer.default_url_options = { host: AppConfig.env.domain_name }
+  config.action_mailer.default_url_options = { host: IdentityConfig.store.domain_name }
   config.action_mailer.asset_host = IdentityConfig.store.mailer_domain_name
 
   config.assets.debug = false

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -12,7 +12,6 @@ AppConfig.require_keys(
     database_host
     database_password
     database_username
-    domain_name
     enable_rate_limiting
     enable_test_routes
     enable_usps_verification

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -2,7 +2,7 @@ require 'feature_management'
 
 SamlIdp.configure do |config|
   protocol = Rails.env.development? ? 'http://' : 'https://'
-  api_base = protocol + AppConfig.env.domain_name + '/api'
+  api_base = protocol + IdentityConfig.store.domain_name + '/api'
 
   config.algorithm = OpenSSL::Digest::SHA256
   # config.signature_alg = 'rsa-sha256'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -12,7 +12,7 @@ options = {
     # Redis expires session after N minutes
     ttl: AppConfig.env.session_timeout_in_minutes.to_i.minutes,
 
-    key_prefix: "#{AppConfig.env.domain_name}:session:",
+    key_prefix: "#{IdentityConfig.store.domain_name}:session:",
     url: IdentityConfig.store.redis_url,
   },
   on_session_load_error: SessionEncryptorErrorHandler,

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -62,7 +62,7 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    ENVS_WHERE_PREFILLING_GPO_CODE_ALLOWED.include?(AppConfig.env.domain_name)
+    ENVS_WHERE_PREFILLING_GPO_CODE_ALLOWED.include?(IdentityConfig.store.domain_name)
   end
 
   def self.show_demo_banner?

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -76,6 +76,7 @@ class IdentityConfig
     config.add(:doc_auth_extend_timeout_by_minutes, type: :integer)
     config.add(:doc_capture_polling_enabled, type: :boolean)
     config.add(:doc_capture_request_valid_for_minutes, type: :integer)
+    config.add(:domain_name, type: :string)
     config.add(:enable_load_testing_mode, type: :boolean)
     config.add(:enable_rate_limiting, type: :boolean)
     config.add(:enable_test_routes, type: :boolean)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -785,7 +785,7 @@ describe SamlIdpController do
       it 'includes an Issuer element inherited from the base URL' do
         expect(issuer.name).to eq('Issuer')
         expect(issuer.namespace.href).to eq(Saml::XML::Namespaces::ASSERTION)
-        expect(issuer.text).to eq("https://#{AppConfig.env.domain_name}/api/saml")
+        expect(issuer.text).to eq("https://#{IdentityConfig.store.domain_name}/api/saml")
       end
 
       it 'includes a Status element with a StatusCode child element' do

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -61,7 +61,7 @@ describe Users::WebauthnSetupController do
       end
 
       before do
-        allow(AppConfig.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
         controller.user_session[:webauthn_challenge] = webauthn_challenge
       end
 

--- a/spec/features/saml/multiple_endpoints_spec.rb
+++ b/spec/features/saml/multiple_endpoints_spec.rb
@@ -10,9 +10,9 @@ describe 'multiple saml endpoints' do
   let(:endpoint_saml_settings) do
     settings = saml_settings
     settings.idp_sso_target_url =
-      "http://#{AppConfig.env.domain_name}/api/saml/auth#{endpoint_suffix}"
+      "http://#{IdentityConfig.store.domain_name}/api/saml/auth#{endpoint_suffix}"
     settings.idp_slo_target_url =
-      "http://#{AppConfig.env.domain_name}/api/saml/logout#{endpoint_suffix}"
+      "http://#{IdentityConfig.store.domain_name}/api/saml/logout#{endpoint_suffix}"
     settings.issuer = 'http://localhost:3000'
     settings.idp_cert_fingerprint = Fingerprinter.fingerprint_cert(endpoint_cert)
     settings

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -73,7 +73,7 @@ feature 'SAML logout' do
         # It should contain an issuer nodeset
         expect(xmldoc.issuer_nodeset.length).to eq(1)
         expect(xmldoc.issuer_nodeset[0].content).to eq(
-          "https://#{AppConfig.env.domain_name}/api/saml",
+          "https://#{IdentityConfig.store.domain_name}/api/saml",
         )
 
         # It should not contain a SHA256 signature nodeset

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -124,7 +124,7 @@ feature 'saml api' do
       it 'populates issuer with the idp name' do
         expect(xmldoc.issuer_nodeset.length).to eq(1)
         expect(xmldoc.issuer_nodeset[0].content).to eq(
-          "https://#{AppConfig.env.domain_name}/api/saml",
+          "https://#{IdentityConfig.store.domain_name}/api/saml",
         )
       end
 

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -10,7 +10,7 @@ describe WebauthnSetupForm do
   describe '#submit' do
     context 'when the input is valid' do
       it 'returns FormResponse with success: true' do
-        allow(IdentityConfig.store.to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
         result = instance_double(FormResponse)
         params = {
           attestation_object: attestation_object,

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -10,7 +10,7 @@ describe WebauthnSetupForm do
   describe '#submit' do
     context 'when the input is valid' do
       it 'returns FormResponse with success: true' do
-        allow(AppConfig.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store.to receive(:domain_name).and_return('localhost:3000')
         result = instance_double(FormResponse)
         params = {
           attestation_object: attestation_object,
@@ -28,7 +28,7 @@ describe WebauthnSetupForm do
       end
 
       it 'sends a recovery information changed event' do
-        allow(AppConfig.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
 
@@ -61,7 +61,7 @@ describe WebauthnSetupForm do
       end
 
       it 'returns false with an error when the attestation response raises an error' do
-        allow(AppConfig.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
         allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
 
         result = instance_double(FormResponse)

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -19,7 +19,7 @@ describe WebauthnVerificationForm do
 
     context 'when the input is valid' do
       it 'returns FormResponse with success: true' do
-        allow(AppConfig.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
 
         result = subject.submit(
           protocol,

--- a/spec/helpers/go_back_helper_spec.rb
+++ b/spec/helpers/go_back_helper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GoBackHelper do
       let(:referer) { 'https://gsa.gov/' }
 
       before do
-        allow(AppConfig.env).to receive(:domain_name).and_return('gsa.gov')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('gsa.gov')
       end
 
       it 'is path from referer' do
@@ -63,7 +63,7 @@ RSpec.describe GoBackHelper do
     let(:domain_name) { nil }
 
     before do
-      allow(AppConfig.env).to receive(:domain_name).and_return(domain_name)
+      allow(IdentityConfig.store).to receive(:domain_name).and_return(domain_name)
     end
 
     subject { app_host }

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -62,7 +62,7 @@ describe 'FeatureManagement', type: :feature do
 
       it 'returns false in production mode when server is pt' do
         allow(Rails.env).to receive(:production?).and_return(true)
-        allow(AppConfig.env).to receive(:domain_name).and_return('idp.pt.login.gov')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('idp.pt.login.gov')
 
         expect(FeatureManagement.prefill_otp_codes?).to eq(false)
       end
@@ -107,7 +107,7 @@ describe 'FeatureManagement', type: :feature do
     context 'server domain name is dev, qa, or int' do
       it 'returns true' do
         %w[idp.dev.login.gov idp.int.login.gov idp.qa.login.gov].each do |domain|
-          allow(AppConfig.env).to receive(:domain_name).and_return(domain)
+          allow(IdentityConfig.store).to receive(:domain_name).and_return(domain)
 
           expect(FeatureManagement.reveal_gpo_code?).to eq(true)
         end
@@ -125,7 +125,7 @@ describe 'FeatureManagement', type: :feature do
     context 'Rails env is not development and server is not dev, qa, or int' do
       it 'returns false' do
         allow(Rails.env).to receive(:development?).and_return(false)
-        allow(AppConfig.env).to receive(:domain_name).and_return('foo.login.gov')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('foo.login.gov')
 
         expect(FeatureManagement.reveal_gpo_code?).to eq(false)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,7 +87,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, js: true) do
-    allow(AppConfig.env).to receive(:domain_name).and_return('127.0.0.1')
+    allow(IdentityConfig.store).to receive(:domain_name).and_return('127.0.0.1')
     server = Capybara.current_session.server
     allow(Rails.application.routes).to receive(:default_url_options).and_return(
       Rails.application.routes.default_url_options.merge(host: "#{server.host}:#{server.port}"),
@@ -95,7 +95,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :controller) do
-    @request.host = AppConfig.env.domain_name
+    @request.host = IdentityConfig.store.domain_name
   end
 
   config.before(:each) do

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   describe 'domain name as the origin' do
     it 'leaves the Access-Control-Allow-Origin header blank' do
       get openid_connect_configuration_path,
-          headers: { 'HTTP_ORIGIN' => AppConfig.env.domain_name.dup }
+          headers: { 'HTTP_ORIGIN' => IdentityConfig.store.domain_name.dup }
 
       aggregate_failures do
         expect(response).to be_ok

--- a/spec/services/gpo_confirmation_exporter_spec.rb
+++ b/spec/services/gpo_confirmation_exporter_spec.rb
@@ -45,8 +45,8 @@ describe GpoConfirmationExporter do
     it 'creates psv string' do
       result = <<~HEREDOC
         01|2\r
-        02|John Johnson|123 Sesame St|""|Anytown|WA|98021|ZYX987|July 6, 2018|July 16, 2018|#{service_provider.friendly_name}|https://#{AppConfig.env.domain_name}\r
-        02|Söme Öne|123 Añy St|Sté 123|Sömewhere|KS|66666-1234|ABC123|July 6, 2018|July 16, 2018|Null ServiceProvider|https://#{AppConfig.env.domain_name}\r
+        02|John Johnson|123 Sesame St|""|Anytown|WA|98021|ZYX987|July 6, 2018|July 16, 2018|#{service_provider.friendly_name}|https://#{IdentityConfig.store.domain_name}\r
+        02|Söme Öne|123 Añy St|Sté 123|Sömewhere|KS|66666-1234|ABC123|July 6, 2018|July 16, 2018|Null ServiceProvider|https://#{IdentityConfig.store.domain_name}\r
       HEREDOC
 
       psv_contents = subject.run

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -22,8 +22,8 @@ module SamlAuthHelper
     settings.security[:signature_method] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
     settings.double_quote_xml_attribute_values = true
     # IdP setting
-    settings.idp_sso_target_url = "http://#{AppConfig.env.domain_name}/api/saml/auth2021"
-    settings.idp_slo_target_url = "http://#{AppConfig.env.domain_name}/api/saml/logout2021"
+    settings.idp_sso_target_url = "http://#{IdentityConfig.store.domain_name}/api/saml/auth2021"
+    settings.idp_slo_target_url = "http://#{IdentityConfig.store.domain_name}/api/saml/logout2021"
     settings.idp_cert_fingerprint = idp_fingerprint
     settings.idp_cert_fingerprint_algorithm = 'http://www.w3.org/2001/04/xmlenc#sha256'
 


### PR DESCRIPTION
**Why**: This change is part of the migration to the new IdentityConfig DSL away from AppConfig

Currently the domain name is specified in app.yml. It is also available on Identity::Hostdata. In the future we should consider moving the domain name out of the config and making it a concern of Hostdata.