### PR TITLE
LG-4370: Update throttled error heading to account for liveness requirement

### DIFF
--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,6 +1,8 @@
 <%= render(
   'idv/shared/error',
-  heading: t('errors.doc_auth.throttled_heading'),
+  heading: FeatureManagement.liveness_checking_enabled? && sp_session[:ial2_strict].presence ?
+    t('errors.doc_auth.throttled_heading_liveness') :
+    t('errors.doc_auth.throttled_heading'),
   options: [
     decorated_session.sp_name && {
       url: return_to_sp_failure_to_proof_path,

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -47,7 +47,8 @@ en:
         limit.  Please contact your service provider for more information.
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
-      throttled_heading: We could not verify your ID and photo of you
+      throttled_heading: We could not verify your ID
+      throttled_heading_liveness: We could not verify your ID and photo of you
       throttled_text_html: "<strong>Please try again in %{timeout}.</strong> For your
         security, we limit the number of times you can attempt to verify a document
         online."

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -48,7 +48,8 @@ es:
         para obtener más información.
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
-      throttled_heading: No pudimos verificar la identificación ni la foto
+      throttled_heading: No pudimos verificar la identificación
+      throttled_heading_liveness: No pudimos verificar la identificación ni la foto
       throttled_text_html: "<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong>
         Por su seguridad, limitamos el número de veces que puede intentar verificar
         un documento en línea."

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -50,7 +50,8 @@ fr:
       send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d’utiliser
         votre ordinateur.
-      throttled_heading: Nous n’avons pas pu vérifier votre identité et votre photo
+      throttled_heading: Nous n’avons pas pu vérifier votre identité
+      throttled_heading_liveness: Nous n’avons pas pu vérifier votre identité et votre photo
       throttled_text_html: "<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
         votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier
         un document en ligne."

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -51,7 +51,8 @@ fr:
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d’utiliser
         votre ordinateur.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
-      throttled_heading_liveness: Nous n’avons pas pu vérifier votre identité et votre photo
+      throttled_heading_liveness: Nous n’avons pas pu vérifier votre identité et votre
+        photo
       throttled_text_html: "<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
         votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier
         un document en ligne."

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -2,10 +2,15 @@ require 'rails_helper'
 
 describe 'idv/session_errors/throttled.html.erb' do
   let(:sp_name) { nil }
+  let(:liveness_checking_enabled) { false }
+  let(:sp_session) { {} }
 
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
+    allow(FeatureManagement).to receive(:liveness_checking_enabled?).
+      and_return(liveness_checking_enabled)
+    allow(view).to receive(:sp_session).and_return(sp_session)
 
     render
   end
@@ -32,6 +37,34 @@ describe 'idv/session_errors/throttled.html.erb' do
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
         href: return_to_sp_failure_to_proof_path,
       )
+    end
+  end
+
+  context 'with liveness feature disabled' do
+    let(:liveness_checking_enabled) { false }
+
+    it 'renders expected heading' do
+      expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
+    end
+  end
+
+  context 'with liveness feature enabled' do
+    let(:liveness_checking_enabled) { true }
+
+    context 'without strict ial2' do
+      let(:sp_session) { {} }
+
+      it 'renders expected heading' do
+        expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
+      end
+    end
+
+    context 'with strict ial2' do
+      let(:sp_session) { { ial2_strict: true } }
+
+      it 'renders expected heading' do
+        expect(rendered).to have_text(t('errors.doc_auth.throttled_heading_liveness'))
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: If the verification does not require liveness, it is confusing to the user if we tell them we cannot verify the "photo of you", since they would not be prompted to capture a photo. We should only show this text if liveness is required.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/116738997-29342e80-a9c1-11eb-823c-a94b41ef341c.png)|![image](https://user-images.githubusercontent.com/1779930/116738962-220d2080-a9c1-11eb-8feb-b9e387b62df1.png)

