### PR TITLE
LG-4397: Include locale in default logging data

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -10,6 +10,7 @@ class Analytics
     analytics_hash = {
       event_properties: attributes.except(:user_id),
       user_id: attributes[:user_id] || user.uuid,
+      locale: I18n.locale,
     }
     analytics_hash.merge!(request_attributes)
 

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -20,6 +20,13 @@ feature 'Internationalization' do
       it 'displays a translated header to the user' do
         expect(page).to have_content t('headings.sign_in_without_sp', locale: 'en')
       end
+
+      it 'initializes front-end logger with default locale' do
+        expect(page).to have_selector(
+          "[data-analytics-endpoint='#{api_logger_path(locale: nil)}']",
+          visible: :all,
+        )
+      end
     end
 
     context 'when the user has set their locale to :es' do
@@ -27,6 +34,13 @@ feature 'Internationalization' do
 
       it 'displays a translated header to the user' do
         expect(page).to have_content t('headings.sign_in_without_sp', locale: 'es')
+      end
+
+      it 'initializes front-end logger with locale parameter' do
+        expect(page).to have_selector(
+          "[data-analytics-endpoint='#{api_logger_path(locale: 'es')}']",
+          visible: :all,
+        )
       end
     end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -37,6 +37,7 @@ describe Analytics do
       analytics_hash = {
         event_properties: {},
         user_id: current_user.uuid,
+        locale: I18n.locale,
       }
 
       expect(ahoy).to receive(:track).
@@ -52,6 +53,7 @@ describe Analytics do
       analytics_hash = {
         event_properties: {},
         user_id: tracked_user.uuid,
+        locale: I18n.locale,
       }
 
       expect(ahoy).to receive(:track).
@@ -89,6 +91,22 @@ describe Analytics do
       expect(browser).to receive(:device_name)
       expect(browser).to receive(:device_type)
       expect(browser).to receive(:bot?)
+
+      analytics.track_event('Trackable Event')
+    end
+
+    it 'includes the locale of the current request' do
+      locale = :fr
+      allow(I18n).to receive(:locale).and_return(locale)
+
+      analytics_hash = {
+        event_properties: {},
+        user_id: current_user.uuid,
+        locale: locale,
+      }
+
+      expect(ahoy).to receive(:track).
+        with('Trackable Event', analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event')
     end


### PR DESCRIPTION
**Why**: To better understand what the language breakdowns look like for our flows, and so that we can identify abnormalities or discrepancies in metrics based on language.