### PR TITLE
ignore users unconfirmed_email and encrypted_otp_secret_key columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[x509_dn_uuid otp_secret_key totp_timestamp unlock_token]
+  self.ignored_columns = %w[x509_dn_uuid otp_secret_key totp_timestamp unlock_token 
+                            unconfirmed_email encrypted_otp_secret_key]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer


### PR DESCRIPTION
Similar to #4988, these columns appear to be old and unused