### PR TITLE
Update identity-hostdata to v3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
 @doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.5.1' }
-@hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v2.0.0' }
+@hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.0.0' }
 @idp_functions_gem ||= { github: '18F/identity-idp-functions', ref:'d9241bdfea85a76c170e456a89' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @proofer_gem ||= { github: '18F/identity-proofer-gem', ref: 'v2.8.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 8fa7ceeb9c5f8a5f3c4ceadba2c86a8a4f780f1f
-  tag: v2.0.0
+  revision: 29c9b463c4e5243e0c98fd2d87374fbb87b9f0cc
+  tag: v3.0.0
   specs:
-    identity-hostdata (2.0.0)
+    identity-hostdata (3.0.0)
       aws-sdk-s3 (~> 1.8)
 
 GIT


### PR DESCRIPTION
**Why**: To pick up a change that allows hostdata configs to be overriden or specified with ENV vars