### PR TITLE
LG-4644: refactoring saml specs

### DIFF
--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -40,7 +40,7 @@ module Test
     def test_saml_settings
       saml_settings(
         overrides: {
-          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         },
       )

--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -38,7 +38,12 @@ module Test
     private
 
     def test_saml_settings
-      sp1_ial1_saml_settings
+      saml_settings(
+        overrides: {
+          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
     end
 
     def render_template_for(validity, response)

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -1,4 +1,27 @@
 test:
+  'saml_sp':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    allow_prompt_login: true
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    certs:
+      - 'saml_test_sp'
+    friendly_name: 'Test SP'
+
+  'saml_sp_ial2':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    allow_prompt_login: true
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    certs:
+      - 'saml_test_sp'
+    friendly_name: 'Test SP'
+    ial: 2
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+
   'http://localhost:3000':
     acs_url: 'http://localhost:3000/test/saml/decode_assertion'
     assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -743,7 +743,7 @@ describe SamlIdpController do
       end
 
       it 'sends the appropriate identifier for non-email NameID SPs' do
-        auth_settings = missing_nameid_format_saml_settings
+        auth_settings = saml_settings(overrides: { name_identifier_format: nil })
         auth_settings.name_identifier_format =
           'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
         IdentityLinker.new(user, auth_settings.issuer).link_identity
@@ -768,7 +768,7 @@ describe SamlIdpController do
           with(Analytics::SAML_AUTH, analytics_hash)
       end
       it 'sends the appropriate identifier for email NameID SPs' do
-        auth_settings = missing_nameid_format_saml_settings
+        auth_settings = saml_settings(overrides: { name_identifier_format: nil })
         auth_settings.name_identifier_format =
           'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
         ServiceProvider.
@@ -796,7 +796,7 @@ describe SamlIdpController do
           with(Analytics::SAML_AUTH, analytics_hash)
       end
       it 'sends the old user ID for legacy SPS' do
-        auth_settings = missing_nameid_format_saml_settings
+        auth_settings = saml_settings(overrides: { name_identifier_format: nil })
         auth_settings.name_identifier_format =
           'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
         ServiceProvider.

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -708,7 +708,10 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        saml_get_auth(email_nameid_saml_settings_for_disallowed_issuer)
+        auth_settings = saml_settings(
+          overrides: { name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL },
+        )
+        saml_get_auth(auth_settings)
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -598,7 +598,12 @@ describe SamlIdpController do
       let(:user) { create(:user, :signed_up) }
 
       before do
-        settings = email_nameid_saml_settings
+        settings = saml_settings(
+          overrides: {
+            issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+          },
+        )
         ServiceProvider.
           find_by(issuer: settings.issuer).
           update!(email_nameid_format_allowed: true)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -205,7 +205,7 @@ describe SamlIdpController do
       end
       let(:this_authn_request) do
         ial2_authnrequest = saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: sp1_issuer,
             authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           },
@@ -273,7 +273,7 @@ describe SamlIdpController do
                errors: {},
                nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
                authn_context: ['http://idmanagement.gov/ns/assurance/ial/2'],
-               service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+               service_provider: sp1_issuer,
                endpoint: '/api/saml/auth2021',
                idv: false,
                finish_profile: false)
@@ -620,7 +620,7 @@ describe SamlIdpController do
       before do
         settings = saml_settings(
           overrides: {
-            issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+            issuer: sp1_issuer,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           },
         )
@@ -694,7 +694,7 @@ describe SamlIdpController do
       it 'defaults to email when added to issuers_with_email_nameid_format' do
         auth_settings = saml_settings(
           overrides: {
-            issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+            issuer: sp1_issuer,
             name_identifier_format: nil,
           },
         )

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -671,8 +671,13 @@ describe SamlIdpController do
           with(Analytics::SAML_AUTH, analytics_hash)
       end
 
-      it 'defaults to email when configured' do
-        auth_settings = missing_nameid_format_saml_settings
+      it 'defaults to email when added to issuers_with_email_nameid_format' do
+        auth_settings = saml_settings(
+          overrides: {
+            issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+            name_identifier_format: nil,
+          },
+        )
         ServiceProvider.
           find_by(issuer: auth_settings.issuer).
           update!(email_nameid_format_allowed: true)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -291,7 +291,11 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        saml_get_auth(invalid_authn_context_settings)
+        saml_get_auth(
+          saml_settings(
+            overrides: { authn_context: 'http://idmanagement.gov/ns/assurance/loa/5' },
+          ),
+        )
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -649,7 +649,7 @@ describe SamlIdpController do
       end
 
       it 'defaults to persistent' do
-        auth_settings = missing_nameid_format_saml_settings
+        auth_settings = saml_settings(overrides: { name_identifier_format: nil })
         IdentityLinker.new(user, auth_settings.issuer).link_identity
         user.identities.last.update!(verified_attributes: ['email'])
         generate_saml_response(user, auth_settings)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -407,7 +407,15 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        generate_saml_response(user, invalid_service_provider_and_authn_context_settings)
+        generate_saml_response(
+          user,
+          saml_settings(
+            overrides: {
+              issuer: 'invalid_provider',
+              authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
+            },
+          ),
+        )
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -337,7 +337,7 @@ describe SamlIdpController do
       let(:user) { create(:user, :signed_up) }
 
       context 'authn_context is missing' do
-        let(:auth_settings) { missing_authn_context_saml_settings }
+        let(:auth_settings) { saml_settings(overrides: { authn_context: nil }) }
 
         it 'returns saml response with default AAL in authn context' do
           decoded_saml_response = generate_decoded_saml_response(user, auth_settings)
@@ -351,7 +351,9 @@ describe SamlIdpController do
 
       context 'authn_context is defined by sp' do
         it 'returns default AAL authn_context when default AAL and IAL1 is requested' do
-          auth_settings = requested_default_aal_authn_context_saml_settings
+          auth_settings = saml_settings(
+            overrides: { authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF },
+          )
           decoded_saml_response = generate_decoded_saml_response(user, auth_settings)
           authn_context_class_ref = saml_response_authn_context(decoded_saml_response)
 
@@ -361,7 +363,9 @@ describe SamlIdpController do
         end
 
         it 'returns default AAL authn_context when IAL1 is requested' do
-          auth_settings = requested_ial1_authn_context_saml_settings
+          auth_settings = saml_settings(
+            overrides: { authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF },
+          )
           decoded_saml_response = generate_decoded_saml_response(user, auth_settings)
           authn_context_class_ref = saml_response_authn_context(decoded_saml_response)
 
@@ -371,7 +375,9 @@ describe SamlIdpController do
         end
 
         it 'returns AAL2 authn_context when AAL2 is requested' do
-          auth_settings = requested_aal2_authn_context_saml_settings
+          auth_settings = saml_settings(
+            overrides: { authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF },
+          )
           decoded_saml_response = generate_decoded_saml_response(user, auth_settings)
           authn_context_class_ref = saml_response_authn_context(decoded_saml_response)
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -371,7 +371,12 @@ describe SamlIdpController do
       it 'responds with an error page' do
         user = create(:user, :signed_up)
 
-        generate_saml_response(user, sp2_saml_settings_inactive)
+        generate_saml_response(
+          user,
+          saml_settings(
+            overrides: { issuer: 'http://localhost:3000/inactive_sp' },
+          ),
+        )
 
         expect(controller).to redirect_to sp_inactive_error_url
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -51,20 +51,24 @@ describe SamlIdpController do
     end
 
     let(:right_cert_settings) do
-      sp1_saml_settings.tap do |settings|
-        settings.issuer = service_provider.issuer
-        settings.assertion_consumer_logout_service_url = 'https://example.com'
-      end
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          assertion_consumer_logout_service_url: 'https://example.com',
+        },
+      )
     end
 
     let(:wrong_cert_settings) do
