### PR TITLE
LG-4204 count ial2_strict and ial_max authentications

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -303,8 +303,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sp_session_ial
-    return 1 if sp_session[:ial].blank?
-    sp_session[:ial]
+    sp_session[:ial].presence || 1
   end
 
   def increment_monthly_auth_count

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -315,10 +315,11 @@ class ApplicationController < ActionController::Base
   end
 
   def first_auth_of_session?(issuer, ial)
-    authenticated_to_sp_token = "auth_counted_ial#{ial}_#{issuer}"
-    authenticated_to_sp = user_session[authenticated_to_sp_token]
+    auth_sp_token = "auth_counted_#{issuer}"
+    auth_sp_token.concat('ial1') if ial == 1
+    authenticated_to_sp = user_session[auth_sp_token]
     return if authenticated_to_sp
-    user_session[authenticated_to_sp_token] = true
+    user_session[auth_sp_token] = true
   end
 
   def mfa_policy
@@ -373,7 +374,13 @@ class ApplicationController < ActionController::Base
   end
 
   def add_sp_cost(token)
-    Db::SpCost::AddSpCost.call(sp_session[:issuer].to_s, sp_session_ial, token)
+    Db::SpCost::AddSpCost.call(
+      sp_session[:issuer].to_s,
+      sp_session_ial,
+      token,
+      transaction_id: nil,
+      user_id: current_user.id,
+    )
   end
 
   def mobile?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -303,19 +303,15 @@ class ApplicationController < ActionController::Base
   end
 
   def sp_session_ial
-    sp_session[:ial]
-  end
-
-  def sp_session_ial_1_or_2
     return 1 if sp_session[:ial].blank?
-    sp_session[:ial] > 1 ? 2 : 1
+    sp_session[:ial]
   end
 
   def increment_monthly_auth_count
     return unless current_user&.id
     issuer = sp_session[:issuer]
     return if issuer.blank? || !first_auth_of_session?(issuer, sp_session_ial)
-    MonthlySpAuthCount.increment(current_user.id, issuer, sp_session_ial_1_or_2)
+    MonthlySpAuthCount.increment(current_user.id, issuer, sp_session_ial)
   end
 
   def first_auth_of_session?(issuer, ial)
@@ -377,7 +373,7 @@ class ApplicationController < ActionController::Base
   end
 
   def add_sp_cost(token)
-    Db::SpCost::AddSpCost.call(sp_session[:issuer].to_s, sp_session_ial_1_or_2, token)
+    Db::SpCost::AddSpCost.call(sp_session[:issuer].to_s, sp_session_ial, token)
   end
 
   def mobile?

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -81,19 +81,15 @@ module Users
     end
 
     def next_step
-      if request_is_ial2?
+      if ial_context.ial2_requested?
         capture_password_url
       else
         after_otp_verification_confirmation_url
       end
     end
 
-    def request_is_ial2?
-      request_ial == Idp::Constants::IAL2
-    end
-
-    def request_ial
-      sp_session ? sp_session_ial_1_or_2 : 1
+    def ial_context
+      @ial_context ||= IalContext.new(ial: sp_session_ial, service_provider: current_sp)
     end
 
     def process_invalid_submission

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ module Users
       )
 
       @request_id = request_id_if_valid
-      @ial = sp_session ? sp_session_ial_1_or_2 : 1
+      @ial = sp_session_ial
       session[:ial2_with_no_sp_campaign] = campaign if sp_session.blank? && params[:ial] == '2'
       super
     end

--- a/app/models/monthly_sp_auth_count.rb
+++ b/app/models/monthly_sp_auth_count.rb
@@ -8,7 +8,10 @@ class MonthlySpAuthCount < ApplicationRecord
       SET auth_count = monthly_sp_auth_counts.auth_count + 1
     SQL
     year_month = Time.zone.today.strftime('%Y%m')
-    query = sanitize_sql_array([sql, issuer.to_s, ial.to_i, year_month, user_id])
+    service_provider = ServiceProvider.from_issuer(issuer)
+    ial_context = IalContext.new(ial: ial, service_provider: service_provider)
+    ial_1_or_2 = ial_context.ial2_or_greater? ? 2 : 1
+    query = sanitize_sql_array([sql, issuer.to_s, ial_1_or_2, year_month, user_id])
     MonthlySpAuthCount.connection.execute(query)
   end
 end

--- a/app/models/monthly_sp_auth_count.rb
+++ b/app/models/monthly_sp_auth_count.rb
@@ -8,10 +8,16 @@ class MonthlySpAuthCount < ApplicationRecord
       SET auth_count = monthly_sp_auth_counts.auth_count + 1
     SQL
     year_month = Time.zone.today.strftime('%Y%m')
