### PR TITLE
LG-3993: Avoid auto-submit for WebOTP autofill

### DIFF
--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -35,7 +35,6 @@ class OneTimeCodeInput {
       });
 
       input.value = code;
-      form?.submit();
     } catch {
       // Thrown errors may be expected if:
       // - the user submits the form and triggers the abort controller's signal. ('AbortError')

--- a/spec/javascripts/packages/one-time-code-input/index-spec.js
+++ b/spec/javascripts/packages/one-time-code-input/index-spec.js
@@ -42,7 +42,7 @@ describe('OneTimeCodeInput', () => {
     });
 
     context('in form', () => {
-      it('fills value and submits form', async () => {
+      it('fills value', async () => {
         const otcInput = initialize({ inForm: true });
 
         await waitFor(() => expect(otcInput.elements.input.value).to.equal('123456'));
@@ -50,7 +50,6 @@ describe('OneTimeCodeInput', () => {
           otp: { transport: ['sms'] },
           signal: sandbox.match.instanceOf(window.AbortSignal),
         });
-        expect(onSubmit).to.have.been.calledOnce();
       });
 
       it('cancels credential receiver on submit', (done) => {
@@ -71,7 +70,6 @@ describe('OneTimeCodeInput', () => {
           otp: { transport: ['sms'] },
           signal: sandbox.match.instanceOf(window.AbortSignal),
         });
-        expect(onSubmit).not.to.have.been.called();
       });
     });
 


### PR DESCRIPTION
**Why**: Since we give users the choice to not remember the current browser so that they will be prompted for OTP on subsequent login attempts. With auto-submit, most users will not know that this option exists, since the prompt to auto-fill shows nearly instantaneously on page load. This is also more consistent with how iOS's "From Messages" OTP auto-fill behaves.