### PR TITLE
LG-4606: re-incorporate lexisnexis gem into idp

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ Layout/LineLength:
   - https
   Exclude:
     - 'config/routes.rb'
+    - 'spec/fixtures/**/*.json'
 
 Metrics/ModuleLength:
   CountComments: false
@@ -227,6 +228,8 @@ Style/StringLiterals:
   - single_quotes
   - double_quotes
   ConsistentQuotesInMultiline: true
+  Exclude:
+    - 'spec/fixtures/**/*.json'
 
 Style/TrailingCommaInArguments:
   # If `comma`, the cop requires a comma after the last argument, but only for
@@ -249,6 +252,8 @@ Style/TrailingCommaInArrayLiteral:
     - comma
     - consistent_comma
     - no_comma
+  Exclude:
+    - 'spec/fixtures/**/*.json'
 
 Style/TrailingCommaInHashLiteral:
   # If `comma`, the cop requires a comma after the last item in an array or
@@ -260,6 +265,8 @@ Style/TrailingCommaInHashLiteral:
     - comma
     - consistent_comma
     - no_comma
+  Exclude:
+    - 'spec/fixtures/**/*.json'
 
 Naming/MethodParameterName:
   MinNameLength: 2

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -50,7 +50,7 @@ class AddressProofingJob < ApplicationJob
     @address_proofer ||= if IdentityConfig.store.proofer_mock_fallback
       Proofing::Mock::AddressMockClient.new
     else
-      LexisNexis::PhoneFinder::Proofer.new(
+      Proofing::LexisNexis::PhoneFinder::Proofer.new(
         phone_finder_workflow: IdentityConfig.store.lexisnexis_phone_finder_workflow,
         account_id: IdentityConfig.store.lexisnexis_account_id,
         base_url: IdentityConfig.store.lexisnexis_base_url,

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -191,7 +191,7 @@ class ResolutionProofingJob < ApplicationJob
     @resolution_proofer ||= if IdentityConfig.store.proofer_mock_fallback
       Proofing::Mock::ResolutionMockClient.new
     else
-      LexisNexis::InstantVerify::Proofer.new(
+      Proofing::LexisNexis::InstantVerify::Proofer.new(
         instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
         account_id: IdentityConfig.store.lexisnexis_account_id,
         base_url: IdentityConfig.store.lexisnexis_base_url,

--- a/app/services/proofing/lexis_nexis/date_formatter.rb
+++ b/app/services/proofing/lexis_nexis/date_formatter.rb
@@ -1,0 +1,33 @@
+module Proofing
+  module LexisNexis
+    class DateFormatter
+      attr_reader :date
+
+      def initialize(date_string)
+        @date = parse_date_string(date_string)
+      end
+
+      def formatted_date
+        {
+          Year: date.year.to_s,
+          Month: date.month.to_s,
+          Day: date.day.to_s,
+        }
+      end
+
+      def yyyymmdd
+        date.strftime('%Y%m%d')
+      end
+
+      private
+
+      def parse_date_string(date_string)
+        if date_string =~ /\A\d{8}\z/
+          Date.strptime(date_string, '%Y%m%d')
+        elsif date_string =~ %r{\A\d{2}/\d{2}/\d{4}\z}
+          Date.strptime(date_string, '%m/%d/%Y')
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -6,14 +6,14 @@ module Proofing
         vendor_name 'lexisnexis:instant_verify'
 
         required_attributes :uuid,
-          :first_name,
-          :last_name,
-          :dob,
-          :ssn,
-          :address1,
-          :city,
-          :state,
-          :zipcode
+                            :first_name,
+                            :last_name,
+                            :dob,
+                            :ssn,
+                            :address1,
+                            :city,
+                            :state,
+                            :zipcode
 
         optional_attributes :address2, :uuid_prefix, :dob_year_only
 

--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -1,0 +1,36 @@
+module Proofing
+  module LexisNexis
+    # Verifies through the RDP platform
+    module InstantVerify
+      class Proofer < LexisNexis::Proofer
+        vendor_name 'lexisnexis:instant_verify'
+
+        required_attributes :uuid,
+          :first_name,
+          :last_name,
+          :dob,
+          :ssn,
+          :address1,
+          :city,
+          :state,
+          :zipcode
+
+        optional_attributes :address2, :uuid_prefix, :dob_year_only
+
+        stage :resolution
+
+        proof do |applicant, result|
+          proof_applicant(applicant, result)
+        end
+
+        def send_verification_request(applicant)
+          VerificationRequest.new(config: config, applicant: applicant).send(
+            response_options: {
+              dob_year_only: applicant[:dob_year_only],
+            },
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -1,0 +1,58 @@
+require 'date'
+require 'json'
+require 'securerandom'
+require 'rails_helper'
+
+module Proofing
+  module LexisNexis
+    module InstantVerify
+      class VerificationRequest < Request
+        private
+
+        def build_request_body # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          {
+            Settings: {
+              AccountNumber: account_number,
+              Mode: mode,
+              Reference: uuid,
+              Locale: 'en_US',
+              Venue: 'online',
+            },
+            Person: {
+              Name: {
+                FirstName: applicant[:first_name],
+                LastName: applicant[:last_name],
+              },
+              SSN: {
+                Number: applicant[:ssn].gsub(/\D/, ''),
+                Type: 'ssn9',
+              },
+              DateOfBirth: DateFormatter.new(applicant[:dob]).formatted_date,
+              Addresses: [formatted_address],
+            },
+          }.to_json
+        end
+
+        def workflow_name
+          config.instant_verify_workflow
+        end
+
+        def formatted_address
+          {
+            StreetAddress1: applicant[:address1],
+            StreetAddress2: applicant[:address2] || '',
+            City: applicant[:city],
+            State: applicant[:state],
+            Zip5: applicant[:zipcode].match(/^\d{5}/).to_s,
+            Country: 'US',
+            Context: 'primary',
+          }
+        end
+
+        def metric_name
+          'lexis_nexis_instant_verify'
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -1,8 +1,3 @@
-require 'date'
-require 'json'
-require 'securerandom'
-require 'rails_helper'
-
 module Proofing
   module LexisNexis
     module InstantVerify

--- a/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
@@ -1,0 +1,28 @@
+module Proofing
+  module LexisNexis
+    module PhoneFinder
+      class Proofer < LexisNexis::Proofer
+        vendor_name 'lexisnexis:phone_finder'
+
+        required_attributes :uuid,
+          :first_name,
+          :last_name,
+          :dob,
+          :ssn,
+          :phone
+
+        optional_attributes :uuid_prefix
+
+        stage :address
+
+        proof do |applicant, result|
+          proof_applicant(applicant, result)
+        end
+
+        def send_verification_request(applicant)
+          VerificationRequest.new(config: config, applicant: applicant).send
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
@@ -5,11 +5,11 @@ module Proofing
         vendor_name 'lexisnexis:phone_finder'
 
         required_attributes :uuid,
-          :first_name,
-          :last_name,
-          :dob,
-          :ssn,
-          :phone
+                            :first_name,
+                            :last_name,
+                            :dob,
+                            :ssn,
+                            :phone
 
         optional_attributes :uuid_prefix
 

--- a/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
@@ -1,0 +1,45 @@
+module Proofing
+  module LexisNexis
+    module PhoneFinder
+      class VerificationRequest < Request
+        private
+
+        def build_request_body # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+          {
+            Settings: {
+              AccountNumber: account_number,
+              Mode: mode,
+              Reference: uuid,
+              Locale: 'en_US',
+              Venue: 'online',
+            },
+            Person: {
+              Name: {
+                FirstName: applicant[:first_name],
+                LastName: applicant[:last_name],
+              },
+              SSN: {
+                Number: applicant[:ssn].gsub(/\D/, ''),
+                Type: 'ssn9',
+              },
+              DateOfBirth: DateFormatter.new(applicant[:dob]).formatted_date,
+              Phones: [
+                {
+                  Number: applicant[:phone],
+                },
+              ],
+            },
+          }.to_json
+        end
+
+        def workflow_name
+          config.phone_finder_workflow
+        end
+
+        def metric_name
+          'lexis_nexis_phone_finder'
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/proofer.rb
+++ b/app/services/proofing/lexis_nexis/proofer.rb
@@ -1,0 +1,49 @@
+require 'proofer'
+require 'redacted_struct'
+
+module Proofing
+  module LexisNexis
+    class Proofer < Proofer::Base
+      Config = RedactedStruct.new(
+        :instant_verify_workflow,
+        :phone_finder_workflow,
+        :account_id,
+        :base_url,
+        :username,
+        :password,
+        :request_mode,
+        :request_timeout,
+        keyword_init: true,
+        allowed_members: [
+          :instant_verify_workflow,
+          :phone_finder_workflow,
+          :base_url,
+          :request_mode,
+          :request_timeout,
+        ]
+      )
+
+      attr_reader :config
+
+      def initialize(**attrs)
+        @config = Config.new(**attrs)
+      end
+
+      def proof_applicant(applicant, result)
+        response = send_verification_request(applicant)
+        result.transaction_id = response.conversation_id
+        return if response.verification_status == 'passed'
+
+        response.verification_errors.each do |key, error_message|
+          result.add_error(key, error_message)
+        end
+      end
+
+      private
+
+      def send_verification_request
+        raise NotImplementedError, "#{__method__} should be defined by a subclass"
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/proofer.rb
+++ b/app/services/proofing/lexis_nexis/proofer.rb
@@ -20,7 +20,7 @@ module Proofing
           :base_url,
           :request_mode,
           :request_timeout,
-        ]
+        ],
       )
 
       attr_reader :config

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -37,14 +37,14 @@ module Proofing
           conn.post(url, body, headers) do |req|
             req.options.context = { service_name: metric_name }
           end,
