### PR TITLE
LG-4504: Log step for phone / verify warning screens Return to SP link

### DIFF
--- a/app/views/idv/phone_errors/_warning.html.erb
+++ b/app/views/idv/phone_errors/_warning.html.erb
@@ -2,6 +2,7 @@
 yields: Warning text to show.
 locals:
 * contact_support_option: Whether to show "Contact Support" option. Defaults to false.
+* name: Slug describing warning screen, for use in analytics.
 %>
 <%= render(
       'idv/shared/error',
@@ -21,7 +22,10 @@ locals:
           url: idv_gpo_path,
         },
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(
+            step: 'phone',
+            location: local_assigns.fetch(:name, 'warning'),
+          ),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
       ].select(&:present?),

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -7,7 +7,7 @@
           url: idv_gpo_path,
         },
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(step: 'phone', location: request.params[:action]),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
         {

--- a/app/views/idv/phone_errors/jobfail.html.erb
+++ b/app/views/idv/phone_errors/jobfail.html.erb
@@ -1,3 +1,7 @@
-<%= render('idv/phone_errors/warning', contact_support_option: true) do %>
-  <p><%= t('idv.failure.phone.jobfail') %></p>
-<% end %>
+<%= render(
+      'idv/phone_errors/warning',
+      contact_support_option: true,
+      name: request.params[:action],
+    ) do %>
+      <p><%= t('idv.failure.phone.jobfail') %></p>
+    <% end %>

--- a/app/views/idv/phone_errors/timeout.html.erb
+++ b/app/views/idv/phone_errors/timeout.html.erb
@@ -1,3 +1,7 @@
-<%= render('idv/phone_errors/warning', contact_support_option: true) do %>
-  <p><%= t('idv.failure.phone.timeout') %></p>
-<% end %>
+<%= render(
+      'idv/phone_errors/warning',
+      contact_support_option: true,
+      name: request.params[:action],
+    ) do %>
+      <p><%= t('idv.failure.phone.timeout') %></p>
+    <% end %>

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -12,7 +12,10 @@
           text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
         },
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_info',
+            location: request.params[:action],
+          ),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
       ].compact,

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -3,7 +3,10 @@
       heading: t('idv.failure.sessions.heading'),
       options: [
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_info',
+            location: request.params[:action],
+          ),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
         {

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -5,7 +5,10 @@
         t('errors.doc_auth.throttled_heading'),
       options: [
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_info',
+            location: request.params[:action],
+          ),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
         {

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -8,7 +8,10 @@
       },
       options: [
         decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path,
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_info',
+            location: request.params[:action],
+          ),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
         },
       ].compact,

--- a/spec/views/idv/phone_errors/_warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/_warning.html.erb_spec.rb
@@ -3,15 +3,13 @@ require 'rails_helper'
 describe 'idv/phone_errors/_warning.html.erb' do
   let(:sp_name) { nil }
   let(:text) { 'A problem occurred' }
-  let(:contact_support_option) { false }
+  let(:assigns) { {} }
 
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
 
-    render('idv/phone_errors/warning', contact_support_option: contact_support_option) do
-      text
-    end
+    render('idv/phone_errors/warning', assigns) { text }
   end
 
   it 'renders heading' do
@@ -37,7 +35,7 @@ describe 'idv/phone_errors/_warning.html.erb' do
     end
 
     context 'with contact support option' do
-      let(:contact_support_option) { true }
+      let(:assigns) { { contact_support_option: true } }
 
       it 'renders a list of troubleshooting options' do
         expect(rendered).to have_link(
@@ -63,8 +61,28 @@ describe 'idv/phone_errors/_warning.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
       )
+    end
+
+    context 'without a name' do
+      it 'renders failure to proof url with default location' do
+        expect(rendered).to have_link(
+          t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+          href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
+        )
+      end
+    end
+
+    context 'with a name' do
+      let(:assigns) { { name: 'fail' } }
+
+      it 'renders failure to proof url with name as location' do
+        expect(rendered).to have_link(
+          t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+          href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'fail'),
+        )
+      end
     end
   end
 end

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe 'idv/phone_errors/failure.html.erb' do
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path,
+      href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
     )
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app: APP_NAME),

--- a/spec/views/idv/phone_errors/jobfail.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/jobfail.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe 'idv/phone_errors/jobfail.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'jobfail'),
       )
       expect(rendered).not_to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end
@@ -45,7 +45,7 @@ describe 'idv/phone_errors/jobfail.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'jobfail'),
       )
       expect(rendered).to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end

--- a/spec/views/idv/phone_errors/timeout.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/timeout.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe 'idv/phone_errors/timeout.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'timeout'),
       )
       expect(rendered).not_to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end
@@ -45,7 +45,7 @@ describe 'idv/phone_errors/timeout.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'timeout'),
       )
       expect(rendered).to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe 'idv/phone_errors/warning.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
       )
       expect(rendered).not_to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end
@@ -45,7 +45,7 @@ describe 'idv/phone_errors/warning.html.erb' do
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
       )
       expect(rendered).to have_link(t('idv.form.activate_by_mail'), href: idv_gpo_path)
     end

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe 'idv/session_errors/exception.html.erb' do
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path,
+      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'exception'),
     )
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app: APP_NAME),

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe 'idv/session_errors/failure.html.erb' do
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path,
+      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'failure'),
     )
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app: APP_NAME),

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe 'idv/session_errors/throttled.html.erb' do
       )
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
     end
   end

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -24,7 +24,7 @@ describe 'idv/session_errors/warning.html.erb' do
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path,
+      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'warning'),
     )
   end
 end


### PR DESCRIPTION
**Why**: So we have better insight into where users are falling off in the proofing flow.