### PR TITLE
Avoid rendering Rules of Use checkbox if feature disabled

### DIFF
--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -40,17 +40,20 @@
                  locals: { f: f, selection: @register_user_email_form.email_language } %>
     </fieldset>
 
-    <div class="margin-bottom-3">
-      <%= f.check_box :terms_accepted, { class: 'usa-checkbox__input',
-                                         required: true, aria: { invalid: false } }, true, false %>
-      <label for="user_terms_accepted" class="usa-checkbox__label">
-        <%= t('sign_up.terms') %>
-        <%= new_window_link_to(t('titles.rules_of_use'), MarketingSite.rules_of_use_url) %>
-      </label>
-      <div class="usa-error-message usa-error-message--with-icon display-if-invalid" role="alert">
-        <%= t('sign_up.agree_to_rules_of_use_and_continue') %>
+    <% if IdentityConfig.store.rules_of_use_enabled %>
+      <div class="margin-bottom-3">
+        <%= f.check_box :terms_accepted, { class: 'usa-checkbox__input',
+                                          required: true, aria: { invalid: false } }, true, false %>
+        <label for="user_terms_accepted" class="usa-checkbox__label">
+          <%= t('sign_up.terms') %>
+          <%= new_window_link_to(t('titles.rules_of_use'), MarketingSite.rules_of_use_url) %>
+        </label>
+        <div class="usa-error-message usa-error-message--with-icon display-if-invalid" role="alert">
+          <%= t('sign_up.agree_to_rules_of_use_and_continue') %>
+        </div>
       </div>
-    </div>
+      <%= javascript_packs_tag_once 'accept-terms-button' %>
+    <% end %>
 
     <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
     <%= f.button :button, t('forms.buttons.submit.default'), type: :submit,
@@ -71,4 +74,4 @@
 </p>
 
 
-<%= javascript_packs_tag_once 'email-validation', 'accept-terms-button' %>
+<%= javascript_packs_tag_once 'email-validation' %>

--- a/spec/views/sign_up/registrations/new.html.erb_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.erb_spec.rb
@@ -72,4 +72,28 @@ describe 'sign_up/registrations/new.html.erb' do
 [target='_blank'][rel='noopener noreferrer']",
       )
   end
+
+  context 'with rules of use disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:rules_of_use_enabled).and_return(false)
+    end
+
+    it 'does not show rules of use checkbox' do
+      render
+
+      expect(rendered).not_to have_content(t('sign_up.terms'))
+    end
+  end
+
+  context 'with rules of use enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:rules_of_use_enabled).and_return(true)
+    end
+
+    it 'does shows rules of use checkbox' do
+      render
+
+      expect(rendered).to have_content(t('sign_up.terms'))
+    end
+  end
 end

--- a/spec/views/sign_up/registrations/new.html.erb_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.erb_spec.rb
@@ -90,7 +90,7 @@ describe 'sign_up/registrations/new.html.erb' do
       allow(IdentityConfig.store).to receive(:rules_of_use_enabled).and_return(true)
     end
 
-    it 'does shows rules of use checkbox' do
+    it 'shows rules of use checkbox' do
       render
 
       expect(rendered).to have_content(t('sign_up.terms'))


### PR DESCRIPTION
**Why**: So that a user will not see the checkbox if the feature is disabled.