### PR TITLE
LG-4370: Refactor "No Camera" warning to use error partial

### DIFF
--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -1,21 +1,18 @@
-<% title t('doc_auth.errors.no_camera.title') %>
+<%= render(
+  'idv/shared/error',
+  type: :warning,
+  title: t('doc_auth.errors.no_camera.title'),
+  heading: t('doc_auth.errors.no_camera.heading'),
+) do %>
+  <p>
+    <% if liveness_checking_enabled? %>
+      <%= t('doc_auth.info.upload_liveness_enabled') %>
+    <% else %>
+      <%= t('doc_auth.info.upload') %>
+    <% end %>
+  </p>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), width: 54, alt: '') %>
-
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('doc_auth.errors.no_camera.heading') %>
-</h1>
-
-<p>
-  <% if liveness_checking_enabled? %>
-    <%= t('doc_auth.info.upload_liveness_enabled') %>
-  <% else %>
-    <%= t('doc_auth.info.upload') %>
-  <% end %>
-</p>
-
-<p class="text-bold">
-  <%= t('doc_auth.errors.no_camera.explanation') %>
-</p>
-
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
+  <p class="text-bold">
+    <%= t('doc_auth.errors.no_camera.explanation') %>
+  </p>
+<% end %>

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -15,4 +15,6 @@
   <p class="text-bold">
     <%= t('doc_auth.errors.no_camera.explanation') %>
   </p>
+
+  <%= render 'idv/doc_auth/start_over_or_cancel' %>
 <% end %>

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -2,7 +2,8 @@
 yields: Page instruction content.
 locals:
 * type: `:warning` or `:error`. Defaults to `:error`.
-* heading: Page title and primary page heading text.
+* heading: Primary page heading text. Also used as page title if title is not given.
+* title: Optional custom page title, defaulting to the heading.
 * action: Optional hash of `text`, `url` of a primary action link.
 * options: Array of troubleshooting options.
 %>
@@ -17,7 +18,7 @@ else
   troubleshooting_heading = t('idv.troubleshooting.headings.having_trouble')
 end
 %>
-<% title heading %>
+<% title local_assigns.fetch(:title, heading) %>
 <%= image_tag(image_src, width: 54, alt: '', class: 'display-block') %>
 
 <h1 class="margin-top-4 margin-bottom-2"><%= heading %></h1>

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe 'idv/shared/_error.html.erb' do
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
+    allow(view).to receive(:title)
 
     render 'idv/shared/error', **params
   end
@@ -31,6 +32,29 @@ describe 'idv/shared/_error.html.erb' do
 
       it 'renders action button' do
         expect(rendered).to have_link('Example', href: '#example')
+      end
+    end
+  end
+
+  describe 'title' do
+    context 'without title' do
+      let(:params) { { heading: heading } }
+
+      it 'sets title as defaulting to heading' do
+        expect(view).to receive(:title).with(heading)
+
+        render 'idv/shared/error', **params
+      end
+    end
+
+    context 'with title' do
+      let(:title) { 'Example Title' }
+      let(:params) { { heading: heading, title: title } }
+
+      it 'sets title' do
+        expect(view).to receive(:title).with(title)
+
+        render 'idv/shared/error', **params
       end
     end
   end

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -11,7 +11,6 @@ describe 'idv/shared/_error.html.erb' do
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
-    allow(view).to receive(:title)
 
     render 'idv/shared/error', **params
   end


### PR DESCRIPTION
**Why**: So that the page is styled consistently with other warning pages in the IAL2 flow.

**Screenshot:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/116427777-5393b980-a812-11eb-819c-f07bcffdcdd7.png)|![image](https://user-images.githubusercontent.com/1779930/116430840-357b8880-a815-11eb-8c1b-224571cfed93.png)