+    current_user = User.find_by(id: user_id)
     service_provider = ServiceProvider.from_issuer(issuer)
-    ial_context = IalContext.new(ial: ial, service_provider: service_provider)
-    ial_1_or_2 = ial_context.ial2_or_greater? ? 2 : 1
-    query = sanitize_sql_array([sql, issuer.to_s, ial_1_or_2, year_month, user_id])
+    ial_context = IalContext.new(ial: ial, service_provider: service_provider, user: current_user)
+    query = sanitize_sql_array(
+      [sql,
+       issuer.to_s,
+       ial_context.bill_for_ial_1_or_2,
+       year_month,
+       user_id],
+    )
     MonthlySpAuthCount.connection.execute(query)
   end
 end

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -27,9 +27,12 @@ module Db
           return
         end
         agency_id = (issuer.present? && ServiceProvider.find_by(issuer: issuer)&.agency_id) || 0
+        service_provider = ServiceProvider.from_issuer(issuer)
+        ial_context = IalContext.new(ial: ial, service_provider: service_provider)
+        ial_1_or_2 = ial_context.ial2_or_greater? ? 2 : 1
         ::SpCost.create(
           issuer: issuer.to_s,
-          ial: ial,
+          ial: ial_1_or_2,
           agency_id: agency_id,
           cost_type: token,
           transaction_id: transaction_id,

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -20,19 +20,23 @@ module Db
         voice
       ].freeze
 
-      def self.call(issuer, ial, token, transaction_id: nil)
+      def self.call(issuer, ial, token, transaction_id: nil, user_id: nil)
         return if token.blank?
         unless TOKEN_WHITELIST.include?(token.to_sym)
           NewRelic::Agent.notice_error(SpCostTypeError.new(token.to_s))
           return
         end
         agency_id = (issuer.present? && ServiceProvider.find_by(issuer: issuer)&.agency_id) || 0
+        current_user = User.find_by(id: user_id)
         service_provider = ServiceProvider.from_issuer(issuer)
-        ial_context = IalContext.new(ial: ial, service_provider: service_provider)
-        ial_1_or_2 = ial_context.ial2_or_greater? ? 2 : 1
+        ial_context = IalContext.new(
+          ial: ial,
+          service_provider: service_provider,
+          user: current_user,
+        )
         ::SpCost.create(
           issuer: issuer.to_s,
-          ial: ial_1_or_2,
+          ial: ial_context.bill_for_ial_1_or_2,
           agency_id: agency_id,
           cost_type: token,
           transaction_id: transaction_id,

--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -32,8 +32,7 @@ class IalContext
   end
 
   def ial2_requested?
-    return true if ialmax_requested? && user_ial2_verified?
-    ial == ::Idp::Constants::IAL2
+    (ialmax_requested? && user_ial2_verified?) || ial == ::Idp::Constants::IAL2
   end
 
   def ial2_or_greater?

--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -1,13 +1,14 @@
 # Wraps up logic for querying the IAL level of an authorization request
 class IalContext
-  attr_reader :ial, :service_provider
+  attr_reader :ial, :service_provider, :user
 
   # @param ial [String, Integer] IAL level as either an integer (see ::Idp::Constants::IAL2, etc)
   #   or a string see Saml::Idp::Constants contexts
   # @param service_provider [ServiceProvider, nil]
-  def initialize(ial:, service_provider:)
+  def initialize(ial:, service_provider:, user: nil)
     @ial = int_ial(ial)
     @service_provider = service_provider
+    @user = user
   end
 
   def ial2_service_provider?
@@ -18,11 +19,20 @@ class IalContext
     ial.nil? && ial2_service_provider?
   end
 
+  def user_ial2_verified?
+    user&.active_profile&.verified_at != nil
+  end
+
   def ialmax_requested?
     ial&.zero?
   end
 
+  def bill_for_ial_1_or_2
+    ial2_or_greater? ? 2 : 1
+  end
+
   def ial2_requested?
+    return true if ialmax_requested? && user_ial2_verified?
     ial == ::Idp::Constants::IAL2
   end
 

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe IalContext do
       ial: sp_ial,
     )
   end
+  let(:user) { nil }
 
-  subject(:ial_context) { IalContext.new(ial: ial, service_provider: service_provider) }
+  subject(:ial_context) { IalContext.new(ial: ial, service_provider: service_provider, user: user) }
 
   describe '#ial' do
     context 'with an integer input' do
@@ -107,6 +108,29 @@ RSpec.describe IalContext do
     end
   end
 
