### PR TITLE
LG-4598: refactoring SAML specs

### DIFF
--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -1,4 +1,27 @@
 test:
+  'saml_sp':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    allow_prompt_login: true
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    certs:
+      - 'saml_test_sp'
+    friendly_name: 'Test SP'
+
+  'saml_sp_ial2':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    allow_prompt_login: true
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    certs:
+      - 'saml_test_sp'
+    friendly_name: 'Test SP'
+    ial: 2
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+
   'http://localhost:3000':
     acs_url: 'http://localhost:3000/test/saml/decode_assertion'
     assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -381,7 +381,7 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        generate_saml_response(user, invalid_service_provider_settings)
+        generate_saml_response(user, saml_settings(overrides: { issuer: 'invalid_provider' }))
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -408,7 +408,15 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        generate_saml_response(user, invalid_service_provider_and_authn_context_settings)
+        generate_saml_response(
+          user,
+          saml_settings(
+            overrides: {
+              issuer: 'invalid_provider',
+              authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
+            },
+          ),
+        )
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -292,7 +292,11 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        saml_get_auth(invalid_authn_context_settings)
+        saml_get_auth(
+          saml_settings(
+            overrides: { authn_context: 'http://idmanagement.gov/ns/assurance/loa/5' },
+          ),
+        )
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -372,7 +372,12 @@ describe SamlIdpController do
       it 'responds with an error page' do
         user = create(:user, :signed_up)
 
-        generate_saml_response(user, sp2_saml_settings_inactive)
+        generate_saml_response(
+          user,
+          saml_settings(
+            overrides: { issuer: 'http://localhost:3000/inactive_sp' },
+          ),
+        )
 
         expect(controller).to redirect_to sp_inactive_error_url
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -51,20 +51,24 @@ describe SamlIdpController do
     end
 
     let(:right_cert_settings) do
-      sp1_saml_settings.tap do |settings|
-        settings.issuer = service_provider.issuer
-        settings.assertion_consumer_logout_service_url = 'https://example.com'
-      end
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          assertion_consumer_logout_service_url: 'https://example.com',
+        },
+      )
     end
 
     let(:wrong_cert_settings) do
-      sp1_saml_settings.tap do |settings|
-        settings.issuer = service_provider.issuer
-        settings.certificate = File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt'))
-        settings.private_key = OpenSSL::PKey::RSA.new(
-          File.read(Rails.root + 'keys/saml_test_sp2.key'),
-        ).to_pem
-      end
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
+          private_key: OpenSSL::PKey::RSA.new(
+            File.read(Rails.root + 'keys/saml_test_sp2.key'),
+          ).to_pem,
+        },
+      )
     end
 
     it 'accepts requests from a correct cert' do

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -43,7 +43,12 @@ describe SamlIdpController do
 
       context 'with signed_response_message_requested false' do
         before do
-          generate_saml_response(user, sp_not_requesting_signed_saml_response_settings)
+          generate_saml_response(
+            user,
+            saml_settings(
+              overrides: { issuer: 'test_saml_sp_not_requesting_signed_response_message' },
+            ),
+          )
         end
 
         it 'only finds one Signature' do

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -15,7 +15,7 @@ feature 'SAML Authorization Confirmation' do
       check :remember_device
       fill_in_code_with_last_phone_otp
       click_submit_default
-      visit saml_authn_request
+      visit request_url
       click_agree_and_continue
       visit sign_out_url
 
@@ -24,7 +24,7 @@ feature 'SAML Authorization Confirmation' do
 
     let(:user1) { create_user_and_remember_device }
     let(:user2) { create_user_and_remember_device }
-    let(:saml_authn_request) { auth_request.create(saml_settings) }
+    let(:request_url) { saml_authn_request_url }
 
     before do
       # Cycle user2 first so user1's remember device will stick
