### PR TITLE
LG-4598: Remove the step indicator feature flag

### DIFF
--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -26,7 +26,6 @@ module Idv
     private
 
     def step_indicator_steps
-      return [] if !IdentityConfig.store.ial2_step_indicator_enabled
       steps = Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
       return steps if idv_session.address_verification_mechanism != 'gpo'
       steps.map do |step|

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -54,7 +54,6 @@ module Idv
     private
 
     def step_indicator_steps
-      return [] if !IdentityConfig.store.ial2_step_indicator_enabled
       steps = Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
       return steps if idv_session.address_verification_mechanism != 'gpo'
       steps.map do |step|

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -150,7 +150,6 @@ module Flow
     end
 
     def step_indicator_params
-      return if !IdentityConfig.store.ial2_step_indicator_enabled
       handler = flow.step_handler(current_step)
       return if !flow.class.const_defined?('STEP_INDICATOR_STEPS') || !handler
       {

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-      current_step: :verify_info,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+    current_step: :verify_info,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('titles.doc_auth.verify') %>

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -1,14 +1,12 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
-        step[:name] == :secure_account ? step.merge(status: :complete) : step
-      end,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
+      step[:name] == :secure_account ? step.merge(status: :complete) : step
+    end,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <%= image_tag(asset_url('come-back.svg'),

--- a/app/views/idv/confirmations/show.html.erb
+++ b/app/views/idv/confirmations/show.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: @step_indicator_steps,
-      current_step: :secure_account,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: @step_indicator_steps,
+    current_step: :secure_account,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('titles.personal_key') %>

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <div class="margin-top-neg-2">

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('titles.doc_auth.otp_delivery') %>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('titles.enter_2fa_code') %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <div id="form-steps-wait-alert">

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -1,12 +1,10 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: @step_indicator_steps,
-      current_step: :secure_account,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: @step_indicator_steps,
+    current_step: :secure_account,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('idv.titles.review') %>

--- a/app/views/users/verify_account/index.html.erb
+++ b/app/views/users/verify_account/index.html.erb
@@ -1,14 +1,12 @@
-<% if IdentityConfig.store.ial2_step_indicator_enabled %>
-  <% content_for(:pre_flash_content) do %>
-    <%= render 'shared/step_indicator', {
-      steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
-        step[:name] == :secure_account ? step.merge(status: :complete) : step
-      end,
-      current_step: :verify_phone_or_address,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-    } %>
-  <% end %>
+<% content_for(:pre_flash_content) do %>
+  <%= render 'shared/step_indicator', {
+    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
+      step[:name] == :secure_account ? step.merge(status: :complete) : step
+    end,
+    current_step: :verify_phone_or_address,
+    locale_scope: 'idv',
+    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  } %>
 <% end %>
 
 <% title t('titles.verify_profile') %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -73,7 +73,6 @@ exception_recipients: user1@example.com,user2@example.com
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 gpo_designated_receiver_pii: '{}'
 hide_phone_mfa_signup: 'false'
-ial2_step_indicator_enabled: 'true'
 identity_pki_disabled: 'false'
 identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '6'
@@ -273,7 +272,6 @@ production:
   enable_usps_verification: 'false'
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'
-  ial2_step_indicator_enabled: 'false'
   issuers_with_email_nameid_format: sp1,sp2
   logins_per_ip_limit: '20'
   logins_per_ip_period: '20'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -130,7 +130,6 @@ class IdentityConfig
     config.add(:hide_phone_mfa_signup, type: :boolean)
     config.add(:hmac_fingerprinter_key, type: :string)
     config.add(:hmac_fingerprinter_key_queue, type: :json)
-    config.add(:ial2_step_indicator_enabled, type: :boolean)
     config.add(:identity_pki_disabled, type: :boolean)
     config.add(:identity_pki_local_dev, type: :boolean)
     config.add(:idv_attempt_window_in_hours, type: :integer)

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -179,18 +179,6 @@ describe Idv::ConfirmationsController do
           )
         end
       end
-
-      context 'ial2 step indicator disabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).and_return(false)
-        end
-
-        it 'assigns empty step indicator steps' do
-          get :show
-
-          expect(assigns(:step_indicator_steps)).to eq([])
-        end
-      end
     end
   end
 

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -4,11 +4,7 @@ feature 'doc auth verify step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
-
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_address_step
   end
@@ -46,20 +42,10 @@ feature 'doc auth verify step' do
     expect(page).to have_current_path(idv_doc_auth_welcome_step)
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_info'),
+    )
   end
 end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -4,15 +4,12 @@ feature 'doc auth document capture step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
   let(:max_attempts) { IdentityConfig.store.acuant_max_attempts }
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { false }
   let(:fake_analytics) { FakeAnalytics.new }
   let(:sp_name) { 'Test SP' }
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     allow(IdentityConfig.store).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
     allow(Identity::Hostdata::EC2).to receive(:load).
