### PR TITLE
LG-4410: remove h3 class from h1 elements, tweak styles

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -30,7 +30,7 @@ linters:
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent))?'
           - ':not(label).btn-border'
           - 'border-(black|gray|white|aqua|orange|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
-          - 'h[1-6]'
+          - 'h3'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:
           - 'js-consent-form'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -30,6 +30,7 @@ linters:
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent))?'
           - ':not(label).btn-border'
           - 'border-(black|gray|white|aqua|orange|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
+          - 'h[1-6]'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:
           - 'js-consent-form'

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -6,7 +6,6 @@
 @import 'basscss-sass/color-base';
 @import 'basscss-sass/color-forms';
 @import 'basscss-sass/color-tables';
-@import 'basscss-sass/type-scale';
 @import 'basscss-sass/utility-typography';
 @import 'basscss-sass/utility-layout';
 @import 'basscss-sass/white-space';

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -6,6 +6,7 @@
 @import 'basscss-sass/color-base';
 @import 'basscss-sass/color-forms';
 @import 'basscss-sass/color-tables';
+@import 'basscss-sass/type-scale';
 @import 'basscss-sass/utility-typography';
 @import 'basscss-sass/utility-layout';
 @import 'basscss-sass/white-space';

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -33,7 +33,7 @@ body { -webkit-font-smoothing: antialiased; }
 // scss-lint:disable SingleLinePerSelector
 h1, .h1 { font-size: $h1; }
 h2, .h2 { font-size: $h2; }
-h3, .h3 { font-size: $h3; }
+h3      { font-size: $h3; }
 h4, .h4 { font-size: $h4; }
 h5, .h5 { font-size: $h5; }
 h6, .h6 { font-size: $h6; }
@@ -41,7 +41,7 @@ h6, .h6 { font-size: $h6; }
 @media #{$breakpoint-sm} {
   h1, .h1 { font-size: $sm-h1; }
   h2, .h2 { font-size: $sm-h2; }
-  h3, .h3 { font-size: $sm-h3; }
+  h3      { font-size: $sm-h3; }
   h4, .h4 { font-size: $sm-h4; }
   h5, .h5 { font-size: $sm-h5; }
   h6, .h6 { font-size: $sm-h6; }

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -30,7 +30,7 @@ body { -webkit-font-smoothing: antialiased; }
 .underline { text-decoration: underline; }
 
 // given how similar & coupled these are, single line preferred
-// scss-lint:disable SingleLinePerSelector
+// scss-lint:disable SingleLinePerSelector, SpaceBeforeBrace
 h1, .h1 { font-size: $h1; }
 h2, .h2 { font-size: $h2; }
 h3      { font-size: $h3; }
@@ -46,7 +46,7 @@ h6, .h6 { font-size: $h6; }
   h5, .h5 { font-size: $sm-h5; }
   h6, .h6 { font-size: $sm-h6; }
 }
-// scss-lint:enable SingleLinePerSelector
+// scss-lint:enable SingleLinePerSelector, SpaceBeforeBrace
 
 //================================================
 // Pending upstream Login Design System revisions:

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -22,17 +22,17 @@ $line-height-2: 1.3 !default;
 $line-height-3: 1.75 !default;
 $line-height-4: 2 !default;
 
-$h1: 1.625rem !default;
-$h2: 1.25rem !default;
+$h1: 1.3125rem !default;
+$h2: 1.125rem !default;
 $h3: 1rem !default;
 $h4: .875rem !default;
 $h5: .8125rem !default;
 $h6: .625rem !default;
 
-$sm-h1: 1.3125rem !default;
-$sm-h2: 1.125rem !default;
-$sm-h3: 1.5rem !default;
-$sm-h4: 1.125rem !default;
+$sm-h1: 1.5rem !default;
+$sm-h2: 1.25rem !default;
+$sm-h3: 1rem !default;
+$sm-h4: .875rem !default;
 $sm-h5: .875rem !default;
 $sm-h6: .8125rem !default;
 

