### PR TITLE
LG-4536: Announce frame states for Acuant SDK to assistive technology

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -296,10 +296,7 @@ function AcuantCaptureCanvas({
       /** @type {AcuantGlobal} */ (window).AcuantCamera.start = (callback, ...args) =>
         originalAcuantCameraStart((response) => {
           const nextFrameState = response?.state || AcuantDocumentState.NO_DOCUMENT;
-          if (nextFrameState !== frameState) {
-            setFrameState(nextFrameState);
-          }
-
+          setFrameState(nextFrameState);
           callback(response);
         }, ...args);
 

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -355,6 +355,7 @@ function AcuantCaptureCanvas({
         <canvas
           id="acuant-video-canvas"
           ref={canvasRef}
+          tabIndex={0}
           aria-labelledby={`acuant-sdk-heading-${instanceId}`}
           aria-describedby={`acuant-sdk-instructions-${instanceId}`}
           style={{
@@ -373,7 +374,7 @@ function AcuantCaptureCanvas({
               {t('doc_auth.accessible_labels.camera_video_capture_instructions')}
             </p>
           )}
-          <button key="button" type="button" aria-disabled={captureType !== 'TAP'}>
+          <button key="button" type="button" disabled={captureType !== 'TAP'}>
             {t('doc_auth.buttons.take_picture')}
           </button>
         </canvas>

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -1,9 +1,40 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useMemo, useEffect, useRef, useState } from 'react';
 import AcuantContext from '../context/acuant';
 import useAsset from '../hooks/use-asset';
 import useI18n from '../hooks/use-i18n';
 import useInstanceId from '../hooks/use-instance-id';
 import useImmutableCallback from '../hooks/use-immutable-callback';
+
+/**
+ * @enum {string}
+ */
+const CaptureStatus = {
+  ALIGN: 'ALIGN',
+  MOVE_CLOSER: 'MOVE_CLOSER',
+  TAP_TO_CAPTURE: 'TAP_TO_CAPTURE',
+  CAPTURING: 'CAPTURING',
+};
+
+/**
+ * @enum {number}
+ */
+const AcuantDocumentState = {
+  NO_DOCUMENT: 0,
+  SMALL_DOCUMENT: 1,
+  GOOD_DOCUMENT: 2,
+};
+
+/**
+ * @enum {number}
+ */
+const AcuantUIState = {
+  CAPTURING: -1,
+  TAP_TO_CAPTURE: -2,
+};
+
+/**
+ * @typedef {AcuantDocumentState & AcuantUIState} AcuantFrameState
+ */
 
 /**
  * Defines a property on the given object, calling the change callback when that property is set to
@@ -77,7 +108,8 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  * @prop {(response: AcuantCaptureImage)=>void} onCaptured Document captured callback.
  * @prop {(response: AcuantSuccessResponse?)=>void} onCropped Document cropped callback. Null if
  * cropping error.
- * @prop {(response: object)=>void=} onFrameAvailable Optional frame available callback.
+ * @prop {(response: AcuantDetectedResult)=>void=} onFrameAvailable Optional frame available
+ * callback.
  */
 
 /**
@@ -94,6 +126,7 @@ export function defineObservableProperty(object, property, onChangeCallback) {
 /**
  * @typedef AcuantCamera
  *
+ * @prop {(callback: (response: AcuantImage)=>void, errorCallback: function)=>void} start
  * @prop {(callback: (response: AcuantImage)=>void)=>void} triggerCapture
  * @prop {(
  *   data: string,
@@ -132,6 +165,12 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  */
 
 /**
+ * @typedef AcuantDetectedResult
+ *
+ * @prop {AcuantFrameState} state
+ */
+
+/**
  * @typedef AcuantSuccessResponse
  *
  * @prop {AcuantImage} image Image object.
@@ -161,6 +200,55 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  */
 
 /**
+ * Returns the computed capture status based on current capture type and frame state.
+ *
+ * @param {AcuantCaptureType} captureType Current capture type.
+ * @param {AcuantFrameState} frameState Current frame state.
+ *
+ * @return {CaptureStatus}
+ */
+function getCaptureStatus(captureType, frameState) {
+  // Acuant internally updates UI state to "Tap to Capture" but does _not_ invoke the
+  // `onFrameAvailable` callback, so we have to track `captureType` separately.
+  if (captureType === 'TAP' || frameState === AcuantUIState.TAP_TO_CAPTURE) {
+    return CaptureStatus.TAP_TO_CAPTURE;
+  }
+
+  switch (frameState) {
+    case AcuantDocumentState.GOOD_DOCUMENT:
+      return CaptureStatus.CAPTURING;
+    case AcuantDocumentState.SMALL_DOCUMENT:
+      return CaptureStatus.MOVE_CLOSER;
+    default:
+      return CaptureStatus.ALIGN;
+  }
+}
+
+/**
+ * Returns the translation key to use for the status text based on current capture status.
+ *
+ * @param {CaptureStatus} captureStatus
+ *
+ * @return {string}
+ */
+function getStatusLabelKey(captureStatus) {
+  switch (captureStatus) {
+    case CaptureStatus.CAPTURING:
+      // i18n-tasks-use t('doc_auth.accessible_labels.status_capturing')
+      return 'doc_auth.accessible_labels.status_capturing';
+    case CaptureStatus.MOVE_CLOSER:
+      // i18n-tasks-use t('doc_auth.accessible_labels.status_move_closer')
+      return 'doc_auth.accessible_labels.status_move_closer';
+    case CaptureStatus.TAP_TO_CAPTURE:
+      // i18n-tasks-use t('doc_auth.accessible_labels.status_tap_to_capture')
+      return 'doc_auth.accessible_labels.status_tap_to_capture';
+    default:
+      // i18n-tasks-use t('doc_auth.accessible_labels.status_align')
+      return 'doc_auth.accessible_labels.status_align';
+  }
+}
+
+/**
  * @param {AcuantCaptureCanvasProps} props Component props.
  */
 function AcuantCaptureCanvas({
@@ -183,6 +271,13 @@ function AcuantCaptureCanvas({
     [onImageCaptureSuccess, onImageCaptureFailure],
   );
   const [captureType, setCaptureType] = useState(/** @type {AcuantCaptureType} */ ('AUTO'));
+  const [frameState, setFrameState] = useState(
+    /** @type {AcuantFrameState} */ (AcuantDocumentState.NO_DOCUMENT),
+  );
+  const captureStatus = useMemo(() => getCaptureStatus(captureType, frameState), [
+    captureType,
+    frameState,
+  ]);
 
   useEffect(() => {
     if (canvasRef.current) {
@@ -195,7 +290,19 @@ function AcuantCaptureCanvas({
   }, []);
 
   useEffect(() => {
+    let originalAcuantCameraStart;
     if (isReady) {
+      originalAcuantCameraStart = /** @type {AcuantGlobal} */ (window).AcuantCamera.start;
+      /** @type {AcuantGlobal} */ (window).AcuantCamera.start = (callback, ...args) =>
+        originalAcuantCameraStart((response) => {
+          const nextFrameState = response?.state || AcuantDocumentState.NO_DOCUMENT;
+          if (nextFrameState !== frameState) {
+            setFrameState(nextFrameState);
+          }
+
+          callback(response);
+        }, ...args);
+
       /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
         {
           onCaptured() {},
@@ -217,6 +324,7 @@ function AcuantCaptureCanvas({
     return () => {
       if (isReady) {
         /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
+        /** @type {AcuantGlobal} */ (window).AcuantCamera.start = originalAcuantCameraStart;
       }
     };
   }, [isReady]);
@@ -260,16 +368,21 @@ function AcuantCaptureCanvas({
             transform: 'translate(-50%, -50%)',
           }}
         >
-          <h2 id={`acuant-sdk-heading-${instanceId}`}>
+          <h2 key="label" id={`acuant-sdk-heading-${instanceId}`}>
             {t('doc_auth.accessible_labels.camera_video_capture_label')}
           </h2>
-          <p id={`acuant-sdk-instructions-${instanceId}`}>
-            {t('doc_auth.accessible_labels.camera_video_capture_instructions')}
-          </p>
-          <button type="button" aria-disabled={captureType !== 'TAP'}>
+          {captureType !== 'TAP' && (
+            <p key="description" id={`acuant-sdk-instructions-${instanceId}`}>
+              {t('doc_auth.accessible_labels.camera_video_capture_instructions')}
+            </p>
+          )}
+          <button key="button" type="button" aria-disabled={captureType !== 'TAP'}>
             {t('doc_auth.buttons.take_picture')}
           </button>
         </canvas>
+        <div role="status" aria-live="polite" className="usa-sr-only">
+          {t(getStatusLabelKey(captureStatus))}
+        </div>
       </div>
     </>
   );

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -18,7 +18,7 @@ const CaptureStatus = {
 /**
  * @enum {number}
  */
-const AcuantDocumentState = {
+export const AcuantDocumentState = {
   NO_DOCUMENT: 0,
   SMALL_DOCUMENT: 1,
   GOOD_DOCUMENT: 2,
@@ -27,7 +27,7 @@ const AcuantDocumentState = {
 /**
  * @enum {number}
  */
-const AcuantUIState = {
+export const AcuantUIState = {
   CAPTURING: -1,
   TAP_TO_CAPTURE: -2,
 };
@@ -290,18 +290,12 @@ function AcuantCaptureCanvas({
   }, []);
 
   useEffect(() => {
-    let originalAcuantCameraStart;
     if (isReady) {
-      originalAcuantCameraStart = /** @type {AcuantGlobal} */ (window).AcuantCamera.start;
-      /** @type {AcuantGlobal} */ (window).AcuantCamera.start = (callback, ...args) =>
-        originalAcuantCameraStart((response) => {
-          const nextFrameState = response?.state || AcuantDocumentState.NO_DOCUMENT;
-          setFrameState(nextFrameState);
-          callback(response);
-        }, ...args);
-
       /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
         {
+          onFrameAvailable(result) {
+            setFrameState(result.state);
+          },
           onCaptured() {},
           onCropped,
         },
@@ -321,7 +315,6 @@ function AcuantCaptureCanvas({
     return () => {
       if (isReady) {
         /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
-        /** @type {AcuantGlobal} */ (window).AcuantCamera.start = originalAcuantCameraStart;
       }
     };
   }, [isReady]);

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -259,6 +259,7 @@ function AcuantCaptureCanvas({
   const { getAssetPath } = useAsset();
   const { t } = useI18n();
   const instanceId = useInstanceId();
+  const [hasCaptured, setHasCaptured] = useState(false);
   const canvasRef = useRef(/** @type {(HTMLCanvasElement & {callback: function})?} */ (null));
   const onCropped = useImmutableCallback(
     (response) => {
@@ -291,12 +292,15 @@ function AcuantCaptureCanvas({
 
   useEffect(() => {
     if (isReady) {
+      setHasCaptured(false);
       /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
         {
           onFrameAvailable(result) {
             setFrameState(result.state);
           },
-          onCaptured() {},
+          onCaptured() {
+            setHasCaptured(true);
+          },
           onCropped,
         },
         onImageCaptureFailure,
@@ -372,7 +376,7 @@ function AcuantCaptureCanvas({
           </button>
         </canvas>
         <div role="status" aria-live="polite" className="usa-sr-only">
-          {t(getStatusLabelKey(captureStatus))}
+          {isReady && !hasCaptured ? t(getStatusLabelKey(captureStatus)) : null}
         </div>
       </div>
     </>

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -1,6 +1,10 @@
 - doc_auth.accessible_labels.camera_video_capture_instructions
 - doc_auth.accessible_labels.camera_video_capture_label
 - doc_auth.accessible_labels.document_capture_dialog
+- doc_auth.accessible_labels.status_align
+- doc_auth.accessible_labels.status_capturing
+- doc_auth.accessible_labels.status_tap_to_capture
+- doc_auth.accessible_labels.status_move_closer
 - doc_auth.buttons.take_or_upload_picture
 - doc_auth.buttons.take_picture
 - doc_auth.buttons.take_picture_retry

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -5,6 +5,10 @@ en:
       camera_video_capture_instructions: We will automatically take the picture
       camera_video_capture_label: Viewfinder with frame to center your ID
       document_capture_dialog: Document capture
+      status_align: Align document in frame
+      status_capturing: Taking photo in three seconds
+      status_tap_to_capture: Automatic capture disabled
+      status_move_closer: Move camera closer to document
     buttons:
       change_address: change
       change_ssn: change

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -7,8 +7,8 @@ en:
       document_capture_dialog: Document capture
       status_align: Align document in frame
       status_capturing: Taking photo in three seconds
-      status_tap_to_capture: Automatic capture disabled
       status_move_closer: Move camera closer to document
+      status_tap_to_capture: Automatic capture disabled
     buttons:
       change_address: change
       change_ssn: change

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -5,6 +5,10 @@ es:
       camera_video_capture_instructions: Tomaremos la foto automáticamente
       camera_video_capture_label: Visor con encuadre para centrar tu documento
       document_capture_dialog: Captura del documento
+      status_align: Alinea el documento dentro del encuadre
+      status_capturing: La foto se tomará en tres segundos
+      status_move_closer: Acerca la cámara al documento
+      status_tap_to_capture: Captura automática desactivada
     buttons:
       change_address: cambio
       change_ssn: cambio

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -5,6 +5,10 @@ fr:
       camera_video_capture_instructions: Nous prendrons automatiquement la photo
       camera_video_capture_label: Viseur avec cadre pour centrer votre pièce d'identité
       document_capture_dialog: Capture du document
+      status_align: Alignez le document dans le cadre
+      status_capturing: Prise de photo en trois secondes
+      status_move_closer: Rapprochez l'appareil photo du document
+      status_tap_to_capture: Capture automatique désactivée
     buttons:
       change_address: changement
       change_ssn: changement

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -98,4 +98,30 @@ describe('document-capture/components/acuant-capture-canvas', () => {
     userEvent.type(button, 'b{space}{enter}', { skipClick: true });
     expect(onClick).to.have.been.calledThrice();
   });
+
+  it('announces "tap to capture" mode', () => {
+    const { getByRole, getByLabelText, getByText } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCaptureCanvas />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    initialize();
+
+    expect(getByText('doc_auth.accessible_labels.camera_video_capture_instructions')).to.be.ok();
+
+    // This assumes that Acuant SDK will assign its own click handlers to respond to clicks on the
+    // canvas, which happens in combination with assigning the callback property to the canvas.
+    const canvas = getByLabelText('doc_auth.accessible_labels.camera_video_capture_label');
+    canvas.callback = () => {};
+
+    expect(() =>
+      getByText('doc_auth.accessible_labels.camera_video_capture_instructions'),
+    ).to.throw();
+    expect(getByRole('status').textContent).to.equal(
+      'doc_auth.accessible_labels.status_tap_to_capture',
+    );
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -83,14 +83,14 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
     const button = getByRole('button', { name: 'doc_auth.buttons.take_picture' });
 
-    expect(button.getAttribute('aria-disabled')).to.equal('true');
+    expect(button.disabled).to.be.true();
 
     // This assumes that Acuant SDK will assign its own click handlers to respond to clicks on the
     // canvas, which happens in combination with assigning the callback property to the canvas.
     const canvas = getByLabelText('doc_auth.accessible_labels.camera_video_capture_label');
     canvas.callback = () => {};
 
-    expect(button.getAttribute('aria-disabled')).to.equal('false');
+    expect(button.disabled).to.be.false();
 
     const onClick = sinon.spy();
     canvas.addEventListener('click', onClick);

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
 import AcuantCaptureCanvas, {
   defineObservableProperty,
+  AcuantDocumentState,
 } from '@18f/identity-document-capture/components/acuant-capture-canvas';
 import { render, useAcuant } from '../../../support/document-capture';
 
@@ -97,6 +98,25 @@ describe('document-capture/components/acuant-capture-canvas', () => {
     userEvent.click(button);
     userEvent.type(button, 'b{space}{enter}', { skipClick: true });
     expect(onClick).to.have.been.calledThrice();
+  });
+
+  it('announces state changes', () => {
+    const { getByRole } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCaptureCanvas />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    initialize();
+
+    const { onFrameAvailable } = window.AcuantCameraUI.start.getCall(0).args[0];
+    onFrameAvailable({ state: AcuantDocumentState.SMALL_DOCUMENT });
+
+    expect(getByRole('status').textContent).to.equal(
+      'doc_auth.accessible_labels.status_move_closer',
+    );
   });
 
   it('announces "tap to capture" mode', () => {

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -119,6 +119,26 @@ describe('document-capture/components/acuant-capture-canvas', () => {
     );
   });
 
+  it('does not announce state changes after capture', () => {
+    // This test case accounts for a quirk of Acuant where `onFrameAvailable` is called with "small
+    // document" after capture has already happened.
+    const { getByRole } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCaptureCanvas />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    initialize();
+
+    const { onFrameAvailable, onCaptured } = window.AcuantCameraUI.start.getCall(0).args[0];
+    onCaptured();
+    onFrameAvailable({ state: AcuantDocumentState.SMALL_DOCUMENT });
+
+    expect(getByRole('status').textContent).to.be.empty();
+  });
+
   it('announces "tap to capture" mode', () => {
     const { getByRole, getByLabelText, getByText } = render(
       <DeviceContext.Provider value={{ isMobile: true }}>


### PR DESCRIPTION
**Why:** As a user who leverages assistive technology, I expect that all non-text content is accompanied by a text alternative, including visual states of the Acuant SDK video capture, so that I can understand its purpose in the page.

Builds on #5126 and #5123.