### PR TITLE
Align success consideration for async document capture result

### DIFF
--- a/app/services/document_capture_session_async_result.rb
+++ b/app/services/document_capture_session_async_result.rb
@@ -29,7 +29,9 @@ DocumentCaptureSessionAsyncResult = RedactedStruct.new(
     status == DocumentCaptureSessionAsyncResult::DONE
   end
 
-  alias_method :success?, :done?
+  def success?
+    done? && result[:success]
+  end
 
   def in_progress?
     status == DocumentCaptureSessionAsyncResult::IN_PROGRESS

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -38,7 +38,7 @@ module Idv
       end
 
       def take_photo_with_phone_successful?
-        document_capture_session_result.present?
+        document_capture_session_result.present? && document_capture_session_result.success?
       end
 
       def document_capture_session_result

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -43,6 +43,14 @@ feature 'doc auth link sent step' do
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
   end
 
+  it 'does not proceed to the next page if the capture flow is unsuccessful' do
+    mock_doc_captured(user.id, IdentityDocAuth::Response.new(success: false))
+
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+  end
+
   it 'shows the step indicator' do
     expect(page).to have_css(
       '.step-indicator__step--current',

--- a/spec/services/document_capture_session_async_result.rb
+++ b/spec/services/document_capture_session_async_result.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe DocumentCaptureSessionAsyncResult do
+  let(:id) { SecureRandom.uuid }
+  let(:status) { DocumentCaptureSessionAsyncResult::NONE }
+  let(:idv_result) { nil }
+
+  describe 'success?' do
+    subject do
+      result = DocumentCaptureSessionAsyncResult.new(id: id, status: status, result: idv_result)
+      EncryptedRedisStructStorage.store(result)
+      EncryptedRedisStructStorage.load(id, type: DocumentCaptureSessionAsyncResult)
+    end
+
+    context 'with incomplete result' do
+      let(:status) { DocumentCaptureSessionAsyncResult::IN_PROGRESS }
+
+      it 'is false' do
+        expect(subject.success?).to eq false
+      end
+    end
+
+    context 'with complete result' do
+      let(:status) { DocumentCaptureSessionAsyncResult::DONE }
+
+      context 'with unsuccessful result' do
+        let(:idv_result) { { success: false, errors: {}, messages: ['some message'] } }
+
+        it 'is false' do
+          expect(subject.success?).to eq false
+        end
+      end
+
+      context 'with successful result' do
+        let(:idv_result) { { success: true, errors: {}, messages: [] } }
+
+        it 'is true' do
+          expect(subject.success?).to eq true
+        end
+      end
+    end
+  end
+end

--- a/spec/support/features/doc_capture_helper.rb
+++ b/spec/support/features/doc_capture_helper.rb
@@ -24,6 +24,14 @@ module DocCaptureHelper
     visit request_uri
   end
 
+  def using_doc_capture_session(user = user_with_2fa, &block)
+    request_uri = doc_capture_request_uri(user)
+    Capybara.using_session('mobile') do
+      visit request_uri
+      yield
+    end
+  end
+
   def complete_doc_capture_steps_before_document_capture_step(user = user_with_2fa)
     complete_doc_capture_steps_before_first_step(user) unless
       current_path == idv_capture_doc_document_capture_step


### PR DESCRIPTION
**Why**: In the current sync flow, we assume presence of a result is sufficient to determine success. In the in-development async flow, we may have a result which is unsuccessful. Thus, we should expand consideration of success to include checking the result.