-          **response_options
+          **response_options,
         )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
         # NOTE: This is only for when Faraday is using NET::HTTP if the adapter is changed
         # this will have to change to handle timeouts
         if e.message == 'execution expired'
           raise ::Proofer::TimeoutError,
-            'LexisNexis timed out waiting for verification response'
+                'LexisNexis timed out waiting for verification response'
         else
           message = "Lexis Nexis request raised #{e.class} with the message: #{e.message}"
           raise LexisNexis::RequestError, message
@@ -74,7 +74,7 @@ module Proofing
       def build_request_url
         URI.join(
           base_url,
-          url_request_path
+          url_request_path,
         ).to_s
       end
 

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -1,0 +1,109 @@
+require 'base64'
+require 'uri'
+require 'faraday'
+require 'active_support/core_ext/object/blank'
+require 'active_support/notifications'
+
+module Proofing
+  module LexisNexis
+    class RequestError < StandardError; end
+
+    class Request
+      attr_reader :config, :applicant, :url, :headers, :body
+
+      def initialize(config:, applicant:)
+        @config = config
+        @applicant = applicant
+        @body = build_request_body
+        @headers = build_request_headers
+        @url = build_request_url
+      end
+
+      # @see Response#initialize
+      # @param [Hash<Symbol, Object>] response_options a hash of options for the Response class
+      #   * +:dob_year_only+
+      def send(response_options: {})
+        conn = Faraday.new do |f|
+          f.request :instrumentation, name: 'request_metric.faraday'
+          f.options.timeout = timeout
+          f.options.read_timeout = timeout
+          f.options.open_timeout = timeout
+          f.options.write_timeout = timeout
+
+          f.basic_auth config.username, config.password
+        end
+
+        Response.new(
+          conn.post(url, body, headers) do |req|
+            req.options.context = { service_name: metric_name }
+          end,
+          **response_options
+        )
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        # NOTE: This is only for when Faraday is using NET::HTTP if the adapter is changed
+        # this will have to change to handle timeouts
+        if e.message == 'execution expired'
+          raise ::Proofer::TimeoutError,
+            'LexisNexis timed out waiting for verification response'
+        else
+          message = "Lexis Nexis request raised #{e.class} with the message: #{e.message}"
+          raise LexisNexis::RequestError, message
+        end
+      end
+
+      private
+
+      def account_number
+        config.account_id
+      end
+
+      def base_url
+        config.base_url
+      end
+
+      def build_request_headers
+        {
+          'Content-Type' => 'application/json',
+        }
+      end
+
+      def build_request_body
+        raise NotImplementedError, "#{__method__} should be defined by a subclass"
+      end
+
+      def build_request_url
+        URI.join(
+          base_url,
+          url_request_path
+        ).to_s
+      end
+
+      def mode
+        config.request_mode
+      end
+
+      def url_request_path
+        "/restws/identity/v2/#{account_number}/#{workflow_name}/conversation"
+      end
+
+      def uuid
+        uuid = applicant.fetch(:uuid, SecureRandom.uuid)
+        uuid_prefix = applicant[:uuid_prefix]
+
+        if uuid_prefix.present?
+          "#{uuid_prefix}:#{uuid}"
+        else
+          uuid
+        end
+      end
+
+      def timeout
+        (config.request_timeout || 5).to_i
+      end
+
+      def metric_name
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -1,9 +1,3 @@
-require 'base64'
-require 'uri'
-require 'faraday'
-require 'active_support/core_ext/object/blank'
-require 'active_support/notifications'
-
 module Proofing
   module LexisNexis
     class RequestError < StandardError; end

--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Proofing
   module LexisNexis
     class Response

