### PR TITLE
Fix miscellaneous styling blemishes

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -177,7 +177,7 @@ input::-webkit-inner-spin-button {
 
 .usa-form-group--error {
   border-left-style: none;
-  margin-top: 0;
+  margin-top: units(3); // Remove after: https://github.com/uswds/uswds/issues/4189
   padding-left: 0;
 
   @include at-media('desktop') {

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -9,8 +9,6 @@ $radio-checkbox-space: 1.5rem;
 }
 
 legend {
-  // short-circuits line-height to stop inheritance
-  font: $small-font-size $serif-font-family;
   font-weight: $heading-font-weight;
 }
 

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -75,7 +75,7 @@
     }
 
     hr {
-      width: 7.5rem;
+      width: 5rem;
     }
 
   }

--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -43,14 +43,6 @@
   }
 }
 
-.authnav-greeting {
-  display: none;
-
-  @include at-media('desktop') {
-    display: block;
-  }
-}
-
 .top-banner {
   display: none;
 

--- a/app/assets/stylesheets/components/_troubleshooting-options.scss
+++ b/app/assets/stylesheets/components/_troubleshooting-options.scss
@@ -11,7 +11,7 @@
     content: '';
     display: block;
     height: 4px;
-    width: 5.5rem;
+    width: 5rem;
   }
 }
 

--- a/app/assets/stylesheets/utilities/_border.scss
+++ b/app/assets/stylesheets/utilities/_border.scss
@@ -1,8 +1,3 @@
-.bw1 { border-width: 1px; }
-.bw2 { border-width: 2px; }
-.bw3 { border-width: 3px; }
-.bw4 { border-width: 4px; }
-
 .border-dashed { border-style: dashed; }
 
 .rounded-md { border-radius: $border-radius-md; }

--- a/app/assets/stylesheets/utilities/_space-misc.scss
+++ b/app/assets/stylesheets/utilities/_space-misc.scss
@@ -30,6 +30,10 @@
   .sm-mtn3 { margin-top: -$space-3; }
 }
 
