### PR TITLE
Update worker log formatting

### DIFF
--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -29,12 +29,14 @@ class AddressProofingJob < ApplicationJob
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
     document_capture_session.store_proofing_result(result)
   ensure
-    logger.info({
-      name: 'ProofAddress',
-      trace_id: trace_id,
-      success: proofer_result&.success?,
-      timing: timer.results,
-    }.to_json)
+    logger.info(
+      {
+        name: 'ProofAddress',
+        trace_id: trace_id,
+        success: proofer_result&.success?,
+        timing: timer.results,
+      }.to_json
+    )
   end
 
   private

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -35,7 +35,7 @@ class AddressProofingJob < ApplicationJob
         trace_id: trace_id,
         success: proofer_result&.success?,
         timing: timer.results,
-      }.to_json
+      }.to_json,
     )
   end
 

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -29,12 +29,12 @@ class AddressProofingJob < ApplicationJob
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
     document_capture_session.store_proofing_result(result)
   ensure
-    logger.info(
+    logger.info({
       name: 'ProofAddress',
       trace_id: trace_id,
       success: proofer_result&.success?,
       timing: timer.results,
-    )
+    }.to_json)
   end
 
   private

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -53,7 +53,7 @@ class DocumentProofingJob < ApplicationJob
         trace_id: trace_id,
         success: proofer_result&.success?,
         timing: timer.results,
-      }.to_json
+      }.to_json,
     )
   end
 

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -47,12 +47,12 @@ class DocumentProofingJob < ApplicationJob
       pii: proofer_result.pii_from_doc,
     )
   ensure
-    logger.info(
+    logger.info({
       name: 'ProofDocument',
       trace_id: trace_id,
       success: proofer_result&.success?,
       timing: timer.results,
-    )
+    }.to_json)
   end
 
   private

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -47,12 +47,14 @@ class DocumentProofingJob < ApplicationJob
       pii: proofer_result.pii_from_doc,
     )
   ensure
-    logger.info({
-      name: 'ProofDocument',
-      trace_id: trace_id,
-      success: proofer_result&.success?,
-      timing: timer.results,
-    }.to_json)
+    logger.info(
+      {
+        name: 'ProofDocument',
+        trace_id: trace_id,
+        success: proofer_result&.success?,
+        timing: timer.results,
+      }.to_json
+    )
   end
 
   private

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -38,13 +38,13 @@ class ResolutionProofingJob < ApplicationJob
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
     document_capture_session.store_proofing_result(callback_log_data.result)
   ensure
-    logger.info(
+    logger.info({
       name: 'ProofResolution',
       trace_id: trace_id,
       resolution_success: callback_log_data&.resolution_success,
       state_id_success: callback_log_data&.state_id_success,
       timing: timer.results,
-    )
+    }.to_json)
   end
 
   private

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -38,13 +38,15 @@ class ResolutionProofingJob < ApplicationJob
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
     document_capture_session.store_proofing_result(callback_log_data.result)
   ensure
-    logger.info({
-      name: 'ProofResolution',
-      trace_id: trace_id,
-      resolution_success: callback_log_data&.resolution_success,
-      state_id_success: callback_log_data&.state_id_success,
-      timing: timer.results,
-    }.to_json)
+    logger.info(
+      {
+        name: 'ProofResolution',
+        trace_id: trace_id,
+        resolution_success: callback_log_data&.resolution_success,
+        state_id_success: callback_log_data&.state_id_success,
+        timing: timer.results,
+      }.to_json
+    )
   end
 
   private

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -45,7 +45,7 @@ class ResolutionProofingJob < ApplicationJob
         resolution_success: callback_log_data&.resolution_success,
         state_id_success: callback_log_data&.state_id_success,
         timing: timer.results,
-      }.to_json
+      }.to_json,
     )
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,15 @@ module Upaya
 
     if AppConfig.env.ruby_workers_enabled == 'true'
       config.active_job.queue_adapter = :delayed_job
+
+      FileUtils.mkdir_p(Rails.root.join('log'))
+      config.active_job.logger = ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
     else
       config.active_job.queue_adapter = :inline
     end
+
+    config.active_job.logger.formatter = config.log_formatter
+
     config.time_zone = 'UTC'
 
     # Generate CSRF tokens that are encoded in URL-safe Base64.

--- a/config/initializers/zxcvbn_overrides.rb
+++ b/config/initializers/zxcvbn_overrides.rb
@@ -1,12 +1,14 @@
 require 'zxcvbn'
 
-module Zxcvbn
-  class Tester
-    attr_accessor :data_path
-    def initialize
-      @data_path = Rails.root.join('node_modules', 'zxcvbn', 'dist', 'zxcvbn.js')
-      src = File.open(@data_path || DATA_PATH, 'r').read
-      @context = ExecJS.compile(src)
+if Identity::Hostdata.instance_role != 'worker'
+  module Zxcvbn
+    class Tester
+      attr_accessor :data_path
+      def initialize
+        @data_path = Rails.root.join('node_modules', 'zxcvbn', 'dist', 'zxcvbn.js')
+        src = File.open(@data_path || DATA_PATH, 'r').read
+        @context = ExecJS.compile(src)
+      end
     end
   end
 end

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -122,19 +122,19 @@ RSpec.describe DocumentProofingJob, type: :job do
       end
 
       it 'logs the trace_id and timing info' do
-        expect(instance.logger).to receive(:info).with(
-          hash_including(
+        expect(instance.logger).to receive(:info) do |message|
+          expect(JSON.parse(message, symbolize_names: true)).to include(
             trace_id: trace_id,
             timing: hash_including(
-              'decrypt.back' => kind_of(Float),
-              'decrypt.front' => kind_of(Float),
-              'decrypt.selfie' => kind_of(Float),
-              'download.back' => kind_of(Float),
-              'download.front' => kind_of(Float),
-              'download.selfie' => kind_of(Float),
+              'decrypt.back': kind_of(Float),
+              'decrypt.front': kind_of(Float),
+              'decrypt.selfie': kind_of(Float),
+              'download.back': kind_of(Float),
+              'download.front': kind_of(Float),
+              'download.selfie': kind_of(Float),
             ),
-          ),
-        )
+          )
+        end
 
         perform
       end

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -194,8 +194,12 @@ RSpec.describe ResolutionProofingJob, type: :job do
         end
 
         it 'logs the trace_id and timing info' do
-          expect(instance.logger).to receive(:info).
-            with(hash_including(:timing, trace_id: trace_id))
+          expect(instance.logger).to receive(:info) do |message|
+            expect(JSON.parse(message, symbolize_names: true)).to include(
+              :timing,
+              trace_id: trace_id,
+            )
+          end
 
           perform
         end


### PR DESCRIPTION
Before:
- Log messages from the jobs went to `production.log`
- They were formatted with like `[ActiveJob] [blah] {:foo => true}`

After
- Log messages from the jobs goes to `worker.log`
- Example log message has correct formatting:
```
{"name":"ProofDocument","trace_id":"Root=1-60871e1c-445195a90aa4e4d11a218247","success":true,"timing":{"download.front":141.2,"decrypt.front":1.91,"download.back":39.25,"decrypt.back":0.46,"download.selfie":30.87,"decrypt.selfie":0.86,"proof_documents":2.75}}
```