### PR TITLE
LG-4504: Track Return to SP step via FlowStateMachine#next_step

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -15,10 +15,7 @@ module Idv
     }.freeze
 
     def return_to_sp
-      redirect_to return_to_sp_failure_to_proof_url(
-        step: next_step,
-        **params.permit(:location).to_h.symbolize_keys,
-      )
+      redirect_to return_to_sp_failure_to_proof_url(step: next_step, location: params[:location])
     end
 
     private

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -14,6 +14,13 @@ module Idv
       analytics_id: Analytics::DOC_AUTH,
     }.freeze
 
+    def return_to_sp
+      redirect_to return_to_sp_failure_to_proof_url(
+        step: next_step,
+        **params.permit(:location).to_h.symbolize_keys,
+      )
+    end
+
     private
 
     def ensure_user_id_in_session

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -20,10 +20,7 @@ module Idv
     }.freeze
 
     def return_to_sp
-      redirect_to return_to_sp_failure_to_proof_url(
-        step: next_step,
-        **params.permit(:location).to_h.symbolize_keys,
-      )
+      redirect_to return_to_sp_failure_to_proof_url(step: next_step, location: params[:location])
     end
 
     def redirect_if_mail_bounced

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -19,6 +19,13 @@ module Idv
       analytics_id: Analytics::DOC_AUTH,
     }.freeze
 
+    def return_to_sp
+      redirect_to return_to_sp_failure_to_proof_url(
+        step: next_step,
+        **params.permit(:location).to_h.symbolize_keys,
+      )
+    end
+
     def redirect_if_mail_bounced
       redirect_to idv_gpo_url if current_user.decorate.gpo_mail_bounced?
     end

--- a/app/views/idv/capture_doc/document_capture.html.erb
+++ b/app/views/idv/capture_doc/document_capture.html.erb
@@ -3,7 +3,7 @@
   flow_session: flow_session,
   flow_path: 'hybrid',
   sp_name: decorated_session.sp_name,
-  failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
+  failure_to_proof_url: idv_capture_doc_return_to_sp_url,
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -3,7 +3,7 @@
   flow_session: flow_session,
   flow_path: 'standard',
   sp_name: decorated_session.sp_name,
-  failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
+  failure_to_proof_url: idv_doc_auth_return_to_sp_url,
   front_image_upload_url: front_image_upload_url,
   back_image_upload_url: back_image_upload_url,
   selfie_image_upload_url: selfie_image_upload_url,

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -79,7 +79,7 @@
       heading: t('idv.troubleshooting.headings.missing_required_items'),
       options: [
         {
-          url: return_to_sp_failure_to_proof_path,
+          url: idv_doc_auth_return_to_sp_path,
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
       ],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,7 @@ Rails.application.routes.draw do
       get '/address' => 'address#new'
       post '/address' => 'address#update'
       get '/doc_auth' => 'doc_auth#index'
+      get '/doc_auth/return_to_sp' => 'doc_auth#return_to_sp'
       get '/doc_auth/:step' => 'doc_auth#show', as: :doc_auth_step
       put '/doc_auth/:step' => 'doc_auth#update'
       get '/doc_auth/link_sent/poll' => 'capture_doc_status#show', as: :capture_doc_status
@@ -290,6 +291,7 @@ Rails.application.routes.draw do
       get '/capture-doc' => 'capture_doc#index',
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
+      get '/capture_doc/return_to_sp' => 'capture_doc#return_to_sp'
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
     end

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -1,42 +1,51 @@
 require 'rails_helper'
 
 feature 'doc auth welcome step' do
+  include IdvHelper
   include DocAuthHelper
 
   def expect_doc_auth_upload_step
     expect(page).to have_current_path(idv_doc_auth_upload_step)
   end
 
+  let(:fake_analytics) { FakeAnalytics.new }
+  let(:maintenance_window) { [] }
+  let(:sp_name) { 'Test SP' }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).and_return(sp_name)
+    start, finish = maintenance_window
+    allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
+    allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
+
+    visit_idp_from_sp_with_ial2(:oidc)
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_welcome_step
+  end
+
+  it 'logs return to sp link click' do
+    click_on t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name)
+
+    expect(fake_analytics).to have_logged_event(
+      Analytics::RETURN_TO_SP_FAILURE_TO_PROOF,
+      step: 'welcome',
+    )
+  end
+
   context 'skipping upload step', :js, driver: :headless_chrome_mobile do
-    let(:fake_analytics) { FakeAnalytics.new }
-
-    before do
-      allow_any_instance_of(ApplicationController).
-        to receive(:analytics).and_return(fake_analytics)
-
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_welcome_step
-      click_continue
-    end
-
     it 'progresses to the agreement screen' do
+      click_continue
       expect(page).to have_current_path(idv_doc_auth_agreement_step)
     end
   end
 
   context 'during the acuant maintenance window' do
     context 'during the acuant maintenance window' do
-      let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
-      let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
-      let(:finish) { Time.zone.parse('2020-01-01T23:59:59Z') }
-
-      before do
-        allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
-        allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
-
-        sign_in_and_2fa_user
-        complete_doc_auth_steps_before_welcome_step
+      let(:maintenance_window) do
+        [Time.zone.parse('2020-01-01T00:00:00Z'), Time.zone.parse('2020-01-01T23:59:59Z')]
       end
+      let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
 
       around do |ex|
         Timecop.travel(now) { ex.run }


### PR DESCRIPTION
**Why**: So that we have better insight into steps where users are dropping off in the proofing flow. Centralizing to controllers allows for simplified coverage in proofing flows.

In practical terms, adds `step` detail for the "Welcome" screen "Get help at SP" link. It doesn't yet include:

- Cancellations
- Failures