### PR TITLE
LG-4536: Add accessible label for Acuant SDK camera canvas

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -188,8 +188,6 @@ function AcuantCaptureCanvas({
       <div id="acuant-sdk-capture-view">
         <canvas
           id="acuant-video-canvas"
-          tabIndex={0}
-          aria-label={t('doc_auth.accessible_labels.camera_video_capture')}
           style={{
             width: '100%',
             position: 'absolute',

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -188,6 +188,8 @@ function AcuantCaptureCanvas({
       <div id="acuant-sdk-capture-view">
         <canvas
           id="acuant-video-canvas"
+          tabIndex={0}
+          aria-label="Live video from device camera"
           style={{
             width: '100%',
             position: 'absolute',

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -189,7 +189,7 @@ function AcuantCaptureCanvas({
         <canvas
           id="acuant-video-canvas"
           tabIndex={0}
-          aria-label="Live video from device camera"
+          aria-label={t('doc_auth.accessible_labels.camera_video_capture')}
           style={{
             width: '100%',
             position: 'absolute',

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -410,7 +410,7 @@ function AcuantCapture(
     <div className={[className, 'document-capture-acuant-capture'].filter(Boolean).join(' ')}>
       {isCapturingEnvironment && (
         <FullScreen
-          label="Document capture dialog"
+          label={t('doc_auth.accessible_labels.document_capture_dialog')}
           onRequestClose={() => setIsCapturingEnvironment(false)}
         >
           <AcuantCaptureCanvas

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -409,7 +409,10 @@ function AcuantCapture(
   return (
     <div className={[className, 'document-capture-acuant-capture'].filter(Boolean).join(' ')}>
       {isCapturingEnvironment && (
-        <FullScreen onRequestClose={() => setIsCapturingEnvironment(false)}>
+        <FullScreen
+          label="Document capture dialog"
+          onRequestClose={() => setIsCapturingEnvironment(false)}
+        >
           <AcuantCaptureCanvas
             onImageCaptureSuccess={onAcuantImageCaptureSuccess}
             onImageCaptureFailure={(error) => {

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -50,43 +50,36 @@ function useFocusTrap(containerRef, onRequestClose) {
   }, []);
 }
 
-const useBodyClass = (() => {
+/**
+ * @param {string} className Class name to add to body element
+ * @param {React.ComponentType<any>} Component React component definition
+ */
+function useBodyClass(className, Component) {
   /**
-   * @type {WeakMap<any, number>}
+   * Increments the number of active instances for the current component by the given amount, adding
+   * or removing the body class for the first and last instance respectively.
+   *
+   * @param {number} amount
    */
-  const activeInstancesByComponent = new WeakMap();
+  function incrementActiveInstances(amount) {
+    const activeInstances = useBodyClass.activeInstancesByComponent.get(Component) || 0;
+    const nextActiveInstances = activeInstances + amount;
 
-  return (
-    /**
-     * @param {string} className Class name to add to body element
-     * @param {React.ComponentType<any>} Component React component definition
-     */
-    (className, Component) => {
-      /**
-       * Increments the number of active instances for the current component by the given amount,
-       * adding or removing the body class for the first and last instance respectively.
-       *
-       * @param {number} amount
-       */
-      function incrementActiveInstances(amount) {
-        const activeInstances = activeInstancesByComponent.get(Component) || 0;
-        const nextActiveInstances = activeInstances + amount;
-
-        if (nextActiveInstances === 1 || nextActiveInstances === 0) {
-          document.body.classList.toggle(className, nextActiveInstances > 0);
-          document.documentElement.classList.toggle(className, nextActiveInstances > 0);
-        }
-
-        activeInstancesByComponent.set(Component, nextActiveInstances);
-      }
-
-      useEffect(() => {
-        incrementActiveInstances(1);
-        return () => incrementActiveInstances(-1);
-      }, []);
+    if (nextActiveInstances === 1 || nextActiveInstances === 0) {
+      document.body.classList.toggle(className, nextActiveInstances > 0);
+      document.documentElement.classList.toggle(className, nextActiveInstances > 0);
     }
-  );
-})();
+
+    useBodyClass.activeInstancesByComponent.set(Component, nextActiveInstances);
+  }
+
+  useEffect(() => {
+    incrementActiveInstances(1);
+    return () => incrementActiveInstances(-1);
+  }, []);
+}
+
+useBodyClass.activeInstancesByComponent = /** @type {WeakMap<*, number>} */ (new WeakMap());
 
 /**
  * @param {React.MutableRefObject<HTMLElement?>} containerRef

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -10,30 +10,23 @@ import useImmutableCallback from '../hooks/use-immutable-callback';
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
- * @typedef {()=>void} RequestCloseCallback
- */
-
-/**
  * @typedef FullScreenProps
  *
- * @prop {RequestCloseCallback=} onRequestClose Callback invoked when user initiates close intent.
+ * @prop {()=>void=} onRequestClose Callback invoked when user initiates close intent.
  * @prop {string} label Accessible label for modal.
  * @prop {ReactNode} children Child elements.
  */
 
 /**
  * @param {React.MutableRefObject<HTMLElement?>} containerRef
- * @param {RequestCloseCallback} onRequestClose
+ * @param {import('focus-trap').Options=} options
  */
-function useFocusTrap(containerRef, onRequestClose) {
+function useFocusTrap(containerRef, options) {
   const trapRef = useRef(/** @type {FocusTrap?} */ (null));
 
   useEffect(() => {
     if (containerRef.current) {
-      trapRef.current = createFocusTrap(containerRef.current, {
-        onDeactivate: onRequestClose,
-        clickOutsideDeactivates: true,
-      });
+      trapRef.current = createFocusTrap(containerRef.current, options);
 
       trapRef.current.activate();
     }
@@ -74,7 +67,10 @@ function FullScreen({ onRequestClose = () => {}, label, children }) {
   const { getAssetPath } = useAsset();
   const containerRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const onFocusTrapDeactivate = useImmutableCallback(onRequestClose);
-  useFocusTrap(containerRef, onFocusTrapDeactivate);
+  useFocusTrap(containerRef, {
+    clickOutsideDeactivates: true,
+    onDeactivate: onFocusTrapDeactivate,
+  });
   useToggleBodyClassByPresence('has-full-screen-overlay', FullScreen);
   useSoleAccessibleContent(containerRef);
 

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -4,6 +4,7 @@ import { createFocusTrap } from 'focus-trap';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
 import useToggleBodyClassByPresence from '../hooks/use-toggle-body-class-by-presence';
+import useImmutableCallback from '../hooks/use-immutable-callback';
 
 /** @typedef {import('focus-trap').FocusTrap} FocusTrap */
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -26,19 +27,11 @@ import useToggleBodyClassByPresence from '../hooks/use-toggle-body-class-by-pres
  */
 function useFocusTrap(containerRef, onRequestClose) {
   const trapRef = useRef(/** @type {FocusTrap?} */ (null));
-  const onRequestCloseRef = useRef(onRequestClose);
-
-  useEffect(() => {
-    // Since the focus trap is only initialized once, but the callback could
-    // be changed, ensure that the current reference is kept as a mutable value
-    // to reference in the deactivation.
-    onRequestCloseRef.current = onRequestClose;
-  }, [onRequestClose]);
 
   useEffect(() => {
     if (containerRef.current) {
       trapRef.current = createFocusTrap(containerRef.current, {
-        onDeactivate: () => onRequestCloseRef.current(),
+        onDeactivate: onRequestClose,
         clickOutsideDeactivates: true,
       });
 
@@ -80,7 +73,8 @@ function FullScreen({ onRequestClose = () => {}, label, children }) {
   const { t } = useI18n();
   const { getAssetPath } = useAsset();
   const containerRef = useRef(/** @type {HTMLDivElement?} */ (null));
-  useFocusTrap(containerRef, onRequestClose);
+  const onFocusTrapDeactivate = useImmutableCallback(onRequestClose);
+  useFocusTrap(containerRef, onFocusTrapDeactivate);
   useToggleBodyClassByPresence('has-full-screen-overlay', FullScreen);
   useSoleAccessibleContent(containerRef);
 

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -1,10 +1,10 @@
 import { useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { createFocusTrap } from 'focus-trap';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
 import useToggleBodyClassByPresence from '../hooks/use-toggle-body-class-by-presence';
 import useImmutableCallback from '../hooks/use-immutable-callback';
+import useFocusTrap from '../hooks/use-focus-trap';
 
 /** @typedef {import('focus-trap').FocusTrap} FocusTrap */
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -16,26 +16,6 @@ import useImmutableCallback from '../hooks/use-immutable-callback';
  * @prop {string} label Accessible label for modal.
  * @prop {ReactNode} children Child elements.
  */
-
-/**
- * @param {React.MutableRefObject<HTMLElement?>} containerRef
- * @param {import('focus-trap').Options=} options
- */
-function useFocusTrap(containerRef, options) {
-  const trapRef = useRef(/** @type {FocusTrap?} */ (null));
-
-  useEffect(() => {
-    if (containerRef.current) {
-      trapRef.current = createFocusTrap(containerRef.current, options);
-
-      trapRef.current.activate();
-    }
-
-    return () => {
-      trapRef.current?.deactivate();
-    };
-  }, []);
-}
 
 /**
  * @param {React.MutableRefObject<HTMLElement?>} containerRef

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -1,33 +1,32 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { createFocusTrap } from 'focus-trap';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
 
+/** @typedef {import('focus-trap').FocusTrap} FocusTrap */
 /** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef {()=>void} RequestCloseCallback
+ */
 
 /**
  * @typedef FullScreenProps
  *
- * @prop {()=>void=} onRequestClose Callback invoked when user initiates close intent.
- * @prop {ReactNode} children       Child elements.
+ * @prop {RequestCloseCallback=} onRequestClose Callback invoked when user initiates close intent.
+ * @prop {string} label Accessible label for modal.
+ * @prop {ReactNode} children Child elements.
  */
 
 /**
- * Number of active instances of FullScreen currently mounted, used in determining when overlay body
- * class should be added or removed.
- *
- * @type {number}
+ * @param {React.MutableRefObject<HTMLElement?>} containerRef
+ * @param {RequestCloseCallback} onRequestClose
  */
-let activeInstances = 0;
-
-/**
- * @param {FullScreenProps} props Props object.
- */
-function FullScreen({ onRequestClose = () => {}, children }) {
-  const { t } = useI18n();
-  const { getAssetPath } = useAsset();
-  const trapRef = useRef(/** @type {?import('focus-trap').FocusTrap} */ (null));
+function useFocusTrap(containerRef, onRequestClose) {
+  const trapRef = useRef(/** @type {FocusTrap?} */ (null));
   const onRequestCloseRef = useRef(onRequestClose);
+
   useEffect(() => {
     // Since the focus trap is only initialized once, but the callback could
     // be changed, ensure that the current reference is kept as a mutable value
@@ -35,47 +34,106 @@ function FullScreen({ onRequestClose = () => {}, children }) {
     onRequestCloseRef.current = onRequestClose;
   }, [onRequestClose]);
 
-  const setFocusTrapRef = useCallback((node) => {
-    if (trapRef.current) {
-      trapRef.current.deactivate();
-    }
-
-    if (node) {
-      trapRef.current = createFocusTrap(node, {
+  useEffect(() => {
+    if (containerRef.current) {
+      trapRef.current = createFocusTrap(containerRef.current, {
         onDeactivate: () => onRequestCloseRef.current(),
         clickOutsideDeactivates: true,
       });
 
       trapRef.current.activate();
     }
-  }, []);
-
-  useEffect(() => {
-    if (activeInstances++ === 0) {
-      document.body.classList.add('has-full-screen-overlay');
-      document.documentElement.classList.add('has-full-screen-overlay');
-    }
 
     return () => {
-      if (--activeInstances === 0) {
-        document.body.classList.remove('has-full-screen-overlay');
-        document.documentElement.classList.remove('has-full-screen-overlay');
-      }
+      trapRef.current?.deactivate();
     };
   }, []);
+}
+
+const useBodyClass = (() => {
+  /**
+   * @type {WeakMap<any, number>}
+   */
+  const activeInstancesByComponent = new WeakMap();
 
   return (
-    <div ref={setFocusTrapRef} aria-modal="true" className="full-screen bg-white">
+    /**
+     * @param {string} className Class name to add to body element
+     * @param {React.ComponentType<any>} Component React component definition
+     */
+    (className, Component) => {
+      /**
+       * Increments the number of active instances for the current component by the given amount,
+       * adding or removing the body class for the first and last instance respectively.
+       *
+       * @param {number} amount
+       */
+      function incrementActiveInstances(amount) {
+        const activeInstances = activeInstancesByComponent.get(Component) || 0;
+        const nextActiveInstances = activeInstances + amount;
+
+        if (nextActiveInstances === 1 || nextActiveInstances === 0) {
+          document.body.classList.toggle(className, nextActiveInstances > 0);
+          document.documentElement.classList.toggle(className, nextActiveInstances > 0);
+        }
+
+        activeInstancesByComponent.set(Component, nextActiveInstances);
+      }
+
+      useEffect(() => {
+        incrementActiveInstances(1);
+        return () => incrementActiveInstances(-1);
+      }, []);
+    }
+  );
+})();
+
+/**
+ * @param {React.MutableRefObject<HTMLElement?>} containerRef
+ */
+function useSoleAccessibleContent(containerRef) {
+  useEffect(() => {
+    const container = containerRef.current;
+
+    /**
+     * @type {Element[]}
+     */
+    let siblings = [];
+    if (container && container.parentNode) {
+      siblings = Array.from(container.parentNode.children).filter(
+        (node) => node !== container && !node.hasAttribute('aria-hidden'),
+      );
+    }
+
+    siblings.forEach((node) => node.setAttribute('aria-hidden', 'true'));
+    return () => siblings.forEach((node) => node.removeAttribute('aria-hidden'));
+  });
+}
+
+/**
+ * @param {FullScreenProps} props Props object.
+ */
+function FullScreen({ onRequestClose = () => {}, label, children }) {
+  const { t } = useI18n();
+  const { getAssetPath } = useAsset();
+  const containerRef = useRef(/** @type {HTMLDivElement?} */ (null));
+  useFocusTrap(containerRef, onRequestClose);
+  useBodyClass('has-full-screen-overlay', FullScreen);
+  useSoleAccessibleContent(containerRef);
+
+  return createPortal(
+    <div ref={containerRef} role="dialog" aria-label={label} className="full-screen bg-white">
+      {children}
       <button
         type="button"
         aria-label={t('users.personal_key.close')}
-        onClick={() => trapRef.current?.deactivate()}
+        onClick={onRequestClose}
         className="full-screen-close-button usa-button padding-2 margin-2"
       >
         <img alt="" src={getAssetPath('close-white-alt.svg')} className="full-screen-close-icon" />
       </button>
-      {children}
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { createFocusTrap } from 'focus-trap';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
+import useToggleBodyClassByPresence from '../hooks/use-toggle-body-class-by-presence';
 
 /** @typedef {import('focus-trap').FocusTrap} FocusTrap */
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -51,37 +52,6 @@ function useFocusTrap(containerRef, onRequestClose) {
 }
 
 /**
- * @param {string} className Class name to add to body element
- * @param {React.ComponentType<any>} Component React component definition
- */
-function useBodyClass(className, Component) {
-  /**
-   * Increments the number of active instances for the current component by the given amount, adding
-   * or removing the body class for the first and last instance respectively.
-   *
-   * @param {number} amount
-   */
-  function incrementActiveInstances(amount) {
-    const activeInstances = useBodyClass.activeInstancesByComponent.get(Component) || 0;
-    const nextActiveInstances = activeInstances + amount;
-
-    if (nextActiveInstances === 1 || nextActiveInstances === 0) {
-      document.body.classList.toggle(className, nextActiveInstances > 0);
-      document.documentElement.classList.toggle(className, nextActiveInstances > 0);
-    }
-
-    useBodyClass.activeInstancesByComponent.set(Component, nextActiveInstances);
-  }
-
-  useEffect(() => {
-    incrementActiveInstances(1);
-    return () => incrementActiveInstances(-1);
-  }, []);
-}
-
-useBodyClass.activeInstancesByComponent = /** @type {WeakMap<*, number>} */ (new WeakMap());
-
-/**
  * @param {React.MutableRefObject<HTMLElement?>} containerRef
  */
 function useSoleAccessibleContent(containerRef) {
@@ -111,7 +81,7 @@ function FullScreen({ onRequestClose = () => {}, label, children }) {
   const { getAssetPath } = useAsset();
   const containerRef = useRef(/** @type {HTMLDivElement?} */ (null));
   useFocusTrap(containerRef, onRequestClose);
-  useBodyClass('has-full-screen-overlay', FullScreen);
+  useToggleBodyClassByPresence('has-full-screen-overlay', FullScreen);
   useSoleAccessibleContent(containerRef);
 
   return createPortal(

--- a/app/javascript/packages/document-capture/hooks/use-focus-trap.js
+++ b/app/javascript/packages/document-capture/hooks/use-focus-trap.js
@@ -1,0 +1,34 @@
+import { useRef, useEffect } from 'react';
+import { createFocusTrap } from 'focus-trap';
+
+/** @typedef {import('focus-trap').FocusTrap} FocusTrap */
+
+/**
+ * React hook which activates a focus trap on the given container ref while the component is
+ * mounted, with any options for the underlying focus trap instance. The hook does not detect
+ * changes to the options argument, thus new option values are not reflected and conversely
+ * memoization is not necessary. Returns ref with trap instance assigned as current after mount.
+ *
+ * @param {React.MutableRefObject<HTMLElement?>} containerRef
+ * @param {import('focus-trap').Options=} options
+ *
+ * @param {React.MutableRefObject<FocusTrap?>} containerRef
+ */
+function useFocusTrap(containerRef, options) {
+  const trapRef = useRef(/** @type {FocusTrap?} */ (null));
+
+  useEffect(() => {
+    if (containerRef.current) {
+      trapRef.current = createFocusTrap(containerRef.current, options);
+      trapRef.current.activate();
+    }
+
+    return () => {
+      trapRef.current?.deactivate();
+    };
+  }, []);
+
+  return trapRef;
+}
+
+export default useFocusTrap;

--- a/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
+++ b/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
@@ -11,7 +11,7 @@ import { useRef, useEffect, useCallback } from 'react';
  * @param {F} fn
  * @param {any[]=} dependencies Callback dependencies
  *
- * @return F
+ * @return {F}
  */
 function useImmutableCallback(fn, dependencies = []) {
   const ref = useRef(/** @type {F} */ (() => {}));
@@ -20,7 +20,7 @@ function useImmutableCallback(fn, dependencies = []) {
     ref.current = fn;
   }, [fn, ...dependencies]);
 
-  return useCallback((...args) => ref.current(...args), [ref]);
+  return useCallback(/** @type {F} */ ((...args) => ref.current(...args)), [ref]);
 }
 
 export default useImmutableCallback;

--- a/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
+++ b/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
@@ -20,7 +20,7 @@ function useImmutableCallback(fn, dependencies = []) {
     ref.current = fn;
   }, [fn, ...dependencies]);
 
-  return useCallback(() => ref.current(), [ref]);
+  return useCallback((...args) => ref.current(...args), [ref]);
 }
 
 export default useImmutableCallback;

--- a/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
+++ b/app/javascript/packages/document-capture/hooks/use-immutable-callback.js
@@ -1,0 +1,26 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * React hook which returns a callback function which itself maintains a constant reference, but
+ * which invokes the latest reference of the given function.
+ *
+ * @see https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback
+ *
+ * @template {(...args: any[]) => any} F
+ *
+ * @param {F} fn
+ * @param {any[]=} dependencies Callback dependencies
+ *
+ * @return F
+ */
+function useImmutableCallback(fn, dependencies = []) {
+  const ref = useRef(/** @type {F} */ (() => {}));
+
+  useEffect(() => {
+    ref.current = fn;
+  }, [fn, ...dependencies]);
+
+  return useCallback(() => ref.current(), [ref]);
+}
+
+export default useImmutableCallback;

--- a/app/javascript/packages/document-capture/hooks/use-toggle-body-class-by-presence.js
+++ b/app/javascript/packages/document-capture/hooks/use-toggle-body-class-by-presence.js
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+/**
+ * @type {WeakMap<*, number>}
+ */
+const activeInstancesByType = new WeakMap();
+
+/**
+ * React hook to add a CSS class to the page body element as long as any instance of the given
+ * component type is rendered to the page.
+ *
+ * @param {string} className Class name to add to body element
+ * @param {React.ComponentType<any>} Component React component definition
+ */
+function useToggleBodyClassByPresence(className, Component) {
+  /**
+   * Increments the number of active instances for the current component by the given amount, adding
+   * or removing the body class for the first and last instance respectively.
+   *
+   * @param {number} amount
+   */
+  function incrementActiveInstances(amount) {
+    const activeInstances = activeInstancesByType.get(Component) || 0;
+    const nextActiveInstances = activeInstances + amount;
+
+    if (!activeInstances && nextActiveInstances) {
+      document.body.classList.add(className);
+    } else if (activeInstances && !nextActiveInstances) {
+      document.body.classList.remove(className);
+    }
+
+    activeInstancesByType.set(Component, nextActiveInstances);
+  }
+
+  useEffect(() => {
+    incrementActiveInstances(1);
+    return () => incrementActiveInstances(-1);
+  }, []);
+}
+
+export default useToggleBodyClassByPresence;

--- a/app/javascript/packages/document-capture/package.json
+++ b/app/javascript/packages/document-capture/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "focus-trap": "^6.2.3",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   }
 }

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -1,4 +1,3 @@
-- doc_auth.accessible_labels.camera_video_capture
 - doc_auth.accessible_labels.document_capture_dialog
 - doc_auth.buttons.take_or_upload_picture
 - doc_auth.buttons.take_picture

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -1,3 +1,5 @@
+- doc_auth.accessible_labels.camera_video_capture
+- doc_auth.accessible_labels.document_capture_dialog
 - doc_auth.buttons.take_or_upload_picture
 - doc_auth.buttons.take_picture
 - doc_auth.buttons.take_picture_retry

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   doc_auth:
+    accessible_labels:
+      camera_video_capture: Live video from device camera
+      document_capture_dialog: Document capture
     buttons:
       change_address: change
       change_ssn: change

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -2,7 +2,6 @@
 en:
   doc_auth:
     accessible_labels:
-      camera_video_capture: Live video from device camera
       document_capture_dialog: Document capture
     buttons:
       change_address: change

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -2,7 +2,6 @@
 es:
   doc_auth:
     accessible_labels:
-      camera_video_capture: Video en vivo desde la cámara del dispositivo
       document_capture_dialog: Captura de documentos
     buttons:
       change_address: cambio

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -2,7 +2,7 @@
 es:
   doc_auth:
     accessible_labels:
-      document_capture_dialog: Captura de documentos
+      document_capture_dialog: Captura del documento
     buttons:
       change_address: cambio
       change_ssn: cambio

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -1,6 +1,9 @@
 ---
 es:
   doc_auth:
+    accessible_labels:
+      camera_video_capture: Video en vivo desde la cámara del dispositivo
+      document_capture_dialog: Captura de documentos
     buttons:
       change_address: cambio
       change_ssn: cambio

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -2,7 +2,7 @@
 fr:
   doc_auth:
     accessible_labels:
-      document_capture_dialog: Saisie de documents
+      document_capture_dialog: Capture du document
     buttons:
       change_address: changement
       change_ssn: changement

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -1,6 +1,9 @@
 ---
 fr:
   doc_auth:
+    accessible_labels:
+      camera_video_capture: Vidéo en direct de la caméra de l'appareil
+      document_capture_dialog: Saisie de documents
     buttons:
       change_address: changement
       change_ssn: changement

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -2,7 +2,6 @@
 fr:
   doc_auth:
     accessible_labels:
-      camera_video_capture: Vidéo en direct de la caméra de l'appareil
       document_capture_dialog: Saisie de documents
     buttons:
       change_address: changement

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -224,9 +224,8 @@ describe('document-capture/components/acuant-capture', () => {
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
-      await new Promise((resolve) => onChange.callsFake(resolve));
 
-      expect(onChange).to.have.been.calledWith(
+      await expect(onChange).to.eventually.be.calledWith(
         'data:image/png,',
         sinon.match({
           assessment: 'success',
@@ -245,7 +244,7 @@ describe('document-capture/components/acuant-capture', () => {
           width: sinon.match.number,
         }),
       );
-      expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
+      await expect(window.AcuantCameraUI.end).to.eventually.be.called();
     });
 
     it('ends the capture when the component unmounts', () => {

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -54,9 +54,9 @@ describe('document-capture/components/full-screen', () => {
   });
 
   it('is rendered as an accessible modal', () => {
-    const { baseElement } = render(<FullScreen>Content</FullScreen>);
+    const { getByRole } = render(<FullScreen>Content</FullScreen>);
 
-    expect(baseElement.querySelector('[role]').getAttribute('role')).to.equal('dialog');
+    expect(getByRole('dialog')).to.be.ok();
   });
 
   it('calls close callback when close button is clicked', () => {

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -12,9 +12,9 @@ describe('document-capture/components/full-screen', () => {
   });
 
   it('is rendered as an accessible modal', () => {
-    const { container } = render(<FullScreen>Content</FullScreen>);
+    const { baseElement } = render(<FullScreen>Content</FullScreen>);
 
-    expect(container.firstChild.hasAttribute('aria-modal')).to.be.true();
+    expect(baseElement.querySelector('[role]').getAttribute('role')).to.equal('dialog');
   });
 
   it('calls close callback when close button is clicked', () => {
@@ -30,19 +30,19 @@ describe('document-capture/components/full-screen', () => {
   });
 
   it('transitions focus into the modal', (done) => {
-    const { container } = render(<FullScreen>Content</FullScreen>);
+    const { baseElement } = render(<FullScreen>Content</FullScreen>);
 
     // The `focus-trap` library only assigns initial focus after a timeout.
     // Schedule to assert immediately following.
     setTimeout(() => {
-      expect(container.contains(document.activeElement)).to.be.true();
+      expect(baseElement.contains(document.activeElement)).to.be.true();
 
       done();
     }, 0);
   });
 
   it('traps focus', (done) => {
-    const { container, getByLabelText } = render(<FullScreen>Content</FullScreen>);
+    const { baseElement, getByLabelText } = render(<FullScreen>Content</FullScreen>);
 
     const button = getByLabelText('users.personal_key.close');
 
@@ -57,7 +57,7 @@ describe('document-capture/components/full-screen', () => {
     setTimeout(() => {
       fireEvent(button, event);
 
-      expect(container.contains(document.activeElement)).to.be.true();
+      expect(baseElement.contains(document.activeElement)).to.be.true();
 
       done();
     }, 0);

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -7,6 +7,8 @@ import FullScreen, {
   useInertSiblingElements,
 } from '@18f/identity-document-capture/components/full-screen';
 
+const delay = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe('document-capture/components/full-screen', () => {
   describe('useInertSiblingElements', () => {
     beforeEach(() => {
@@ -51,6 +53,27 @@ describe('document-capture/components/full-screen', () => {
     const button = getByLabelText('users.personal_key.close');
 
     expect(button.nodeName).to.equal('BUTTON');
+  });
+
+  it('focuses the first interactive element', async () => {
+    const { getByRole } = render(
+      <FullScreen>
+        <button type="button">One</button>
+        <button type="button">Two</button>
+      </FullScreen>,
+    );
+
+    await delay(); // focus-trap delays initial focus by default
+    expect(document.activeElement).to.equal(getByRole('button', { name: 'One' }));
+  });
+
+  it('focuses the close button as a fallback', async () => {
+    const { getByRole } = render(<FullScreen />);
+
+    await delay(); // focus-trap delays initial focus by default
+    expect(document.activeElement).to.equal(
+      getByRole('button', { name: 'users.personal_key.close' }),
+    );
   });
 
   it('is rendered as an accessible modal', () => {

--- a/spec/javascripts/packages/document-capture/hooks/use-focus-trap-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-focus-trap-spec.jsx
@@ -1,0 +1,71 @@
+import sinon from 'sinon';
+import { useRef } from 'react';
+import { screen } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import { renderHook } from '@testing-library/react-hooks';
+import useFocusTrap from '@18f/identity-document-capture/hooks/use-focus-trap';
+
+const delay = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('document-capture/hooks/use-focus-trap', () => {
+  // Common options for test instances. Default delayed initial focus adds complexity to assertions.
+  const DEFAULT_OPTIONS = { delayInitialFocus: false };
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="container">
+        <button data-testid="containerButton"></button>
+      </div>
+      <button data-testid="outsideButton"></button>
+    `;
+    screen.getByTestId('outsideButton').focus();
+  });
+
+  it('returns focus trap ref', () => {
+    const container = document.querySelector('.container');
+    const { result } = renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
+
+    const trapRef = result.current;
+    expect(trapRef.current.deactivate).to.be.a('function');
+  });
+
+  it('traps focus', () => {
+    const container = document.querySelector('.container');
+    renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
+
+    expect(container.contains(document.activeElement)).to.be.true();
+    userEvent.tab();
+    expect(container.contains(document.activeElement)).to.be.true();
+  });
+
+  it('restores focus on deactivate', async () => {
+    const originalActiveElement = document.activeElement;
+    const container = document.querySelector('.container');
+    const { result } = renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
+
+    const trapRef = result.current;
+    trapRef.current.deactivate();
+
+    // Delay for focus return isn't configurable.
+    await delay();
+
+    expect(document.activeElement).to.equal(originalActiveElement);
+  });
+
+  it('accepts options', () => {
+    const container = document.querySelector('.container');
+    const onDeactivate = sinon.spy();
+    renderHook(() =>
+      useFocusTrap(useRef(container), {
+        ...DEFAULT_OPTIONS,
+        clickOutsideDeactivates: true,
+        onDeactivate,
+      }),
+    );
+
+    const outsideButton = screen.getByTestId('outsideButton');
+
+    userEvent.click(outsideButton);
+    expect(onDeactivate).to.have.been.called();
+  });
+});

--- a/spec/javascripts/packages/document-capture/hooks/use-immutable-callback-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-immutable-callback-spec.jsx
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+import { renderHook } from '@testing-library/react-hooks';
+import useImmutableCallback from '@18f/identity-document-capture/hooks/use-immutable-callback';
+
+describe('document-capture/hooks/use-immutable-callback', () => {
+  const callback1 = () => {};
+  const callback2 = sinon.stub().callsFake(() => {});
+
+  it('maintains a consistent reference', () => {
+    const { rerender, result } = renderHook(({ fn }) => useImmutableCallback(fn), {
+      initialProps: { fn: callback1 },
+    });
+
+    const { current: renderedCallback1 } = result;
+    rerender({ fn: callback2 });
+    const { current: renderedCallback2 } = result;
+
+    expect(renderedCallback1).to.equal(renderedCallback2);
+  });
+
+  it('invokes the latest reference of callback', () => {
+    const { rerender, result } = renderHook(({ fn }) => useImmutableCallback(fn), {
+      initialProps: { fn: callback1 },
+    });
+
+    rerender({ fn: callback2 });
+    result.current();
+
+    expect(callback2).to.have.been.called();
+  });
+});

--- a/spec/javascripts/packages/document-capture/hooks/use-immutable-callback-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-immutable-callback-spec.jsx
@@ -24,8 +24,9 @@ describe('document-capture/hooks/use-immutable-callback', () => {
     });
 
     rerender({ fn: callback2 });
-    result.current();
+    const args = [1, 2];
+    result.current(...args);
 
-    expect(callback2).to.have.been.called();
+    expect(callback2).to.have.been.calledWith(...args);
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-toggle-body-class-by-presence-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-toggle-body-class-by-presence-spec.jsx
@@ -1,0 +1,58 @@
+import { renderHook, cleanup } from '@testing-library/react-hooks';
+import useToggleBodyClassByPresence from '@18f/identity-document-capture/hooks/use-toggle-body-class-by-presence';
+
+describe('document-capture/hooks/use-toggle-body-class-by-presence', () => {
+  function ComponentOne() {}
+  function ComponentTwo() {}
+
+  afterEach(cleanup);
+
+  it('adds body class while hook is active', () => {
+    renderHook(() => useToggleBodyClassByPresence('component-one', ComponentOne));
+
+    expect(document.body.classList.contains('component-one')).to.be.true();
+  });
+
+  it('removes body class after hook is deactivated', () => {
+    const { unmount } = renderHook(() =>
+      useToggleBodyClassByPresence('component-one', ComponentOne),
+    );
+
+    unmount();
+
+    expect(document.body.classList.contains('component-one')).to.be.false();
+  });
+
+  it('does not remove body class if one of multiple instances is removed', () => {
+    renderHook(() => useToggleBodyClassByPresence('component-one', ComponentOne));
+    const { unmount: unmountSecond } = renderHook(() =>
+      useToggleBodyClassByPresence('component-one', ComponentOne),
+    );
+
+    unmountSecond();
+
+    expect(document.body.classList.contains('component-one')).to.be.true();
+  });
+
+  it('tracks multiple components', () => {
+    const { unmount: unmountComponentOne } = renderHook(() =>
+      useToggleBodyClassByPresence('component-one', ComponentOne),
+    );
+    const { unmount: unmountComponentTwo } = renderHook(() =>
+      useToggleBodyClassByPresence('component-two', ComponentTwo),
+    );
+
+    expect(document.body.classList.contains('component-one')).to.be.true();
+    expect(document.body.classList.contains('component-two')).to.be.true();
+
+    unmountComponentOne();
+
+    expect(document.body.classList.contains('component-one')).to.be.false();
+    expect(document.body.classList.contains('component-two')).to.be.true();
+
+    unmountComponentTwo();
+
+    expect(document.body.classList.contains('component-one')).to.be.false();
+    expect(document.body.classList.contains('component-two')).to.be.false();
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -9,11 +9,11 @@ import { sinonChaiAsPromised } from './support/sinon';
 import { createObjectURLAsDataURL } from './support/file';
 import { useBrowserCompatibleEncrypt } from './support/crypto';
 
-chai.use(dirtyChai);
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 chai.use(chaiConsoleSpy);
 chai.use(sinonChaiAsPromised);
+chai.use(dirtyChai);
 global.expect = chai.expect;
 
 // Emulate a DOM, since many modules will assume the presence of these globals exist as a side


### PR DESCRIPTION
**Why**: As a user who relies on assistive technology, I expect that the document capture element is labelled in a way that I can understand its purpose.

**Changes:**

- ~Acuant capture canvas has accessible label describing purpose ([G68](https://www.w3.org/WAI/WCAG21/Techniques/general/G68))~
   - This was removed in 1a85a24, to be addressed separately as part of LG-4539 (#5126)
- Full screen dialog prefers shifting focus to first interactive element in given children if present, rather than always the "Close" button
- Acuant capture canvas is focusable so that canvas becomes focused element upon opening dialog
- Avoid using `aria-modal` ([poor support](https://a11ysupport.io/tech/aria/aria-modal_attribute), [buggy](https://bugs.webkit.org/show_bug.cgi?id=174667))
- While dialog is present, screen reader cannot escape to read outside page content using `aria-hidden`
   - Workaround for behavior normally expected through `aria-modal` (see ["Notes on `aria-modal` and `aria-hidden`"](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html))
- Ensure full screen dialogs are labelled ([WAI-ARIA Practices example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html), [dialog role guidance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role))
