### PR TITLE
Try enabling Rubocop linter for ERBLint

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,47 @@
 EnableDefaultLinters: false
 linters:
+  Rubocop:
+    enabled: true
+    # There's no special reason for these excludes other than the fact that they have existing
+    # issues that haven't been resolved yet. Fix 'em up!
+    exclude:
+      - '*/app/views/account_reset/*'
+      - '*/app/views/accounts/*'
+      - '*/app/views/devise/*'
+      - '*/app/views/idv/address/*'
+      - '*/app/views/idv/cancellations/*'
+      - '*/app/views/idv/come_back_later/*'
+      - '*/app/views/idv/confirmations/*'
+      - '*/app/views/idv/capture_doc/*'
+      - '*/app/views/idv/doc_auth/*'
+      - '*/app/views/idv/forgot_password/*'
+      - '*/app/views/idv/gpo/*'
+      - '*/app/views/idv/otp_delivery_method/*'
+      - '*/app/views/idv/otp_verification/*'
+      - '*/app/views/idv/phone/*'
+      - '*/app/views/idv/review/*'
+      - '*/app/views/idv/shared/*'
+      - '*/app/views/forgot_password/*'
+      - '*/app/views/event_disavowal/*'
+      - '*/app/views/events/*'
+      - '*/app/views/layouts/*'
+      - '*/app/views/mfa_confirmation/*'
+      - '*/app/views/pages/*'
+      - '*/app/views/partials/*'
+      - '*/app/views/password_capture/*'
+      - '*/app/views/reactivate_account/*'
+      - '*/app/views/saml_idp/*'
+      - '*/app/views/service_provider_mfa/*'
+      - '*/app/views/session_timeout/*'
+      - '*/app/views/shared/*'
+      - '*/app/views/sign_up/*'
+      - '*/app/views/test/*'
+      - '*/app/views/two_factor_authentication/*'
+      - '*/app/views/user_mailer/*'
+      - '*/app/views/users/*'
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
   DeprecatedClasses:
     enabled: true
     rule_set:

--- a/app/views/idv/activated.html.erb
+++ b/app/views/idv/activated.html.erb
@@ -4,6 +4,8 @@
   <%= t('idv.titles.activated') %>
 </h1>
 <p class='mt-tiny margin-bottom-0'>
-  <%= t('idv.messages.activated_html',
-        link: link_to(t('idv.messages.activated_link'), MarketingSite.contact_url)) %>
+  <%= t(
+        'idv.messages.activated_html',
+        link: link_to(t('idv.messages.activated_link'), MarketingSite.contact_url),
+      ) %>
 </p>

--- a/app/views/idv/fail.html.erb
+++ b/app/views/idv/fail.html.erb
@@ -8,7 +8,9 @@
 
 <% if decorated_session.sp_name %>
   <div class='margin-top-2'>
-    <%= t('idv.failure.help.get_help_html',
-          sp_name: link_to(decorated_session.sp_name, return_to_sp_failure_to_proof_path)) %>
+    <%= t(
+          'idv.failure.help.get_help_html',
+          sp_name: link_to(decorated_session.sp_name, return_to_sp_failure_to_proof_path),
+        ) %>
   </div>
 <% end %>