+  describe '#user_ial2_verified?' do
+    context 'when the user is nil' do
+      let(:user) { nil }
+      it { expect(ial_context.user_ial2_verified?).to eq(false) }
+    end
+
+    context 'when the user has not proofed' do
+      let(:user) { create(:user, :signed_up) }
+      it { expect(ial_context.user_ial2_verified?).to eq(false) }
+    end
+
+    context 'when the user has proofed for ial2' do
+      let(:user) do
+        create(
+          :user,
+          :signed_up,
+          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
+        )
+      end
+      it { expect(ial_context.user_ial2_verified?).to eq(true) }
+    end
+  end
+
   describe '#ialmax_requested?' do
     context 'when ialmax is requested' do
       let(:ial) { Idp::Constants::IAL_MAX }
@@ -126,6 +150,52 @@ RSpec.describe IalContext do
     context 'when ial 2 strict is requested' do
       let(:ial) { Idp::Constants::IAL2_STRICT }
       it { expect(ial_context.ialmax_requested?).to eq(false) }
+    end
+  end
+
+  describe '#bill_for_ial_1_or_2' do
+    context 'when ial is nil' do
+      let(:ial) { nil }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
+    end
+
+    context 'when ial1' do
+      let(:ial) { Idp::Constants::IAL1 }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
+    end
+
+    context 'when ial1' do
+      let(:ial) { Idp::Constants::IAL2 }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
+    end
+
+    context 'when ial max and the user is nil' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) { nil }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
+    end
+
+    context 'when ial max and the user has not proofed' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) { create(:user, :signed_up) }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
+    end
+
+    context 'when ial max and the user has proofed for ial2' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) do
+        create(
+          :user,
+          :signed_up,
+          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
+        )
+      end
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
+    end
+
+    context 'when ial strict' do
+      let(:ial) { Idp::Constants::IAL2_STRICT }
+      it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
     end
   end
 
@@ -235,6 +305,18 @@ RSpec.describe IalContext do
     context 'when the SP is nil' do
       let(:service_provider) { nil }
       let(:ial) { Idp::Constants::IAL2 }
+      it { expect(ial_context.ial2_requested?).to eq(true) }
+    end
+
+    context 'when ial max and the user has proofed for ial2' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) do
+        create(
+          :user,
+          :signed_up,
+          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
+        )
+      end
       it { expect(ial_context.ial2_requested?).to eq(true) }
     end
   end

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe IalContext do
       it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
     end
 
-    context 'when ial1' do
+    context 'when ial2' do
       let(:ial) { Idp::Constants::IAL2 }
       it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
     end
@@ -193,7 +193,7 @@ RSpec.describe IalContext do
       it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
     end
 
-    context 'when ial strict' do
+    context 'when ial2 strict' do
       let(:ial) { Idp::Constants::IAL2_STRICT }
       it { expect(ial_context.bill_for_ial_1_or_2).to eq(2) }
     end

--- a/spec/support/features/idv_from_sp_helper.rb
+++ b/spec/support/features/idv_from_sp_helper.rb
@@ -18,6 +18,14 @@ module IdvFromSpHelper
     click_agree_and_continue
   end
 
+  def reproof_for_ial2_strict
+    complete_all_doc_auth_steps
+    click_continue
+    fill_in 'Password', with: password
+    click_continue
+    click_acknowledge_personal_key
+  end
+
   def create_ial1_user_from_sp(email)
     visit_idp_from_sp_with_ial1(:oidc)
     register_user(email)

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -15,6 +15,20 @@ module OidcAuthHelper
     oidc_path
   end
 
+  def visit_idp_from_ial2_strict_oidc_sp(**args)
+    params = ial2_strict_params args
+    oidc_path = openid_connect_authorize_path params
+    visit oidc_path
+    oidc_path
+  end
+
+  def visit_idp_from_ial_max_oidc_sp(**args)
+    params = ial_max_params args
+    oidc_path = openid_connect_authorize_path params
+    visit oidc_path
+    oidc_path
+  end
+
   def visit_idp_from_ial2_oidc_sp(**args)
     params = ial2_params args
     oidc_path = openid_connect_authorize_path params
@@ -70,6 +84,40 @@ module OidcAuthHelper
     }
     ial2_params[:prompt] = prompt if prompt
     ial2_params
+  end
+
+  def ial2_strict_params(prompt: nil,
+                         state: SecureRandom.hex,
+                         nonce: SecureRandom.hex,
+                         client_id: OIDC_ISSUER)
+    ial2_strict_params = {
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email profile:name social_security_number',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      nonce: nonce,
+    }
+    ial2_strict_params[:prompt] = prompt if prompt
+    ial2_strict_params
+  end
+
+  def ial_max_params(prompt: nil,
+                     state: SecureRandom.hex,
+                     nonce: SecureRandom.hex,
+                     client_id: OIDC_ISSUER)
+    ial_max_params = {
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email profile:name social_security_number',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      nonce: nonce,
+    }
+    ial_max_params[:prompt] = prompt if prompt
+    ial_max_params
   end
 
   def include_aal3(params)

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -16,14 +16,16 @@ module OidcAuthHelper
   end
 
   def visit_idp_from_ial2_strict_oidc_sp(**args)
