### PR TITLE
Invert "not_to have" as "to have_no" in feature specs

### DIFF
--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -59,7 +59,7 @@ feature 'doc auth verify step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -53,7 +53,7 @@ feature 'doc auth document capture step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 
@@ -191,7 +191,7 @@ feature 'doc auth document capture step' do
     end
 
     it 'does not show the selfie upload option' do
-      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+      expect(page).to have_no_content(t('doc_auth.headings.document_capture_selfie'))
     end
 
     it 'displays document capture tips' do
@@ -204,9 +204,9 @@ feature 'doc auth document capture step' do
     end
 
     it 'does not display selfie tips' do
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
     end
 
     it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -32,7 +32,7 @@ feature 'doc auth email sent step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -135,7 +135,7 @@ feature 'doc auth link sent step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -136,7 +136,7 @@ feature 'doc auth send link step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -50,7 +50,7 @@ feature 'doc auth ssn step' do
       let(:ial2_step_indicator_enabled) { false }
 
       it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
+        expect(page).to have_no_css('.step-indicator')
       end
     end
   end
@@ -107,7 +107,7 @@ feature 'doc auth ssn step' do
       let(:ial2_step_indicator_enabled) { false }
 
       it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
+        expect(page).to have_no_css('.step-indicator')
       end
     end
   end

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -66,7 +66,7 @@ feature 'doc auth upload step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -157,7 +157,7 @@ feature 'doc auth verify step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 

--- a/spec/features/idv/doc_capture/capture_complete_step_spec.rb
+++ b/spec/features/idv/doc_capture/capture_complete_step_spec.rb
@@ -32,7 +32,7 @@ feature 'capture complete step' do
     let(:ial2_step_indicator_enabled) { false }
 
     it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
+      expect(page).to have_no_css('.step-indicator')
     end
   end
 end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -97,7 +97,7 @@ feature 'doc capture document capture step' do
       let(:ial2_step_indicator_enabled) { false }
 
       it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
+        expect(page).to have_no_css('.step-indicator')
       end
     end
 
@@ -120,7 +120,7 @@ feature 'doc capture document capture step' do
       end
 
       it 'does not show the selfie upload option' do
-        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+        expect(page).to have_no_content(t('doc_auth.headings.document_capture_selfie'))
       end
 
       it 'displays doc capture tips' do
@@ -133,9 +133,9 @@ feature 'doc capture document capture step' do
       end
 
       it 'does not display selfie tips' do
-        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
-        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
-        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
+        expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+        expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+        expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
     end
 
@@ -253,7 +253,7 @@ feature 'doc capture document capture step' do
     end
 
     it 'does not show the selfie upload option' do
-      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+      expect(page).to have_no_content(t('doc_auth.headings.document_capture_selfie'))
     end
 
     it 'displays document capture tips' do
@@ -266,9 +266,9 @@ feature 'doc capture document capture step' do
     end
 
     it 'does not display selfie tips' do
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
-      expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+      expect(page).to have_no_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
     end
 
     it 'proceeds to the next page with valid info' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -287,7 +287,7 @@ feature 'Two Factor Authentication' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
 
-      expect(page).not_to have_link(t('two_factor_authentication.piv_cac_fallback.question'))
+      expect(page).to have_no_link(t('two_factor_authentication.piv_cac_fallback.question'))
     end
   end
 

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -38,7 +38,7 @@ feature 'Password recovery via personal key' do
 
     visit account_path
 
-    expect(page).not_to have_content(t('headings.account.verified_account'))
+    expect(page).to have_no_content(t('headings.account.verified_account'))
 
     click_link t('account.index.reactivation.link')
     click_on t('links.account.reactivate.without_key')
@@ -89,7 +89,7 @@ feature 'Password recovery via personal key' do
       click_on t('links.account.reactivate.without_key')
       click_on t('links.cancel')
 