--- a/app/javascript/packages/document-capture/components/page-heading.jsx
+++ b/app/javascript/packages/document-capture/components/page-heading.jsx
@@ -10,7 +10,7 @@ import { forwardRef } from 'react';
  * @param {PageHeadingProps & Record<string,any>} props Props object.
  */
 function PageHeading({ children, className, ...props }, ref) {
-  const classes = ['page-heading', 'h3', className].filter(Boolean).join(' ');
+  const classes = ['page-heading', className].filter(Boolean).join(' ');
 
   return (
     // Disable reason: Intended as pass-through to heading HTML element.

--- a/app/views/account_reset/cancel/show.html.erb
+++ b/app/views/account_reset/cancel/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('account_reset.cancel_request.title') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('account_reset.cancel_request.title') %>
 </h1>
 

--- a/app/views/account_reset/confirm_request/show.html.erb
+++ b/app/views/account_reset/confirm_request/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="margin-top-neg-2">
   <%= image_tag asset_url('check-email.svg'), alt: '', width: 24, class: 'left-0 right-0 ico-heading' %>
-  <h1 class="margin-top-2 margin-left-1 h3 ico-heading"><%= t('headings.verify_email') %></h1>
+  <h1 class="margin-top-2 margin-left-1 ico-heading"><%= t('headings.verify_email') %></h1>
 </div>
 
 <p><%= t('account_reset.confirm_request.instructions_start') %>

--- a/app/views/account_reset/delete_account/show.html.erb
+++ b/app/views/account_reset/delete_account/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('account_reset.delete_account.title') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('account_reset.delete_account.title') %>
 </h1>
 <p class='mt-tiny margin-bottom-0'>

--- a/app/views/account_reset/pending/cancel.html.erb
+++ b/app/views/account_reset/pending/cancel.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h3"><%= t('account_reset.pending.cancelled') %></h1>
+<h1><%= t('account_reset.pending.cancelled') %></h1>
 
 <%= link_to(
   t('links.continue_sign_in'),

--- a/app/views/account_reset/pending/show.html.erb
+++ b/app/views/account_reset/pending/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h3"><%= t('account_reset.pending.header') %></h1>
+<h1><%= t('account_reset.pending.header') %></h1>
 
 <p>
   <%= t(

--- a/app/views/account_reset/recover/email_sent.html.erb
+++ b/app/views/account_reset/recover/email_sent.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('check-email.svg'), alt: '', width: 48) %>
 
-<h1 class='h3 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('recover.request.email_check') %>
 </h1>
 

--- a/app/views/account_reset/recover/show.html.erb
+++ b/app/views/account_reset/recover/show.html.erb
@@ -2,13 +2,13 @@
 
 <%= image_tag(asset_url('alert/warning.svg'), size: '60') %>
 
-<h1 class='h3 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('recover.request.reverify') %>
 </h1>
 
 <hr />
 
-<h1 class='h3 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('recover.request.confirm_email') %>
 </h1>
 

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="clearfix padding-top-2 padding-bottom-4 tablet:padding-y-0 margin-bottom-4 bg-lightest-blue sm-bg-none">
   <div class="sm-col sm-col-4">
-    <h1 class="h3 margin-0 center sm-left-align">
+    <h1 class="margin-0 center sm-left-align">
       <span class="regular sans-serif tablet:display-none">
         <%= t('account.welcome') %>,
         <span class="bold">

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -14,6 +14,6 @@
   </div>
   <%= render 'accounts/badges' %>
 </div>
-<div class="padding-x-2 padding-bottom-1 bold h3 tablet:display-none serif">
+<h1 class="padding-bottom-1 bold tablet:display-none serif">
   <%= t('headings.account.login_info') %>
-</div>
+</h1>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.passwords.change') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.passwords.change') %>
 </h1>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
 
 <%= render 'shared/sp_alert' %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.passwords.forgot') %>
 </h1>
 

--- a/app/views/devise/sessions/bounced.html.erb
+++ b/app/views/devise/sessions/bounced.html.erb
@@ -1,5 +1,5 @@
 <% title t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
 </h1>
 <p class='margin-top-2 margin-bottom-2'>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
     <%= render decorated_session.registration_heading %>
   </div>
 <% else %>
-  <h1 class='h3 margin-y-0'>
+  <h1 class='margin-y-0'>
     <%= decorated_session.new_session_heading %>
   </h1>
 <% end %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.passwords.change') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.passwords.change') %>
 </h1>
 

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -9,7 +9,7 @@
 
 <div class="margin-top-neg-2">
   <%= image_tag asset_url('check-email.svg'), alt: '', width: 24, class: 'left-0 right-0 ico-heading' %>
-  <h1 class="margin-top-2 margin-left-1 h3 ico-heading"><%= t('headings.verify_email') %></h1>
+  <h1 class="margin-top-2 margin-left-1 ico-heading"><%= t('headings.verify_email') %></h1>
 </div>
 
 <p><%= t('notices.forgot_password.first_paragraph_start') %>

--- a/app/views/idv/activated.html.erb
+++ b/app/views/idv/activated.html.erb
@@ -1,6 +1,6 @@
 <% title t('idv.titles.activated') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('idv.titles.activated') %>
 </h1>
 <p class='mt-tiny margin-bottom-0'>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -11,7 +11,7 @@
 
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('doc_auth.headings.address') %>
 </h1>
 

--- a/app/views/idv/cancel.html.erb
+++ b/app/views/idv/cancel.html.erb
@@ -1,6 +1,6 @@
 <% title t('idv.titles.cancel') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('idv.titles.cancel') %>
 </h1>
 

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/fail-x.svg'), width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('headings.cancellations.confirmation') %>
 </h1>
 

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('headings.cancellations.prompt') %>
 </h1>
 

--- a/app/views/idv/capture_doc/capture_complete.html.erb
+++ b/app/views/idv/capture_doc/capture_complete.html.erb
@@ -4,7 +4,7 @@
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 
-<h1 class='h2 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('doc_auth.instructions.switch_back') %>
 </h1>
 <%= image_tag(asset_url('idv/switch.png'), width: 193) %>

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -8,7 +8,7 @@
   } %>
 <% end %>
 
