### PR TITLE
Reduce CI duplication to improve speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,6 @@ jobs:
             cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
             bundle exec rake db:create db:migrate --trace
             bundle exec rake db:seed
-            bundle exec rake assets:precompile
       - run:
           name: Run Tests
           command: |
@@ -170,7 +169,6 @@ jobs:
             bin/rails zeitwerk:check
 
             bundle exec rake knapsack:rspec
-            yarn test
       - run:
           name: Code Climate Test Coverage
           command: |
@@ -186,6 +184,21 @@ jobs:
           command: |
             aws s3 sync "s3://login-gov-test-coverage/coverage/$CIRCLE_BUILD_NUM" coverage/
             ./cc-test-reporter sum-coverage --output - --parts $CIRCLE_NODE_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+  javascript_build:
+    working_directory: ~/identity-idp
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - bundle-yarn-install
+      - run:
+          name: Test Setup
+          command: |
+            bundle exec rake assets:precompile
+      - run:
+          name: Run Tests
+          command: |
+            yarn test
+
   lints:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -271,6 +284,7 @@ workflows:
   release:
     jobs:
       - build
+      - javascript_build
       - lints
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
             cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
             bundle exec rake db:create db:migrate --trace
             bundle exec rake db:seed
+            bundle exec rake assets:precompile
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,21 @@ commands:
           destination: capybara
 
 jobs:
+  setup:
+    working_directory: ~/identity-idp
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - bundle-yarn-install
+      - run:
+          name: Test Setup
+          command: |
+            bundle exec rake assets:precompile
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - "public/assets"
+
   build:
     executor: ruby_browsers
 
@@ -128,6 +143,8 @@ jobs:
     steps:
       - checkout
       - bundle-yarn-install
+      - attach_workspace:
+          at: "."
       - run:
           name: Install AWS CLI
           command: |
@@ -190,10 +207,6 @@ jobs:
     steps:
       - checkout
       - bundle-yarn-install
-      - run:
-          name: Test Setup
-          command: |
-            bundle exec rake assets:precompile
       - run:
           name: Run Tests
           command: |
@@ -283,9 +296,16 @@ workflows:
   version: 2
   release:
     jobs:
-      - build
-      - javascript_build
-      - lints
+      - setup
+      - build:
+          requires:
+            - setup
+      - javascript_build:
+          requires:
+            - setup
+      - lints:
+          requires:
+            - setup
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo
   # because they share credentials and would mess each other up if run concurrently

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,9 @@ jobs:
           command: |
             bundle exec rake assets:precompile
       - persist_to_workspace:
-          root: "."
+          root: .
           paths:
-            - "public/assets"
+            - public/assets
 
   build:
     executor: ruby_browsers
@@ -143,8 +143,6 @@ jobs:
     steps:
       - checkout
       - bundle-yarn-install
-      - attach_workspace:
-          at: "."
       - run:
           name: Install AWS CLI
           command: |
@@ -178,7 +176,8 @@ jobs:
             cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
             bundle exec rake db:create db:migrate --trace
             bundle exec rake db:seed
-            bundle exec rake assets:precompile
+      - attach_workspace:
+          at: .
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,8 @@ jobs:
           root: .
           paths:
             - public/assets
+            - public/packs
+            - public/packs-test
 
   build:
     executor: ruby_browsers


### PR DESCRIPTION
Currently we run the JS tests and asset precompilation in our parallel Ruby tests, so they get run 5 times instead of once. The changes here create a required initial setup step that does dependency installation and asset precompilation. JS tests are also split into their own step.

Dependencies are already cached, but they can still take some time when they are updated since we re-download all of them. Moving the dependency installation up into the initial setup ensures that the Lint, JS test, and Ruby test steps have a warm cache and don't all re-download the same dependencies.

The asset precompilation is required for some feature tests and the files are passed from the setup step to the Ruby build step via `persist_to_workspace`.