--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -1,0 +1,81 @@
+require 'json'
+
+module Proofing
+  module LexisNexis
+    class Response
+      class UnexpectedHTTPStatusCodeError < StandardError; end
+      class UnexpectedVerificationStatusCodeError < StandardError; end
+      class VerificationTransactionError < StandardError; end
+
+      attr_reader :response
+
+      # @param [Boolean] dob_year_only
+      # @see VerificationErrorParser#initialize
+      def initialize(response, dob_year_only: false)
+        @response = response
+        @dob_year_only = dob_year_only
+        handle_unexpected_http_status_code_error
+        handle_unexpected_verification_status_error
+        handle_verification_transaction_error
+      end
+
+      def dob_year_only?
+        @dob_year_only
+      end
+
+      def verification_errors
+        return {} unless verification_status == 'failed'
+
+        verification_error_parser.parsed_errors
+      end
+
+      def verification_status
+        verification_error_parser.verification_status
+      end
+
+      def conversation_id
+        @conversation_id ||= response_body.dig('Status', 'ConversationId')
+      end
+
+      def reference
+        @reference ||= response_body.dig('Status', 'Reference')
+      end
+
+      # @api private
+      def response_body
+        @response_body ||= JSON.parse(response.body)
+      end
+
+      private
+
+      def verification_error_parser
+        @verification_error_parser ||= VerificationErrorParser.new(response_body, dob_year_only: dob_year_only?)
+      end
+
+      def handle_unexpected_http_status_code_error
+        return if response.success?
+
+        message = "Unexpected status code '#{response.status}': #{response.body}"
+        raise UnexpectedHTTPStatusCodeError, message
+      end
+
+      def handle_unexpected_verification_status_error
+        return if %w[passed failed error].include?(verification_status)
+
+        message = "Invalid status in response body: '#{verification_status}'"
+        raise UnexpectedVerificationStatusCodeError, message
+      end
+
+      def handle_verification_transaction_error
+        return unless verification_status == 'error'
+
+        error_code = response_body.dig('Status', 'TransactionReasonCode', 'Code')
+        error_information = response_body.fetch('Information', {}).to_json
+        tracking_ids = "(LN ConversationId: #{conversation_id}; Reference: #{reference}) "
+
+        message = "#{tracking_ids} Response error with code '#{error_code}': #{error_information}"
+        raise VerificationTransactionError, message
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -49,7 +49,10 @@ module Proofing
       private
 
       def verification_error_parser
-        @verification_error_parser ||= VerificationErrorParser.new(response_body, dob_year_only: dob_year_only?)
+        @verification_error_parser ||= VerificationErrorParser.new(
+          response_body,
+          dob_year_only: dob_year_only?,
+        )
       end
 
       def handle_unexpected_http_status_code_error

--- a/app/services/proofing/lexis_nexis/verification_error_parser.rb
+++ b/app/services/proofing/lexis_nexis/verification_error_parser.rb
@@ -1,0 +1,95 @@
+module Proofing
+  module LexisNexis
+    class VerificationErrorParser
+      attr_reader :body
+
+      # @param [Boolean] dob_year_only when true, only enforce that the year
+      # from the date of birth must match
+      def initialize(response_body, dob_year_only: false)
+        @body = response_body
+        @dob_year_only = dob_year_only
+        @base_error_message = parse_base_error_message
+        @product_error_messages = parse_product_error_messages
+      end
+
+      def dob_year_only?
+        @dob_year_only
+      end
+
+      def parsed_errors
+        { base: base_error_message }.merge(product_error_messages)
+      end
+
+      def verification_status
+        @verification_status ||=
+          begin
+            status = body.dig('Status', 'TransactionStatus')
+
+            if status == 'failed' && dob_year_only? && product_error_messages.empty?
+              'passed'
+            else
+              status
+            end
+          end
+      end
+
+      private
+
+      attr_reader :base_error_message, :product_error_messages
+
+      def parse_base_error_message
+        error_code = body.dig('Status', 'TransactionReasonCode', 'Code')
+        conversation_id = body.dig('Status', 'ConversationId')
+        reference = body.dig('Status', 'Reference')
+        tracking_ids = "(LN ConversationId: #{conversation_id}; Reference: #{reference}) "
+
+        return "#{tracking_ids} Verification failed without a reason code" if error_code.nil?
+
+        "#{tracking_ids} Verification failed with code: '#{error_code}'"
+      end
+
+      def parse_product_error_messages
+        products = body['Products']
+        return { products: 'Products missing from response' } if products.nil?
+
+        products.each_with_object({}) do |product, error_messages|
+          if product['ProductType'] == 'InstantVerify'
+            original_passed = (product['ProductStatus'] == 'pass')
+            passed_partial_dob = instant_verify_dob_year_only_pass?(product['Items'])
+
+            Rails.logger.info({
+              name: 'lexisnexis_partial_dob',
+              original_passed: original_passed,
+              passed_partial_dob: passed_partial_dob,
+              partial_dob_override_enabled: dob_year_only?,
+            }.to_json) if defined?(Rails) && Rails.logger
+
+            next if original_passed || (dob_year_only? && passed_partial_dob)
+          else
+            next if product['ProductStatus'] == 'pass'
+          end
+
+          key = product.fetch('ExecutedStepName').to_sym
+          error_messages[key] = product
+        end
+      end
+
+      # if DOBYearVerified passes, but DOBFullVerified fails, we can still allow a pass
+      def instant_verify_dob_year_only_pass?(items)
+        dob_full_verified = items.find { |item| item['ItemName'] == 'DOBFullVerified' }
+        dob_year_verified = items.find { |item| item['ItemName'] == 'DOBYearVerified' }
+        other_checks = items.reject do |item|
+          %w[DOBYearVerified DOBFullVerified].include?(item['ItemName'])
+        end
+
+        dob_full_verified.present? &&
+          item_passed?(dob_year_verified) &&
+          other_checks.all? { |item| item_passed?(item) }
+      end
+
+      def item_passed?(item)
+        item && item['ItemStatus'] == 'pass'
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/verification_error_parser.rb
+++ b/app/services/proofing/lexis_nexis/verification_error_parser.rb
@@ -57,12 +57,14 @@ module Proofing
             original_passed = (product['ProductStatus'] == 'pass')
             passed_partial_dob = instant_verify_dob_year_only_pass?(product['Items'])
 
