### PR TITLE
Convert a left over AppConfig session timeout call

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -2,7 +2,7 @@ require 'utf8_cleaner'
 
 Ahoy.api = false
 # Period of inactivity before a new visit is created
-Ahoy.visit_duration = AppConfig.env.session_timeout_in_minutes.to_i.minutes
+Ahoy.visit_duration = IdentityConfig.store.session_timeout_in_minutes.minutes
 Ahoy.server_side_visits = false
 Ahoy.geocode = false
 Ahoy.user_agent_parser = :device_detector


### PR DESCRIPTION
**Why**: We moved the session timeout in minutes into IdentityConfig