-<h1 class="h3"><%= t('doc_auth.headings.lets_go') %></h1>
+<h1><%= t('doc_auth.headings.lets_go') %></h1>
 <p><%= t('doc_auth.info.lets_go') %></p>
 <h2><%= t('doc_auth.headings.verify_identity') %></h2>
 <p><%= t('doc_auth.info.verify_identity') %></p>

--- a/app/views/idv/doc_auth/email_sent.html.erb
+++ b/app/views/idv/doc_auth/email_sent.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('state-id-confirm@3x.png'), width: 210) %>
 
-<h1 class='h3 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('doc_auth.instructions.email_sent', email: current_user.email) %>
 </h1>
 

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -11,7 +11,7 @@
     message: flow_session[:error_message],
   } %>
 <% end %>
-<h1 class='h3 margin-y-0'><%= t('doc_auth.headings.text_message') %></h1>
+<h1 class='margin-y-0'><%= t('doc_auth.headings.text_message') %></h1>
 
 <br />
 

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), width: 54, alt: '') %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('doc_auth.errors.no_camera.heading') %>
 </h1>
 

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -6,9 +6,9 @@
   } %>
 <% end %>
 
-<h1 class='h3 margin-y-0'><%= t('recover.overview.heading') %></h1>
+<h1 class='margin-y-0'><%= t('recover.overview.heading') %></h1>
 <p class='mt-tiny margin-bottom-4'><%= t('recover.overview.description') %></p>
-<h1 class='h3 margin-bottom-2'><%= t('recover.instructions.heading') %></h1>
+<h1 class='margin-bottom-2'><%= t('recover.instructions.heading') %></h1>
 
 <ul class='list-reset'>
   <li class='padding-top-2 padding-bottom-1'>

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -8,7 +8,7 @@
 
 <h1 class='margin-y-0'><%= t('recover.overview.heading') %></h1>
 <p class='mt-tiny margin-bottom-4'><%= t('recover.overview.description') %></p>
