### PR TITLE
Step Indicator: Improve current step scroll centering

### DIFF
--- a/app/javascript/packages/step-indicator/index.js
+++ b/app/javascript/packages/step-indicator/index.js
@@ -32,9 +32,15 @@ class StepIndicator {
   }
 
   setScrollOffset() {
-    const { currentStep } = this.elements;
+    const { currentStep, scroller } = this.elements;
     if (currentStep) {
-      currentStep.scrollIntoView({ inline: 'center', block: 'nearest' });
+      const scrollerPaddingLeft = parseInt(window.getComputedStyle(scroller).paddingLeft, 10);
+      const { scrollWidth: scrollerScrollWidth, clientWidth: scrollerClientWidth } = scroller;
+      const { offsetLeft: currentStepOffsetLeft } = currentStep;
+      scroller.scrollLeft =
+        currentStepOffsetLeft -
+        scrollerPaddingLeft -
+        (scrollerScrollWidth - scrollerClientWidth) / 2;
     }
   }
 


### PR DESCRIPTION
**Why**: While `scrollIntoView` is a convenient abstraction to center the current step in the view, it is designed to scroll elements with the _viewport_, not within any scrollable container. As such, the behavior can cause undesirable effects depending if the user has scrolled beyond the step indicator before the JavaScript has finished initializing, since it will forcibly bring the current step back into the viewport.

Operating on the scrollable container's `scrollLeft` property is more cumbersome and math-heavy, but maintains the same effect of horizontal centering without risk of shifting the user's viewport.