### PR TITLE
LG-4632: Mark backup codes as "Least secure" to discourage use

### DIFF
--- a/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
@@ -6,7 +6,7 @@ module TwoFactorAuthentication
 
     # :reek:UtilityFunction
     def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.less_secure_label')
+      I18n.t('two_factor_authentication.two_factor_choice_options.least_secure_label')
     end
   end
 end

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -137,8 +137,10 @@ en:
       backup_code_info_html: We’ll give you 10 codes. You can use backup codes as your
         only authentication method, but it is the least recommended method since
         notes can get lost. Keep them in a safe place.
+      least_secure_label: Least secure
       less_secure_label: Less secure
       more_secure_label: More Secure
+      most_secure_label: Most Secure
       phone: Phone
       phone_info_html: Get security codes by text message (SMS) or phone call.
       phone_info_no_voip: Please do not use web-based (VOIP) phone services.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -148,8 +148,10 @@ es:
       backup_code_info_html: Le daremos 10 códigos para usar y guardar en un lugar
         seguro. Puede usar códigos de respaldo como su único método de
         autenticación.
-      less_secure_label: Menos seguridad
-      more_secure_label: Más seguridad
+      least_secure_label: Lo menos seguro
+      less_secure_label: Menos seguro
+      more_secure_label: Más seguro
+      most_secure_label: Lo más seguro
       phone: Teléfono
       phone_info_html: Obtenga códigos de seguridad por mensaje de texto (SMS) o
         llamada telefónica.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -151,8 +151,10 @@ fr:
       backup_code_info_html: Nous vous donnerons 10 codes à utiliser et à conserver
         dans un endroit sûr. Vous pouvez utiliser des codes de sauvegarde comme
         seule méthode d’authentification.
-      less_secure_label: Moins de protection
-      more_secure_label: Plus de protection
+      least_secure_label: Le moins sécurisé
+      less_secure_label: Moins sécurisé
+      more_secure_label: Plus sécurisé
+      most_secure_label: Le plus sécurisé
       phone: Téléphone
       phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique.
       phone_info_no_voip: Veuillez ne pas utiliser les services téléphoniques basés
@@ -160,7 +162,7 @@ fr:
       piv_cac: Numéro d’employé du gouvernement
       piv_cac_info_html: Insérez votre carte PIV ou CAC du gouvernement ou militaire
         et entrez votre code PIN.
-      secure_label: A une protection
+      secure_label: Sécurisé
       sms: SMS
       sms_info_html: Obtenez votre code de sécurité par SMS.
       voice: Appel téléphonique


### PR DESCRIPTION
As a user, when presented with the choice of MFA options, I want to know that Backup Codes are considered the least secure option, so that if I'm given the choice between Phone and Backup Codes, I'm not motivated to choose Backup Codes out of convenience absent any indication they're considered relatively less secure.

This is an action item out of the analysis of LG-3791, where it was discovered that we saw an uptick in selections of "Backup Code" as an MFA option after we had changed the label of "Phone" to be described as equally "Less Secure". Since we consider Phone to be relatively more secure than Backup Codes, we should avoid presenting them as equally secure.

To do this, we changed the label of Backup Codes to "Least Secure". We also refreshed the translation of all labels, with the resulting screens shown below:

|**en**|**es**|**fr**
|------|------|------
|![mfa-options-en](https://user-images.githubusercontent.com/2583060/121961964-18076d00-cd36-11eb-88e1-13b8cc81bcc9.png)|![mfa-options-es](https://user-images.githubusercontent.com/2583060/121961968-18a00380-cd36-11eb-8846-42cfd9aff174.png)|![mfa-options-fr](https://user-images.githubusercontent.com/2583060/121961969-19389a00-cd36-11eb-9e11-d51fabf5df8f.png)


