### PR TITLE
Add the ID's state to the vendor response event log (LG-4395)

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -73,7 +73,8 @@ module Idv
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
       )
-      response = response.merge(extra_attributes_response(state: response.pii_from_doc[:state]))
+      response.extra.merge!(extra_attributes)
+      response.extra.merge!(state: response.pii_from_doc[:state])
 
       update_analytics(response)
 
@@ -82,7 +83,7 @@ module Idv
 
     def validate_pii_from_doc(client_response)
       response = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
-      response = response.merge(extra_attributes_response)
+      response.extra.merge!(extra_attributes)
 
       track_event(
         Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
@@ -92,20 +93,7 @@ module Idv
 
       response
     end
-
-    def extra_attributes_response(state: nil)
-      @extra_attributes_response ||= begin
-         extras = extra_attributes
-         extras[:state] = state if state
-
-         Idv::DocAuthFormResponse.new(
-           success: true,
-           errors: {},
-           extra: extras,
-         )
-      end
-    end
-
+    
     def extra_attributes
       @extra_attributes ||= {
         remaining_attempts: remaining_attempts,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -73,7 +73,7 @@ module Idv
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
       )
-      response = response.merge(extra_attributes_response)
+      response = response.merge(extra_attributes_response(state: response.pii_from_doc[:state]))
 
       update_analytics(response)
 
@@ -93,12 +93,17 @@ module Idv
       response
     end
 
-    def extra_attributes_response
-      @extra_attributes_response ||= Idv::DocAuthFormResponse.new(
-        success: true,
-        errors: {},
-        extra: extra_attributes,
-      )
+    def extra_attributes_response(state: nil)
+      @extra_attributes_response ||= begin
+         extras = extra_attributes
+         extras[:state] = state if state
+
+         Idv::DocAuthFormResponse.new(
+           success: true,
+           errors: {},
+           extra: extras,
+         )
+      end
     end
 
     def extra_attributes

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -218,6 +218,7 @@ describe Idv::ImageUploadsController do
           billed: true,
           exception: nil,
           result: 'Passed',
+          state: 'MT',
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
           client_image_metrics: {
@@ -283,6 +284,7 @@ describe Idv::ImageUploadsController do
               billed: true,
               exception: nil,
               result: 'Passed',
+              state: 'ND',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -326,6 +328,7 @@ describe Idv::ImageUploadsController do
               billed: true,
               exception: nil,
               result: 'Passed',
+              state: 'Maryland',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -369,6 +372,7 @@ describe Idv::ImageUploadsController do
               billed: true,
               exception: nil,
               result: 'Passed',
+              state: 'ND',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -435,6 +439,7 @@ describe Idv::ImageUploadsController do
           },
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
+          state: nil,
           exception: nil,
           client_image_metrics: {
             front: { glare: 99.99 },
@@ -482,6 +487,7 @@ describe Idv::ImageUploadsController do
           },
           billed: true,
           result: 'Caution',
+          state: nil,
           exception: nil,
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Idv::ApiImageUploadForm do
   end
 
   describe '#submit' do
-    context 'valid form' do
+    context 'with a valid form' do
       it 'logs analytics' do
         form.submit
 
@@ -105,6 +105,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           result: 'Passed',
           billed: true,
           remaining_attempts: AppConfig.env.acuant_max_attempts.to_i,
+          state: 'MT',
           user_id: nil,
           client_image_metrics: {
             front: JSON.parse(front_image_metadata, symbolize_names: true),


### PR DESCRIPTION
We want to be able to detect if certain state licenses are having more trouble than others. This PR adds the `state` found in the PII bundle, returned from the doc_auth client, to the logged event.