### PR TITLE
log more things in the resolution proofing step (LG-4266)

### DIFF
--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -53,14 +53,27 @@ module Idv
 
       def add_proofing_costs(results)
         vendors = results[:context][:stages]
-        vendors.each do |hash|
-          if hash[:state_id]
-            # transaction_id comes from TransactionLocatorId
-            add_cost(:aamva, transaction_id: hash[:transaction_id])
+        # backwards-compatibility, can be removed after next deploy (2021-04-29)
+        if vendors.is_a?(Array)
+          vendors.each do |hash|
+            if hash[:state_id]
+              # transaction_id comes from TransactionLocatorId
+              add_cost(:aamva, transaction_id: hash[:transaction_id])
+            end
+            if hash[:resolution]
+              # transaction_id comes from ConversationId
+              add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+            end
           end
-          if hash[:resolution]
-            # transaction_id comes from ConversationId
-            add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+        else
+          vendors.each do |stage, hash|
+            if stage == :resolution
+              # transaction_id comes from ConversationId
+              add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+            elsif stage == :state_id
+              # transaction_id comes from TransactionLocatorId
+              add_cost(:aamva, transaction_id: hash[:transaction_id])
+            end
           end
         end
       end

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -28,18 +28,21 @@ module Idv
 
       def async_state_done(current_async_state)
         add_proofing_costs(current_async_state.result)
-        response = idv_result_to_form_response(current_async_state.result)
-        response = check_ssn(flow_session[:pii_from_doc]) if response.success?
-        summarize_result_and_throttle_failures(response)
+        form_response = idv_result_to_form_response(current_async_state.result)
+        if form_response.success?
+          response = check_ssn(flow_session[:pii_from_doc]) if form_response.success?
+          form_response = form_response.merge(response)
+        end
+        summarize_result_and_throttle_failures(form_response)
         delete_async
 
-        if response.success?
+        if form_response.success?
           mark_step_complete(:verify_wait)
         else
           mark_step_incomplete(:verify)
         end
 
