### PR TITLE
replace deprecated axe gem and fix new issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'axe-matchers', '~> 2.6.0'
+  gem 'axe-core-rspec', '~> 4.2'
   gem 'capybara-screenshot', '>= 1.0.23'
   gem 'capybara-selenium', '>= 0.0.6'
   gem 'simplecov', '~> 0.21.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,9 +193,16 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    axe-matchers (2.6.1)
-      dumb_delegator (~> 0.8)
-      virtus (~> 1.0)
+    axe-core-api (4.2.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-rspec (4.2.0)
+      axe-core-api
+      dumb_delegator
+      virtus
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -287,7 +294,7 @@ GEM
     dotiw (5.1.0)
       activesupport
       i18n
-    dumb_delegator (0.8.1)
+    dumb_delegator (1.0.0)
     email_spec (2.2.0)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -665,6 +672,9 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
+    watir (6.19.1)
+      regexp_parser (>= 1.2, < 3)
+      selenium-webdriver (>= 3.142.7)
     webauthn (2.5.0)
       android_key_attestation (~> 0.3.0)
       awrence (~> 1.1)
@@ -720,7 +730,7 @@ DEPENDENCIES
   aws-sdk-eventbridge
   aws-sdk-kms (~> 1.4)
   aws-sdk-ses (~> 1.6)
-  axe-matchers (~> 2.6.0)
+  axe-core-rspec (~> 4.2)
   base32-crockford
   better_errors (>= 2.5.1)
   binding_of_caller

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,8 +7,7 @@
 <%= validated_form_for(@reset_password_form,
     url: user_password_path,
     html: { autocomplete: 'off',
-    method: :put,
-    role: 'form' }) do |f| %>
+            method: :put }) do |f| %>
   <%= f.input :reset_password_token, as: :hidden %>
   <%= f.full_error :reset_password_token %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -13,7 +13,7 @@
 
 <%= validated_form_for(@password_reset_email_form,
                        url: user_password_path,
-                       html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :post }) do |f| %>
   <%= f.input :email,
               required: true,
               input_html: { autocorrect: 'off',

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
   resource,
   as: resource_name,
   url: session_path(resource_name),
-  html: { autocomplete: 'off', role: 'form' }) do |f|
+  html: { autocomplete: 'off' }) do |f|
 %>
   <%= f.input :email,
               label: t('account.index.email'),

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -7,8 +7,7 @@
 <%= validated_form_for(@password_reset_from_disavowal_form,
     url: events_disavowal_url,
     html: { autocomplete: 'off',
-    method: :post,
-    role: 'form' }) do |f| %>
+    method: :post }) do |f| %>
     <%= f.input :disavowal_token, as: :hidden,
                 input_html: { value: @disavowal_token, name: :disavowal_token } %>
     <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <%= validated_form_for @view_model.password_reset_email_form,
-                       html: { autocomplete: 'off', method: :post, role: 'form', class: 'margin-bottom-2' },
+                       html: { autocomplete: 'off', method: :post, class: 'margin-bottom-2' },
                        url: user_password_path do |f| %>
 
   <%= f.input :email, as: :hidden, wrapper: false %>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -17,7 +17,7 @@
 
 <div class="margin-top-4 margin-bottom-4">
   <%= validated_form_for(:idv_form, url: idv_address_path, method: 'POST',
-                         html: {autocomplete: 'off', role: 'form', class: 'margin-top-2'}) do |f| %>
+                         html: {autocomplete: 'off', class: 'margin-top-2'}) do |f| %>
 
     <%= f.input :address1, label: t('idv.form.address1'), wrapper_html: {class: 'margin-bottom-1'},
                 required: true, maxlength: 255, input_html: { aria: { invalid: false }, value: @pii['address1'] } %>

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -18,7 +18,7 @@
 <%= validated_form_for :doc_auth,
                        url: url_for,
                        method: 'put',
