### PR TITLE
enable phone for Northern Mariana Islands

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -627,6 +627,11 @@ MO:
   name: Macau
   supports_sms: true
   supports_voice: false
+MP:
+  country_code: '1'
+  name: Northern Mariana Islands
+  supports_sms: true
+  supports_voice: true
 MQ:
   country_code: '596'
   name: Martinique


### PR DESCRIPTION
placeholder while we determine the exact level of support for SMS/Voice in the Northern Mariana Islands