### PR TITLE
ignore users unlock token column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[x509_dn_uuid otp_secret_key totp_timestamp]
+  self.ignored_columns = %w[x509_dn_uuid otp_secret_key totp_timestamp unlock_token]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer


### PR DESCRIPTION
This column isn't used, and has an index on it, so we should drop it 🙂 