-                       html: { autocomplete: 'off', role: 'form', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
+                       html: { autocomplete: 'off', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
   <br/>
   <label class="margin-top-neg-1 margin-bottom-4" for="ial2_consent_given">
     <div class="checkbox">

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -19,7 +19,7 @@
 <p class='mt-tiny margin-bottom-4'><%= t('doc_auth.instructions.send_sms') %></p>
 
 <%= validated_form_for(:doc_auth, url: url_for, method: 'PUT',
-        html: { autocomplete: 'off', role: 'form', class: 'margin-top-2' }) do |f| %>
+        html: { autocomplete: 'off', class: 'margin-top-2' }) do |f| %>
   <div class='clearfix margin-x-neg-1'>
     <div class='sm-col sm-col-8 padding-x-1'>
       <!-- using :phone for mobile numeric keypad -->

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -15,7 +15,7 @@
   :doc_auth,
   url: url_for,
   method: :put,
-  html: { autocomplete: 'off', role: 'form', class: 'margin-top-2' }
+  html: { autocomplete: 'off', class: 'margin-top-2' }
 ) do |f| %>
   <div class='clearfix margin-x-neg-1'>
     <div class='sm-col sm-col-8 padding-x-1 margin-top-2'>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -50,7 +50,7 @@
       :doc_auth,
       url: url_for(type: :mobile),
       method: 'PUT',
-      html: { autocomplete: 'off', role: 'form', class: 'margin-top-2' },
+      html: { autocomplete: 'off', class: 'margin-top-2' },
     ) do %>
       <button type="submit" class="usa-button usa-button--big margin-top-05">
         <%= t('doc_auth.buttons.use_phone') %>
@@ -69,7 +69,7 @@
       :doc_auth,
       url: url_for(type: :desktop),
       method: 'PUT',
-      html: { autocomplete: 'off', role: 'form', class: 'inline' }
+      html: { autocomplete: 'off', class: 'inline' }
     ) do %>
       <button type="submit" class="usa-button usa-button--unstyled">
         <%= t('doc_auth.info.upload_computer_link') %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -93,7 +93,7 @@
   <%= validated_form_for :doc_auth,
                          url: url_for,
                          method: 'put',
-                         html: { autocomplete: 'off', role: 'form', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
+                         html: { autocomplete: 'off', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
     <br/>
     <%= f.button :button, t('doc_auth.buttons.continue'), type: :submit,
                  class: 'usa-button--big usa-button--wide' %>

--- a/app/views/idv/gpo/_new_address.html.erb
+++ b/app/views/idv/gpo/_new_address.html.erb
@@ -1,5 +1,5 @@
 <%=  validated_form_for(:idv_form, url: idv_gpo_path, method: 'POST',
-                        html: { autocomplete: 'off', role: 'form', class: 'margin-top-2' }) do |f| %>
+                        html: { autocomplete: 'off', class: 'margin-top-2' }) do |f| %>
 
   <%= f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'margin-bottom-1' },
                 required: true, input_html: { aria: { invalid: false } }, maxlength: 255 %>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -20,7 +20,7 @@
 
 
 <%= form_tag(idv_otp_delivery_method_url,
-             autocomplete: 'off', role: 'form', class: 'margin-top-4',
+             autocomplete: 'off', class: 'margin-top-4',
              method: :put) do |f| %>
 
   <fieldset class="margin-bottom-4 padding-0 border-none">

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -19,7 +19,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= form_tag(:idv_otp_verification, method: :put, role: 'form', class: 'margin-top-4') do %>
+<%= form_tag(:idv_otp_verification, method: :put, class: 'margin-top-4') do %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
       <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -57,7 +57,6 @@
                        html: {
                          autocomplete: 'off',
                          method: :put,
-                         role: 'form',
                          class: 'margin-top-2',
                        }) do |f| %>
  <%= f.label :phone, label: t('idv.form.phone'), class: 'bold' %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -23,7 +23,7 @@
                        MarketingSite.security_url)%>
 
 <%= validated_form_for(current_user, url: idv_review_path,
-                       html: { autocomplete: 'off', method: :put, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :put }) do |f| %>
   <%= f.input :password, label: t('idv.form.password'), required: true,
               input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div class="right-align margin-top-neg-2 margin-bottom-6">

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -47,7 +47,7 @@
     :doc_auth,
     url: url_for,
     method: 'PUT',
-    html: { autocomplete: 'off', role: 'form', class: 'margin-top-2 js-document-capture-form' }
+    html: { autocomplete: 'off', class: 'margin-top-2 js-document-capture-form' }
   ) do |f| %>
     <%# ---- Front Image ----- %>
 

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -9,7 +9,7 @@
 </p>
 <%= validated_form_for(current_user,
                        url: reauthn_user_password_path,
-                       html: { autocomplete: 'off', role: 'form', method: 'post' }) do |f| %>
+                       html: { autocomplete: 'off', method: 'post' }) do |f| %>
   <%= f.input :password, required: true, input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-top-2' %>
 <% end %>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -8,7 +8,7 @@
                        as: :user,
                        url: capture_password_url,
                        method: :post,