@@ -28,6 +25,13 @@ feature 'doc auth document capture step' do
     complete_doc_auth_steps_before_document_capture_step
   end
 
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
+  end
+
   context 'when javascript is enabled', js: true do
     it 'logs return to sp link click' do
       click_on t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name)
@@ -37,23 +41,6 @@ feature 'doc auth document capture step' do
         step: 'document_capture',
         location: 'documents_having_trouble',
       )
-    end
-  end
-
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
     end
   end
 

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -4,11 +4,7 @@ feature 'doc auth email sent step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
-
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_email_sent_step
   end
@@ -19,20 +15,10 @@ feature 'doc auth email sent step' do
     expect(page).to have_content(t('doc_auth.instructions.email_sent', email: user.email))
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -5,13 +5,10 @@ feature 'doc auth link sent step' do
   include DocAuthHelper
   include DocCaptureHelper
 
-  let(:ial2_step_indicator_enabled) { true }
   let(:user) { sign_in_and_2fa_user }
   let(:doc_capture_polling_enabled) { false }
 
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).
       and_return(doc_capture_polling_enabled)
     user
@@ -44,6 +41,13 @@ feature 'doc auth link sent step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+  end
+
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 
   context 'cancelled' do
@@ -121,21 +125,4 @@ feature 'doc auth link sent step' do
 
   it_behaves_like 'with doc capture polling enabled'
   it_behaves_like 'with doc capture polling disabled'
-
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
-  end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -4,11 +4,7 @@ feature 'doc auth send link step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
-
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_send_link_step
   end
@@ -123,20 +119,10 @@ feature 'doc auth send link step' do
     expect(document_capture_session).to have_attributes(requested_at: a_kind_of(Time))
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -6,11 +6,7 @@ feature 'doc auth ssn step' do
   include DocCaptureHelper
 
   context 'desktop' do
-    let(:ial2_step_indicator_enabled) { true }
-
     before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_ssn_step
     end
@@ -37,30 +33,16 @@ feature 'doc auth ssn step' do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
-    context 'ial2 step indicator enabled' do
-      it 'shows the step indicator' do
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.verify_info'),
-        )
-      end
-    end
-
-    context 'ial2 step indicator disabled' do
-      let(:ial2_step_indicator_enabled) { false }
-
-      it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
-      end
+    it 'shows the step indicator' do
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_info'),
+      )
     end
   end
 
   context 'doc capture hand-off' do
-    let(:ial2_step_indicator_enabled) { true }
-
     before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
       allow(Identity::Hostdata::EC2).to receive(:load).
         and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
       in_doc_capture_session { complete_doc_capture_steps_before_capture_complete_step }
@@ -94,21 +76,11 @@ feature 'doc auth ssn step' do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
-    context 'ial2 step indicator enabled' do
-      it 'shows the step indicator' do
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.verify_info'),
-        )
-      end
-    end
-
-    context 'ial2 step indicator disabled' do
-      let(:ial2_step_indicator_enabled) { false }
-
-      it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
-      end
+    it 'shows the step indicator' do
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_info'),
+      )
     end
   end
 end

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -4,11 +4,7 @@ feature 'doc auth upload step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
-
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_upload_step
   end
@@ -53,20 +49,10 @@ feature 'doc auth upload step' do
     end
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -4,13 +4,10 @@ feature 'doc auth verify step' do
   include IdvStepHelper
   include DocAuthHelper
 
-  let(:ial2_step_indicator_enabled) { true }
   let(:skip_step_completion) { false }
   let(:max_attempts) { idv_max_attempts }
   let(:fake_analytics) { FakeAnalytics.new }
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     unless skip_step_completion
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
@@ -144,21 +141,11 @@ feature 'doc auth verify step' do
     )
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_info'),
+    )
   end
 
   context 'when the user lives in an AAMVA supported state' do

--- a/spec/features/idv/doc_capture/capture_complete_step_spec.rb
+++ b/spec/features/idv/doc_capture/capture_complete_step_spec.rb
@@ -5,11 +5,7 @@ feature 'capture complete step' do
   include DocAuthHelper
   include DocCaptureHelper
 
