### PR TITLE
validate password character length by graphemes (LG-4523)

### DIFF
--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -8,6 +8,7 @@ module FormPasswordValidator
     validates :password,
               presence: true,
               length: { in: Devise.password_length }
+    validate :password_graphemes_length
     validate :strong_password
     validate :not_pwned
   end
@@ -20,6 +21,15 @@ module FormPasswordValidator
     return unless errors.messages.blank? && password_score.score < min_password_score
 
     errors.add :password, :weak_password, i18n_variables
+  end
+
+  def password_graphemes_length
+    return if errors.messages.present?
+    if password.grapheme_clusters.length < Devise.password_length.min
+      errors.add(:password, :too_short, count: Devise.password_length.min)
+    elsif password.grapheme_clusters.length > Devise.password_length.max
+      errors.add(:password, :too_long, count: Devise.password_length.max)
+    end
   end
 
   def password_score

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -12,19 +12,16 @@ describe PasswordForm, type: :model do
         user = build_stubbed(:user)
 
         form = PasswordForm.new(user)
-
         password = 'valid password'
-
         extra = {
           user_id: user.uuid,
           request_id_present: false,
         }
 
-        result = instance_double(FormResponse)
+        result = form.submit(password: password)
 
-        expect(FormResponse).to receive(:new).
-          with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit(password: password)).to eq result
+        expect(result.success?).to eq true
+        expect(result.extra).to eq extra
       end
     end
 
@@ -33,23 +30,19 @@ describe PasswordForm, type: :model do
         user = build_stubbed(:user, uuid: '123')
 
         form = PasswordForm.new(user)
-
         password = 'invalid'
-
         errors = {
           password: ["is too short (minimum is #{Devise.password_length.first} characters)"],
         }
-
         extra = {
           user_id: '123',
           request_id_present: false,
         }
 
-        result = instance_double(FormResponse)
-
-        expect(FormResponse).to receive(:new).
-          with(success: false, errors: errors, extra: extra).and_return(result)
-        expect(form.submit(password: password)).to eq result
+        result = form.submit(password: password)
+        expect(result.success?).to eq false
+        expect(result.errors).to eq errors
+        expect(result.extra).to eq extra
       end
     end
 
@@ -62,11 +55,10 @@ describe PasswordForm, type: :model do
           user_id: user.uuid,
           request_id_present: true,
         }
-        result = instance_double(FormResponse)
 
-        expect(FormResponse).to receive(:new).
-          with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit(password: password, request_id: 'foo')).to eq result
+        result = form.submit(password: password, request_id: 'foo')
+        expect(result.success?).to eq true
+        expect(result.extra).to eq extra
       end
     end
 
@@ -79,11 +71,9 @@ describe PasswordForm, type: :model do
           user_id: user.uuid,
           request_id_present: true,
         }
-        result = instance_double(FormResponse)
-
-        expect(FormResponse).to receive(:new).
-          with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit(password: password, request_id: "\xFFbar\xF8")).to eq result
+        result = form.submit(password: password, request_id: "\xFFbar\xF8")
+        expect(result.success?).to eq true
+        expect(result.extra).to eq extra
       end
     end
   end

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -10,17 +10,12 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    extra = hash_including(user_id: '123')
-    result = instance_double(FormResponse)
 
-    if %w[PasswordForm ResetPasswordForm].include?(form_class)
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-    else
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-    end
-    expect(form.submit(password: password)).to eq result
+    result = form.submit(password: password)
+
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(errors)
+    expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
   it 'does not allow a password that needs more words' do
@@ -33,17 +28,12 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    extra = hash_including(user_id: '123')
-    result = instance_double(FormResponse)
 
-    if %w[PasswordForm ResetPasswordForm].include?(form_class)
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-    else
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-    end
-    expect(form.submit(password: password)).to eq result
+    result = form.submit(password: password)
+
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(errors)
+    expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
   # This test is disabled for now because zxcvbn doesn't support this
