### PR TITLE
LG-4442: Log user clicks on document capture front, back images

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/sinon": "^9.0.11",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^7.16.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -2,14 +2,18 @@ import { Crypto } from '@peculiar/webcrypto';
 import chai from 'chai';
 import dirtyChai from 'dirty-chai';
 import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 import { createDOM, useCleanDOM } from './support/dom';
 import { chaiConsoleSpy, useConsoleLogSpy } from './support/console';
+import { sinonChaiAsPromised } from './support/sinon';
 import { createObjectURLAsDataURL } from './support/file';
 import { useBrowserCompatibleEncrypt } from './support/crypto';
 
 chai.use(dirtyChai);
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 chai.use(chaiConsoleSpy);
+chai.use(sinonChaiAsPromised);
 global.expect = chai.expect;
 
 // Emulate a DOM, since many modules will assume the presence of these globals exist as a side

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,6 +2464,13 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"


### PR DESCRIPTION
**Why**: To understand how many users are bouncing from the document capture step without ever beginning to try capturing or uploading images of their state-issued ID.