### PR TITLE
fix user not being saved when rules of use is disabled

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -99,9 +99,8 @@ class RegisterUserEmailForm
 
   def process_successful_submission(request_id, instructions)
     self.success = true
-    if IdentityConfig.store.rules_of_use_enabled
-      UpdateUser.new(user: user, attributes: { accepted_terms_at: Time.zone.now }).call
-    end
+    user.accepted_terms_at = Time.zone.now if IdentityConfig.store.rules_of_use_enabled
+    user.save!
     Funnel::Registration::Create.call(user.id)
     SendSignUpEmailConfirmation.new(user).call(
       request_id: request_id,

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -244,5 +244,25 @@ describe RegisterUserEmailForm do
         expect(submit_form.errors).to eq errors
       end
     end
+
+    context 'when email is not already taken and rules of use is disabled' do
+      it 'is valid without checking rules of use box' do
+        allow(IdentityConfig.store).to receive(:rules_of_use_enabled).and_return(false)
+
+        submit_form = subject.submit(email: 'not_taken@example.com')
+        extra = {
+          email_already_exists: false,
+          throttled: false,
+          user_id: User.find_with_email('not_taken@example.com').uuid,
+          domain_name: 'example.com',
+        }
+
+        expect(submit_form.to_h).to eq(
+          success: true,
+          errors: {},
+          **extra,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/18F/identity-idp/pull/4968/files#diff-2219765553b20c3a8eda4854f307ca5e4b0ef35264cdae827216d0cdef8d3b3cL94 leads to the user not being created if Rules of Use is disabled