@@ -59,17 +49,11 @@ shared_examples 'strong password' do |form_class|
         ' Uncommon words are better'],
     }
 
-    extra = hash_including(user_id: '123')
-    result = instance_double(FormResponse)
+    result = form.submit(password: password)
 
-    if %w[PasswordForm ResetPasswordForm].include?(form_class)
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-    else
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-    end
-    expect(form.submit(password: password)).to eq result
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(errors)
+    expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
   it 'does not allow a password that is the user email' do
@@ -82,17 +66,11 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    extra = hash_including(user_id: '123')
-    result = instance_double(FormResponse)
+    result = form.submit(password: password)
 
-    if %w[PasswordForm ResetPasswordForm].include?(form_class)
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-    else
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-    end
-    expect(form.submit(password: password)).to eq result
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(errors)
+    expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
   it 'does not allow a password that does not have the minimum number of graphemes' do

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -101,7 +101,7 @@ shared_examples 'strong password' do |form_class|
     form = form_class.constantize.new(user)
     password = 'a7K!hf🇺🇸🇺🇸🇺🇸'
     errors = {
-      password: ['is too short (minimum is 12 characters)'],
+      password: [t('errors.messages.too_short', count: 12)],
     }
     extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -96,7 +96,7 @@ shared_examples 'strong password' do |form_class|
   end
 
   it 'does not allow a password that does not have the minimum number of graphemes' do
-    user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
+    user = build_stubbed(:user, email: 'custom@example.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
     password = 'a7K!hf🇺🇸🇺🇸🇺🇸'

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -103,7 +103,6 @@ shared_examples 'strong password' do |form_class|
     errors = {
       password: ['is too short (minimum is 12 characters)'],
     }
-    binding.pry
     extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)
 

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -94,4 +94,27 @@ shared_examples 'strong password' do |form_class|
     end
     expect(form.submit(password: password)).to eq result
   end
+
+  it 'does not allow a password that does not have the minimum number of graphemes' do
+    user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
+    allow(user).to receive(:reset_password_period_valid?).and_return(true)
+    form = form_class.constantize.new(user)
+    password = 'a7K!hf🇺🇸🇺🇸🇺🇸'
+    errors = {
+      password: ['is too short (minimum is 12 characters)'],
+    }
+    binding.pry
+    extra = hash_including(user_id: '123')
+    result = instance_double(FormResponse)
+
+    if %w[PasswordForm ResetPasswordForm].include?(form_class)
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+    else
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors).and_return(result)
+    end
+
+    expect(form.submit(password: password)).to eq result
+  end
 end

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -103,17 +103,10 @@ shared_examples 'strong password' do |form_class|
     errors = {
       password: [t('errors.messages.too_short', count: 12)],
     }
-    extra = hash_including(user_id: '123')
-    result = instance_double(FormResponse)
+    result = form.submit(password: password)
 
-    if %w[PasswordForm ResetPasswordForm].include?(form_class)
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-    else
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-    end
-
-    expect(form.submit(password: password)).to eq result
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(errors)
+    expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 end


### PR DESCRIPTION
We currently count codepoints when determining password length. NIST only describes "characters" when counting password length and a conservative interpretation would be to count graphemes instead of codepoints. This may lead to longer requirements for passwords in languages where glyphs are combined to create what appears to be one "character".

Example:
The 🇺🇸 emoji is two unicode codepoints  (🇺and 🇸) that would be three graphemes when separated by a space that become one grapheme when placed next to one another.

```ruby
"🇺 🇸".grapheme_clusters
# => ["🇺", " ", "🇸"]
"🇺 🇸".gsub(" ", "").grapheme_clusters
# => ["🇺🇸"]
```

The password "123456🇺🇸🇺🇸🇺🇸" would be valid before these changes despite only appearing to be 9 characters. We would now require 3 more "characters".