### PR TITLE
Seed ServiceProvider PEMs directly to database certs column

### DIFF
--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -13,14 +13,21 @@ class ServiceProviderSeeder
     service_providers.each do |issuer, config|
       next unless write_service_provider?(config)
       ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
+        cert_pems = Array(config['certs']).map do |cert|
+          cert_path = Rails.root.join('certs', 'sp', "#{cert}.crt")
+          cert_path.read if cert_path.exist?
+        end.compact
+
         sp.update(
           approved: true,
           active: true,
           native: true,
           friendly_name: config['friendly_name'],
+          certs: cert_pems,
         )
       end.update!(config.except(
         'agency',
+        'certs',
         'restrict_to_deploy_env',
         'uuid_priority',
         'protocol',

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -18,11 +18,14 @@ RSpec.describe ServiceProviderSeeder do
       expect { run }.to change(ServiceProvider, :count)
     end
 
-    it 'updates the plural certs column' do
+    it 'updates the plural certs column with the PEM content of certs' do
+      cert_names = ['saml_test_sp', 'saml_test_sp2']
+      pems = cert_names.map { |cert| Rails.root.join('certs', 'sp', "#{cert}.crt").read }
+
       run
 
       sp = ServiceProvider.from_issuer('http://localhost:3000')
-      expect(sp.certs).to eq(['saml_test_sp', 'saml_test_sp2'])
+      expect(sp.certs).to eq(pems)
     end
 
     context 'with other existing service providers in the database' do


### PR DESCRIPTION
**Why**: So we can share config data faster, instead of
having to wait on the local filesystem of each host to
update


Note:
Existing code already handles reading both cert names and PEMs from the DB (we use the PEM behavior mainly in INT/lower environments already):
https://github.com/18F/identity-idp/blob/main/spec/models/service_provider_spec.rb#L73-L100