+.margin-top-neg-4 {
+  margin-top: units(-4);
+}
+
 @include at-media('tablet') {
   .tablet\:margin-x-neg-6 {
     margin-left: units(-6);

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -137,7 +137,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
   ) : (
     <>
       {submissionError && !(submissionError instanceof UploadFormEntriesError) && (
-        <Alert type="error" className="margin-bottom-4 margin-top-2 tablet:margin-top-0">
+        <Alert type="error" className="margin-bottom-4">
           {t('doc_auth.errors.general.network_error')}
         </Alert>
       )}

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -213,11 +213,7 @@ function FormSteps({
     <form ref={formRef} onSubmit={toNextStep}>
       {Object.keys(values).length > 0 && <PromptOnNavigate />}
       {unknownFieldErrors.map(({ field, error }) => (
-        <Alert
-          key={[field, error.message].join()}
-          type="error"
-          className="margin-bottom-4 margin-top-2 tablet:margin-top-0"
-        >
+        <Alert key={[field, error.message].join()} type="error" className="margin-bottom-4">
           <FormErrorMessage error={error} />
         </Alert>
       ))}

--- a/app/presenters/backup_code_create_presenter.rb
+++ b/app/presenters/backup_code_create_presenter.rb
@@ -14,7 +14,7 @@ class BackupCodeCreatePresenter
   end
 
   def other_option_title
-    t('forms.backup_code.are_you_sure_other_option')
+    t('two_factor_authentication.choose_another_option')
   end
 
   def continue_bttn_prologue

--- a/app/views/account_reset/confirm_request/show.html.erb
+++ b/app/views/account_reset/confirm_request/show.html.erb
@@ -10,8 +10,8 @@
   <%= t('account_reset.confirm_request.instructions_end') %>
 </p>
 
-<div class="col-3">
-  <hr class="margin-y-4 bw3 border-teal rounded"/>
+<div class="width-10">
+  <hr class="margin-y-4 border-width-05 border-teal">
 </div>
 
 <% if sms_phone %>

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -1,20 +1,20 @@
 <div class="bg-white">
   <div class="container tablet:padding-x-2 tablet:padding-y-4">
     <div class="clearfix">
-      <div class="margin-y-1 margin-left-2 tablet:margin-0 col col-4">
+      <div class="margin-y-105 margin-left-2 tablet:margin-0 col col-4">
         <%= link_to image_tag(asset_url('logo.svg'),
                               alt: APP_NAME,
                               class: 'text-bottom',
                               width: 170), root_path %>
       </div>
-      <div class="right-align col col-8 padding-right-1 authnav-greeting">
-        <div class="inline-block margin-right-1 truncate-inline">
-          <p class="inline-block truncate margin-0">
+      <div class="col col-8 padding-right-1 display-none desktop:display-flex flex-justify-end">
+        <div class="margin-right-1 truncate-inline">
+          <p class="truncate margin-0">
             <%= t('account.welcome') %>
             <strong><%= greeting %></strong>
           </p>
         </div>
-        <div class="inline-block right border-silver border-left">
+        <div class="border-silver border-left">
           <p class="margin-0">
             <%= link_to t('links.sign_out'), destroy_user_session_path,
                         class: 'padding-left-1' %>
@@ -22,7 +22,7 @@
         </div>
       </div>
       <div class="desktop:display-none display-flex flex-row flex-justify-end">
-        <%= link_to t('links.sign_out'), destroy_user_session_path, class: 'margin-top-1 margin-right-2'%>
+        <%= link_to t('links.sign_out'), destroy_user_session_path, class: 'margin-top-105 margin-right-2'%>
         <% if enable_mobile_nav %>
           <button class="usa-menu-btn"><%= t('account.navigation.menu') %></button>
         <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -23,5 +23,5 @@
 <% end %>
 
 <div class="margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), decorated_session.cancel_link_url, class: 'h5' %>
+  <%= link_to t('links.cancel'), decorated_session.cancel_link_url %>
 </div>

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -17,8 +17,8 @@
    <%= t('notices.forgot_password.first_paragraph_end') %>
 </p>
 
-<div class="col-3">
-  <hr class="margin-y-4 bw3 border-teal rounded"/>
+<div class="width-10">
+  <hr class="margin-y-4 border-width-05 border-teal">
 </div>
 
 <%= validated_form_for @view_model.password_reset_email_form,

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -4,7 +4,7 @@
       steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
       current_step: :verify_info,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -2,11 +2,9 @@
 
 <%= image_tag(asset_url('alert/fail-x.svg'), alt: '', width: 54) %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-top-4 margin-bottom-2">
   <%= t('headings.cancellations.confirmation') %>
 </h1>
-
-<hr>
 
 <ul class='list-reset red-dots'>
   <li><%= t('idv.cancel.warnings.warning_2') %></li>

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -1,6 +1,6 @@
 <% title t('headings.cancellations.confirmation') %>
 
-<%= image_tag(asset_url('alert/fail-x.svg'), width: 54) %>
+<%= image_tag(asset_url('alert/fail-x.svg'), alt: '', width: 54) %>
 
 <h1 class="margin-bottom-1 margin-top-4 margin-y-0">
   <%= t('headings.cancellations.confirmation') %>

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -2,11 +2,9 @@
 
 <%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
+<h1 class="margin-top-4 margin-bottom-2">
   <%= t('headings.cancellations.prompt') %>
 </h1>
-
-<hr>
 
 <p class='margin-bottom-1 bold'><%= t('sign_up.cancel.warning_header') %></p>
 

--- a/app/views/idv/capture_doc/capture_complete.html.erb
+++ b/app/views/idv/capture_doc/capture_complete.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.doc_auth.verify') %>
 
-<%= render 'shared/alert', { type: 'success', class: 'margin-bottom-4 margin-top-2' } do %>
+<%= render 'shared/alert', { type: 'success', class: 'margin-bottom-4' } do %>
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -6,7 +6,7 @@
       end,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/confirmations/show.html.erb
+++ b/app/views/idv/confirmations/show.html.erb
@@ -4,7 +4,7 @@
       steps: @step_indicator_steps,
       current_step: :secure_account,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'shared/alert', {
   type: 'success',
-  class: 'margin-bottom-4 margin-top-2 tablet:margin-top-0'
+  class: 'margin-bottom-4'
 } do %>
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -4,7 +4,7 @@
       steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -4,7 +4,7 @@
       steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -4,7 +4,7 @@
       steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -4,7 +4,7 @@
       steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -76,7 +76,7 @@
 <% end %>
 
 <div class="margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), idv_cancel_path, class: 'h5' %>
+  <%= link_to t('links.cancel'), idv_cancel_path %>
 </div>
 
 <% javascript_packs_tag_once 'form-steps-wait' %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -4,7 +4,7 @@
       steps: @step_indicator_steps,
       current_step: :secure_account,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -37,10 +37,10 @@
   <% end %>
 
   <%= f.button(
-    :submit,
-    t('forms.buttons.continue'),
-    class: 'usa-button--big usa-button--wide margin-top-4',
-  ) %>
+        :submit,
+        t('forms.buttons.continue'),
+        class: 'usa-button--big usa-button--wide margin-top-4',
+      ) %>
 <% end %>
 
 <div class="margin-top-6 margin-top-2 padding-top-1 border-top border-primary-light">

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -40,5 +40,5 @@
 <% end %>
 
 <div class="margin-top-6 margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), idv_cancel_path, class: 'h5' %>
+  <%= link_to t('links.cancel'), idv_cancel_path %>
 </div>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -36,7 +36,11 @@
                phone: PhoneFormatter.format(@applicant[:phone]) %>
   <% end %>
 
-  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide' %>
+  <%= f.button(
+    :submit,
+    t('forms.buttons.continue'),
+    class: 'usa-button--big usa-button--wide margin-top-4',
+  ) %>
 <% end %>
 
 <div class="margin-top-6 margin-top-2 padding-top-1 border-top border-primary-light">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -67,7 +67,7 @@
       <% end %>
     </div>
     <div class="container">
-      <div class="padding-x-2 padding-y-2 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>" role="main">
+      <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>" role="main">
         <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
         <%= render 'shared/flashes' %>
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -5,7 +5,7 @@
       locale_scope: flow_namespace,
       steps: step_indicator[:steps],
       current_step: step_indicator[:current_step],
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4'
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4'
     ) %>
   <% end %>
 <% end %>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -2,7 +2,7 @@
   <p class="bold center margin-top-1 padding-top-1 fs-20p">
     <%= t('users.personal_key.header') %>
   </p>
-  <div class="margin-top-6 margin-bottom-6 padding-x-0 tablet:padding-x-1 padding-y-2 center bg-white bw2 separator-text bg-pk-box">
+  <div class="margin-top-6 margin-bottom-6 padding-x-0 tablet:padding-x-1 padding-y-2 center bg-white border-width-2px separator-text bg-pk-box">
     <%- code.split('-').each do |word|
       -%><div class="inline fs-20p bold navy"
         ><code class="monospace" data-personal-key="word"

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -4,7 +4,7 @@
       <h2 class="margin-y-2 fs-20p sans-serif regular center">
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>
-      <hr class="margin-bottom-4 bw4 rounded" />
+      <hr class="margin-bottom-4 border-width-05" />
       <div class="margin-bottom-8">
         <%= t('instructions.account.reactivate.modal.copy') %>
       </div>

--- a/app/views/service_provider_mfa/new.html.erb
+++ b/app/views/service_provider_mfa/new.html.erb
@@ -14,7 +14,7 @@
                        url: two_factor_options_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-none">
-      <legend class="margin-bottom-2 serif bold"><%= t('forms.two_factor_choice.legend') %>:</legend>
+      <legend class="margin-bottom-2"><%= t('forms.two_factor_choice.legend') %>:</legend>
       <% @presenter.options.each do |option| %>
         <%= label_tag "two_factor_options_form_selection_#{option.type}",
                       class: "btn-border col-12 margin-bottom-2 #{option.html_class}",

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -4,7 +4,7 @@
       <h2 class='margin-y-2 fs-20p sans-serif regular center'>
         <%= t('headings.session_timeout_warning') %>
       </h2>
-      <hr class='margin-bottom-4 bw4 rounded' />
+      <hr class='margin-bottom-4 border-width-05' />
       <div class='margin-bottom-6'>
         <p>
           <%= modal.message %>

--- a/app/views/shared/_cancel_or_back_to_options.html.erb
+++ b/app/views/shared/_cancel_or_back_to_options.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-top-2 padding-top-1 border-top border-primary-light">
   <% if MfaPolicy.new(current_user).two_factor_enabled? %>
-    <%= link_to t('links.cancel'), account_path, class: 'h5' %>
+    <%= link_to t('links.cancel'), account_path %>
   <% else %>
     <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
   <% end %>

--- a/app/views/shared/_failure.html.erb
+++ b/app/views/shared/_failure.html.erb
@@ -12,7 +12,7 @@
 
 <% if presenter.message.present? %>
   <div class="col-2">
-    <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-<%= presenter.state_color %>" />
+    <hr class="margin-top-4 margin-bottom-2 border-width-05 border-<%= presenter.state_color %>" />
   </div>
 
   <h2 class="h4 margin-bottom-2 margin-top-4 margin-y-0">

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -18,8 +18,8 @@
    <%= t('notices.signed_up_but_unconfirmed.first_paragraph_end') %>
 </p>
 
-<div class="col-3">
-  <hr class="margin-y-4 bw3 border-teal rounded"/>
+<div class="width-10">
+  <hr class="margin-y-4 border-width-05 border-teal">
 </div>
 
 <%= validated_form_for @resend_email_confirmation_form,

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -24,7 +24,7 @@
     </span>
 
     <fieldset class="usa-fieldset">
-      <legend class="sans-serif margin-bottom-1">
+      <legend class="margin-bottom-1">
         <%= t('forms.registration.labels.email_language') %>
       </legend>
 

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -13,14 +13,14 @@
     <%= hidden_field_tag(:redirect_uri, @referrer) %>
     <div class="clearfix margin-x-neg-1">
       <div class="col col-12 padding-x-1">
-        <legend class="margin-bottom-1 h4 serif bold">
+        <legend class="margin-bottom-1">
           Certificate Subject
         </legend>
         <%= text_field_tag(:subject, '', class: 'block col-12 field monospace') %>
       </div>
       <div class="margin-bottom-4">
         <fieldset class="margin-0 padding-0 border-none">
-          <legend class="margin-bottom-1 h4 serif bold">
+          <legend class="margin-bottom-1">
             Error Conditions
           </legend>
           <label class="btn-border col-12 margin-bottom-2">

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -14,7 +14,7 @@
         url: login_two_factor_options_path) do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-none">
-      <legend class="margin-bottom-2 serif bold">
+      <legend class="margin-bottom-2">
         <%= @presenter.label %>
       </legend>
       <% @presenter.options.each_with_index do |option, index| %>

--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -7,7 +7,7 @@
 </h1>
 
 <div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow"></hr>
+  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>
 </div>
 
 <p class="margin-bottom-6">

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -7,7 +7,7 @@
 </h1>
 
 <div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow"></hr>
+  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>
 </div>
 
 <p class="margin-bottom-6">

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -13,7 +13,7 @@
 <br>
 <div class="margin-top-2 padding-top-1 border-top border-primary-light">
   <% if MfaPolicy.new(current_user).two_factor_enabled? %>
-    <%= link_to t('links.cancel'), account_path, class: 'h5' %>
+    <%= link_to t('links.cancel'), account_path %>
   <% else %>
     <%= link_to @presenter.other_option_title, two_factor_options_path %>
   <% end %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -4,7 +4,7 @@
   <h1 class="margin-y-2 fs-20p sans-serif regular center">
     <%= t('users.delete.heading') %>
   </h1>
-  <hr class="margin-bottom-4 bw4 rounded" />
+  <hr class="margin-bottom-4 border-width-05" />
   <div class="margin-bottom-1 bold">
     <%= t('users.delete.subheading') %>
   </div>

--- a/app/views/users/edit_phone/_delivery_preference_selection.html.erb
+++ b/app/views/users/edit_phone/_delivery_preference_selection.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-none">
-    <legend class="margin-bottom-1 h4 serif bold">
+    <legend class="margin-bottom-1">
       <%= t('two_factor_authentication.otp_delivery_preference.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_delivery_preference_instruction">

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-none">
-    <legend class="margin-bottom-1 h4 serif bold">
+    <legend class="margin-bottom-1">
       <%= t('two_factor_authentication.otp_make_default_number.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -12,7 +12,7 @@
 
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
   <fieldset class="usa-fieldset">
-    <legend class="sans-serif margin-bottom-1">
+    <legend class="margin-bottom-1">
       <%= t('account.email_language.please_select') %>
     </legend>
     <%= render partial: 'shared/email_languages',

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -18,8 +18,8 @@
    <%= t('notices.signed_up_and_confirmed.first_paragraph_end') %>
 </p>
 
-<div class="col-3">
-  <hr class="margin-y-4 bw3 border-teal rounded"/>
+<div class="width-10">
+  <hr class="margin-y-4 border-width-05 border-teal">
 </div>
 
 <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -1,13 +1,12 @@
 <% title t('titles.phone_setup') %>
 <%= image_tag asset_url('2FA-voice.svg'), alt: '', width: 200, class: 'margin-bottom-2' %>
 
-<h1 class="margin-y-0">
-  <%= t('titles.phone_setup') %>
-</h1>
-<p class="mt-tiny margin-bottom-0">
+<h1><%= t('titles.phone_setup') %></h1>
+
+<p>
   <%= t('two_factor_authentication.phone_info_html') %>
 </p>
-<p class="mt-tiny margin-bottom-1">
+<p>
   <%= t('two_factor_authentication.phone_fee_disclosure') %>
   <% if IdentityConfig.store.voip_block %>
     <%= t('two_factor_authentication.two_factor_choice_options.phone_info_no_voip') %>
@@ -36,7 +35,7 @@
 <% end %>
 
 
-<div class="margin-top-2 padding-top-1 border-top border-primary-light">
+<div class="margin-top-4 padding-top-1 border-top border-primary-light">
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
 
   <%= stylesheet_link_tag 'intl-tel-input/build/css/intlTelInput' %>

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -1,12 +1,11 @@
 <%= title t('titles.add_info.phone') %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.add_info.phone') %>
-</h1>
-<p class="mt-tiny margin-bottom-0">
+<h1><%= t('headings.add_info.phone') %></h1>
+
+<p>
   <%= t('two_factor_authentication.phone_info_html') %>
 </p>
-<p class="mt-tiny margin-bottom-1">
+<p>
   <%= t('two_factor_authentication.phone_fee_disclosure') %>
   <% if IdentityConfig.store.voip_block %>
     <%= t('two_factor_authentication.two_factor_choice_options.phone_info_no_voip') %>

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -7,7 +7,7 @@
 </h1>
 
 <div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow">
+  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">
 </div>
 <div class="p.margin-bottom-6">
   <%= t('forms.piv_cac_delete.caution') %>

--- a/app/views/users/shared/_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.erb
@@ -7,7 +7,7 @@
 
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-none">
-    <legend class="margin-bottom-1 h4 serif bold">
+    <legend class="margin-bottom-1">
       <%= t('two_factor_authentication.otp_delivery_preference.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_delivery_preference_instruction">

--- a/app/views/users/shared/_otp_make_default_number.html.erb
+++ b/app/views/users/shared/_otp_make_default_number.html.erb
@@ -5,7 +5,7 @@
 
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-none">
-    <legend class="margin-bottom-1 h4 serif bold">
+    <legend class="margin-bottom-1">
       <%= t('two_factor_authentication.otp_make_default_number.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -7,7 +7,7 @@
 </h1>
 
 <div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow">
+  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">
 </div>
 <div>
   <%= t('forms.totp_delete.caution') %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -18,7 +18,7 @@
                        url: two_factor_options_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-none">
-      <legend class="margin-bottom-2 serif bold"><%= t('forms.two_factor_choice.legend') %>:</legend>
+      <legend class="margin-bottom-2"><%= t('forms.two_factor_choice.legend') %>:</legend>
       <% @presenter.options.each do |option| %>
         <%= label_tag "two_factor_options_form_selection_#{option.type}",
                       class: "btn-border col-12 margin-bottom-2 #{option.html_class}",

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -6,7 +6,7 @@
       end,
       current_step: :verify_phone_or_address,
       locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-2 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
     } %>
   <% end %>
 <% end %>

--- a/app/views/users/webauthn_setup/delete.html.erb
+++ b/app/views/users/webauthn_setup/delete.html.erb
@@ -4,7 +4,7 @@
 <h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t('forms.webauthn_delete.confirm') %></h1>
 
 <div class="col-2">
-  <hr class="margin-top-4 margin-bottom-2 bw4 rounded border-yellow" />
+  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow" />
 </div>
 <br />
 <p><%= t('forms.webauthn_delete.caution') %></p>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -4,7 +4,7 @@ SimpleForm.setup do |config|
 
   config.button_class = 'usa-button'
   config.boolean_label_class = nil
-  config.default_form_class = 'margin-top-4 tablet:margin-top-4'
+  config.default_form_class = 'margin-top-4'
   config.wrapper_mappings = { inline: :append }
 
   config.wrappers :base do |b|

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -10,7 +10,6 @@ en:
         you continue with backup codes, keep them safe</b>.  We’ll give you 10 codes
         that you can download, print, copy or write down.  Later, you’ll have to enter
         one every time you sign in."
-      are_you_sure_other_option: Choose a different method
       are_you_sure_title: Are you sure?  We’ll give you backup codes to save and use.
       caution_delete: If you delete your backup codes you will no longer be able to
         use them to sign in.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -11,7 +11,6 @@ es:
         de seguridad, manténgalos seguros </b>. Le daremos 10 códigos que puede descargar,
         imprimir, copiar o escribir. Más tarde, deberás ingresar un codigo cada vez
         que inicies sesión."
-      are_you_sure_other_option: Elige un método diferente
       are_you_sure_title: "¿Estás seguro? Le daremos códigos de respaldo para guardar
         y usar."
       caution_delete: Si elimina sus códigos de respaldo, ya no podrá usarlos para

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -11,7 +11,6 @@ fr:
         des codes de sauvegarde, protégez-les </b>. Nous vous donnerons 10 codes que
         vous pourrez télécharger, imprimer, copier ou écrire. Plus tard, vous devrez
         en entrer un à chaque fois que vous vous connectez."
-      are_you_sure_other_option: Choisissez une autre méthode
       are_you_sure_title: Êtes-vous sûr? Nous vous donnerons des codes de sauvegarde
         à sauvegarder et à utiliser.
       caution_delete: Si vous supprimez vos codes de sauvegarde, vous ne pourrez plus

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -74,7 +74,7 @@ en:
       address1: Address
       address2: Address (optional)
       city: City
-      no_alternate_phone_html: "<strong>%{link}</strong>  We’ll mail you a letter
+      no_alternate_phone_html: "<strong>%{link}</strong>. We’ll mail you a letter
         with a code in it."
       password: Password
       phone: Phone Number

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -77,7 +77,7 @@ es:
       address1: Dirección
       address2: Dirección (opcional)
       city: Ciudad
-      no_alternate_phone_html: "<strong>%{link}</strong> Le enviaremos una carta con
+      no_alternate_phone_html: "<strong>%{link}</strong>. Le enviaremos una carta con
         un código."
       password: Contraseña
       phone: Teléfono

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -77,8 +77,8 @@ es:
       address1: Dirección
       address2: Dirección (opcional)
       city: Ciudad
-      no_alternate_phone_html: "<strong>%{link}</strong>. Le enviaremos una carta con
-        un código."
+      no_alternate_phone_html: "<strong>%{link}</strong>. Le enviaremos una carta
+        con un código."
       password: Contraseña
       phone: Teléfono
       ssn_label_html: Número de Seguro Social

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -82,7 +82,7 @@ fr:
       address1: Adresse
       address2: Adresse (optional)
       city: Ville
-      no_alternate_phone_html: "<strong>%{link}</strong> Nous vous ferons parvenir
+      no_alternate_phone_html: "<strong>%{link}</strong>. Nous vous ferons parvenir
         une lettre contenant un code."
       password: Mot de passe
       phone: Numéro de téléphone

--- a/config/locales/sign_up/en.yml
+++ b/config/locales/sign_up/en.yml
@@ -4,7 +4,7 @@ en:
     agree_and_continue: Agree and continue
     cancel:
       success: Your account has been deleted. We did not save your information.
-      warning_header: If you cancel now
+      warning_header: 'If you cancel now:'
     email:
       invalid_email_alert_head: 'Error: This is not a real email address. Make sure
         it includes an @ and a domain name.'

--- a/config/locales/sign_up/es.yml
+++ b/config/locales/sign_up/es.yml
@@ -4,7 +4,7 @@ es:
     agree_and_continue: Aceptar y continuar
     cancel:
       success: Su cuenta ha sido eliminada. No guardamos su información.
-      warning_header: Si cancela ahora
+      warning_header: 'Si cancela ahora:'
     email:
       invalid_email_alert_head: 'Error: No es una dirección de correo electrónico
         real. Asegúrese de que incluye una @ y un nombre de dominio.'

--- a/config/locales/sign_up/fr.yml
+++ b/config/locales/sign_up/fr.yml
@@ -4,7 +4,7 @@ fr:
     agree_and_continue: Acceptez et continuez
     cancel:
       success: Le dossier contenant votre information a été effacé
-      warning_header: Si vous annulez maintenant
+      warning_header: 'Si vous annulez maintenant:'
     email:
       invalid_email_alert_head: 'Erreur: Ce n’est pas une vraie adresse email. Assurez-vous
         qu’il comprend un @ et un nom de domaine.'

--- a/spec/presenters/backup_code_create_presenter_spec.rb
+++ b/spec/presenters/backup_code_create_presenter_spec.rb
@@ -25,7 +25,8 @@ describe BackupCodeCreatePresenter do
 
   describe '#other_option_title' do
     it 'uses localization' do
-      expect(presenter.other_option_title).to eq t('forms.backup_code.are_you_sure_other_option')
+      expect(presenter.other_option_title).
+        to eq t('two_factor_authentication.choose_another_option')
     end
   end
 


### PR DESCRIPTION
@anniehirshman-gsa and I spent some time yesterday morning pairing to discover and resolve a number of minor styling blemishes throughout the application. These are changes which on their own wouldn't warrant a dedicated ticket, but which may reflect poorly in the user's experience.

There's a bunch of changes here, some of which are larger than others. I'm happy to split this up into a few smaller pull requests if it's easier to review.

## Screenshots:

### Use consistent separator styles for colored horizontal rule (13f911b)

Before|After
---|---
![b-colored-separator-before](https://user-images.githubusercontent.com/1779930/117058623-e0e07d80-acec-11eb-951c-57b8a3742598.png)|![b-colored-separator-after](https://user-images.githubusercontent.com/1779930/117057331-50556d80-aceb-11eb-8986-05fe22843b42.png)

### Remove serif style from fieldset legend (f8464d0)

Before|After
---|---
![b-serif-before](https://user-images.githubusercontent.com/1779930/117058119-3c5e3b80-acec-11eb-8999-8c29a150a38a.png)|![b-serif-after](https://user-images.githubusercontent.com/1779930/117059985-64e73500-acee-11eb-839c-8f43b63f3d70.png)

### Remove inconsistent "other option" label for backup code MFA (4aa8deb)

Before|After
---|---
![b-backup-another-option-before](https://user-images.githubusercontent.com/1779930/117058227-5f88eb00-acec-11eb-8605-32575cafdae9.png)|![b-backup-another-option-after](https://user-images.githubusercontent.com/1779930/117057356-59463f00-aceb-11eb-9765-77ade2689545.png)

### Remove H5 styling from Cancel links (df1ac49)

Before|After
---|---
![b-cancel-before](https://user-images.githubusercontent.com/1779930/117059669-0cb03300-acee-11eb-8c04-9f6cf9985da6.png)|![b-cancel-after](https://user-images.githubusercontent.com/1779930/117059713-18035e80-acee-11eb-8ae2-742a0e226ab4.png)

### Add missing period in GPO alternative option text (66a68e0)

Before|After
---|---
![b-gpo-before](https://user-images.githubusercontent.com/1779930/117059405-c65ad400-aced-11eb-8d4d-7dc373819450.png)|![b-gpo-after](https://user-images.githubusercontent.com/1779930/117057741-d2459680-aceb-11eb-9526-7817d84752de.png)

### Increase default mobile container padding (f9eb874)

Before|After
---|---
![b-mobile-before](https://user-images.githubusercontent.com/1779930/117058015-22bcf400-acec-11eb-838e-6a0b280d9215.png)|![b-mobile-after](https://user-images.githubusercontent.com/1779930/117057912-03be6200-acec-11eb-95ff-99a9bdfe187e.png)

### Improve consistency of IAL2 cancellation screens (f7e86b5)

Before|After
---|---
![b-verify-cancel-before](https://user-images.githubusercontent.com/1779930/117058949-45034180-aced-11eb-8442-a9acec31aa16.png)|![b-verify-cancel-after](https://user-images.githubusercontent.com/1779930/117057420-6a8f4b80-aceb-11eb-8dc7-4e3a00b02335.png)
![b-verify-cancel-2-before](https://user-images.githubusercontent.com/1779930/117058975-4b91b900-aced-11eb-96a1-efefd4048f81.png)|![b-verify-cancel-2-after](https://user-images.githubusercontent.com/1779930/117057418-6a8f4b80-aceb-11eb-9e3c-3743d753a0c2.png)

### Increase spacing on review step (bcc120c)

Before|After
---|---
![b-verify-before](https://user-images.githubusercontent.com/1779930/117059493-da9ed100-aced-11eb-8e9f-abbbd2668f96.png)|![b-verify-after](https://user-images.githubusercontent.com/1779930/117057822-e5586680-aceb-11eb-88d4-5789de7822bf.png)

### Increase spacing on "Add Phone" screens (6ab7c14)

Before|After
---|---
![b-phone-setup-before](https://user-images.githubusercontent.com/1779930/117058868-2604af80-aced-11eb-8c31-f680a8562204.png)|![b-phone-setup-after](https://user-images.githubusercontent.com/1779930/117057443-724ef000-aceb-11eb-87ae-ea0c4f8731b6.png)

### Fix header excess spacing (f1bcd8c)

Before|After
---|---
![b-account-header-before](https://user-images.githubusercontent.com/1779930/117058761-01a8d300-aced-11eb-9c0a-ad8965610713.png)|![b-account-header-after](https://user-images.githubusercontent.com/1779930/117057473-7e3ab200-aceb-11eb-8c56-80e8caa7151b.png)
![b-account-header-mobile-before](https://user-images.githubusercontent.com/1779930/117060084-86482100-acee-11eb-854f-c077ba08632f.png)|![b-account-header-mobile-after](https://user-images.githubusercontent.com/1779930/117060222-af68b180-acee-11eb-9c79-bf24c8abfb0b.png)

### Set form group override styles to preserve label margin (0a83b20bc)

Before|After
---|---
![b-error-group-before](https://user-images.githubusercontent.com/1779930/117059121-72e88600-aced-11eb-93d1-acf99632f000.png)|![b-error-group-after](https://user-images.githubusercontent.com/1779930/117057613-a88c6f80-aceb-11eb-8721-7b669fa614f2.png)
