### PR TITLE
LG-4365: Redirect desktop session to error page when throttled in hybrid flow

### DIFF
--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -11,26 +11,34 @@ module Idv
     private
 
     def document_capture_session_poll_render_result
-      return { plain: 'Unauthorized', status: :unauthorized } unless flow_session
-      session_uuid = flow_session[:document_capture_session_uuid]
-      document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
-      return { plain: 'Unauthorized', status: :unauthorized } unless document_capture_session
-      return { plain: 'Cancelled', status: :gone } if document_capture_session.cancelled_at
+      return { json: nil, status: :unauthorized } unless flow_session
+      return { json: nil, status: :unauthorized } unless document_capture_session
+      return { json: nil, status: :gone } if document_capture_session.cancelled_at
+      return {
+        json: { redirect: idv_session_errors_throttled_url },
+        status: :too_many_requests,
+      } if is_throttled
 
-      render_result(document_capture_session)
-    end
-
-    def render_result(document_capture_session)
       result = document_capture_session.load_result ||
                document_capture_session.load_doc_auth_async_result
 
-      return { plain: 'Pending', status: :accepted } if result.blank?
-      return { plain: 'Unauthorized', status: :unauthorized } unless result.success?
-      { plain: 'Complete', status: :ok }
+      return { json: nil, status: :accepted } if result.blank?
+      return { json: nil, status: :unauthorized } unless result.success?
+      { json: nil, status: :ok }
     end
 
     def flow_session
       user_session['idv/doc_auth']
+    end
+
+    def document_capture_session
+      return @document_capture_session if defined?(@document_capture_session)
+      session_uuid = flow_session[:document_capture_session_uuid]
+      @document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
+    end
+
+    def is_throttled
+      Throttler::IsThrottled.call(document_capture_session.user_id, :idv_acuant)
     end
   end
 end

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -5,29 +5,42 @@ module Idv
     respond_to :json
 
     def show
-      render document_capture_session_poll_render_result
+      render(
+        json: {
+          redirect: status == :too_many_requests ? idv_session_errors_throttled_url : nil,
+        }.compact,
+        status: status,
+      )
     end
 
     private
 
-    def document_capture_session_poll_render_result
-      return { json: nil, status: :unauthorized } if !flow_session || !document_capture_session
-      return { json: nil, status: :gone } if document_capture_session.cancelled_at
-      return {
-        json: { redirect: idv_session_errors_throttled_url },
-        status: :too_many_requests,
-      } if throttled?
-
-      result = document_capture_session.load_result ||
-               document_capture_session.load_doc_auth_async_result
-
-      return { json: nil, status: :accepted } if result.blank?
-      return { json: nil, status: :unauthorized } unless result.success?
-      { json: nil, status: :ok }
+    def status
+      @status ||= begin
+        if !flow_session || !document_capture_session
+          :unauthorized
+        elsif document_capture_session.cancelled_at
+          :gone
+        elsif throttled?
+          :too_many_requests
+        elsif session_result.blank?
+          :accepted
+        elsif !session_result.success?
+          :unauthorized
+        else
+          :ok
+        end
+      end
     end
 
     def flow_session
       user_session['idv/doc_auth']
+    end
+
+    def session_result
+      return @session_result if defined?(@session_result)
+      @session_result = document_capture_session.load_result ||
+                        document_capture_session.load_doc_auth_async_result
     end
 
     def document_capture_session

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -16,7 +16,7 @@ module Idv
       return {
         json: { redirect: idv_session_errors_throttled_url },
         status: :too_many_requests,
-      } if is_throttled
+      } if throttled?
 
       result = document_capture_session.load_result ||
                document_capture_session.load_doc_auth_async_result
@@ -36,7 +36,7 @@ module Idv
       @document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
     end
 
-    def is_throttled
+    def throttled?
       Throttler::IsThrottled.call(document_capture_session.user_id, :idv_acuant)
     end
   end

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -11,8 +11,7 @@ module Idv
     private
 
     def document_capture_session_poll_render_result
-      return { json: nil, status: :unauthorized } unless flow_session
-      return { json: nil, status: :unauthorized } unless document_capture_session
+      return { json: nil, status: :unauthorized } if !flow_session || !document_capture_session
       return { json: nil, status: :gone } if document_capture_session.cancelled_at
       return {
         json: { redirect: idv_session_errors_throttled_url },

--- a/app/javascript/packages/document-capture-polling/index.js
+++ b/app/javascript/packages/document-capture-polling/index.js
@@ -22,7 +22,7 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
  */
 
 /**
- * @enum
+ * @enum {string}
  */
 const ResultType = {
   SUCCESS: 'SUCCESS',

--- a/app/javascript/packages/document-capture-polling/index.js
+++ b/app/javascript/packages/document-capture-polling/index.js
@@ -22,6 +22,15 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
  */
 
 /**
+ * @enum {number}
+ */
+const StatusCodes = {
+  SUCCESS: 200,
+  GONE: 410,
+  TOO_MANY_REQUESTS: 429,
+};
+
+/**
  * @enum {string}
  */
 const ResultType = {
@@ -105,15 +114,15 @@ export class DocumentCapturePolling {
     const response = await window.fetch(this.statusEndpoint);
 
     switch (response.status) {
-      case 200:
+      case StatusCodes.SUCCESS:
         this.onComplete();
         break;
 
-      case 410:
+      case StatusCodes.GONE:
         this.onComplete({ result: ResultType.CANCELLED });
         break;
 
-      case 429: {
+      case StatusCodes.TOO_MANY_REQUESTS: {
         const { redirect } = await response.json();
         this.onComplete({ result: ResultType.THROTTLED, redirect });
         break;

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -33,7 +33,6 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(401)
-        expect(response.body).to eq('Unauthorized')
       end
     end
 
@@ -44,7 +43,6 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(401)
-        expect(response.body).to eq('Unauthorized')
       end
     end
 
@@ -58,7 +56,19 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(410)
-        expect(response.body).to eq('Cancelled')
+      end
+    end
+
+    context 'when the user is throttled' do
+      before do
+        allow(Throttler::IsThrottled).to receive(:call).with(user.id, :idv_acuant).and_return(true)
+      end
+
+      it 'returns throttled with redirect' do
+        get :show
+
+        expect(response.status).to eq(429)
+        expect(JSON.parse(response.body)).to include('redirect')
       end
     end
 
@@ -67,7 +77,6 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(202)
-        expect(response.body).to eq('Pending')
       end
     end
 
@@ -86,7 +95,6 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(401)
-        expect(response.body).to eq('Unauthorized')
       end
     end
 
@@ -105,7 +113,6 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(200)
-        expect(response.body).to eq('Complete')
       end
     end
   end

--- a/spec/javascripts/support/dom.js
+++ b/spec/javascripts/support/dom.js
@@ -76,7 +76,6 @@ export function useCleanDOM() {
     while (document.body.firstChild) {
       document.body.removeChild(document.body.firstChild);
     }
+    window.location.hash = '';
   });
-
-  window.location.hash = '';
 }


### PR DESCRIPTION
**Why**: As a user, I expect that if I encounter rate-limiting within the mobile document capture session that my desktop "Link sent" screen is updated to reflect this, so that I'm kept informed of the current progress of the hybrid session, and that I'm not waiting for the page to update if there's no chance that it will.