### PR TITLE
Enforce formatted punctuation in locale strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,7 @@ group :test do
   gem 'rack-test', '>= 1.1.0'
   gem 'rails-controller-testing', '>= 1.0.4'
   gem 'rspec-retry'
+  gem 'rubypants-unicode', '~> 0.2.5'
   gem 'shoulda-matchers', '~> 4.0', require: false
   gem 'timecop'
   gem 'webdrivers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,7 @@ GEM
       rexml
     ruby-statistics (2.1.2)
     ruby2_keywords (0.0.2)
+    rubypants-unicode (0.2.5)
     rubyzip (1.3.0)
     safe_target_blank (1.0.2)
       rails
@@ -809,6 +810,7 @@ DEPENDENCIES
   rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml
+  rubypants-unicode (~> 0.2.5)
   safe_target_blank (>= 1.0.2)
   saml_idp!
   sassc-rails (~> 2.1.2)

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -98,7 +98,7 @@ en:
       two_factor_authentication: Your authentication methods
       your_account: Your Account
     re_verify:
-      banner: We've hidden your profile information to protect your privacy.
+      banner: We’ve hidden your profile information to protect your privacy.
       footer: Authenticate to view your information.
     revoke_consent:
       link_title: Disconnect

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -19,7 +19,7 @@ es:
       sentence_connector: o
       updated: Se actualizó su preferencia de idioma de correo electrónico.
     forget_all_browsers:
-      longer_description: Una vez que elija "olvidar todos los navegadores", necesitaremos
+      longer_description: Una vez que elija “olvidar todos los navegadores”, necesitaremos
         información adicional para saber que en realidad está iniciando sesión en
         su cuenta. Le pediremos un método de autenticación de múltiples factores (como
         texto / código de SMS o una clave de seguridad) cada vez que desee acceder

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -13,16 +13,16 @@ fr:
         e-mail dans %{list}."
       name:
         en: Anglais
-        es: l'Espagnol
+        es: l’Espagnol
         fr: langue française
       please_select: Veuillez sélectionner votre préférence de langue ci-dessous.
       sentence_connector: ou
       updated: Votre préférence de langue pour les e-mails a été mise à jour.
     forget_all_browsers:
-      longer_description: Une fois que vous aurez choisi "d'oublier tous les navigateurs",
-        nous aurons besoin d'informations supplémentaires pour savoir qu'il s'agit
+      longer_description: Une fois que vous aurez choisi “d’oublier tous les navigateurs”,
+        nous aurons besoin d’informations supplémentaires pour savoir qu’il s’agit
         bien de votre connexion à votre compte. Nous vous demanderons une méthode
-        d'authentification multifacteur (comme un code texte / SMS ou une clé de sécurité)
+        d’authentification multifacteur (comme un code texte / SMS ou une clé de sécurité)
         chaque fois que vous souhaitez accéder à votre compte.
     index:
       address: Adresse actuelle
@@ -49,16 +49,16 @@ fr:
       piv_cac_disabled: désactivée
       piv_cac_enabled: activée
       reactivation:
-        instructions: Votre profil a été récemment désactivé en raison d'une réinitialisation
+        instructions: Votre profil a été récemment désactivé en raison d’une réinitialisation
           de mot passe. Vous pouvez utiliser votre clé personnelle pour réactiver
           votre profil.
         link: Réactivez votre profil maintenant.
       sign_in_location_and_ip: "%{ip} (adresse IP probablement située dans %{location})"
-      ssn: Numéro d'assurance sociale
-      totp_confirm_delete: Oui, supprimez l'application d'authentification
+      ssn: Numéro d’assurance sociale
+      totp_confirm_delete: Oui, supprimez l’application d’authentification
       unknown_location: lieu inconnu
       verification:
-        bounced: Le service postal n'a pas pu envoyer la lettre à votre adresse.
+        bounced: Le service postal n’a pas pu envoyer la lettre à votre adresse.
         instructions: Votre compte nécessite un code de confirmation pour être vérifié.
         reactivate_button: Entrez le code que vous avez reçu par la poste
         success: Votre compte a été vérifié.
@@ -74,7 +74,7 @@ fr:
       delete_account: Effacer
       regenerate_personal_key: Obtenez une nouvelle clé
     login:
-      piv_cac: Connectez-vous avec votre ID d'employé du gouvernement
+      piv_cac: Connectez-vous avec votre ID d’employé du gouvernement
       piv_cac_info:
         ial1: Si vous avez ajouté votre carte PIV / CAC à votre compte, vous pouvez
           l’utiliser à la place de votre adresse courriel et de votre mot de passe.
@@ -84,9 +84,9 @@ fr:
     navigation:
       access_services: Accédez à vos avantages et services gouvernementaux depuis
         votre compte login.gov.
-      add_authentication_apps: Ajouter des applications d'authentification
+      add_authentication_apps: Ajouter des applications d’authentification
       add_email: Ajouter une adresse e-mail
-      add_federal_id: Ajouter un identifiant d'employé fédéral
+      add_federal_id: Ajouter un identifiant d’employé fédéral
       add_phone_number: Ajouter un numéro de téléphone
       add_security_key: Ajouter une clé de sécurité
       connected_accounts: Vos comptes connectés
@@ -95,10 +95,10 @@ fr:
       edit_password: Modifier le mot de passe
       forget_browsers: Oubliez tous les navigateurs
       get_backup_codes: Obtenez des codes de secours
-      history: L'histoire
+      history: L’histoire
       learn_more: En savoir plus sur login.gov
       menu: Menu
-      two_factor_authentication: Vos méthodes d'authentification
+      two_factor_authentication: Vos méthodes d’authentification
       your_account: Votre compte
     re_verify:
       banner: Nous avons masqué les informations de votre profil pour protéger votre
@@ -108,10 +108,10 @@ fr:
     revoke_consent:
       link_title: Déconnecter
       longer_description_html: Vos informations ne seront plus partagées avec %{service_provider}.
-        Pour accéder à %{service_provider} à l'avenir, vous devez donner votre consentement
+        Pour accéder à %{service_provider} à l’avenir, vous devez donner votre consentement
         pour partager vos informations. Vous pouvez donner votre consentement en allant
         sur le site %{service_provider} et en vous connectant.
     security:
-      link: En apprendre davantage dans le Centre d'aide
-      text: L'information de votre profil est verrouillée pour votre sécurité.
+      link: En apprendre davantage dans le Centre d’aide
+      text: L’information de votre profil est verrouillée pour votre sécurité.
     welcome: Bienvenue

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -7,14 +7,14 @@ en:
       cancel_button: Cancel delete account
       title: Cancel delete account
     confirm_delete_account:
-      cta_html: You may %{link} or close this window if you're done.
+      cta_html: You may %{link} or close this window if you’re done.
       info_html: The account for <strong>%{email}</strong> has been deleted. We sent
         an email confirmation of the account deletion.
       link_text: create a new account
       title: You have deleted your account
     confirm_request:
       check_your_email: Check your email
-      close_window: You can close this window if you're done.
+      close_window: You can close this window if you’re done.
       instructions_end: to begin the account delete process. Follow the instructions
         in your email to complete the process.
       instructions_start: We sent an email to
@@ -38,7 +38,7 @@ en:
         you will receive an email with instructions to complete the deletion.
     request:
       access_your_account: access your account
-      are_you_sure: Are you sure you don't have access to any of your authentication
+      are_you_sure: Are you sure you don’t have access to any of your authentication
         methods?
       delete_account: Delete your account
       delete_account_info: Deleting your existing account and creating a new one will
@@ -48,14 +48,14 @@ en:
         will first receive an email confirmation.  As a security measure, you will
         receive another email with the link to continue deleting your account 24 hours
         after the initial confirmation email arrives.
-      info: If you can't access your account using the authentication methods you
+      info: If you can’t access your account using the authentication methods you
         set up previously, deleting your account and creating a new one is the only
-        option. <br><br> We can't undo an account delete, so please verify if you
+        option. <br><br> We can’t undo an account delete, so please verify if you
         have another authentication method you can use instead.
       no_cancel: No, cancel
       personal_key: Do you have your personal key?
       personal_key_info: Your personal key is a 16 character code that was given to
-        you at account creation as a recovery method--see example below.
+        you at account creation as a recovery method–see example below.
       personal_key_trailer: If you have your personal key, you can use it to %{link}
         instead of resetting.
       title: Account deletion and reset

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -30,37 +30,37 @@ fr:
         pouvez en créer un nouveau en utilisant la même adresse e-mail.
       title: La suppression de votre compte devrait être votre dernier recours
     pending:
-      cancel_request: Demande d'annulation
+      cancel_request: Demande d’annulation
       cancelled: Nous avons annulé votre demande de suppression de votre compte.
       confirm: Si vous annulez maintenant, vous devez créer une nouvelle demande et
         attendre encore 24 heures pour supprimer votre compte.
       header: Vous avez demandé de supprimer votre compte
-      wait_html: Il y a un délai d'attente de 24 heures pour supprimer votre compte.
+      wait_html: Il y a un délai d’attente de 24 heures pour supprimer votre compte.
         Dans <strong>%{interval}</strong>, vous recevrez un e-mail avec des instructions
         pour terminer la suppression.
     request:
       access_your_account: accéder à votre compte
-      are_you_sure: Êtes-vous sûr de n'avoir accès à aucune de vos méthodes de sécurité?
+      are_you_sure: Êtes-vous sûr de n’avoir accès à aucune de vos méthodes de sécurité?
       delete_account: Supprimer votre compte
       delete_account_info: Supprimer votre compte existant et en créer un nouveau
-        vous permet d'utiliser la même adresse e-mail et de définir de nouvelles options
+        vous permet d’utiliser la même adresse e-mail et de définir de nouvelles options
         de sécurité. cependant, la suppression supprimera toutes les applications
-        d'agence que vous avez liées à votre compte et vous devrez restaurer chaque
-        connexion. <br> <br> Si vous continuez, vous recevra d'abord un email de confirmation.
+        d’agence que vous avez liées à votre compte et vous devrez restaurer chaque
+        connexion. <br> <br> Si vous continuez, vous recevra d’abord un email de confirmation.
         Par mesure de sécurité, vous devrez recevoir un autre e-mail avec le lien
-        pour continuer la suppression de votre compte 24 heures après l'email de confirmation
+        pour continuer la suppression de votre compte 24 heures après l’email de confirmation
         initial arrive.
       info: Si vous ne pouvez pas accéder à votre compte via les options de sécurité
         que vous avez définies auparavant, la suppression de votre compte et la création
-        d'un nouveau compte est la seule option.  <br><br> Nous ne pouvons pas annuler
-        un compte supprimer, alors s'il vous plaît assurez-vous que vous n'avez pas
+        d’un nouveau compte est la seule option.  <br><br> Nous ne pouvons pas annuler
+        un compte supprimer, alors s’il vous plaît assurez-vous que vous n’avez pas
         une autre option de sécurité que vous pouvez utiliser à la place.
       no_cancel: Non, annuler
       personal_key: Avez-vous votre clé personnelle?
       personal_key_info: Votre clé personnelle est un code de 16 caractères qui a
         été donné à vous à la création de compte comme une méthode de récupération
-        - voir l'exemple ci-dessous.
-      personal_key_trailer: Si vous avez votre clé personnelle, vous pouvez l'utiliser
+        - voir l’exemple ci-dessous.
+      personal_key_trailer: Si vous avez votre clé personnelle, vous pouvez l’utiliser
         pour %{link} au lieu de réinitialiser.
       title: Suppression de compte et réinitialisation
       yes_continue: Oui, continuez la suppression.

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -14,12 +14,12 @@ en:
       sign_in: Please sign in.
     failure:
       already_authenticated: ''
-      inactive: Your account hasn't been activated.
-      invalid_html: The email or password you've entered is wrong. Try %{link}.
+      inactive: Your account hasn’t been activated.
+      invalid_html: The email or password you’ve entered is wrong. Try %{link}.
       invalid_link_text: resetting your password
       last_attempt: You have one more attempt before your account is locked.
       locked: Your account has been locked.
-      not_found_in_database_html: The email or password you've entered is wrong. Try
+      not_found_in_database_html: The email or password you’ve entered is wrong. Try
         %{link}.
       not_found_in_database_link_text: resetting your password
       session_limited: Your login credentials were used in another browser. Please
@@ -34,8 +34,8 @@ en:
       choose_new_password: Choose a new password.
       invalid_token: The reset password token is invalid. Try again.
       no_token: To reset your password please use the link in the <strong>Password
-        Reset</strong> email you received. If you're pasting the link into your browser,
-        please make sure you've pasted the entire link.
+        Reset</strong> email you received. If you’re pasting the link into your browser,
+        please make sure you’ve pasted the entire link.
       send_instructions: You will receive an email with instructions on how to reset
         your password in a few minutes.
       send_paranoid_instructions: You will receive an email with instructions on how
@@ -45,7 +45,7 @@ en:
       updated_not_active: Your password has been changed. Please sign in with your
         new password.
     registrations:
-      close_window: You can close this window if you're done.
+      close_window: You can close this window if you’re done.
       destroyed: Your account has been successfully deleted.
       phone_update_needs_confirmation: Your request to update your phone configuration
         was processed, but we need to confirm your new number before you can use it.

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -7,20 +7,20 @@ fr:
       confirmed_but_must_set_password: Vous avez confirmé votre adresse courriel
       confirmed_but_remove_from_other_account: Cette adresse électronique est déjà
         associée à un compte login.gov, nous ne pouvons donc pas l’ajouter à un autre
-        compte. Vous devez d'abord le supprimer ou le supprimer du compte auquel il
+        compte. Vous devez d’abord le supprimer ou le supprimer du compte auquel il
         est associé. Pour ce faire, connectez-vous avec cette adresse e-mail.
       confirmed_but_sign_in: Vous avez confirmé votre adresse email. Veuillez vous
         connecter pour voir votre profil.
       sign_in: Veuillez vous connecter de nouveau.
     failure:
       already_authenticated: ''
-      inactive: Votre compte n'est pas encore activé.
-      invalid_html: L'adresse courriel ou le mot de passe que vous avez entré est
+      inactive: Votre compte n’est pas encore activé.
+      invalid_html: L’adresse courriel ou le mot de passe que vous avez entré est
         erroné. Essayez de %{link}.
       invalid_link_text: réinitialiser votre mot de passe
       last_attempt: Il vous reste un essai avant que votre compte ne soit verrouillé.
       locked: Votre compte est maintenant verrouillé.
-      not_found_in_database_html: L'adresse courriel ou le mot de passe que vous avez
+      not_found_in_database_html: L’adresse courriel ou le mot de passe que vous avez
         entré est erroné. Essayez de %{link}.
       not_found_in_database_link_text: réinitialiser votre mot de passe
       session_limited: Vos authentifiants ont été utilisés dans un autre navigateur.
@@ -35,10 +35,10 @@ fr:
         subject: Votre mot de passe a été modifié
     passwords:
       choose_new_password: Choisissez un nouveau mot de passe.
-      invalid_token: Le jeton de réinitialisation de mot de passe n'est pas valide.
+      invalid_token: Le jeton de réinitialisation de mot de passe n’est pas valide.
         Veuillez essayer de nouveau.
       no_token: Vous ne pouvez accéder à cette page que depuis un courriel de réinitialisation
-        de mot de passe. Si vous avez été redirigé à partir d'un courriel de réinitialisation
+        de mot de passe. Si vous avez été redirigé à partir d’un courriel de réinitialisation
         de mot de passe, veuillez vous assurer que vous avez utilisé le lien fourni
         complet.
       send_instructions: Vous recevrez dans quelques instants un courriel avec des
@@ -54,14 +54,14 @@ fr:
       close_window: Vous pouvez fermer cette fenêtre si vous avez terminé.
       destroyed: Votre compte a bien été supprimé.
       phone_update_needs_confirmation: Votre demande de mise à jour de votre numéro
-        de téléphone a été traitée, mais nous devons d'abord confirmer votre nouveau
+        de téléphone a été traitée, mais nous devons d’abord confirmer votre nouveau
         numéro. Veuillez suivre les instructions ci-dessous. Si vous ne confirmez
-        pas votre nouveau numéro, nous continuerons d'utiliser votre ancien numéro
+        pas votre nouveau numéro, nous continuerons d’utiliser votre ancien numéro
         de téléphone.
       start:
         accordion: Vous aurez aussi besoin
         bullet_1_html: Une <strong>adresse e-mail</strong>.
-        bullet_2_html: Activez <strong>l'authentification à deux facteurs</strong>.
+        bullet_2_html: Activez <strong>l’authentification à deux facteurs</strong>.
         bullet_3_html: Pour fournir des <strong>informations de base</strong>, telles
           que votre nom, adresse et numéro de téléphone.
         bullet_4_html: Votre <strong>numéro de Sécurité Sociale</strong>.
@@ -69,7 +69,7 @@ fr:
           de téléphone ou adresse postale où vous recevez du courrier électronique</strong>.
         bullet_6_html: Lorsque vous avez terminé ce processus, nous allons vous donner
           un <strong>clé personnelle</strong>. Ecrivez-le et rangez-le dans un endroit
-          sûr. C'est important. La clé personnelle vous sera demandée chaque fois
+          sûr. C’est important. La clé personnelle vous sera demandée chaque fois
           que vous apportez des modifications à votre compte.
         learn_more: En savoir plus sur la vérification de votre identité
     sessions:

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -14,68 +14,68 @@ en:
       use_phone: Use your phone
     errors:
       alerts:
-        barcode_content_check: We couldn't read the barcode on the back of your ID.
+        barcode_content_check: We couldn’t read the barcode on the back of your ID.
           It could be because of a problem with the barcode, or the barcode is a new
-          type that we don't recognize yet. Use another state-issued ID if you have
+          type that we don’t recognize yet. Use another state-issued ID if you have
           one.
-        barcode_read_check: We couldn't read the barcode on the back of your ID. Try
+        barcode_read_check: We couldn’t read the barcode on the back of your ID. Try
           taking a new picture.
         birth_date_checks: We couldn’t read the birth date on your ID. Try taking
           new pictures.
-        control_number_check: We couldn't read the reference number on the back of
+        control_number_check: We couldn’t read the reference number on the back of
           your ID. Try taking a new picture.
         doc_crosscheck: We couldn’t recognize your ID. It may be worn or damaged,
-          or the front and the back of the ID don't match. Try taking new pictures.
+          or the front and the back of the ID don’t match. Try taking new pictures.
         doc_number_checks: We couldn’t read the document number on your ID. Try taking
           new pictures.
-        expiration_checks: The document has expired, or we couldn't read the expiration
+        expiration_checks: The document has expired, or we couldn’t read the expiration
           date on your ID. If your ID is not expired, try taking new pictures.
-        full_name_check: We couldn't read the full name on your ID. Try taking new
+        full_name_check: We couldn’t read the full name on your ID. Try taking new
           pictures.
         id_not_recognized: We couldn’t recognize your ID. It may be worn, damaged,
           or a type of ID that we don’t recognize. Try taking new pictures.
-        id_not_verified: We couldn't verify your ID. It might have moved when you
+        id_not_verified: We couldn’t verify your ID. It might have moved when you
           took the picture. Try taking new pictures.
-        issue_date_checks: We couldn't read the issue date on your ID. Try taking
+        issue_date_checks: We couldn’t read the issue date on your ID. Try taking
           new pictures.
-        ref_control_number_check: We couldn't read the control number barcode. Try
+        ref_control_number_check: We couldn’t read the control number barcode. Try
           taking new pictures.
-        selfie_failure: We couldn't match the photo of you to your ID. Try taking
+        selfie_failure: We couldn’t match the photo of you to your ID. Try taking
           a new picture of yourself or the front of your ID.
-        sex_check: We couldn't read the sex on your ID. Try taking new pictures.
-        visible_color_check: We couldn't verify your ID. It might have moved when
+        sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
+        visible_color_check: We couldn’t verify your ID. It might have moved when
           you took the picture, or the picture is too dark. Try taking new pictures
           in brighter lighting.
-        visible_photo_check: We couldn't verify the photo on your ID. Try taking new
+        visible_photo_check: We couldn’t verify the photo on your ID. Try taking new
           pictures.
       camera:
         blocked: Your camera is blocked
         failed: Camera failed to start, please try again.
       dpi:
-        top_msg: We couldn't read your ID. Your image size may be too small, or your
+        top_msg: We couldn’t read your ID. Your image size may be too small, or your
           ID is too small or blurry in the photo. Make sure your ID is large within
           the image frame and try taking a new picture.
-        top_msg_plural: We couldn't read your ID. Your image sizes may be too small,
+        top_msg_plural: We couldn’t read your ID. Your image sizes may be too small,
           or your ID is too small or blurry in the photos. Make sure your ID is large
           within the image frame and try taking new pictures.
       file_type:
         invalid: This file type is not accepted, please choose a JPG, PNG, BMP, or
           TIFF file.
       general:
-        liveness: We couldn't verify your ID and photo of yourself. Try taking new
+        liveness: We couldn’t verify your ID and photo of yourself. Try taking new
           pictures.
-        multiple_back_id_failures: We couldn't verify the back of your ID. Try taking
+        multiple_back_id_failures: We couldn’t verify the back of your ID. Try taking
           a new picture.
-        multiple_front_id_failures: We couldn't verify the front of your ID. Try taking
+        multiple_front_id_failures: We couldn’t verify the front of your ID. Try taking
           a new picture.
         network_error: We are having technical difficulties on our end. Please try
           to submit your images again later.
-        no_liveness: We couldn't verify your ID. Try taking new pictures.
+        no_liveness: We couldn’t verify your ID. Try taking new pictures.
       glare:
         failed_short: Image has glare, please try again.
-        top_msg: We couldn't read your ID. Your photo may have glare. Make sure that
+        top_msg: We couldn’t read your ID. Your photo may have glare. Make sure that
           the flash on your camera is off and try taking a new picture.
-        top_msg_plural: We couldn't read your ID. Your photos may have glare. Make
+        top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make
           sure that the flash on your camera is off and try taking new pictures.
       no_camera:
         explanation: To continue, sign in to your login.gov account on any device
@@ -87,9 +87,9 @@ en:
         birth_date_min_age: Your birthday does not meet the minimum age requirement.
       sharpness:
         failed_short: Image is blurry, please try again.