-                       html: { autocomplete: 'off', role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off' }) do |f| %>
   <%= f.input :password, label: t('account.index.password'), required: true,
               input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div>

--- a/app/views/service_provider_mfa/new.html.erb
+++ b/app/views/service_provider_mfa/new.html.erb
@@ -9,7 +9,7 @@
 <p class="mt-tiny"><%== @presenter.intro %></p>
 
 <%= validated_form_for @two_factor_options_form,
-                       html: { autocomplete: 'off', role: 'form' },
+                       html: { autocomplete: 'off' },
                        method: :patch,
                        url: two_factor_options_path do |f| %>
   <div class="margin-bottom-4">

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -5,7 +5,7 @@
 </h1>
 <%= validated_form_for(@resend_email_confirmation_form,
                        url: sign_up_register_path,
-                       html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :post }) do |f| %>
   <%= f.input :email,
               label: t('forms.registration.labels.email'),
               required: true,

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -10,7 +10,7 @@
 <%= validated_form_for(@password_form,
                        url: sign_up_create_password_path,
                        method: :post,
-                       html: { role: 'form', autocomplete: 'off' }) do |f| %>
+                       html: { autocomplete: 'off' }) do |f| %>
   <%= f.input :password, required: true,
               input_html: { aria: { invalid: false, describedby: 'password-description' },
                             class: 'password-toggle' } %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -12,7 +12,7 @@
 
 <div class='margin-bottom-6'>
   <%= validated_form_for(@register_user_email_form,
-      html: { autocomplete: 'off', role: 'form' },
+      html: { autocomplete: 'off' },
       url: sign_up_register_path) do |f| %>
     <%= f.input :email,
                 label: t('forms.registration.labels.email'),

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= validated_form_for(@backup_code_form, url: login_two_factor_backup_code_path,
-                       html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :post }) do |f| %>
   <%= render 'partials/backup_code/entry_fields', f: f, attribute_name: :backup_code %>
   <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide' %>
 <% end %>

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= validated_form_for(@two_factor_options_form,
-        html: { autocomplete: 'off', role: 'form' },
+        html: { autocomplete: 'off' },
         method: :post,
         url: login_two_factor_options_path) do |f| %>
   <div class="margin-bottom-4">

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -8,7 +8,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= form_tag(:login_otp, method: :post, role: 'form', class: 'margin-top-4') do %>
+<%= form_tag(:login_otp, method: :post, class: 'margin-top-4') do %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= validated_form_for(@personal_key_form, url: login_two_factor_personal_key_path,
-                       html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :post }) do |f| %>
   <%= render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key %>
   <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide' %>
 <% end %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -4,7 +4,7 @@
   <%= @presenter.header %>
 </h1>
 
-<%= form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'margin-top-4 tablet:margin-top-6') do %>
+<%= form_tag(:login_two_factor_authenticator, method: :post, class: 'margin-top-4 tablet:margin-top-6') do %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -8,7 +8,7 @@
   <%= @presenter.webauthn_help %>
 </div>
 