-<h1 class='margin-bottom-2'><%= t('recover.instructions.heading') %></h1>
+<h2 class='margin-bottom-2'><%= t('recover.instructions.heading') %></h2>
 
 <ul class='list-reset'>
   <li class='padding-top-2 padding-bottom-1'>

--- a/app/views/idv/doc_auth/recover.html.erb
+++ b/app/views/idv/doc_auth/recover.html.erb
@@ -2,11 +2,11 @@
 
 <%= image_tag(asset_url('alert/success.svg'), width: 60) %>
 
-<h1 class='h1 margin-bottom-2 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
   <%= t('recover.reverify.email_confirmed') %>
 </h1>
 <hr/>
-<h1 class='h1 margin-bottom-1 margin-top-4 margin-y-0'>
+<h1 class='margin-bottom-1 margin-top-4 margin-y-0'>
   <%= t('recover.reverify.reverify') %>
 </h1>
 <%= t('recover.reverify.instructions') %>

--- a/app/views/idv/doc_auth/recover.html.erb
+++ b/app/views/idv/doc_auth/recover.html.erb
@@ -6,9 +6,9 @@
   <%= t('recover.reverify.email_confirmed') %>
 </h1>
 <hr/>
-<h1 class='margin-bottom-1 margin-top-4 margin-y-0'>
+<h2 class='margin-bottom-1 margin-top-4 margin-y-0'>
   <%= t('recover.reverify.reverify') %>
-</h1>
+</h2>
 <%= t('recover.reverify.instructions') %>
 <br/>
 <br/>

--- a/app/views/idv/doc_auth/recover_verify_wait.html.erb
+++ b/app/views/idv/doc_auth/recover_verify_wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { "#{@meta_refresh}" } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="h3 margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -8,7 +8,7 @@
   } %>
 <% end %>
 
-<h1 class='h3'>
+<h1>
   <%= t('doc_auth.headings.take_picture') %>
 </h1>
 

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -7,7 +7,7 @@
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('doc_auth.headings.ssn') %>
 </h1>
 

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class='h3 margin-top-0 margin-bottom-1'>
+<h1 class='margin-top-0 margin-bottom-1'>
   <% if liveness_checking_enabled? %>
     <%= t('doc_auth.headings.upload_liveness_enabled') %>
   <% else %>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -2,7 +2,7 @@
 
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('doc_auth.headings.verify') %>
 </h1>
 <div class='margin-top-4 margin-bottom-2'>

--- a/app/views/idv/doc_auth/verify_wait.html.erb
+++ b/app/views/idv/doc_auth/verify_wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { "#{@meta_refresh}" } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="h3 margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -3,7 +3,7 @@
 <% step = 0 %>
 
 <%= render 'shared/maintenance_window_alert' do %>
-  <h1 class="h3"><%= t('doc_auth.headings.welcome') %></h1>
+  <h1><%= t('doc_auth.headings.welcome') %></h1>
   <p class='mt-tiny margin-bottom-0'><%= t('doc_auth.info.welcome_html') %></p>
   <h2 class='margin-bottom-0'><%= t('doc_auth.instructions.welcome') %></h2>
 

--- a/app/views/idv/fail.html.erb
+++ b/app/views/idv/fail.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/temp-lock.svg'), width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t('idv.titles.hardfail', app: APP_NAME) %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t('idv.titles.hardfail', app: APP_NAME) %></h1>
 
 <p><%= t('idv.messages.hardfail', hours: IdentityConfig.store.idv_attempt_window_in_hours) %></p>
 

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/forgot.svg'), width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('idv.forgot_password.modal_header') %>
 </h1>
 

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -11,7 +11,7 @@
 
 <div class="margin-top-neg-2">
   <%= image_tag asset_url('check-email.svg'), alt: '', width: 24, class: 'left-0 right-0 ico-heading' %>