-        top_msg: We couldn't read your ID. Your photo may be too blurry or dark. Try
+        top_msg: We couldn’t read your ID. Your photo may be too blurry or dark. Try
           taking a new picture in a bright area.
-        top_msg_plural: We couldn't read your ID. Your photos may be too blurry or
+        top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or
           dark. Try taking new pictures in a bright area.
       upload_error: Sorry, something went wrong on our end.
     forms:
@@ -118,7 +118,7 @@ en:
       document_capture_selfie: Your photo
       front: Front
       interstitial: We are processing your images
-      lets_go: Let's get started
+      lets_go: Let’s get started
       photo: Photo
       review_issues: Check your images and try again
       secure_account: Secure your account
@@ -161,24 +161,24 @@ en:
       privacy_html: Login.gov is a secure, government website that adheres to the
         highest standards in data protection. We only use your data to verify your
         identity. %{link} about our privacy and security measures.
-      secure_account: After you verify, we'll ask you to encrypt your account. Encryption
+      secure_account: After you verify, we’ll ask you to encrypt your account. Encryption
         means your data is protected and only you, the account holder, will be able
         to access or change your information.
       tag: Recommended
       take_picture: Use the camera on your mobile phone and upload images of your
         ID.  We only use the images to verify your identity.
-      upload: We'll collect information about you by reading your state-issued ID.
+      upload: We’ll collect information about you by reading your state-issued ID.
       upload_computer_link: Upload from your computer
-      upload_from_computer: Don't have a phone?
+      upload_from_computer: Don’t have a phone?
       upload_from_computer_not_allowed: Sign in to your login.gov account on any device
         that has a camera, like a tablet or computer with a webcam.
       upload_from_phone: Upload pictures directly from your phone camera
-      upload_liveness_enabled: We'll collect information about you by reading your
-        state-issued ID. Then, you'll take a photo of yourself to confirm that you
+      upload_liveness_enabled: We’ll collect information about you by reading your
+        state-issued ID. Then, you’ll take a photo of yourself to confirm that you
         are the owner of the ID.
       upload_no_image_storage: We do not store images you upload. We only verify your
         identity.
-      verify_identity: We'll ask for your personal information. We'll use, keep and
+      verify_identity: We’ll ask for your personal information. We’ll use, keep and
         share some of your personal information to verify your identity against public
         records.
       verifying: Verifying…
@@ -195,19 +195,19 @@ en:
         and look for a notification in your browser or check your system settings
         to confirm camera access."
       document_capture_selfie_consent_banner: login.gov needs permission to use your
-        device's camera
+        device’s camera
       document_capture_selfie_consent_blocked: login.gov needs permission to use your
         camera so that you can prove your ID belongs to you.
-      document_capture_selfie_consent_blocked_action: Check your web browser's settings
-        for this site or your computer's system settings to allow login.gov to access
+      document_capture_selfie_consent_blocked_action: Check your web browser’s settings
+        for this site or your computer’s system settings to allow login.gov to access
         the camera.
-      document_capture_selfie_instructions: Now take a picture of yourself. We'll
+      document_capture_selfie_instructions: Now take a picture of yourself. We’ll
         compare it to the image on the front of your ID.
       email_sent: Link sent to %{email}. Please check your desktop email and follow
         instructions to verify your identity.
       learn_more: Learn more
       privacy: Our privacy and security standards
-      send_sms: We'll send a text message to your device with a link.  Follow that
+      send_sms: We’ll send a text message to your device with a link.  Follow that
         link to your browser to take photos of the front and back of your ID.
       switch_back: Switch back to your computer to finish verifying your identity
       text1: ''

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -171,7 +171,7 @@ es:
         de la identificación emitida por su estado.
       link_sent_complete_js: El siguiente paso se cargará automáticamente una vez
         que verifiques tu identidad a través de tu teléfono.
-      link_sent_complete_nojs: Cuando termines, haz clic en "Continuar" para completar
+      link_sent_complete_nojs: Cuando termines, haz clic en “Continuar” para completar
         la verificación de tu identidad.
       privacy_html: Login.gov es un sitio web gubernamental seguro que cumple con
         las normas más estrictas de protección de datos. Solo utilizamos sus datos

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -14,102 +14,102 @@ fr:
       use_phone: Utilisez votre téléphone
     errors:
       alerts:
-        barcode_content_check: Nous n'avons pas pu lire le code-barres au verso de
-          votre carte d'identité. Cela pourrait être dû à un problème avec le code-barres,
-          ou le code-barres est d'un type nouveau que nous ne reconnaissons pas encore.
-          Utilisez une autre carte d'identité délivrée par l'État si vous en avez
+        barcode_content_check: Nous n’avons pas pu lire le code-barres au verso de
+          votre carte d’identité. Cela pourrait être dû à un problème avec le code-barres,
+          ou le code-barres est d’un type nouveau que nous ne reconnaissons pas encore.
+          Utilisez une autre carte d’identité délivrée par l’État si vous en avez
           une.
-        barcode_read_check: Nous n'avons pas pu lire le code-barres au verso de votre
-          carte d'identité. Essayez de prendre une nouvelle photo.
-        birth_date_checks: Nous n'avons pas pu lire la date de naissance sur votre
-          pièce d'identité. Essayez de prendre de nouvelles photos.
-        control_number_check: Nous n'avons pas pu lire le numéro de référence au verso
-          de votre carte d'identité. Essayez de prendre une nouvelle photo.
-        doc_crosscheck: Nous n'avons pas pu reconnaître votre pièce d'identité. Il
-          se peut qu'elle soit usée ou endommagée, ou que le recto et le verso de
-          la carte d'identité ne correspondent pas. Essayez de prendre de nouvelles
+        barcode_read_check: Nous n’avons pas pu lire le code-barres au verso de votre
+          carte d’identité. Essayez de prendre une nouvelle photo.
+        birth_date_checks: Nous n’avons pas pu lire la date de naissance sur votre
+          pièce d’identité. Essayez de prendre de nouvelles photos.
+        control_number_check: Nous n’avons pas pu lire le numéro de référence au verso
+          de votre carte d’identité. Essayez de prendre une nouvelle photo.
+        doc_crosscheck: Nous n’avons pas pu reconnaître votre pièce d’identité. Il
+          se peut qu’elle soit usée ou endommagée, ou que le recto et le verso de
+          la carte d’identité ne correspondent pas. Essayez de prendre de nouvelles
           photos.
-        doc_number_checks: Nous n'avons pas pu lire le numéro du document sur votre
-          carte d'identité. Essayez de prendre de nouvelles photos.
-        expiration_checks: Le document a expiré ou nous n'avons pas pu lire la date
-          d'expiration sur votre carte d'identité. Si votre pièce d'identité n'est
+        doc_number_checks: Nous n’avons pas pu lire le numéro du document sur votre
+          carte d’identité. Essayez de prendre de nouvelles photos.
+        expiration_checks: Le document a expiré ou nous n’avons pas pu lire la date
+          d’expiration sur votre carte d’identité. Si votre pièce d’identité n’est
           pas expirée, essayez de prendre de nouvelles photos.
-        full_name_check: Nous n'avons pas pu lire le nom complet sur votre pièce d'identité.
+        full_name_check: Nous n’avons pas pu lire le nom complet sur votre pièce d’identité.
           Essayez de prendre de nouvelles photos.
-        id_not_recognized: Nous n'avons pas pu reconnaître votre pièce d'identité.
-          Elle est peut-être usée ou endommagée, ou bien il s'agit d'un type de carte
-          d'identité que nous ne reconnaissons pas. Essayez de prendre de nouvelles
+        id_not_recognized: Nous n’avons pas pu reconnaître votre pièce d’identité.
+          Elle est peut-être usée ou endommagée, ou bien il s’agit d’un type de carte
+          d’identité que nous ne reconnaissons pas. Essayez de prendre de nouvelles
           photos.
-        id_not_verified: Nous n'avons pas pu vérifier votre pièce d'identité. Il se
-          peut qu'elle ait bougé lorsque vous avez pris la photo. Essayez de prendre
+        id_not_verified: Nous n’avons pas pu vérifier votre pièce d’identité. Il se
+          peut qu’elle ait bougé lorsque vous avez pris la photo. Essayez de prendre
           de nouvelles photos.
-        issue_date_checks: Nous n'avons pas pu lire la date d'émission sur votre pièce
-          d'identité. Essayez de prendre de nouvelles photos.
-        ref_control_number_check: Nous n'avons pas pu lire le code-barres du numéro
+        issue_date_checks: Nous n’avons pas pu lire la date d’émission sur votre pièce
+          d’identité. Essayez de prendre de nouvelles photos.
+        ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro
           de contrôle. Essayez de prendre de nouvelles photos.
-        selfie_failure: Nous n'avons pas pu associer votre photo à votre pièce d'identité.
+        selfie_failure: Nous n’avons pas pu associer votre photo à votre pièce d’identité.
           Essayez de prendre une nouvelle photo de vous-même ou du recto de votre
-          carte d'identité.
-        sex_check: Nous n'avons pas pu lire le sexe sur votre pièce d'identité. Essayez
+          carte d’identité.
+        sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
-        visible_color_check: Nous n'avons pas pu vérifier votre pièce d'identité.
+        visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité.
           Elle a peut-être bougé lorsque vous avez pris la photo, ou la photo est
           trop sombre. Essayez de prendre de nouvelles photos avec un éclairage plus
           fort.
-        visible_photo_check: Nous n'avons pas pu vérifier la photo sur votre pièce
-          d'identité. Essayez de prendre de nouvelles photos.
+        visible_photo_check: Nous n’avons pas pu vérifier la photo sur votre pièce
+          d’identité. Essayez de prendre de nouvelles photos.
       camera:
         blocked: Votre caméra est bloquée
-        failed: L'appareil photo n'a pas réussi à démarrer, veuillez réessayer.
+        failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
       dpi:
-        top_msg: Nous n'avons pas pu lire votre pièce d'identité. La taille de votre
-          image est peut-être trop petite ou il se peut que votre pièce d'identité
+        top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre
+          image est peut-être trop petite ou il se peut que votre pièce d’identité
           soit trop petite ou floue sur la photo. Assurez-vous que la taille de votre
-          pièce d'identité est grande et qu'elle est située dans le cadre de l'image
+          pièce d’identité est grande et qu’elle est située dans le cadre de l’image
           puis essayez de prendre une nouvelle photo.
-        top_msg_plural: Nous n'avons pas pu lire votre pièce d'identité. La taille
-          de vos images est peut-être trop petite ou il se peut que votre pièce d'identité
+        top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. La taille
+          de vos images est peut-être trop petite ou il se peut que votre pièce d’identité
           soit trop petite ou floue sur les photos. Assurez-vous que la taille de
-          votre pièce d'identité est grande et qu'elle est située dans le cadre de
-          l'image puis essayez de prendre des nouvelles photos.
+          votre pièce d’identité est grande et qu’elle est située dans le cadre de
+          l’image puis essayez de prendre des nouvelles photos.
       file_type:
-        invalid: Ce type de fichier n'est pas accepté, veuillez choisir un fichier
+        invalid: Ce type de fichier n’est pas accepté, veuillez choisir un fichier
           JPG, PNG, BMP ou TIFF.
       general:
-        liveness: Nous n'avons pas pu vérifier votre pièce d'identité et votre photo.
+        liveness: Nous n’avons pas pu vérifier votre pièce d’identité et votre photo.
           Essayez de prendre de nouvelles photos.
-        multiple_back_id_failures: Nous n'avons pas pu vérifier le verso de votre
-          pièce d'identité. Essayez de prendre une nouvelle photo.
-        multiple_front_id_failures: Nous n'avons pas pu vérifier le recto de votre
-          pièce d'identité. Essayez de prendre une nouvelle photo.
+        multiple_back_id_failures: Nous n’avons pas pu vérifier le verso de votre
+          pièce d’identité. Essayez de prendre une nouvelle photo.
+        multiple_front_id_failures: Nous n’avons pas pu vérifier le recto de votre
+          pièce d’identité. Essayez de prendre une nouvelle photo.
         network_error: Nous avons des difficultés techniques de notre côté. Veuillez
           essayer de soumettre à nouveau vos images plus tard.
-        no_liveness: Nous n'avons pas pu vérifier votre pièce d'identité. Essayez
+        no_liveness: Nous n’avons pas pu vérifier votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
       glare:
-        failed_short: L'image a des reflets, veuillez réessayer.
-        top_msg: Nous n'avons pas pu lire votre pièce d'identité. Votre photo peut
+        failed_short: L’image a des reflets, veuillez réessayer.
+        top_msg: Nous n’avons pas pu lire votre pièce d’identité. Votre photo peut
           avoir des reflets. Assurez-vous que le flash de votre appareil photo est
           désactivé puis essayez de prendre une nouvelle photo.
-        top_msg_plural: Nous n'avons pas pu lire votre pièce d'identité. Vos photos
+        top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Vos photos
           peuvent avoir des reflets. Assurez-vous que le flash de votre appareil photo
           est désactivé puis essayez de prendre de nouvelles photos.
       no_camera:
         explanation: Nous recueillons des informations vous concernant en lisant votre
-          carte d'identité délivrée par l'État. Ensuite, vous prendrez une photo de
+          carte d’identité délivrée par l’État. Ensuite, vous prendrez une photo de
           vous-même pour confirmer que vous êtes bien le propriétaire de la carte
-          d'identité.
-        heading: Vous avez besoin d'une caméra pour vérifier votre identité
+          d’identité.
+        heading: Vous avez besoin d’une caméra pour vérifier votre identité
         title: Appareil photo nécessaire
-      not_a_file: La sélection n'était pas un fichier valide.
+      not_a_file: La sélection n’était pas un fichier valide.
       pii:
-        birth_date_min_age: Votre anniversaire ne correspond pas à l'âge minimum requis.
+        birth_date_min_age: Votre anniversaire ne correspond pas à l’âge minimum requis.
       sharpness:
-        failed_short: L'image est floue, veuillez réessayer.
-        top_msg: Nous n'avons pas pu lire votre pièce d'identité. Votre photo est
+        failed_short: L’image est floue, veuillez réessayer.
+        top_msg: Nous n’avons pas pu lire votre pièce d’identité. Votre photo est
           peut-être trop floue ou trop sombre. Essayez de prendre une nouvelle photo
           dans un endroit lumineux.
-        top_msg_plural: Nous n'avons pas pu lire votre pièce d'identité. Vos photos
+        top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Vos photos
           sont peut-être trop floues ou trop sombres. Essayez de prendre de nouvelles
           photos dans un endroit lumineux.
       upload_error: Désolé, quelque chose a mal tourné de notre côté.
@@ -130,13 +130,13 @@ fr:
     headings:
       address: Adresse mail
       back: Verso
-      capture_complete: Nous avons vérifié votre carte d'identité délivrée par l'État
-      document_capture: Ajoutez votre carte d'identité délivrée par l'État
-      document_capture_back: Verso de votre carte d'identité
-      document_capture_front: Recto de votre carte d'identité
-      document_capture_heading_html: Téléchargez votre pièce d'identité délivrée par
-        l'État
-      document_capture_heading_with_selfie_html: Téléchargez votre pièce d'identité
+      capture_complete: Nous avons vérifié votre carte d’identité délivrée par l’État
+      document_capture: Ajoutez votre carte d’identité délivrée par l’État
+      document_capture_back: Verso de votre carte d’identité
+      document_capture_front: Recto de votre carte d’identité
+      document_capture_heading_html: Téléchargez votre pièce d’identité délivrée par
+        l’État
+      document_capture_heading_with_selfie_html: Téléchargez votre pièce d’identité
         officielle et une photo de vous
       document_capture_selfie: Votre photo
       front: Recto
@@ -146,17 +146,17 @@ fr:
       review_issues: Vérifiez vos images et essayez à nouveau
       secure_account: Sécuriser votre compte
       selfie: Prenez une photo de vous-même
-      ssn: S'il vous plaît entrez votre numéro de sécurité sociale.
+      ssn: S’il vous plaît entrez votre numéro de sécurité sociale.
       take_picture: Prendre une photo avec un téléphone
       text_message: Nous avons envoyé un message à votre téléphone
-      upload: Comment souhaitez-vous télécharger votre carte d'identité délivrée par
-        l'État?
+      upload: Comment souhaitez-vous télécharger votre carte d’identité délivrée par
+        l’État?
       upload_from_phone: Prenez une photo avec un téléphone portable pour télécharger
-        votre pièce d'identité
+        votre pièce d’identité
       upload_from_phone_liveness_enabled: Utilisez un téléphone portable pour ajouter
-        votre pièce d'identité et prendre une photo de vous-même
+        votre pièce d’identité et prendre une photo de vous-même
       upload_liveness_enabled: Comment souhaitez-vous vérifier votre identité?
-      verify: S'il vous plaît vérifier vos informations
+      verify: S’il vous plaît vérifier vos informations
       verify_identity: Vérifier votre identité
       welcome: Vérifiez votre identité pour accéder en toute sécurité aux services
         gouvernementaux
@@ -168,26 +168,26 @@ fr:
       capture_status_small_document: Approchez-vous
       capture_status_tap_to_capture: Appuyez pour capturer
       document_capture_intro_acknowledgment: Nous collecterons des informations sur
-        vous en lisant votre pièce d'identité officielle. Nous ne stockons pas les
+        vous en lisant votre pièce d’identité officielle. Nous ne stockons pas les
         images que vous téléchargez. Nous vérifions uniquement votre identité.
-      document_capture_upload_image: Nous n'utilisons votre identifiant que pour vérifier
-        votre identité, et nous n'enregistrerons aucune image.
-      get_help_at_sp_html: "<strong>Vous avez des problèmes?</strong> Obtenez de l'aide
+      document_capture_upload_image: Nous n’utilisons votre identifiant que pour vérifier
+        votre identité, et nous n’enregistrerons aucune image.
+      get_help_at_sp_html: "<strong>Vous avez des problèmes?</strong> Obtenez de l’aide
         à %{sp_name}"
       image_updated: Image mise à jour
-      interstitial_eta: Cette opération peut prendre jusqu'à une minute. Nous chargerons
-        automatiquement l'étape suivante lorsqu'elle sera terminée.
+      interstitial_eta: Cette opération peut prendre jusqu’à une minute. Nous chargerons
+        automatiquement l’étape suivante lorsqu’elle sera terminée.
       interstitial_thanks: Merci de votre patience!
       keep_window_open: Ne fermez pas cette fenêtre.
-      lets_go: La vérification de l'identité se fait en deux temps
+      lets_go: La vérification de l’identité se fait en deux temps
       link_sent: Veuillez vérifier votre téléphone et suivre les instructions pour
-        prendre une photo de votre identité émise par l'État.
-      link_sent_complete_js: L'étape suivante se chargera automatiquement une fois
-        que vous aurez confirmé votre identifiant à l'aide de votre téléphone.
+        prendre une photo de votre identité émise par l’État.
+      link_sent_complete_js: L’étape suivante se chargera automatiquement une fois
+        que vous aurez confirmé votre identifiant à l’aide de votre téléphone.
       link_sent_complete_nojs: Quand vous aurez fini, cliquez sur « Continuer » ici
         pour terminer la vérification de votre identité.
       privacy_html: Login.gov est un site gouvernemental sécurisé qui respecte les
-        normes les plus strictes en matière de protection des données. Nous n'utilisons
+        normes les plus strictes en matière de protection des données. Nous n’utilisons
         vos données uniquement pour vérifier votre identité. %{link} sur nos mesures
         de confidentialité et de sécurité.
       secure_account: Après avoir vérifié votre identité, nous vous demanderons de
@@ -195,50 +195,50 @@ fr:
         seul vous, le titulaire du compte, pourrez accéder à vos informations ou les
         modifier.
       tag: Recommandation
-      take_picture: Utilisez l'appareil photo sur votre téléphone portable et téléchargez
+      take_picture: Utilisez l’appareil photo sur votre téléphone portable et téléchargez
         des images de votre identifiant. Nous utilisons uniquement les images pour
         vérifier votre identité.
       upload: Nous recueillons des informations vous concernant en lisant votre carte
-        d'identité délivrée par l'État.
+        d’identité délivrée par l’État.
       upload_computer_link: Téléchargez depuis votre ordinateur
-      upload_from_computer: Vous n'avez pas de téléphone?
+      upload_from_computer: Vous n’avez pas de téléphone?
       upload_from_computer_not_allowed: Connectez-vous à votre compte login.gov sur
-        tout appareil doté d'une caméra, comme une tablette ou un ordinateur avec
+        tout appareil doté d’une caméra, comme une tablette ou un ordinateur avec
         une caméra Web.
-      upload_from_phone: Téléchargez des images directement depuis l'appareil photo
+      upload_from_phone: Téléchargez des images directement depuis l’appareil photo
         de votre téléphone
       upload_liveness_enabled: Nous recueillons des informations sur vous en lisant
-        votre carte d'identité délivrée par l'État. Ensuite, vous prendrez une photo
+        votre carte d’identité délivrée par l’État. Ensuite, vous prendrez une photo
         de vous-même pour confirmer que vous êtes bien le propriétaire de la carte
-        d'identité.
+        d’identité.
       upload_no_image_storage: Nous ne stockons pas les images que vous téléchargez.
       verify_identity: Nous vous demanderons vos renseignements personnels. Nous utiliserons,
         conserverons et partagerons certains de vos renseignements personnels pour
         vérifier votre identité par rapport aux registres publics.
       verifying: Vérification…
-      welcome_html: L'agence à laquelle vous essayez d'accéder doit s'assurer qu'il
-        s'agit bien de vous, et non de quelqu'un qui se fait passer pour vous.
+      welcome_html: L’agence à laquelle vous essayez d’accéder doit s’assurer qu’il
+        s’agit bien de vous, et non de quelqu’un qui se fait passer pour vous.
     instructions:
-      bullet1: Votre carte d'identité émise par l'État
-      bullet1a: Un appareil équipé d'une caméra
+      bullet1: Votre carte d’identité émise par l’État
+      bullet1a: Un appareil équipé d’une caméra
       bullet2: Votre numéro de sécurité sociale
       bullet3: Un numéro de téléphone associé à un forfait téléphonique à votre nom
       consent: En cochant cette case, vous autorisez login.gov à demander, utiliser,
         conserver et partager vos renseignements personnels. Nous ne les utiliserons
         que pour vérifier votre identité.
