### PR TITLE
Cleanup: remove otp_use_alphanumeric feature flag

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -118,7 +118,6 @@ min_password_score: '3'
 mx_timeout: '3'
 otp_delivery_blocklist_maxretry: '10'
 otp_valid_for: '10'
-otp_use_alphanumeric: 'true'
 otps_per_ip_limit: '25'
 otps_per_ip_period: '300'
 otps_per_ip_track_only_mode: 'true'
@@ -282,7 +281,6 @@ production:
   no_sp_campaigns_whitelist: '[]'
   nonessential_email_banlist: '[]'
   otp_delivery_blocklist_findtime: '5'
-  otp_use_alphanumeric: 'false'
   participate_in_dap: 'true'
   password_pepper:
   piv_cac_verify_token_secret:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -178,7 +178,6 @@ class IdentityConfig
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)
     config.add(:otp_valid_for, type: :integer)
-    config.add(:otp_use_alphanumeric, type: :boolean)
     config.add(:otps_per_ip_limit, type: :integer)
     config.add(:otps_per_ip_period, type: :integer)
     config.add(:otps_per_ip_track_only_mode, type: :boolean)

--- a/lib/otp_code_generator.rb
+++ b/lib/otp_code_generator.rb
@@ -2,15 +2,11 @@ require 'securerandom'
 
 class OtpCodeGenerator
   def self.generate_digits(digits)
-    if IdentityConfig.store.otp_use_alphanumeric
-      ProfanityDetector.without_profanity do
-        # 5 bits per character means we must multiply what we want by 5
-        # :length adds zero padding in case it's a smaller number
-        random_bytes = SecureRandom.random_number(2**(digits * 5))
-        Base32::Crockford.encode(random_bytes, length: digits)
-      end
-    else
-      SecureRandom.random_number(10**digits).to_s.rjust(digits, '0')
+    ProfanityDetector.without_profanity do
+      # 5 bits per character means we must multiply what we want by 5
+      # :length adds zero padding in case it's a smaller number
+      random_bytes = SecureRandom.random_number(2**(digits * 5))
+      Base32::Crockford.encode(random_bytes, length: digits)
     end
   end
 end

--- a/spec/lib/otp_code_generator_spec.rb
+++ b/spec/lib/otp_code_generator_spec.rb
@@ -2,11 +2,6 @@ require 'rails_helper'
 
 RSpec.describe OtpCodeGenerator do
   describe '.generate_digits' do
-    before do
-      allow(IdentityConfig.store).to receive(:otp_use_alphanumeric).and_return(otp_use_alphanumeric)
-    end
-    let(:otp_use_alphanumeric) { true }
-
     subject(:generate_digits) do
       OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable::DIRECT_OTP_LENGTH)
     end
@@ -31,20 +26,6 @@ RSpec.describe OtpCodeGenerator do
       expect(SecureRandom).to receive(:random_number).and_return(0)
 
       expect(generate_digits).to eq('0' * TwoFactorAuthenticatable::DIRECT_OTP_LENGTH)
-    end
-
-    context 'wehn otp_use_alphanumeric is disabled' do
-      let(:otp_use_alphanumeric) { false }
-
-
-      it 'is a digits-only code' do
-        int_value = Base32::Crockford.decode('ABC')
-
-        expect(SecureRandom).to receive(:random_number).
-          and_return(int_value)
-
-        expect(generate_digits).to eq("0#{int_value}")
-      end
     end
   end
 end


### PR DESCRIPTION
Now that https://github.com/18F/identity-idp/pull/4965 is in prod, we can clean up this code