-  <h1 class="margin-top-2 margin-left-1 h3 ico-heading"><%= @presenter.title %></h1>
+  <h1 class="margin-top-2 margin-left-1 ico-heading"><%= @presenter.title %></h1>
 </div>
 
 <p>

--- a/app/views/idv/gpo/wait.html.erb
+++ b/app/views/idv/gpo/wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { '15' } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="h3 margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -11,7 +11,7 @@
 
 <% title t('titles.doc_auth.otp_delivery') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('idv.titles.otp_delivery_method') %>
 </h1>
 <p class="margin-top-1">

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -11,7 +11,7 @@
 
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('two_factor_authentication.header_text') %>
 </h1>
 

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -19,7 +19,7 @@
 
 <% title t('idv.titles.phone') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('idv.titles.session.phone') %>
 </h1>
 

--- a/app/views/idv/phone/wait.html.erb
+++ b/app/views/idv/phone/wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { '15' } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="h3 margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/fail-x.svg', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
 
 <p><%= t("idv.failure.phone.fail_html") %></p>
 

--- a/app/views/idv/phone_errors/jobfail.html.erb
+++ b/app/views/idv/phone_errors/jobfail.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
 
 <p><%= t("idv.failure.phone.jobfail") %></p>
 

--- a/app/views/idv/phone_errors/timeout.html.erb
+++ b/app/views/idv/phone_errors/timeout.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
 
 <p><%= t("idv.failure.phone.timeout") %></p>
 

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.phone.heading") %></h1>
 
 <p><%= t("idv.failure.phone.warning") %></p>
 

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -11,7 +11,7 @@
 
 <% title t('idv.titles.review') %>
 
