### PR TITLE
Reduce parallelism to 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       CC_TEST_REPORTER_ID: faecd27e9aed532634b3f4d3e251542d7de9457cfca96a94208a63270ef9b42e
       COVERAGE: true
 
-    parallelism: 8
+    parallelism: 5
 
     working_directory: ~/identity-idp
 


### PR DESCRIPTION
**Why**: Parallism of 8 seems a touch too high. Queue times are up when there are lots of builds and it is gumming up the works.