### PR TITLE
Async doc auth analytics (LG-4488)

### DIFF
--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -21,13 +21,20 @@ module Idv
     def submit
       throttled_else_increment
 
-      FormResponse.new(
+      response = FormResponse.new(
         success: valid?,
         errors: errors,
         extra: {
           remaining_attempts: remaining_attempts,
         },
       )
+
+      @analytics.track_event(
+        Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+        response.to_h,
+      )
+
+      response
     end
 
     def remaining_attempts

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -48,14 +48,14 @@ class DocumentProofingJob < ApplicationJob
       pii: proofer_result.pii_from_doc,
     )
 
-    analytics = Analytics.new(user: user, request: nil, sp: nil)
+    analytics = Analytics.new(user: user, request: nil, sp: dcs.issuer)
 
     remaining_attempts = Throttler::RemainingCount.call(
       user.id,
       :idv_acuant,
     )
 
-    analytics.track_non_browser_event(
+    analytics.track_event(
       Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
       proofer_result.to_h.merge(
         state: proofer_result.pii_from_doc[:state],

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -21,7 +21,26 @@ class Analytics
     # https://www.rubydoc.info/github/newrelic/rpm/NewRelic/Agent#add_custom_attributes-instance_method
     ::NewRelic::Agent.add_custom_attributes(
       user_id: analytics_hash[:user_id],
-      user_ip: request.remote_ip,
+      user_ip: request&.remote_ip,
+      service_provider: sp,
+      event_name: event,
+    )
+  end
+
+  def track_non_browser_event(event, attributes = {})
+    analytics_hash = {
+      event_properties: attributes.except(:user_id),
+      user_id: attributes[:user_id] || user.uuid,
+      locale: I18n.locale,
+    }
+
+    ahoy.track(event, analytics_hash)
+    register_doc_auth_step_from_analytics_event(event, attributes)
+
+    # Tag NewRelic APM trace with a handful of useful metadata
+    # https://www.rubydoc.info/github/newrelic/rpm/NewRelic/Agent#add_custom_attributes-instance_method
+    ::NewRelic::Agent.add_custom_attributes(
+      user_id: analytics_hash[:user_id],
       service_provider: sp,
       event_name: event,
     )

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -12,7 +12,8 @@ class Analytics
       user_id: attributes[:user_id] || user.uuid,
       locale: I18n.locale,
     }
-    analytics_hash.merge!(request_attributes)
+
+    analytics_hash.merge!(request_attributes) if request
 
     ahoy.track(event, analytics_hash)
     register_doc_auth_step_from_analytics_event(event, attributes)
@@ -22,25 +23,6 @@ class Analytics
     ::NewRelic::Agent.add_custom_attributes(
       user_id: analytics_hash[:user_id],
       user_ip: request&.remote_ip,
-      service_provider: sp,
-      event_name: event,
-    )
-  end
-
-  def track_non_browser_event(event, attributes = {})
-    analytics_hash = {
-      event_properties: attributes.except(:user_id),
-      user_id: attributes[:user_id] || user.uuid,
-      locale: I18n.locale,
-    }
-
-    ahoy.track(event, analytics_hash)
-    register_doc_auth_step_from_analytics_event(event, attributes)
-
-    # Tag NewRelic APM trace with a handful of useful metadata
-    # https://www.rubydoc.info/github/newrelic/rpm/NewRelic/Agent#add_custom_attributes-instance_method
-    ::NewRelic::Agent.add_custom_attributes(
-      user_id: analytics_hash[:user_id],
       service_provider: sp,
       event_name: event,
     )

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -49,6 +49,10 @@ module Idv
           verify_document_capture_session,
           liveness_checking_enabled: liveness_checking_enabled?,
           trace_id: amzn_trace_id,
+          analytics_data: {
+            client_image_metrics: image_metadata,
+            browser_attributes: @flow.analytics.browser_attributes,
+          },
         )
 
         nil
@@ -61,6 +65,20 @@ module Idv
           ['encryption_key', 'front_image_iv', 'back_image_iv', 'selfie_image_iv',
            'front_image_url', 'back_image_url', 'selfie_image_url'],
         )
+      end
+
+
+      def image_metadata
+        params.permit(:front_image_metadata, :back_image_metadata).
+          to_h.
+          transform_values do |str|
+            JSON.parse(str)
+          rescue JSON::ParserError
+            nil
+          end.
+          compact.
+          transform_keys { |key| key.gsub(/_image_metadata$/, '') }.
+          deep_symbolize_keys
       end
     end
   end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -43,6 +43,11 @@ module Idv
       def async_state_done(async_result)
         doc_pii_form_result = Idv::DocPiiForm.new(async_result.pii).submit
 
+        @flow.analytics.track_event(
+          Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
+          doc_pii_form_result.to_h,
+        )
+
         delete_async
         if doc_pii_form_result.success?
           extract_pii_from_doc(async_result)
