### PR TITLE
LG-4472: defer to the SP for default IAL level

### DIFF
--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -27,7 +27,11 @@ module FederatedProtocols
     attr_reader :request
 
     def default_authn_context
-      ::Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      if current_service_provider&.ial
+        ::Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[current_service_provider.ial]
+      else
+        ::Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      end
     end
 
     def current_service_provider

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -35,7 +35,7 @@ class ServiceProviderRequestHandler
 
   def sp_stored_in_session
     return if sp_request_id.blank?
-    ServiceProviderRequestProxy.from_uuid(sp_session[:request_id]).issuer
+    ServiceProviderRequestProxy.from_uuid(sp_request_id).issuer
   end
 
   def pull_request_id_from_current_sp_session_id

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -417,13 +417,10 @@ module SamlAuthHelper
     saml_authn_request
   end
 
-  def visit_idp_from_saml_sp(saml_overrides: {}, saml_security_overrides: {})
+  def visit_idp_from_saml_sp(saml_overrides: {})
     settings = saml_settings.dup
-    saml_overrides.each do |setting,value|
+    saml_overrides.each do |setting, value|
       settings.send("#{setting}=", value)
-    end
-    saml_security_overrides.each do |setting,value|
-      settings.security[setting] = value
     end
     @saml_authn_request = auth_request.create(settings)
     visit @saml_authn_request

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -417,6 +417,18 @@ module SamlAuthHelper
     saml_authn_request
   end
 
+  def visit_idp_from_saml_sp(saml_overrides: {}, saml_security_overrides: {})
+    settings = saml_settings.dup
+    saml_overrides.each do |setting,value|
+      settings.send("#{setting}=", value)
+    end
+    saml_security_overrides.each do |setting,value|
+      settings.security[setting] = value
+    end
+    @saml_authn_request = auth_request.create(settings)
+    visit @saml_authn_request
+  end
+
   private
 
   def link_user_to_identity(user, link, settings)


### PR DESCRIPTION
If a SAML SP is configured with IAL2, then a 500 error is displayed when authenticating with the "Sign in with your government employee ID" link

**Reproduction steps:**

1. Ensure you have an IAL2 verified account, configured with your PIV card
1. Go to the sample SAML app, choose `ServiceProvider configuration` for IAL level and sign in
1. Select "Sign in with your government employee ID"
1. Login with a PIV card

**Observed behaviour:**
A 500 error is displayed "undefined method `[]' for nil:NilClass"

**Expected behaviour:**
The user should be prompted for their password so PII can be decrypted