### PR TITLE
Fix active, disabled, unstyled button background color (again)

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -64,6 +64,18 @@
   // of a link.
   display: inline;
   width: auto;
+
+  // Temporary: To be backported to design system. Unstyled buttons should not ever show the default
+  // opaque disabled background color. Typically a button would not be both disabled and active, but
+  // it is possible in some browsers when e.g. disabling a button in response to its own click.
+  &.usa-button:disabled:hover,
+  &.usa-button:disabled.usa-button--hover,
+  &.usa-button:disabled:active,
+  &.usa-button:disabled.usa-button--active,
+  &.usa-button:disabled:focus,
+  &.usa-button:disabled.usa-focus {
+    background-color: transparent;
+  }
 }
 
 .usa-button--disabled {


### PR DESCRIPTION
This restores the fix from #4881, which was prematurely removed in #5014, as it had not been ported upstream to `identity-style-guide`. This is fixed in [USWDS v2.11.2](https://designsystem.digital.gov/about/releases/#version-2112) (https://github.com/uswds/uswds/pull/4077), so a future USWDS version sync in `identity-style-guide` will resolve it and allow us to remove it from the IdP.

**Why**: When an unstyled button is used as the submit button in a form, it can cause an issue where clicking the button would make it both disabled and active. This is because our default form validation will disable all submit buttons when a form is submitted. Since this happens at the same time as the link activation, and since the USWDS default disabled button styles conflict with the unstyled link appearance, an undesirable background color can be shown.

**Screenshot:**

Before|After
---|---
![Screen Shot 2021-05-04 at 8 52 29 AM](https://user-images.githubusercontent.com/1779930/117006641-aeb42900-acb6-11eb-89a7-fad9e388fdf4.png)|![Screen Shot 2021-05-04 at 8 53 27 AM](https://user-images.githubusercontent.com/1779930/117006648-b07dec80-acb6-11eb-8823-576356e59bca.png)
