### PR TITLE
[LG-4666] Move email NameID format config to the DB

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -38,12 +38,10 @@ module SamlIdpAuthConcern
   end
 
   def default_name_id_format
-    return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL if sp_uses_email_nameid_format?
+    if current_service_provider.email_nameid_format_allowed
+      return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
+    end
     Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-  end
-
-  def sp_uses_email_nameid_format?
-    Saml::Idp::Constants::ISSUERS_WITH_EMAIL_NAMEID_FORMAT.include?(current_service_provider.issuer)
   end
 
   def store_saml_request

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -18,6 +18,7 @@ class NullServiceProvider
     created_at
     default_aal
     description
+    email_nameid_format_allowed
     failure_to_proof_url
     help_text
     iaa

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -62,7 +62,7 @@ class SamlRequestValidator
 
   def authorized_email_nameid_format
     return unless email_nameid_format?
-    return if service_provider_allowed_to_use_email_nameid_format?
+    return if service_provider.email_nameid_format_allowed
 
     errors.add(:nameid_format, :unauthorized_nameid_format)
   end
@@ -72,9 +72,5 @@ class SamlRequestValidator
       'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
       'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
     ].include?(nameid_format)
-  end
-
-  def service_provider_allowed_to_use_email_nameid_format?
-    Saml::Idp::Constants::ISSUERS_WITH_EMAIL_NAMEID_FORMAT.include?(service_provider.issuer)
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -334,7 +334,7 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: 'true'
-  issuers_with_email_nameid_format: https://rp1.serviceprovider.com/auth/saml/metadata
+  issuers_with_email_nameid_format: ''
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: '5'
   logins_per_email_and_ip_limit: '2'

--- a/db/migrate/20210614145845_add_email_name_id_format_to_service_providers.rb
+++ b/db/migrate/20210614145845_add_email_name_id_format_to_service_providers.rb
@@ -1,0 +1,22 @@
+class AddEmailNameIdFormatToServiceProviders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_providers, :email_nameid_format_allowed, :boolean
+    change_column_default :service_providers, :email_nameid_format_allowed, from: nil, to: false
+
+    reversible do |dir|
+      dir.up do
+        if IdentityConfig.store.respond_to?(:issuers_with_email_nameid_format)
+          issuers = IdentityConfig.store.issuers_with_email_nameid_format
+          unless issuers.empty?
+            query = <<~SQL
+              UPDATE service_providers
+              SET email_nameid_format_allowed = 't'
+              WHERE issuer in (#{issuers.map { |i| "'#{i}'" }.join(', ')})
+            SQL
+            ActiveRecord::Base.connection.execute(query)
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_215515) do
+ActiveRecord::Schema.define(version: 2021_06_14_145845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -563,6 +563,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_215515) do
     t.string "app_id"
     t.integer "default_aal"
     t.string "certs", array: true
+    t.boolean "email_nameid_format_allowed", default: false
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -88,6 +88,7 @@ describe SamlRequestValidator do
     context 'valid authn context and authorized email nameid format for SP' do
       it 'returns FormResponse with success: true' do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')
+        sp.update!(email_nameid_format_allowed: true)
         authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
         name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
         extra = {
@@ -111,6 +112,7 @@ describe SamlRequestValidator do
 
       it 'returns FormResponse with success: true for ial2 on ial:2 sp' do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')
+        sp.update!(email_nameid_format_allowed: true)
         sp.ial = 2
         authn_context = [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF]
         name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -133,17 +133,9 @@ module SamlAuthHelper
     settings
   end
 
-  def email_nameid_saml_settings_for_allowed_issuer
+  def email_nameid_saml_settings
     settings = saml_settings.dup
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
-    settings
-  end
-
-  def missing_nameid_format_saml_settings_for_allowed_email_issuer
-    settings = saml_settings.dup
-    settings.name_identifier_format = nil
-    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
     settings
   end
 
@@ -173,7 +165,6 @@ module SamlAuthHelper
 
   def sp1_ial2_saml_settings
     settings = sp1_saml_settings.dup
-    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     settings.authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     settings
   end


### PR DESCRIPTION
Resolves LG-4666

* Add allow_email_nameid_format column to the service_providers table,
  defaulting to false, and populate all of the currently configured SPs
  to be true
* Update SAML controller to use this column instead of comparing against
  the list of issuers in the config
* Update specs as necessary

I'll add a PR to remove the old config separately and it should only be merged after this is deployed.