### PR TITLE
Fix PartnerApiReport job call

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -204,5 +204,5 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'Partner API report',
   interval: 24 * 60 * 60, # 24 hours
   timeout: 300,
-  callback: -> { Agreements::Reports::PartnerApiReport.new.call },
+  callback: -> { Agreements::Reports::PartnerApiReport.new.run },
 )


### PR DESCRIPTION
Looks like it uses `.run` instead of `.call` 🙂 