-        response
+        form_response
       end
 
       def async_state

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -109,16 +109,26 @@ RSpec.describe ResolutionProofingJob, type: :job do
           success: true,
           timed_out: false,
           context: {
-            stages: [
-              {
-                resolution: LexisNexis::InstantVerify::Proofer.vendor_name,
+            dob_year_only: dob_year_only,
+            should_proof_state_id: true,
+            stages: {
+              resolution: {
+                client: LexisNexis::InstantVerify::Proofer.vendor_name,
+                errors: {},
+                exception: nil,
+                success: true,
+                timed_out: false,
                 transaction_id: lexisnexis_transaction_id,
               },
-              {
-                state_id: Aamva::Proofer.vendor_name,
+              state_id: {
+                client: Aamva::Proofer.vendor_name,
+                errors: {},
+                exception: nil,
+                success: true,
+                timed_out: false,
                 transaction_id: aamva_transaction_id,
               },
-            ],
+            },
           },
           transaction_id: lexisnexis_transaction_id,
         )
@@ -160,16 +170,26 @@ RSpec.describe ResolutionProofingJob, type: :job do
             success: false,
             timed_out: false,
             context: {
-              stages: [
-                {
-                  state_id: Aamva::Proofer.vendor_name,
+              dob_year_only: dob_year_only,
+              should_proof_state_id: true,
+              stages: {
+                state_id: {
+                  client: Aamva::Proofer.vendor_name,
+                  errors: {},
+                  exception: nil,
+                  success: true,
+                  timed_out: false,
                   transaction_id: aamva_transaction_id,
                 },
-                {
-                  resolution: LexisNexis::InstantVerify::Proofer.vendor_name,
+                resolution: {
+                  client: LexisNexis::InstantVerify::Proofer.vendor_name,
+                  errors: {},
+                  exception: kind_of(String),
+                  success: false,
+                  timed_out: false,
                   transaction_id: nil,
                 },
-              ],
+              },
             },
             transaction_id: nil,
           )
@@ -255,10 +275,30 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
           result = document_capture_session.load_proofing_result[:result]
 
-          expect(result.dig(:context, :stages)).to eq [
-            { state_id: 'aamva:state_id', transaction_id: aamva_transaction_id },
-            { resolution: 'lexisnexis:instant_verify', transaction_id: lexisnexis_transaction_id },
-          ]
+          expect(result[:context]).to eq(
+            {
+              dob_year_only: dob_year_only,
+              should_proof_state_id: true,
+              stages: {
+                state_id: {
+                  client: 'aamva:state_id',
+                  errors: {},
+                  exception: nil,
+                  success: true,
+                  timed_out: false,
+                  transaction_id: aamva_transaction_id,
+                },
+                resolution: {
+                  client: 'lexisnexis:instant_verify',
+                  errors: {},
+                  exception: nil,
+                  success: true,
+                  timed_out: false,
+                  transaction_id: lexisnexis_transaction_id,
+                },
+              },
+            },
+          )
 
           expect(result.dig(:transaction_id)).to eq(lexisnexis_transaction_id)
         end

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -29,10 +29,7 @@ describe Idv::Agent do
 
           result = document_capture_session.load_proofing_result.result
           expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
-          expect(result[:context][:stages]).to_not include(
-            state_id: 'StateIdMock',
-            transaction_id: Proofing::StateIdMockClient::TRANSACTION_ID,
-          )
+          expect(result[:context][:stages].key?(:state_id)).to eq false
         end
 
         it 'does proof state_id if resolution succeeds' do
@@ -48,8 +45,8 @@ describe Idv::Agent do
             document_capture_session, should_proof_state_id: true, trace_id: trace_id
           )
           result = document_capture_session.load_proofing_result.result
-          expect(result[:context][:stages]).to include(
-            state_id: 'StateIdMock',
+          expect(result[:context][:stages][:state_id]).to include(
+            client: 'StateIdMock',
             transaction_id: Proofing::StateIdMockClient::TRANSACTION_ID,
           )
         end
@@ -66,10 +63,7 @@ describe Idv::Agent do
           )
           result = document_capture_session.load_proofing_result.result
           expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
-          expect(result[:context][:stages]).to_not include(
-            state_id: 'StateIdMock',
-            transaction_id: Proofing::StateIdMockClient::TRANSACTION_ID,
-          )
+          expect(result[:context][:stages].key?(:state_id)).to eq false
         end
 
         it 'does not proof state_id if resolution succeeds' do


### PR DESCRIPTION
We currently lose a lot of information from the resolution proofing step, making it hard to understand dropoff and the types of errors users see in the proofing flow. The verify step is tricky since it may call one or both of AAMVA and LexisNexis in any order, and we want to preserve each individual call's results while still maintaining the format that the FlowStateMachine steps expect to be returned as a response.

This ends up duplicating a lot sometimes, but I'd rather err on the side of too much logging for now. We can pare it back if needed.

This does change the format of the context and stages, but I talked with @stevegsa and it doesn't sound like they are used for any reports. I also am assuming the reports don't depend on it since data is missing a lot of the time.

Example of success in current format:
Note that information about AAMVA/LexisNexis calls are not there.

```json
{
  "user_id": 12,
  "name": "IdV: doc auth optional verify_wait submitted",
  "properties": {
    "event_properties": {
      "success": true,
      "errors": {},
      "ssn_is_unique": false,
      "step": "verify_wait_step_show"
    },
    "user_id": "071ab412-a14a-4a07-9057-aed06c929361",
    "user_ip": "127.0.0.1",
    "hostname": "localhost",
    "pid": 88408,
    "service_provider": null,
    "trace_id": null,
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0",
    "browser_name": "Firefox",
    "browser_version": "88.0",
    "browser_platform_name": "Mac",
    "browser_platform_version": "10.15",
    "browser_device_name": null,
    "browser_device_type": "desktop",
    "browser_bot": false
  },
  "time": "2021-04-27T20:03:03.411Z",
  "id": "016b75dd-08b7-4c82-875c-218698e6f146",
  "visitor_id": "4ef893e3-e2fe-44aa-93b2-32c2efbd9ece",
  "visit_id": "6a08de55-a29d-4312-b9ef-f198cc59597d"
}
```

Example success in new format:

```json
{
  "user_id": 12,
  "name": "Doc Auth optional submitted",
  "properties": {
    "event_properties": {
      "success": true,
      "errors": {},
      "proofing_results": {
        "messages": [],
        "exception": null,
        "transaction_id": "resolution-mock-transaction-id-123",
        "timed_out": false,
        "context": {
          "dob_year_only": false,
          "should_proof_state_id": true,
          "stages": {
            "resolution": {
              "client": "ResolutionMock",
              "errors": {},
              "exception": null,
              "success": true,
              "timed_out": false,
              "transaction_id": "resolution-mock-transaction-id-123"
            },
            "state_id": {
              "client": "StateIdMock",
              "errors": {},
              "success": true,
              "timed_out": false,
              "exception": null,
              "transaction_id": "state-id-mock-transaction-id-456"
            }
          }
        }
      },
      "ssn_is_unique": false,
      "step": "verify_wait_step_show"
    },
    "user_id": "071ab412-a14a-4a07-9057-aed06c929361",
    "user_ip": "127.0.0.1",
    "hostname": "localhost",
    "pid": 20055,
    "service_provider": null,
    "trace_id": null,
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0",
    "browser_name": "Firefox",
    "browser_version": "88.0",
    "browser_platform_name": "Mac",
    "browser_platform_version": "10.15",
    "browser_device_name": null,
    "browser_device_type": "desktop",
    "browser_bot": false
  },
  "time": "2021-04-30T20:38:41.567Z",
  "id": "7fc56309-b4d3-4fa5-8bd9-4a9bf90a27b1",
  "visitor_id": "4ef893e3-e2fe-44aa-93b2-32c2efbd9ece",
  "visit_id": "5a689e0b-ed2e-4354-8e90-c448fb0b0232"
}
```

Example error in new format:

```json
{
  "user_id": 12,
  "name": "Doc Auth optional submitted",
  "properties": {
    "event_properties": {
      "success": false,
      "errors": {
        "ssn": [
          "Unverified SSN."
        ]
      },
      "proofing_results": {
        "messages": [],
        "exception": null,
        "transaction_id": "resolution-mock-transaction-id-123",
        "timed_out": false,
        "context": {
          "dob_year_only": false,
          "should_proof_state_id": true,
          "stages": {
            "resolution": {
              "client": "ResolutionMock",
              "errors": {
                "ssn": [
                  "Unverified SSN."
                ]
              },
              "exception": null,
              "success": false,
              "timed_out": false,
              "transaction_id": "resolution-mock-transaction-id-123"
            }
          }
        }
      },
      "step": "verify_wait_step_show"
    },
    "user_id": "071ab412-a14a-4a07-9057-aed06c929361",
    "user_ip": "127.0.0.1",
    "hostname": "localhost",
    "pid": 20055,
    "service_provider": null,
    "trace_id": null,
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0",
    "browser_name": "Firefox",
    "browser_version": "88.0",
    "browser_platform_name": "Mac",
    "browser_platform_version": "10.15",
    "browser_device_name": null,
    "browser_device_type": "desktop",
    "browser_bot": false
  },
  "time": "2021-04-30T20:31:03.233Z",
  "id": "cb0482a0-19f9-4e73-9128-19e0cd378086",
  "visitor_id": "4ef893e3-e2fe-44aa-93b2-32c2efbd9ece",
  "visit_id": "5a689e0b-ed2e-4354-8e90-c448fb0b0232"
}
```