-      sp1_saml_settings.tap do |settings|
-        settings.issuer = service_provider.issuer
-        settings.certificate = File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt'))
-        settings.private_key = OpenSSL::PKey::RSA.new(
-          File.read(Rails.root + 'keys/saml_test_sp2.key'),
-        ).to_pem
-      end
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
+          private_key: OpenSSL::PKey::RSA.new(
+            File.read(Rails.root + 'keys/saml_test_sp2.key'),
+          ).to_pem,
+        },
+      )
     end
 
     it 'accepts requests from a correct cert' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -380,7 +380,7 @@ describe SamlIdpController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        generate_saml_response(user, invalid_service_provider_settings)
+        generate_saml_response(user, saml_settings(overrides: { issuer: 'invalid_provider' }))
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -43,7 +43,12 @@ describe SamlIdpController do
 
       context 'with signed_response_message_requested false' do
         before do
-          generate_saml_response(user, sp_not_requesting_signed_saml_response_settings)
+          generate_saml_response(
+            user,
+            saml_settings(
+              overrides: { issuer: 'test_saml_sp_not_requesting_signed_response_message' },
+            ),
+          )
         end
 
         it 'only finds one Signature' do

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -23,7 +23,10 @@ describe SamlIdpController do
 
       context 'with signed_response_message_requested true' do
         before do
-          generate_saml_response(user, sp_requesting_signed_saml_response_settings)
+          settings = saml_settings(
+            overrides: { issuer: 'test_saml_sp_requesting_signed_response_message' },
+          )
+          generate_saml_response(user, settings)
         end
 
         it 'finds Signatures in the message and assertion' do

--- a/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
+++ b/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
@@ -8,7 +8,7 @@ describe 'Strong IAL2' do
 
   context 'with an sp that requires livess and a new account' do
     before do
-      ServiceProvider.find_by(issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata').
+      ServiceProvider.find_by(issuer: sp1_issuer).
         update!(liveness_checking_required: true)
     end
 

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -88,7 +88,7 @@ feature 'idv review step' do
 
         if sp == :saml
           expect(gpo_confirmation_entry[:issuer]).
-            to eq('https://rp1.serviceprovider.com/auth/saml/metadata')
+            to eq(sp1_issuer)
         else
           expect(gpo_confirmation_entry[:issuer]).
             to eq('urn:gov:gsa:openidconnect:sp:server')

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -77,7 +77,20 @@ describe 'authorization count' do
       end
 
       it 'counts IAL1 auth when ial max is requested' do
-        visit_idp_from_ial_max_saml_sp(issuer: issuer_1)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: issuer_1,
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+          saml_security_overrides: {
+            embed_sign: false,
+          },
+        )
         click_agree_and_continue
         expect_ial1_count_only(issuer_1)
       end
@@ -222,7 +235,20 @@ describe 'authorization count' do
       end
 
       it 'counts IAL2 auth when ial max is requested' do
-        visit_idp_from_ial_max_saml_sp(issuer: issuer_1)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: issuer_1,
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+          saml_security_overrides: {
+            embed_sign: false,
+          },
+        )
         click_agree_and_continue
         expect_ial2_count_only(issuer_1)
       end

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -76,6 +76,7 @@ describe 'authorization count' do
         expect_ial1_and_ial2_count(issuer_1)
       end
 