-<%= form_tag(login_two_factor_webauthn_path, method: :patch, role: 'form', class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
+<%= form_tag(login_two_factor_webauthn_path, method: :patch, class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
   <%= hidden_field_tag :user_challenge,
     '[' + user_session[:webauthn_challenge].split.join(',') + ']', id: 'user_challenge' %>
   <%= hidden_field_tag :credential_ids, @presenter.credential_ids, id: 'credential_ids' %>

--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -14,7 +14,7 @@
   <%= t('forms.backup_code.caution_delete') %>
 </p>
 
-<%= form_tag(backup_code_delete_path, method: :delete, role: 'form') do %>
+<%= form_tag(backup_code_delete_path, method: :delete) do %>
   <%= button_tag t('account.index.backup_code_confirm_delete'), type: 'submit',
                  class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -44,7 +44,7 @@
   </div>
 </div>
 
-<%= form_tag(backup_code_continue_path, method: :patch, role: 'form') do %>
+<%= form_tag(backup_code_continue_path, method: :patch) do %>
   <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>
 <% end %>
 

--- a/app/views/users/backup_code_setup/depleted.html.erb
+++ b/app/views/users/backup_code_setup/depleted.html.erb
@@ -7,7 +7,7 @@
   <%= @presenter.continue_bttn_prologue %>
 <% end %>
 
-<%= form_tag(backup_code_setup_path, method: :patch, role: 'form') do %>
+<%= form_tag(backup_code_setup_path, method: :patch) do %>
   <div class="clearfix margin-x-neg-1">
     <div class="col col-12 sm-col-8 padding-x-1">
       <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -14,7 +14,7 @@
   <%= t('forms.backup_code_regenerate.caution') %>
 </p>
 
-<%= form_tag(backup_code_setup_path, method: :patch, role: 'form') do %>
+<%= form_tag(backup_code_setup_path, method: :patch) do %>
   <%= button_tag t('account.index.backup_code_confirm_regenerate'), type: 'submit',
                  class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -2,7 +2,7 @@
 <p class="mt-tiny margin-bottom-4"><%== @presenter.description %></p>
 
 <% if @presenter.other_option_display %>
-  <%= form_tag(backup_code_setup_path, method: :patch, role: 'form') do %>
+  <%= form_tag(backup_code_setup_path, method: :patch) do %>
     <div class="clearfix margin-x-neg-1">
       <div class="col col-12 sm-col-8 padding-x-1">
         <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -16,7 +16,7 @@
   </ul>
   <div>
     <%= validated_form_for(current_user, url: account_delete_path,
-                           html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                           html: { autocomplete: 'off', method: :post }) do |f| %>
       <div class="margin-bottom-4">
         <%= t('users.delete.instructions') %>
       </div>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -4,7 +4,7 @@
 </h1>
 
 <%= validated_form_for(@edit_phone_form,
-                       html: {autocomplete: 'off', method: :put, role: 'form'},
+                       html: {autocomplete: 'off', method: :put},
                        url: manage_phone_path(id: @phone_configuration.id)) do |f| %>
 
   <div class="margin-bottom-1 h4">

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="margin-bottom-6">
   <%= validated_form_for(@add_user_email_form,
-          html: { autocomplete: 'off', role: 'form' },
+          html: { autocomplete: 'off' },
           url: add_email_path) do |f| %>
     <%= f.input :email, label: t('forms.registration.labels.email'), required: true,
                 input_html: { aria: { invalid: false } } %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= validated_form_for(@update_user_password_form, url: manage_password_path,
-                       html: { autocomplete: 'off', method: :patch, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :patch }) do |f| %>
   <%= f.error_notification %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
               input_html: { aria: { invalid: false, describedby: 'password-description' }, class: 'password-toggle' } %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -14,7 +14,7 @@
 </p>
 
 <%= validated_form_for(@new_phone_form,
-                       html: { autocomplete: 'off', method: :patch, role: 'form' },
+                       html: { autocomplete: 'off', method: :patch },
                        data: { international_phone_form: true },
                        url: phone_setup_path) do |f| %>
 

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= validated_form_for(@new_phone_form,
-                       html: {autocomplete: 'off', method: :post, role: 'form'},
+                       html: {autocomplete: 'off', method: :post},
                        data: {international_phone_form: true},
                        url: add_phone_path) do |f| %>
 

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -14,7 +14,7 @@
 </div>
 <br>
 
-<%= form_tag(disable_piv_cac_url(id: params[:id]), method: :delete, role: 'form') do %>
+<%= form_tag(disable_piv_cac_url(id: params[:id]), method: :delete) do %>
   <%= button_tag t('account.index.piv_cac_confirm_delete'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>
 <%= link_to t('links.cancel'), account_path, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>

--- a/app/views/users/rules_of_use/new.html.erb
+++ b/app/views/users/rules_of_use/new.html.erb
@@ -11,7 +11,7 @@
 <%= t('users.rules_of_use.details_html') %>
 <div class='margin-bottom-6'>
   <%= validated_form_for(@rules_of_use_form,
-      html: { autocomplete: 'off', role: 'form' },
+      html: { autocomplete: 'off' },
       url: rules_of_use_path) do |f| %>
 
     <div class="margin-bottom-3">

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -14,7 +14,7 @@
 </div>
 <br>
 
-<%= form_tag(disable_totp_path(id: params[:id]), method: :delete, role: 'form') do %>
+<%= form_tag(disable_totp_path(id: params[:id]), method: :delete) do %>
   <%= button_tag t('account.index.totp_confirm_delete'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>
 <%= link_to t('links.cancel'), account_path, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -4,7 +4,7 @@
                                   MarketingSite.help_authentication_app_url %>
 <h1 class="margin-y-0"><%= t('headings.totp_setup.new') %></h1>
 <p class="mt-tiny margin-bottom-4"><%= t('forms.totp_setup.totp_intro_html', link: help_link) %></p>
-<%= form_tag(authenticator_setup_path, method: :patch, role: 'form', class: 'margin-bottom-1') do %>
+<%= form_tag(authenticator_setup_path, method: :patch, class: 'margin-bottom-1') do %>
   <ul class="list-reset">
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -13,7 +13,7 @@
 <%= render('shared/alert') { t('two_factor_authentication.lockout_information') } %>
 
 <%= validated_form_for @two_factor_options_form,
-                       html: { autocomplete: 'off', role: 'form' },
+                       html: { autocomplete: 'off' },
                        method: :patch,
                        url: two_factor_options_path do |f| %>
   <div class="margin-bottom-4">

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -20,7 +20,7 @@
   <%= t('forms.verify_profile.instructions') %>
 </p>
 <%= validated_form_for(@verify_account_form, url: verify_account_path,
-                     html: { autocomplete: 'off', method: :post, role: 'form' }) do |f| %>
+                     html: { autocomplete: 'off', method: :post }) do |f| %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
       <%= f.input :otp,

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= validated_form_for(current_user, url: update_verify_password_path,
-                       html: { autocomplete: 'off', method: :put, role: 'form' }) do |f| %>
+                       html: { autocomplete: 'off', method: :put }) do |f| %>
   <%= f.input :password, label: t('idv.form.password'), required: true,
               input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide' %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -12,7 +12,7 @@
 </p>
 
 <div>
-   <%= form_tag(webauthn_setup_path, method: :patch, role: 'form', class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
+   <%= form_tag(webauthn_setup_path, method: :patch, class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
       <%= hidden_field_tag :user_id, current_user.id, id: 'user_id' %>
       <%= hidden_field_tag :user_email, current_user.email, id: 'user_email' %>
       <%= hidden_field_tag :user_challenge, '[' + user_session[:webauthn_challenge].split.join(',') + ']', id: 'user_challenge' %>

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require 'axe/rspec'
+require 'axe-rspec'
 
 feature 'Accessibility on IDV pages', :js do
   describe 'IDV pages' do
@@ -10,7 +10,7 @@ feature 'Accessibility on IDV pages', :js do
 
       visit idv_path
 
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -21,7 +21,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_cancel_path
 
       expect(current_path).to eq idv_cancel_path
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -32,7 +32,7 @@ feature 'Accessibility on IDV pages', :js do
       complete_all_doc_auth_steps
 
       expect(current_path).to eq idv_phone_path
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -44,7 +44,7 @@ feature 'Accessibility on IDV pages', :js do
       click_idv_continue
 
       expect(page).to have_current_path(idv_review_path)
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -58,7 +58,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_confirmations_path
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -72,7 +72,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_confirmations_path
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -86,7 +86,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_confirmations_path
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end

--- a/spec/features/accessibility/static_pages_spec.rb
+++ b/spec/features/accessibility/static_pages_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'axe/rspec'
+require 'axe-rspec'
 
 feature 'Accessibility on static pages', :js do
   scenario 'not found page' do
     visit '/non_existent_page'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -13,7 +13,7 @@ feature 'Accessibility on static pages', :js do
   scenario '401 page' do
     visit '/401'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -21,7 +21,7 @@ feature 'Accessibility on static pages', :js do
   scenario '406 page' do
     visit '/406'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -29,7 +29,7 @@ feature 'Accessibility on static pages', :js do
   scenario '422 page' do
     visit '/422'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -37,7 +37,7 @@ feature 'Accessibility on static pages', :js do
   scenario '429 page' do
     visit '/429'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -45,7 +45,7 @@ feature 'Accessibility on static pages', :js do
   scenario '500 page' do
     visit '/500'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require 'axe/rspec'
+require 'axe-rspec'
 
 feature 'Accessibility on pages that require authentication', :js do
   scenario 'user registration page' do
@@ -7,7 +7,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_up_with(email)
 
     expect(current_path).to eq(sign_up_verify_email_path)
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -18,7 +18,7 @@ feature 'Accessibility on pages that require authentication', :js do
       confirm_last_user
 
       expect(current_path).to eq(sign_up_enter_password_path)
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -27,7 +27,7 @@ feature 'Accessibility on pages that require authentication', :js do
       visit sign_up_create_email_confirmation_path(confirmation_token: '123456')
 
       expect(current_path).to eq(sign_up_email_resend_path)
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -38,7 +38,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_up_and_set_password
 
       expect(current_path).to eq(two_factor_options_path)
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -49,7 +49,7 @@ feature 'Accessibility on pages that require authentication', :js do
       click_button t('forms.buttons.continue')
 
       expect(current_path).to eq(phone_setup_path)
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -59,7 +59,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_in_before_2fa(user)
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))
-      expect(page).to be_accessible.according_to :section508, :"best-practice"
+      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -71,7 +71,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'sms')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(page).to be_accessible.according_to :section508, :"best-practice"
+        expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
         expect(page).to label_required_fields
         expect(page).to be_uniquely_titled
       end
@@ -84,7 +84,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'voice')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
-        expect(page).to be_accessible.according_to :section508, :"best-practice"
+        expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
         expect(page).to label_required_fields
         expect(page).to be_uniquely_titled
       end