-<h1 class="h3">
+<h1>
   <%= t('idv.titles.session.review') %>
 </h1>
 

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.exception") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.exception") %></h1>
 
 <p>
   <%= t('idv.failure.exceptions.text_html',

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/fail-x.svg', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
 
 <p><%= t("idv.failure.sessions.fail_html") %></p>
 

--- a/app/views/idv/session_errors/recovery_exception.html.erb
+++ b/app/views/idv/session_errors/recovery_exception.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.exception") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.exception") %></h1>
 
 <p>
   <%= t('idv.failure.exceptions.text_html',

--- a/app/views/idv/session_errors/recovery_failure.html.erb
+++ b/app/views/idv/session_errors/recovery_failure.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/fail-x.svg', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
 
 <p><%= t("idv.failure.sessions.fail_html") %></p>
 

--- a/app/views/idv/session_errors/recovery_warning.html.erb
+++ b/app/views/idv/session_errors/recovery_warning.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
 
 <p><%= t("idv.failure.sessions.warning") %></p>
 

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag('alert/warning-lg.svg', alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t("idv.failure.sessions.heading") %></h1>
 
 <p><%= t("idv.failure.sessions.warning") %></p>
 

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -35,7 +35,7 @@
 <div class="no-js">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-  <h1 class="h3 margin-y-0">
+  <h1 class="margin-y-0">
     <% if liveness_checking_enabled? %>
       <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
     <% else %>

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.passwords.confirm') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('headings.passwords.confirm') %>
 </h1>
 <p class='mt-tiny margin-bottom-0'>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.visitors.index') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('headings.passwords.confirm') %>
 </h1>
 

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<h1 class="h3 margin-top-0 margin-bottom-2">
+<h1 class="margin-top-0 margin-bottom-2">
   <%= t('headings.account.reactivate') %>
 </h1>
 

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -10,7 +10,7 @@
   <body>
     <div class="container tablet:padding-y-6">
       <div class="card margin-x-auto sm-col-6">
-        <h1 class="h3 margin-y-0">
+        <h1 class="margin-y-0">
           <%= t('.heading') %>
         </h1>
 

--- a/app/views/service_provider_mfa/new.html.erb
+++ b/app/views/service_provider_mfa/new.html.erb
@@ -4,7 +4,7 @@
   <%= image_tag(asset_url(@presenter.icon), class: 'margin-bottom-3', alt: 'important alert icon') %>
 <% end %>
 
-<h1 class="h4 margin-y-0"><%= @presenter.heading %></h1>
+<h1 class="margin-y-0"><%= @presenter.heading %></h1>
 
 <p class="mt-tiny"><%== @presenter.intro %></p>
 

--- a/app/views/shared/_failure.html.erb
+++ b/app/views/shared/_failure.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url(presenter.state_icon), alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= presenter.header %>
 </h1>
 

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h3 margin-y-0"><%= t('headings.personal_key') %></h1>
+<h1 class="margin-y-0"><%= t('headings.personal_key') %></h1>
 <p class="mt-tiny margin-bottom-6">
   <%= t('instructions.personal_key.info_html',
         accent: content_tag(:strong, t('instructions.personal_key.accent'))) %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -3,7 +3,7 @@
   <div class="center">
     <%= image_tag asset_url(@view_model.image_name), width: 140, alt: '', class: 'margin-bottom-2'  %>
   </div>
-  <h1 class="h3 margin-bottom-2 margin-y-0 tablet:margin-right-1 tablet:margin-left-1 center">
+  <h1 class="margin-bottom-2 margin-y-0 tablet:margin-right-1 tablet:margin-left-1 center">
     <%= @view_model.heading %>
   </h1>
   <%= render @view_model.service_provider_partial %>

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.confirmations.new') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('headings.confirmations.new') %>
 </h1>
 <%= validated_form_for(@resend_email_confirmation_form,

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="margin-top-neg-2">
   <%= image_tag asset_url('check-email.svg'), alt: '', width: 24, class: 'left-0 right-0 ico-heading' %>
-  <h1 class="margin-top-2 margin-left-1 h3 ico-heading"><%= t('headings.verify_email') %></h1>
+  <h1 class="margin-top-2 margin-left-1 ico-heading"><%= t('headings.verify_email') %></h1>
 </div>
 
 <p><%= t('notices.signed_up_but_unconfirmed.first_paragraph_start') %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.confirmations.show') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('forms.confirmation.show_hdr') %>
 </h1>
 

--- a/app/views/sign_up/registrations/_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_registration_heading.html.erb
@@ -1,3 +1,3 @@
-<h1 class='h3 margin-bottom-4 blue regular'>
+<h1 class='margin-bottom-4 blue regular'>
   <%= t('headings.create_account_without_sp') %>
 </h1>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,4 +1,4 @@
-<h1 class='h3 margin-bottom-4 blue regular'>
+<h1 class='margin-bottom-4 blue regular'>
   <strong>
     <%= decorated_session.sp_name %>
   </strong>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -8,7 +8,7 @@
   message: t('sign_up.email.invalid_email_alert_head'),
 } %>
 
-<h1 class='h3 margin-y-0'><%= t('headings.registrations.enter_email') %></h1>
+<h1 class='margin-y-0'><%= t('headings.registrations.enter_email') %></h1>
 
 <div class='margin-bottom-6'>
   <%= validated_form_for(@register_user_email_form,

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -1,6 +1,6 @@
 <% title 'Enter PIV/CAC Test Information' %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   Enter PIV/CAC Test Information
 </h1>
 

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('two_factor_authentication.backup_code_header_text') %>
 </h1>
 

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= @presenter.heading %>
 </h1>
 

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= @presenter.header %>
 </h1>
 

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('two_factor_authentication.personal_key_header_text') %>
 </h1>
 

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.present_piv_cac') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= @presenter.header %>
 </h1>
 

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= @presenter.header %>
 </h1>
 

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.present_webauthn') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('two_factor_authentication.webauthn_header_text') %>
 </h1>
 

--- a/app/views/users/authorization_confirmation/show.html.erb
+++ b/app/views/users/authorization_confirmation/show.html.erb
@@ -7,7 +7,7 @@
     <%= render decorated_session.registration_heading %>
   </div>
 <% else %>
-  <h1 class='h3 margin-y-0'>
+  <h1 class='margin-y-0'>
     <%= decorated_session.new_session_heading %>
   </h1>
 <% end %>

--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('forms.backup_code.confirm_delete') %>
 </h1>
 

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -1,6 +1,6 @@
 <% title t('forms.backup_code.title') %>
 
-<h1 class="h3 margin-y-0 margin-top-0">
+<h1 class="margin-y-0 margin-top-0">
   <%= t('forms.backup_code.subtitle') %>
 </h1>
 

--- a/app/views/users/backup_code_setup/depleted.html.erb
+++ b/app/views/users/backup_code_setup/depleted.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h3 margin-y-0 margin-top-0"><%= @presenter.title %></h1>
+<h1 class="margin-y-0 margin-top-0"><%= @presenter.title %></h1>
 <p class="mt-tiny margin-bottom-4"><%= @presenter.description %></p>
 
 <% if @presenter.other_option_display %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('forms.backup_code_regenerate.confirm') %>
 </h1>
 

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h3 margin-y-0 margin-top-0"><%= @presenter.title %></h1>
+<h1 class="margin-y-0 margin-top-0"><%= @presenter.title %></h1>
 <p class="mt-tiny margin-bottom-4"><%== @presenter.description %></p>
 
 <% if @presenter.other_option_display %>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('titles.edit_info.phone') %>
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.edit_info.phone') %>
 </h1>
 

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.edit_info.email_language') %>
 
-<h1 class="h2"><%= t('account.email_language.edit_title') %></h1>
+<h1><%= t('account.email_language.edit_title') %></h1>
 
 <p class="margin-bottom-4">
   <%= t('account.email_language.languages_list',

--- a/app/views/users/emails/confirm_delete.html.erb
+++ b/app/views/users/emails/confirm_delete.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.confirmations.delete') %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= @presenter.confirm_delete_message %>
 </h1>
 

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'shared/sp_alert' %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.add_email') %>
 </h1>
 

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -10,7 +10,7 @@
 
 <div class="margin-top-neg-2">
   <%= image_tag asset_url('check-email.svg'), alt: '', width: 24, class: 'left-0 right-0 ico-heading' %>
-  <h1 class="margin-top-2 margin-left-1 h3 ico-heading"><%= t('headings.verify_email') %></h1>
+  <h1 class="margin-top-2 margin-left-1 ico-heading"><%= t('headings.verify_email') %></h1>
 </div>
 
 <p><%= t('notices.signed_up_and_confirmed.first_paragraph_start') %>

--- a/app/views/users/forget_all_browsers/show.html.erb
+++ b/app/views/users/forget_all_browsers/show.html.erb
@@ -1,6 +1,6 @@
 <%= title t('titles.forget_all_browsers') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('titles.forget_all_browsers') %>
 </h1>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.edit_info.password') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.edit_info.password') %>
 </h1>
 

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.phone_setup') %>
 <%= image_tag asset_url('2FA-voice.svg'), alt: '', width: 200, class: 'margin-bottom-2' %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('titles.phone_setup') %>
 </h1>
 <p class="mt-tiny margin-bottom-0">

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -1,6 +1,6 @@
 <%= title t('titles.add_info.phone') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('headings.add_info.phone') %>
 </h1>
 <p class="mt-tiny margin-bottom-0">

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= @presenter.heading %>
 </h1>
 

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class='h3 margin-y-0'><%= t('titles.piv_cac_login.add') %></h1>
+<h1 class='margin-y-0'><%= t('titles.piv_cac_login.add') %></h1>
 <p class='mt-tiny margin-bottom-4'><%= t('headings.piv_cac_login.add') %></p>
 
 <%= form_tag(submit_new_piv_cac_url) do %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= @presenter.heading %>
 </h1>
 

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= @presenter.heading %>
 </h1>
 

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -2,9 +2,9 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<div class="h1 h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('forms.piv_cac_delete.confirm') %>
-</div>
+</h1>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow">

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.piv_cac_login.add') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('titles.piv_cac_login.add') %>
 </h1>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag asset_url('alert/success.svg'), width: 90 %>
 
-<h1 class="h3 margin-bottom-2 margin-top-4 margin-y-0"><%= t('headings.piv_cac_login.success') %></h1>
+<h1 class="margin-bottom-2 margin-top-4 margin-y-0"><%= t('headings.piv_cac_login.success') %></h1>
 <br>
 
 <%= button_to t('forms.buttons.continue'), login_add_piv_cac_success_path,

--- a/app/views/users/service_provider_revoke/show.html.erb
+++ b/app/views/users/service_provider_revoke/show.html.erb
@@ -1,6 +1,6 @@
 <%= title t('titles.revoke_consent') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('titles.revoke_consent') %>
 </h1>
 

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -2,9 +2,9 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<div class="h1 h3 margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('forms.totp_delete.confirm') %>
-</div>
+</h1>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -2,7 +2,7 @@
 
 <% help_link = new_window_link_to t('links.what_is_totp'),
                                   MarketingSite.help_authentication_app_url %>
-<h1 class="h3 margin-y-0"><%= t('headings.totp_setup.new') %></h1>
+<h1 class="margin-y-0"><%= t('headings.totp_setup.new') %></h1>
 <p class="mt-tiny margin-bottom-4"><%= t('forms.totp_setup.totp_intro_html', link: help_link) %></p>
 <%= form_tag(authenticator_setup_path, method: :patch, role: 'form', class: 'margin-bottom-1') do %>
   <ul class="list-reset">

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -6,7 +6,7 @@
                 alt: @presenter.icon_alt_text) %>
 <% end %>
 
-<h1 class="h4 margin-y-0"><%= @presenter.heading %></h1>
+<h1 class="margin-y-0"><%= @presenter.heading %></h1>
 
 <p class="mt-tiny"><%== @presenter.intro %></p>
 

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -13,7 +13,7 @@
 
 <% title t('titles.verify_profile') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('forms.verify_profile.title') %>
 </h1>
 <p class="mt-tiny margin-bottom-0">

--- a/app/views/users/verify_account/throttled.html.erb
+++ b/app/views/users/verify_account/throttled.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.verify_profile') %>
 
-<h1 class="h3 margin-y-0">
+<h1 class="margin-y-0">
   <%= t('forms.verify_profile.title') %>
 </h1>
 

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('idv.titles.review') %>
 
-<h1 class='h3'>
+<h1>
   <%= t('idv.titles.session.review') %>
 </h1>
 

--- a/app/views/users/webauthn_setup/delete.html.erb
+++ b/app/views/users/webauthn_setup/delete.html.erb
@@ -1,7 +1,7 @@
 <% title t('forms.webauthn_delete.confirm') %>
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<h1 class="h3 margin-bottom-1 margin-top-4 margin-y-0"><%= t('forms.webauthn_delete.confirm') %></h1>
+<h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t('forms.webauthn_delete.confirm') %></h1>
 
 <div class="col-2">
   <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow" />

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -4,7 +4,7 @@
 
 <%= image_tag asset_url('security-key.svg'), alt: '', width: '90', class: 'margin-left-1' %>
 
-<h1 class='h3 margin-y-0'>
+<h1 class='margin-y-0'>
   <%= t('headings.webauthn_setup.new') %>
 </h1>
 <p class='mt-tiny margin-bottom-4'>


### PR DESCRIPTION
As a user, I want a clear visual hierarchy of headings on mobile and desktop, consistent across all pages on the IdP, so that I can easily understand the most important information on the page.

Previously we had used the `h2`, `h3`, and `h4` classes to change the font-size of `h1` elements throughout our code. To make things consistent, we are getting rid of these and tweaking the size of the headers in the app css.

This is currently deployed at https://idp.solipet.identitysandbox.gov/