@@ -56,15 +61,6 @@ module Idv
 
       def process_result(async_state)
         add_cost(:acuant_result) if async_state.result.to_h[:billed]
-        @flow.analytics.track_event(
-          Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
-          async_state.result.to_h.merge(
-            state: async_state.pii[:state],
-            async: true,
-            remaining_attempts: remaining_attempts,
-            client_image_metrics: nil, # Need to resolve how to capture image metrics, see LG-4488
-          ),
-        )
       end
 
       def verify_document_capture_session

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -45,7 +45,7 @@ module Idv
 
         @flow.analytics.track_event(
           Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
-          doc_pii_form_result.to_h,
+          doc_pii_form_result.to_h.merge(remaining_attempts: remaining_attempts),
         )
 
         delete_async

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -35,7 +35,8 @@ module Idv
       )
     end
 
-    def proof_document(document_capture_session, liveness_checking_enabled:, trace_id:)
+    def proof_document(document_capture_session, liveness_checking_enabled:, trace_id:,
+                       analytics_data:)
       encrypted_arguments = Encryption::Encryptors::SessionEncryptor.new.encrypt(
         { document_arguments: @applicant }.to_json,
       )
@@ -45,6 +46,7 @@ module Idv
         liveness_checking_enabled: liveness_checking_enabled,
         result_id: document_capture_session.result_id,
         trace_id: trace_id,
+        analytics_data: analytics_data,
       )
     end
   end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe OpenidConnectTokenForm do
         expect(submission.to_h).to include(
           success: false,
           errors: form.errors.messages,
-          error_details: hash_including(*form.errors.keys),
+          error_details: hash_including(*form.errors.attribute_names),
           client_id: nil,
           user_id: nil,
         )

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -45,7 +45,10 @@ RSpec.describe DocumentProofingJob, type: :job do
     )
   end
 
-  let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.hex) }
+  let(:user) { create(:user) }
+  let(:document_capture_session) do
+    DocumentCaptureSession.create(user_id: user.id, result_id: SecureRandom.hex)
+  end
 
   describe '.perform_later' do
     it 'stores results' do
@@ -54,6 +57,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         liveness_checking_enabled: liveness_checking_enabled,
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
+        analytics_data: {},
       )
 
       result = document_capture_session.load_doc_auth_async_result
@@ -69,6 +73,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         liveness_checking_enabled: liveness_checking_enabled,
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
+        analytics_data: {},
       )
     end
 

--- a/spec/services/phone_confirmation/confirmaton_session_spec.rb
+++ b/spec/services/phone_confirmation/confirmaton_session_spec.rb
@@ -48,9 +48,10 @@ RSpec.describe PhoneConfirmation::ConfirmationSession do
   end
 
   describe '#matches_code?' do
+    let(:code) { OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable::DIRECT_OTP_LENGTH) }
     subject do
       described_class.new(
-        code: '123456',
+        code: code,
         phone: '+1 (202) 123-4567',
         sent_at: Time.zone.now,
         delivery_method: :sms,
@@ -58,11 +59,22 @@ RSpec.describe PhoneConfirmation::ConfirmationSession do
     end
 
     it 'returns true if the code matches' do
-      expect(subject.matches_code?('123456')).to eq(true)
+      expect(subject.matches_code?(code)).to eq(true)
+    end
+
+    it 'returns true if the code matches with different case' do
+      random_case_code = code.chars.map { |c| (rand 2) == 0 ? c.downcase : c.upcase }.join
+      lowercase_code = code.downcase
+      uppercase_code = code.upcase
+
+      expect(subject.matches_code?(random_case_code )).to eq(true)
+      expect(subject.matches_code?(lowercase_code)).to eq(true)
+      expect(subject.matches_code?(uppercase_code)).to eq(true)
     end
 
     it 'returns false if the code does not match' do
-      expect(subject.matches_code?('111111')).to eq(false)
+      bad_code = '1' * (TwoFactorAuthenticatable::DIRECT_OTP_LENGTH - 1)
+      expect(subject.matches_code?('11111')).to eq(false)
     end
 
     it 'uses a secure comparison' do

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -11,10 +11,6 @@ class FakeAnalytics
     nil
   end
 
-  def track_non_browser_event(event, attributes = {})
-    track_event(event, attributes)
-  end
-
   def track_mfa_submit_event(_attributes)
     # no-op
   end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -11,8 +11,16 @@ class FakeAnalytics
     nil
   end
 
+  def track_non_browser_event(event, attributes = {})
+    track_event(event, attributes)
+  end
+
   def track_mfa_submit_event(_attributes)
     # no-op
+  end
+
+  def browser_attributes
+    {}
   end
 end
 


### PR DESCRIPTION
Adds the `IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM` and `IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION` events to the async document step flow. Moves the `IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR` event to be in the proofing job, and to pass the browser and client image metadata to the job for inclusion in the event data.