@@ -35,18 +35,18 @@ feature 'SAML Authorization Confirmation' do
     it 'it confirms the user wants to continue to the SP after signing in again' do
       sign_in_user(user1)
 
-      visit saml_authn_request
+      visit request_url
 
       expect(current_url).to match(user_authorization_confirmation_path)
       continue_as(user1.email)
 
-      expect(current_url).to eq(saml_authn_request)
+      expect(current_url).to eq(request_url)
     end
 
     it 'it allows the user to switch accounts prior to continuing to the SP' do
       sign_in_user(user1)
 
-      visit saml_authn_request
+      visit request_url
       expect(current_url).to match(user_authorization_confirmation_path)
       continue_as(user2.email, user2.password)
 
@@ -54,12 +54,12 @@ feature 'SAML Authorization Confirmation' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_url).to eq(saml_authn_request)
+      expect(current_url).to eq(request_url)
     end
 
     it 'does not render an error if a user goes back after opting to switch accounts' do
       sign_in_user(user1)
-      visit saml_authn_request
+      visit request_url
 
       expect(current_path).to eq(user_authorization_confirmation_path)
 

--- a/spec/features/saml/ial1/account_creation_spec.rb
+++ b/spec/features/saml/ial1/account_creation_spec.rb
@@ -5,8 +5,7 @@ feature 'Canceling Account Creation' do
 
   context 'From the enter email page', email: true do
     it 'redirects to the branded start page' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       sp_request_id = ServiceProviderRequestProxy.last.uuid
       click_link t('links.create_account')
       click_link t('links.cancel')
@@ -17,8 +16,7 @@ feature 'Canceling Account Creation' do
 
   context 'From the enter password page', email: true do
     it 'redirects to the branded start page' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       click_link t('links.create_account')
       submit_form_with_valid_email
       click_confirmation_link_in_email('test@test.com')
@@ -32,8 +30,7 @@ feature 'Canceling Account Creation' do
     end
 
     it 'redirects to the password page after cancelling the cancellation' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       click_link t('links.create_account')
       submit_form_with_valid_email
       click_confirmation_link_in_email('test@test.com')

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -6,10 +6,10 @@ feature 'IAL1 Single Sign On' do
   context 'First time registration', email: true do
     it 'takes user to agency handoff page when sign up flow complete' do
       email = 'test@test.com'
-      authn_request = auth_request.create(saml_settings)
+      request_url = saml_authn_request_url
 
       perform_in_browser(:one) do
-        visit authn_request
+        visit request_url
         sign_up_user_from_sp_without_confirming_email(email)
       end
 
@@ -31,35 +31,34 @@ feature 'IAL1 Single Sign On' do
 
         continue_as(email)
 
-        expect(current_url).to eq authn_request
+        expect(current_url).to eq request_url
         expect(page.get_rack_session.keys).to include('sp')
       end
     end
 
     it 'takes user to the service provider, allows user to visit IDP' do
       user = create(:user, :signed_up)
-      saml_authn_request = auth_request.create(saml_settings)
+      request_url = saml_authn_request_url
 
-      visit saml_authn_request
+      visit request_url
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
       click_agree_and_continue
 
-      expect(current_url).to eq saml_authn_request
+      expect(current_url).to eq request_url
 
       visit root_path
       expect(current_path).to eq account_path
     end
 
     it 'shows user the start page without accordion' do
-      saml_authn_request = auth_request.create(saml_settings)
       sp_content = [
         'Your friendly Government Agency',
         t('headings.create_account_with_sp.sp_text'),
       ].join(' ')
 
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(current_url).to match new_user_session_path
       expect(page).to have_content(sp_content)
@@ -67,9 +66,7 @@ feature 'IAL1 Single Sign On' do
     end
 
     it 'shows user the start page with a link back to the SP' do
