### PR TITLE
Remove SAML API endpoints from being scraped by bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /users/password/edit
 Disallow: /sign_up/enter_password
 Disallow: /sign_up/email/confirm
+Disallow: /api/saml/*

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Disallow: /users/password/edit
 Disallow: /sign_up/enter_password
 Disallow: /sign_up/email/confirm
-Disallow: /api/saml/*
+Disallow: /api/saml/


### PR DESCRIPTION
Got a notification that `/api/saml/auth2021` was scraped by the Google search crawler and had empty content, which is kind of expected, seems easier to remove this from the index