### PR TITLE
Put the USPS configs back and make them empty strings

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -299,6 +299,10 @@ production:
   telephony_adapter: pinpoint
   use_kms: 'true'
   usps_confirmation_max_days: '30'
+  usps_upload_sftp_directory: ''
+  usps_upload_sftp_host: ''
+  usps_upload_sftp_password: ''
+  usps_upload_sftp_username: ''
 
 test:
   aal_authn_context_enabled: 'true'


### PR DESCRIPTION
**Why**: Since they don't have a top-level value, removing them means they are still nil