### PR TITLE
LG-4387: Restructure image metrics to align to backend metrics

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -197,7 +197,7 @@ module Idv
       update_funnel(client_response)
       track_event(
         Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
-        client_response.to_h.merge(image_metadata),
+        client_response.to_h.merge(client_image_metrics: image_metadata),
       )
     end
 
@@ -205,12 +205,13 @@ module Idv
       params.permit(:front_image_metadata, :back_image_metadata).
         to_h.
         transform_values do |str|
-          JSON.parse(str, symbolize_names: true)
+          JSON.parse(str)
         rescue JSON::ParserError
           nil
         end.
         compact.
-        symbolize_keys
+        transform_keys { |key| key.gsub(/_image_metadata$/, '') }.
+        deep_symbolize_keys
     end
 
     def add_costs(response)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -9,7 +9,9 @@ describe Idv::ImageUploadsController do
     let(:params) do
       {
         front: DocAuthImageFixtures.document_front_image_multipart,
+        front_image_metadata: '{"glare":99.99}',
         back: DocAuthImageFixtures.document_back_image_multipart,
+        back_image_metadata: '{"glare":99.99}',
         selfie: DocAuthImageFixtures.selfie_image_multipart,
         document_capture_session_uuid: document_capture_session.uuid,
       }
@@ -218,6 +220,10 @@ describe Idv::ImageUploadsController do
           result: 'Passed',
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+          client_image_metrics: {
+            front: { glare: 99.99 },
+            back: { glare: 99.99 },
+          },
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -279,6 +285,10 @@ describe Idv::ImageUploadsController do
               result: 'Passed',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+              client_image_metrics: {
+                front: { glare: 99.99 },
+                back: { glare: 99.99 },
+              },
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -318,6 +328,10 @@ describe Idv::ImageUploadsController do
               result: 'Passed',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+              client_image_metrics: {
+                front: { glare: 99.99 },
+                back: { glare: 99.99 },
+              },
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -357,6 +371,10 @@ describe Idv::ImageUploadsController do
               result: 'Passed',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+              client_image_metrics: {
+                front: { glare: 99.99 },
+                back: { glare: 99.99 },
+              },
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -418,6 +436,10 @@ describe Idv::ImageUploadsController do
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
           exception: nil,
+          client_image_metrics: {
+            front: { glare: 99.99 },
+            back: { glare: 99.99 },
+          },
         )
 
         action
@@ -463,6 +485,10 @@ describe Idv::ImageUploadsController do
           exception: nil,
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+          client_image_metrics: {
+            front: { glare: 99.99 },
+            back: { glare: 99.99 },
+          },
         )
 
         action

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -106,8 +106,10 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_image_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
-          back_image_metadata: JSON.parse(back_image_metadata, symbolize_names: true),
+          client_image_metrics: {
+            front: JSON.parse(front_image_metadata, symbolize_names: true),
+            back: JSON.parse(back_image_metadata, symbolize_names: true),
+          },
         )
       end
     end
@@ -127,7 +129,9 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
           user_id: nil,
-          front_image_metadata: JSON.parse(front_image_metadata, symbolize_names: true),
+          client_image_metrics: {
+            front: JSON.parse(front_image_metadata, symbolize_names: true),
+          },
         )
       end
     end


### PR DESCRIPTION
**Why**: Since the purpose of including the client-side image metadata is to better compare front-end and back-end metrics, it's sensible to structure them in such a way that they're identifiably separate, but organizationally similar.

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td><pre><code>{
  front_image_metadata: {
    glare: 99.99,
    mimeType: 'image/jpeg',
    // ...
  },
  back_image_metadata: {
    // ...
  },
  image_metrics: {
    front: {
      GlareMetric: 99,
      // ...
    },
    back: {
      // ...
    }
  }
}</code></pre></td><td><pre><code>{
  client_image_metrics: {
    front: {
      glare: 99.99,
      mimeType: 'image/jpeg',
      // ...
    },
    back: {
      // ...
    },
  },
  image_metrics: {
    front: {
      GlareMetric: 99,
      // ...
    },
    back: {
      // ...
    }
  }
}</code></pre></td></tr>
</tbody>
</table>