### PR TITLE
Fix email changed RISC event

### DIFF
--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -42,9 +42,15 @@ module Users
       email_address.user.confirmed_email_addresses.each do |confirmed_email_address|
         UserMailer.email_added(email_address.user, confirmed_email_address.email).deliver_now
       end
+      notify_subscribers(email_address)
+    end
 
-      event = PushNotification::RecoveryInformationChangedEvent.new(user: email_address.user)
-      PushNotification::HttpPush.deliver(event)
+    def notify_subscribers(email_address)
+      user = email_address.user
+      email_event = PushNotification::EmailChangedEvent.new(user: user, email: email_address.email)
+      PushNotification::HttpPush.deliver(email_event)
+      recovery_event = PushNotification::RecoveryInformationChangedEvent.new(user: user)
+      PushNotification::HttpPush.deliver(recovery_event)
     end
 
     def process_unsuccessful_confirmation

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -53,7 +53,6 @@ class AddUserEmailForm
     @success = true
     email_address.save!
     SendAddEmailConfirmation.new(user).call(email_address)
-    notify_subscribers
   end
 
   def extra_analytics_attributes
@@ -65,10 +64,5 @@ class AddUserEmailForm
 
   def existing_user
     @_user ||= User.find_with_email(email) || AnonymousUser.new
-  end
-
-  def notify_subscribers
-    event = PushNotification::EmailChangedEvent.new(user: existing_user, email: email_address.email)
-    PushNotification::HttpPush.deliver(event)
   end
 end

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -22,13 +22,6 @@ RSpec.describe AddUserEmailForm do
       expect(email_address_record.confirmed_at).to be_nil
     end
 
-    it 'notifies subscribers that the email was changed' do
-      expect(PushNotification::HttpPush).to receive(:deliver).
-        with(PushNotification::EmailChangedEvent.new(user: user, email: new_email))
-
-      submit
-    end
-
     context 'when the new email address has an expired previous attempt for the same account' do
       before do
         create(


### PR DESCRIPTION
**Why**: Adding an email should not fire the RISC event until the email is confirmed. Follow up to https://github.com/18F/identity-idp/pull/4909