### PR TITLE
LG-3993: Enable WebOTP for OTP verification

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -178,7 +178,7 @@ module Users
         otp: current_user.direct_otp,
         expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         channel: method.to_sym,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       }
       Telephony.send(send_otp_method_name, params)
     end

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -59,7 +59,7 @@ module Idv
         to: phone,
         expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         channel: delivery_method,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       )
       add_cost
       otp_sent_response

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -25,7 +25,6 @@
       <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
       <%= render(
         'shared/one_time_code_input',
-        transport: nil,
         name: :code,
         value: @code,
         required: true,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -15,7 +15,6 @@
       <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
       <%= render(
         'shared/one_time_code_input',
-        transport: nil,
         name: :code,
         value: @presenter.code_value,
         required: true,

--- a/spec/controllers/test/telephony_controller_spec.rb
+++ b/spec/controllers/test/telephony_controller_spec.rb
@@ -8,14 +8,14 @@ describe Test::TelephonyController do
         otp: '123456',
         expiration: 10,
         channel: :sms,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       )
       Telephony.send_authentication_otp(
         to: '(555) 555-5000',
         otp: '654321',
         expiration: 10,
         channel: :voice,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       )
 
       get :index
@@ -43,14 +43,14 @@ describe Test::TelephonyController do
         otp: '123456',
         expiration: 10,
         channel: :sms,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       )
       Telephony.send_authentication_otp(
         to: '(555) 555-5000',
         otp: '654321',
         expiration: 10,
         channel: :voice,
-        domain: Identity::Hostdata.domain,
+        domain: IdentityConfig.store.domain_name,
       )
 
       delete :destroy

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -250,7 +250,7 @@ describe Users::TwoFactorAuthenticationController do
           to: MfaContext.new(subject.current_user).phone_configurations.first.phone,
           expiration: 10,
           channel: :sms,
-          domain: Identity::Hostdata.domain,
+          domain: IdentityConfig.store.domain_name,
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -327,7 +327,7 @@ describe Users::TwoFactorAuthenticationController do
           to: MfaContext.new(subject.current_user).phone_configurations.first.phone,
           expiration: 10,
           channel: :voice,
-          domain: Identity::Hostdata.domain,
+          domain: IdentityConfig.store.domain_name,
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -383,7 +383,7 @@ describe Users::TwoFactorAuthenticationController do
           to: @unconfirmed_phone,
           expiration: 10,
           channel: :sms,
-          domain: Identity::Hostdata.domain,
+          domain: IdentityConfig.store.domain_name,
         )
       end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -42,7 +42,7 @@ feature 'Changing authentication factor' do
             to: old_phone,
             expiration: 10,
             channel: :sms,
-            domain: Identity::Hostdata.domain,
+            domain: IdentityConfig.store.domain_name,
           )
 
           expect(current_path).

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -58,7 +58,7 @@ describe Idv::SendPhoneConfirmationOtp do
           to: phone,
           expiration: 10,
           channel: :sms,
-          domain: Identity::Hostdata.domain,
+          domain: IdentityConfig.store.domain_name,
         )
       end
     end
@@ -84,7 +84,7 @@ describe Idv::SendPhoneConfirmationOtp do
           to: phone,
           expiration: 10,
           channel: :voice,
-          domain: Identity::Hostdata.domain,
+          domain: IdentityConfig.store.domain_name,
         )
       end
     end


### PR DESCRIPTION
Previously: #4965, #4915

In #4965, we initially disabled the WebOTP behavior for OTP inputs, since it wasn't yet working in Android. Further testing revealed this was because the domain was too broad ("identitysandbox.gov" regardless of sandbox), and using the most specific host allows auto-fill to work as expected.
