### PR TITLE
LG-4524: updates to the copy on phone verification and gpo letter request

### DIFF
--- a/app/views/idv/gpo/_address_on_file.html.erb
+++ b/app/views/idv/gpo/_address_on_file.html.erb
@@ -1,5 +1,4 @@
 <%= button_to @presenter.button,
               idv_gpo_path,
               method: 'put',
-              class: 'usa-button usa-button--big usa-button--wide',
-              form_class: 'margin-right-2' %>
+              class: 'usa-button usa-button--big usa-button--wide' %>

--- a/app/views/idv/gpo/_address_on_file.html.erb
+++ b/app/views/idv/gpo/_address_on_file.html.erb
@@ -2,4 +2,4 @@
               idv_gpo_path,
               method: 'put',
               class: 'usa-button usa-button--big usa-button--wide',
-              form_class: 'inline-block margin-right-2' %>
+              form_class: 'margin-right-2' %>

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -16,7 +16,7 @@
 
 <p>
   <%= @presenter.byline %>
-  <strong><%= t('idv.messages.gpo.success') %></strong>
+  <%= t('idv.messages.gpo.timeframe') %>
 </p>
 
 <div class="margin-top-6 margin-bottom-4">

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -108,7 +108,8 @@ en:
         new_address: We will mail a letter with a confirmation code to the address
           you specify.
         resend: Send me another letter
-        success: It should arrive in 5 to 10 business days.
+        timeframe: Letters are sent the next business day via USPS First Class Mail,
+          and typically take 3 to 7 business days.
       hardfail: We can’t log you in right now, but you can try verifying your identity
         again in %{hours} hours.
       mail_sent: Your letter is on its way
@@ -124,7 +125,8 @@ en:
           this can be a different number."
         phone_of_record: Phone of record
         rules:
-        - be on a phone plan with your name on it
+        - be a phone plan associated with your name. You do not need to be the primary
+          account holder.
         - not be a virtual phone (such as Google Voice or Skype)
         - be a U.S. number
       return_to_profile: "‹ Return to your login.gov profile"

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -110,7 +110,8 @@ es:
         new_address: Le enviaremos una carta con un código de confirmación a la dirección
           que especifique.
         resend: Envíeme otra carta
-        success: Debe llegar en 5 a 10 días laborales.
+        timeframe: Las correspondencias se envían al día siguiente por correo de primera
+          clase de USPS, y por lo general tardan entre 3 y 7 días laborables.
       hardfail: No puedes iniciar sesión en estos instantes pero puedes intentar verificar
         tu edad de nuevo en %{hours} horas.
       mail_sent: Su carta está en camino
@@ -119,16 +120,16 @@ es:
       personal_key: Esta es su nueva clave personal. Escríbala y guárdela en un lugar
         seguro. La necesitará si pierde su contraseña.
       phone:
-        alert_html: Este número de teléfono <strong>debe ser</strong>
+        alert_html: "<strong>Este número de teléfono debe…</strong>"
         description: Verificamos los registros para asegurarnos de que eres quien
           eres, y de que eres el propietario de tu cuenta.
         final_note_html: "<strong>Si configura un teléfono para la autenticación de
           dos factores</strong>, este puede ser un número diferente."
         phone_of_record: Teléfono del registro
         rules:
-        - en un plan de teléfono con su nombre en él
+        - ser un plan telefónico que esté asociado a su nombre. En este caso, no es
+          necesario que usted sea el titular principal de la cuenta.
         - no es un teléfono virtual (como Google Voice o Skype)
-        - no es un número de teléfono prepago
         - un número de EE. UU.
       return_to_profile: "‹ Volver a tu perfil de login.gov"
       review:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -118,7 +118,8 @@ fr:
         new_address: Nous vous enverrons une lettre avec un code de confirmation à
           l’adresse que vous spécifiez.
         resend: Envoyez-moi une autre lettre
-        success: Elle devrait arriver dans 5 à 10 jours ouvrables.
+        timeframe: Les lettres sont envoyées le jour ouvrable suivant par courrier
+          de première classe USPS et prennent généralement de 3 à 7 jours ouvrables.
       hardfail: Nous ne pouvons pas vous connecter pour le moment, mais vous pouvez
         retenter d’effectuer la vérification de votre identité dans %{hours} heures.
       mail_sent: Votre lettre est en route
@@ -128,16 +129,16 @@ fr:
         dans un endroit sécuritaire. Vous en aurez besoin si vous perdez votre mot
         de passe.
       phone:
-        alert_html: Ce numéro de téléphone <strong>doit être</strong>
+        alert_html: "<strong>Ce numéro de téléphone doit…</strong>"
         description: Nous vérifions les dossiers pour vous assurer que vous êtes ce
           que vous dites et que vous êtes propriétaire de votre compte.
         final_note_html: "<strong>Si vous configurez un téléphone pour l’authentification
           à deux facteurs</strong>, il peut s’agir d’un numéro différent."
         phone_of_record: numéro de téléphone enregistré
         rules:
-        - sur un plan de téléphone avec votre nom dessus
+        - être un plan téléphonique associé à votre nom. Il n'est pas nécessaire que
+          vous soyez le titulaire principal du compte.
         - pas un téléphone virtuel (comme Google Voice ou Skype)
-        - pas un numéro de téléphone prépayé
         - un numéro américain
       return_to_profile: "‹ Revenir à votre profil login.gov"
       review:


### PR DESCRIPTION
Just a couple of updates to the `Verify phone` and `Verify by mail` pages.

The updated pages (mobile view):
Verify Phone:
English|Spanish|French
---|---|---
![verify-phone-en](https://user-images.githubusercontent.com/2583060/118168728-2a6c4f00-b3f6-11eb-9b81-8a71102a6d77.png)|![verify-phone-es](https://user-images.githubusercontent.com/2583060/118168730-2b04e580-b3f6-11eb-83bd-269729a05f03.png)|![verify-phone-fr](https://user-images.githubusercontent.com/2583060/118168731-2b04e580-b3f6-11eb-9977-c00bd01b7516.png)

Request a letter:
English|Spanish|French
---|---|---
![gpo-request-en](https://user-images.githubusercontent.com/2583060/118168784-3821d480-b3f6-11eb-9747-b72b2d06bafc.png)|![gpo-request-es](https://user-images.githubusercontent.com/2583060/118168786-3821d480-b3f6-11eb-882e-f516099533cd.png)|![gpo-request-fr](https://user-images.githubusercontent.com/2583060/118168787-38ba6b00-b3f6-11eb-972f-b16a84f29c9c.png)
