### PR TITLE
Update reports in S3 to have correct extensions

### DIFF
--- a/app/services/agreements/reports/agencies_report.rb
+++ b/app/services/agreements/reports/agencies_report.rb
@@ -9,6 +9,7 @@ module Agreements
         save_report(
           'agencies',
           AgencyBlueprint.render(agencies, root: :agencies),
+          extension: 'json',
         )
       end
 

--- a/app/services/agreements/reports/agency_iaas_report.rb
+++ b/app/services/agreements/reports/agency_iaas_report.rb
@@ -12,6 +12,7 @@ module Agreements
         save_report(
           'agreements',
           IaaBlueprint.render(iaas, root: :agreements),
+          extension: 'json',
         )
       end
 

--- a/app/services/agreements/reports/agency_partner_accounts_report.rb
+++ b/app/services/agreements/reports/agency_partner_accounts_report.rb
@@ -10,6 +10,7 @@ module Agreements
         save_report(
           'partner_accounts',
           PartnerAccountBlueprint.render(partner_accounts, root: :partner_accounts),
+          extension: 'json',
         )
       end
 

--- a/app/services/agreements/reports/base_report.rb
+++ b/app/services/agreements/reports/base_report.rb
@@ -19,7 +19,7 @@ module Agreements
         upload_file_to_s3_bucket(
           path: s3_path,
           body: body,
-          content_type: Mime::Type.lookup_by_extension(extension).to_s
+          content_type: Mime::Type.lookup_by_extension(extension).to_s,
         )
       end
 

--- a/app/services/agreements/reports/base_report.rb
+++ b/app/services/agreements/reports/base_report.rb
@@ -6,17 +6,21 @@ module Agreements
         "#{prefix}.#{ec2_data.account_id}-#{ec2_data.region}"
       end
 
-      def save_report(report_name, body)
+      def save_report(report_name, body, extension:)
         if !IdentityConfig.store.s3_reports_enabled
           logger.info('Not uploading report to S3, s3_reports_enabled is false')
           return body
         end
-        upload_file_to_s3(report_name, body)
+        upload_file_to_s3(report_name, body, extension)
       end
 
-      def upload_file_to_s3(report_name, body)
+      def upload_file_to_s3(report_name, body, extension)
         s3_path = "#{report_path}#{report_name}"
-        upload_file_to_s3_bucket(path: s3_path, body: body, content_type: 'application/json')
+        upload_file_to_s3_bucket(
+          path: s3_path,
+          body: body,
+          content_type: Mime::Type.lookup_by_extension(extension).to_s
+        )
       end
 
       # The following public method should be defined in the child class

--- a/app/services/reports/agency_invoice_iaa_supplement_report.rb
+++ b/app/services/reports/agency_invoice_iaa_supplement_report.rb
@@ -16,7 +16,7 @@ module Reports
 
       results = combine_by_iaa_month(raw_results)
 
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
 
     # @return [Array<String>]

--- a/app/services/reports/agency_invoice_issuer_supplement_report.rb
+++ b/app/services/reports/agency_invoice_issuer_supplement_report.rb
@@ -11,7 +11,7 @@ module Reports
 
       results = combine_by_issuer_month(raw_results)
 
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
 
     def service_providers

--- a/app/services/reports/agency_user_counts_report.rb
+++ b/app/services/reports/agency_user_counts_report.rb
@@ -8,7 +8,7 @@ module Reports
       user_counts = transaction_with_timeout do
         Db::AgencyIdentity::AgencyUserCounts.call
       end
