### PR TITLE
Use the agency UUID instead of the SP UUID in the user report

### DIFF
--- a/app/services/data_requests/create_user_report.rb
+++ b/app/services/data_requests/create_user_report.rb
@@ -30,8 +30,12 @@ module DataRequests
 
     def requesting_issuer_uuid
       return user.uuid if requesting_issuers.blank?
-      user.identities.where(service_provider: requesting_issuers).first&.uuid ||
+      user.agency_identities.where(agency: requesting_agencies).first&.uuid ||
         "NonSPUser##{user.id}"
+    end
+
+    def requesting_agencies
+      ServiceProvider.where(issuer: requesting_issuers).map(&:agency).uniq
     end
 
     def user_events_report

--- a/spec/services/data_requests/create_user_report_spec.rb
+++ b/spec/services/data_requests/create_user_report_spec.rb
@@ -17,16 +17,20 @@ describe DataRequests::CreateUserReport do
   context 'with a requesting SP issuer provided' do
     it 'includes the UUID for a SP if one exists' do
       user = create(:user)
-      identity = create(:service_provider_identity, user: user, service_provider: 'test123')
+      service_provider = create(:service_provider)
+      identity = create(
+        :service_provider_identity, user: user, service_provider: service_provider.issuer
+      )
+      AgencyIdentity.create!(user: user, agency: service_provider.agency, uuid: identity.uuid)
 
-      result = described_class.new(user, 'test123').call
+      result = described_class.new(user, service_provider.issuer).call
 
       expect(result[:user_id]).to eq(user.id)
       expect(result[:login_uuid]).to eq(user.uuid)
       expect(result[:requesting_issuer_uuid]).to eq(identity.uuid)
     end
 
-    it 'includes the ID of the user if the user is not associated with the SP' do
+    it 'includes the ID of the user if the user is not associated with the agency' do
       user = create(:user)
 
       result = described_class.new(user, 'test123').call


### PR DESCRIPTION
**Why**: So that when agencies have many service providers, we can get a UUID they will recognize by searching with only the requesting service provider.