-  let(:ial2_step_indicator_enabled) { true }
-
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     complete_doc_capture_steps_before_capture_complete_step
     allow_any_instance_of(DeviceDetector).to receive(:device_type).and_return('mobile')
   end
@@ -19,20 +15,10 @@ feature 'capture complete step' do
     expect(page).to have_content(t('doc_auth.headings.capture_complete'))
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    let(:ial2_step_indicator_enabled) { false }
-
-    it 'does not show the step indicator' do
-      expect(page).not_to have_css('.step-indicator')
-    end
+  it 'shows the step indicator' do
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -5,7 +5,6 @@ feature 'doc capture document capture step' do
   include DocAuthHelper
   include DocCaptureHelper
 
-  let(:ial2_step_indicator_enabled) { true }
   let(:max_attempts) { IdentityConfig.store.acuant_max_attempts }
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { true }
@@ -13,8 +12,6 @@ feature 'doc capture document capture step' do
   let(:fake_analytics) { FakeAnalytics.new }
   let(:sp_name) { 'Test SP' }
   before do
-    allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-      and_return(ial2_step_indicator_enabled)
     allow(IdentityConfig.store).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
     allow(Identity::Hostdata::EC2).to receive(:load).
@@ -75,30 +72,17 @@ feature 'doc capture document capture step' do
   end
 
   context 'when liveness checking is enabled' do
-    let(:ial2_step_indicator_enabled) { true }
     let(:liveness_enabled) { true }
 
     before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
       complete_doc_capture_steps_before_first_step(user)
     end
 
-    context 'ial2 step indicator enabled' do
-      it 'shows the step indicator' do
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.verify_id'),
-        )
-      end
-    end
-
-    context 'ial2 step indicator disabled' do
-      let(:ial2_step_indicator_enabled) { false }
-
-      it 'does not show the step indicator' do
-        expect(page).not_to have_css('.step-indicator')
-      end
+    it 'shows the step indicator' do
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     context 'when the SP does not request strict IAL2' do

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -16,6 +16,20 @@ feature 'verify profile with OTP' do
   end
 
   context 'GPO letter' do
+
+    it 'shows step indicator progress with current verify step, completed secure account' do
+      sign_in_live_with_2fa(user)
+
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_phone_or_address'),
+      )
+      expect(page).to have_css(
+        '.step-indicator__step--complete',
+        text: t('step_indicator.flows.idv.secure_account'),
+      )
+    end
+
     scenario 'valid OTP' do
       sign_in_live_with_2fa(user)
       fill_in t('forms.verify_profile.name'), with: otp
@@ -44,34 +58,6 @@ feature 'verify profile with OTP' do
       expect(current_path).to eq verify_account_path
       expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
       expect(page.body).to_not match('the wrong code')
-    end
-
-    context 'ial2 step indicator enabled' do
-      before do
-        sign_in_live_with_2fa(user)
-      end
-
-      it 'shows step indicator progress with current verify step, completed secure account' do
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.verify_phone_or_address'),
-        )
-        expect(page).to have_css(
-          '.step-indicator__step--complete',
-          text: t('step_indicator.flows.idv.secure_account'),
-        )
-      end
-    end
-
-    context 'ial2 step indicator disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).and_return(false)
-        sign_in_live_with_2fa(user)
-      end
-
-      it 'does not show step indicator progress' do
-        expect(page).not_to have_css('.step-indicator')
-      end
     end
   end
 end

--- a/spec/support/idv_examples/confirmation_step.rb
+++ b/spec/support/idv_examples/confirmation_step.rb
@@ -1,10 +1,6 @@
 shared_examples 'idv confirmation step' do |sp|
   context 'after choosing to verify by letter' do
-    let(:ial2_step_indicator_enabled) { true }
-
     before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
       start_idv_from_sp(sp)
       complete_idv_steps_with_gpo_before_confirmation_step
     end
@@ -25,35 +21,21 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     context 'user selected gpo verification' do
-      context 'ial2 step indicator enabled' do
-        it 'shows step indicator progress with pending verify phone step' do
-          expect(page).to have_css(
-            '.step-indicator__step--current',
-            text: t('step_indicator.flows.idv.secure_account'),
-          )
-          expect(page).to have_css(
-            '.step-indicator__step--pending',
-            text: t('step_indicator.flows.idv.verify_phone_or_address'),
-          )
-        end
-      end
-
-      context 'ial2 step indicator disabled' do
-        let(:ial2_step_indicator_enabled) { false }
-
-        it 'does not show step indicator progress' do
-          expect(page).not_to have_css('.step-indicator')
-        end
+      it 'shows step indicator progress with pending verify phone step' do
+        expect(page).to have_css(
+          '.step-indicator__step--current',
+          text: t('step_indicator.flows.idv.secure_account'),
+        )
+        expect(page).to have_css(
+          '.step-indicator__step--pending',
+          text: t('step_indicator.flows.idv.verify_phone_or_address'),
+        )
       end
     end
   end
 
   context 'after choosing to verify by phone' do
