### PR TITLE
Convert the read only database connection configs to IdentityConfig

### DIFF
--- a/app/services/db/establish_connection/read_replica_connection.rb
+++ b/app/services/db/establish_connection/read_replica_connection.rb
@@ -14,27 +14,31 @@ module Db
       private
 
       def read_replica_connection_params
-        rails_env = Rails.env
-        env = AppConfig.env
         {
           adapter: 'postgresql',
-          database: rails_env.production? ? env.database_name : "upaya_#{rails_env}",
-          host: env.database_read_replica_host,
-          username: env.database_readonly_username,
-          password: env.database_readonly_password,
+          database: database_name,
+          host: IdentityConfig.store.database_read_replica_host,
+          username: IdentityConfig.store.database_readonly_username,
+          password: IdentityConfig.store.database_readonly_password,
         }
       end
 
       def primary_connection_params
-        rails_env = Rails.env
-        env = AppConfig.env
         {
           adapter: 'postgresql',
-          database: rails_env.production? ? env.database_name : "upaya_#{rails_env}",
-          host: env.database_host,
-          username: env.database_username,
-          password: env.database_password,
+          database: database_name,
+          host: IdentityConfig.store.database_host,
+          username: IdentityConfig.store.database_username,
+          password: IdentityConfig.store.database_password,
         }
+      end
+
+      def database_name
+        if Rails.env.production?
+          IdentityConfig.store.database_name
+        else
+          "upaya_#{Rails.env}"
+        end
       end
     end
   end


### PR DESCRIPTION
**Why**: To wrap up the migration to IdentityConfig from AppConfig