-      saml_authn_request = auth_request.create(saml_settings)
-
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(page).to have_link(
         t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: return_to_sp_cancel_path
@@ -78,9 +75,9 @@ feature 'IAL1 Single Sign On' do
 
     it 'after session timeout, signing in takes user back to SP' do
       user = create(:user, :signed_up)
-      saml_authn_request = auth_request.create(saml_settings)
+      request_url = saml_authn_request_url
 
-      visit saml_authn_request
+      visit request_url
       sp_request_id = ServiceProviderRequestProxy.last.uuid
 
       visit timeout_path
@@ -91,13 +88,13 @@ feature 'IAL1 Single Sign On' do
       click_submit_default
       click_agree_and_continue
 
-      expect(current_url).to eq saml_authn_request
+      expect(current_url).to eq request_url
     end
   end
 
   context 'fully signed up user authenticates new sp' do
     let(:user) { create(:user, :signed_up) }
-    let(:saml_authn_request) { auth_request.create(saml_settings) }
+    let(:saml_authn_request) { saml_authn_request_url }
 
     before do
       sign_in_user(user)
@@ -139,8 +136,7 @@ feature 'IAL1 Single Sign On' do
       user = create(:user, :signed_up)
       sign_in_user(user)
 
-      saml_authn_request = auth_request.create(saml_settings)
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
     end
@@ -150,8 +146,7 @@ feature 'IAL1 Single Sign On' do
     it 'prompts to set up 2FA' do
       sign_in_user
 
-      saml_authn_request = auth_request.create(saml_settings)
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(current_path).to eq two_factor_options_path
     end
@@ -159,8 +154,7 @@ feature 'IAL1 Single Sign On' do
 
   context 'visiting IdP via SP, then using the language selector' do
     it 'preserves the request_id in the url' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
 
       within(:css, '.i18n-desktop-dropdown', visible: false) do
         find_link(t('i18n.locale.es'), visible: false).click
@@ -172,12 +166,12 @@ feature 'IAL1 Single Sign On' do
 
   context 'visiting IdP via SP, then going back to SP and visiting IdP again' do
     it 'displays the branded page' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      request_url = saml_authn_request_url
+      visit request_url
 
       expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
 
-      visit authn_request
+      visit request_url
 
       expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
     end
@@ -186,9 +180,8 @@ feature 'IAL1 Single Sign On' do
   context 'canceling sign in after email and password' do
     it 'returns to the branded landing page' do
       user = create(:user, :signed_up)
-      authn_request = auth_request.create(saml_settings)
 
-      visit authn_request
+      visit saml_authn_request_url
       fill_in_credentials_and_submit(user.email, user.password)
       sp_request_id = ServiceProviderRequestProxy.last.uuid
       sp = ServiceProvider.from_issuer('http://localhost:3000')
@@ -202,7 +195,15 @@ feature 'IAL1 Single Sign On' do
   context 'requesting verified_at for an IAL1 account' do
     it 'shows verified_at as a requested attribute, even if blank' do
       user = create(:user, :signed_up)
-      saml_authn_request = auth_request.create(ial1_with_verified_at_saml_settings)
+      saml_authn_request = saml_authn_request_url(
+        saml_overrides: {
+          issuer: 'saml_sp_ial2',
+          authn_context: [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
+          ],
+        },
+      )
 
       visit saml_authn_request
       fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -5,9 +5,22 @@ feature 'IAL2 Single Sign On' do
   include IdvStepHelper
   include DocAuthHelper
 
+  def saml_ial2_request_url
+    saml_authn_request_url(
+      saml_overrides: {
+        issuer: 'saml_sp_ial2',
+        authn_context: [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+        # name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+      },
+    )
+  end
+
   def perform_id_verification_with_gpo_without_confirming_code(user)
-    saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
-    visit saml_authn_request
+    visit saml_ial2_request_url
     fill_in_credentials_and_submit(user.email, user.password)
     uncheck(t('forms.messages.remember_device'))
     fill_in_code_with_last_phone_otp
@@ -23,7 +36,7 @@ feature 'IAL2 Single Sign On' do
 
   def expected_gpo_return_to_sp_url
     URI.join(
-      ServiceProvider.find_by(issuer: ial2_with_bundle_saml_settings.issuer).acs_url,
+      ServiceProvider.find_by(issuer: 'saml_sp_ial2').acs_url,
       '/',
     ).to_s
   end
@@ -46,27 +59,21 @@ feature 'IAL2 Single Sign On' do
 
   context 'First time registration' do
     let(:email) { 'test@test.com' }
-    before do
-      @saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
-    end
 
     it 'shows user the start page with accordion' do
-      saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
       sp_content = [
         'Test SP',
         t('headings.create_account_with_sp.sp_text'),
       ].join(' ')
 
-      visit saml_authn_request
+      visit saml_ial2_request_url
 
       expect(current_path).to match new_user_session_path
       expect(page).to have_content(sp_content)
     end
 
     it 'shows user the start page with a link back to the SP' do
-      saml_authn_request = auth_request.create(saml_settings)
-
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(page).to have_link(
         t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: return_to_sp_cancel_path
@@ -186,14 +193,14 @@ feature 'IAL2 Single Sign On' do
     context 'returning to verify after canceling during the same session' do
       it 'allows the user to verify' do
         user = create(:user, :signed_up)
-        saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
+        request_url = saml_ial2_request_url
 
-        visit saml_authn_request
+        visit request_url
         sign_in_live_with_2fa(user)
         complete_all_doc_auth_steps
         click_on t('links.cancel')
         click_on t('forms.buttons.cancel')
-        visit saml_authn_request
+        visit request_url
         complete_all_doc_auth_steps
 
         expect(current_path).to eq idv_phone_path

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -4,17 +4,17 @@ feature 'SAML logout' do
   include SamlAuthHelper
 
   let(:user) { create(:user, :signed_up) }
-  let(:sp_saml_settings) { sp1_saml_settings }
-  let(:service_provider) { ServiceProvider.from_issuer(sp_saml_settings.issuer) }
 
   context 'with a SAML request' do
     context 'when logging out from the SP' do
       it 'contains all redirect_uris in CSP when user is logged out of the IDP' do
         sign_in_and_2fa_user(user)
-        visit auth_request.create(sp_saml_settings)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: 'saml_sp_ial2',
+          },
+        )
         click_continue
-
-        settings = sp_saml_settings.dup
 
         # Sign out of the IDP
         visit account_path
@@ -22,8 +22,11 @@ feature 'SAML logout' do
         expect(current_path).to eq root_path
 
         # SAML logout request
-        request = OneLogin::RubySaml::Logoutrequest.new
-        visit request.create(settings)
+        visit_saml_logout_request_url(
+          saml_overrides: {
+            issuer: 'saml_sp_ial2',
+          },
+        )
 
         # contains all redirect_uris in content security policy
         expect(page.response_headers['Content-Security-Policy']).to include(
@@ -34,14 +37,19 @@ feature 'SAML logout' do
 
       it 'contains all redirect_uris in CSP when user is logged in to the IDP' do
         sign_in_and_2fa_user(user)
-        visit auth_request.create(sp_saml_settings)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: 'saml_sp_ial2',
+          },
+        )
         click_continue
 
-        settings = sp_saml_settings.dup
-
         # SAML logout request
-        request = OneLogin::RubySaml::Logoutrequest.new
-        visit request.create(settings)
+        visit_saml_logout_request_url(
+          saml_overrides: {
+            issuer: 'saml_sp_ial2',
+          },
+        )
 
         # contains all redirect_uris in content security policy
         expect(page.response_headers['Content-Security-Policy']).to include(
@@ -54,13 +62,10 @@ feature 'SAML logout' do
     context 'the SP implements SLO' do
       it 'logs the user out and redirects to the SP' do
         sign_in_and_2fa_user(user)
-        visit auth_request.create(sp_saml_settings)
+        visit_saml_authn_request_url
         click_continue
 
-        settings = sp_saml_settings.dup
-
-        request = OneLogin::RubySaml::Logoutrequest.new
-        visit request.create(settings)
+        visit_saml_logout_request_url
 
         xmldoc = SamlResponseDoc.new('feature', 'logout_assertion')
 
@@ -87,11 +92,12 @@ feature 'SAML logout' do
 
     context 'the user is not signed in' do
       it 'redirects to the SP' do
-        settings = sp_saml_settings.dup
-        settings.name_identifier_value = 'asdf-1234'
-
-        request = OneLogin::RubySaml::Logoutrequest.new
-        visit request.create(settings)
+        visit_saml_logout_request_url(
+          saml_overrides: {
+            issuer: 'saml_sp_ial2',
+            name_identifier_value: 'asdf-1234',
+          },
+        )
 
         # It should contain a SAMLResponse
         expect(page.find('#SAMLResponse', visible: false)).to be_truthy
@@ -106,12 +112,15 @@ feature 'SAML logout' do
       it 'renders an error' do
         sign_in_and_2fa_user(user)
 
-        settings = invalid_service_provider_settings.dup
-        settings.name_identifier_value = 'asdf-1234'
-        settings.security[:logout_requests_signed] = false
-
-        request = OneLogin::RubySaml::Logoutrequest.new
-        visit request.create(settings)
+        visit_saml_logout_request_url(
+          saml_overrides: {
+            issuer: 'invalid_provider',
+            name_identifier_value: 'asdf-1234',
+          },
+          saml_security_overrides: {
+            logout_requests_signed: false,
+          },
+        )
 
         expect(current_path).to eq(api_saml_logout2021_path)
         expect(page.driver.status_code).to eq(400)

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -314,10 +314,10 @@ describe AttributeAsserter do
                   "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
                 ],
               },
