### PR TITLE
LG-4504: Track step from IAL2 cancellation

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -9,7 +9,6 @@ linters:
       - '*/app/views/accounts/*'
       - '*/app/views/devise/*'
       - '*/app/views/idv/address/*'
-      - '*/app/views/idv/cancellations/*'
       - '*/app/views/idv/come_back_later/*'
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'

--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -8,18 +8,23 @@ module Idv
 
     def new
       properties = ParseControllerFromReferer.new(request.referer).call
-      analytics.track_event(Analytics::IDV_CANCELLATION, properties)
+      analytics.track_event(Analytics::IDV_CANCELLATION, properties.merge(step: params[:step]))
       @go_back_path = go_back_path || idv_path
     end
 
     def destroy
-      analytics.track_event(Analytics::IDV_CANCELLATION_CONFIRMED)
+      analytics.track_event(Analytics::IDV_CANCELLATION_CONFIRMED, step: params[:step])
       idv_session = user_session[:idv]
       idv_session&.clear
+      @return_to_sp_path = return_to_sp_failure_to_proof_path(location_params)
       reset_doc_auth
     end
 
     private
+
+    def location_params
+      params.permit(:step, :location).to_h.symbolize_keys
+    end
 
     def reset_doc_auth
       user_session.delete('idv/doc_auth')

--- a/app/services/idv/actions/cancel_capture_doc_action.rb
+++ b/app/services/idv/actions/cancel_capture_doc_action.rb
@@ -6,7 +6,7 @@ module Idv
         return unless dcs
         dcs.cancelled_at = Time.zone.now
         dcs.save!
-        redirect_to idv_cancel_url
+        redirect_to idv_cancel_url(step: 'document_capture')
       end
     end
   end

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -15,8 +15,7 @@
 
 <% if decorated_session.sp_name %>
   <div class='margin-top-2'>
-    <%= link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
-      return_to_sp_failure_to_proof_path %>
+    <%= link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}", @return_to_sp_path %>
   </div>
 <% else %>
   <div class='margin-top-2'>

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -17,11 +17,18 @@
 </ul>
 
 <div class='margin-top-4'>
-  <%= button_to t('forms.buttons.cancel'), idv_cancel_path,
-    method: :delete, class: 'usa-button usa-button--big usa-button--wide' %>
+  <%= button_to(
+        t('forms.buttons.cancel'),
+        idv_cancel_path(step: params[:step], location: 'cancel'),
+        method: :delete,
+        class: 'usa-button usa-button--big usa-button--wide',
+      ) %>
 </div>
 
 <div class='margin-top-2'>
-  <%= link_to t('links.go_back'), @go_back_path,
-    class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>
+  <%= link_to(
+        t('links.go_back'),
+        @go_back_path,
+        class: 'usa-button usa-button--big usa-button--wide usa-button--outline',
+      ) %>
 </div>

--- a/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
+++ b/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
@@ -1,2 +1,2 @@
 <%= render 'idv/doc_auth/start_over' %>
-<%= render 'shared/cancel', link: idv_cancel_path %>
+<%= render 'shared/cancel', link: idv_cancel_path(step: local_assigns[:step]) %>

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -36,7 +36,7 @@
 
 
 <% if user_fully_authenticated? %>
-  <%= render 'shared/cancel', link: idv_cancel_path %>
+  <%= render 'shared/cancel', link: idv_cancel_path(step: 'agreement') %>
 <% else %>
   <div class='margin-top-2 padding-top-1 border-top border-primary-light'>
     <%= link_to(t('two_factor_authentication.choose_another_option'), two_factor_options_path) %>

--- a/app/views/idv/doc_auth/email_sent.html.erb
+++ b/app/views/idv/doc_auth/email_sent.html.erb
@@ -6,4 +6,4 @@
   <%= t('doc_auth.instructions.email_sent', email: current_user.email) %>
 </h1>
 
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'email_sent' %>

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -16,5 +16,5 @@
     <%= t('doc_auth.errors.no_camera.explanation') %>
   </p>
 
-  <%= render 'idv/doc_auth/start_over_or_cancel' %>
+  <%= render 'idv/doc_auth/start_over_or_cancel', step: 'device_choice_no_camera' %>
 <% end %>

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -16,5 +16,5 @@
     <%= t('doc_auth.errors.no_camera.explanation') %>
   </p>
 