-    params = ial2_strict_params args
+    args[:acr_values] = Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
+    params = ial2_params args
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
   end
 
   def visit_idp_from_ial_max_oidc_sp(**args)
-    params = ial_max_params args
+    args[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+    params = ial2_params args
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
@@ -72,11 +74,12 @@ module OidcAuthHelper
   def ial2_params(prompt: nil,
                   state: SecureRandom.hex,
                   nonce: SecureRandom.hex,
-                  client_id: OIDC_ISSUER)
+                  client_id: OIDC_ISSUER,
+                  acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
     ial2_params = {
       client_id: client_id,
       response_type: 'code',
-      acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+      acr_values: acr_values,
       scope: 'openid email profile:name social_security_number',
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
@@ -84,40 +87,6 @@ module OidcAuthHelper
     }
     ial2_params[:prompt] = prompt if prompt
     ial2_params
-  end
-
-  def ial2_strict_params(prompt: nil,
-                         state: SecureRandom.hex,
-                         nonce: SecureRandom.hex,
-                         client_id: OIDC_ISSUER)
-    ial2_strict_params = {
-      client_id: client_id,
-      response_type: 'code',
-      acr_values: Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
-      scope: 'openid email profile:name social_security_number',
-      redirect_uri: 'http://localhost:7654/auth/result',
-      state: state,
-      nonce: nonce,
-    }
-    ial2_strict_params[:prompt] = prompt if prompt
-    ial2_strict_params
-  end
-
-  def ial_max_params(prompt: nil,
-                     state: SecureRandom.hex,
-                     nonce: SecureRandom.hex,
-                     client_id: OIDC_ISSUER)
-    ial_max_params = {
-      client_id: client_id,
-      response_type: 'code',
-      acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-      scope: 'openid email profile:name social_security_number',
-      redirect_uri: 'http://localhost:7654/auth/result',
-      state: state,
-      nonce: nonce,
-    }
-    ial_max_params[:prompt] = prompt if prompt
-    ial_max_params
   end
 
   def include_aal3(params)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -179,6 +179,18 @@ module SamlAuthHelper
     settings
   end
 
+  def sp1_ial_max_saml_settings
+    settings = sp1_saml_settings.dup
+    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+    settings
+  end
+
+  def sp1_ial2_strict_saml_settings
+    settings = sp1_saml_settings.dup
+    settings.authn_context = Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
+    settings
+  end
+
   def loa3_saml_settings
     settings = sp1_saml_settings.dup
     settings.authn_context = Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
@@ -203,6 +215,26 @@ module SamlAuthHelper
 
   def ial2_with_bundle_saml_settings
     settings = sp1_ial2_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+    ]
+    settings
+  end
+
+  def ial_max_with_bundle_saml_settings
+    settings = sp1_ial_max_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+    ]
+    settings
+  end
+
+  def ial2_strict_with_bundle_saml_settings
+    settings = sp1_ial2_strict_saml_settings
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
@@ -344,6 +376,26 @@ module SamlAuthHelper
     visit api_saml_auth2021_path(
       SAMLRequest: CGI.unescape(saml_request(saml_settings)),
     )
+  end
+
+  def visit_idp_from_ial2_strict_saml_sp(**args)
+    settings = ial2_strict_with_bundle_saml_settings
+    settings.security[:embed_sign] = false
+    settings.issuer = args[:issuer] if args[:issuer]
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
+    saml_authn_request = auth_request.create(settings)
+    visit saml_authn_request
+    saml_authn_request
+  end
+
+  def visit_idp_from_ial_max_saml_sp(**args)
+    settings = ial_max_with_bundle_saml_settings
+    settings.security[:embed_sign] = false
+    settings.issuer = args[:issuer] if args[:issuer]
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
+    saml_authn_request = auth_request.create(settings)
+    visit saml_authn_request
+    saml_authn_request
   end
 
   def visit_idp_from_ial2_saml_sp(**args)


### PR DESCRIPTION
Why
LG-4204 is a [follow up story to this PR ](https://github.com/18F/identity-idp/pull/4661) where we fixed the monthly auth counts.

This PR moves IAL2_STRICT and IAL_MAX to IalContext. This also fixes the monthly authentication counts and adds test coverage.