### PR TITLE
increment identity-doc-auth version to handle physical document presence error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
 @aamva_api_gem ||= { github: '18F/identity-aamva-api-client-gem', tag: 'v4.2.0' }
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.6.0' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.6.1' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @lexisnexis_api_gem ||= { github: '18F/identity-lexisnexis-api-client-gem', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: d848096ab0f3995ea1a999770e7f8f654d65cb9a
-  tag: v0.6.0
+  revision: 9d5ad9a7f8f29ad89386267e0a8879c6a2d7377a
+  tag: v0.6.1
   specs:
-    identity-doc-auth (0.6.0)
+    identity-doc-auth (0.6.1)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)


### PR DESCRIPTION
Includes changes from https://github.com/18F/identity-doc-auth/pull/16