### PR TITLE
Fix always stale pii fingerprint

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -63,7 +63,7 @@ class Profile < ApplicationRecord
     @personal_key = personal_key
   end
 
-  def self.build_compound_pii_fingerprint(pii)
+  def self.build_compound_pii(pii)
     values = [
       pii.first_name,
       pii.last_name,
@@ -72,8 +72,7 @@ class Profile < ApplicationRecord
     ]
 
     return unless values.all?(&:present?)
-
-    Pii::Fingerprinter.fingerprint(values.join(':'))
+    values.join(':')
   end
 
   def includes_liveness_check?
@@ -93,8 +92,11 @@ class Profile < ApplicationRecord
   end
 
   def encrypt_compound_pii_fingerprint(pii)
-    compound_pii_fingerprint = self.class.build_compound_pii_fingerprint(pii)
-    self.name_zip_birth_year_signature = compound_pii_fingerprint if compound_pii_fingerprint
+    compound_pii = self.class.build_compound_pii(pii)
+
+    if compound_pii
+      self.name_zip_birth_year_signature = Pii::Fingerprinter.fingerprint(compound_pii)
+    end
   end
 
   def send_push_notifications

--- a/app/services/key_rotator/hmac_fingerprinter.rb
+++ b/app/services/key_rotator/hmac_fingerprinter.rb
@@ -26,7 +26,8 @@ module KeyRotator
         ssn_signature: ssn_fingerprint,
       }
 
-      if (compound_pii_fingerprint = Profile.build_compound_pii_fingerprint(pii_attributes))
+      if (compound_pii = Profile.build_compound_pii(pii_attributes))
+        compound_pii_fingerprint = Pii::Fingerprinter.fingerprint(compound_pii)
         columns_to_update[:name_zip_birth_year_signature] = compound_pii_fingerprint
       end
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -68,9 +68,9 @@ module Pii
       return false unless profile
       decrypted_pii = fetch
       return false unless decrypted_pii
-      fingerprint = Profile.build_compound_pii_fingerprint(decrypted_pii)
-      return false unless fingerprint
-      Pii::Fingerprinter.stale?(fingerprint, profile.name_zip_birth_year_signature)
+      compound_pii = Profile.build_compound_pii(decrypted_pii)
+      return false unless compound_pii
+      Pii::Fingerprinter.stale?(compound_pii, profile.name_zip_birth_year_signature)
     end
   end
 end

--- a/spec/services/device_tracking/create_device_spec.rb
+++ b/spec/services/device_tracking/create_device_spec.rb
@@ -6,24 +6,18 @@ describe DeviceTracking::CreateDevice do
   let(:remote_ip) { '1.2.3.4' }
   let(:user_agent) { 'Chrome/58.0.3029.110 Safari/537.36' }
   let(:uuid) { 'abc123' }
-  let(:device) { Device.all.first }
 
   it 'creates a new device' do
-    subject.call(user.id, remote_ip, user_agent, uuid)
-
-    expect_device_attribute(:cookie_uuid, uuid)
-    expect_device_attribute(:user_agent, user_agent)
-    expect_device_attribute(:last_ip, remote_ip)
+    device = subject.call(user.id, remote_ip, user_agent, uuid)
+    expect(device.cookie_uuid).to eq uuid
+    expect(device.user_agent).to eq user_agent
+    expect(device.last_ip).to eq remote_ip
     expect(device.last_used_at).to be_present
   end
 
   it 'uuid defaults to new random string if no cookie uuid is supplied' do
-    subject.call(user.id, remote_ip, user_agent, nil)
+    device = subject.call(user.id, remote_ip, user_agent, nil)
 
-    expect(Device.all.first.cookie_uuid.length).to eq(DeviceTracking::CreateDevice::COOKIE_LENGTH)
-  end
-
-  def expect_device_attribute(key, val)
-    expect(device.send(key)).to eq(val)
+    expect(device.cookie_uuid.length).to eq(DeviceTracking::CreateDevice::COOKIE_LENGTH)
   end
 end


### PR DESCRIPTION
Found a small bug during the stale check for compound PII where we were comparing the signature to the fingerprint of the fingerprint, leading to the PII to always be considered stale. This meant updating all of the signatures, etc. any time a user with a profile logged in.

The impact is relatively low, we'll save maybe tens of milliseconds on session creation for the small percentage of users that have a profile.