-            Rails.logger.info({
-              name: 'lexisnexis_partial_dob',
-              original_passed: original_passed,
-              passed_partial_dob: passed_partial_dob,
-              partial_dob_override_enabled: dob_year_only?,
-            }.to_json) if defined?(Rails) && Rails.logger
+            Rails.logger.info(
+              {
+                name: 'lexisnexis_partial_dob',
+                original_passed: original_passed,
+                passed_partial_dob: passed_partial_dob,
+                partial_dob_override_enabled: dob_year_only?,
+              }.to_json,
+            )
 
             next if original_passed || (dob_year_only? && passed_partial_dob)
           else

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/date_of_birth_full_fail_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/date_of_birth_full_fail_response.json
@@ -1,0 +1,62 @@
+{
+  "Status": {
+    "ConversationId": "123456",
+    "RequestId": "7890",
+    "TransactionStatus": "failed",
+    "Reference": "aaa-bbb-ccc"
+  },
+  "Products": [
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "Execute Instant Verify",
+      "ProductConfigurationName": "REDACTED_CONFIGURATION",
+      "ProductStatus": "fail",
+      "Items": [
+        {
+          "ItemName": "Addr1Zip_StateMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnFullNameMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnDeathMatchVerification",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNSSAValid",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "IdentityOccupancyVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrDeliverable",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrNotHighRisk",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "SSNLowIssuance",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "LexIDDeathMatch",
+          "ItemStatus": "pass"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/error_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/error_response.json
@@ -1,0 +1,24 @@
+{
+  "Status": {
+    "ConversationId": "5556787618334595970",
+    "RequestId": "1234-abcd",
+    "TransactionStatus": "error",
+    "TransactionReasonCode": {
+      "Code": "invalid_transaction_initiate"
+    },
+    "Reference": "1234-abcd",
+    "ServerInfo": "ALANARABA01-W7D"
+  },
+  "Information": [
+    {
+      "InformationType": "error-details",
+      "Code": "invalid_transaction_initiate",
+      "Description": "Error: Invalid Transaction Initiate",
+      "DetailDescription": [
+        {
+          "Text": "Invalid account."
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/failed_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/failed_response.json
@@ -1,0 +1,44 @@
+{
+  "Status": {
+    "ConversationId": "31000123456789",
+    "RequestId": "13936762",
+    "TransactionStatus": "failed",
+    "TransactionReasonCode": {
+      "Code": "total.scoring.model.verification.fail"
+    },
+    "Reference": "1234-abcd",
+    "ServerInfo": "ASERVER-W7D"
+  },
+  "Products": [
+    {
+      "ProductType": "Discovery",
+      "ExecutedStepName": "Discovery",
+      "ProductStatus": "pass"
+    },
+    {
+      "ProductType": "SomeOtherProduct",
+      "ExecutedStepName": "SomeOtherProduct",
+      "ProductStatus": "fail",
+      "ProductReason": {
+        "Code": "individual_not_found"
+      }
+    },
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "InstantVerify",
+      "ProductStatus": "fail",
+      "ProductReason": {
+        "Code": "total.scoring.model.verification.fail"
+      },
+      "Items": [
+        {
+          "ItemName": "FirstName",
+          "ItemStatus": "fail",
+          "ItemReason": {
+            "Code": "first_name_does_not_match"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/request.json
@@ -1,0 +1,35 @@
+{
+  "Settings": {
+    "AccountNumber": "test_account",
+    "Mode": "testing",
+    "Reference": "0987:1234-abcd",
+    "Locale": "en_US",
+    "Venue": "online"
+  },
+  "Person": {
+    "Name": {
+      "FirstName": "Testy",
+      "LastName": "McTesterson"
+    },
+    "SSN": {
+      "Number": "123456789",
+      "Type": "ssn9"
+    },
+    "DateOfBirth": {
+      "Year": "1980",
+      "Month": "1",
+      "Day": "1"
+    },
+    "Addresses": [
+      {
+        "StreetAddress1": "123 Main St",
+        "StreetAddress2": "Ste 3",
+        "City": "Baton Rouge",
+        "State": "LA",
+        "Zip5": "70802",
+        "Country": "US",
+        "Context": "primary"
+      }
+    ]
+  }
+}

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/successful_response.json
@@ -1,0 +1,57 @@
+{
+  "Status": {
+    "ConversationId": "8624642277235233040",
+    "RequestId": "13936712",
+    "TransactionStatus": "passed",
+    "Reference": "Reference1",
+    "ServerInfo": "ASERVER-W7D"
+  },
+  "Products": [
+    {
+      "ProductType": "Discovery",
+      "ExecutedStepName": "Discovery",
+      "ProductStatus": "pass"
+    },
+    {
+      "ProductType": "Velocity",
+      "ExecutedStepName": "Velocity",
+      "ProductStatus": "pass",
+      "Items": [
+        {
+          "ItemName": "FREQUENCY",
+          "ItemStatus": "pass"
+        }
+      ]
+    },
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "InstantVerify",
+      "ProductStatus": "pass",
+      "Items": [
+        {
+          "ItemName": "SsnDeathMatchVerification",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNSSAValid",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "OFAC",
+          "ItemStatus": "pass",
+          "ItemReason": {
+            "Code": "ipatriot"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/year_of_birth_fail_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/year_of_birth_fail_response.json
@@ -1,0 +1,62 @@
+{
+  "Status": {
+    "ConversationId": "123456",
+    "RequestId": "7890",
+    "TransactionStatus": "failed",
+    "Reference": "aaa-bbb-ccc"
+  },
+  "Products": [
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "Execute Instant Verify",
+      "ProductConfigurationName": "REDACTED_CONFIGURATION",
+      "ProductStatus": "fail",
+      "Items": [
+        {
+          "ItemName": "Addr1Zip_StateMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnFullNameMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnDeathMatchVerification",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNSSAValid",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "IdentityOccupancyVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrDeliverable",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrNotHighRisk",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNLowIssuance",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "LexIDDeathMatch",
+          "ItemStatus": "pass"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/phone_finder/fail_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/phone_finder/fail_response.json
@@ -1,0 +1,27 @@
+{
+  "Status": {
+    "ConversationId": "31000000000000",
+    "RequestId": "1000000",
+    "TransactionStatus": "failed",
+    "Reference": "Reference1"
+  },
+  "Products": [
+    {
+      "ProductType": "PhoneFinder",
+      "ExecutedStepName": "PhoneFinder",
+      "ProductConfigurationName": "PhoneFinder_PF",
+      "ProductStatus": "fail",
+      "ProductReason": { "Code": "phone_finder_fail" }
+    },
+    {
+      "ProductType": "PhoneFinder",
+      "ExecutedStepName": "PhoneFinder Checks",
+      "ProductConfigurationName": "PHONE_FINDER_FAIL",
+      "ProductStatus": "fail",
+      "ProductReason": {
+        "Code": "phone_finder_fail",
+        "Description": "Failed - Input phone number could not be verified to name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/proofing/lexis_nexis/phone_finder/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/phone_finder/request.json
@@ -1,0 +1,29 @@
+{
+  "Settings": {
+    "AccountNumber": "test_account",
+    "Mode": "testing",
+    "Reference": "0987:1234-abcd",
+    "Locale": "en_US",
+    "Venue": "online"
+  },
+  "Person": {
+    "Name": {
+      "FirstName": "Testy",
+      "LastName": "McTesterson"
+    },
+    "SSN": {
+      "Number": "123456789",
+      "Type": "ssn9"
+    },
+    "DateOfBirth": {
+      "Year": "1980",
+      "Month": "1",
+      "Day": "1"
+    },
+    "Phones": [
+      {
+        "Number": "5551231234"
+      }
+    ]
+  }
+}

--- a/spec/fixtures/proofing/lexis_nexis/phone_finder/response.json
+++ b/spec/fixtures/proofing/lexis_nexis/phone_finder/response.json
@@ -1,0 +1,28 @@
+{
+  "Status": {
+    "ConversationId": "31000000000000",
+    "RequestId": "1000000",
+    "TransactionStatus": "passed",
+    "Reference": "Reference1"
+  },
+  "Products": [
+    {
+      "ProductType": "Discovery",
+      "ExecutedStepName": "Discovery",
+      "ProductConfigurationName": "Discovery_PF",
+      "ProductStatus": "pass"
+    },
+    {
+      "ProductType": "PhoneFinder",
+      "ExecutedStepName": "Phone Finder",
+      "ProductConfigurationName": "PhoneFinder_PF",
+      "ProductStatus": "pass"
+    }
+  ],
+  "PassThroughs": [
+    {
+      "Type": "phone.finder",
+      "Data": "{\"PhoneFinderSearchResponseEx\":{\"response\":{\"Header\":{\"Status\":0,\"TransactionId\":\"158881733R929275\"}}}}"
+    }
+  ]
+}

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:lexisnexis_transaction_id) { SecureRandom.uuid }
   let(:aamva_transaction_id) { SecureRandom.uuid }
   let(:resolution_proofer) do
-    instance_double(LexisNexis::InstantVerify::Proofer, class: LexisNexis::InstantVerify::Proofer)
+    instance_double(Proofing::LexisNexis::InstantVerify::Proofer, class: Proofing::LexisNexis::InstantVerify::Proofer)
   end
   let(:state_id_proofer) do
     instance_double(Proofing::Aamva::Proofer, class: Proofing::Aamva::Proofer)
@@ -118,7 +118,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
             should_proof_state_id: true,
             stages: {
               resolution: {
-                client: LexisNexis::InstantVerify::Proofer.vendor_name,
+                client: Proofing::LexisNexis::InstantVerify::Proofer.vendor_name,
                 errors: {},
                 exception: nil,
                 success: true,
@@ -187,7 +187,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
                   transaction_id: aamva_transaction_id,
                 },
                 resolution: {
-                  client: LexisNexis::InstantVerify::Proofer.vendor_name,
+                  client: Proofing::LexisNexis::InstantVerify::Proofer.vendor_name,
                   errors: {},
                   exception: kind_of(String),
                   success: false,

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:lexisnexis_transaction_id) { SecureRandom.uuid }
   let(:aamva_transaction_id) { SecureRandom.uuid }
   let(:resolution_proofer) do
-    instance_double(Proofing::LexisNexis::InstantVerify::Proofer, class: Proofing::LexisNexis::InstantVerify::Proofer)
+    instance_double(
+      Proofing::LexisNexis::InstantVerify::Proofer,
+      class: Proofing::LexisNexis::InstantVerify::Proofer,
+    )
   end
   let(:state_id_proofer) do
     instance_double(Proofing::Aamva::Proofer, class: Proofing::Aamva::Proofer)

--- a/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
+++ b/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
@@ -26,7 +26,7 @@ describe Proofing::LexisNexis::DateFormatter do
       expect(date_formatter.formatted_date).to eq(
         Year: '2020',
         Month: '4',
-        Day: '15'
+        Day: '15',
       )
     end
   end

--- a/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
+++ b/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::DateFormatter do
+  subject(:date_formatter) { described_class.new(date_string) }
+
+  describe '#date' do
+    subject(:date) { date_formatter.date }
+
+    context 'with a MM/DD/YYYY formatted date' do
+      let(:date_string) { '01/02/1993' }
+
+      it { is_expected.to eq(Date.new(1993, 1, 2)) }
+    end
+
+    context 'with a YYYYMMDD formatted date' do
+      let(:date_string) { '19930102' }
+
+      it { is_expected.to eq(Date.new(1993, 1, 2)) }
+    end
+  end
+
+  describe '#formatted_date' do
+    let(:date_string) { '04/15/2020' }
+
+    it 'is a hash' do
+      expect(date_formatter.formatted_date).to eq(
+        Year: '2020',
+        Month: '4',
+        Day: '15'
+      )
+    end
+  end
+
+  describe '#yyyymmdd' do
+    let(:date_string) { '01/31/2020' }
+
+    it 'is a correctly-formatted string' do
+      expect(date_formatter.yyyymmdd).to eq('20200131')
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofer_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::InstantVerify::Proofer do
+  let(:applicant) do
+    {
+      uuid_prefix: '0987',
+      uuid: '1234-abcd',
+      first_name: 'Testy',
+      last_name: 'McTesterson',
+      ssn: '123456789',
+      dob: '01/01/1980',
+      address1: '123 Main St',
+      address2: 'Ste 3',
+      city: 'Baton Rouge',
+      state: 'LA',
+      zipcode: '70802-12345',
+    }
+  end
+  let(:verification_request) do
+    Proofing::LexisNexis::InstantVerify::VerificationRequest.new(
+      applicant: applicant,
+      config: LexisNexisFixtures.example_config,
+    )
+  end
+
+  it_behaves_like 'a lexisnexis proofer'
+
+  describe '#send' do
+    context 'when the request times out' do
+      it 'raises a timeout error' do
+        stub_request(:post, verification_request.url).to_timeout
+
+        expect { verification_request.send }.to raise_error(
+          Proofer::TimeoutError,
+          'LexisNexis timed out waiting for verification response'
+        )
+      end
+    end
+
+    context 'when the request is made' do
+      it 'it looks like the right request' do
+        request = stub_request(:post, verification_request.url).
+          with(body: verification_request.body, headers: verification_request.headers).
+          to_return(body: LexisNexisFixtures.instant_verify_success_response_json, status: 200)
+
+        verification_request.send
+
+        expect(request).to have_been_requested.once
+      end
+    end
+  end
+
+  subject(:instance) { Proofing::LexisNexis::InstantVerify::Proofer.new(**LexisNexisFixtures.example_config.to_h) }
+
+  describe '#proof' do
+    subject(:result) { instance.proof(applicant) }
+    let(:applicant) { super().merge(dob_year_only: dob_year_only) }
+
+    before do
+      stub_request(:post, verification_request.url).
+        to_return(body: response_body, status: 200)
+    end
+
+    context 'when dob_year_only is false' do
+      let(:dob_year_only) { false }
+
+      context 'when the response is a full match' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }
+
+        it 'is a successful result' do
+          expect(result.success?).to eq(true)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context 'when the response is a year-of-birth failure only' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json }
+
+        it 'is a failure result' do
+          expect(result.success?).to eq(false)
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
+        end
+      end
+
+      context 'when the response is a year-of-birth failure and a date-of-birth failure' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+
+        it 'is a failure result' do
+          expect(result.success?).to eq(false)
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
+        end
+      end
+    end
+
+    context 'when dob_year_only is true' do
+      let(:dob_year_only) { true }
+
+      context 'when the response is a full match' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }
+
+        it 'is a successful result' do
+          expect(result.success?).to eq(true)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context 'when the response is a year-of-birth failure only' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json }
+
+        it 'is a successful result' do
+          expect(result.errors).to be_empty
+          expect(result.success?).to eq(true)
+        end
+      end
+
+      context 'when the response is a year-of-birth failure and a date-of-birth failure' do
+        let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+
+        it 'is a failure result' do
+          expect(result.success?).to eq(false)
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofer_spec.rb
@@ -32,7 +32,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
 
         expect { verification_request.send }.to raise_error(
           Proofer::TimeoutError,
-          'LexisNexis timed out waiting for verification response'
+          'LexisNexis timed out waiting for verification response',
         )
       end
     end
@@ -50,7 +50,9 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
     end
   end
 
-  subject(:instance) { Proofing::LexisNexis::InstantVerify::Proofer.new(**LexisNexisFixtures.example_config.to_h) }
+  subject(:instance) do
+    Proofing::LexisNexis::InstantVerify::Proofer.new(**LexisNexisFixtures.example_config.to_h)
+  end
 
   describe '#proof' do
     subject(:result) { instance.proof(applicant) }
@@ -80,19 +82,21 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
           expect(result.success?).to eq(false)
           expect(result.errors).to include(
             base: include(a_kind_of(String)),
-            'Execute Instant Verify': include(a_kind_of(Hash))
+            'Execute Instant Verify': include(a_kind_of(Hash)),
           )
         end
       end
 
       context 'when the response is a year-of-birth failure and a date-of-birth failure' do
-        let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+        let(:response_body) do
+          LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json
+        end
 
         it 'is a failure result' do
           expect(result.success?).to eq(false)
           expect(result.errors).to include(
             base: include(a_kind_of(String)),
-            'Execute Instant Verify': include(a_kind_of(Hash))
+            'Execute Instant Verify': include(a_kind_of(Hash)),
           )
         end
       end
@@ -120,13 +124,15 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
       end
 
       context 'when the response is a year-of-birth failure and a date-of-birth failure' do
-        let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+        let(:response_body) do
+          LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json
+        end
 
         it 'is a failure result' do
           expect(result.success?).to eq(false)
           expect(result.errors).to include(
             base: include(a_kind_of(String)),
-            'Execute Instant Verify': include(a_kind_of(Hash))
+            'Execute Instant Verify': include(a_kind_of(Hash)),
           )
         end
       end

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
+  let(:applicant) do
+    {
+      uuid_prefix: '0987',
+      uuid: '1234-abcd',
+      first_name: 'Testy',
+      last_name: 'McTesterson',
+      ssn: '123-45-6789',
+      dob: '01/01/1980',
+      address1: '123 Main St',
+      address2: 'Ste 3',
+      city: 'Baton Rouge',
+      state: 'LA',
+      zipcode: '70802-12345',
+    }
+  end
+  let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }
+  subject { described_class.new(applicant: applicant, config: LexisNexisFixtures.example_config) }
+
+  it_behaves_like 'a lexisnexis request'
+
+  describe '#body' do
+    it 'returns a properly formed request body' do
+      expect(subject.body).to eq(LexisNexisFixtures.instant_verify_request_json)
+    end
+
+    context 'without an address line 2' do
+      let(:applicant) do
+        hash = super()
+        hash.delete(:address2)
+        hash
+      end
+
+      it 'sets StreetAddress2 to and empty string' do
+        parsed_body = JSON.parse(subject.body, symbolize_names: true)
+        expect(parsed_body[:Person][:Addresses][0][:StreetAddress2]).to eq('')
+      end
+    end
+
+    context 'without a uuid_prefix' do
+      let(:applicant) do
+        hash = super()
+        hash.delete(:uuid_prefix)
+        hash
+      end
+
+      it 'does not prepend' do
+        parsed_body = JSON.parse(subject.body, symbolize_names: true)
+        expect(parsed_body[:Settings][:Reference]).to eq(applicant[:uuid])
+      end
+    end
+  end
+
+  describe '#url' do
+    it 'returns a url for the Instant Verify endpoint' do
+      expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/customers.gsa.instant.verify.workflow/conversation')
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/phone_finder/proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/proofer_spec.rb
@@ -34,13 +34,15 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
     end
 
     context 'when the response is a failure' do
-      let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+      let(:response_body) do
+        LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json
+      end
 
       it 'is a failure result' do
         expect(result.success?).to eq(false)
         expect(result.errors).to include(
           base: include(a_kind_of(String)),
-          'Execute Instant Verify': include(a_kind_of(Hash))
+          'Execute Instant Verify': include(a_kind_of(Hash)),
         )
       end
     end

--- a/spec/services/proofing/lexis_nexis/phone_finder/proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/proofer_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::PhoneFinder::Proofer do
+  let(:applicant) do
+    {
+      uuid_prefix: '0987',
+      uuid: '1234-abcd',
+      first_name: 'Testy',
+      last_name: 'McTesterson',
+      ssn: '123-45-6789',
+      dob: '01/01/1980',
+      phone: '5551231234',
+    }
+  end
+  let(:verification_request) do
+    Proofing::LexisNexis::PhoneFinder::VerificationRequest.new(
+      applicant: applicant,
+      config: LexisNexisFixtures.example_config,
+    )
+  end
+
+  it_behaves_like 'a lexisnexis proofer'
+
+  subject(:instance) do
+    Proofing::LexisNexis::PhoneFinder::Proofer.new(**LexisNexisFixtures.example_config.to_h)
+  end
+
+  describe '#proof' do
+    subject(:result) { instance.proof(applicant) }
+
+    before do
+      stub_request(:post, verification_request.url).
+        to_return(body: response_body, status: 200)
+    end
+
+    context 'when the response is a failure' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_date_of_birth_full_fail_response_json }
+
+      it 'is a failure result' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(
+          base: include(a_kind_of(String)),
+          'Execute Instant Verify': include(a_kind_of(Hash))
+        )
+      end
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::PhoneFinder::VerificationRequest do
+  let(:applicant) do
+    {
+      uuid_prefix: '0987',
+      uuid: '1234-abcd',
+      first_name: 'Testy',
+      last_name: 'McTesterson',
+      ssn: '123456789',
+      dob: '01/01/1980',
+      phone: '5551231234',
+    }
+  end
+  let(:response_body) { LexisNexisFixtures.phone_finder_success_response_json }
+  subject { described_class.new(applicant: applicant, config: LexisNexisFixtures.example_config) }
+
+  it_behaves_like 'a lexisnexis request'
+
+  describe '#body' do
+    it 'returns a properly formed request body' do
+      expect(subject.body).to eq(LexisNexisFixtures.phone_finder_request_json)
+    end
+
+    context 'without a uuid_prefix' do
+      let(:applicant) do
+        hash = super()
+        hash.delete(:uuid_prefix)
+        hash
+      end
+
+      it 'does not prepend' do
+        parsed_body = JSON.parse(subject.body, symbolize_names: true)
+        expect(parsed_body[:Settings][:Reference]).to eq(applicant[:uuid])
+      end
+    end
+  end
+
+  describe '#url' do
+    it 'returns a url for the Phone Finder endpoint' do
+      expect(subject.url).to eq(
+        'https://example.com/restws/identity/v2/test_account/customers.gsa.phonefinder.workflow/conversation',
+      )
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe Proofing::LexisNexis::Response do
+  let(:response_status_code) { 200 }
+  let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }
+  let(:response) do
+    Faraday::Response.new(
+      status: response_status_code,
+      body: response_body
+    )
+  end
+
+  subject { Proofing::LexisNexis::Response.new(response) }
+
+  describe '.new' do
+    context 'with an HTTP status error code' do
+      let(:response_status_code) { 500 }
+      let(:response_body) { 'something went horribly wrong' }
+
+      it 'raises an error that includes the status code and the body' do
+        expect { subject }.to raise_error(
+          Proofing::LexisNexis::Response::UnexpectedHTTPStatusCodeError,
+          "Unexpected status code '500': something went horribly wrong"
+        )
+      end
+    end
+
+    context 'with an invalid transaction status' do
+      let(:response_body) do
+        parsed_body = JSON.parse(super())
+        parsed_body['Status']['TransactionStatus'] = 'fake_status'
+        parsed_body.to_json
+      end
+
+      it 'raises an error that includes the transaction status code' do
+        expect { subject }.to raise_error(
+          Proofing::LexisNexis::Response::UnexpectedVerificationStatusCodeError,
+          "Invalid status in response body: 'fake_status'"
+        )
+      end
+    end
+
+    context 'with a transaction error' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_error_response_json }
+
+      it 'raises an error that includes the reason code and information from the response' do
+        error = begin
+                  subject
+                rescue Proofing::LexisNexis::Response::VerificationTransactionError => e
+                  e
+                end
+
+        expect(error).to be_a(Proofing::LexisNexis::Response::VerificationTransactionError)
+        expect(error.message).to include("5556787618334595970")
+        expect(error.message).to include("1234-abcd")
+        expect(error.message).to include("invalid_transaction_initiate")
+        expect(error.message).to include(JSON.parse(response_body)['Information'].to_json)
+      end
+    end
+  end
+
+  describe '#verification_errors' do
+    context 'with a failed verification' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_failure_response_json }
+      it 'returns a hash of errors' do
+        errors = subject.verification_errors
+
+        expect(errors).to be_a(Hash)
+        expect(errors).to include(:base, :SomeOtherProduct, :InstantVerify)
+      end
+    end
+
+    context 'with a passed verification' do
+      it { expect(subject.verification_errors).to eq({}) }
+    end
+  end
+
+  describe '#verification_status' do
+    context 'passed' do
+      it { expect(subject.verification_status).to eq('passed') }
+    end
+
+    context 'failed' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_failure_response_json }
+      it { expect(subject.verification_status).to eq('failed') }
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -6,7 +6,7 @@ describe Proofing::LexisNexis::Response do
   let(:response) do
     Faraday::Response.new(
       status: response_status_code,
-      body: response_body
+      body: response_body,
     )
   end
 
@@ -20,7 +20,7 @@ describe Proofing::LexisNexis::Response do
       it 'raises an error that includes the status code and the body' do
         expect { subject }.to raise_error(
           Proofing::LexisNexis::Response::UnexpectedHTTPStatusCodeError,
-          "Unexpected status code '500': something went horribly wrong"
+          "Unexpected status code '500': something went horribly wrong",
         )
       end
     end
@@ -35,7 +35,7 @@ describe Proofing::LexisNexis::Response do
       it 'raises an error that includes the transaction status code' do
         expect { subject }.to raise_error(
           Proofing::LexisNexis::Response::UnexpectedVerificationStatusCodeError,
-          "Invalid status in response body: 'fake_status'"
+          "Invalid status in response body: 'fake_status'",
         )
       end
     end
@@ -44,16 +44,17 @@ describe Proofing::LexisNexis::Response do
       let(:response_body) { LexisNexisFixtures.instant_verify_error_response_json }
 
       it 'raises an error that includes the reason code and information from the response' do
-        error = begin
-                  subject
-                rescue Proofing::LexisNexis::Response::VerificationTransactionError => e
-                  e
-                end
+        error =
+          begin
+            subject
+          rescue Proofing::LexisNexis::Response::VerificationTransactionError => e
+            e
+          end
 
         expect(error).to be_a(Proofing::LexisNexis::Response::VerificationTransactionError)
-        expect(error.message).to include("5556787618334595970")
-        expect(error.message).to include("1234-abcd")
-        expect(error.message).to include("invalid_transaction_initiate")
+        expect(error.message).to include('5556787618334595970')
+        expect(error.message).to include('1234-abcd')
+        expect(error.message).to include('invalid_transaction_initiate')
         expect(error.message).to include(JSON.parse(response_body)['Information'].to_json)
       end
     end

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
   subject(:error_parser) { described_class.new(response_body) }
 
   describe '#initialize' do
-    let(:response_body) { JSON.parse(LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json) }
+    let(:response_body) do
+      JSON.parse(LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json)
+    end
 
     context 'outside of Rails' do
       it { expect(error_parser).to be }
@@ -31,9 +33,9 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
     subject(:errors) { error_parser.parsed_errors }
 
     it 'should return an array of errors from the response' do
-      expect(errors[:base]).to include("total.scoring.model.verification.fail")
-      expect(errors[:base]).to include("31000123456789")
-      expect(errors[:base]).to include("1234-abcd")
+      expect(errors[:base]).to include('total.scoring.model.verification.fail')
+      expect(errors[:base]).to include('31000123456789')
+      expect(errors[:base]).to include('1234-abcd')
 
       expect(errors[:Discovery]).to eq(nil) # This should be absent since it passed
       expect(errors[:SomeOtherProduct]).to eq(response_body['Products'][1])
@@ -68,7 +70,7 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
       it { is_expected.to eq(true) }
     end
 
-    context 'with both DOBYearVerified and DOBFullVerified passing but some other product failing' do
+    context 'with both DOBYearVerified and DOBFullVerified passing, some other product failing' do
       let(:items) do
         [
           { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
@@ -90,7 +92,7 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
       it { is_expected.to eq(true) }
     end
 
-    context 'with both DOBYearVerified passed, and DOBFullVerified failing and some other product failing' do
+    context 'with DOBYearVerified passed and DOBFullVerified failing, some other product failing' do
       let(:items) do
         [
           { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
+  let(:response_body) { JSON.parse(LexisNexisFixtures.instant_verify_failure_response_json) }
+  subject(:error_parser) { described_class.new(response_body) }
+
+  describe '#initialize' do
+    let(:response_body) { JSON.parse(LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json) }
+
+    context 'outside of Rails' do
+      it { expect(error_parser).to be }
+    end
+
+    context 'within a Rails app' do
+      it 'logs a message formatted as JSON' do
+        expect(Rails.logger).to receive(:info) do |arg|
+          expect(JSON.parse(arg, symbolize_names: true)).to eq(
+            name: 'lexisnexis_partial_dob',
+            original_passed: false,
+            passed_partial_dob: true,
+            partial_dob_override_enabled: false,
+          )
+        end
+
+        expect(error_parser).to be
+      end
+    end
+  end
+
+  describe '#parsed_errors' do
+    subject(:errors) { error_parser.parsed_errors }
+
+    it 'should return an array of errors from the response' do
+      expect(errors[:base]).to include("total.scoring.model.verification.fail")
+      expect(errors[:base]).to include("31000123456789")
+      expect(errors[:base]).to include("1234-abcd")
+
+      expect(errors[:Discovery]).to eq(nil) # This should be absent since it passed
+      expect(errors[:SomeOtherProduct]).to eq(response_body['Products'][1])
+      expect(errors[:InstantVerify]).to eq(response_body['Products'][2])
+    end
+  end
+
+  describe '#instant_verify_dob_year_only_pass?' do
+    subject(:dob_year_only_pass) do
+      error_parser.send(:instant_verify_dob_year_only_pass?, items)
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing but some other product failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'fail' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with both DOBYearVerified passed, and DOBFullVerified failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'fail' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified passed, and DOBFullVerified failing and some other product failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'fail' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'fail' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with DOBYearVerified missing and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with DOBYearVerified passing and DOBFullVerified missing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -9,23 +9,17 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
       JSON.parse(LexisNexisFixtures.instant_verify_year_of_birth_fail_response_json)
     end
 
-    context 'outside of Rails' do
-      it { expect(error_parser).to be }
-    end
-
-    context 'within a Rails app' do
-      it 'logs a message formatted as JSON' do
-        expect(Rails.logger).to receive(:info) do |arg|
-          expect(JSON.parse(arg, symbolize_names: true)).to eq(
-            name: 'lexisnexis_partial_dob',
-            original_passed: false,
-            passed_partial_dob: true,
-            partial_dob_override_enabled: false,
-          )
-        end
-
-        expect(error_parser).to be
+    it 'logs a message formatted as JSON' do
+      expect(Rails.logger).to receive(:info) do |arg|
+        expect(JSON.parse(arg, symbolize_names: true)).to eq(
+          name: 'lexisnexis_partial_dob',
+          original_passed: false,
+          passed_partial_dob: true,
+          partial_dob_override_enabled: false,
+        )
       end
+
+      expect(error_parser).to be
     end
   end
 

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -1,22 +1,75 @@
+require 'rails_helper'
+
 module LexisNexisFixtures
-  def self.true_id_response_success
-    load_response_fixture('true_id_response_success.json')
-  end
+  class << self
+    def example_config
+      LexisNexis::Proofer::Config.new(
+        base_url: 'https://example.com',
+        request_mode: 'testing',
+        account_id: 'test_account',
+        username: 'test_username',
+        password: 'test_password',
+        instant_verify_workflow: 'customers.gsa.instant.verify.workflow',
+        phone_finder_workflow: 'customers.gsa.phonefinder.workflow',
+        )
+    end
 
-  def self.true_id_response_success_2
-    load_response_fixture('true_id_response_success_2.json')
-  end
+    def instant_verify_request_json
+      raw = read_fixture_file_at_path('instant_verify/request.json')
+      JSON.parse(raw).to_json
+    end
 
-  def self.true_id_response_failure
-    load_response_fixture('true_id_response_failure_no_liveness.json')
-  end
+    def instant_verify_success_response_json
+      raw = read_fixture_file_at_path('instant_verify/successful_response.json')
+      JSON.parse(raw).to_json
+    end
 
-  def self.load_response_fixture(filename)
-    path = File.join(
-      File.dirname(__FILE__),
-      '../fixtures/lexis_nexis_responses',
-      filename,
-    )
-    File.read(path)
+    def instant_verify_failure_response_json
+      raw = read_fixture_file_at_path('instant_verify/failed_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def instant_verify_error_response_json
+      raw = read_fixture_file_at_path('instant_verify/error_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def instant_verify_year_of_birth_fail_response_json
+      raw = read_fixture_file_at_path('instant_verify/year_of_birth_fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def instant_verify_date_of_birth_full_fail_response_json
+      raw = read_fixture_file_at_path('instant_verify/date_of_birth_full_fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def phone_finder_request_json
+      raw = read_fixture_file_at_path('phone_finder/request.json')
+      JSON.parse(raw).to_json
+    end
+
+    def phone_finder_success_response_json
+      raw = read_fixture_file_at_path('phone_finder/response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def phone_finder_fail_response_json
+      raw = read_fixture_file_at_path('phone_finder/fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    private
+
+    def read_fixture_file_at_path(filepath)
+      expanded_path = Rails.root.join(
+        'spec',
+        'fixtures',
+        'proofing',
+        'lexis_nexis',
+        filepath,
+      )
+      File.read(expanded_path)
+    end
   end
 end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -11,7 +11,7 @@ module LexisNexisFixtures
         password: 'test_password',
         instant_verify_workflow: 'customers.gsa.instant.verify.workflow',
         phone_finder_workflow: 'customers.gsa.phonefinder.workflow',
-        )
+      )
     end
 
     def instant_verify_request_json

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -38,9 +38,9 @@ shared_examples 'a lexisnexis proofer' do
 
         expect(result.success?).to eq(false)
         expect(result.errors).to eq(
-                                   base: ['test error'],
-                                   Discovery: ['another test error']
-                                 )
+          base: ['test error'],
+          Discovery: ['another test error'],
+        )
         expect(result.transaction_id).to eq(conversation_id)
       end
     end

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -1,0 +1,85 @@
+shared_examples 'a lexisnexis proofer' do
+  let(:verification_status) { 'passed' }
+  let(:conversation_id) { 'foo' }
+  let(:verification_errors) { {} }
+  let(:result) { Proofer::Result.new }
+
+  before do
+    response = instance_double(Proofing::LexisNexis::Response)
+    allow(response).to receive(:verification_status).and_return(verification_status)
+    allow(response).to receive(:conversation_id).and_return(conversation_id)
+    allow(response).to receive(:verification_errors).and_return(verification_errors)
+
+    allow(verification_request).to receive(:send).and_return(response)
+    allow(verification_request.class).to receive(:new).
+      with(applicant: applicant, config: kind_of(Proofing::LexisNexis::Proofer::Config)).
+      and_return(verification_request)
+  end
+
+  describe '#proof_applicant' do
+    context 'when proofing succeeds' do
+      it 'results in a successful result' do
+        result = subject.proof(applicant)
+
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+        expect(result.transaction_id).to eq(conversation_id)
+      end
+    end
+
+    context 'when proofing fails' do
+      let(:verification_status) { 'failed' }
+      let(:verification_errors) do
+        { base: 'test error', Discovery: 'another test error' }
+      end
+
+      it 'results in an unsuccessful result' do
+        result = subject.proof(applicant)
+
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(
+                                   base: ['test error'],
+                                   Discovery: ['another test error']
+                                 )
+        expect(result.transaction_id).to eq(conversation_id)
+      end
+    end
+  end
+end
+
+shared_examples 'a lexisnexis request' do |basic_auth: true|
+  describe '#http_headers' do
+    it 'contains the content type' do
+      expect(subject.headers).to include('Content-Type' => 'application/json')
+    end
+  end
+
+  describe '#send' do
+    if basic_auth
+      it 'includes the basic auth header' do
+        credentials = Base64.strict_encode64('test_username:test_password')
+        expected_value = "Basic #{credentials}"
+
+        stub_request(:post, subject.url).
+          to_return(status: 200, body: response_body)
+
+        subject.send
+
+        expect(a_request(:post, subject.url).with(headers: { 'Authorization' => expected_value })).
+          to have_been_requested
+      end
+    end
+
+    it 'returns a response object initialized with the http response' do
+      stub_request(:post, subject.url).
+        to_return(status: 200, body: response_body)
+
+      verification_response = instance_double(Proofing::LexisNexis::Response)
+      expect(Proofing::LexisNexis::Response).to receive(:new).
+        with(kind_of(Faraday::Response), anything).
+        and_return(verification_response)
+
+      expect(subject.send).to eq(verification_response)
+    end
+  end
+end


### PR DESCRIPTION
The lexisnexis gem was written as a gem originally to allow it to be a closed-source implementation. Now that it is open-source, there is no value in having the code in a separate repository and it should be incorporated into the idp.

All classes and specs have been copied over and modified as necessary to be part of the idp.