### PR TITLE
Remove Recaptcha domains from CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,7 +11,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   default_csp_config = {
     default_src: ["'self'"],
-    child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src
+    child_src: ["'self'"], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: connect_src.flatten,
@@ -32,8 +32,6 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
       '*.nr-data.net',
       'dap.digitalgov.gov',
       '*.google-analytics.com',
-      'www.google.com',
-      'www.gstatic.com',
       AppConfig.env.asset_host,
     ],
     style_src: ["'self'", AppConfig.env.asset_host],


### PR DESCRIPTION
Follow-up to #4984 (see https://github.com/18F/identity-idp/pull/4984#issuecomment-827834210)

**Why**: We should keep CSP domains strictly limited to required usage. These two domains are used by Recaptcha, which was removed in #4984. DAP Universal Analytics is expected to suffice with google-analytics.com.

See: https://developers.google.com/tag-manager/web/csp#universal_analytics_google_analytics