### PR TITLE
Bump identity-hostdata to 3.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.1.3'
 # Variables can be overridden for local dev in Gemfile-dev
 @aamva_api_gem ||= { github: '18F/identity-aamva-api-client-gem', tag: 'v4.2.0' }
 @doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.5.1' }
-@hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.1.0' }
+@hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.1.2' }
 @lexisnexis_api_gem ||= { github: '18F/identity-lexisnexis-api-client-gem', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @proofer_gem ||= { github: '18F/identity-proofer-gem', ref: 'v2.8.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: 4f978b9f2e573e99f54c69869846c7aae983c4ae
-  tag: v3.1.0
+  revision: cd29dea582710c8eee7572bfe23f0788fada13e2
+  tag: v3.1.2
   specs:
-    identity-hostdata (3.1.0)
+    identity-hostdata (3.1.2)
       activesupport (~> 6.1)
       aws-sdk-s3 (~> 1.8)
 


### PR DESCRIPTION
**Why**: To pick up a fix to hostdata that was preventing migration instances from working