@@ -95,7 +95,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_in_and_2fa_user
     visit manage_personal_key_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -105,7 +105,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -116,7 +116,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit delete_email_path(id: user.email_addresses.take.id)
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -126,7 +126,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_password_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -136,7 +136,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_email_language_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -146,7 +146,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit add_phone_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -156,7 +156,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_phone_path(id: user.phone_configurations.first.id)
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -166,7 +166,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_personal_key_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -176,7 +176,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit '/authenticator_setup'
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -188,7 +188,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_events_path(id: device.id)
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -198,7 +198,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_delete_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'axe/rspec'
+require 'axe-rspec'
 
 feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'login / root path' do
     visit root_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -13,7 +13,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'forgot password page' do
     visit new_user_password_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -21,7 +21,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'new user start registration page' do
     visit new_user_session_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -29,7 +29,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'new user registration page' do
     visit sign_up_email_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -37,7 +37,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'new user cancel registration page' do
     visit sign_up_cancel_path
 
-    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -76,7 +76,7 @@ module DocAuthHelper
 
   def complete_doc_auth_steps_before_welcome_step(expect_accessible: false)
     visit idv_doc_auth_welcome_step unless current_path == idv_doc_auth_welcome_step
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
   end
 
   def complete_doc_auth_steps_before_agreement_step(expect_accessible: false)