--- a/app/views/idv/phone_errors/_warning.html.erb
+++ b/app/views/idv/phone_errors/_warning.html.erb
@@ -4,25 +4,25 @@ locals:
 * contact_support_option: Whether to show "Contact Support" option. Defaults to false.
 %>
 <%= render(
-  'idv/shared/error',
-  type: :warning,
-  heading: t('idv.failure.phone.heading'),
-  action: {
-    text: t('idv.failure.button.warning'),
-    url: idv_phone_path,
-  },
-  options: [
-    local_assigns[:contact_support_option] && {
-      url: MarketingSite.contact_url,
-      text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
-    },
-    FeatureManagement.enable_gpo_verification? && {
-      text: t('idv.form.activate_by_mail'),
-      url: idv_gpo_path,
-    },
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-  ].select(&:present?)
-) { yield } %>
+      'idv/shared/error',
+      type: :warning,
+      heading: t('idv.failure.phone.heading'),
+      action: {
+        text: t('idv.failure.button.warning'),
+        url: idv_phone_path,
+      },
+      options: [
+        local_assigns[:contact_support_option] && {
+          url: MarketingSite.contact_url,
+          text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
+        },
+        FeatureManagement.enable_gpo_verification? && {
+          text: t('idv.form.activate_by_mail'),
+          url: idv_gpo_path,
+        },
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+      ].select(&:present?),
+    ) { yield } %>

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -1,25 +1,27 @@
 <%= render(
-  'idv/shared/error',
-  heading: t('idv.failure.phone.heading'),
-  options: [
-    FeatureManagement.enable_gpo_verification? && {
-      text: t('idv.form.activate_by_mail'),
-      url: idv_gpo_path,
-    },
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-    {
-      url: MarketingSite.contact_url,
-      text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
-    },
-  ].select(&:present?)
-) do %>
-  <p>
-    <%= t(
-      'idv.failure.phone.fail_html',
-      timeout: distance_of_time_in_words(IdentityConfig.store.idv_attempt_window_in_hours.hours),
-    ) %>
-  </p>
-<% end %>
+      'idv/shared/error',
+      heading: t('idv.failure.phone.heading'),
+      options: [
+        FeatureManagement.enable_gpo_verification? && {
+          text: t('idv.form.activate_by_mail'),
+          url: idv_gpo_path,
+        },
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+        {
+          url: MarketingSite.contact_url,
+          text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
+        },
+      ].select(&:present?),
+    ) do %>
+      <p>
+        <%= t(
+              'idv.failure.phone.fail_html',
+              timeout: distance_of_time_in_words(
+                IdentityConfig.store.idv_attempt_window_in_hours.hours,
+              ),
+            ) %>
+      </p>
+    <% end %>

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -1,26 +1,26 @@
 <%= render(
-  'idv/shared/error',
-  type: :warning,
-  heading: t('idv.failure.sessions.exception'),
-  action: {
-    text: t('idv.failure.button.warning'),
-    url: idv_doc_auth_path,
-  },
-  options: [
-    {
-      url: MarketingSite.contact_url,
-      text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
-    },
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-  ].compact,
-) do %>
-  <p>
-    <%= t(
-      'idv.failure.exceptions.text_html',
-      link: link_to(t('idv.failure.exceptions.link'), MarketingSite.contact_url)
-    ) %>
-  </p>
-<% end %>
+      'idv/shared/error',
+      type: :warning,
+      heading: t('idv.failure.sessions.exception'),
+      action: {
+        text: t('idv.failure.button.warning'),
+        url: idv_doc_auth_path,
+      },
+      options: [
+        {
+          url: MarketingSite.contact_url,
+          text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
+        },
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+      ].compact,
+    ) do %>
+      <p>
+        <%= t(
+              'idv.failure.exceptions.text_html',
+              link: link_to(t('idv.failure.exceptions.link'), MarketingSite.contact_url),
+            ) %>
+      </p>
+    <% end %>

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -1,21 +1,23 @@
 <%= render(
-  'idv/shared/error',
-  heading: t('idv.failure.sessions.heading'),
-  options: [
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-    {
-      url: MarketingSite.contact_url,
-      text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
-    },
-  ].select(&:present?)
-) do %>
-  <p>
-    <%= t(
-      'idv.failure.sessions.fail_html',
-      timeout: distance_of_time_in_words(IdentityConfig.store.idv_attempt_window_in_hours.hours),
-    ) %>
-  </p>
-<% end %>
+      'idv/shared/error',
+      heading: t('idv.failure.sessions.heading'),
+      options: [
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+        {
+          url: MarketingSite.contact_url,
+          text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
+        },
+      ].select(&:present?),
+    ) do %>
+      <p>
+        <%= t(
+              'idv.failure.sessions.fail_html',
+              timeout: distance_of_time_in_words(
+                IdentityConfig.store.idv_attempt_window_in_hours.hours,
+              ),
+            ) %>
+      </p>
+    <% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,25 +1,25 @@
 <%= render(
-  'idv/shared/error',
-  heading: FeatureManagement.liveness_checking_enabled? && sp_session[:ial2_strict].presence ?
-    t('errors.doc_auth.throttled_heading_liveness') :
-    t('errors.doc_auth.throttled_heading'),
-  options: [
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-    {
-      url: MarketingSite.contact_url,
-      text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
-    },
-  ].select(&:present?)
-) do %>
-  <p>
-    <%= t(
-      'errors.doc_auth.throttled_text_html',
-      timeout: distance_of_time_in_words(
-        IdentityConfig.store.acuant_attempt_window_in_minutes.minutes,
-      ),
-    ) %>
-  </p>
-<% end %>
+      'idv/shared/error',
+      heading: FeatureManagement.liveness_checking_enabled? && sp_session[:ial2_strict].presence ?
+        t('errors.doc_auth.throttled_heading_liveness') :
+        t('errors.doc_auth.throttled_heading'),
+      options: [
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+        {
+          url: MarketingSite.contact_url,
+          text: t('idv.troubleshooting.options.contact_support', app: APP_NAME),
+        },
+      ].select(&:present?),
+    ) do %>
+      <p>
+        <%= t(
+              'errors.doc_auth.throttled_text_html',
+              timeout: distance_of_time_in_words(
+                IdentityConfig.store.acuant_attempt_window_in_minutes.minutes,
+              ),
+            ) %>
+      </p>
+    <% end %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,18 +1,18 @@
 <%= render(
-  'idv/shared/error',
-  type: :warning,
-  heading: t('idv.failure.sessions.heading'),
-  action: {
-    text: t('idv.failure.button.warning'),
-    url: idv_doc_auth_path,
-  },
-  options: [
-    decorated_session.sp_name && {
-      url: return_to_sp_failure_to_proof_path,
-      text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-    },
-  ].compact,
-) do %>
-  <p><%= t('idv.failure.sessions.warning') %></p>
-  <p><strong><%= t('idv.failure.attempts', count: @remaining_step_attempts) %></strong></p>
-<% end %>
+      'idv/shared/error',
+      type: :warning,
+      heading: t('idv.failure.sessions.heading'),
+      action: {
+        text: t('idv.failure.button.warning'),
+        url: idv_doc_auth_path,
+      },
+      options: [
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path,
+          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+        },
+      ].compact,
+    ) do %>
+      <p><%= t('idv.failure.sessions.warning') %></p>
+      <p><strong><%= t('idv.failure.attempts', count: @remaining_step_attempts) %></strong></p>
+    <% end %>


### PR DESCRIPTION
**Why**: So that we lint .erb files the same way we lint .rb files.

You're probably going to want to [hide whitespace changes](https://user-images.githubusercontent.com/1779930/119189407-0a6a0a80-ba4a-11eb-8443-90aa06bd09a3.png) for review, though it may be worth considering if the sorts of whitespace changes are changes we're okay with.