-      document_capture_selfie_consent_action: "<lg-underline>Autorisez l'accès à la
+      document_capture_selfie_consent_action: "<lg-underline>Autorisez l’accès à la
         caméra</lg-underline> et recherchez une notification dans votre navigateur
-        ou vérifiez les paramètres de votre système pour confirmer l'accès à la caméra."
-      document_capture_selfie_consent_banner: login.gov a besoin d'une autorisation
+        ou vérifiez les paramètres de votre système pour confirmer l’accès à la caméra."
+      document_capture_selfie_consent_banner: login.gov a besoin d’une autorisation
         pour utiliser la caméra de votre appareil
-      document_capture_selfie_consent_blocked: login.gov a besoin d'une autorisation
+      document_capture_selfie_consent_blocked: login.gov a besoin d’une autorisation
         pour utiliser votre caméra afin que vous puissiez prouver que votre identifiant
         vous appartient.
       document_capture_selfie_consent_blocked_action: Vérifiez les paramètres de votre
         navigateur Web pour ce site ou les paramètres système de votre ordinateur
-        pour permettre à login.gov d'accéder à la caméra.
+        pour permettre à login.gov d’accéder à la caméra.
       document_capture_selfie_instructions: Maintenant, prenez une photo de vous.
-        Nous le comparerons à l'image au recto de votre pièce d'identité.
+        Nous le comparerons à l’image au recto de votre pièce d’identité.
       email_sent: Lien envoyé à %{email}. Veuillez vérifier votre email de bureau
         et suivez les instructions pour vérifier votre identité.
       learn_more: En savoir plus
@@ -249,9 +249,9 @@ fr:
       switch_back: Revenez sur votre ordinateur pour terminer la vérification de votre
         identité
       text1: ''
-      text1a: tel qu'un téléphone ou un ordinateur
-      text2: Vous n'aurez pas besoin de la carte avec vous.
-      text3: Il n'est pas nécessaire que vous soyez le titulaire principal de la ligne.
+      text1a: tel qu’un téléphone ou un ordinateur
+      text2: Vous n’aurez pas besoin de la carte avec vous.
+      text3: Il n’est pas nécessaire que vous soyez le titulaire principal de la ligne.
         Si votre numéro de téléphone ne remplit pas les conditions requises, nous
         pouvons vous envoyer le code de vérification par courrier dans un délai de
         3 à 7 jours ouvrables.
@@ -261,19 +261,19 @@ fr:
       document_capture_hint: Doit être un JPG, BMP, PNG ou TIFF
       document_capture_id_text1: Utilisez un fond sombre
       document_capture_id_text2: Prenez la photo sur une surface plane
-      document_capture_id_text3: N'utilisez pas le flash de votre appareil photo
-      document_capture_id_text4: La taille du fichier doit être d'au moins 2 Mo
-      document_capture_selfie_text1: Faites face à l'appareil photo et assurez-vous
+      document_capture_id_text3: N’utilisez pas le flash de votre appareil photo
+      document_capture_id_text4: La taille du fichier doit être d’au moins 2 Mo
+      document_capture_selfie_text1: Faites face à l’appareil photo et assurez-vous
         que toute votre tête est visible sur la photo
       document_capture_selfie_text2: Prenez une photo avec un arrière-plan uni
       document_capture_selfie_text3: Ne pas porter de chapeau ou de lunettes
-      review_issues_id_header_text: 'Examinez les images de votre carte d''identité
-        délivrée par l''État:'
+      review_issues_id_header_text: 'Examinez les images de votre carte d’identité
+        délivrée par l’État:'
       review_issues_id_text1: Avez-vous utilisé un fond sombre?
       review_issues_id_text2: Avez-vous pris la photo sur une surface plane?
       review_issues_id_text3: Le flash de votre caméra est-il éteint?
       review_issues_id_text4: Tous les détails sont-ils nets et clairement visibles?
-      review_issues_selfie_header_text: 'Examinez l''auto-portrait:'
+      review_issues_selfie_header_text: 'Examinez l’auto-portrait:'
       review_issues_selfie_text1: Êtes-vous face à la caméra?
       review_issues_selfie_text2: Est-ce que vous avez toute la tête et le visage
         sur la photo?

--- a/config/locales/email_addresses/fr.yml
+++ b/config/locales/email_addresses/fr.yml
@@ -9,6 +9,6 @@ fr:
       bullet2: Vous ne recevrez pas de notifications de compte à cette adresse email
       confirm: Etes-vous sûr que vous voulez supprimer %{email}?
       failure: Impossible de supprimer cette adresse email.
-      success: L'adresse email a été supprimée.
+      success: L’adresse email a été supprimée.
       warning: Si vous supprimez votre adresse e-mail
     unconfirmed: "(non confirmé)"

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -55,16 +55,16 @@ en:
       invalid_type: This file type is not accepted, please try again.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
-    max_password_attempts_reached: You've entered too many incorrect passwords. You
-      can reset your password using the "Forgot your password?" link.
+    max_password_attempts_reached: You’ve entered too many incorrect passwords. You
+      can reset your password using the “Forgot your password?” link.
     messages:
       already_confirmed: was already confirmed, please try signing in
       blank: Please fill in this field.
       confirmation_code_incorrect: Incorrect code. Did you type it in correctly?
       confirmation_invalid_token: Invalid confirmation link. Either the link expired
         or you already confirmed your account.
-      confirmation_period_expired: Expired confirmation link. You can click "Resend
-        confirmation instructions" to get another one.
+      confirmation_period_expired: Expired confirmation link. You can click “Resend
+        confirmation instructions” to get another one.
       expired: has expired, please request a new one
       format_mismatch: Please match the requested format.
       gpo_otp_expired: Your confirmation code has expired. Please request another
@@ -74,9 +74,9 @@ en:
       invalid_calling_area: Calls to that phone number are not supported. Please try
         SMS if you have an SMS-capable phone.
       invalid_phone_number: The phone number entered is not valid.
-      invalid_sms_number: The phone number entered doesn't support text messaging.
+      invalid_sms_number: The phone number entered doesn’t support text messaging.
         Try the Phone call option.
-      invalid_voice_number: Invalid phone number. Check that you've entered the correct
+      invalid_voice_number: Invalid phone number. Check that you’ve entered the correct
         country code or area code.
       missing_field: Please fill in this field.
       must_have_us_country_code: Invalid phone number. Please make sure you enter
@@ -89,7 +89,7 @@ en:
         as an authenticator. Please use a different phone number.
       phone_unsupported: Sorry, we are unable to send SMS at this time. Please try
         the phone call option below, or use your personal key.
-      pwned_password: The password you entered is not safe. It's in a list of known
+      pwned_password: The password you entered is not safe. It’s in a list of known
         passwords exposed in data breaches.
       try_again: Please try again.
       unauthorized_authn_context: Unauthorized authentication context
@@ -110,7 +110,7 @@ en:
     webauthn_setup:
       already_registered: Security key already registered. Please try a different
         security key.
-      attestation_error: Sorry, but your security key doesn't appear to be a FIDO
+      attestation_error: Sorry, but your security key doesn’t appear to be a FIDO
         security key.  Please make sure your device is listed at https://fidoalliance.org/certification/fido-certified-products/
         and if you believe the error is ours, please contact us at hello@login.gov.
       general_error: There was an error adding your hardware security key. Please

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -57,7 +57,7 @@ es:
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.
-      Puede restablecer su contraseña usando el enlace "¿Olvidó su contraseña?".
+      Puede restablecer su contraseña usando el enlace “¿Olvidó su contraseña?”.
     messages:
       already_confirmed: ya estaba confirmado, por favor intente iniciar una sesión
       blank: Por favor, rellenar este campo.
@@ -65,7 +65,7 @@ es:
       confirmation_invalid_token: El enlace de confirmación no es válido. El enlace
         expiró o usted ya ha confirmado su cuenta.
       confirmation_period_expired: El enlace de confirmación expiró. Puede hacer clic
-        en "Reenviar instrucciones de confirmación" para obtener otro.
+        en “Reenviar instrucciones de confirmación” para obtener otro.
       expired: ha caducado, por favor solicite uno nuevo
       format_mismatch: Por favor, use el formato solicitado.
       gpo_otp_expired: Tu código de confirmación ha caducado. Vuelve a solicitar otra

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -2,40 +2,40 @@
 fr:
   errors:
     account_reset:
-      cancel_token_invalid: le jeton d'annulation n'est pas valide
-      cancel_token_missing: le jeton d'annulation est manquant
+      cancel_token_invalid: le jeton d’annulation n’est pas valide
+      cancel_token_missing: le jeton d’annulation est manquant
       granted_token_expired: Le lien pour supprimer votre compte login.gov a expiré.
         Veuillez créer une autre demande pour supprimer votre compte.
-      granted_token_invalid: Le lien de suppression de votre compte login.gov n'est
+      granted_token_invalid: Le lien de suppression de votre compte login.gov n’est
         pas valide. Veuillez réessayer en cliquant sur le lien dans votre e-mail.
-      granted_token_missing: Le lien de suppression de votre compte login.gov n'est
+      granted_token_missing: Le lien de suppression de votre compte login.gov n’est
         pas valide. Veuillez réessayer en cliquant sur le lien dans votre e-mail.
     capture_doc:
-      invalid_link: Ce lien a expiré ou n'est pas valide. Veuillez demander un autre
+      invalid_link: Ce lien a expiré ou n’est pas valide. Veuillez demander un autre
         lien pour vérifier votre identité sur un téléphone mobile.
     confirm_password_incorrect: Mot de passe incorrect.
     doc_auth:
       consent_form: Avant de pouvoir continuer, vous devez nous donner la permission.
         Veuillez cocher la case ci-dessous puis cliquez sur continuer.
       document_capture_cancelled: Vous avez annulé le téléchargement des photos de
-        votre pièce d'identité sur votre téléphone.
+        votre pièce d’identité sur votre téléphone.
       document_capture_info_html: |-
         <div class="bold">Veuillez vérifier que:</div>
         <ul>
         <li>Les images sont claires (non floues) et nettes</li>
-        <li>Aucun éblouissement, ombre ou reflet n'est présent</li>
-        <li>Votre identifiant n'a pas de code à barres endommagé</li>
-        <li>Votre pièce d'identité représente 80% de l'image globale</li>
-        <li>Votre pièce d'identité est sur un fond sombre et uni</li>
+        <li>Aucun éblouissement, ombre ou reflet n’est présent</li>
+        <li>Votre identifiant n’a pas de code à barres endommagé</li>
+        <li>Votre pièce d’identité représente 80% de l’image globale</li>
+        <li>Votre pièce d’identité est sur un fond sombre et uni</li>
         </ul>
       document_capture_info_with_selfie_html: |-
         <div class="bold">Veuillez vérifier que:</div>
         <ul>
         <li>Images are clear (not blurry) and in focus</li>
-        <li>Aucun éblouissement, ombre ou reflet n'est présent</li>
-        <li>Votre identifiant n'a pas de code à barres endommagé</li>
-        <li>Votre pièce d'identité représente 80% de l'image globale</li>
-        <li>Votre pièce d'identité est sur un fond sombre et uni</li>
+        <li>Aucun éblouissement, ombre ou reflet n’est présent</li>
+        <li>Votre identifiant n’a pas de code à barres endommagé</li>
+        <li>Votre pièce d’identité représente 80% de l’image globale</li>
+        <li>Votre pièce d’identité est sur un fond sombre et uni</li>
         <li>Votre selfie est pris dans une zone bien éclairée avec un arrière-plan uni</li>
         <li>Vous ne portez pas de chapeau ni de lunettes et votre tête est entièrement visible</li>
         </ul>
@@ -45,18 +45,18 @@ fr:
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
-        vérification d'identité. Veuillez contacter votre fournisseur de services
-        pour plus d'informations.
+        vérification d’identité. Veuillez contacter votre fournisseur de services
+        pour plus d’informations.
       send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
-        10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
+        10 minutes. Vous pouvez également cliquer sur recommencer et choisir d’utiliser
         votre ordinateur.
       throttled_heading: Nous n’avons pas pu vérifier votre identité et votre photo
       throttled_text_html: "<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
         votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier
         un document en ligne."
     file_input:
-      invalid_type: Ce type de fichier n'est pas accepté, veuillez réessayer.
-    invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
+      invalid_type: Ce type de fichier n’est pas accepté, veuillez réessayer.
+    invalid_authenticity_token: Oups, une erreur s’est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects
@@ -65,7 +65,7 @@ fr:
     messages:
       already_confirmed: a déjà été confirmé, veuillez essayer de vous connecter
       blank: Veuillez remplir ce champ.
-      confirmation_code_incorrect: Code non valide. L'avez-vous inscrit correctement?
+      confirmation_code_incorrect: Code non valide. L’avez-vous inscrit correctement?
       confirmation_invalid_token: Lien de confirmation non valide. Le lien est expiré
         ou vous avez déjà confirmé votre compte.
       confirmation_period_expired: Lien de confirmation expiré. Vous pouvez cliquer
@@ -74,45 +74,45 @@ fr:
       expired: est expiré, veuillez en demander un nouveau
       format_mismatch: Veuillez vous assurer de respecter le format requis.
       gpo_otp_expired: Votre code de confirmation a expiré. Veuillez solliciter une
-        autre lettre afin d'obtenir un nouveau code.
+        autre lettre afin d’obtenir un nouveau code.
       improbable_phone: Numéro de téléphone non valide. Veillez à saisir un numéro
         de téléphone valide.
       invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris
         en charge. Veuillez essayer par SMS si vous possédez un téléphone disposant
         de cette fonction.
-      invalid_phone_number: Le numéro de téléphone saisi n'est pas valide.
+      invalid_phone_number: Le numéro de téléphone saisi n’est pas valide.
       invalid_sms_number: Le numéro de téléphone saisi ne prend pas en charge les
-        messages textuels. Veuillez essayer l'option d'appel téléphonique.
+        messages textuels. Veuillez essayer l’option d’appel téléphonique.
       invalid_voice_number: Numéro de téléphone invalide. Vérifiez que vous avez entré
         le bon indicatif international ou régional.
       missing_field: Veuillez remplir ce champ.
       must_have_us_country_code: Numéro de téléphone non valide. Veuillez vous assurer
         de saisir un numéro de téléphone avec un code pays des États-Unis.
       no_pending_profile: Aucun profil en attente de vérification
-      otp_failed: Échec de l'envoi de votre code de sécurité.
+      otp_failed: Échec de l’envoi de votre code de sécurité.
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
       phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez
-        entré en tant qu'authentificateur. Veuillez utiliser un numéro de téléphone
+        entré en tant qu’authentificateur. Veuillez utiliser un numéro de téléphone
         différent.
-      phone_unsupported: Désolé, nous ne sommes pas en mesure d'envoyer des SMS pour
-        le moment. S'il vous plaît essayez l'option d'appel téléphonique ci-dessous,
+      phone_unsupported: Désolé, nous ne sommes pas en mesure d’envoyer des SMS pour
+        le moment. S’il vous plaît essayez l’option d’appel téléphonique ci-dessous,
         ou utilisez votre clé personnelle.
-      pwned_password: Le mot de passe que vous avez entré n'est pas sécurisé. C'est
+      pwned_password: Le mot de passe que vous avez entré n’est pas sécurisé. C’est
         dans une liste de mots de passe connus exposés dans les violations de données.
       try_again: Veuillez réessayer.
-      unauthorized_authn_context: Contexte d'authentification non autorisé
-      unauthorized_nameid_format: Format non autorisé du nom d'identification
+      unauthorized_authn_context: Contexte d’authentification non autorisé
+      unauthorized_nameid_format: Format non autorisé du nom d’identification
       unauthorized_service_provider: Fournisseur de service non autorisé
       voip_check_error: Il y a eu une erreur lors de la vérification de votre téléphone,
         veuillez réessayer
       voip_phone: Ce numéro est un service téléphonique basé sur le Web (Voix sur
         IP). Veuillez sélectionner un autre numéro et réessayer
-      weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
+      weak_password: Votre mot de passe n’est pas assez fort. %{feedback}
     piv_cac_setup:
       unique_name: Ce nom est déjà pris. Veuillez choisir un autre nom.
     two_factor_auth_setup:
-      must_select_option: Sélectionnez une méthode d'authentification.
+      must_select_option: Sélectionnez une méthode d’authentification.
     verify_personal_key:
       throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans 15 minutes.
     verify_profile:
@@ -123,9 +123,9 @@ fr:
       attestation_error: Désolé, votre clé de sécurité ne semble pas être une clé
         de sécurité FIDO. Veuillez vous assurer que votre appareil est répertorié
         sur https://fidoalliance.org/certification/fido-certified-products/ et si
-        vous pensez que l'erreur est la nôtre, veuillez nous contacter à l'adresse
+        vous pensez que l’erreur est la nôtre, veuillez nous contacter à l’adresse
         hello@login.gov.
-      general_error: Une erreur s'est produite lors de l'ajout de votre clé de sécurité
+      general_error: Une erreur s’est produite lors de l’ajout de votre clé de sécurité
         physique. Veuillez réessayer.
       not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité
         FIDO. Les dernières versions de Chrome, Firefox, Edge et Safari prennent en

--- a/config/locales/event_disavowals/fr.yml
+++ b/config/locales/event_disavowals/fr.yml
@@ -8,4 +8,4 @@ fr:
         pour changer votre mot de passe.
       event_not_found: Le lien pour changer votre mot de passe est invalide. Connectez-vous
         pour changer votre mot de passe.
-      no_account: Aucun compte n'est associé à cet événement.
+      no_account: Aucun compte n’est associé à cet événement.

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -5,7 +5,7 @@ fr:
     account_verified: Compte vérifié
     authenticated_at: Connecté à %{service_provider}
     authenticated_at_html: Connecté à %{service_provider_link}
-    authenticator_disabled: Application d'authentification supprimée
+    authenticator_disabled: Application d’authentification supprimée
     authenticator_enabled: Application authenticator ajoutée
     backup_codes_added: Codes de sauvegarde ajoutés
     eastern_timestamp: "%{timestamp} (est)"

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -7,11 +7,11 @@ en:
       are_you_sure_desc: "<br><b>Backup codes are not very safe</b> because they can
         easily be lost or stolen. <b>If you can, choose a different method</b> (use
         a phone, download an authentication application, or use a security key). <br><br><b>If
-        you continue with backup codes, keep them safe</b>.  We'll give you 10 codes
-        that you can download, print, copy or write down.  Later, you'll have to enter
+        you continue with backup codes, keep them safe</b>.  We’ll give you 10 codes
+        that you can download, print, copy or write down.  Later, you’ll have to enter
         one every time you sign in."
       are_you_sure_other_option: Choose a different method
-      are_you_sure_title: Are you sure?  We'll give you backup codes to save and use.
+      are_you_sure_title: Are you sure?  We’ll give you backup codes to save and use.
       caution_delete: If you delete your backup codes you will no longer be able to
         use them to sign in.
       confirm_delete: Are you sure you want to delete your backup codes?
@@ -23,7 +23,7 @@ en:
       generate: Get codes
       print: Print
       regenerate: Get new codes
-      subinfo_html: "<b>Don't lose these codes</b>. Download, print, or copy them.
+      subinfo_html: "<b>Don’t lose these codes</b>. Download, print, or copy them.
         Each code can only be used once. After you’ve used all 10 codes, we’ll give
         you 10 new codes.  Keep your codes as safe as your password."
       subtitle: Your backup codes
@@ -65,7 +65,7 @@ en:
           password: New password
       show: Show password
     personal_key:
-      alternative: Don't have your personal key?
+      alternative: Don’t have your personal key?
       confirmation_label: Personal key
       instructions: Please confirm you have a copy of your personal key by entering
         it below.
@@ -74,7 +74,7 @@ en:
       buttons:
         delete: Remove phone
     piv_cac_delete:
-      caution: If you remove your PIV/CAC card you won't be able to use it to access
+      caution: If you remove your PIV/CAC card you won’t be able to use it to access
         your login.gov account.
       confirm: Are you sure you want to remove your PIV/CAC card?
     piv_cac_login:
@@ -84,9 +84,9 @@ en:
     piv_cac_setup:
       nickname: PIV/CAC nickname
       no_thanks: No thanks
-      piv_cac_intro_html: We'll ask you to present your PIV/CAC card <strong>each
+      piv_cac_intro_html: We’ll ask you to present your PIV/CAC card <strong>each
         time you sign in</strong> as part of two-factor authentication.<br><br>After
-        clicking "Add PIV/CAC" your browser will prompt you for your PIV/CAC PIN and
+        clicking “Add PIV/CAC” your browser will prompt you for your PIV/CAC PIN and
         have you select a certificate.
       submit: Add PIV/CAC card
     registration:
@@ -96,14 +96,14 @@ en:
     ssn:
       show: Show Social Security Number
     totp_delete:
-      caution: If you remove your authentication app you won't be able to use it to
+      caution: If you remove your authentication app you won’t be able to use it to
         access your login.gov account.
       confirm: Are you sure you want to remove your authentication app?
     totp_setup:
       totp_intro_html: Set up an authentication app to sign in using temporary security
         codes. %{link}
       totp_step_1: Give it a nickname
-      totp_step_1a: If you add more than one app, you'll know which ones which.
+      totp_step_1a: If you add more than one app, you’ll know which ones which.
       totp_step_2: Open your authentication app
       totp_step_3: Scan this QR barcode with your app
       totp_step_4: Enter the temporary code from your app
@@ -120,7 +120,7 @@ en:
       submit: Confirm account
       title: Confirm your account
     webauthn_delete:
-      caution: If you remove your security key you won't be able to use it to access
+      caution: If you remove your security key you won’t be able to use it to access
         your login.gov account.
       confirm: Are you sure you want to remove your security key?
     webauthn_setup:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -91,7 +91,7 @@ es:
       no_thanks: No, gracias
       piv_cac_intro_html: Le pediremos que presente su tarjeta PIV/CAC <strong>cada
         vez que inicie sesión</strong> como parte de la autenticación de dos factores.<br><br>Después