+      # rubocop:disable Layout/LineLength
       it 'counts IAL1 auth when ial max is requested' do
         visit_saml_authn_request_url(
           saml_overrides: {
@@ -96,18 +97,45 @@ describe 'authorization count' do
       end
 
       it 'counts IAL2 auth when ial2 strict is requested' do
-        visit_idp_from_ial2_strict_saml_sp(issuer: issuer_1)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: issuer_1,
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [
+              Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+          saml_security_overrides: {
+            embed_sign: false,
+          },
+        )
         click_agree_and_continue
         expect_ial2_count_only(issuer_1)
       end
 
       it 'proofs the user and counts IAL2 auth when ial2 strict is requested' do
         allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
-        visit_idp_from_ial2_strict_saml_sp(issuer: issuer_1)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: issuer_1,
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [
+              Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+          saml_security_overrides: {
+            embed_sign: false,
+          },
+        )
         reproof_for_ial2_strict
         click_agree_and_continue
         expect_ial2_count_only(issuer_1)
       end
+      # rubocop:enable Layout/LineLength
     end
   end
 
@@ -234,6 +262,7 @@ describe 'authorization count' do
         expect_ial2_count_only(issuer_2)
       end
 
+      # rubocop:disable Layout/LineLength
       it 'counts IAL2 auth when ial max is requested' do
         visit_saml_authn_request_url(
           saml_overrides: {
@@ -255,11 +284,25 @@ describe 'authorization count' do
 
       it 're-proofs and counts IAL2 auth when ial2 strict is requested' do
         allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
-        visit_idp_from_ial2_strict_saml_sp(issuer: issuer_1)
+        visit_saml_authn_request_url(
+          saml_overrides: {
+            issuer: issuer_1,
+            name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [
+              Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+          saml_security_overrides: {
+            embed_sign: false,
+          },
+        )
         reproof_for_ial2_strict
         click_agree_and_continue
         expect_ial2_count_only(issuer_1)
       end
+      # rubocop:enable Layout/LineLength
     end
   end
 

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 
 def visit_idp_from_ial1_saml_sp(issuer:)
   visit_saml_authn_request_url(
-    saml_overrides: {
+    overrides: {
       issuer: issuer,
       name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
       authn_context: [
         Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
       ],
-    },
-    saml_security_overrides: {
-      embed_sign: false,
+      security: {
+        embed_sign: false,
+      },
     },
   )
 end
 
 def visit_idp_from_ial2_saml_sp(issuer:)
   visit_saml_authn_request_url(
-    saml_overrides: {
+    overrides: {
       issuer: issuer,
       name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
       authn_context: [
@@ -26,9 +26,9 @@ def visit_idp_from_ial2_saml_sp(issuer:)
         "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
         "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
       ],
-    },
-    saml_security_overrides: {
-      embed_sign: false,
+      security: {
+        embed_sign: false,
+      },
     },
   )
 end
@@ -43,7 +43,7 @@ describe 'authorization count' do
   let(:today) { Time.zone.today }
   let(:client_id_1) { 'urn:gov:gsa:openidconnect:sp:server' }
   let(:client_id_2) { 'urn:gov:gsa:openidconnect:sp:server_two' }
-  let(:issuer_1) { 'https://rp1.serviceprovider.com/auth/saml/metadata' }
+  let(:issuer_1) { sp1_issuer }
   let(:issuer_2) { 'https://rp3.serviceprovider.com/auth/saml/metadata' }
 
   context 'an IAL1 user with an active session' do
@@ -112,7 +112,7 @@ describe 'authorization count' do
       # rubocop:disable Layout/LineLength
       it 'counts IAL1 auth when ial max is requested' do
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: issuer_1,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
             authn_context: [
@@ -120,9 +120,9 @@ describe 'authorization count' do
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
-          },
-          saml_security_overrides: {
-            embed_sign: false,
+            security: {
+              embed_sign: false,
+            },
           },
         )
         click_agree_and_continue
@@ -131,7 +131,7 @@ describe 'authorization count' do
 
       it 'counts IAL2 auth when ial2 strict is requested' do
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: issuer_1,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
             authn_context: [
@@ -139,9 +139,9 @@ describe 'authorization count' do
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
-          },
-          saml_security_overrides: {
-            embed_sign: false,
+            security: {
+              embed_sign: false,
+            },
           },
         )
         click_agree_and_continue
@@ -151,7 +151,7 @@ describe 'authorization count' do
       it 'proofs the user and counts IAL2 auth when ial2 strict is requested' do
         allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: issuer_1,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
             authn_context: [
@@ -159,9 +159,9 @@ describe 'authorization count' do
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
-          },
-          saml_security_overrides: {
-            embed_sign: false,
+            security: {
+              embed_sign: false,
+            },
           },
         )
         reproof_for_ial2_strict
@@ -298,7 +298,7 @@ describe 'authorization count' do
       # rubocop:disable Layout/LineLength
       it 'counts IAL2 auth when ial max is requested' do
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: issuer_1,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
             authn_context: [
@@ -306,9 +306,9 @@ describe 'authorization count' do
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
-          },
-          saml_security_overrides: {
-            embed_sign: false,
+            security: {
+              embed_sign: false,
+            },
           },
         )
         click_agree_and_continue
@@ -318,7 +318,7 @@ describe 'authorization count' do
       it 're-proofs and counts IAL2 auth when ial2 strict is requested' do
         allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: issuer_1,
             name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
             authn_context: [
@@ -326,9 +326,9 @@ describe 'authorization count' do
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
-          },
-          saml_security_overrides: {
-            embed_sign: false,
+            security: {
+              embed_sign: false,
+            },
           },
         )
         reproof_for_ial2_strict

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
+def visit_idp_from_ial1_saml_sp(issuer:)
+  visit_saml_authn_request_url(
+    saml_overrides: {
+      issuer: issuer,
+      name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+      authn_context: [
+        Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
+      ],
+    },
+    saml_security_overrides: {
+      embed_sign: false,
+    },
+  )
+end
+
 describe 'authorization count' do
   include IdvFromSpHelper
   include OidcAuthHelper

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -16,6 +16,23 @@ def visit_idp_from_ial1_saml_sp(issuer:)
   )
 end
 
+def visit_idp_from_ial2_saml_sp(issuer:)
+  visit_saml_authn_request_url(
+    saml_overrides: {
+      issuer: issuer,
+      name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+      authn_context: [
+        Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+      ],
+    },
+    saml_security_overrides: {
+      embed_sign: false,
+    },
+  )
+end
+
 describe 'authorization count' do
   include IdvFromSpHelper
   include OidcAuthHelper

--- a/spec/features/saml/aal3_required_spec.rb
+++ b/spec/features/saml/aal3_required_spec.rb
@@ -19,7 +19,7 @@ describe 'AAL3 authentication required in an SAML context' do
     context 'user does not have aal3 auth configured' do
       it 'sends user to set up AAL3 auth' do
         sign_in_and_2fa_user(user_with_2fa)
-        visit aal3_sp1_authnrequest
+        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
 
         expect(current_url).to eq(two_factor_options_url)
         expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
@@ -30,14 +30,14 @@ describe 'AAL3 authentication required in an SAML context' do
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
         sign_in_before_2fa(user_with_aal3_2fa)
-        visit aal3_sp1_authnrequest
+        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
         visit login_two_factor_path(otp_delivery_preference: 'sms')
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
 
       it 'does not allow an already signed in user to bypass AAL3 auth' do
         sign_in_and_2fa_user(user_with_aal3_2fa)
-        visit aal3_sp1_authnrequest
+        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end

--- a/spec/features/saml/aal3_required_spec.rb
+++ b/spec/features/saml/aal3_required_spec.rb
@@ -19,7 +19,7 @@ describe 'AAL3 authentication required in an SAML context' do
     context 'user does not have aal3 auth configured' do
       it 'sends user to set up AAL3 auth' do
         sign_in_and_2fa_user(user_with_2fa)
-        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
+        visit_saml_authn_request_url(overrides: { issuer: aal3_issuer, authn_context: nil })
 
         expect(current_url).to eq(two_factor_options_url)
         expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
@@ -30,14 +30,14 @@ describe 'AAL3 authentication required in an SAML context' do
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
         sign_in_before_2fa(user_with_aal3_2fa)
-        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
+        visit_saml_authn_request_url(overrides: { issuer: aal3_issuer, authn_context: nil })
         visit login_two_factor_path(otp_delivery_preference: 'sms')
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
 
       it 'does not allow an already signed in user to bypass AAL3 auth' do
         sign_in_and_2fa_user(user_with_aal3_2fa)
-        visit_saml_authn_request_url(saml_overrides: { issuer: aal3_issuer, authn_context: nil })
+        visit_saml_authn_request_url(overrides: { issuer: aal3_issuer, authn_context: nil })
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -15,7 +15,7 @@ feature 'SAML Authorization Confirmation' do
       check :remember_device
       fill_in_code_with_last_phone_otp
       click_submit_default
-      visit saml_authn_request
+      visit request_url
       click_agree_and_continue
       visit sign_out_url
 
@@ -24,7 +24,7 @@ feature 'SAML Authorization Confirmation' do
 
     let(:user1) { create_user_and_remember_device }
     let(:user2) { create_user_and_remember_device }
-    let(:saml_authn_request) { auth_request.create(saml_settings) }
+    let(:request_url) { saml_authn_request_url }
 
     before do
       # Cycle user2 first so user1's remember device will stick
@@ -35,18 +35,18 @@ feature 'SAML Authorization Confirmation' do
     it 'it confirms the user wants to continue to the SP after signing in again' do
       sign_in_user(user1)
 
-      visit saml_authn_request
+      visit request_url
 
       expect(current_url).to match(user_authorization_confirmation_path)
       continue_as(user1.email)
 
-      expect(current_url).to eq(saml_authn_request)
+      expect(current_url).to eq(request_url)
     end
 
     it 'it allows the user to switch accounts prior to continuing to the SP' do
       sign_in_user(user1)
 
-      visit saml_authn_request
+      visit request_url
       expect(current_url).to match(user_authorization_confirmation_path)
       continue_as(user2.email, user2.password)
 
@@ -54,12 +54,12 @@ feature 'SAML Authorization Confirmation' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_url).to eq(saml_authn_request)
+      expect(current_url).to eq(request_url)
     end
 
     it 'does not render an error if a user goes back after opting to switch accounts' do
       sign_in_user(user1)
-      visit saml_authn_request
+      visit request_url
 
       expect(current_path).to eq(user_authorization_confirmation_path)
 

--- a/spec/features/saml/ial1/account_creation_spec.rb
+++ b/spec/features/saml/ial1/account_creation_spec.rb
@@ -5,8 +5,7 @@ feature 'Canceling Account Creation' do
 
   context 'From the enter email page', email: true do
     it 'redirects to the branded start page' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       sp_request_id = ServiceProviderRequestProxy.last.uuid
       click_link t('links.create_account')
       click_link t('links.cancel')
@@ -17,8 +16,7 @@ feature 'Canceling Account Creation' do
 
   context 'From the enter password page', email: true do
     it 'redirects to the branded start page' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       click_link t('links.create_account')
       submit_form_with_valid_email
       click_confirmation_link_in_email('test@test.com')
@@ -32,8 +30,7 @@ feature 'Canceling Account Creation' do
     end
 
     it 'redirects to the password page after cancelling the cancellation' do
-      authn_request = auth_request.create(saml_settings)
-      visit authn_request
+      visit saml_authn_request_url
       click_link t('links.create_account')
       submit_form_with_valid_email
       click_confirmation_link_in_email('test@test.com')

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -196,8 +196,8 @@ feature 'IAL1 Single Sign On' do
     it 'shows verified_at as a requested attribute, even if blank' do
       user = create(:user, :signed_up)
       saml_authn_request = saml_authn_request_url(
-        saml_overrides: {
-          issuer: 'saml_sp_ial2',
+        overrides: {
+          issuer: sp1_issuer,
           authn_context: [
             Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -5,9 +5,22 @@ feature 'IAL2 Single Sign On' do
   include IdvStepHelper
   include DocAuthHelper
 
+  def saml_ial2_request_url
+    saml_authn_request_url(
+      saml_overrides: {
+        issuer: 'saml_sp_ial2',
+        authn_context: [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+        # name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+      },
+    )
+  end
+
   def perform_id_verification_with_gpo_without_confirming_code(user)
-    saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
-    visit saml_authn_request
+    visit saml_ial2_request_url
     fill_in_credentials_and_submit(user.email, user.password)
     uncheck(t('forms.messages.remember_device'))
     fill_in_code_with_last_phone_otp
@@ -23,7 +36,7 @@ feature 'IAL2 Single Sign On' do
 
   def expected_gpo_return_to_sp_url
     URI.join(
-      ServiceProvider.find_by(issuer: ial2_with_bundle_saml_settings.issuer).acs_url,
+      ServiceProvider.find_by(issuer: 'saml_sp_ial2').acs_url,
       '/',
     ).to_s
   end
@@ -46,27 +59,21 @@ feature 'IAL2 Single Sign On' do
 
   context 'First time registration' do
     let(:email) { 'test@test.com' }
-    before do
-      @saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
-    end
 
     it 'shows user the start page with accordion' do
-      saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
       sp_content = [
         'Test SP',
         t('headings.create_account_with_sp.sp_text'),
       ].join(' ')
 
-      visit saml_authn_request
+      visit saml_ial2_request_url
 
       expect(current_path).to match new_user_session_path
       expect(page).to have_content(sp_content)
     end
 
     it 'shows user the start page with a link back to the SP' do
-      saml_authn_request = auth_request.create(saml_settings)
-
-      visit saml_authn_request
+      visit saml_authn_request_url
 
       expect(page).to have_link(
         t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: return_to_sp_cancel_path
@@ -186,14 +193,14 @@ feature 'IAL2 Single Sign On' do
     context 'returning to verify after canceling during the same session' do
       it 'allows the user to verify' do
         user = create(:user, :signed_up)
-        saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
+        request_url = saml_ial2_request_url
 
-        visit saml_authn_request
+        visit request_url
         sign_in_live_with_2fa(user)
         complete_all_doc_auth_steps
         click_on t('links.cancel')
         click_on t('forms.buttons.cancel')
-        visit saml_authn_request
+        visit request_url
         complete_all_doc_auth_steps
 
         expect(current_path).to eq idv_phone_path

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -212,7 +212,12 @@ feature 'IAL2 Single Sign On' do
     it 'redirects to idv_path' do
       sign_in_and_2fa_user
 
-      visit ial2_authnrequest
+      visit_saml_authn_request_url(
+        saml_overrides: {
+          issuer: sp1_issuer,
+          authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
       visit sign_up_completed_path
 
       expect(current_path).to eq idv_doc_auth_step_path(step: :welcome)

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -7,14 +7,13 @@ feature 'IAL2 Single Sign On' do
 
   def saml_ial2_request_url
     saml_authn_request_url(
-      saml_overrides: {
+      overrides: {
         issuer: 'saml_sp_ial2',
         authn_context: [
           Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
         ],
-        # name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
       },
     )
   end
@@ -213,7 +212,7 @@ feature 'IAL2 Single Sign On' do
       sign_in_and_2fa_user
 
       visit_saml_authn_request_url(
-        saml_overrides: {
+        overrides: {
           issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
         },

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -10,7 +10,7 @@ feature 'SAML logout' do
       it 'contains all redirect_uris in CSP when user is logged out of the IDP' do
         sign_in_and_2fa_user(user)
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'saml_sp_ial2',
           },
         )
@@ -23,7 +23,7 @@ feature 'SAML logout' do
 
         # SAML logout request
         visit_saml_logout_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'saml_sp_ial2',
           },
         )
@@ -38,7 +38,7 @@ feature 'SAML logout' do
       it 'contains all redirect_uris in CSP when user is logged in to the IDP' do
         sign_in_and_2fa_user(user)
         visit_saml_authn_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'saml_sp_ial2',
           },
         )
@@ -46,7 +46,7 @@ feature 'SAML logout' do
 
         # SAML logout request
         visit_saml_logout_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'saml_sp_ial2',
           },
         )
@@ -93,7 +93,7 @@ feature 'SAML logout' do
     context 'the user is not signed in' do
       it 'redirects to the SP' do
         visit_saml_logout_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'saml_sp_ial2',
             name_identifier_value: 'asdf-1234',
           },
@@ -113,12 +113,12 @@ feature 'SAML logout' do
         sign_in_and_2fa_user(user)
 
         visit_saml_logout_request_url(
-          saml_overrides: {
+          overrides: {
             issuer: 'invalid_provider',
             name_identifier_value: 'asdf-1234',
-          },
-          saml_security_overrides: {
-            logout_requests_signed: false,
+            security: {
+              logout_requests_signed: false,
+            },
           },
         )
 

--- a/spec/features/saml/saml_relay_state_spec.rb
+++ b/spec/features/saml/saml_relay_state_spec.rb
@@ -10,8 +10,8 @@ feature 'SAML RelayState' do
 
     it 'returns RelayState on GET authn request' do
       visit_saml_authn_request_url(
-        saml_overrides: {
-          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        overrides: {
+          issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         },
         params: params,
@@ -26,7 +26,7 @@ feature 'SAML RelayState' do
     it 'returns RelayState on POST authn request' do
       auth_settings = saml_settings(
         overrides: {
-          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         },
       )
@@ -44,8 +44,8 @@ feature 'SAML RelayState' do
 
     it 'does not return RelayState on GET authn request' do
       visit_saml_authn_request_url(
-        saml_overrides: {
-          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        overrides: {
+          issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         },
       )
@@ -61,7 +61,7 @@ feature 'SAML RelayState' do
     it 'does not return RelayState on POST authn request' do
       auth_settings = saml_settings(
         overrides: {
-          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          issuer: sp1_issuer,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         },
       )

--- a/spec/features/saml/saml_relay_state_spec.rb
+++ b/spec/features/saml/saml_relay_state_spec.rb
@@ -9,7 +9,13 @@ feature 'SAML RelayState' do
     let(:params) { { RelayState: relay_state_value } }
 
     it 'returns RelayState on GET authn request' do
-      get_saml_authn_request(sp1_ial1_saml_settings, params)
+      visit_saml_authn_request_url(
+        saml_overrides: {
+          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        },
+        params: params,
+      )
 
       login_and_confirm_sp(user)
 
@@ -18,7 +24,13 @@ feature 'SAML RelayState' do
     end
 
     it 'returns RelayState on POST authn request' do
-      post_saml_authn_request(sp1_ial1_saml_settings, params)
+      auth_settings = saml_settings(
+        overrides: {
+          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
+      post_saml_authn_request(auth_settings, params)
 
       login_and_confirm_sp(user)
 
@@ -31,7 +43,12 @@ feature 'SAML RelayState' do
     let(:user) { create(:user, :signed_up) }
 
     it 'does not return RelayState on GET authn request' do
-      get_saml_authn_request(sp1_ial1_saml_settings)
+      visit_saml_authn_request_url(
+        saml_overrides: {
+          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
 
       login_and_confirm_sp(user)
 
@@ -42,7 +59,13 @@ feature 'SAML RelayState' do
     end
 
     it 'does not return RelayState on POST authn request' do
-      post_saml_authn_request(sp1_ial1_saml_settings)
+      auth_settings = saml_settings(
+        overrides: {
+          issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
+      post_saml_authn_request(auth_settings)
 
       login_and_confirm_sp(user)
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -11,7 +11,7 @@ feature 'saml api' do
 
   context 'when assertion consumer service url is defined' do
     before do
-      visit_saml_auth_path
+      visit_saml_authn_request_url
       expect(sp.acs_url).to_not be_blank
     end
 
@@ -29,7 +29,7 @@ feature 'saml api' do
 
   context 'when assertion consumer service url is blank' do
     before do
-      visit_saml_auth_path
+      visit_saml_authn_request_url
       sp.acs_url = ''
       sp.save
     end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -219,7 +219,7 @@ feature 'saml api' do
 
       before do
         sign_in_and_2fa_user(logout_user)
-        visit sp1_authnrequest
+        visit_saml_authn_request_url(saml_overrides: { issuer: sp1_issuer })
       end
 
       it 'redirects to root' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -89,7 +89,7 @@ feature 'saml api' do
     context 'service provider does not explicitly disable encryption' do
       before do
         sign_in_and_2fa_user(user)
-        visit_saml_authn_request_url(saml_overrides: { issuer: sp2_issuer })
+        visit_saml_authn_request_url(overrides: { issuer: sp2_issuer })
         click_agree_and_continue
       end
 
@@ -219,7 +219,7 @@ feature 'saml api' do
 
       before do
         sign_in_and_2fa_user(logout_user)
-        visit_saml_authn_request_url(saml_overrides: { issuer: sp1_issuer })
+        visit_saml_authn_request_url(overrides: { issuer: sp1_issuer })
       end
 
       it 'redirects to root' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -89,7 +89,7 @@ feature 'saml api' do
     context 'service provider does not explicitly disable encryption' do
       before do
         sign_in_and_2fa_user(user)
-        visit sp2_authnrequest
+        visit_saml_authn_request_url(saml_overrides: { issuer: sp2_issuer })
         click_agree_and_continue
       end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -835,7 +835,7 @@ feature 'Sign in' do
     it 'returns ial1 info for a non-verified user' do
       user = create(:user, :signed_up)
       visit_saml_authn_request_url(
-        saml_overrides: {
+        overrides: {
           issuer: sp1_issuer,
           authn_context: [
             Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
@@ -862,7 +862,7 @@ feature 'Sign in' do
         pii: { first_name: 'John', ssn: '111223333' }
       ).user
       visit_saml_authn_request_url(
-        saml_overrides: {
+        overrides: {
           issuer: sp1_issuer,
           authn_context: [
             Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -834,7 +834,16 @@ feature 'Sign in' do
   context 'saml sp requests ialmax' do
     it 'returns ial1 info for a non-verified user' do
       user = create(:user, :signed_up)
-      visit_idp_from_saml_sp_with_ialmax
+      visit_saml_authn_request_url(
+        saml_overrides: {
+          issuer: sp1_issuer,
+          authn_context: [
+            Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+          ],
+        },
+      )
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
@@ -852,7 +861,16 @@ feature 'Sign in' do
         :profile, :active, :verified,
         pii: { first_name: 'John', ssn: '111223333' }
       ).user
-      visit_idp_from_saml_sp_with_ialmax
+      visit_saml_authn_request_url(
+        saml_overrides: {
+          issuer: sp1_issuer,
+          authn_context: [
+            Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+          ],
+        },
+      )
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -37,7 +37,15 @@ describe AttributeAsserter do
     )
     CGI.unescape ial1_authn_request_url.split('SAMLRequest').last
   end
-  let(:raw_ial2_authn_request) { CGI.unescape ial2_authnrequest.split('SAMLRequest').last }
+  let(:raw_ial2_authn_request) do
+    ial2_authnrequest = saml_authn_request_url(
+      saml_overrides: {
+        issuer: sp1_issuer,
+        authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
+    CGI.unescape ial2_authnrequest.split('SAMLRequest').last
+  end
   let(:raw_ial1_aal3_authn_request) do
     CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last
   end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -26,7 +26,10 @@ describe AttributeAsserter do
       metadata: {},
     )
   end
-  let(:raw_sp1_authn_request) { CGI.unescape sp1_authnrequest.split('SAMLRequest').last }
+  let(:raw_sp1_authn_request) do
+    sp1_authnrequest = saml_authn_request_url(saml_overrides: { issuer: sp1_issuer })
+    CGI.unescape sp1_authnrequest.split('SAMLRequest').last
+  end
   let(:raw_aal3_sp1_authn_request) do
     ial1_aal3_authnrequest = saml_authn_request_url(
       saml_overrides: {

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -27,12 +27,12 @@ describe AttributeAsserter do
     )
   end
   let(:raw_sp1_authn_request) do
-    sp1_authnrequest = saml_authn_request_url(saml_overrides: { issuer: sp1_issuer })
+    sp1_authnrequest = saml_authn_request_url(overrides: { issuer: sp1_issuer })
     CGI.unescape sp1_authnrequest.split('SAMLRequest').last
   end
   let(:raw_aal3_sp1_authn_request) do
     ial1_aal3_authnrequest = saml_authn_request_url(
-      saml_overrides: {
+      overrides: {
         issuer: sp1_issuer,
         authn_context: [
           Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -44,7 +44,7 @@ describe AttributeAsserter do
   end
   let(:raw_ial1_authn_request) do
     ial1_authn_request_url = saml_authn_request_url(
-      saml_overrides: {
+      overrides: {
         issuer: sp1_issuer,
         authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
       },
@@ -53,7 +53,7 @@ describe AttributeAsserter do
   end
   let(:raw_ial2_authn_request) do
     ial2_authnrequest = saml_authn_request_url(
-      saml_overrides: {
+      overrides: {
         issuer: sp1_issuer,
         authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
       },
@@ -62,7 +62,7 @@ describe AttributeAsserter do
   end
   let(:raw_ial1_aal3_authn_request) do
     ial1_aal3_authnrequest = saml_authn_request_url(
-      saml_overrides: {
+      overrides: {
         issuer: sp1_issuer,
         authn_context: [
           Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -209,8 +209,8 @@ describe AttributeAsserter do
           # rubocop:disable Layout/LineLength
           let(:raw_ial2_authn_request) do
             request_url = saml_authn_request_url(
-              saml_overrides: {
-                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+              overrides: {
+                issuer: sp1_issuer,
                 authn_context: [
                   Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                   "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
@@ -370,8 +370,8 @@ describe AttributeAsserter do
           # rubocop:disable Layout/LineLength
           let(:raw_sp1_authn_request) do
             request_url = saml_authn_request_url(
-              saml_overrides: {
-                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+              overrides: {
+                issuer: sp1_issuer,
                 authn_context: [
                   Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                   Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -340,10 +340,10 @@ describe AttributeAsserter do
                   "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
                 ],
               },
-              )
+            )
             CGI.unescape(
               request_url.split('SAMLRequest').last,
-              )
+            )
           end
           # rubocop:enable Layout/LineLength
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -28,7 +28,15 @@ describe AttributeAsserter do
   end
   let(:raw_sp1_authn_request) { CGI.unescape sp1_authnrequest.split('SAMLRequest').last }
   let(:raw_aal3_sp1_authn_request) { CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last }
-  let(:raw_ial1_authn_request) { CGI.unescape ial1_authnrequest.split('SAMLRequest').last }
+  let(:raw_ial1_authn_request) do
+    ial1_authn_request_url = saml_authn_request_url(
+      saml_overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
+    CGI.unescape ial1_authn_request_url.split('SAMLRequest').last
+  end
   let(:raw_ial2_authn_request) { CGI.unescape ial2_authnrequest.split('SAMLRequest').last }
   let(:raw_ial1_aal3_authn_request) do
     CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -167,11 +167,23 @@ describe AttributeAsserter do
         end
 
         context 'authn request specifies bundle' do
+          # rubocop:disable Layout/LineLength
           let(:raw_ial2_authn_request) do
+            request_url = saml_authn_request_url(
+              saml_overrides: {
+                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+                authn_context: [
+                  Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ],
+              },
+            )
             CGI.unescape(
-              auth_request.create(ial2_with_bundle_saml_settings).split('SAMLRequest').last,
+              request_url.split('SAMLRequest').last,
             )
           end
+          # rubocop:enable Layout/LineLength
 
           it 'uses authn request bundle' do
             expect(user.asserted_attributes.keys).
@@ -316,11 +328,24 @@ describe AttributeAsserter do
         end
 
         context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
+          # rubocop:disable Layout/LineLength
           let(:raw_sp1_authn_request) do
+            request_url = saml_authn_request_url(
+              saml_overrides: {
+                issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+                authn_context: [
+                  Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ],
+              },
+              )
             CGI.unescape(
-              auth_request.create(ial1_with_bundle_saml_settings).split('SAMLRequest').last,
-            )
+              request_url.split('SAMLRequest').last,
+              )
           end
+          # rubocop:enable Layout/LineLength
 
           it 'only includes uuid, email, aal, and ial' do
             expect(user.asserted_attributes.keys).to eq(%i[uuid email aal ial])

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -27,11 +27,22 @@ describe AttributeAsserter do
     )
   end
   let(:raw_sp1_authn_request) { CGI.unescape sp1_authnrequest.split('SAMLRequest').last }
-  let(:raw_aal3_sp1_authn_request) { CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last }
+  let(:raw_aal3_sp1_authn_request) do
+    ial1_aal3_authnrequest = saml_authn_request_url(
+      saml_overrides: {
+        issuer: sp1_issuer,
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+        ],
+      },
+    )
+    CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last
+  end
   let(:raw_ial1_authn_request) do
     ial1_authn_request_url = saml_authn_request_url(
       saml_overrides: {
-        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        issuer: sp1_issuer,
         authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
       },
     )
@@ -47,6 +58,15 @@ describe AttributeAsserter do
     CGI.unescape ial2_authnrequest.split('SAMLRequest').last
   end
   let(:raw_ial1_aal3_authn_request) do
+    ial1_aal3_authnrequest = saml_authn_request_url(
+      saml_overrides: {
+        issuer: sp1_issuer,
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+        ],
+      },
+    )
     CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last
   end
   let(:sp1_authn_request) do

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -59,7 +59,6 @@ module IdvHelper
     if sp == :saml
       saml_overrides = {
         issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
-        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
         authn_context: [
           Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -57,15 +57,26 @@ module IdvHelper
 
   def visit_idp_from_sp_with_ial2(sp, **extra)
     if sp == :saml
-      settings = ial2_with_bundle_saml_settings
-      settings.security[:embed_sign] = false
+      saml_overrides = {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+        authn_context: [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+      }
       if javascript_enabled?
         idp_domain_name = "#{page.server.host}:#{page.server.port}"
-        settings.idp_sso_target_url = "http://#{idp_domain_name}/api/saml/auth"
-        settings.idp_slo_target_url = "http://#{idp_domain_name}/api/saml/logout"
+        saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
+        saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
       end
-      @saml_authn_request = auth_request.create(settings)
-      visit @saml_authn_request
+      visit_saml_authn_request_url(
+        saml_overrides: saml_overrides,
+        saml_security_overrides: {
+          embed_sign: false,
+        },
+      )
     elsif sp == :oidc
       @state = SecureRandom.hex
       @client_id = 'urn:gov:gsa:openidconnect:sp:server'
@@ -120,14 +131,28 @@ module IdvHelper
   end
 
   def visit_idp_from_saml_sp_with_loa3
-    settings = loa3_with_bundle_saml_settings
-    settings.security[:embed_sign] = false
+    # settings = loa3_with_bundle_saml_settings
+    # settings.security[:embed_sign] = false
+    saml_overrides = {
+      issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+      authn_context: [
+        Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+        "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+      ],
+    }
     if javascript_enabled?
       idp_domain_name = "#{page.server.host}:#{page.server.port}"
-      settings.idp_sso_target_url = "http://#{idp_domain_name}/api/saml/auth"
-      settings.idp_slo_target_url = "http://#{idp_domain_name}/api/saml/logout"
+      saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
+      saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
     end
-    @saml_authn_request = auth_request.create(settings)
-    visit @saml_authn_request
+    # @saml_authn_request = auth_request.create(settings)
+    # visit @saml_authn_request
+    visit_saml_authn_request_url(
+      saml_overrides: saml_overrides,
+      saml_security_overrides: {
+        embed_sign: false,
+      },
+    )
   end
 end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -58,24 +58,22 @@ module IdvHelper
   def visit_idp_from_sp_with_ial2(sp, **extra)
     if sp == :saml
       saml_overrides = {
-        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        issuer: sp1_issuer,
         authn_context: [
           Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
         ],
+        security: {
+          embed_sign: false,
+        },
       }
       if javascript_enabled?
         idp_domain_name = "#{page.server.host}:#{page.server.port}"
         saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
         saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
       end
-      visit_saml_authn_request_url(
-        saml_overrides: saml_overrides,
-        saml_security_overrides: {
-          embed_sign: false,
-        },
-      )
+      visit_saml_authn_request_url(overrides: saml_overrides)
     elsif sp == :oidc
       @state = SecureRandom.hex
       @client_id = 'urn:gov:gsa:openidconnect:sp:server'
@@ -133,12 +131,15 @@ module IdvHelper
     # settings = loa3_with_bundle_saml_settings
     # settings.security[:embed_sign] = false
     saml_overrides = {
-      issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+      issuer: sp1_issuer,
       authn_context: [
         Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
         "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
         "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
       ],
+      security: {
+        embed_sign: false,
+      },
     }
     if javascript_enabled?
       idp_domain_name = "#{page.server.host}:#{page.server.port}"
@@ -147,11 +148,6 @@ module IdvHelper
     end
     # @saml_authn_request = auth_request.create(settings)
     # visit @saml_authn_request
-    visit_saml_authn_request_url(
-      saml_overrides: saml_overrides,
-      saml_security_overrides: {
-        embed_sign: false,
-      },
-    )
+    visit_saml_authn_request_url(overrides: saml_overrides)
   end
 end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -128,8 +128,6 @@ module IdvHelper
   end
 
   def visit_idp_from_saml_sp_with_loa3
-    # settings = loa3_with_bundle_saml_settings
-    # settings.security[:embed_sign] = false
     saml_overrides = {
       issuer: sp1_issuer,
       authn_context: [
@@ -146,8 +144,6 @@ module IdvHelper
       saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
       saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
     end
-    # @saml_authn_request = auth_request.create(settings)
-    # visit @saml_authn_request
     visit_saml_authn_request_url(overrides: saml_overrides)
   end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,18 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def ial1_with_aal3_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-        ],
-      },
-    )
-  end
-
   def sp1_authnrequest
     auth_request.create(
       saml_settings(
@@ -173,10 +161,6 @@ module SamlAuthHelper
         },
       ),
     )
-  end
-
-  def ial1_aal3_authnrequest
-    auth_request.create(ial1_with_aal3_saml_settings)
   end
 
   def requested_aal2_authn_context_saml_settings

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,13 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_service_provider_and_authn_context_settings
-    settings = saml_settings.dup
-    settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'
-    settings.issuer = 'invalid_provider'
-    settings
-  end
-
   def sp1_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,14 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp1_authnrequest
-    auth_request.create(
-      saml_settings(
-        overrides: { issuer: sp1_issuer },
-      ),
-    )
-  end
-
   def sp2_authnrequest
     auth_request.create(
       saml_settings(

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -117,7 +117,6 @@ module SamlAuthHelper
       overrides: {
         issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
         authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
       },
     )
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,15 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp1_ial2_strict_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-  end
-
   def loa3_saml_settings
     saml_settings(
       overrides: {
@@ -165,16 +156,6 @@ module SamlAuthHelper
 
   def ialmax_with_bundle_saml_settings
     settings = ialmax_saml_settings
-    settings.authn_context = [
-      settings.authn_context,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
-  end
-
-  def ial2_strict_with_bundle_saml_settings
-    settings = sp1_ial2_strict_saml_settings
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
@@ -316,16 +297,6 @@ module SamlAuthHelper
 
   def saml_response_authn_context(decoded_saml_response)
     REXML::XPath.match(decoded_saml_response, '//AuthnContext/AuthnContextClassRef')[0][0]
-  end
-
-  def visit_idp_from_ial2_strict_saml_sp(**args)
-    settings = ial2_strict_with_bundle_saml_settings
-    settings.security[:embed_sign] = false
-    settings.issuer = args[:issuer] if args[:issuer]
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-    saml_authn_request = auth_request.create(settings)
-    visit saml_authn_request
-    saml_authn_request
   end
 
   def visit_idp_from_ial2_saml_sp(**args)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -133,16 +133,12 @@ module SamlAuthHelper
     'https://rp1.serviceprovider.com/auth/saml/metadata'
   end
 
-  ##################################################################################################
-  ##################################################################################################
-
-  def sp2_authnrequest
-    auth_request.create(
-      saml_settings(
-        overrides: { issuer: 'https://rp2.serviceprovider.com/auth/saml/metadata' },
-      ),
-    )
+  def sp2_issuer
+    'https://rp2.serviceprovider.com/auth/saml/metadata'
   end
+
+  ##################################################################################################
+  ##################################################################################################
 
   def aal3_sp1_authnrequest
     auth_request.create(

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,13 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def missing_nameid_format_saml_settings_for_allowed_email_issuer
-    settings = saml_settings.dup
-    settings.name_identifier_format = nil
-    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
   def missing_nameid_format_saml_settings
     settings = saml_settings.dup
     settings.name_identifier_format = nil

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,16 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def authnrequest_get(issuer: nil)
-    auth_request.create(saml_spec_settings(issuer: issuer))
-  end
-
-  def saml_spec_settings(issuer: nil)
-    settings = saml_settings.dup
-    settings.issuer = issuer || 'http://localhost:3000'
-    settings
-  end
-
   def invalid_authn_context_settings
     settings = saml_settings.dup
     settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,13 +109,7 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp_requesting_signed_saml_response_settings
-    settings = saml_settings.dup
-    settings.issuer = 'test_saml_sp_requesting_signed_response_message'
-    settings
-  end
-
-  def email_nameid_saml_settings
+  def email_nameid_saml_settings_for_allowed_issuer
     settings = saml_settings.dup
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     settings

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def missing_nameid_format_saml_settings
-    settings = saml_settings.dup
-    settings.name_identifier_format = nil
-    settings
-  end
-
   def email_nameid_saml_settings_for_disallowed_issuer
     settings = saml_settings.dup
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,13 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def aal3_sp1_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = nil
-    settings.issuer = 'https://aal3.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
   def sp2_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp2.serviceprovider.com/auth/saml/metadata'
@@ -328,7 +321,14 @@ module SamlAuthHelper
   end
 
   def aal3_sp1_authnrequest
-    auth_request.create(aal3_sp1_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: {
+          issuer: 'https://aal3.serviceprovider.com/auth/saml/metadata',
+          authn_context: nil,
+        },
+      ),
+    )
   end
 
   def ial1_aal3_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -64,7 +64,7 @@ module SamlAuthHelper
   end
 
   def saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {}, params: {})
-    auth_request.create(
+    @saml_authn_request = auth_request.create(
       saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides),
       params,
     )

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp2_saml_settings_inactive
-    settings = saml_settings.dup
-    settings.issuer = 'http://localhost:3000/inactive_sp'
-    settings
-  end
-
   def sp_not_requesting_signed_saml_response_settings
     settings = saml_settings.dup
     settings.issuer = 'test_saml_sp_not_requesting_signed_response_message'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,20 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def ial1_with_bundle_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-        ],
-      },
-    )
-  end
-
   def ial1_with_aal3_saml_settings
     saml_settings(
       overrides: {

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,12 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_authn_context_settings
-    settings = saml_settings.dup
-    settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'
-    settings
-  end
-
   def invalid_service_provider_settings
     settings = saml_settings.dup
     settings.issuer = 'invalid_provider'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -137,19 +137,12 @@ module SamlAuthHelper
     'https://rp2.serviceprovider.com/auth/saml/metadata'
   end
 
-  ##################################################################################################
-  ##################################################################################################
-
-  def aal3_sp1_authnrequest
-    auth_request.create(
-      saml_settings(
-        overrides: {
-          issuer: 'https://aal3.serviceprovider.com/auth/saml/metadata',
-          authn_context: nil,
-        },
-      ),
-    )
+  def aal3_issuer
+    'https://aal3.serviceprovider.com/auth/saml/metadata'
   end
+
+  ##################################################################################################
+  ##################################################################################################
 
   def requested_aal2_authn_context_saml_settings
     settings = saml_settings.dup

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def ial1_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    settings
-  end
-
   def sp1_ial1_saml_settings
     saml_settings(
       overrides: {
@@ -467,8 +461,9 @@ module SamlAuthHelper
 
   def visit_idp_from_sp_with_ial1(sp)
     if sp == :saml
-      @saml_authn_request = auth_request.create(ial1_saml_settings)
-      visit @saml_authn_request
+      visit_saml_authn_request_url(
+        saml_overrides: { authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF },
+      )
     elsif sp == :oidc
       @state = SecureRandom.hex
       @client_id = 'urn:gov:gsa:openidconnect:sp:server'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -63,31 +63,34 @@ module SamlAuthHelper
     @logout_request ||= OneLogin::RubySaml::Logoutrequest.new
   end
 
-  def saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
+  def saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {}, params: {})
     auth_request.create(
       saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides),
+      params,
     )
   end
 
-  def saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {})
+  def saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {}, params: {})
     logout_request.create(
       saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides),
+      params,
     )
   end
 
-  def visit_saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
+  def visit_saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {}, params: {})
     authn_request_url = saml_authn_request_url(
       saml_overrides: saml_overrides,
       saml_security_overrides: saml_security_overrides,
+      params: params,
     )
     visit authn_request_url
   end
 
-  def visit_saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {})
-    settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
+  def visit_saml_logout_request_url(saml_overrides: {}, saml_security_overrides: {}, params: {})
     logout_request_url = saml_logout_request_url(
       saml_overrides: saml_overrides,
       saml_security_overrides: saml_security_overrides,
+      params: params,
     )
     visit logout_request_url
   end
@@ -108,15 +111,6 @@ module SamlAuthHelper
 
   ##################################################################################################
   ##################################################################################################
-
-  def sp1_ial1_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
-        authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-  end
 
   def sp1_ial2_saml_settings
     saml_settings(
@@ -266,10 +260,6 @@ module SamlAuthHelper
         overrides: { issuer: 'https://rp2.serviceprovider.com/auth/saml/metadata' },
       ),
     )
-  end
-
-  def ial1_authnrequest
-    auth_request.create(sp1_ial1_saml_settings)
   end
 
   def ial2_authnrequest
@@ -435,11 +425,6 @@ module SamlAuthHelper
     auth_params = OneLogin::RubySaml::Authrequest.new.create_params(settings, params)
     auth_params.merge(params)
     auth_params
-  end
-
-  def get_saml_authn_request(settings = saml_settings, params = {})
-    saml_authn_request = auth_request.create(settings, params)
-    visit saml_authn_request
   end
 
   def post_saml_authn_request(settings = saml_settings, params = {})

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -105,12 +105,6 @@ module SamlAuthHelper
     post :auth, params: { SAMLRequest: CGI.unescape(saml_request) }
   end
 
-  def visit_saml_auth_path
-    visit api_saml_auth2021_path(
-      SAMLRequest: CGI.unescape(saml_request(saml_settings)),
-    )
-  end
-
   private
 
   def saml_request(settings)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,12 +111,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def invalid_service_provider_settings
-    settings = saml_settings.dup
-    settings.issuer = 'invalid_provider'
-    settings
-  end
-
   def invalid_service_provider_and_authn_context_settings
     settings = saml_settings.dup
     settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,25 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def ialmax_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-  end
-
-  def ialmax_with_bundle_saml_settings
-    settings = ialmax_saml_settings
-    settings.authn_context = [
-      settings.authn_context,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
-  end
-
   def ial1_with_verified_at_saml_settings
     saml_settings(
       overrides: {
@@ -431,10 +412,5 @@ module SamlAuthHelper
       prompt: 'login',
       nonce: nonce,
     )
-  end
-
-  def visit_idp_from_saml_sp_with_ialmax
-    @saml_authn_request = auth_request.create(ialmax_with_bundle_saml_settings)
-    visit @saml_authn_request
   end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -172,27 +172,6 @@ module SamlAuthHelper
     REXML::XPath.match(decoded_saml_response, '//AuthnContext/AuthnContextClassRef')[0][0]
   end
 
-  def visit_idp_from_ial2_saml_sp(**args)
-    settings = saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-        ],
-        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-      },
-      security_overrides: {
-        embed_sign: false,
-      },
-    )
-    settings.issuer = args[:issuer] if args[:issuer]
-    saml_authn_request = auth_request.create(settings)
-    visit saml_authn_request
-    saml_authn_request
-  end
-
   private
 
   def link_user_to_identity(user, link, settings)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -76,11 +76,9 @@ module SamlAuthHelper
   end
 
   def visit_saml_authn_request_url(saml_overrides: {}, saml_security_overrides: {})
-    # settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
-    # @saml_authn_request = auth_request.create(settings)
     authn_request_url = saml_authn_request_url(
       saml_overrides: saml_overrides,
-      saml_security_overrides: saml_security_overrides
+      saml_security_overrides: saml_security_overrides,
     )
     visit authn_request_url
   end
@@ -89,7 +87,7 @@ module SamlAuthHelper
     settings = saml_settings(overrides: saml_overrides, security_overrides: saml_security_overrides)
     logout_request_url = saml_logout_request_url(
       saml_overrides: saml_overrides,
-      saml_security_overrides: saml_security_overrides
+      saml_security_overrides: saml_security_overrides,
     )
     visit logout_request_url
   end
@@ -110,12 +108,6 @@ module SamlAuthHelper
 
   ##################################################################################################
   ##################################################################################################
-
-  def sp1_saml_settings
-    settings = saml_settings.dup
-    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
 
   def aal3_sp1_saml_settings
     settings = saml_settings.dup
@@ -173,39 +165,58 @@ module SamlAuthHelper
   end
 
   def sp1_ial1_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def sp1_ial2_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        name_identifier_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
+      },
+    )
   end
 
   def sp1_ial_max_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def sp1_ial2_strict_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def loa3_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def ialmax_saml_settings
-    settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      },
+    )
   end
 
   def ialmax_with_bundle_saml_settings
@@ -259,36 +270,49 @@ module SamlAuthHelper
   end
 
   def ial1_with_verified_at_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
+        ],
+      },
+    )
   end
 
   def ial1_with_bundle_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+        ],
+      },
+    )
   end
 
   def ial1_with_aal3_saml_settings
-    settings = sp1_saml_settings
-    settings.authn_context = [
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-    ]
-    settings
+    saml_settings(
+      overrides: {
+        issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+        ],
+      },
+    )
   end
 
   def sp1_authnrequest
-    auth_request.create(sp1_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: { issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata' },
+      ),
+    )
   end
 
   def sp2_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def email_nameid_saml_settings_for_disallowed_issuer
-    settings = saml_settings.dup
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-    settings
-  end
-
   def ial1_saml_settings
     settings = saml_settings.dup
     settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,15 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp1_ial_max_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-  end
-
   def sp1_ial2_strict_saml_settings
     saml_settings(
       overrides: {
@@ -174,16 +165,6 @@ module SamlAuthHelper
 
   def ialmax_with_bundle_saml_settings
     settings = ialmax_saml_settings
-    settings.authn_context = [
-      settings.authn_context,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
-  end
-
-  def ial_max_with_bundle_saml_settings
-    settings = sp1_ial_max_saml_settings
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
@@ -339,16 +320,6 @@ module SamlAuthHelper
 
   def visit_idp_from_ial2_strict_saml_sp(**args)
     settings = ial2_strict_with_bundle_saml_settings
-    settings.security[:embed_sign] = false
-    settings.issuer = args[:issuer] if args[:issuer]
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-    saml_authn_request = auth_request.create(settings)
-    visit saml_authn_request
-    saml_authn_request
-  end
-
-  def visit_idp_from_ial_max_saml_sp(**args)
-    settings = ial_max_with_bundle_saml_settings
     settings.security[:embed_sign] = false
     settings.issuer = args[:issuer] if args[:issuer]
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -144,34 +144,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def requested_aal2_authn_context_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
-    settings
-  end
-
-  def requested_ial1_authn_context_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    settings
-  end
-
-  def requested_default_aal_authn_context_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
-    settings
-  end
-
-  def missing_authn_context_saml_settings
-    settings = saml_settings.dup
-    settings.authn_context = nil
-    settings
-  end
-
-  def saml_test_key
-    @saml_test_key ||= File.read(Rails.root.join('keys', 'saml_test_sp.key'))
-  end
-
   # generates a SAML response and returns a parsed Nokogiri XML document
   def generate_saml_response(user, settings = saml_settings, link: true)
     # user needs to be signed in in order to generate an assertion

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,18 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def ial1_with_verified_at_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
-        ],
-      },
-    )
-  end
-
   def ial1_with_bundle_saml_settings
     saml_settings(
       overrides: {
@@ -277,16 +265,6 @@ module SamlAuthHelper
       },
     )
     settings.issuer = args[:issuer] if args[:issuer]
-    saml_authn_request = auth_request.create(settings)
-    visit saml_authn_request
-    saml_authn_request
-  end
-
-  def visit_idp_from_ial1_saml_sp(**args)
-    settings = ial1_with_verified_at_saml_settings
-    settings.security[:embed_sign] = false
-    settings.issuer = args[:issuer] if args[:issuer]
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
     saml_authn_request = auth_request.create(settings)
     visit saml_authn_request
     saml_authn_request

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp2_saml_settings
-    settings = saml_settings.dup
-    settings.issuer = 'https://rp2.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
   def sp2_saml_settings_inactive
     settings = saml_settings.dup
     settings.issuer = 'http://localhost:3000/inactive_sp'
@@ -309,7 +303,11 @@ module SamlAuthHelper
   end
 
   def sp2_authnrequest
-    auth_request.create(sp2_saml_settings)
+    auth_request.create(
+      saml_settings(
+        overrides: { issuer: 'https://rp2.serviceprovider.com/auth/saml/metadata' },
+      ),
+    )
   end
 
   def ial1_authnrequest

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,12 +109,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def sp_not_requesting_signed_saml_response_settings
-    settings = saml_settings.dup
-    settings.issuer = 'test_saml_sp_not_requesting_signed_response_message'
-    settings
-  end
-
   def sp_requesting_signed_saml_response_settings
     settings = saml_settings.dup
     settings.issuer = 'test_saml_sp_requesting_signed_response_message'

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -109,9 +109,10 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def email_nameid_saml_settings_for_allowed_issuer
+  def missing_nameid_format_saml_settings_for_allowed_email_issuer
     settings = saml_settings.dup
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
+    settings.name_identifier_format = nil
+    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
     settings
   end
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -136,15 +136,6 @@ module SamlAuthHelper
   ##################################################################################################
   ##################################################################################################
 
-  def loa3_saml_settings
-    saml_settings(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-  end
-
   def ialmax_saml_settings
     saml_settings(
       overrides: {
@@ -156,16 +147,6 @@ module SamlAuthHelper
 
   def ialmax_with_bundle_saml_settings
     settings = ialmax_saml_settings
-    settings.authn_context = [
-      settings.authn_context,
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-    ]
-    settings
-  end
-
-  def loa3_with_bundle_saml_settings
-    settings = loa3_saml_settings
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -61,7 +61,9 @@ class SamlResponseDoc
       Nokogiri::XML(
         OneLogin::RubySaml::Response.new(
           raw_xml_response,
-          settings: sp1_saml_settings,
+          settings: saml_settings(
+            overrides: { issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata' },
+          ),
         ).decrypted_document.to_s,
       )
     else

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -62,7 +62,7 @@ class SamlResponseDoc
         OneLogin::RubySaml::Response.new(
           raw_xml_response,
           settings: saml_settings(
-            overrides: { issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata' },
+            overrides: { issuer: sp1_issuer },
           ),
         ).decrypted_document.to_s,
       )

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -277,8 +277,8 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
   user.piv_cac_configurations.create(x509_dn_uuid: 'some-uuid-to-identify-account', name: 'foo')
 
   visit_saml_authn_request_url(
-    saml_overrides: {
-      issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
+    overrides: {
+      issuer: sp1_issuer,
       authn_context: nil,
     },
   )

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -276,7 +276,7 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
   user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
   user.piv_cac_configurations.create(x509_dn_uuid: 'some-uuid-to-identify-account', name: 'foo')
 
-  visit_idp_from_saml_sp(
+  visit_saml_authn_request_url(
     saml_overrides: {
       issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata',
       authn_context: nil,


### PR DESCRIPTION
Working on making the saml spec helpers configurable, so that we can have the configuration live with the spec, not be obfuscated in a web of largely pointless helper methods. This does make the specs more verbose, but also easier to understand what the intent is.

This PR eliminates the vast majority of the saml helper methods as they made it very difficult to determine what was actually being tested against, and in many cases were being used incorrectly anyway, e.g., calling a helper to get saml settings that are different from the default by only the issuer, only to then set the issuer to something else. There is a lot to review, but if it is easier, the entire PR is a series of commits with each commit completing a specific refactoring, e.g., removing one custom settings method at a time.

Plenty of additional improvements that could be made in the future...