### PR TITLE
Heartbeat Job (LG-4613)

### DIFF
--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -1,0 +1,7 @@
+class HeartbeatJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    true
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -206,3 +206,17 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   timeout: 300,
   callback: -> { Agreements::Reports::PartnerApiReport.new.run },
 )
+
+if IdentityConfig.store.ruby_workers_enabled
+  # Queue heartbeat job to DelayedJob
+  JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
+    name: 'Job Queue Heartbeat',
+    interval: 5 * 60, # 5 minutes
+    timeout: 4 * 60,
+    callback: -> do
+      HeartbeatJob.perform_later
+    end,
+    health_critical: false,
+    failures_before_alarm: 0,
+  )
+end

--- a/spec/jobs/heartbeat_job_spec.rb
+++ b/spec/jobs/heartbeat_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe HeartbeatJob, type: :job do
+  describe '#perform' do
+    it 'returns true' do
+      result = HeartbeatJob.new.perform
+
+      expect(result).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Creates a regularly scheduled heartbeat job for use by metrics to be able to ensure jobs are moving