### PR TITLE
Pass IE-required title argument for createHTMLDocument

### DIFF
--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -31,7 +31,7 @@ const DEFAULT_OPTIONS = {
  * @return {Document} DOM document.
  */
 export function getDOMFromHTML(html) {
-  const dom = document.implementation.createHTMLDocument();
+  const dom = document.implementation.createHTMLDocument('');
   dom.body.innerHTML = html;
   return dom;
 }

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -8,14 +8,15 @@ import {
   getPageErrorMessage,
 } from '../../../app/javascript/packs/form-steps-wait';
 
-const POLL_PAGE_MARKUP = '<!doctype html><title>x</title><meta content="1" http-equiv="refresh">';
-const NON_POLL_PAGE_MARKUP = '<!doctype html><title>x</title>';
+const POLL_PAGE_MARKUP =
+  '<!doctype html><title>x</title><meta content="1" http-equiv="refresh">Example';
+const NON_POLL_PAGE_MARKUP = '<!doctype html><title>x</title>Example';
 
 describe('getDOMFromHTML', () => {
   it('returns document of given markup', () => {
     const dom = getDOMFromHTML(NON_POLL_PAGE_MARKUP);
 
-    expect(dom.querySelector('title').textContent).to.equal('x');
+    expect(dom.body.textContent).to.equal('Example');
   });
 });
 

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -8,9 +8,8 @@ import {
   getPageErrorMessage,
 } from '../../../app/javascript/packs/form-steps-wait';
 
-const POLL_PAGE_MARKUP =
-  '<!doctype html><title>x</title><meta content="1" http-equiv="refresh">Example';
-const NON_POLL_PAGE_MARKUP = '<!doctype html><title>x</title>Example';
+const POLL_PAGE_MARKUP = '<meta content="1" http-equiv="refresh">Example';
+const NON_POLL_PAGE_MARKUP = 'Example';
 
 describe('getDOMFromHTML', () => {
   it('returns document of given markup', () => {


### PR DESCRIPTION
**Why**: So that Internet Explorer doesn't throw an error when clicking wait buttons.

See: https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument

(Specifically, note about "Except in IE" for otherwise-optional `title` argument)

Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1619123286193700