### PR TITLE
Remove AuthnContextClassRef AAL feature flag (LG-3486)

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -57,24 +57,7 @@ module SamlIdpAuthConcern
 
   def requested_authn_contexts
     @requested_authn_contexts ||= saml_request.requested_authn_contexts.presence ||
-                                  [default_authn_context]
-  end
-
-  def requested_authn_context
-    if IdentityConfig.store.aal_authn_context_enabled
-      requested_aal_authn_context
-    else
-      sp_defined_aal_context = saml_request.requested_aal_authn_context
-      sp_defined_aal_context.presence || requested_ial_authn_context
-    end
-  end
-
-  def default_authn_context
-    if IdentityConfig.store.aal_authn_context_enabled
-      default_aal_context
-    else
-      default_ial_context
-    end
+                                  [default_aal_context]
   end
 
   def default_aal_context
@@ -153,7 +136,7 @@ module SamlIdpAuthConcern
     encode_response(
       current_user,
       name_id_format: name_id_format,
-      authn_context_classref: requested_authn_context,
+      authn_context_classref: requested_aal_authn_context,
       reference_id: active_identity.session_uuid,
       encryption: encryption_opts,
       signature: saml_response_signature_options,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -14,7 +14,6 @@
 
 # Make sure any new entries you add are enclosed in single quotes.
 
-aal_authn_context_enabled: 'false'
 aamva_auth_request_timeout: '5'
 aamva_auth_url: 'https://example.org:12345/auth/url'
 aamva_cert_enabled: 'true'
@@ -192,7 +191,6 @@ voip_block: 'true'
 voip_allowed_phones: '[]'
 
 development:
-  aal_authn_context_enabled: 'true'
   aamva_private_key: 123abc
   aamva_public_key: 123abc
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
@@ -245,7 +243,6 @@ development:
 # includes *.identitysandbox.gov and *.login.gov.
 #
 production:
-  aal_authn_context_enabled: 'false'
   aamva_auth_url: 'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
   aamva_private_key: ''
   aamva_public_key: ''
@@ -307,7 +304,6 @@ production:
   usps_upload_sftp_username: ''
 
 test:
-  aal_authn_context_enabled: 'true'
   aamva_private_key: 123abc
   aamva_public_key: 123abc
   acuant_assure_id_url: https://example.com

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -53,7 +53,6 @@ class IdentityConfig
 
   def self.build_store(config_map)
     config = IdentityConfig.new(config_map)
-    config.add(:aal_authn_context_enabled, type: :boolean)
     config.add(:aamva_auth_request_timeout, type: :integer)
     config.add(:aamva_auth_url, type: :string)
     config.add(:aamva_cert_enabled, type: :boolean)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -385,7 +385,7 @@ describe SamlIdpController do
           success: false,
           errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'invalid_provider',
         }
 
@@ -608,7 +608,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: false,
@@ -630,7 +630,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata',
           idv: false,
           finish_profile: false,
@@ -656,7 +656,7 @@ describe SamlIdpController do
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'http://localhost:3000',
         }
 
@@ -1162,7 +1162,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: false,
@@ -1191,7 +1191,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [request_authn_context],
+          authn_context: request_authn_context,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: true,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -385,7 +385,7 @@ describe SamlIdpController do
           success: false,
           errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'invalid_provider',
         }
 
@@ -608,7 +608,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: false,
@@ -630,7 +630,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata',
           idv: false,
           finish_profile: false,
@@ -656,7 +656,7 @@ describe SamlIdpController do
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'http://localhost:3000',
         }
 
@@ -1162,7 +1162,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: false,
@@ -1191,7 +1191,7 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: request_authn_context,
+          authn_context: request_authn_contexts,
           service_provider: 'http://localhost:3000',
           idv: false,
           finish_profile: true,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -310,7 +310,7 @@ describe SamlIdpController do
       end
     end
 
-    context 'inspecting authn_context_enabled' do
+    context 'authn_context scenarios' do
       let(:user) { create(:user, :signed_up) }
 
       context 'authn_context is missing' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1127,7 +1127,10 @@ describe SamlIdpController do
           success: true,
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF],
+          authn_context: [
+            Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          ],
           service_provider: 'http://localhost:3000',
           idv: true,
           finish_profile: false,

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -8,11 +8,12 @@ class FakeSamlRequest
   end
 
   def requested_authn_context
-    Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
   end
 
   def requested_authn_contexts
     [
+      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
       Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
     ]
   end
@@ -22,7 +23,7 @@ class FakeSamlRequest
   end
 
   def requested_aal_authn_context
-    nil
+    Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
   end
 
   def valid?

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -31,11 +31,7 @@ module SamlAuthHelper
   end
 
   def request_authn_context
-    if IdentityConfig.store.aal_authn_context_enabled
-      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
-    else
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    end
+    Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
   end
 
   def sp_fingerprint

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -31,7 +31,10 @@ module SamlAuthHelper
   end
 
   def request_authn_context
-    Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+    [
+      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+    ]
   end
 
   def sp_fingerprint

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -10,7 +10,7 @@ module SamlAuthHelper
     settings.assertion_consumer_logout_service_url = 'http://localhost:3000/test/saml/decode_slo_request'
     settings.certificate = saml_test_sp_cert
     settings.private_key = saml_test_sp_key
-    settings.authn_context = request_authn_context
+    settings.authn_context = request_authn_contexts
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
 
     # SP + IdP Settings
@@ -30,7 +30,7 @@ module SamlAuthHelper
     settings
   end
 
-  def request_authn_context
+  def request_authn_contexts
     [
       Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
       Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,


### PR DESCRIPTION
The flag has been turned on in all environments so we no longer need it or the conditional context it brings.