### PR TITLE
Remove unused method on FakeAnalytics

### DIFF
--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -14,13 +14,6 @@ class FakeAnalytics
   def track_mfa_submit_event(_attributes)
     # no-op
   end
-
-  def allowable_frontend_events
-    [
-      Analytics::FRONTEND_DOC_AUTH_ASYNC_UPLOAD,
-      Analytics::FRONTEND_DOC_AUTH_ACUANT_WEB_SDK_RESULT,
-    ]
-  end
 end
 
 RSpec::Matchers.define :have_logged_event do |event_name, attributes|


### PR DESCRIPTION
A question in https://github.com/18F/identity-idp/pull/5042/files#r628487526 got me digging around to see what we actually log from the frontend, found this unused method ... with contants that no longer exist 🙊 