### PR TITLE
ensure OTP phone confirmation is case-insensitive during identity proofing

### DIFF
--- a/app/services/phone_confirmation/confirmation_session.rb
+++ b/app/services/phone_confirmation/confirmation_session.rb
@@ -28,7 +28,7 @@ module PhoneConfirmation
     end
 
     def matches_code?(candidate_code)
-      Devise.secure_compare(candidate_code, code)
+      Base32::Crockford.normalize(candidate_code) == Base32::Crockford.normalize(code)
     end
 
     def expired?

--- a/app/services/phone_confirmation/confirmation_session.rb
+++ b/app/services/phone_confirmation/confirmation_session.rb
@@ -28,7 +28,11 @@ module PhoneConfirmation
     end
 
     def matches_code?(candidate_code)
-      Base32::Crockford.normalize(candidate_code) == Base32::Crockford.normalize(code)
+      return Devise.secure_compare(candidate_code, code) if code.nil? || candidate_code.nil?
+
+      crockford_candidate_code = Base32::Crockford.normalize(candidate_code)
+      crockford_code = Base32::Crockford.normalize(code)
+      Devise.secure_compare(crockford_candidate_code, crockford_code)
     end
 
     def expired?


### PR DESCRIPTION
From https://github.com/18F/identity-idp/pull/4965, our OTP codes are alphanumeric and should be case-insensitive. If you confirm your phone during the proofing process, the OTP check is currently case sensitive