### PR TITLE
Use the session expiration for the sp issuer cookie timeout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,7 +104,7 @@ class ApplicationController < ActionController::Base
                           else
                             {
                               value: current_sp.issuer,
-                              expires: AppConfig.env.issuer_cookie_expiration,
+                              expires: IdentityConfig.store.session_timeout_in_minutes.minutes,
                             }
                           end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -32,7 +32,11 @@ describe ApplicationController do
       it 'sets sets the cookie sp_issuer' do
         get :index
 
+        controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
+        cookie_expiration = controller_set_cookies['sp_issuer'][:expires]
+
         expect(cookies[:sp_issuer]).to eq(sp.issuer)
+        expect(cookie_expiration).to be_within(3.seconds).of(15.minutes.from_now)
       end
     end
 


### PR DESCRIPTION
**Why**: This cookie is here to allow the ALB to sort out requests by issuer. If the session has ended then the request is no longer associated with that issuer.

This config does not appear to be set anywhere so currently the cookie has no expiration