-    let(:ial2_step_indicator_enabled) { true }
-
     before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
       start_idv_from_sp(sp)
       complete_idv_steps_with_phone_before_confirmation_step
     end
@@ -91,22 +73,12 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     context 'user selected gpo verification' do
-      context 'ial2 step indicator enabled' do
-        it 'shows step indicator progress without pending verify step' do
-          expect(page).to have_css(
-            '.step-indicator__step--current',
-            text: t('step_indicator.flows.idv.secure_account'),
-          )
-          expect(page).not_to have_css('.step-indicator__step--pending')
-        end
-      end
-
-      context 'ial2 step indicator disabled' do
-        let(:ial2_step_indicator_enabled) { false }
-
-        it 'does not show step indicator progress' do
-          expect(page).not_to have_css('.step-indicator')
-        end
+      it 'shows step indicator progress without pending verify step' do
+        expect(page).to have_css(
+          '.step-indicator__step--current',
+          text: t('step_indicator.flows.idv.secure_account'),
+        )
+        expect(page).not_to have_css('.step-indicator__step--pending')
       end
     end
   end

--- a/spec/views/idv/come_back_later/show.html.erb_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.erb_spec.rb
@@ -55,30 +55,16 @@ describe 'idv/come_back_later/show.html.erb' do
     end
   end
 
-  context 'ial2 step indicator enabled' do
-    it 'shows step indicator with pending status' do
-      render
+  it 'shows step indicator with pending status' do
+    render
 
-      expect(view.content_for(:pre_flash_content)).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_phone_or_address'),
-      )
-      expect(view.content_for(:pre_flash_content)).to have_css(
-        '.step-indicator__step--complete',
-        text: t('step_indicator.flows.idv.secure_account'),
-      )
-    end
-  end
-
-  context 'ial2 step indicator disabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).and_return(false)
-    end
-
-    it 'does not show step indicator' do
-      render
-
-      expect(view.content_for(:pre_flash_content)).not_to have_css('.step-indicator')
-    end
+    expect(view.content_for(:pre_flash_content)).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_phone_or_address'),
+    )
+    expect(view.content_for(:pre_flash_content)).to have_css(
+      '.step-indicator__step--complete',
+      text: t('step_indicator.flows.idv.secure_account'),
+    )
   end
 end

--- a/spec/views/idv/review/new.html.erb_spec.rb
+++ b/spec/views/idv/review/new.html.erb_spec.rb
@@ -4,8 +4,6 @@ describe 'idv/review/new.html.erb' do
   include XPathHelper
 
   context 'user has completed all steps' do
-    let(:ial2_step_indicator_enabled) { true }
-
     before do
       user = build_stubbed(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(user)
@@ -21,8 +19,6 @@ describe 'idv/review/new.html.erb' do
         phone: '+1 (213) 555-0000',
       }
       @step_indicator_steps = Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
-      allow(IdentityConfig.store).to receive(:ial2_step_indicator_enabled).
-        and_return(ial2_step_indicator_enabled)
 
       render
     end
@@ -51,21 +47,11 @@ describe 'idv/review/new.html.erb' do
       expect(rendered).to have_content(t('idv.messages.review.intro'))
     end
 
-    context 'ial2 step indicator enabled' do
-      it 'shows the step indicator' do
-        expect(view.content_for(:pre_flash_content)).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.secure_account'),
-        )
-      end
-    end
-
-    context 'ial2 step indicator disabled' do
-      let(:ial2_step_indicator_enabled) { false }
-
-      it 'does not show the step indicator' do
-        expect(view.content_for(:pre_flash_content)).not_to have_css('.step-indicator')
-      end
+    it 'shows the step indicator' do
+      expect(view.content_for(:pre_flash_content)).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.secure_account'),
+      )
     end
   end
 end


### PR DESCRIPTION
Now that the step indicator is deployed, turned on in all environments, and loved by all, we no longer have a need to be able to turn it off. Thus the feature flag that controlled it's display has served its purpose, and is ready to retire to the feature flag farm in the country where it can spend its days relaxing with its friends.

Once this PR is deployed, we will need to go through all of the envs' settings to remove it there as well.