### PR TITLE
LG-4253 Combine Acuant and TrueID error translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
 @aamva_api_gem ||= { github: '18F/identity-aamva-api-client-gem', tag: 'v4.2.0' }
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.5.1' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.6.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @lexisnexis_api_gem ||= { github: '18F/identity-lexisnexis-api-client-gem', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 3463710b398e4a6a89de51c0f80a5b0cf0b6b6cb
-  tag: v0.5.1
+  revision: d848096ab0f3995ea1a999770e7f8f654d65cb9a
+  tag: v0.6.0
   specs:
-    identity-doc-auth (0.5.1)
+    identity-doc-auth (0.6.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -105,7 +105,7 @@ module DocAuthRouter
     def translate_doc_auth_errors!(response)
       # acuant selfie errors are handled in translate_generic_errors!
       error_keys = IdentityDocAuth::ErrorGenerator::ERROR_KEYS.dup
-      error_keys.delete(:selfie) if DocAuthRouter::doc_auth_vendor  == 'acuant'
+      error_keys.delete(:selfie) if DocAuthRouter::doc_auth_vendor == 'acuant'
 
       error_keys.each do |category|
         response.errors[category]&.map! do |plain_error|

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -121,7 +121,6 @@ module DocAuthRouter
       end
     end
 
-    # rubocop:disable Style/GuardClause
     def translate_generic_errors!(response)
       if response.errors[:network] == true
         response.errors[:network] = I18n.t('doc_auth.errors.general.network_error')
@@ -132,7 +131,6 @@ module DocAuthRouter
         response.errors[:selfie] = I18n.t('doc_auth.errors.general.liveness')
       end
     end
-    # rubocop:enable Style/GuardClause
   end
 
   def self.client

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DocumentProofingJob, type: :job do
 
     context 'with a successful response from the proofer' do
       before do
-        expect(DocAuthRouter).to receive('doc_auth_vendor').and_return('acuant')
+        expect(DocAuthRouter).to receive('doc_auth_vendor').and_return('acuant').twice
 
         url = URI.join('https://example.com', '/AssureIDService/Document/Instance')
         stub_request(:post, url).to_return(body: '"this-is-a-test-instance-id"')

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe DocAuthRouter do
         ),
       )
 
-      expect(Rails.logger).to receive(:warn).with('unknown LexisNexis error=some_obscure_error')
+      expect(Rails.logger).to receive(:warn).with('unknown DocAuth error=some_obscure_error')
 
       response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
 


### PR DESCRIPTION
Update doc_auth gems and send Acuant and TrueID errors through the same error translation now that they go through the same error generation.