-      expect(page).not_to have_content('[id="reactivate-account-modal"]')
+      expect(page).to have_no_content('[id="reactivate-account-modal"]')
     end
   end
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -137,7 +137,7 @@ def sign_up_and_view_personal_key
 end
 
 def expect_confirmation_modal_to_appear_with_first_code_field_in_focus
-  expect(page).not_to have_xpath("//div[@id='personal-key-confirm'][@class='display-none']")
+  expect(page).to have_no_xpath("//div[@id='personal-key-confirm'][@class='display-none']")
   expect(page.evaluate_script('document.activeElement.name')).to eq 'personal_key'
 end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -11,7 +11,7 @@ feature 'Sign Up' do
 
       sign_up
 
-      expect(page).not_to have_content t('errors.messages.confirmation_invalid_token')
+      expect(page).to have_no_content t('errors.messages.confirmation_invalid_token')
     end
 
     scenario 'with invalid token' do
@@ -20,7 +20,7 @@ feature 'Sign Up' do
 
       sign_up
 
-      expect(page).not_to have_content t('errors.messages.confirmation_invalid_token')
+      expect(page).to have_no_content t('errors.messages.confirmation_invalid_token')
     end
 
     scenario 'with no token and an email address that contains a nil token' do
@@ -30,7 +30,7 @@ feature 'Sign Up' do
 
       sign_up
 
-      expect(page).not_to have_content t('errors.messages.confirmation_invalid_token')
+      expect(page).to have_no_content t('errors.messages.confirmation_invalid_token')
     end
   end
 

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -70,7 +70,7 @@ feature 'verify profile with OTP' do
       end
 
       it 'does not show step indicator progress' do
-        expect(page).not_to have_css('.step-indicator')
+        expect(page).to have_no_css('.step-indicator')
       end
     end
   end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -178,10 +178,10 @@ feature 'Password Recovery' do
     context 'when password form values are invalid' do
       it 'does not allow the user to submit until password score is good', js: true do
         fill_in t('forms.passwords.edit.labels.password'), with: 'invalid'
-        expect(page).not_to have_button(t('forms.passwords.edit.buttons.submit'))
+        expect(page).to have_no_button(t('forms.passwords.edit.buttons.submit'))
 
         fill_in t('forms.passwords.edit.labels.password'), with: 'password@132!'
-        expect(page).not_to have_button(t('forms.passwords.edit.buttons.submit'))
+        expect(page).to have_no_button(t('forms.passwords.edit.buttons.submit'))
 
         fill_in t('forms.passwords.edit.labels.password'), with: 'a unique and exciting zxjsahfas'
         expect(page).to have_button(t('forms.passwords.edit.buttons.submit'))

--- a/spec/support/idv_examples/confirmation_step.rb
+++ b/spec/support/idv_examples/confirmation_step.rb
@@ -42,7 +42,7 @@ shared_examples 'idv confirmation step' do |sp|
         let(:ial2_step_indicator_enabled) { false }
 
         it 'does not show step indicator progress' do
-          expect(page).not_to have_css('.step-indicator')
+          expect(page).to have_no_css('.step-indicator')
         end
       end
     end
@@ -97,7 +97,7 @@ shared_examples 'idv confirmation step' do |sp|
             '.step-indicator__step--current',
             text: t('step_indicator.flows.idv.secure_account'),
           )
-          expect(page).not_to have_css('.step-indicator__step--pending')
+          expect(page).to have_no_css('.step-indicator__step--pending')
         end
       end
 
@@ -105,7 +105,7 @@ shared_examples 'idv confirmation step' do |sp|
         let(:ial2_step_indicator_enabled) { false }
 
         it 'does not show step indicator progress' do
-          expect(page).not_to have_css('.step-indicator')
+          expect(page).to have_no_css('.step-indicator')
         end
       end
     end


### PR DESCRIPTION
**Why**: Theorizing that we're waiting `Capybara.default_max_wait_time` (0.5s) for each instance of this where we expect it not to exist.

See: https://www.cloudbees.com/blog/faster-rails-tests/