### PR TITLE
email confirmation token check should reject null byte in strings

### DIFF
--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -36,7 +36,7 @@ class EmailConfirmationTokenValidator
   end
 
   def self.email_address_from_token(token)
-    return if token.blank?
+    return if token.blank? || token.include?("\x00")
     EmailAddress.find_by(confirmation_token: token)
   end
 


### PR DESCRIPTION
Postgres does not like null bytes