-        de hacer clic en "Agregar PIV/CAC", su navegador le solicitará su PIN PIV/CAC
+        de hacer clic en “Agregar PIV/CAC”, su navegador le solicitará su PIN PIV/CAC
         y le pedirá que seleccione un certificado.
       submit: Agregar tarjeta PIV/CAC
     registration:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -2,11 +2,11 @@
 fr:
   forms:
     backup_code:
-      are_you_sure_continue_prologue: Si vous n'avez accès à aucune autre méthode
-        d'authentification,
+      are_you_sure_continue_prologue: Si vous n’avez accès à aucune autre méthode
+        d’authentification,
       are_you_sure_desc: "<br><b>Les codes de sauvegarde ne sont pas très sûrs</b>
         car ils peuvent facilement être perdus ou volés. <b> Si vous le pouvez, choisissez
-        une autre option</b> (utiliser un téléphone, télécharger une application d'authentification
+        une autre option</b> (utiliser un téléphone, télécharger une application d’authentification
         ou utiliser une clé de sécurité). <br><br><b>Si vous continuez à utiliser
         des codes de sauvegarde, protégez-les </b>. Nous vous donnerons 10 codes que
         vous pourrez télécharger, imprimer, copier ou écrire. Plus tard, vous devrez
@@ -26,14 +26,14 @@ fr:
       print: Impression
       regenerate: Obtenir de nouveaux codes
       subinfo_html: "<b>Ne pas perdre ces codes</b>. Téléchargez, imprimez ou copiez-les.
-        Chaque code ne peut être utilisé qu'une seule fois. Une fois que vous avez
+        Chaque code ne peut être utilisé qu’une seule fois. Une fois que vous avez
         utilisé les 10 codes, nous vous en donnons 10 nouveaux. Gardez vos codes aussi
-        sûr qu'un mot de passe."
+        sûr qu’un mot de passe."
       subtitle: Vos codes de sauvegarde
       title: Codes de sauvegarde
     backup_code_regenerate:
       caution: Si vous régénérez vos codes de sauvegarde, vous recevrez un nouvel
-        ensemble de codes de sauvegarde. Vos codes de sauvegarde d'origine ne seront
+        ensemble de codes de sauvegarde. Vos codes de sauvegarde d’origine ne seront
         plus valides.
       confirm: Êtes-vous sûr de vouloir régénérer vos codes de sauvegarde?
     buttons:
@@ -55,7 +55,7 @@ fr:
       show_hdr: Créez un mot de passe fort
     email:
       buttons:
-        delete: Supprimer l'email
+        delete: Supprimer l’email
     example: 'exemple:'
     file_input:
       file_updated: Fichier mis à jour
@@ -69,16 +69,16 @@ fr:
           password: Nouveau mot de passe
       show: Afficher le mot de passe
     personal_key:
-      alternative: Vous n'avez pas votre clé personnelle?
+      alternative: Vous n’avez pas votre clé personnelle?
       confirmation_label: Clé personnelle
       instructions: Veuillez confirmer que vous avez une copie de votre clé personnelle
-        en l'entrant ci-dessous.
+        en l’entrant ci-dessous.
       title: Entrez votre clé personnelle
     phone:
       buttons:
         delete: Supprimer le numéro de teléfono
     piv_cac_delete:
-      caution: Si vous retirez votre carte PIV/CAC, vous ne pourrez plus l'utiliser
+      caution: Si vous retirez votre carte PIV/CAC, vous ne pourrez plus l’utiliser
         pour accéder à votre compte login.gov.
       confirm: Êtes-vous sûr de vouloir retirer votre carte PIV/CAC?
     piv_cac_login:
@@ -89,8 +89,8 @@ fr:
       nickname: Pseudo PIV/CAC
       no_thanks: Non merci
       piv_cac_intro_html: Nous vous demanderons de présenter votre carte PIV/CAC chaque
-        <strong>fois que vous vous connecterez</strong> dans le cadre de l'authentification
-        à deux facteurs.<br><br>Après avoir cliqué sur "Ajouter PIV/CAC", votre navigateur
+        <strong>fois que vous vous connecterez</strong> dans le cadre de l’authentification
+        à deux facteurs.<br><br>Après avoir cliqué sur “Ajouter PIV/CAC”, votre navigateur
         vous demandera votre code PIN PIV/CAC et vous choisirez un certificat.
       submit: Ajouter une carte PIV/CAC
     registration:
@@ -100,15 +100,15 @@ fr:
     ssn:
       show: Afficher le numéro de sécurité sociale
     totp_delete:
-      caution: Si vous supprimez votre application d'authentification, vous ne pourrez
-        plus l'utiliser pour accéder à votre compte login.gov.
-      confirm: Voulez-vous vraiment supprimer votre application d'authentification?
+      caution: Si vous supprimez votre application d’authentification, vous ne pourrez
+        plus l’utiliser pour accéder à votre compte login.gov.
+      confirm: Voulez-vous vraiment supprimer votre application d’authentification?
     totp_setup:
-      totp_intro_html: Configurez une application d'authentification pour vous connecter
-        à l'aide de codes de sécurité temporaires. %{link}
+      totp_intro_html: Configurez une application d’authentification pour vous connecter
+        à l’aide de codes de sécurité temporaires. %{link}
       totp_step_1: Donnez-lui un surnom
       totp_step_1a: Si vous ajoutez plusieurs applications, vous saurez lesquelles.
-      totp_step_2: Démarrez votre application d'authentification
+      totp_step_2: Démarrez votre application d’authentification
       totp_step_3: Scannez ce code-barres QR avec votre application
       totp_step_4: Entrez le code temporaire de votre application
     two_factor:
@@ -125,7 +125,7 @@ fr:
       submit: Confirmer le compte
       title: Confirmez votre compte
     webauthn_delete:
-      caution: Si vous supprimez votre clé de sécurité, vous ne pourrez plus l'utiliser
+      caution: Si vous supprimez votre clé de sécurité, vous ne pourrez plus l’utiliser
         pour accéder à votre compte login.gov.
       confirm: Êtes-vous sûr de vouloir supprimer votre clé de sécurité?
     webauthn_setup:
@@ -133,7 +133,7 @@ fr:
       instructions_text: Appuyez sur le bouton de votre clé de sécurité pour l’enregistrer
         avec login.gov
       instructions_title: Connectez votre clé de sécurité
-      intro_html: Ajoutez une clé de sécurité en tant que méthode d'authentification
+      intro_html: Ajoutez une clé de sécurité en tant que méthode d’authentification
         à votre compte. Votre clé de sécurité doit prendre en charge le standard FIDO.
         Vous pouvez ajouter autant de clés de sécurité que vous le souhaitez et nous
         en recommandons au moins deux pour faciliter la récupération du compte.

--- a/config/locales/friendly_errors/en.yml
+++ b/config/locales/friendly_errors/en.yml
@@ -2,83 +2,82 @@
 en:
   friendly_errors:
     doc_auth:
-      barcode_could_not_be_read: 'We couldn''t read the barcode on the back of your
+      barcode_could_not_be_read: 'We couldn’t read the barcode on the back of your
         ID. Try taking a new picture. Make sure the entire barcode is visible, clean,
-        and doesn''t have glares. (Error code: 200)'
-      barcode_formatted_incorrectly: 'We couldn''t read the barcode on the back of
+        and doesn’t have glares. (Error code: 200)'
+      barcode_formatted_incorrectly: 'We couldn’t read the barcode on the back of
         your ID. Try taking a new picture. Make sure the entire barcode is visible,
-        clean, and doesn''t have glares. (Error code: 2000)'
-      birth_date_not_valid: 'We couldn''t read the birth date on your ID. Try taking
-        new pictures. Make sure the text is visible, clean, and doesn''t have glares.
+        clean, and doesn’t have glares. (Error code: 2000)'
+      birth_date_not_valid: 'We couldn’t read the birth date on your ID. Try taking
+        new pictures. Make sure the text is visible, clean, and doesn’t have glares.
         (Error code: 700)'
-      birth_dates_do_not_match: 'We couldn''t read the birth date on your ID. Try
-        taking a new picture. Make sure the text and barcode are visible, clean, and
-        don''t have glares. (Error code: 1600)'
-      check_digit_is_incorrect: 'We couldn''t read your ID. It might have moved when
+      birth_dates_do_not_match: 'We couldn’t read the birth date on your ID. Try taking
+        a new picture. Make sure the text and barcode are visible, clean, and don’t
+        have glares. (Error code: 1600)'
+      check_digit_is_incorrect: 'We couldn’t read your ID. It might have moved when
         you took the picture. Try taking new pictures. Make sure the text, images,
-        and barcode are all visible, clean, and don''t have glares. (Error code: 1800)'
-      color_pixel_depth: 'There''s a problem with the color on your document. Make
+        and barcode are all visible, clean, and don’t have glares. (Error code: 1800)'
+      color_pixel_depth: 'There’s a problem with the color on your document. Make
         sure you upload the original image from your camera. Retake the picture using
         a modern camera or cell phone. Color pixel depth must be 24-bit. (Error code:
         2300)'
-      color_response_incorrect: 'We couldn''t verify your ID. It might have moved
-        when you took the picture. Try taking new pictures. Make sure the whole ID
-        is visible, clean, doesn''t have glares, and is on a dark background. (Error
-        code: 1100)'
-      control_numbers_do_not_match: 'We couldn''t verify your ID. Try taking a new
-        picture. Make sure the text and barcode are visible, clean, and don''t have
+      color_response_incorrect: 'We couldn’t verify your ID. It might have moved when
+        you took the picture. Try taking new pictures. Make sure the whole ID is visible,
+        clean, doesn’t have glares, and is on a dark background. (Error code: 1100)'
+      control_numbers_do_not_match: 'We couldn’t verify your ID. Try taking a new
+        picture. Make sure the text and barcode are visible, clean, and don’t have
         glares. (Error code: 1700)'
       document_complete_or_error: 'There was a problem with your internet connection.
         Please try again. (Error code: 2500)'
-      document_has_expired: 'The document has expired or we couldn''t read your ID.
-        Try taking new pictures. Make sure the text is visible, clean, and doesn''t
+      document_has_expired: 'The document has expired or we couldn’t read your ID.
+        Try taking new pictures. Make sure the text is visible, clean, and doesn’t
         have glares. (Error code: 600)'
-      document_image_load_failure: 'Your document couldn''t be uploaded. Check the
-        image''s format and size, then try again. Make sure that if you''re transfering
-        an image between devices, you transfer it in its original size. Don''t take
+      document_image_load_failure: 'Your document couldn’t be uploaded. Check the
+        image’s format and size, then try again. Make sure that if you’re transfering
+        an image between devices, you transfer it in its original size. Don’t take
         a picture of an image. The image must be in BMP, PNG, TIFF, or JPG format
         and at least 1476 x 1039 pixels in size (2953 x 2079 pixels or greater are
         recommended). (Error code: 2100)'
       document_not_found: 'There was a problem with your internet connection. Please
         try again. (Error code: 2200)'
-      document_number_check_digit_is_incorrect: 'We couldn''t verify your ID. Try
-        taking new pictures. Make sure the text, images, and barcode are all visible,
-        clean, and don''t have glares. (Error code: 1400)'
+      document_number_check_digit_is_incorrect: 'We couldn’t verify your ID. Try taking
+        new pictures. Make sure the text, images, and barcode are all visible, clean,
+        and don’t have glares. (Error code: 1400)'
       document_type_could_not_be_determined: 'We couldn’t recognize your ID. It may
         be worn, damaged, or a type of ID that we don’t recognize. (Error code: 100)'
       duplicate_document_side: 'It looks like you uploaded the same side of your ID
         twice. Please upload the Front then the Back of your ID. (Error code: 2400)'
       evidence_tampered: 'We couldn’t recognize your ID. It may be worn, damaged,
         or a type of ID that we don’t recognize. (Error code: 400)'
-      expiration_date_is_not_valid: 'We couldn''t read the expiration date on your
-        ID. Try taking new pictures. Make sure the text is visible, clean, and doesn''t
+      expiration_date_is_not_valid: 'We couldn’t read the expiration date on your
+        ID. Try taking new pictures. Make sure the text is visible, clean, and doesn’t
         have glares. (Error code: 800)'
-      full_names_do_not_match: 'We couldn''t read your name on your ID. Try taking
-        a new picture. Make sure the text and barcode are visible, clean, and don''t
+      full_names_do_not_match: 'We couldn’t read your name on your ID. Try taking
+        a new picture. Make sure the text and barcode are visible, clean, and don’t
         have glares. (Error code: 1300)'
       general_error: We could not read or verify your ID. Try to take and upload new
         images of both the front and back of your ID. Make sure everything can be
         easily read, including the barcode.
       internal_server_error: 'We are having technical difficulties. Please try again
         later. (Error code: 2600)'
-      issue_date_is_not_valid: 'We couldn''t read the issue date on your ID. Try taking
-        new pictures. Make sure the text is visible, clean, and doesn''t have glares.
+      issue_date_is_not_valid: 'We couldn’t read the issue date on your ID. Try taking
+        new pictures. Make sure the text is visible, clean, and doesn’t have glares.
         (Error code: 1200)'
-      pattern_not_found: 'We couldn''t read your ID. It might have moved when you
-        took the picture. Try taking new pictures. Make sure the text, images, and
-        barcode are all visible, clean, and don''t have glares. (Error code: 300)'
-      photo_lacks_expected_appearance: 'We couldn''t verify your ID. It might have
+      pattern_not_found: 'We couldn’t read your ID. It might have moved when you took
+        the picture. Try taking new pictures. Make sure the text, images, and barcode
+        are all visible, clean, and don’t have glares. (Error code: 300)'
+      photo_lacks_expected_appearance: 'We couldn’t verify your ID. It might have
         moved when you took the picture. Try taking new pictures. Make sure the whole
-        ID is visible, clean, doesn''t have glares, and is on a dark background. (Error
+        ID is visible, clean, doesn’t have glares, and is on a dark background. (Error
         code: 1500)'
-      photo_print_technique_not_detected: 'We couldn''t read your ID. It might have
+      photo_print_technique_not_detected: 'We couldn’t read your ID. It might have
         moved when you took the picture. Try taking new pictures. Make sure the text,
-        images, and barcode are all visible, clean, and don''t have glares. (Error
+        images, and barcode are all visible, clean, and don’t have glares. (Error
         code: 500)'
-      sexes_do_not_match: 'We couldn''t read the sex on your ID. Try taking a new
-        picture. Make sure the text and barcode are visible, clean, and don''t have
-        glares. (Error code: 1900)'
-      substrate_print_technique_not_detected: 'We couldn''t read your ID. It might
+      sexes_do_not_match: 'We couldn’t read the sex on your ID. Try taking a new picture.
+        Make sure the text and barcode are visible, clean, and don’t have glares.
+        (Error code: 1900)'
+      substrate_print_technique_not_detected: 'We couldn’t read your ID. It might
         have moved when you took the picture. Try taking new pictures. Make sure the
-        text, images, and barcode are all visible, clean, and don''t have glares.
-        (Error code: 900)'
+        text, images, and barcode are all visible, clean, and don’t have glares. (Error
+        code: 900)'

--- a/config/locales/friendly_errors/fr.yml
+++ b/config/locales/friendly_errors/fr.yml
@@ -2,91 +2,91 @@
 fr:
   friendly_errors:
     doc_auth:
-      barcode_could_not_be_read: 'Nous n''avons pas pu lire le code à barres au verso
-        de votre pièce d''identité. Essayez de prendre une nouvelle photo. Assurez-vous
-        que tout le code à barres est visible, propre et non éblouissant. (Code d''''erreur:
+      barcode_could_not_be_read: 'Nous n’avons pas pu lire le code à barres au verso
+        de votre pièce d’identité. Essayez de prendre une nouvelle photo. Assurez-vous
+        que tout le code à barres est visible, propre et non éblouissant. (Code d’erreur:
         200)'
-      barcode_formatted_incorrectly: 'Nous n''avons pas pu lire le code à barres au
-        verso de votre pièce d''identité. Essayez de prendre une nouvelle photo. Assurez-vous
-        que tout le code à barres est visible, propre et non éblouissant. (Code d''''erreur:
+      barcode_formatted_incorrectly: 'Nous n’avons pas pu lire le code à barres au
+        verso de votre pièce d’identité. Essayez de prendre une nouvelle photo. Assurez-vous
+        que tout le code à barres est visible, propre et non éblouissant. (Code d’erreur:
         2000)'
-      birth_date_not_valid: 'Nous n''avons pas pu lire votre identité. Essayez de
-        prendre de nouvelles photos. Assurez-vous que le texte est visible, propre
-        et non éblouissant. (Code d''''erreur: 700)'
-      birth_dates_do_not_match: 'Nous n''avons pas pu vérifier votre identité. Essayez
+      birth_date_not_valid: 'Nous n’avons pas pu lire votre identité. Essayez de prendre
+        de nouvelles photos. Assurez-vous que le texte est visible, propre et non
+        éblouissant. (Code d’erreur: 700)'
+      birth_dates_do_not_match: 'Nous n’avons pas pu vérifier votre identité. Essayez
         de prendre une nouvelle photo. Assurez-vous que le texte et le code à barres
-        sont visibles, propres et non éblouissants. (Code d''''erreur: 1600)'
-      check_digit_is_incorrect: 'Nous n''avons pas pu lire votre identité. Il aurait
+        sont visibles, propres et non éblouissants. (Code d’erreur: 1600)'
+      check_digit_is_incorrect: 'Nous n’avons pas pu lire votre identité. Il aurait
         pu bouger quand il a pris la photo. Essayez de prendre de nouvelles photos.
         Assurez-vous que le texte, les images et le code à barres sont visibles, propres
-        et n’ont aucune luminosité. (Code d''''erreur: 1800)'
+        et n’ont aucune luminosité. (Code d’erreur: 1800)'
       color_pixel_depth: 'Il y a un problème de couleur dans votre document. Assurez-vous
-        de charger l''image originale à partir de votre appareil photo. Reprenez la
-        photo avec un appareil photo moderne ou un téléphone portable. (Code d''''erreur:
+        de charger l’image originale à partir de votre appareil photo. Reprenez la
+        photo avec un appareil photo moderne ou un téléphone portable. (Code d’erreur:
         2300)'
-      color_response_incorrect: 'Nous n''avons pas pu vérifier votre identité. Il
-        aurait pu bouger quand il a pris la photo. Essayez de prendre de nouvelles
-        photos. Assurez-vous que toutes les pièces d''identité sont visibles, propres,
-        sans éblouissement et sur un fond sombre. (Code d''''erreur: 1100)'
-      control_numbers_do_not_match: 'Nous n''avons pas pu vérifier votre identité.
+      color_response_incorrect: 'Nous n’avons pas pu vérifier votre identité. Il aurait
+        pu bouger quand il a pris la photo. Essayez de prendre de nouvelles photos.
+        Assurez-vous que toutes les pièces d’identité sont visibles, propres, sans
+        éblouissement et sur un fond sombre. (Code d’erreur: 1100)'
+      control_numbers_do_not_match: 'Nous n’avons pas pu vérifier votre identité.
         Essayez de prendre une nouvelle photo. Assurez-vous que le texte et le code
-        à barres sont visibles, propres et non éblouissants. (Code d''''erreur: 1700)'
+        à barres sont visibles, propres et non éblouissants. (Code d’erreur: 1700)'
       document_complete_or_error: 'Ocurrió un problema con tu conexión a Internet.
-        Por favor, inténtalo de nuevo. (Code d''erreur: 2500)'
-      document_has_expired: 'Nous n''avons pas pu lire votre identité. Essayez de
-        prendre de nouvelles photos. Assurez-vous que le texte est visible, propre
-        et non éblouissant. (Code d''''erreur: 600)'
-      document_image_load_failure: 'Votre document n''a pas pu être chargé. Vérifiez
-        le format et la taille de l''image, puis réessayez. Assurez-vous que si vous
+        Por favor, inténtalo de nuevo. (Code d’erreur: 2500)'
+      document_has_expired: 'Nous n’avons pas pu lire votre identité. Essayez de prendre
+        de nouvelles photos. Assurez-vous que le texte est visible, propre et non
+        éblouissant. (Code d’erreur: 600)'
+      document_image_load_failure: 'Votre document n’a pas pu être chargé. Vérifiez
+        le format et la taille de l’image, puis réessayez. Assurez-vous que si vous
         transférez une image entre appareils, vous la transférez dans sa taille originale.
-        Ne prenez pas de photo d''une image. L''image doit être au format BMP, PNG,
-        TIFF ou JPG et avoir une taille d''au moins 1476 x 1039 pixels (2953 x 2079
-        pixels ou plus recommandé). (Code d''''erreur: 2100)'
+        Ne prenez pas de photo d’une image. L’image doit être au format BMP, PNG,
+        TIFF ou JPG et avoir une taille d’au moins 1476 x 1039 pixels (2953 x 2079
+        pixels ou plus recommandé). (Code d’erreur: 2100)'
       document_not_found: 'Ocurrió un problema con tu conexión a Internet. Por favor,
-        inténtalo de nuevo. (Code d''''erreur: 2200)'
-      document_number_check_digit_is_incorrect: 'Nous n''avons pas pu vérifier votre
+        inténtalo de nuevo. (Code d’erreur: 2200)'
+      document_number_check_digit_is_incorrect: 'Nous n’avons pas pu vérifier votre
         identité. Essayez de prendre une nouvelle photo. Assurez-vous que le texte
-        et le code à barres sont visibles, propres et non éblouissants. (Code d''''erreur:
+        et le code à barres sont visibles, propres et non éblouissants. (Code d’erreur:
         1400)'
-      document_type_could_not_be_determined: 'Nous n''avons pas pu reconnaître votre
+      document_type_could_not_be_determined: 'Nous n’avons pas pu reconnaître votre
         identification. Il peut être usé, endommagé ou être un type d’identité que
-        nous ne reconnaissons pas. (Code d''''erreur: 100)'
+        nous ne reconnaissons pas. (Code d’erreur: 100)'
       duplicate_document_side: 'Il semble que vous ayez téléchargé le même côté de
-        votre pièce d''identité deux fois. Chargez le recto et le verso de votre identification.
-        (Code d''''erreur: 2400)'
-      evidence_tampered: 'Nous n''avons pas pu reconnaître votre identification. Il
+        votre pièce d’identité deux fois. Chargez le recto et le verso de votre identification.
+        (Code d’erreur: 2400)'
+      evidence_tampered: 'Nous n’avons pas pu reconnaître votre identification. Il
         peut être usé, endommagé ou être un type d’identité que nous ne reconnaissons
-        pas. (Code d''''erreur: 400)'
-      expiration_date_is_not_valid: 'Nous n''avons pas pu lire votre identité. Essayez
+        pas. (Code d’erreur: 400)'
+      expiration_date_is_not_valid: 'Nous n’avons pas pu lire votre identité. Essayez
         de prendre de nouvelles photos. Assurez-vous que le texte est visible, propre
-        et non éblouissant. (Code d''''erreur: 800)'
-      full_names_do_not_match: 'Nous n''avons pas pu vérifier votre identité. Essayez
+        et non éblouissant. (Code d’erreur: 800)'
+      full_names_do_not_match: 'Nous n’avons pas pu vérifier votre identité. Essayez
         de prendre une nouvelle photo. Assurez-vous que le texte et le code à barres
-        sont visibles, propres et non éblouissants. (Code d''''erreur: 1300)'
-      general_error: Nous n"avons pas pu lire ni vérifier votre identité. Essayez
+        sont visibles, propres et non éblouissants. (Code d’erreur: 1300)'
+      general_error: Nous n’avons pas pu lire ni vérifier votre identité. Essayez
         de prendre et de télécharger de nouvelles images des deux côtés de votre ID.
         Assurez-vous que tout peut être facilement lu, y compris le code à barres.
       internal_server_error: 'Nous rencontrons des difficultés techniques. Veuillez
-        réessayer plus tard. (Code d''''erreur: 2600)'
-      issue_date_is_not_valid: 'Nous n''avons pas pu lire votre identité. Essayez
-        de prendre de nouvelles photos. Assurez-vous que le texte est visible, propre
-        et non éblouissant. (Code d''''erreur: 1200)'
-      pattern_not_found: 'Nous n''avons pas pu lire votre identité. Il aurait pu bouger
+        réessayer plus tard. (Code d’erreur: 2600)'
+      issue_date_is_not_valid: 'Nous n’avons pas pu lire votre identité. Essayez de
+        prendre de nouvelles photos. Assurez-vous que le texte est visible, propre
+        et non éblouissant. (Code d’erreur: 1200)'
+      pattern_not_found: 'Nous n’avons pas pu lire votre identité. Il aurait pu bouger
         quand il a pris la photo. Essayez de prendre de nouvelles photos. Assurez-vous
         que le texte, les images et le code à barres sont visibles, propres et n’ont
-        aucune luminosité. (Code d''''erreur: 300)'
-      photo_lacks_expected_appearance: 'Nous n''avons pas pu vérifier votre identité.
+        aucune luminosité. (Code d’erreur: 300)'
+      photo_lacks_expected_appearance: 'Nous n’avons pas pu vérifier votre identité.
         Il aurait pu bouger quand il a pris la photo. Essayez de prendre de nouvelles
-        photos. Assurez-vous que toutes les pièces d''identité sont visibles, propres,
-        sans éblouissement et sur un fond sombre. (Code d''''erreur: 1500)'
-      photo_print_technique_not_detected: 'Nous n''avons pas pu lire votre identité.
+        photos. Assurez-vous que toutes les pièces d’identité sont visibles, propres,
+        sans éblouissement et sur un fond sombre. (Code d’erreur: 1500)'
+      photo_print_technique_not_detected: 'Nous n’avons pas pu lire votre identité.
         Il aurait pu bouger quand il a pris la photo. Essayez de prendre de nouvelles
         photos. Assurez-vous que le texte, les images et le code à barres sont visibles,
-        propres et n’ont aucune luminosité. (Code d''''erreur: 500)'
-      sexes_do_not_match: 'Nous n''avons pas pu vérifier votre identité. Essayez de
+        propres et n’ont aucune luminosité. (Code d’erreur: 500)'
+      sexes_do_not_match: 'Nous n’avons pas pu vérifier votre identité. Essayez de
         prendre une nouvelle photo. Assurez-vous que le texte et le code à barres
-        sont visibles, propres et non éblouissants. (Code d''''erreur: 1900)'
-      substrate_print_technique_not_detected: 'Nous n''avons pas pu lire votre identité.
+        sont visibles, propres et non éblouissants. (Code d’erreur: 1900)'
+      substrate_print_technique_not_detected: 'Nous n’avons pas pu lire votre identité.
         Il aurait pu bouger quand il a pris la photo. Essayez de prendre de nouvelles
         photos. Assurez-vous que le texte, les images et le code à barres sont visibles,
-        propres et n’ont aucune luminosité. (Code d''''erreur: 900)'
+        propres et n’ont aucune luminosité. (Code d’erreur: 900)'

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -29,7 +29,7 @@ en:
     edit_info:
       password: Change your password
       phone: Manage your phone settings
-    lock_failure: Here's what you can do
+    lock_failure: Here’s what you can do
     passwords:
       change: Change your password
       confirm: Confirm your current password to continue

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -3,7 +3,7 @@ fr:
   headings:
     account:
       activity: Activité
-      authentication_apps: Applications d'authentification
+      authentication_apps: Applications d’authentification
       connected_accounts: Vos comptes connectés
       devices: Dispositifs
       events: Événements
@@ -11,7 +11,7 @@ fr:
       login_info: Votre compte
       profile_info: Information du profil
       reactivate: Réactivez votre compte
-      two_factor: Vos méthodes d'authentification
+      two_factor: Vos méthodes d’authentification
       unphishable: Incapable de phishing
       verified_account: Compte vérifié
     add_email: Ajouter une nouvelle adresse e-mail
@@ -37,23 +37,23 @@ fr:
     personal_key: Enregistrez votre clé personnelle
     piv_cac:
       certificate:
-        bad: Le certificat PIV/CAC que vous avez sélectionné n'est pas valide.
+        bad: Le certificat PIV/CAC que vous avez sélectionné n’est pas valide.
         expired: Le certificat PIV/CAC que vous avez sélectionné a expiré.
-        invalid: Le certificat PIV/CAC que vous avez sélectionné n'est pas valide.
+        invalid: Le certificat PIV/CAC que vous avez sélectionné n’est pas valide.
         none: Nous ne pouvons pas détecter un certificat sur votre carte PIV/CAC.
         not_auth_cert: Veuillez choisir un autre certificat de votre carte PIV/CAC.
         revoked: Le certificat PIV/CAC que vous avez sélectionné a été retiré de votre
           carte.
-        unverified: Le certificat PIV/CAC que vous avez sélectionné n'est pas valide.
-      did_not_work: Votre PIV / CAC n'a pas fonctionné
+        unverified: Le certificat PIV/CAC que vous avez sélectionné n’est pas valide.
+      did_not_work: Votre PIV / CAC n’a pas fonctionné
       token:
         bad: Erreur interne.
-        invalid: Le certificat PIV/CAC sélectionné n'est pas valide.
+        invalid: Le certificat PIV/CAC sélectionné n’est pas valide.
         missing: Erreur interne.
     piv_cac_login:
-      account_not_found: Votre PIV / CAC n'est pas connecté à un compte
-      add: Configurez votre PIV ou votre CAC en tant que méthode d'authentification
-        à deux facteurs pour pouvoir l'utiliser pour vous connecter.
+      account_not_found: Votre PIV / CAC n’est pas connecté à un compte
+      add: Configurez votre PIV ou votre CAC en tant que méthode d’authentification
+        à deux facteurs pour pouvoir l’utiliser pour vous connecter.
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
       success: Vous avez correctement configuré PIV/CAC en tant que méthode d’authentification.
     piv_cac_setup:
@@ -67,7 +67,7 @@ fr:
     sign_in_without_sp: Connexion
     sp_handoff_bounced: Un problème est survenu lors de la connexion à %{sp_name}
     totp_setup:
-      new: Ajouter une application d'authentification
+      new: Ajouter une application d’authentification
     verify_email: Consultez vos courriels
     verify_personal_key: Vérifier votre clé personnelle
     webauthn_setup:

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   help_text:
-    change_factor: Before you're able to edit your %{factor}, you will need to confirm
+    change_factor: Before you’re able to edit your %{factor}, you will need to confirm
       your password and receive a security code on your phone.
     no_factor:
       delete_account: To delete your account, please confirm your password and security
@@ -11,7 +11,7 @@ en:
       birthdate: Date of birth
       email: Email address
       full_name: Full name
-      intro_html: 'We''ll share this information with %{sp}:'
+      intro_html: 'We’ll share this information with %{sp}:'
       outro_html: "%{sp} will only use this information to connect to your account"
       phone: Phone number
       social_security_number: Social Security Number

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -10,11 +10,11 @@ en:
       send_confirmation_code: Continue
     cancel:
       warnings:
-        warning_1: We won't be able to verify your identity
-        warning_2: We won't keep a record of your name, address, birth date, or Social
+        warning_1: We won’t be able to verify your identity
+        warning_2: We won’t keep a record of your name, address, birth date, or Social
           Security number
-        warning_3: You won't be able to securely access your information using %{app}
-        warning_4: You'll still have a login.gov account for your email address
+        warning_3: You won’t be able to securely access your information using %{app}
+        warning_4: You’ll still have a login.gov account for your email address
         warning_5: You can manage or delete that account on your profile page
     errors:
       incorrect_password: The password you entered is not correct.
@@ -61,20 +61,20 @@ en:
     forgot_password:
       link_html: Forgot password? %{link}
       link_text: Follow these instructions
-      modal_header: Are you sure you can't remember your password?
+      modal_header: Are you sure you can’t remember your password?
       reset_password: Reset password
       try_again: Try again
       warnings:
-        warning_1: If you forgot your password, you'll need to reset it and fill out
+        warning_1: If you forgot your password, you’ll need to reset it and fill out
           the form again.
-        warning_2: You'll have to re-enter your personal information, like your name,
+        warning_2: You’ll have to re-enter your personal information, like your name,
           state ID number, etc.
     form:
       activate_by_mail: Verify your address by mail instead
       address1: Address
       address2: Address (optional)
       city: City
-      no_alternate_phone_html: "<strong>%{link}</strong>  We'll mail you a letter
+      no_alternate_phone_html: "<strong>%{link}</strong>  We’ll mail you a letter
         with a code in it."
       password: Password
       phone: Phone Number
@@ -83,7 +83,7 @@ en:
       zipcode: ZIP Code
     index:
       id:
-        need_html: If you're creating an account, you'll need a <strong>current state-issued
+        need_html: If you’re creating an account, you’ll need a <strong>current state-issued
           ID</strong>.
     messages:
       activated_html: Your identity has been verified. If you need to change your
@@ -109,17 +109,17 @@ en:
           you specify.
         resend: Send me another letter
         success: It should arrive in 5 to 10 business days.
-      hardfail: We can't log you in right now, but you can try verifying your identity
+      hardfail: We can’t log you in right now, but you can try verifying your identity
         again in %{hours} hours.
       mail_sent: Your letter is on its way
       otp_delivery_method:
-        phone_number_html: We'll send a code to <strong>%{phone}</strong>
+        phone_number_html: We’ll send a code to <strong>%{phone}</strong>
       personal_key: This is your new personal key. Write it down and keep it in a
         safe place. You will need it if you ever lose your password.
       phone:
-        alert_html: "<strong>This phone number must...</strong>"
-        description: We'll check this number with phone bill records.  This is to
-          help verify your identity; we won't use it to call or text you.
+        alert_html: "<strong>This phone number must…</strong>"
+        description: We’ll check this number with phone bill records.  This is to
+          help verify your identity; we won’t use it to call or text you.
         final_note_html: "<strong>If you set up a phone for two-factor authentication</strong>,
           this can be a different number."
         phone_of_record: Phone of record
@@ -140,7 +140,7 @@ en:
           - TEST SITE
         read_more_encrypt: Read more about how login.gov protects your personal information
         review_message: When you re-enter your password, login.gov will protect the
-          information you've given us, so that only you can access it
+          information you’ve given us, so that only you can access it
     review:
       dob: Date of birth
       full_name: Full name
@@ -150,7 +150,7 @@ en:
       activated: Your identity has already been verified
       cancel: We cannot verify your identity
       come_back_later: Come back soon.
-      hardfail: We weren't able to verify your identity with %{app}
+      hardfail: We weren’t able to verify your identity with %{app}
       mail:
         resend: Want another letter?
         verify: Want a letter?

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -26,7 +26,7 @@ fr:
           exemple : ABC1-DEF2-G3HI-J456'
         ssn: 'Votre numéro de sécurité sociale doit être inscrit de cette façon :
           ###-##-####'
-        state_id_number: Votre numéro d'identification ne peut excéder 25 caractères
+        state_id_number: Votre numéro d’identification ne peut excéder 25 caractères
         zipcode: 'Votre code ZIP doit être inscrit de cette façon : #####-####'
       unsupported_otp_delivery_method: Sélectionnez une méthode pour recevoir un code.
     failure:
@@ -36,25 +36,25 @@ fr:
       button:
         warning: Essayez à nouveau
       exceptions:
-        internal_error: Une erreur interne s'est produite lors du traitement de votre
+        internal_error: Une erreur interne s’est produite lors du traitement de votre
           demande. Veuillez réessayer.
         link: contactez-nous
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       help:
-        get_help_html: Obtenir de l'aide à <strong>%{sp_name}</strong>
+        get_help_html: Obtenir de l’aide à <strong>%{sp_name}</strong>
       phone:
         fail_html: "<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier
           votre numéro de téléphone en ligne."
         heading: Nous n’avons pas pu associer votre nom et votre adresse à ce numéro
           de téléphone
-        jobfail: Un problème s'est produit et nous ne pouvons pas traiter votre demande
+        jobfail: Un problème s’est produit et nous ne pouvons pas traiter votre demande
           pour le moment. Veuillez réessayer.
         timeout: Notre demande de vérification de vos renseignements a expiré. Veuillez
           réessayer.
         warning: Veuillez vérifier les informations que vous avez saisies et réessayer.
       sessions:
-        exception: Une erreur interne s'est produite lors du traitement de votre demande.
+        exception: Une erreur interne s’est produite lors du traitement de votre demande.
         fail_html: "<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier
           des informations personnelles en ligne."
@@ -63,8 +63,8 @@ fr:
         warning: Veuillez vérifier les informations que vous avez saisies et réessayer.
           Les erreurs les plus courantes sont un numéro de sécurité sociale ou un
           code postal incorrect.
-      timeout: Le temps d'attente pour le traitement de votre demande est plus long
-        que d'habitude Veuillez réessayer.
+      timeout: Le temps d’attente pour le traitement de votre demande est plus long
+        que d’habitude Veuillez réessayer.
     forgot_password:
       link_html: Mot de passe oublié? %{link}
       link_text: Suivez ces instructions
@@ -91,8 +91,8 @@ fr:
       zipcode: Code ZIP
     index:
       id:
-        need_html: Si vous créez un compte, vous aurez besoin d'un <strong>identifiant
-          actuel émis par l'état</strong>.
+        need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant
+          actuel émis par l’état</strong>.
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier votre
         information vérifiée, veuillez %{link}.
@@ -101,7 +101,7 @@ fr:
       agency_login_html: Vous pouvez maintenant accéder et vous connecter à <br><strong>%{sp}</strong>.
       cancel: Pour continuer, %{app} doit vérifier votre identité. Nous devons recueillir
         quelques informations personnelles de base ainsi que certaines informations
-        financières pour compléter ce processus. Si vous n'avez pas cette information
+        financières pour compléter ce processus. Si vous n’avez pas cette information
         sous la main, vous pouvez continuer plus tard.
       clear_and_start_over: Supprimer mes données et recommencer
       come_back_later: Une fois que votre lettre vous sera parvenue, veuillez vous
@@ -113,26 +113,26 @@ fr:
         moment.
       confirm: Vous avez crypté vos données vérifiées
       gpo:
-        address_on_file: Nous posterons une lettre à l'adresse vérifiée dans nos dossiers.
+        address_on_file: Nous posterons une lettre à l’adresse vérifiée dans nos dossiers.
           Celle-ci contient un code de confirmation.
         new_address: Nous vous enverrons une lettre avec un code de confirmation à
-          l'adresse que vous spécifiez.
+          l’adresse que vous spécifiez.
         resend: Envoyez-moi une autre lettre
         success: Elle devrait arriver dans 5 à 10 jours ouvrables.
       hardfail: Nous ne pouvons pas vous connecter pour le moment, mais vous pouvez
-        retenter d'effectuer la vérification de votre identité dans %{hours} heures.
+        retenter d’effectuer la vérification de votre identité dans %{hours} heures.
       mail_sent: Votre lettre est en route
       otp_delivery_method:
         phone_number_html: Nous enverrons un code au <strong>%{phone}</strong>
-      personal_key: Il s'agit de votre nouvelle clé personnelle. Notez-la et conservez-la
+      personal_key: Il s’agit de votre nouvelle clé personnelle. Notez-la et conservez-la
         dans un endroit sécuritaire. Vous en aurez besoin si vous perdez votre mot
         de passe.
       phone:
         alert_html: Ce numéro de téléphone <strong>doit être</strong>
         description: Nous vérifions les dossiers pour vous assurer que vous êtes ce
           que vous dites et que vous êtes propriétaire de votre compte.
-        final_note_html: "<strong>Si vous configurez un téléphone pour l'authentification
-          à deux facteurs</strong>, il peut s'agir d'un numéro différent."
+        final_note_html: "<strong>Si vous configurez un téléphone pour l’authentification
+          à deux facteurs</strong>, il peut s’agir d’un numéro différent."
         phone_of_record: numéro de téléphone enregistré
         rules:
         - sur un plan de téléphone avec votre nom dessus
@@ -144,15 +144,15 @@ fr:
         info_verified_html: Nous avons trouvé des données qui correspondent à votre
           %{phone_message}
         intro: Vos informations vérifiées
-      select_verification_with_sp: Afin de vous protéger des fraudes d'identité, vous
-        ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne l'aurez
+      select_verification_with_sp: Afin de vous protéger des fraudes d’identité, vous
+        ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne l’aurez
         pas activé en entrant votre code de confirmation.
       select_verification_without_sp: Afin de protéger votre compte des fraudes liées
-        à l'identité, votre profil ne sera pas activé tant que vous n'aurez pas entré
+        à l’identité, votre profil ne sera pas activé tant que vous n’aurez pas entré
         votre code de confirmation.
       sessions:
-        no_pii: SITE DE TEST - N'utilisez pas de véritables données personnelles (il
-          s'agit d'une démonstration seulement) - SITE DE TEST
+        no_pii: SITE DE TEST - N’utilisez pas de véritables données personnelles (il
+          s’agit d’une démonstration seulement) - SITE DE TEST
         read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos
           informations personnelles
         review_message: Lorsque vous entrez à nouveau votre mot de passe, login.gov
@@ -166,7 +166,7 @@ fr:
       activated: Votre identité a déjà été vérifiée
       cancel: Nous ne pouvons pas vérifier votre identité
       come_back_later: Revenez vite.
-      hardfail: Nous sommes dans l'incapacité de vérifier votre identité avec %{app}
+      hardfail: Nous sommes dans l’incapacité de vérifier votre identité avec %{app}
       mail:
         resend: Vous voulez une autre lettre?
         verify: Vous voulez une lettre?

--- a/config/locales/image_description/fr.yml
+++ b/config/locales/image_description/fr.yml
@@ -2,5 +2,5 @@
 fr:
   image_description:
     camera_mobile_phone: Appareil photo clignotant sur un téléphone mobile
-    totp_qrcode: Code QR pour l'application d'authentification
+    totp_qrcode: Code QR pour l’application d’authentification
     us_flag: Drapeau américain

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -3,15 +3,15 @@ en:
   instructions:
     account:
       reactivate:
-        begin: Let's get started.
+        begin: Let’s get started.
         explanation: 'When you created your account, we gave you a list of words and
           asked you to store them in a safe place. It looked similar to this:'
         intro: We take extra steps to keep your personal information secure and private,
           so resetting your password takes a little extra effort.
         modal:
-          copy: If you don't have your personal key, you will need to verify your
+          copy: If you don’t have your personal key, you will need to verify your
             identity again.
-          heading: Don't have your personal key?
+          heading: Don’t have your personal key?
         with_key: Do you have your personal key?
     forgot_password:
       close_window: You can close this browser window once you have reset your password.
@@ -25,12 +25,12 @@ en:
         manual_entry: Or enter this code manually into your authentication app
       piv_cac:
         account_not_found_html: "<p><strong>%{sign_in}</strong> with your email address
-          and password. Then add your PIV/CAC to your account.</p> <p><strong>Don't
+          and password. Then add your PIV/CAC to your account.</p> <p><strong>Don’t
           have a login.gov account?</strong> %{create_account}</p>"
-        add_from_sign_in_html: <strong>Instructions:</strong> Insert your PIV or CAC
-          on <strong>"ADD PIV/CAC"</strong>. You'll need to <strong>choose a certificate</strong>
+        add_from_sign_in_html: "<strong>Instructions:</strong> Insert your PIV or
+          CAC on <strong>“ADD PIV/CAC”</strong>. You’ll need to <strong>choose a certificate</strong>
           (the right one likely has your name of it) and <strong>enter your PIN</strong>
-          (your PIN was created when you set up your PIV/CAC).
+          (your PIN was created when you set up your PIV/CAC)."
         already_associated_html: Please choose a certificate from a different PIV/CAC,
           contact your administrator to ensure your PIV/CAC is up to date. If you
           think this is an error, %{try_again}.
@@ -50,13 +50,13 @@ en:
           Please %{please_try_again} with a different certificate. If this problem
           continues, contact your agency administrator.
         please_try_again: try again
-        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
+        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you’ve
           set up PIV/CAC</strong> as a two-factor authentication method.
         step_1: Give it a nickname
-        step_1_info: If you add more than one PIV/CAC, you'll know which one's which.
+        step_1_info: If you add more than one PIV/CAC, you’ll know which one’s which.
         step_2: Insert your PIV/CAC into your card reader
         step_3: Add your PIV/CAC
-        step_3_info_html: You'll need to <strong>choose a certificate</strong> (the
+        step_3_info_html: You’ll need to <strong>choose a certificate</strong> (the
           right one likely has your name in it) and <strong>enter your PIN</strong>
           (your PIN was created when you set up your PIV/CAC).
         try_again: try again
@@ -86,7 +86,7 @@ en:
       help_text_header: Password safety tips
       info:
         lead: It must be at least %{min_length} characters long and not be a commonly
-          used password. That's it!
+          used password. That’s it!
       strength:
         i: Very weak
         ii: Weak
@@ -96,11 +96,11 @@ en:
         v: Great!
     personal_key:
       accent: Write it down or print it out.
-      email_body: Don't lose your personal key or share it with others.  We'll ask
+      email_body: Don’t lose your personal key or share it with others.  We’ll ask
         for it if you reset your password.
       email_title: Save it.  Keep it safe.
-      info_html: You'll need this personal key if you forget your password.  If you
-        reset your password and don't have this key, you'll have to verify your identity
+      info_html: You’ll need this personal key if you forget your password.  If you
+        reset your password and don’t have this key, you’ll have to verify your identity
         again.
     sp_handoff_bounced: Your sign in was successful, but %{sp_name} sent you back
       to login.gov. Please contact %{sp_link} for help.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -28,10 +28,10 @@ es:
         account_not_found_html: "<p><strong>%{sign_in}</strong> con su dirección de
           correo electrónico y contraseña. Luego agregue su PIV/CAC a su cuenta.</p>
           <p><strong>¿No tiene una cuenta login.gov?</strong> %{create_account}</p>"
-        add_from_sign_in_html: '<strong> Instrucciones: </strong> inserte su PIV o
-          CAC en <strong> "AGREGAR PIV / CAC" </strong>. Tendrá que <strong> elegir
+        add_from_sign_in_html: "<strong> Instrucciones: </strong> inserte su PIV o
+          CAC en <strong> “AGREGAR PIV / CAC” </strong>. Tendrá que <strong> elegir
           un certificado </strong> (el correcto probablemente tenga su nombre) e <strong>
-          ingrese su PIN </strong> (su PIN se creó cuando configuró su PIV / CAC )'
+          ingrese su PIN </strong> (su PIN se creó cuando configuró su PIV / CAC )"
         already_associated_html: Elige un certificado de una PIV/CAC distinta o ponte
           en contacto con el administrador para confirmar que tu PIV/CAC está al día.
           Si cree que se trata de un error, %{try_again}.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -9,60 +9,60 @@ fr:
           était similaire à ceci:'
         intro: Nous en faisons un peu plus pour garder votre information sécurisée
           et confidentielle, alors réinitialiser votre mot de passe demande un peu
-          plus d'effort.
+          plus d’effort.
         modal:
-          copy: Si vous n'avez pas votre clé personnelle, vous devrez vérifier votre
+          copy: Si vous n’avez pas votre clé personnelle, vous devrez vérifier votre
             identité de nouveau.
           heading: Ne disposez-vous pas de votre clé personnelle ?
-        with_key: Vous n'avez pas votre clé personnelle?
+        with_key: Vous n’avez pas votre clé personnelle?
     forgot_password:
       close_window: Vous pourrez fermer cette fenêtre de navigateur lorsque vous aurez
         réinitialisé votre mot de passe.
-    go_back_to_mobile_app: Pour continuer, veuillez retourner à l'application %{friendly_name}
+    go_back_to_mobile_app: Pour continuer, veuillez retourner à l’application %{friendly_name}
       et vous connecter.
     mfa:
       authenticator:
-        confirm_code_html: Entrez le code à partir de votre application d'authentification.
+        confirm_code_html: Entrez le code à partir de votre application d’authentification.
           Si vous avez plusieurs comptes configurés dans votre application, entrez
           le code correspondant à %{email} à %{app}.
-        manual_entry: Ou entrez ce code manuellement dans votre application d'authentification
+        manual_entry: Ou entrez ce code manuellement dans votre application d’authentification
       piv_cac:
         account_not_found_html: "<p><strong>%{sign_in}</strong> votre adresse email
           et votre mot de passe. Ajoutez ensuite votre PIV/CAC à votre compte.</p>
-          <p><strong>Vous n'avez pas de compte login.gov?</strong> %{create_account}</p>"
-        add_from_sign_in_html: '<strong> Instructions: </ strong> insérez votre PIV
-          ou votre CAC dans <strong> "AJOUTER PIV / CAC" </ strong>. Vous devez <strong>
+          <p><strong>Vous n’avez pas de compte login.gov?</strong> %{create_account}</p>"
+        add_from_sign_in_html: "<strong> Instructions: </ strong> insérez votre PIV
+          ou votre CAC dans <strong> “AJOUTER PIV / CAC” </ strong>. Vous devez <strong>
           choisir un certificat </ strong> (le bon en a probablement votre nom) et
           <strong> saisir votre code confidentiel </ strong> (votre code confidentiel
-          a été créé lors de la configuration de votre PIV / CAC). ).'
+          a été créé lors de la configuration de votre PIV / CAC). )."
         already_associated_html: Veuillez choisir un certificat associé à une autre
           carte PIV/CAC ou contactez votre administrateur afin de vérifier que votre
-          carte PIV/CAC est bien à jour. Si vous pensez que c'est une erreur, %{try_again}.
+          carte PIV/CAC est bien à jour. Si vous pensez que c’est une erreur, %{try_again}.
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.
         confirm_piv_cac_only_html: Cette application nécessite un niveau de sécurité
-          plus élevé. Vous devez vérifier votre identité à l'aide d'un badge d'employé
+          plus élevé. Vous devez vérifier votre identité à l’aide d’un badge d’employé
           du gouvernement que vous avez précédemment configuré pour accéder à vos
           informations.
         confirm_piv_cac_or_aal3_html: Cette application nécessite un niveau de sécurité
-          plus élevé. Vous devez vérifier votre identité à l'aide d'un dispositif
-          physique tel qu'une clé de sécurité ou un badge d'employé du gouvernement
+          plus élevé. Vous devez vérifier votre identité à l’aide d’un dispositif
+          physique tel qu’une clé de sécurité ou un badge d’employé du gouvernement
           (PIV ou CAC) pour accéder à vos informations.
         did_not_work_html: Veuillez %{please_try_again}. Si ce problème persiste,
-          contactez l'administrateur de votre agence.
+          contactez l’administrateur de votre agence.
         no_certificate_html: Veuillez vous assurer que votre PIV/CAC est connecté
-          et %{try_again}. Si ce problème persiste, contactez l'administrateur de
+          et %{try_again}. Si ce problème persiste, contactez l’administrateur de
           votre agence.
-        not_auth_cert_html: Le certificat que vous avez sélectionné n'est pas valide
+        not_auth_cert_html: Le certificat que vous avez sélectionné n’est pas valide
           pour ce compte. Veuillez %{please_try_again} avec un autre certificat. Si
-          ce problème persiste, contactez l'administrateur de votre agence.
+          ce problème persiste, contactez l’administrateur de votre agence.
         please_try_again: réessayer
-        sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
+        sign_in: Assurez-vous que <strong>vous disposez d’un compte login.gov</strong>
           et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
-          d'authentification à deux facteurs.
+          d’authentification à deux facteurs.
         step_1: Donnez-lui un surnom
-        step_1_info: Si vous ajoutez plus d'un PIV / CAC, vous saurez lequel.
+        step_1_info: Si vous ajoutez plus d’un PIV / CAC, vous saurez lequel.
         step_2: Insérez votre PIV/CAC dans votre lecteur de carte
         step_3: Ajoutez votre PIV/CAC
         step_3_info_html: Vous devrez <strong> choisir un certificat </strong> (celui
@@ -71,8 +71,8 @@ fr:
           PIV / CAC ).
         try_again: réessayer
       sms:
-        confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.
-          Les frais liés aux messages texte peuvent s'appliquer.
+        confirm_code_html: Vous avez besoin d’un autre code? %{resend_code_link}.
+          Les frais liés aux messages texte peuvent s’appliquer.
         number_message_html: Nous avons envoyé un code de sécurité au %{number}. Ce
           code expirera dans %{expiration} minutes.
       voice:
@@ -81,24 +81,24 @@ fr:
       webauthn:
         confirm_webauthn_html: Présentez la clé de sécurité associée à votre compte.
         confirm_webauthn_only_html: Cette application nécessite un niveau de sécurité
-          plus élevé. Vous devez vérifier votre identité à l'aide d'une clé de sécurité
+          plus élevé. Vous devez vérifier votre identité à l’aide d’une clé de sécurité
           que vous avez précédemment configurée pour accéder à vos informations.
         confirm_webauthn_or_aal3_html: Cette application nécessite un niveau de sécurité
-          plus élevé. Vous devez vérifier votre identité à l'aide d'un dispositif
-          physique tel qu'une clé de sécurité ou un badge d'employé du gouvernement
+          plus élevé. Vous devez vérifier votre identité à l’aide d’un dispositif
+          physique tel qu’une clé de sécurité ou un badge d’employé du gouvernement
           (PIV ou CAC) pour accéder à vos informations.
       wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir
         confirmé votre adresse courriel.
       help_text: Plus long et inhabituel est le mot de passe, plus difficile il sera
-        à trouver. Évitez donc d'utiliser des phrases communes. Évitez aussi de répéter
-        des mots de passe d'autres comptes en ligne comme les comptes bancaires, les
+        à trouver. Évitez donc d’utiliser des phrases communes. Évitez aussi de répéter
+        des mots de passe d’autres comptes en ligne comme les comptes bancaires, les
         comptes courriel et les comptes de médias sociaux.
       help_text_header: Conseils sur la sécurité du mot de passe
       info:
         lead: Il doit avoir une longueur minimale de %{min_length} caractères et ne
-          pas être un mot de passe couramment utilisé. C'est tout!
+          pas être un mot de passe couramment utilisé. C’est tout!
       strength:
         i: Très faible
         ii: Faible
@@ -115,5 +115,5 @@ fr:
         mot de passe. Si vous réinitialisez votre mot de passe et que vous ne possédez
         pas cette clé, vous devrez vérifier votre identité à nouveau.
     sp_handoff_bounced: Votre connexion a réussi, mais %{sp_name} vous a renvoyé à
-      login.gov. Veuillez contacter %{sp_link} pour obtenir de l'aide.
+      login.gov. Veuillez contacter %{sp_link} pour obtenir de l’aide.
     sp_handoff_bounced_with_no_sp: votre fournisseur de service

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -4,7 +4,7 @@ en:
     account:
       reactivate:
         with_key: I have my key
-        without_key: I don't have my key
+        without_key: I don’t have my key
     back_to_sp: Back to %{sp}
     cancel: Cancel
     cancel_account_creation: "‹ Cancel account creation"

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -3,8 +3,8 @@ fr:
   links:
     account:
       reactivate:
-        with_key: J'ai ma clé
-        without_key: Je n'ai pas ma clé
+        with_key: J’ai ma clé
+        without_key: Je n’ai pas ma clé
     back_to_sp: Retour à %{sp}
     cancel: Annuler
     cancel_account_creation: "‹ Annuler la création du compte"
@@ -25,5 +25,5 @@ fr:
     sign_out: Déconnexion
     two_factor_authentication:
       get_another_code: Obtenir un autre code
-    what_is_totp: Qu'est-ce qu'une application d'authentification?
-    what_is_webauthn: Qu'est-ce qu'une clé de sécurité physique?
+    what_is_totp: Qu’est-ce qu’une application d’authentification?
+    what_is_webauthn: Qu’est-ce qu’une clé de sécurité physique?

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -29,7 +29,7 @@ en:
       security_and_privacy_practices: Security and Privacy Practices
     resend_confirmation_email:
       success: We sent another confirmation email.
-    session_cleared: For your security, we clear what you entered if you don't move
+    session_cleared: For your security, we clear what you entered if you don’t move
       to a new page within %{minutes} minutes.
     session_timedout: We signed you out. For your security, %{app} ends your session
       when you haven’t moved to a new page for %{minutes} minutes.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -4,13 +4,13 @@ fr:
     account_reactivation: Excellent! Vous avez votre clé personnelle.
     backup_codes_configured: Les codes de sauvegarde ont été ajoutés à votre compte.
     backup_codes_deleted: Vos codes de sauvegarde ont été supprimés de votre compte.
-    dap_participation: Nous participons au programme d'analytique du gouvernement
+    dap_participation: Nous participons au programme d’analytique du gouvernement
       des États-Unis. Consultez les données à analytics.usa.gov.
     forgot_password:
       first_paragraph_end: avec un lien pour réinitialiser votre mot de passe. Suivez
         le lien pour continuer à réinitialiser votre mot de passe.
       first_paragraph_start: Nous avons envoyé un courriel à
-      no_email_sent_explanation_start: Vous n'avez pas reçu de courriel?
+      no_email_sent_explanation_start: Vous n’avez pas reçu de courriel?
       resend_email_success: Nous avons envoyé un autre courriel de réinitialisation
         de mot de passe.
       use_diff_email:
@@ -19,8 +19,8 @@ fr:
     maintenance:
       contact_us: Nous contacter
       currently_under_maintenance_html: Nous sommes actuellement <b>en maintenance
-        jusqu'au %{finish}</b> pour certains de nos services.
-      need_assistance: Besoin d'assistance?
+        jusqu’au %{finish}</b> pour certains de nos services.
+      need_assistance: Besoin d’assistance?
     password_changed: Vous avez changé votre mot de passe.
     phone_confirmed: Un téléphone a été ajouté à votre compte.
     piv_cac_configured: Une carte PIV / CAC a été ajoutée à votre compte.
@@ -30,7 +30,7 @@ fr:
       security_and_privacy_practices: Pratiques de sécurité et de confidentialité
     resend_confirmation_email:
       success: Nous avons envoyé un autre courriel de confirmation.
-    session_cleared: Pour votre sécurité, nous effacerons l'information que vous avez
+    session_cleared: Pour votre sécurité, nous effacerons l’information que vous avez
       entrée si vous ne vous déplacez pas vers une nouvelle page dans les %{minutes}
       prochaines minutes.
     session_timedout: Nous vous avons déconnecté. Pour votre sécurité, %{app} désactive
@@ -40,12 +40,12 @@ fr:
       first_paragraph_end: avec un lien pour confirmer votre adresse email. Suivez
         le lien pour continuer à ajouter cet email à votre compte.
       first_paragraph_start: Nous avons envoyé un email à
-      no_email_sent_explanation_start: Vous n'avez pas reçu de courrier électronique?
+      no_email_sent_explanation_start: Vous n’avez pas reçu de courrier électronique?
     signed_up_but_unconfirmed:
       first_paragraph_end: avec un lien pour confirmer votre adresse courriel. Suivez
         le lien pour continuer à créer votre compte.
       first_paragraph_start: Nous avons envoyé un courriel à
-      no_email_sent_explanation_start: Vous n'avez pas reçu d'e-mail?
+      no_email_sent_explanation_start: Vous n’avez pas reçu d’e-mail?
     timeout_warning:
       partially_signed_in:
         continue: Continuer la connexion
@@ -54,10 +54,10 @@ fr:
       signed_in:
         continue: Gardez ma connexion active
         message_html: Pour votre sécurité, nous vous déconnecterons dans %{time_left_in_session},
-          sauf en cas d'avis contraire de votre part.
+          sauf en cas d’avis contraire de votre part.
         sign_out: Déconnectez-moi
-    totp_configured: Une application d'authentification a été ajoutée à votre compte.
-    totp_disabled: Votre application d'authentification a été supprimée de votre compte.
+    totp_configured: Une application d’authentification a été ajoutée à votre compte.
+    totp_disabled: Votre application d’authentification a été supprimée de votre compte.
     use_diff_email:
       link: utilisez une adresse courriel différente
       text_html: Ou %{link}

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -25,7 +25,7 @@ en:
         invalid_aud: Invalid audience claim, expected %{url}
         invalid_authentication: Client must authenticate via PKCE or private_key_jwt,
           missing either code_challenge or client_assertion
-        invalid_code: is invalid either because it expired, or it doesn't match any
+        invalid_code: is invalid either because it expired, or it doesn’t match any
           user. Please see our documentation at https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier did not match code_challenge
         invalid_iat: iat must be an integer or floating point Unix timestamp representing

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -5,8 +5,8 @@ fr:
       errors:
         bad_client_id: Mauvaise client_id
         invalid_verified_within_duration:
-          one: la valeur doit être d'au moins %{count} jour ou plus
-          other: la valeur doit être d'au moins %{count} jours ou plus
+          one: la valeur doit être d’au moins %{count} jour ou plus
+          other: la valeur doit être d’au moins %{count} jours ou plus
         invalid_verified_within_format: Format non reconnu pour verified_within
         liveness_checking_disabled: La vérification de la vivacité est désactivée
         missing_ial: Manque un niveau IAL valide
@@ -19,23 +19,23 @@ fr:
         unauthorized_scope: Portée non autorisée
     logout:
       errors:
-        id_token_hint: id_token_hint n'a pas été reconnu
+        id_token_hint: id_token_hint n’a pas été reconnu
     token:
       errors:
-        invalid_aud: Affirmation liée à l'auditoire non valide, attendu %{url}
-        invalid_authentication: Le client doit s'authentifier par PKCE ou private_key_jwt,
+        invalid_aud: Affirmation liée à l’auditoire non valide, attendu %{url}
+        invalid_authentication: Le client doit s’authentifier par PKCE ou private_key_jwt,
           code_challenge ou client_assertion manquant
-        invalid_code: est non valide soit parce qu'il est périmé, soit parce qu'il
+        invalid_code: est non valide soit parce qu’il est périmé, soit parce qu’il
           ne correspond à aucun utilisateur. Veuillez consulter notre documentation
           à https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier ne correspondait pas à code_challenge
         invalid_iat: iat doit être un horodatage Unix entier ou à virgule flottante
           représentant une heure dans le passé
-        invalid_signature: Impossible de valider l'assertion contre les clés publiques
+        invalid_signature: Impossible de valider l’assertion contre les clés publiques
           enregistrées
     user_info:
       errors:
-        malformed_authorization: Forme de l'en-tête d'autorisation non valide
-        no_authorization: Aucune en-tête d'autorisation fournie
-        not_found: L'autorisation pour le contenu du access_token fourni introuvable
+        malformed_authorization: Forme de l’en-tête d’autorisation non valide
+        no_authorization: Aucune en-tête d’autorisation fournie
+        not_found: L’autorisation pour le contenu du access_token fourni introuvable
           ou il peut être expiré

--- a/config/locales/pages/fr.yml
+++ b/config/locales/pages/fr.yml
@@ -3,4 +3,4 @@ fr:
   pages:
     page_took_too_long:
       body: Veuillez réessayer dans quelques minutes. (503)
-      header: Le système d'information a pris trop de temps à traiter votre demande.
+      header: Le système d’information a pris trop de temps à traiter votre demande.

--- a/config/locales/risc/fr.yml
+++ b/config/locales/risc/fr.yml
@@ -6,13 +6,13 @@ fr:
         alg_unsupported: algorithme non pris en charge, doit être signé avec %{expected_alg}
         aud_invalid: revendication aud non valide, %{url} attendu
         event_type_missing: event manquant
-        event_type_unsupported: type d'événement non pris en charge %{event_type}
+        event_type_unsupported: type d’événement non pris en charge %{event_type}
         exp_present: Les événements SET ne doivent pas avoir de réclamation exp
-        jti_not_unique: jti n'était pas unique
+        jti_not_unique: jti n’était pas unique
         jti_required: La revendication jti est requise
-        jwt_could_not_parse: impossible d'analyser JWT
-        no_public_key: impossible de charger la clé publique de l'émetteur
+        jwt_could_not_parse: impossible d’analyser JWT
+        no_public_key: impossible de charger la clé publique de l’émetteur
         sub_not_found: revendication event.subject.sub non valide
-        sub_unsupported: la sub-revendication de niveau supérieur n'est pas acceptée
+        sub_unsupported: la sub-revendication de niveau supérieur n’est pas acceptée
         subject_type_unsupported: subject_type doit être %{expected_subject_type}
-        typ_error: l'en-tête typ doit être %{expected_typ}
+        typ_error: l’en-tête typ doit être %{expected_typ}

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -9,7 +9,7 @@ en:
         instructions: "%{sp_name} no longer uses login.gov as a sign-in service for
           their website. If you already created a login.gov account, it is still active
           and can be used to access other participating government websites."
-        instructions2: Please visit the agency's website to contact them for more
+        instructions2: Please visit the agency’s website to contact them for more
           information.
     help_text:
       default:

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -15,11 +15,11 @@ fr:
     help_text:
       default:
         forgot_password: Si vous avez déjà un profil %{sp_name}, veuillez utiliser
-          l'adresse e-mail principale ou secondaire que vous avez utilisée pour %{sp_name}
+          l’adresse e-mail principale ou secondaire que vous avez utilisée pour %{sp_name}
           pour <a href=%{sp_create_link}> créer votre nouveau compte login.gov</a>
           <p><a href="https://login.gov/help/">En savoir plus.</a>
         sign_in: <b>Êtes-vous venu(e) de %{sp_name}?</b><p> Si vous avez déjà un profil
-          %{sp_name}, veuillez utiliser l'adresse e-mail principale ou secondaire
+          %{sp_name}, veuillez utiliser l’adresse e-mail principale ou secondaire
           que vous avez utilisée pour %{sp_name} pour <a href=%{sp_create_link}> créer
           votre nouveau compte login.gov</a> <p><a href="https://login.gov/help/">En
           savoir plus.</a>

--- a/config/locales/sign_up/fr.yml
+++ b/config/locales/sign_up/fr.yml
@@ -6,7 +6,7 @@ fr:
       success: Le dossier contenant votre information a été effacé
       warning_header: Si vous annulez maintenant
     email:
-      invalid_email_alert_head: 'Erreur: Ce n''est pas une vraie adresse email. Assurez-vous
-        qu''il comprend un @ et un nom de domaine.'
+      invalid_email_alert_head: 'Erreur: Ce n’est pas une vraie adresse email. Assurez-vous
+        qu’il comprend un @ et un nom de domaine.'
       invalid_email_alert_inline: Entrez une adresse email réelle
       invalid_request: Le formulaire email est invalide

--- a/config/locales/step_indicator/fr.yml
+++ b/config/locales/step_indicator/fr.yml
@@ -8,7 +8,7 @@ fr:
         secure_account: Sécurisez votre compte
         verify_id: Vérifier votre identité
         verify_info: Vérifier vos données personnelles
-        verify_phone_or_address: Vérifier le téléphone ou l'adresse
+        verify_phone_or_address: Vérifier le téléphone ou l’adresse
     status:
       complete: Terminé
       current: Étape en cours

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -40,12 +40,12 @@ en:
       new: Sign up for an account
     revoke_consent: Revoke Consent
     sign_up:
-      completion_html: You've %{accent} with %{app}
+      completion_html: You’ve %{accent} with %{app}
       confirmation: Continue to sign in
       loa1: created an account
       new_sp: You are now signing in for the first time
-      refresh_consent: It's been a year since you gave us consent to share your information
-      verified: You've verified your identity with %{app}
+      refresh_consent: It’s been a year since you gave us consent to share your information
+      verified: You’ve verified your identity with %{app}
     totp_setup:
       new: Add authentication app
     two_factor_setup: Two-factor authentication setup

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -37,7 +37,7 @@ fr:
     present_webauthn: Branchez votre clé de sécurité physique
     reactivate_account: Réactiver le profil
     registrations:
-      new: S'inscrire et créer un compte
+      new: S’inscrire et créer un compte
     revoke_consent: Révoquer le consentement
     sign_up:
       completion_html: Vous avez %{accent} avec %{app}
@@ -48,8 +48,8 @@ fr:
         pour partager vos informations
       verified: Vous avez verifié votre identité avec %{app}
     totp_setup:
-      new: Ajouter une application d'authentification
-    two_factor_setup: Configuration de l'authentification à deux facteurs
+      new: Ajouter une application d’authentification
+    two_factor_setup: Configuration de l’authentification à deux facteurs
     verify_email: Consultez vos courriels
     verify_profile: Activez votre compte
     visitors:

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -15,12 +15,12 @@ en:
       reverify_link: re-verify your identity
       successful_cancel: Thank you. Your request to delete your login.gov account
         has been cancelled.
-      text_html: If you can't use any of the authentication methods above, you can
+      text_html: If you can’t use any of the authentication methods above, you can
         reset your preferences by %{link}.
     backup_code_fallback:
-      question: Don't have your backup codes available?
+      question: Don’t have your backup codes available?
     backup_code_header_text: Enter your backup security code
-    backup_code_prompt: You can use this security code once. After you enter it, you'll
+    backup_code_prompt: You can use this security code once. After you enter it, you’ll
       need to use a new key.
     choose_another_option: "‹ Choose another option"
     devices:
@@ -83,8 +83,8 @@ en:
     no_auth_option: No authentication option could be found for you to sign in.
     otp_delivery_preference:
       instruction: You can change this selection the next time you sign in. If you
-        entered a landline, please select "Phone call" below.
-      phone_unsupported: We're unable to make phone calls to people in %{location}
+        entered a landline, please select “Phone call” below.
+      phone_unsupported: We’re unable to make phone calls to people in %{location}
         at this time.
       sms: Text message (SMS)
       title: How should we send you a code?
@@ -95,26 +95,26 @@ en:
       label: Default phone number
       title: Make this your default phone number?
     personal_key_fallback:
-      question: Don't have your personal key?
+      question: Don’t have your personal key?
     personal_key_header_text: Enter your personal key
-    personal_key_prompt: You can use this personal key once. After you enter it, you'll
+    personal_key_prompt: You can use this personal key once. After you enter it, you’ll
       be provided a new key.
     phone:
       delete:
         failure: Unable to remove your phone.
         success: Your phone has been removed.
     phone_fallback:
-      question: Don't have access to your phone right now?
+      question: Don’t have access to your phone right now?
     phone_fee_disclosure: Message and data rates may apply.
-    phone_info_html: We'll send you a security code <strong>each time you sign in</strong>.
+    phone_info_html: We’ll send you a security code <strong>each time you sign in</strong>.
     phone_label: Phone number
-    phone_sms_info_html: We'll text a security code <strong>each time you sign in</strong>.
+    phone_sms_info_html: We’ll text a security code <strong>each time you sign in</strong>.
     phone_sms_label: Mobile phone number
-    phone_voice_info_html: We'll call you with a security code <strong>each time you
+    phone_voice_info_html: We’ll call you with a security code <strong>each time you
       sign in</strong>.
     phone_voice_label: Phone number
     piv_cac_fallback:
-      question: Don't have your PIV or CAC available?
+      question: Don’t have your PIV or CAC available?
     piv_cac_header_text: Present your PIV/CAC
     piv_cac_webauthn_available: Use your security key
     please_try_again_html: Please try again in <strong id=%{id}>%{time_remaining}</strong>.
@@ -122,7 +122,7 @@ en:
       link: read about two-factor authentication
       text_html: You can %{link} and why we use it at our Help page.
     totp_fallback:
-      question: Don't have your authenticator app?
+      question: Don’t have your authenticator app?
     totp_header_text: Enter your authentication app code
     two_factor_aal3_choice: Additional authentication required
     two_factor_aal3_choice_intro: This app requires a higher level of security. You
@@ -161,7 +161,7 @@ en:
       You need to verify your identity using a government employee ID (PIV/CAC) to
       access your information.
     webauthn_fallback:
-      question: Don't have your security key available?
+      question: Don’t have your security key available?
     webauthn_header_text: Connect your security key
     webauthn_piv_available: Use your PIV or CAC
     webauthn_verified:

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -7,7 +7,7 @@ fr:
       pending_html: Vous avez actuellement une demande en attente pour supprimer votre
         compte.  Il faut compter 24 heures à partir du moment où vous avez fait la
         demande pour terminer le processus.  Veuillez vérifier plus tard. %{cancel_link}
-      recover_html: Si vous ne pouvez utiliser aucune des méthodes d'authentification
+      recover_html: Si vous ne pouvez utiliser aucune des méthodes d’authentification
         ci-dessus, vous pouvez %{reverify_link}. Votre nom, votre adresse et votre
         numéro de sécurité sociale doivent correspondre à votre profil de compte.
         Si ce n’est pas le cas, vous pouvez %{reset_link}.
@@ -16,36 +16,36 @@ fr:
       reverify_link: re-vérifier votre identité
       successful_cancel: Je vous remercie. Votre demande de suppression de votre compte
         login.gov a été annulée.
-      text_html: Si vous ne pouvez pas utiliser l'une de ces options de sécurité ci-dessus,
+      text_html: Si vous ne pouvez pas utiliser l’une de ces options de sécurité ci-dessus,
         vous pouvez réinitialiser vos préférences par %{link}.
     backup_code_fallback:
-      question: Vous n'avez pas vos codes de secours disponibles?
+      question: Vous n’avez pas vos codes de secours disponibles?
     backup_code_header_text: Entrez votre code de sécurité de secours
-    backup_code_prompt: Vous pouvez utiliser ce code de sécurité une fois. Après l'avoir
+    backup_code_prompt: Vous pouvez utiliser ce code de sécurité une fois. Après l’avoir
       entré, vous devrez utiliser une nouvelle clé.
     choose_another_option: "‹ Choisissez une autre option"
     devices:
-      auth_app: Application d'authentification
+      auth_app: Application d’authentification
       backup_code: Codes de sécurité personnels
       phone: Téléphone
       piv_cac: PIV/CAC
       webauthn: Clé de sécurité
     header_text: Entrez votre code de sécurité
-    important_alert_icon: Icône d'alerte importante
+    important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.
-    invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l'entrer
+    invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l’entrer
       de nouveau ou demander un nouveau code de sécurité à utilisation unique.
     invalid_personal_key: Cette clé personnelle est non valide.
     invalid_piv_cac: Ce PIV/CAC n’a pas fonctionné. Assurez-vous que c’est le bon
-      PIV/CAC pour ce compte. Si c'est le cas, votre PIV/CAC, votre NIP ou un problème
+      PIV/CAC pour ce compte. Si c’est le cas, votre PIV/CAC, votre NIP ou un problème
       survenu de notre côté pourrait bien poser problème. Réessayez ou choisissez
-      une autre méthode d'authentification.
+      une autre méthode d’authentification.
     lockout_information: Conservez ces informations en toute sécurité. Vous serez
-      bloqué et devrez créer un nouveau compte si vous perdez votre méthode d'authentification.
+      bloqué et devrez créer un nouveau compte si vous perdez votre méthode d’authentification.
     login_intro: Vous les avez configurés lorsque vous avez crée votre compte
     login_options:
-      auth_app: Application d'authentification
-      auth_app_info_html: Utilisez votre application d'authentification pour obtenir
+      auth_app: Application d’authentification
+      auth_app_info_html: Utilisez votre application d’authentification pour obtenir
         votre code de sécurité
       backup_code: Codes de sauvegarde
       backup_code_info_html: Utilisez un code de sauvegarde de votre liste de codes
@@ -86,7 +86,7 @@ fr:
       bloqué en raison de la saisie de mauvais identifiants PIV/CAC à de trop nombreuses
       reprises.
     mobile_terms_of_service: Conditions de service mobile
-    no_auth_option: Aucune option d'authentification n'a été trouvée pour vous connecter
+    no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
       phone_unsupported: Nous ne sommes pas en mesure de passer des appels téléphoniques
@@ -101,16 +101,16 @@ fr:
       label: Numéro de téléphone par défaut
       title: Faites-en votre numéro de téléphone par défaut?
     personal_key_fallback:
-      question: Vous n'avez pas votre clé personnelle?
+      question: Vous n’avez pas votre clé personnelle?
     personal_key_header_text: Entrez votre clé personnelle
     personal_key_prompt: Vous pouvez utiliser cette clé personnelle une fois seulement.
-      Une fois que vous l'entrez, vous recevrez une nouvelle clé.
+      Une fois que vous l’entrez, vous recevrez une nouvelle clé.
     phone:
       delete:
         failure: Impossible de supprimer votre numéro de téléphone.
         success: Votre numéro de téléphone a été supprimé.
     phone_fallback:
-      question: Vous n'avez pas accès à votre téléphone maintenant?
+      question: Vous n’avez pas accès à votre téléphone maintenant?
     phone_fee_disclosure: Des messages et débits de données peuvent être appliqués.
     phone_info_html: Nous vous enverrons ou appellerons avec un code de sécurité <strong>chaque
       fois que vous vous connectez</strong>.
@@ -122,39 +122,39 @@ fr:
       fois que vous vous connectez</strong>.
     phone_voice_label: Numéro de téléphone
     piv_cac_fallback:
-      question: Votre PIV ou CAC n'est pas disponible?
+      question: Votre PIV ou CAC n’est pas disponible?
     piv_cac_header_text: Veuillez présenter votre carte PIV/CAC
     piv_cac_webauthn_available: Utilisez votre clé de sécurité
     please_try_again_html: Veuillez essayer de nouveau dans <strong id=%{id}>%{time_remaining}</strong>.
     read_about_two_factor_authentication:
-      link: lire sur l'authentification à deux facteurs
-      text_html: Vous pouvez %{link} et pourquoi nous l'utilisons sur notre page d'aide.
+      link: lire sur l’authentification à deux facteurs
+      text_html: Vous pouvez %{link} et pourquoi nous l’utilisons sur notre page d’aide.
     totp_fallback:
-      question: Vous n'avez pas votre application d'authentification?
-    totp_header_text: Entrez votre code d'application d'authentification
+      question: Vous n’avez pas votre application d’authentification?
+    totp_header_text: Entrez votre code d’application d’authentification
     two_factor_aal3_choice: Authentification supplémentaire requise
     two_factor_aal3_choice_intro: Cette application nécessite un niveau de sécurité
-      plus élevé. Vous devez vérifier votre identité à l'aide d'un dispositif physique
-      tel qu'une clé de sécurité ou un badge d'employé du gouvernement (PIV ou CAC)
+      plus élevé. Vous devez vérifier votre identité à l’aide d’un dispositif physique
+      tel qu’une clé de sécurité ou un badge d’employé du gouvernement (PIV ou CAC)
       pour accéder à vos informations.
-    two_factor_choice: Configuration de la méthode d'authentification
+    two_factor_choice: Configuration de la méthode d’authentification
     two_factor_choice_intro: Ajoutez une deuxième couche de sécurité pour que vous
       puissiez vous connecter à votre compte.
     two_factor_choice_options:
-      auth_app: Application d'authentification
-      auth_app_info_html: Obtenir des codes d'une application sur votre téléphone,
+      auth_app: Application d’authentification
+      auth_app_info_html: Obtenir des codes d’une application sur votre téléphone,
         votre ordinateur ou votre tablette.
-      backup_code: Je n'ai rien de ce qui précède
+      backup_code: Je n’ai rien de ce qui précède
       backup_code_info_html: Nous vous donnerons 10 codes à utiliser et à conserver
         dans un endroit sûr. Vous pouvez utiliser des codes de sauvegarde comme seule
-        méthode d'authentification.
+        méthode d’authentification.
       less_secure_label: Moins de protection
       more_secure_label: Plus de protection
       phone: Téléphone
       phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique.
       phone_info_no_voip: Veuillez ne pas utiliser les services téléphoniques basés
         sur le Web (VOIP).
-      piv_cac: Numéro d'employé du gouvernement
+      piv_cac: Numéro d’employé du gouvernement
       piv_cac_info_html: Insérez votre carte PIV ou CAC du gouvernement ou militaire
         et entrez votre code PIN.
       secure_label: A une protection
@@ -168,11 +168,11 @@ fr:
         téléphone (il ressemble souvent à une clé USB).
     two_factor_hspd12_choice: Authentification supplémentaire requise
     two_factor_hspd12_choice_intro: Cette application nécessite un haut niveau de
-      sécurité. Vous devez vérifier votre identité à l'aide d'un appareil physique
-      tel qu'une clé de sécurité ou un identifiant d'employé du gouvernement (PIC/CAC)
+      sécurité. Vous devez vérifier votre identité à l’aide d’un appareil physique
+      tel qu’une clé de sécurité ou un identifiant d’employé du gouvernement (PIC/CAC)
       pour accéder à vos informations.
     webauthn_fallback:
-      question: Vous n'avez pas votre clé de sécurité avec vous?
+      question: Vous n’avez pas votre clé de sécurité avec vous?
     webauthn_header_text: Connectez votre clé de sécurité
     webauthn_piv_available: Utilisez votre PIV ou CAC
     webauthn_verified:

--- a/config/locales/user_authorization_confirmation/fr.yml
+++ b/config/locales/user_authorization_confirmation/fr.yml
@@ -2,6 +2,6 @@
 fr:
   user_authorization_confirmation:
     continue: Continuer
-    currently_logged_in: 'Vous êtes déjà connecté(e) avec l''adresse e-mail suivante:'
+    currently_logged_in: 'Vous êtes déjà connecté(e) avec l’adresse e-mail suivante:'
     or: Ou
-    sign_in: Changer d'adresse e-mail
+    sign_in: Changer d’adresse e-mail

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -5,7 +5,7 @@ en:
       intro_html: This email address is not yet associated with a %{app} account.
         If you’d like to create a login.gov account using this email address, please
         click the link below or copy and paste the entire link into your browser.
-        If you didn't request a password reset, you can ignore this message.
+        If you didn’t request a password reset, you can ignore this message.
       link_text: Create your account
       subject: Your login.gov password reset request
     account_reset_cancel:
@@ -21,13 +21,13 @@ en:
       help_html: If you don’t want to delete your account, %{cancel_account_reset}.
       intro_html: Your 24 hour waiting period has ended. Please complete step 2 of
         the process.<br><br> If you’ve been unable to locate your authentication methods,
-        select "confirm deletion" to delete your %{app} account.<br><br> In the future,
+        select “confirm deletion” to delete your %{app} account.<br><br> In the future,
         if you need to access participating government websites who use %{app}, you
         can create a new %{app} account using the same email address after your account
         is deleted.<br><br>
       subject: Delete your login.gov account
     account_reset_request:
-      cancel: Don't want to delete your account? Sign in to your login.gov account
+      cancel: Don’t want to delete your account? Sign in to your login.gov account
         to cancel.
       header: Your account will be deleted in 24 hours
       intro_html: 'As a security measure, %{app} requires a two-step process to delete
@@ -52,7 +52,7 @@ en:
         and sign in with this email address. If you are not trying to add this email
         address to an account, you can ignore this message.
       link_text: Go to %{app}
-      reset_password_html: If you can't remember your password, go to %{app} to reset
+      reset_password_html: If you can’t remember your password, go to %{app} to reset
         it.
     contact_link_text: contact us
     deleted_accounts_report:
@@ -60,7 +60,7 @@ en:
       name: Name
       subject: Deleted accounts report
     doc_auth_link:
-      message: You've requested to verify your identity on a desktop computer.  Please
+      message: You’ve requested to verify your identity on a desktop computer.  Please
         sign in to %{sp_link}
       subject: Verify your identity on a desktop computer
     email_added:
@@ -73,7 +73,7 @@ en:
       email_not_found: Email not found
       first_sentence:
         confirmed: Trying to change your email address?
-        forgot_password: You tried to reset your login.gov password but we don't have
+        forgot_password: You tried to reset your login.gov password but we don’t have
           an account linked to this email address.
         unconfirmed: Thanks for submitting your email address.
       footer: This link will expire in %{confirmation_period}.
@@ -110,12 +110,12 @@ en:
       intro_html: You have a new password for your %{app} account.
     personal_key_regenerated:
       help_html: <p>Your login.gov account was just issued a new 16-character personal
-        key. You're getting this email to make sure it was you.</p><p>If you just
-        signed in and regenerated your personal key, great! There's nothing you need
-        to do.</p><p>If you did not just regenerate your personal key, or if you're
+        key. You’re getting this email to make sure it was you.</p><p>If you just
+        signed in and regenerated your personal key, great! There’s nothing you need
+        to do.</p><p>If you did not just regenerate your personal key, or if you’re
         not sure, please immediately take these steps to secure your account:<ol><li><strong><a
         href="%{reset_password_url}">Change your password</a>.</strong> Choose a password
-        that you haven't already used with this account.</li><li><strong><a href="%{account_url}">Sign
+        that you haven’t already used with this account.</li><li><strong><a href="%{account_url}">Sign
         in to your login.gov account</a></strong> and make sure you recognize all
         of the information on your account page, including the methods you use for
         two-factor authentication, such as phone number, authentication app, or security
@@ -127,12 +127,12 @@ en:
       subject: Account Security Alert
     personal_key_sign_in:
       help_html: <p>Your login.gov account was just signed into using your 16-character
-        personal key. You're getting this email to make sure it was you.</p> <p>If
-        you just signed in using your personal key, great! There's nothing you need
-        to do.</p><p>If you did not sign in with a personal key, or if you're not
+        personal key. You’re getting this email to make sure it was you.</p> <p>If
+        you just signed in using your personal key, great! There’s nothing you need
+        to do.</p><p>If you did not sign in with a personal key, or if you’re not
         sure, please immediately take these steps to secure your account:<ol><li><strong><a
         href="%{reset_password_url}">Change your password</a>.</strong> Choose a password
-        that you haven't already used with this account.</li><li><strong><a href="%{account_url}">Sign
+        that you haven’t already used with this account.</li><li><strong><a href="%{account_url}">Sign
         in to your login.gov account</a></strong> and make sure you recognize all
         of the information on your account page, including the methods you use for
         two-factor authentication, such as phone number, authentication app, or security
@@ -172,11 +172,11 @@ en:
       help_html: If you did not request a new account or suspect an error, please
         visit the %{app} %{help_link} or %{contact_link}.
       intro_html: This email address is already associated with a %{app} account,
-        so we can't use it to create a new account. To sign in with your existing
+        so we can’t use it to create a new account. To sign in with your existing
         account, follow the link below.  If you are not trying to sign in with this
         email address, you can ignore this message.
       link_text: Go to %{app}
-      reset_password_html: If you can't remember your password, go to %{app} to reset
+      reset_password_html: If you can’t remember your password, go to %{app} to reset
         it.
     sps_over_quota_limit:
       help: ''

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -22,7 +22,7 @@ es:
       help_html: Si no desea eliminar su cuenta, %{cancel_account_reset}.
       intro_html: Su período de espera de 24 horas ha finalizado. Complete el paso
         2 del proceso.<br><br>Si no ha podido localizar sus métodos de autenticación,
-        seleccione "confirmar eliminación" para eliminar su cuenta de %{app}.<br><br>
+        seleccione “confirmar eliminación” para eliminar su cuenta de %{app}.<br><br>
         En el futuro, si necesita acceder a los sitios web gubernamentales participantes
         que utilizan %{app}, puede crear una nueva cuenta %{app} con la misma dirección
         de correo electrónico después de que se elimine su cuenta.<br><br>
@@ -164,7 +164,7 @@ es:
         de inicio de sesión. por teléfono o correo electrónico</b>. Puede tomar medidas
         adicionales para proteger su cuenta habilitando la autenticación de dos factores.
       step_1: Visite el sitio web login.gov y seleccione iniciar sesión
-      step_2: Seleccione "¿olvidó su contraseña?" al final de la página
+      step_2: Seleccione “¿olvidó su contraseña?” al final de la página
       step_3: Siga las instrucciones para restablecer su contraseña
       subject: Actividad inusual — restablezca su contraseña de login.gov
     reset_password_instructions:

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -2,10 +2,10 @@
 fr:
   user_mailer:
     account_does_not_exist:
-      intro_html: Cette adresse e-mail n'est pas encore associée à un compte %{app}.
+      intro_html: Cette adresse e-mail n’est pas encore associée à un compte %{app}.
         Si vous souhaitez créer un compte login.gov avec cette adresse e-mail, veuillez
-        cliquer sur le lien ci-dessous ou faites un copier-coller de l'intégralité
-        du lien sur votre navigateur. Si vous n'avez pas sollicité une réinitialisation
+        cliquer sur le lien ci-dessous ou faites un copier-coller de l’intégralité
+        du lien sur votre navigateur. Si vous n’avez pas sollicité une réinitialisation
         de votre mot de passe, nous vous prions de bien vouloir ignorer ce message.
       link_text: Créer votre compte
       subject: Votre demande de réinitialisation de votre mot de passe login.gov
@@ -20,10 +20,10 @@ fr:
       button: Oui, continuez la suppression
       cancel_link_text: veuillez annuler
       help_html: Si vous ne souhaitez pas supprimer votre compte, %{cancel_account_reset}.
-      intro_html: Votre période d'attente de 24 heures est terminée. Veuillez terminer
-        l'étape 2 du processus.<br><br> Si vous ne parvenez pas à localiser vos méthodes
-        d'authentification, sélectionnez "confirmer la suppression" pour supprimer
-        votre compte %{app}.<br><br> À l'avenir, si vous devez accéder aux sites Web
+      intro_html: Votre période d’attente de 24 heures est terminée. Veuillez terminer
+        l’étape 2 du processus.<br><br> Si vous ne parvenez pas à localiser vos méthodes
+        d’authentification, sélectionnez “confirmer la suppression” pour supprimer
+        votre compte %{app}.<br><br> À l’avenir, si vous devez accéder aux sites Web
         gouvernementaux participants qui utilisent %{app}, vous pouvez créer un nouveau
         compte %{app} en utilisant la même adresse e-mail après la suppression de
         votre compte.<br><br>
@@ -33,28 +33,28 @@ fr:
         login.gov pour annuler.
       header: Votre compte sera supprimé dans 24 heures
       intro_html: 'Par mesure de sécurité, %{app} nécessite un processus en deux étapes
-        pour supprimer votre compte: <br> <br> Étape 1: Il y a une période d''attente
-        de 24 heures si vous avez perdu l''accès à vos méthodes d''authentification
-        et devez supprimer votre compte. Si vous trouvez vos méthodes d''authentification,
+        pour supprimer votre compte: <br> <br> Étape 1: Il y a une période d’attente
+        de 24 heures si vous avez perdu l’accès à vos méthodes d’authentification
+        et devez supprimer votre compte. Si vous trouvez vos méthodes d’authentification,
         vous pouvez vous connecter à votre compte %{app} pour annuler cette demande.
-        <br> <br> Deuxième étape: après votre période d''attente de 24 heures, vous
+        <br> <br> Deuxième étape: après votre période d’attente de 24 heures, vous
         recevrez un e-mail qui vous demandera de confirmer la suppression de votre
-        compte %{app}. Votre compte ne sera pas supprimé tant que vous ne l''aurez
+        compte %{app}. Votre compte ne sera pas supprimé tant que vous ne l’aurez
         pas confirmé.'
       subject: Comment supprimer votre compte login.gov
     add_email:
       footer: Ce lien expirera dans %{confirmation_period}.
-      header: Merci d'avoir ajouté un email. S'il vous plaît cliquez sur le lien ci-dessous
+      header: Merci d’avoir ajouté un email. S’il vous plaît cliquez sur le lien ci-dessous
         ou copiez et collez le lien en entier dans votre navigateur.
       subject: Confirmez votre email
     add_email_associated_with_another_account:
-      help_html: Si vous n'avez pas demandé de nouvel email ou que vous suspectez
+      help_html: Si vous n’avez pas demandé de nouvel email ou que vous suspectez
         une erreur, veuillez visiter le %{app} %{help_link} ou %{contact_link}.
       intro_html: Cette adresse électronique est déjà associée à un compte %{app},
-        nous ne pouvons donc pas l’ajouter à un autre compte. Vous devez d'abord le
+        nous ne pouvons donc pas l’ajouter à un autre compte. Vous devez d’abord le
         supprimer ou le supprimer du compte auquel il est associé. Pour ce faire,
         suivez le lien ci-dessous et connectez-vous avec cette adresse e-mail. Si
-        vous n'essayez pas d'ajouter cette adresse électronique à un compte, vous
+        vous n’essayez pas d’ajouter cette adresse électronique à un compte, vous
         pouvez ignorer ce message.
       link_text: Allez à %{app}
       reset_password_html: Si vous ne vous souvenez plus de votre mot de passe, allez
@@ -70,7 +70,7 @@ fr:
       subject: Vérifiez votre identité sur un ordinateur de bureau
     email_added:
       header: Une nouvelle adresse e-mail a été ajoutée à votre profil login.gov.
-      help: Si vous n'avez pas apporté cette modification, connectez-vous à votre
+      help: Si vous n’avez pas apporté cette modification, connectez-vous à votre
         profil et gérez vos adresses e-mail. Nous vous recommandons de changer également
         votre mot de passe.
       subject: Nouvelle adresse email ajoutée
@@ -82,7 +82,7 @@ fr:
         forgot_password: Vous avez essayé de réinitialiser le mot de passe de votre
           compte login.gov, mais nous ne possédons pas de compte associé à cette adresse
           courriel.
-        unconfirmed: Merci d'avoir envoyé votre adresse email.
+        unconfirmed: Merci d’avoir envoyé votre adresse email.
       footer: Ce lien expirera dans %{confirmation_period}.
       header: "%{intro} Veuillez cliquer sur le lien ci-dessous ou copier et coller
         le lien complet dans votre navigateur."
@@ -97,69 +97,69 @@ fr:
       help_html: Si vous ne souhaitez pas supprimer cette adresse électronique veuillez
         visiter le %{help_link} de %{app} ou %{contact_link}.
       subject: Adresse email supprimée
-    help_link_text: Centre d'aide
+    help_link_text: Centre d’aide
     letter_reminder:
       info_html: La lettre que vous êtes sur le point de recevoir contiendra un code
         de confirmation nous permettant de vérifier votre adresse. Vous pouvez terminer
-        le processus de vérification d'identité en vous connectant à %{link} et en
+        le processus de vérification d’identité en vous connectant à %{link} et en
         entrant le code de confirmation.
-      subject: Nous avons envoyé une lettre à l'adresse que vous avez en dossier
+      subject: Nous avons envoyé une lettre à l’adresse que vous avez en dossier
     new_device_sign_in:
       disavowal_link: ici
-      help_html: Si vous n'avez pas changé votre mot de passe, vous pouvez réinitialiser
-        votre mot de passe %{disavowal_link}. Pour plus d'aide, veuillez visiter le
+      help_html: Si vous n’avez pas changé votre mot de passe, vous pouvez réinitialiser
+        votre mot de passe %{disavowal_link}. Pour plus d’aide, veuillez visiter le
         %{help_link} de %{app} ou %{contact_link}.
       info_html: "<p>Votre compte login.gov a été connecté sur un nouvel appareil.</p><br/><br/>
         <p><strong>%{date}<br/>%{location}</strong></p>"
       subject: Nouvelle connexion avec votre compte Login.gov
     password_changed:
       disavowal_link: ici
-      help_html: Si vous n'avez pas changé votre mot de passe, vous pouvez réinitialiser
-        votre mot de passe %{disavowal_link}. Pour plus d'aide, veuillez visiter le
+      help_html: Si vous n’avez pas changé votre mot de passe, vous pouvez réinitialiser
+        votre mot de passe %{disavowal_link}. Pour plus d’aide, veuillez visiter le
         %{help_link} de %{app} ou %{contact_link}.
       intro_html: Le mot de passe de votre compte %{app} a été changé.
     personal_key_regenerated:
       help_html: <p>Votre compte login.gov vient de recevoir une nouvelle clé personnelle
-        de 16 caractères. Le but de cet e-mail est de s'assurer que c'est bien vous
-        qui en êtes à l'origine.</p><p> Si vous venez de vous connecter et de régénérer
-        votre clé personnelle, c'est parfait ! Vous n'avez rien à faire.</p><p> Si
+        de 16 caractères. Le but de cet e-mail est de s’assurer que c’est bien vous
+        qui en êtes à l’origine.</p><p> Si vous venez de vous connecter et de régénérer
+        votre clé personnelle, c’est parfait ! Vous n’avez rien à faire.</p><p> Si
         vous ne venez pas de régénérer votre clé personnelle, ou en cas de doute,
         effectuez immédiatement les actions suivantes pour sécuriser votre compte :<ol><li><strong><a
         href="%{reset_password_url}"> Modifiez votre mot de passe</a>.</strong> Choisissez
-        un mot de passe que vous n'avez pas encore utilisé avec ce compte.</li><li><strong><a
+        un mot de passe que vous n’avez pas encore utilisé avec ce compte.</li><li><strong><a
         href="%{account_url}"> Connectez-vous à votre compte login.gov</a></strong>
         et vérifiez bien que toutes les informations sur la page de votre compte sont
         correctes, y compris les méthodes que vous utilisez pour l’authentification
         à deux facteurs, dont le numéro de téléphone, l’application d’authentification
         ou la clé de sécurité.</li><li><strong>Sur votre <a href="%{account_url}">page
-        de compte login.gov</a>, demandez une nouvelle clé personnelle.</strong> N'oubliez
-        pas de ne jamais la partager, sauf si vous l'utilisez pour vous connecter
-        à un site de confiance qui utilise login.gov.</li></ol></p><br>Merci,<br>L'équipe
+        de compte login.gov</a>, demandez une nouvelle clé personnelle.</strong> N’oubliez
+        pas de ne jamais la partager, sauf si vous l’utilisez pour vous connecter
+        à un site de confiance qui utilise login.gov.</li></ol></p><br>Merci,<br>L’équipe
         login.gov
       intro: Nouvelle clé personnelle émise
       subject: Alerte de sécurité du compte
     personal_key_sign_in:
-      help_html: <p>Votre compte login.gov a été connecté à l'aide de votre clé personnelle.
-        Vous recevez cet email pour vous assurer que c'était bien vous.</p><p>Si vous
-        venez de vous connecter avec votre clé personnelle, c'est parfait! Vous ne
+      help_html: <p>Votre compte login.gov a été connecté à l’aide de votre clé personnelle.
+        Vous recevez cet email pour vous assurer que c’était bien vous.</p><p>Si vous
+        venez de vous connecter avec votre clé personnelle, c’est parfait! Vous ne
         devez rien faire.</p><p>Si vous ne vous êtes pas connecté avec une clé personnelle
         ou si vous n’êtes pas sûr, prenez immédiatement les mesures suivantes pour
         sécuriser votre compte:<ol><li><strong><a href="%{reset_password_url}">Changez
-        votre mot de passe</a>.</strong> Choisissez un mot de passe que vous n'avez
+        votre mot de passe</a>.</strong> Choisissez un mot de passe que vous n’avez
         pas encore utilisé avec ce compte.</li><li><strong><a href="%{account_url}">Connectez-vous
         à votre compte login.gov</a></strong> et assurez-vous de reconnaître toutes
         les informations de la page de votre compte, y compris les méthodes que vous
-        utilisez pour l'authentification à deux facteurs, telles que le numéro de
-        téléphone, l'application d'authentification ou la clé de sécurité.</li><li><strong>Sur
+        utilisez pour l’authentification à deux facteurs, telles que le numéro de
+        téléphone, l’application d’authentification ou la clé de sécurité.</li><li><strong>Sur
         la page de votre compte login.gov, demandez une nouvelle clé personnelle.</strong>
-        N'oubliez pas de ne jamais le partager à moins que vous ne l'utilisiez pour
-        vous connecter à un site Web de confiance utilisant login.gov.</li></ol></p><br>Merci,<br>L'équipe
+        N’oubliez pas de ne jamais le partager à moins que vous ne l’utilisiez pour
+        vous connecter à un site Web de confiance utilisant login.gov.</li></ol></p><br>Merci,<br>L’équipe
         login.gov
       intro: La clé personnelle utilisée pour vous connecter
       subject: Alerte de sécurité du compte
     phone_added:
       disavowal_link: réinitialiser votre mot de passe
-      help: Si vous n'avez pas apporté cette modification, connectez-vous à votre
+      help: Si vous n’avez pas apporté cette modification, connectez-vous à votre
         profil et gérez vos numéros de téléphone. Nous vous recommandons également
         de %{disavowal_link}.
       intro: Un nouveau numéro de téléphone a été ajouté à votre profil %{app}.
@@ -169,15 +169,15 @@ fr:
         conserver votre informations sûres. Veuillez suivre les étapes ci-dessous
         pour réinitialiser votre mot de passe et Sécurise ton compte:'
       intro: Nous avons détecté une activité inhabituelle sur votre compte login.gov.
-        Nous sommes concernés quelqu'un d'autre que vous tente peut-être d'accéder
+        Nous sommes concernés quelqu’un d’autre que vous tente peut-être d’accéder
         à vos informations.
       learn_more_link_text: En savoir plus sur vos options
       reminder_html: Pour rappel, <b>login.gov ne vous demandera jamais vos identifiants
         de connexion par téléphone ou par e-mail</b>. Vous pouvez prendre des mesures
-        supplémentaires pour sécuriser votre compte en activant l'authentification
+        supplémentaires pour sécuriser votre compte en activant l’authentification
         à deux facteurs.
       step_1: Visitez le site Web login.gov et sélectionnez Connexion
-      step_2: Sélectionnez "Vous avez oublié votre mot de passe?" au bas de la page
+      step_2: Sélectionnez “Vous avez oublié votre mot de passe?” au bas de la page
       step_3: Suivez les instructions pour réinitialiser votre mot de passe
       subject: Activité inhabituelle — réinitialisez votre mot de passe login.gov
     reset_password_instructions:
@@ -187,11 +187,11 @@ fr:
       link_text: Réinitialisez votre mot de passe
       subject: Réinitialisez votre mot de passe
     signup_with_your_email:
-      help_html: Si vous n'avez pas demandé un nouveau compte ou que vous soupçonnez
-        qu'une erreur s'est produite, veuillez visiter le %{help_link} de %{app} ou
+      help_html: Si vous n’avez pas demandé un nouveau compte ou que vous soupçonnez
+        qu’une erreur s’est produite, veuillez visiter le %{help_link} de %{app} ou
         %{contact_link}.
       intro_html: Cette adresse courriel est déjà associée à un compte %{app}, nous
-        ne pouvons donc pas l'utiliser pour créer un nouveau compte. Pour vous connecter
+        ne pouvons donc pas l’utiliser pour créer un nouveau compte. Pour vous connecter
         à votre compte existant, suivez le lien ci-dessous. Si vous ne tentez pas
         de vous connecter avec cette adresse courriel, vous pouvez ignorer ce message.
       link_text: Allez à %{app}

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -7,11 +7,11 @@ en:
       actions:
         cancel: Cancel and return to your profile
         delete: Delete account
-      bullet_1: You won't have a %{app} account
-      bullet_2_loa1: We'll delete your email address, password, and phone number
+      bullet_1: You won’t have a %{app} account
+      bullet_2_loa1: We’ll delete your email address, password, and phone number
       bullet_2_loa3: "%{app} will delete your email address, password, phone number,
         name, address, date of birth and Social Security number from our system."
-      bullet_3: You won't be able to securely access your information using %{app}.
+      bullet_3: You won’t be able to securely access your information using %{app}.
       bullet_4: We will notify the agencies you access with %{app} that you no longer
         have an account
       heading: Are you sure you want to delete your account?
@@ -19,7 +19,7 @@ en:
       subheading: If you delete your account
     personal_key:
       close: Close
-      confirmation_error: You've entered an incorrect personal key.
+      confirmation_error: You’ve entered an incorrect personal key.
       generated_on_html: Generated on %{date}
       header: Your personal key
       print: Print

--- a/config/locales/users/fr.yml
+++ b/config/locales/users/fr.yml
@@ -7,7 +7,7 @@ fr:
       actions:
         cancel: Annuler et retourner à votre profil
         delete: Supprimer le compte
-      bullet_1: Vous n'aurez pas de compte %{app}.
+      bullet_1: Vous n’aurez pas de compte %{app}.
       bullet_2_loa1: Nous effacerons votre adresse email, votre mot de passe et votre
         numéro de téléphone
       bullet_2_loa3: "%{app} supprimera votre adresse e-mail, votre mot de passe et

--- a/config/locales/valid_email/fr.yml
+++ b/config/locales/valid_email/fr.yml
@@ -3,5 +3,5 @@ fr:
   valid_email:
     validations:
       email:
-        invalid: Format d'adresse courriel ou domaine entré non valide. Corrigez l'adresse
+        invalid: Format d’adresse courriel ou domaine entré non valide. Corrigez l’adresse
           et entrez-la de nouveau.

--- a/config/locales/zxcvbn/en.yml
+++ b/config/locales/zxcvbn/en.yml
@@ -24,11 +24,11 @@ en:
       names_and_surnames_by_themselves_are_easy_to_guess: Names and surnames by themselves
         are easy to guess
       predictable_substitutions_like__instead_of_a_dont_help_very_much: Predictable
-        substitutions like '@' instead of 'a' don’t help very much
+        substitutions like ‘@’ instead of ‘a’ don’t help very much
       recent_years_are_easy_to_guess: Recent years are easy to guess
-      repeats_like_aaa_are_easy_to_guess: Repeats like "aaa" are easy to guess
+      repeats_like_aaa_are_easy_to_guess: Repeats like “aaa” are easy to guess
       repeats_like_abcabcabc_are_only_slightly_harder_to_guess_than_abc: Repeats like
-        "abcabcabc" are only slightly harder to guess than "abc"
+        “abcabcabc” are only slightly harder to guess than “abc”
       reversed_words_arent_much_harder_to_guess: Reversed words aren’t much harder
         to guess
       sequences_like_abc_or_6543_are_easy_to_guess: Sequences like abc or 6543 are

--- a/config/locales/zxcvbn/es.yml
+++ b/config/locales/zxcvbn/es.yml
@@ -25,13 +25,13 @@ es:
         si solos son fáciles de adivinar
       predictable_substitutions_like__instead_of_a_dont_help_very_much: No hay necesidad
         de símbolos, dígitos o letras mayúsculas
-      recent_years_are_easy_to_guess: Sustituciones predecibles como '@' en lugar
-        de 'a' no ayudan mucho
+      recent_years_are_easy_to_guess: Sustituciones predecibles como ‘@’ en lugar
+        de ‘a’ no ayudan mucho
       repeats_like_aaa_are_easy_to_guess: Los años recientes son fáciles de adivinar
       repeats_like_abcabcabc_are_only_slightly_harder_to_guess_than_abc: Las repeticiones
-        como "aaa" son fáciles de adivinar
-      reversed_words_arent_much_harder_to_guess: Las repeticiones como "abcabcabc"
-        son sólo un poco más difíciles de adivinar que "abc"
+        como “aaa” son fáciles de adivinar
+      reversed_words_arent_much_harder_to_guess: Las repeticiones como “abcabcabc”
+        son sólo un poco más difíciles de adivinar que “abc”
       sequences_like_abc_or_6543_are_easy_to_guess: Las palabras invertidas no son
         mucho más difíciles de adivinar
       short_keyboard_patterns_are_easy_to_guess: Las secuencias como abc o 6543 son

--- a/config/locales/zxcvbn/fr.yml
+++ b/config/locales/zxcvbn/fr.yml
@@ -13,7 +13,7 @@ fr:
       avoid_repeated_words_and_characters: Évitez les mots et caractères répétés
       avoid_sequences: Évitez les séquences
       avoid_years_that_are_associated_with_you: Évitez les années qui vous sont associées
-      capitalization_doesnt_help_very_much: La capitalisation n'aide pas beaucoup
+      capitalization_doesnt_help_very_much: La capitalisation n’aide pas beaucoup
       common_names_and_surnames_are_easy_to_guess: Les prénoms et noms de famille
         communs sont faciles à deviner
       dates_are_often_easy_to_guess: Les dates sont souvent faciles à deviner
@@ -23,7 +23,7 @@ fr:
       names_and_surnames_by_themselves_are_easy_to_guess: Les prénoms et noms de famille
         seuls sont faciles à deviner
       predictable_substitutions_like__instead_of_a_dont_help_very_much: Les remplacements
-        prévisibles comme es « @ » au lieu de « à » n'aident pas beaucoup
+        prévisibles comme es « @ » au lieu de « à » n’aident pas beaucoup
       recent_years_are_easy_to_guess: Les années récentes sont faciles à deviner
       repeats_like_aaa_are_easy_to_guess: Les répétitions comme « aaa » sont faciles
         à deviner
@@ -40,11 +40,11 @@ fr:
         sont faciles à deviner
       there_is_no_need_for_symbols_digits_or_uppercase_letters: Les symboles, les
         chiffres ou les lettres majuscules ne sont pas nécessaires
-      this_is_a_top_100_common_password: Il s'agit d'un des 100 mots de passe les
+      this_is_a_top_100_common_password: Il s’agit d’un des 100 mots de passe les
         plus communs
-      this_is_a_top_10_common_password: Il s'agit d'un des 10 mots de passe les plus
+      this_is_a_top_10_common_password: Il s’agit d’un des 10 mots de passe les plus
         communs
-      this_is_a_very_common_password: Il s'agit d'un mot de passe très commun
+      this_is_a_very_common_password: Il s’agit d’un mot de passe très commun
       this_is_similar_to_a_commonly_used_password: Ceci est similaire à un mot de
         passe souvent utilisé
       use_a_longer_keyboard_pattern_with_more_turns: Utilisez un motif de clavier

--- a/spec/fixtures/ial2_test_credential_forces_error.yml
+++ b/spec/fixtures/ial2_test_credential_forces_error.yml
@@ -1,1 +1,1 @@
-friendly_error: "We couldn't read the barcode on the back of your ID. Try taking a new picture. Make sure the entire barcode is visible, clean, and doesn't have glares. (Error code: 200)"
+friendly_error: "We couldn’t read the barcode on the back of your ID. Try taking a new picture. Make sure the entire barcode is visible, clean, and doesn’t have glares. (Error code: 200)"


### PR DESCRIPTION
**Why**: So that the texts we display to users are formatted with proper typographical punctuation (quotes, apostrophes, ellipsis).

Related:

- https://practicaltypography.com/straight-and-curly-quotes.html
- https://daringfireball.net/projects/smartypants/
- https://developer.wordpress.org/reference/functions/wptexturize/