-              )
+            )
             CGI.unescape(
               request_url.split('SAMLRequest').last,
-              )
+            )
           end
           # rubocop:enable Layout/LineLength
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -141,11 +141,23 @@ describe AttributeAsserter do
         end
 
         context 'authn request specifies bundle' do
+          # rubocop:disable Layout/LineLength
           let(:raw_ial2_authn_request) do
+            request_url = saml_authn_request_url(
+              saml_overrides: {
+                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+                authn_context: [
+                  Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ],
+              },
+            )
             CGI.unescape(
-              auth_request.create(ial2_with_bundle_saml_settings).split('SAMLRequest').last,
+              request_url.split('SAMLRequest').last,
             )
           end
+          # rubocop:enable Layout/LineLength
 
           it 'uses authn request bundle' do
             expect(user.asserted_attributes.keys).
@@ -290,11 +302,24 @@ describe AttributeAsserter do
         end
 
         context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
+          # rubocop:disable Layout/LineLength
           let(:raw_sp1_authn_request) do
+            request_url = saml_authn_request_url(
+              saml_overrides: {
+                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+                authn_context: [
+                  Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ],
+              },
+              )
             CGI.unescape(
-              auth_request.create(ial1_with_bundle_saml_settings).split('SAMLRequest').last,
-            )
+              request_url.split('SAMLRequest').last,
+              )
           end
