### PR TITLE
[LG-4634] Downcase agency in Partner API agreements path

### DIFF
--- a/app/services/agreements/reports/agencies_report.rb
+++ b/app/services/agreements/reports/agencies_report.rb
@@ -9,8 +9,12 @@ module Agreements
         save_report(
           'agencies',
           AgencyBlueprint.render(agencies, root: :agencies),
-          '',
         )
+      end
+
+      # Save in the root directory
+      def report_path
+        ''
       end
 
       private

--- a/app/services/agreements/reports/agency_iaas_report.rb
+++ b/app/services/agreements/reports/agency_iaas_report.rb
@@ -12,8 +12,11 @@ module Agreements
         save_report(
           'agreements',
           IaaBlueprint.render(iaas, root: :agreements),
-          "agencies/#{agency}/",
         )
+      end
+
+      def report_path
+        "agencies/#{agency.downcase}/"
       end
 
       private

--- a/app/services/agreements/reports/agency_partner_accounts_report.rb
+++ b/app/services/agreements/reports/agency_partner_accounts_report.rb
@@ -2,7 +2,7 @@ module Agreements
   module Reports
     class AgencyPartnerAccountsReport < BaseReport
       def initialize(agency:, partner_accounts:)
-        @agency = agency.downcase
+        @agency = agency
         @partner_accounts = partner_accounts.sort_by(&:requesting_agency)
       end
 
@@ -10,8 +10,11 @@ module Agreements
         save_report(
           'partner_accounts',
           PartnerAccountBlueprint.render(partner_accounts, root: :partner_accounts),
-          "agencies/#{agency}/",
         )
+      end
+
+      def report_path
+        "agencies/#{agency.downcase}/"
       end
 
       private

--- a/app/services/agreements/reports/base_report.rb
+++ b/app/services/agreements/reports/base_report.rb
@@ -6,18 +6,26 @@ module Agreements
         "#{prefix}.#{ec2_data.account_id}-#{ec2_data.region}"
       end
 
-      def save_report(report_name, body, path = nil)
+      def save_report(report_name, body)
         if !IdentityConfig.store.s3_reports_enabled
           logger.info('Not uploading report to S3, s3_reports_enabled is false')
           return body
         end
-        upload_file_to_s3(report_name, body, path)
+        upload_file_to_s3(report_name, body)
       end
 
-      def upload_file_to_s3(report_name, body, path)
-        s3_path = "#{path}#{report_name}"
+      def upload_file_to_s3(report_name, body)
+        s3_path = "#{report_path}#{report_name}"
         upload_file_to_s3_bucket(path: s3_path, body: body, content_type: 'application/json')
       end
+
+      # The following public method should be defined in the child class
+      #
+      # The path to save the report to in S3. For files in the root path this
+      # should be an empty string, otherwise it should end with a forward slash
+      # def report_path
+      #   'foo/'
+      # end
     end
   end
 end

--- a/spec/services/agreements/reports/agencies_report_spec.rb
+++ b/spec/services/agreements/reports/agencies_report_spec.rb
@@ -7,4 +7,12 @@ RSpec.describe Agreements::Reports::AgenciesReport do
 
     expect(described_class.new(agencies: [agency]).run).to eq(expected)
   end
+
+  describe '#report_path' do
+    it 'saves to the root directory' do
+      report = described_class.new(agencies: [build(:agency)])
+
+      expect(report.report_path).to eq('')
+    end
+  end
 end

--- a/spec/services/agreements/reports/agency_iaas_report_spec.rb
+++ b/spec/services/agreements/reports/agency_iaas_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Agreements::Reports::AgencyIaasReport do
-  let(:agency) { create(:agency) }
+  let(:agency) { create(:agency, abbreviation: 'ABC') }
   let(:partner_account1) { create(:partner_account, agency: agency, requesting_agency: 'DEF') }
   let(:partner_account2) { create(:partner_account, agency: agency, requesting_agency: 'ABC') }
   let(:gtc1) { create(:iaa_gtc, partner_account: partner_account1, gtc_number: 'LGAADEF210001') }
@@ -22,5 +22,12 @@ RSpec.describe Agreements::Reports::AgencyIaasReport do
     expected = Agreements::IaaBlueprint.render(sorted_iaas, root: :agreements)
     report_object = described_class.new(agency: agency.abbreviation, iaas: iaas)
     expect(report_object.run).to eq(expected)
+  end
+
+  describe '#report_path' do
+    it 'nests the report under the downcased agency abbreviation' do
+      report_object = described_class.new(agency: agency.abbreviation, iaas: iaas)
+      expect(report_object.report_path).to eq('agencies/abc/')
+    end
   end
 end

--- a/spec/services/agreements/reports/agency_partner_accounts_report_spec.rb
+++ b/spec/services/agreements/reports/agency_partner_accounts_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Agreements::Reports::AgencyPartnerAccountsReport do
-  let(:agency) { create(:agency) }
+  let(:agency) { create(:agency, abbreviation: 'ABC') }
   let(:partner_accounts) do
     build_pair(:partner_account, agency: agency).sort_by(&:requesting_agency)
   end
@@ -13,5 +13,15 @@ RSpec.describe Agreements::Reports::AgencyPartnerAccountsReport do
       partner_accounts: partner_accounts,
     )
     expect(report_object.run).to eq(expected)
+  end
+
+  describe '#report_path' do
+    it 'nests the report under the downcased agency abbreviation' do
+      report_object = described_class.new(
+        agency: agency.abbreviation,
+        partner_accounts: partner_accounts,
+      )
+      expect(report_object.report_path).to eq('agencies/abc/')
+    end
   end
 end


### PR DESCRIPTION
**Why:** There's a discrepancy between the two existing reports (agreements and accounts) that resulted in the agreements endpoint having uppercase agency paths (e.g. `GSA` instead of `gsa`). I'm going to try and make the paths all lowercase so that it's easier to have Lambda@Edge make the CloudFront distribution case-insensitive so needed to add this here.