-  <%= render 'idv/doc_auth/start_over_or_cancel', step: 'device_choice_no_camera' %>
+  <%= render 'idv/doc_auth/start_over_or_cancel', step: 'no_camera' %>
 <% end %>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -40,4 +40,4 @@
     </button>
   </div>
 <% end %>
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'ssn' %>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -83,5 +83,5 @@
   </div>
 </div>
 
-<%= render 'idv/doc_auth/start_over_or_cancel', step: 'device_choice' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'upload' %>
 <%= javascript_packs_tag_once 'upload-step' %>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -83,5 +83,5 @@
   </div>
 </div>
 
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'device_choice' %>
 <%= javascript_packs_tag_once 'upload-step' %>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -79,4 +79,4 @@
 </div>
 
 <% javascript_packs_tag_once 'form-steps-wait' %>
-<%= render 'idv/doc_auth/start_over_or_cancel', step: 'verify_info' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'verify' %>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -79,4 +79,4 @@
 </div>
 
 <% javascript_packs_tag_once 'form-steps-wait' %>
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
+<%= render 'idv/doc_auth/start_over_or_cancel', step: 'verify_info' %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -103,7 +103,7 @@
 
 
   <% if user_fully_authenticated? %>
-    <%= render 'shared/cancel', link: idv_cancel_path %>
+    <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
   <% else %>
     <div class='margin-top-2 padding-top-1 border-top border-primary-light'>
       <%= link_to(t('two_factor_authentication.choose_another_option'), two_factor_options_path) %>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -68,6 +68,6 @@
 
 <div class="margin-top-4 border-top border-primary-light">
   <div class="margin-top-1">
-    <%= link_to(t('links.cancel'), idv_cancel_path) %>
+    <%= link_to(t('links.cancel'), idv_cancel_path(step: 'phone')) %>
   </div>
 </div>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -68,6 +68,6 @@
 
 <div class="margin-top-4 border-top border-primary-light">
   <div class="margin-top-1">
-    <%= link_to(t('links.cancel'), idv_cancel_path(step: 'phone')) %>
+    <%= link_to(t('links.cancel'), idv_cancel_path(step: 'phone_otp_delivery_selection')) %>
   </div>
 </div>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -50,6 +50,6 @@
 
 <div class="margin-top-4 border-top border-primary-light">
   <div class="margin-top-1">
-    <%= link_to t('links.cancel'), idv_cancel_path(step: 'phone') %>
+    <%= link_to t('links.cancel'), idv_cancel_path(step: 'phone_otp_verification') %>
   </div>
 </div>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -50,6 +50,6 @@
 
 <div class="margin-top-4 border-top border-primary-light">
   <div class="margin-top-1">
-    <%= link_to t('links.cancel'), idv_cancel_path %>
+    <%= link_to t('links.cancel'), idv_cancel_path(step: 'phone') %>
   </div>
 </div>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -76,7 +76,7 @@
 <% end %>
 
 <div class="margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), idv_cancel_path %>
+  <%= link_to t('links.cancel'), idv_cancel_path(step: 'phone') %>
 </div>
 
 <% javascript_packs_tag_once 'form-steps-wait' %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -44,5 +44,5 @@
 <% end %>
 
 <div class="margin-top-6 margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), idv_cancel_path(step: 'review_info') %>
+  <%= link_to t('links.cancel'), idv_cancel_path(step: 'review') %>
 </div>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -44,5 +44,5 @@
 <% end %>
 
 <div class="margin-top-6 margin-top-2 padding-top-1 border-top border-primary-light">
-  <%= link_to t('links.cancel'), idv_cancel_path %>
+  <%= link_to t('links.cancel'), idv_cancel_path(step: 'review_info') %>
 </div>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -136,7 +136,7 @@
                   class: 'usa-button usa-button--unstyled') %>
   </div>
 <% else %>
-  <%= render 'shared/cancel', link: idv_cancel_path %>
+  <%= render 'shared/cancel', link: idv_cancel_path(step: 'document_capture') %>
 <% end %>
 
 <%= nonced_javascript_tag do %>

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -11,7 +11,7 @@ describe Idv::CancellationsController do
     it 'tracks the event in analytics when referer is nil' do
       stub_sign_in
       stub_analytics
