### PR TITLE
LG-4392: Set Acuant canvas width as HTML attribute

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -185,18 +185,17 @@ function AcuantCaptureCanvas({
       )}
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video id="acuant-player" controls autoPlay playsInline style={{ display: 'none' }} />
-      <div id="acuant-sdk-capture-view">
-        <canvas
-          id="acuant-video-canvas"
-          style={{
-            width: '100%',
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-          }}
-        />
-      </div>
+      <canvas
+        id="acuant-video-canvas"
+        width="100%"
+        height="auto"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
Follow-up to: #4929

**Why**: As of Acuant SDK v11.4.4, the SDK now sets width and height attributes based on a desirable aspect ratio (see `setDimens` function, [Acuant SDK v11.4.4](https://github.com/Acuant/JavascriptWebSDKV11/blob/11.4.4/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js) L828). Inline styles conflict with these attributes because they are of higher specificity, which can cause unexpected behavior.

Relevant documentation: https://github.com/Acuant/JavascriptWebSDKV11/tree/master/SimpleHTMLApp#start-live-capture