+          # rubocop:enable Layout/LineLength
 
           it 'only includes uuid, email, aal, and ial' do
             expect(user.asserted_attributes.keys).to eq(%i[uuid email aal ial])

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -57,15 +57,26 @@ module IdvHelper
 
   def visit_idp_from_sp_with_ial2(sp, **extra)
     if sp == :saml
-      settings = ial2_with_bundle_saml_settings
-      settings.security[:embed_sign] = false
+      saml_overrides = {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+        authn_context: [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+      }
       if javascript_enabled?
         idp_domain_name = "#{page.server.host}:#{page.server.port}"
-        settings.idp_sso_target_url = "http://#{idp_domain_name}/api/saml/auth"
-        settings.idp_slo_target_url = "http://#{idp_domain_name}/api/saml/logout"
+        saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
+        saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
       end
-      @saml_authn_request = auth_request.create(settings)
-      visit @saml_authn_request
+      visit_saml_authn_request_url(
+        saml_overrides: saml_overrides,
+        saml_security_overrides: {
+          embed_sign: false,
+        },
+      )
     elsif sp == :oidc
       @state = SecureRandom.hex
       @client_id = 'urn:gov:gsa:openidconnect:sp:server'
@@ -120,14 +131,28 @@ module IdvHelper
   end
 
   def visit_idp_from_saml_sp_with_loa3
-    settings = loa3_with_bundle_saml_settings
-    settings.security[:embed_sign] = false
+    # settings = loa3_with_bundle_saml_settings
+    # settings.security[:embed_sign] = false
+    saml_overrides = {
+      issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+      authn_context: [
+        Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+      ],
+    }
     if javascript_enabled?
       idp_domain_name = "#{page.server.host}:#{page.server.port}"
-      settings.idp_sso_target_url = "http://#{idp_domain_name}/api/saml/auth"
-      settings.idp_slo_target_url = "http://#{idp_domain_name}/api/saml/logout"
+      saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
+      saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
     end
-    @saml_authn_request = auth_request.create(settings)
-    visit @saml_authn_request
+    # @saml_authn_request = auth_request.create(settings)
+    # visit @saml_authn_request
+    visit_saml_authn_request_url(
+      saml_overrides: saml_overrides,
+      saml_security_overrides: {
+        embed_sign: false,
+      },
+    )
   end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,13 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_service_provider_and_authn_context_settings
-    settings = saml_settings.dup
-    settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'
-    settings.issuer = 'invalid_provider'
-    settings
-  end
-
   def sp1_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,16 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def authnrequest_get(issuer: nil)
-    auth_request.create(saml_spec_settings(issuer: issuer))
-  end
-
-  def saml_spec_settings(issuer: nil)
-    settings = saml_settings.dup
-    settings.issuer = issuer || 'http://localhost:3000'
-    settings
-  end
-
   def invalid_authn_context_settings
     settings = saml_settings.dup
     settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,13 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def aal3_sp1_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = nil
-    settings.issuer = 'https://aal3.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
   def sp2_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp2.serviceprovider.com/auth/saml/metadata'
@@ -336,7 +329,14 @@ module SamlAuthHelper
   end
 
   def aal3_sp1_authnrequest
-    auth_request.create(aal3_sp1_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: {
+          issuer: 'https://aal3.serviceprovider.com/auth/saml/metadata',
+          authn_context: nil,
+        },
+      ),
+    )
   end
 
   def ial1_aal3_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -76,11 +76,9 @@ module SamlAuthHelper
   end
 
   def visit_saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
