### PR TITLE
Fix smoke tests

### DIFF
--- a/spec/support/monitor/monitor_idp_steps.rb
+++ b/spec/support/monitor/monitor_idp_steps.rb
@@ -24,7 +24,7 @@ module MonitorIdpSteps
   # @return [String] email address for the account
   def create_new_account_up_until_password(email_address = random_email_address)
     fill_in 'user_email', with: email_address
-    check t('sign_up.terms')
+    check 'user_terms_accepted', allow_label_click: true
     click_on 'Submit'
     confirmation_link = monitor.check_for_confirmation_link
     visit confirmation_link


### PR DESCRIPTION
**Why**: Smoke tests run outside of Rails, so I18n
is not available

---

Small problem with #4968


Error

```
  1) smoke test: sign in and out creates account, signs out, signs back in
     Failure/Error: check t('sign_up.terms')
     
     NoMethodError:
       undefined method `t' for #<RSpec::ExampleGroups::SmokeTestSignInAndOut:0x0000558ab874b3d0>
     # ./spec/support/monitor/monitor_idp_steps.rb:27:in `create_new_account_up_until_password'
```