### PR TITLE
LG-3452 Updating the doc-auth gem and adding the acuant http error translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
 @aamva_api_gem ||= { github: '18F/identity-aamva-api-client-gem', tag: 'v4.2.0' }
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.9.1' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.9.2' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @lexisnexis_api_gem ||= { github: '18F/identity-lexisnexis-api-client-gem', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 589e750db2e3c04af74062bcd47af28b6bccb318
-  tag: v0.9.1
+  revision: 8c502903130a272fa08937be820e4bbd753b5a6f
+  tag: v0.9.2
   specs:
-    identity-doc-auth (0.9.1)
+    identity-doc-auth (0.9.2)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -73,6 +73,12 @@ module DocAuthRouter
     IdentityDocAuth::Errors::GLARE_LOW_ONE_SIDE => 'doc_auth.errors.glare.top_msg',
     # i18n-tasks-use t('doc_auth.errors.glare.top_msg_plural')
     IdentityDocAuth::Errors::GLARE_LOW_BOTH_SIDES => 'doc_auth.errors.glare.top_msg_plural',
+    # i18n-tasks-use t('doc_auth.errors.http.image_load')
+    IdentityDocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load',
+    # i18n-tasks-use t('doc_auth.errors.http.pixel_depth')
+    IdentityDocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth',
+    # i18n-tasks-use t('doc_auth.errors.http.image_size')
+    IdentityDocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size',
   }.freeze
 
   class DocAuthErrorTranslatorProxy

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -74,7 +74,7 @@ en:
         image_load: There is something wrong with your image file. Please take new
           photos of your ID and try again.
         image_size: You image size is too large or too small. Please add images of your
-          ID that are about 2025 x 1275.
+          ID that are about 2025 x 1275 pixels.
         pixel_depth: The pixel depth of your image file is not supported. Please take
           new photos of your ID and try again. Supported image pixel depth is
           24-bit RGB.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -70,6 +70,14 @@ en:
           flash on your camera is off and try taking a new picture.
         top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make sure
           that the flash on your camera is off and try taking new pictures.
+      http:
+        image_load: There is something wrong with your image file. Please take new
+          photos of your ID and try again.
+        image_size: You image size is too large or too small. Please add images of your
+          ID that are about 2025 x 1275.
+        pixel_depth: The pixel depth of your image file is not supported. Please take
+          new photos of your ID and try again. Supported image pixel depth is
+          24-bit RGB.
       no_camera:
         explanation: To continue, sign in to your login.gov account on any device that
           has a camera, like a mobile phone, tablet or computer with a webcam.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -90,6 +90,16 @@ es:
         top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos
           tengan reflejos. Asegúrese de que el flash de su cámara esté
           desactivado e intente tomar nuevas fotos.
+      http:
+        image_load: Hay un error en su archivo de imagen. Procure tomar nuevas fotos de
+          su documento de identidad e inténtelo nuevamente.
+        image_size: El tamaño de la imagen es demasiado grande o demasiado pequeño.
+          Añada imágenes de su documento de identidad de unos 2025 x 1275
+          píxeles.
+        pixel_depth: No es compatible con la profundidad de píxeles de su archivo de
+          imagen. Tome nuevas fotos de su documento de identidad e inténtelo
+          nuevamente. La profundidad de píxeles de la imagen admitida es de 24
+          bits RGB.
       no_camera:
         explanation: Recopilaremos información sobre usted leyendo su documento de
           identidad expedido por el estado. Luego, se tomará una foto para

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -94,6 +94,16 @@ fr:
         top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Vos photos
           peuvent avoir des reflets. Assurez-vous que le flash de votre appareil
           photo est désactivé puis essayez de prendre de nouvelles photos.
+      http:
+        image_load: Il y a un problème avec votre fichier image. Veuillez prendre de
+          nouvelles photos de votre pièce d'identité et réessayer.
+        image_size: La taille de votre image est trop grande ou trop petite. Veuillez
+          ajouter des images de votre pièce d'identité d'environ 2025 x 1275
+          pixels.
+        pixel_depth: La profondeur de pixel de votre fichier image n'est pas supportée.
+          Veuillez prendre de nouvelles photos de votre pièce d'identité et
+          réessayer. La profondeur de pixel de l'image prise en charge est de 24
+          bits RGB.
       no_camera:
         explanation: Nous recueillons des informations vous concernant en lisant votre
           carte d’identité délivrée par l’État. Ensuite, vous prendrez une photo

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe DocAuthRouter do
           errors: {
             general: [IdentityDocAuth::Errors::IMAGE_LOAD_FAILURE],
           },
-          exception: IdentityDocAuth::RequestError.new('Test 438 HTTP failure', 438)
+          exception: IdentityDocAuth::RequestError.new('Test 438 HTTP failure', 438),
         ),
       )
 

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -211,5 +211,23 @@ RSpec.describe DocAuthRouter do
         end
       end
     end
+
+    it 'translates http response errors and maintains exceptions' do
+      IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
+        method: :post_images,
+        response: IdentityDocAuth::Response.new(
+          success: false,
+          errors: {
+            general: [IdentityDocAuth::Errors::IMAGE_LOAD_FAILURE],
+          },
+          exception: IdentityDocAuth::RequestError.new('Test 438 HTTP failure', 438)
+        ),
+      )
+
+      response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
+
+      expect(response.errors).to eq(general: [I18n.t('doc_auth.errors.http.image_load')])
+      expect(response.exception.message).to eq('Test 438 HTTP failure')
+    end
   end
 end


### PR DESCRIPTION
LG-3452 Updating the doc-auth gem and adding the acuant http status code error translations.