### PR TITLE
Fix smoke tests again

### DIFF
--- a/spec/support/monitor/monitor_idp_steps.rb
+++ b/spec/support/monitor/monitor_idp_steps.rb
@@ -58,7 +58,7 @@ module MonitorIdpSteps
     fill_in 'user_password', with: monitor.config.login_gov_sign_in_password
     click_on 'Sign in'
 
-    if current_path == rules_of_use_path
+    if current_path == '/rules_of_use'
       check 'user_terms_accepted', allow_label_click: true
       click_button 'Continue'
     end


### PR DESCRIPTION
**Why**: Smoke tests run outside of rails,
so path helpers are not available

---

This time, from https://github.com/18F/identity-idp/pull/5040

(Deja vu? Last one was https://github.com/18F/identity-idp/pull/5084 for #4968)


Error

```
  5) smoke test: SP initiated sign in OIDC redirects back to SP
     Failure/Error: if current_path == rules_of_use_path
     
     NameError:
       undefined local variable or method `rules_of_use_path' for #<RSpec::ExampleGroups::SmokeTestSPInitiatedSignIn::OIDC:0x000056038d95ada8>
     # ./spec/support/monitor/monitor_idp_steps.rb:61:in `sign_in_and_2fa'
```