### PR TITLE
Fix untranslated custom validation error messages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@
 require:
   - rubocop-rails
   - ./lib/linters/url_options_linter.rb
+  - ./lib/linters/localized_validation_message_linter.rb
 
 AllCops:
   Exclude:
@@ -29,6 +30,9 @@ IdentityIdp/UrlOptionsLinter:
   Enabled: true
   Exclude:
     - 'spec/**/*.rb'
+
+IdentityIdp/LocalizedValidationMessageLinter:
+  Enabled: true
 
 Metrics/BlockLength:
   CountComments: false  # count full line comments?

--- a/app/forms/idv/consent_form.rb
+++ b/app/forms/idv/consent_form.rb
@@ -2,7 +2,8 @@ module Idv
   class ConsentForm
     include ActiveModel::Model
 
-    validates :ial2_consent_given?, acceptance: { message: I18n.t('errors.doc_auth.consent_form') }
+    validates :ial2_consent_given?,
+              acceptance: { message: Proc.new { I18n.t('errors.doc_auth.consent_form') } }
 
     def submit(params)
       @ial2_consent_given = params[:ial2_consent_given] == 'true'

--- a/app/validators/account_reset/cancel_token_validator.rb
+++ b/app/validators/account_reset/cancel_token_validator.rb
@@ -3,7 +3,10 @@ module AccountReset
     extend ActiveSupport::Concern
 
     included do
-      validates :token, presence: { message: I18n.t('errors.account_reset.cancel_token_missing') }
+      validates :token,
+                presence: {
+                  message: Proc.new { I18n.t('errors.account_reset.cancel_token_missing') },
+                },
       validate :valid_token
     end
 

--- a/app/validators/account_reset/cancel_token_validator.rb
+++ b/app/validators/account_reset/cancel_token_validator.rb
@@ -6,7 +6,7 @@ module AccountReset
       validates :token,
                 presence: {
                   message: Proc.new { I18n.t('errors.account_reset.cancel_token_missing') },
-                },
+                }
       validate :valid_token
     end
 

--- a/app/validators/account_reset/granted_token_validator.rb
+++ b/app/validators/account_reset/granted_token_validator.rb
@@ -3,7 +3,10 @@ module AccountReset
     extend ActiveSupport::Concern
 
     included do
-      validates :token, presence: { message: I18n.t('errors.account_reset.granted_token_missing') }
+      validates :token,
+                presence: {
+                  message: Proc.new { I18n.t('errors.account_reset.granted_token_missing') },
+                },
       validate :token_exists, if: :token_present?
       validate :token_not_expired, if: :token_present?
     end

--- a/app/validators/account_reset/granted_token_validator.rb
+++ b/app/validators/account_reset/granted_token_validator.rb
@@ -6,7 +6,7 @@ module AccountReset
       validates :token,
                 presence: {
                   message: Proc.new { I18n.t('errors.account_reset.granted_token_missing') },
-                },
+                }
       validate :token_exists, if: :token_present?
       validate :token_not_expired, if: :token_present?
     end

--- a/lib/linters/localized_validation_message_linter.rb
+++ b/lib/linters/localized_validation_message_linter.rb
@@ -1,0 +1,40 @@
+module RuboCop
+  module Cop
+    module IdentityIdp
+      class LocalizedValidationMessageLinter < RuboCop::Cop::Cop
+        MSG = 'Use Proc.new when translating validation message'.freeze
+
+        RESTRICT_ON_SEND = [
+          :validate,
+          :validates,
+          :validates!,
+          :validates_with,
+          :validates_absence_of,
+          :validates_acceptance_of,
+          :validates_confirmation_of,
+          :validates_exclusion_of,
+          :validates_format_of,
+          :validates_inclusion_of,
+          :validates_length_of,
+          :validates_numericality_of,
+          :validates_presence_of,
+          :validates_size_of,
+        ].freeze
+
+        def_node_matcher :translated_validation_message?, <<~PATTERN
+          (send nil? /^validate|validates|validates!$/ _ (hash (pair _ (hash (pair (sym :message) (send (const nil? :I18n) :t ...))))))
+        PATTERN
+
+        def_node_matcher :translated_validation_helper_message?, <<~PATTERN
+          (send nil? /^validates_.+_of$/ _ (hash (pair (sym :message) (send (const nil? :I18n) :t ...))))
+        PATTERN
+
+        def on_send(node)
+          if translated_validation_message?(node) || translated_validation_helper_message?(node)
+            add_offense(node, location: :expression)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/linters/localized_validation_mesasge_linter_spec.rb
+++ b/spec/lib/linters/localized_validation_mesasge_linter_spec.rb
@@ -1,0 +1,41 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../lib/linters/localized_validation_message_linter'
+
+describe RuboCop::Cop::IdentityIdp::LocalizedValidationMessageLinter do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:config) { RuboCop::Config.new }
+  let(:cop) { RuboCop::Cop::IdentityIdp::LocalizedValidationMessageLinter.new(config) }
+
+  context 'plain validation' do
+    it 'registers an offense when using static translated string as validation message' do
+      expect_offense(<<~RUBY)
+        validates :a, presence: { message: I18n.t('error') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Proc.new when translating validation message
+      RUBY
+    end
+
+    it 'registers no offense when using proc as validation message' do
+      expect_no_offenses(<<~RUBY)
+        validates :a, presence: { message: Proc.new { I18n.t('error') } }
+      RUBY
+    end
+  end
+
+  context 'validation helper' do
+    it 'registers an offense when using static translated string as validation message' do
+      expect_offense(<<~RUBY)
+        validates_presence_of :a, message: I18n.t('error')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Proc.new when translating validation message
+      RUBY
+    end
+
+    it 'registers no offense when using proc as validation message' do
+      expect_no_offenses(<<~RUBY)
+        validates_presence_of :a, message: Proc.new { I18n.t('error') }
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that as a user navigating login.gov in a language other than English, error messages are translated in my preferred language.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/118523018-b76f1b00-b70a-11eb-87f9-0b343cf99105.png)|![image](https://user-images.githubusercontent.com/1779930/118522355-f2248380-b709-11eb-8ff8-50629774cf2d.png)