-      properties = { request_came_from: 'no referer' }
+      properties = { request_came_from: 'no referer', step: nil }
 
       expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
 
@@ -22,11 +22,21 @@ describe Idv::CancellationsController do
       stub_sign_in
       stub_analytics
       request.env['HTTP_REFERER'] = 'http://example.com/'
-      properties = { request_came_from: 'users/sessions#new' }
+      properties = { request_came_from: 'users/sessions#new', step: nil }
 
       expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
 
       get :new
+    end
+
+    it 'tracks the event in analytics when step param is present' do
+      stub_sign_in
+      stub_analytics
+      properties = { request_came_from: 'no referer', step: 'first' }
+
+      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
+
+      get :new, params: { step: 'first' }
     end
   end
 
@@ -38,10 +48,9 @@ describe Idv::CancellationsController do
       expect(@analytics).to receive(:track_event).with(
         Analytics::IDV_CANCELLATION_CONFIRMED,
         step: 'first',
-        location: 'top',
       )
 
-      delete :destroy, params: { step: 'first', location: 'top' }
+      delete :destroy, params: { step: 'first' }
     end
   end
 end

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -35,9 +35,13 @@ describe Idv::CancellationsController do
       stub_sign_in
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION_CONFIRMED)
+      expect(@analytics).to receive(:track_event).with(
+        Analytics::IDV_CANCELLATION_CONFIRMED,
+        step: 'first',
+        location: 'top',
+      )
 
-      delete :destroy
+      delete :destroy, params: { step: 'first', location: 'top' }
     end
   end
 end

--- a/spec/features/idv/doc_auth/cancel_spec.rb
+++ b/spec/features/idv/doc_auth/cancel_spec.rb
@@ -14,7 +14,7 @@ feature 'doc auth cancel' do
 
     click_link t('links.cancel')
 
-    expect(page).to have_current_path(idv_cancel_path)
+    expect(page).to have_current_path(idv_cancel_path(step: 'verify'))
 
     click_button t('forms.buttons.cancel')
 

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -40,6 +40,32 @@ feature 'doc auth welcome step' do
     end
   end
 
+  context 'cancelling' do
+    let(:sp_name) { 'Test SP' }
+    before do
+      sp = build_stubbed(:service_provider, friendly_name: sp_name)
+      allow_any_instance_of(ApplicationController).to receive(:current_sp).and_return(sp)
+    end
+
+    it 'logs events when returning to sp' do
+      click_on t('links.cancel')
+      expect(fake_analytics).to have_logged_event(Analytics::IDV_CANCELLATION, step: 'welcome')
+
+      click_on t('forms.buttons.cancel')
+      expect(fake_analytics).to have_logged_event(
+        Analytics::IDV_CANCELLATION_CONFIRMED,
+        step: 'welcome',
+      )
+
+      click_on "‹ #{t('links.back_to_sp', sp: sp_name)}"
+      expect(fake_analytics).to have_logged_event(
+        Analytics::RETURN_TO_SP_FAILURE_TO_PROOF,
+        step: 'welcome',
+        location: 'cancel',
+      )
+    end
+  end
+
   context 'during the acuant maintenance window' do
     context 'during the acuant maintenance window' do
       let(:maintenance_window) do

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -37,7 +37,7 @@ shared_examples 'cancel at idv step' do |step, sp|
 
       expect(page).to have_link(
         "‹ #{t('links.back_to_sp', sp: sp_name)}",
-        href: return_to_sp_failure_to_proof_path,
+        href: return_to_sp_failure_to_proof_path(step: step, location: 'cancel'),
       )
 
       # After visiting /verify, expect to redirect to the jurisdiction step,


### PR DESCRIPTION
**Why**: So that we have better insight into where users are dropping from the proofing flow.

This should be the last of the pull requests related to this ticket, and covers cases where a user chooses "Cancel" from a step. There are multiple screens where a user is asked to confirm the cancellation before returning to the service provider. To track step, we retain this in a query parameter passed along between these screens.

Note that this uses [proposed updated canonical names](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1621606419027400) for steps (e.g. "device_choice" instead of "upload"), but I don't feel strongly about keeping this if there's worry it might cause confusion from the inconsistency.