-      save_report(REPORT_NAME, user_counts.to_json)
+      save_report(REPORT_NAME, user_counts.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -38,26 +38,26 @@ module Reports
       end
     end
 
-    def save_report(report_name, body)
+    def save_report(report_name, body, extension:)
       if !IdentityConfig.store.s3_reports_enabled
         logger.info('Not uploading report to S3, s3_reports_enabled is false')
         return body
       end
-      upload_file_to_s3_timestamped_and_latest(report_name, body)
+      upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
     end
 
-    def upload_file_to_s3_timestamped_and_latest(report_name, body)
-      latest_path, path = generate_s3_paths(report_name)
+    def upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
+      latest_path, path = generate_s3_paths(report_name, extension)
       url = upload_file_to_s3_bucket(path: path, body: body, content_type: 'application/json')
       upload_file_to_s3_bucket(path: latest_path, body: body, content_type: 'application/json')
       url
     end
 
-    def generate_s3_paths(name)
+    def generate_s3_paths(name, extension)
       host_data_env = Identity::Hostdata.env
-      latest = "#{host_data_env}/#{name}/latest.#{name}.json"
+      latest = "#{host_data_env}/#{name}/latest.#{name}.#{extension}"
       now = Time.zone.now
-      [latest, "#{host_data_env}/#{name}/#{now.year}/#{now.strftime('%F')}.#{name}.json"]
+      [latest, "#{host_data_env}/#{name}/#{now.year}/#{now.strftime('%F')}.#{name}.#{extension}"]
     end
 
     def logger

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -48,8 +48,9 @@ module Reports
 
     def upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
       latest_path, path = generate_s3_paths(report_name, extension)
-      url = upload_file_to_s3_bucket(path: path, body: body, content_type: 'application/json')
-      upload_file_to_s3_bucket(path: latest_path, body: body, content_type: 'application/json')
+      content_type = Mime::Type.lookup_by_extension(extension).to_s
+      url = upload_file_to_s3_bucket(path: path, body: body, content_type: content_type)
+      upload_file_to_s3_bucket(path: latest_path, body: body, content_type: content_type)
       url
     end
 

--- a/app/services/reports/doc_auth_drop_off_rates_per_sprint_report.rb
+++ b/app/services/reports/doc_auth_drop_off_rates_per_sprint_report.rb
@@ -7,7 +7,7 @@ module Reports
 
     def call
       ret = generate_report
-      save_report(REPORT_NAME, ret.join)
+      save_report(REPORT_NAME, ret.join, extension: 'txt')
     end
 
     private

--- a/app/services/reports/doc_auth_drop_off_rates_report.rb
+++ b/app/services/reports/doc_auth_drop_off_rates_report.rb
@@ -6,7 +6,7 @@ module Reports
 
     def call
       ret = generate_report
-      save_report(REPORT_NAME, ret.join)
+      save_report(REPORT_NAME, ret.join, extension: 'txt')
     end
 
     private

--- a/app/services/reports/doc_auth_funnel_report.rb
+++ b/app/services/reports/doc_auth_funnel_report.rb
@@ -8,7 +8,7 @@ module Reports
       report = transaction_with_timeout do
         Db::DocAuthLog::DocAuthFunnelSummaryStats.new.call
       end
-      save_report(REPORT_NAME, report.to_json)
+      save_report(REPORT_NAME, report.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/gpo_report.rb
+++ b/app/services/reports/gpo_report.rb
@@ -15,7 +15,7 @@ module Reports
 
     def call
       create_reports
-      save_report(REPORT_NAME, @results.to_json)
+      save_report(REPORT_NAME, @results.to_json, extension: 'json')
       @results.to_json
     end
 

--- a/app/services/reports/iaa_billing_report.rb
+++ b/app/services/reports/iaa_billing_report.rb
@@ -19,7 +19,7 @@ module Reports
           results << iaa_results
         end
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
 
     private

--- a/app/services/reports/monthly_gpo_letter_requests_report.rb
+++ b/app/services/reports/monthly_gpo_letter_requests_report.rb
@@ -11,8 +11,12 @@ module Reports
       end
       totals = calculate_totals(daily_results)
       save_report(
-        REPORT_NAME, {total_letter_requests: totals,
-                      daily_letter_requests: daily_results}.to_json
+        REPORT_NAME,
+        {
+          total_letter_requests: totals,
+          daily_letter_requests: daily_results,
+        }.to_json,
+        extension: 'json',
       )
     end
 

--- a/app/services/reports/omb_fitara_report.rb
+++ b/app/services/reports/omb_fitara_report.rb
@@ -10,7 +10,7 @@ module Reports
       results = transaction_with_timeout do
         report_hash
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
 
     private

--- a/app/services/reports/proofing_costs_report.rb
+++ b/app/services/reports/proofing_costs_report.rb
@@ -8,7 +8,7 @@ module Reports
       report = transaction_with_timeout do
         Db::ProofingCost::ProofingCostsSummary.new.call
       end
-      save_report(REPORT_NAME, report.to_json)
+      save_report(REPORT_NAME, report.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_active_users_over_period_of_performance_report.rb
+++ b/app/services/reports/sp_active_users_over_period_of_performance_report.rb
@@ -8,7 +8,7 @@ module Reports
       results = transaction_with_timeout do
         Db::Identity::SpActiveUserCountsWithinIaaWindow.call
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_active_users_report.rb
+++ b/app/services/reports/sp_active_users_report.rb
@@ -8,7 +8,7 @@ module Reports
       results = transaction_with_timeout do
         Db::Identity::SpActiveUserCounts.call(fiscal_start_date)
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_cost_report.rb
+++ b/app/services/reports/sp_cost_report.rb
@@ -8,7 +8,7 @@ module Reports
       results = transaction_with_timeout do
         Db::SpCost::SpCostSummary.call(first_of_this_month, end_of_today)
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_success_rate_report.rb
+++ b/app/services/reports/sp_success_rate_report.rb
@@ -8,7 +8,7 @@ module Reports
       results = transaction_with_timeout do
         Db::SpReturnLog.success_rate_by_sp
       end
-      save_report(REPORT_NAME, results.to_json)
+      save_report(REPORT_NAME, results.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_user_counts_report.rb
+++ b/app/services/reports/sp_user_counts_report.rb
@@ -8,7 +8,7 @@ module Reports
       user_counts = transaction_with_timeout do
         Db::Identity::SpUserCounts.call
       end
-      save_report(REPORT_NAME, user_counts.to_json)
+      save_report(REPORT_NAME, user_counts.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/sp_user_quotas_report.rb
+++ b/app/services/reports/sp_user_quotas_report.rb
@@ -17,7 +17,7 @@ module Reports
       @sp_user_quotas_list = transaction_with_timeout do
         Db::Identity::SpUserQuotas.call(fiscal_start_date)
       end
-      save_report(REPORT_NAME, @sp_user_quotas_list.to_json)
+      save_report(REPORT_NAME, @sp_user_quotas_list.to_json, extension: 'json')
     end
 
     def update_quota_limit_cache

--- a/app/services/reports/total_monthly_auths_report.rb
+++ b/app/services/reports/total_monthly_auths_report.rb
@@ -8,7 +8,7 @@ module Reports
       auth_counts = transaction_with_timeout do
         Db::MonthlySpAuthCount::TotalMonthlyAuthCounts.call
       end
-      save_report(REPORT_NAME, auth_counts.to_json)
+      save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/total_sp_cost_report.rb
+++ b/app/services/reports/total_sp_cost_report.rb
@@ -8,7 +8,7 @@ module Reports
       auth_counts = transaction_with_timeout do
         Db::SpCost::TotalSpCostSummary.call(first_of_this_month, end_of_today)
       end
-      save_report(REPORT_NAME, auth_counts.to_json)
+      save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/unique_monthly_auths_report.rb
+++ b/app/services/reports/unique_monthly_auths_report.rb
@@ -8,7 +8,7 @@ module Reports
       auth_counts = transaction_with_timeout do
         Db::MonthlySpAuthCount::UniqueMonthlyAuthCounts.call
       end
-      save_report(REPORT_NAME, auth_counts.to_json)
+      save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')
     end
   end
 end

--- a/app/services/reports/unique_yearly_auths_report.rb
+++ b/app/services/reports/unique_yearly_auths_report.rb
@@ -8,7 +8,7 @@ module Reports
       auth_counts = transaction_with_timeout do
         Db::MonthlySpAuthCount::UniqueYearlyAuthCounts.call
       end
-      save_report(REPORT_NAME, auth_counts.to_json)
+      save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')
     end
   end
 end

--- a/spec/features/reports/omb_fitara_report_spec.rb
+++ b/spec/features/reports/omb_fitara_report_spec.rb
@@ -38,7 +38,7 @@ feature 'OMB Fitara compliance officer runs report' do
       expect(Identity::Hostdata).to receive(:env).and_return('ci')
 
       Timecop.travel Date.new(2018, 1, 2) do
-        expect(Reports::OmbFitaraReport.new.send(:generate_s3_paths, report_name)).
+        expect(Reports::OmbFitaraReport.new.send(:generate_s3_paths, report_name, 'json')).
           to eq(
             ['ci/omb-fitara-report/latest.omb-fitara-report.json',
              'ci/omb-fitara-report/2018/2018-01-02.omb-fitara-report.json'],


### PR DESCRIPTION
As part of LG-4648, I'm going to update the dropoff reports to have JSON versions as well, this takes the current ✌️  JSON ✌️  files and labels them as `txt` appropriately