-    # settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
-    # @saml_authn_request = auth_request.create(settings)
     authn_request_url = saml_authn_request_url(
       saml_overrides: saml_overrides,
-      saml_security_overrides: saml_security_overrides
+      saml_security_overrides: saml_security_overrides,
     )
     visit authn_request_url
   end
@@ -89,7 +87,7 @@ module SamlAuthHelper
     settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
     logout_request_url = saml_logout_request_url(
       saml_overrides: saml_overrides,
-      saml_security_overrides: saml_security_overrides
+      saml_security_overrides: saml_security_overrides,
     )
     visit logout_request_url
   end
@@ -110,12 +108,6 @@ module SamlAuthHelper
 
   ##################################################################################################
   ##################################################################################################
-
-  def sp1_saml_settings
-    settings = saml_settings.dup
-    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
 
   def aal3_sp1_saml_settings
     settings = saml_settings.dup
@@ -181,40 +173,58 @@ module SamlAuthHelper
   end
 
   def sp1_ial1_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def sp1_ial2_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-    settings.authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+      },
+    )
   end
 
   def sp1_ial_max_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def sp1_ial2_strict_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def loa3_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def ialmax_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def ialmax_with_bundle_saml_settings
@@ -268,36 +278,49 @@ module SamlAuthHelper
   end
 
   def ial1_with_verified_at_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
