### PR TITLE
Remove building release container from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,18 +203,6 @@ jobs:
             make check_asset_strings
             make lint_optimized_assets
             NODE_ENV=production ./bin/webpack && yarn es5-safe
-  build-release-container:
-    working_directory: ~/identity-idp
-    docker:
-      - image: circleci/ruby:2.6
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: |
-          if [ -z "$CIRCLE_TAG" ]; then exit 0; fi # this shouldn't be necessary...
-          docker build -t logindotgov/idp:$CIRCLE_TAG -f production.Dockerfile .
-          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-          docker push logindotgov/idp:$CIRCLE_TAG
   smoketest-dev:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -283,12 +271,6 @@ workflows:
     jobs:
       - build
       - lints
-      - build-release-container:
-          requires:
-            - build
-          filters:
-            tags:
-              only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo
   # because they share credentials and would mess each other up if run concurrently


### PR DESCRIPTION
**Why**: We're not using it right now

If we *really* wanted to be bold... would drop our `production.Dockerfile` too 😈 