### PR TITLE
check device constraints for PIV/CAC before querying database

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -222,7 +222,7 @@ module Users
     end
 
     def redirect_url
-      if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled? && !mobile?
+      if !mobile? && TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled?
         login_two_factor_piv_cac_url(reauthn_params)
       elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
         login_two_factor_webauthn_url(reauthn_params)


### PR DESCRIPTION
Found shortly after merging #4944 

Potentially save a roundtrip to the database by checking whether the device is mobile first