@@ -95,7 +95,7 @@ module DocAuthHelper
     complete_doc_auth_steps_before_upload_step(expect_accessible: expect_accessible)
     # JavaScript-enabled mobile devices will skip directly to document capture, so stop as complete.
     return if page.current_path == idv_doc_auth_document_capture_step
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
     click_on t('doc_auth.info.upload_computer_link')
   end
 
@@ -115,20 +115,20 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
 
   def complete_doc_auth_steps_before_ssn_step(expect_accessible: false)
     complete_doc_auth_steps_before_document_capture_step(expect_accessible: expect_accessible)
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
     attach_and_submit_images
   end
 
   def complete_doc_auth_steps_before_verify_step(expect_accessible: false)
     complete_doc_auth_steps_before_ssn_step(expect_accessible: expect_accessible)
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
     fill_out_ssn_form_ok
     click_idv_continue
   end
 
   def complete_doc_auth_steps_before_address_step(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
     click_link t('doc_auth.buttons.change_address')
   end
 
@@ -145,7 +145,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
 
   def complete_all_doc_auth_steps(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
-    expect(page).to be_accessible.according_to :section508, :"best-practice" if expect_accessible
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
     click_idv_continue
   end
 


### PR DESCRIPTION
[axe-matchers](https://github.com/dequelabs/axe-matchers) has been deprecated for a number of months, and this PR replaces it with the recommended [axe-core-rspec](https://github.com/dequelabs/axe-core-gems/tree/develop/packages/axe-core-rspec)

Some of the rule implementations changed, notably the guidance around `role='form'` on form tags, which is now under "best practice" rules: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#best-practices-rules

Example failure:

```
       1) aria-allowed-role: ARIA role should be appropriate for the element (minor)
           https://dequeuniversity.com/rules/axe/4.2/aria-allowed-role?application=axeAPI
           The following 2 nodes violate this rule:

               Selector: .simple_form.margin-top-2[autocomplete="off"]
               HTML: <form autocomplete="off" role="form" class="simple_form margin-top-2" data-validate="true" action="/verify/doc_auth/upload?type=mobile" accept-charset="UTF-8" method="post">
               Fix any of the following:
               - ARIA role form is not allowed for given element

               Selector: .inline
               HTML: <form autocomplete="off" role="form" class="simple_form inline" data-validate="true" action="/verify/doc_auth/upload?type=desktop" accept-charset="UTF-8" method="post">
               Fix any of the following:
               - ARIA role form is not allowed for given element
```

I also added the WCAG 2.1 rules, though it doesn't look like we are failing any of those.