### PR TITLE
allow exception notifier to use :expected option to avoid false alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '~> 2.6.5'
+ruby '~> 2.6'
 
 gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
 @aamva_api_gem ||= { github: '18F/identity-aamva-api-client-gem', tag: 'v4.2.0' }
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.6.1' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.7.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @lexisnexis_api_gem ||= { github: '18F/identity-lexisnexis-api-client-gem', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 9d5ad9a7f8f29ad89386267e0a8879c6a2d7377a
-  tag: v0.6.1
+  revision: 1694588b91ac4b5ab633d32dc87ae2514a908fa9
+  tag: v0.7.0
   specs:
-    identity-doc-auth (0.6.1)
+    identity-doc-auth (0.7.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -177,11 +177,11 @@ module DocAuthRouter
     end
   end
 
-  def self.notify_exception(exception, custom_params = nil)
+  def self.notify_exception(exception, custom_params = nil, expected = false)
     if custom_params
-      NewRelic::Agent.notice_error(exception, custom_params: custom_params)
+      NewRelic::Agent.notice_error(exception, custom_params: custom_params, expected: expected)
     else
-      NewRelic::Agent.notice_error(exception)
+      NewRelic::Agent.notice_error(exception, expected: expected)
     end
   end
 

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DocAuthRouter do
     let(:exception) { RuntimeError.new }
 
     it 'notifies NewRelic' do
-      expect(NewRelic::Agent).to receive(:notice_error).with(exception)
+      expect(NewRelic::Agent).to receive(:notice_error).with(exception, expected: false)
 
       DocAuthRouter.notify_exception(exception)
     end
@@ -46,7 +46,11 @@ RSpec.describe DocAuthRouter do
       let(:params) { { count: 1 } }
 
       it 'forwards on custom_params to NewRelic' do
-        expect(NewRelic::Agent).to receive(:notice_error).with(exception, custom_params: params)
+        expect(NewRelic::Agent).to receive(:notice_error).with(
+          exception,
+          custom_params: params,
+          expected: false,
+        )
 
         DocAuthRouter.notify_exception(exception, params)
       end


### PR DESCRIPTION
Brings in https://github.com/18F/identity-doc-auth/pull/17