+        ],
+      },
+    )
   end
 
   def ial1_with_bundle_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+      },
+    )
   end
 
   def ial1_with_aal3_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+        ],
+      },
+    )
   end
 
   def sp1_authnrequest
-    auth_request.create(sp1_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: { issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata' },
+      ),
+    )
   end
 
   def sp2_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp2_saml_settings
-    settings = saml_settings.dup
-    settings.issuer = 'https://rp2.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
   def sp2_saml_settings_inactive
     settings = saml_settings.dup
     settings.issuer = 'http://localhost:3000/inactive_sp'
@@ -317,7 +311,11 @@ module SamlAuthHelper
   end
 
   def sp2_authnrequest
-    auth_request.create(sp2_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: { issuer: 'https://rp2.serviceprovider.com/auth/saml/metadata' },
+      ),
+    )
   end
 
   def ial1_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp2_saml_settings_inactive
-    settings = saml_settings.dup
-    settings.issuer = 'http://localhost:3000/inactive_sp'
-    settings
-  end
-
   def sp_not_requesting_signed_saml_response_settings
     settings = saml_settings.dup
     settings.issuer = 'test_saml_sp_not_requesting_signed_response_message'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,12 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_authn_context_settings
-    settings = saml_settings.dup
-    settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'
-    settings
-  end
-
   def invalid_service_provider_settings
     settings = saml_settings.dup
     settings.issuer = 'invalid_provider'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -2,15 +2,15 @@ require 'saml_idp_constants'
 
 ## GET /api/saml/auth helper methods
 module SamlAuthHelper
-  def saml_settings
+  def saml_settings(overrides: {}, security_overrides: {})
     settings = OneLogin::RubySaml::Settings.new
 
     # SP settings
     settings.assertion_consumer_service_url = 'http://localhost:3000/test/saml/decode_assertion'
     settings.assertion_consumer_logout_service_url = 'http://localhost:3000/test/saml/decode_slo_request'
+    settings.authn_context = request_authn_contexts
     settings.certificate = saml_test_sp_cert
     settings.private_key = saml_test_sp_key
-    settings.authn_context = request_authn_contexts
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
 
     # SP + IdP Settings
@@ -21,11 +21,19 @@ module SamlAuthHelper
     settings.security[:digest_method] = 'http://www.w3.org/2001/04/xmlenc#sha256'
     settings.security[:signature_method] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
     settings.double_quote_xml_attribute_values = true
+
     # IdP setting
     settings.idp_sso_target_url = "http://#{IdentityConfig.store.domain_name}/api/saml/auth2021"
     settings.idp_slo_target_url = "http://#{IdentityConfig.store.domain_name}/api/saml/logout2021"
     settings.idp_cert_fingerprint = idp_fingerprint
     settings.idp_cert_fingerprint_algorithm = 'http://www.w3.org/2001/04/xmlenc#sha256'
+
+    overrides.each do |setting, value|
+      settings.send("#{setting}=", value)
+    end
+    security_overrides.each do |setting, value|
+      settings.security[setting] = value
+    end
 
     settings
   end
@@ -37,10 +45,8 @@ module SamlAuthHelper
     ]
   end
 
-  def sp_fingerprint
-    @sp_fingerprint ||= Fingerprinter.fingerprint_cert(
-      OpenSSL::X509::Certificate.new(saml_test_sp_cert),
-    )
+  def saml_test_sp_cert
+    @saml_test_sp_cert ||= File.read(Rails.root.join('certs', 'sp', 'saml_test_sp.crt'))
   end
 
   def idp_fingerprint
@@ -48,6 +54,47 @@ module SamlAuthHelper
       OpenSSL::X509::Certificate.new(saml_test_idp_cert),
     )
   end
+
+  def auth_request
+    @auth_request ||= OneLogin::RubySaml::Authrequest.new
+  end
+
+  def logout_request
+    @logout_request ||= OneLogin::RubySaml::Logoutrequest.new
+  end
+
+  def saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
+    auth_request.create(
+      saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides),
+    )
+  end
+
+  def saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {})
+    logout_request.create(
+      saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides),
+    )
+  end
+
+  def visit_saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
+    # settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
+    # @saml_authn_request = auth_request.create(settings)
+    authn_request_url = saml_authn_request_url(
+      saml_overrides: saml_overrides,
+      saml_security_overrides: saml_security_overrides
+    )
+    visit authn_request_url
+  end
+
+  def visit_saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {})
+    settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
+    logout_request_url = saml_logout_request_url(
+      saml_overrides: saml_overrides,
+      saml_security_overrides: saml_security_overrides
+    )
+    visit logout_request_url
+  end
+
+  private
 
   def saml_test_sp_key
     @private_key ||= OpenSSL::PKey::RSA.new(
@@ -59,13 +106,10 @@ module SamlAuthHelper
     AppArtifacts.store.saml_2021_cert
   end
 
-  def saml_test_sp_cert
-    @saml_test_sp_cert ||= File.read(Rails.root.join('certs', 'sp', 'saml_test_sp.crt'))
-  end
+  public
 
-  def auth_request
-    @auth_request ||= OneLogin::RubySaml::Authrequest.new
-  end
+  ##################################################################################################
+  ##################################################################################################
 
   def authnrequest_get(issuer: nil)
     auth_request.create(saml_spec_settings(issuer: issuer))
@@ -415,15 +459,6 @@ module SamlAuthHelper
     saml_authn_request = auth_request.create(settings)
     visit saml_authn_request
     saml_authn_request
-  end
-
-  def visit_idp_from_saml_sp(saml_overrides: {})
-    settings = saml_settings.dup
-    saml_overrides.each do |setting, value|
-      settings.send("#{setting}=", value)
-    end
-    @saml_authn_request = auth_request.create(settings)
-    visit @saml_authn_request
   end
 
   private

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,12 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_service_provider_settings
-    settings = saml_settings.dup
-    settings.issuer = 'invalid_provider'
-    settings
-  end
-
   def invalid_service_provider_and_authn_context_settings
     settings = saml_settings.dup
     settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp_not_requesting_signed_saml_response_settings
-    settings = saml_settings.dup
-    settings.issuer = 'test_saml_sp_not_requesting_signed_response_message'
-    settings
-  end
-
   def sp_requesting_signed_saml_response_settings
     settings = saml_settings.dup
     settings.issuer = 'test_saml_sp_requesting_signed_response_message'

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -61,7 +61,9 @@ class SamlResponseDoc
       Nokogiri::XML(
         OneLogin::RubySaml::Response.new(
           raw_xml_response,
-          settings: sp1_saml_settings,
+          settings: saml_settings(
+            overrides: { issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata' },
+          ),
         ).decrypted_document.to_s,
       )
     else

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -276,7 +276,7 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
   user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
   user.piv_cac_configurations.create(x509_dn_uuid: 'some-uuid-to-identify-account', name: 'foo')
 
-  visit_idp_from_saml_sp(
+  visit_saml_authn_request_url(
     saml_overrides: {
       issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
       authn_context: nil,


### PR DESCRIPTION
=== DRAFT ===

Working on making the saml spec helpers configurable, so that we can have the configuration live with the spec, not be obfuscated in a web of largely pointless helper methods.

A series of commits with each commit completing a specific refactoring (currently just removing one `custom_settings` method at a time).