### PR TITLE
Add daily auths report (LG-4648)

### DIFF
--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -54,10 +54,9 @@ module Reports
       url
     end
 
-    def generate_s3_paths(name, extension)
+    def generate_s3_paths(name, extension, now: Time.zone.now)
       host_data_env = Identity::Hostdata.env
       latest = "#{host_data_env}/#{name}/latest.#{name}.#{extension}"
-      now = Time.zone.now
       [latest, "#{host_data_env}/#{name}/#{now.year}/#{now.strftime('%F')}.#{name}.#{extension}"]
     end
 

--- a/app/services/reports/daily_auths_report.rb
+++ b/app/services/reports/daily_auths_report.rb
@@ -1,0 +1,67 @@
+module Reports
+  class DailyAuthsReport < BaseReport
+    REPORT_NAME = 'daily-auths-report'
+
+    attr_reader :report_date
+
+    # @param [Date] report_date
+    def initialize(report_date)
+      @report_date = report_date
+    end
+
+    def call
+      _latest, path = generate_s3_paths(REPORT_NAME, 'json', now: report_date)
+
+      upload_file_to_s3_bucket(
+        path: path,
+        body: report_body.to_json,
+        content_type: 'application/json',
+      )
+    end
+
+    def start
+      report_date.beginning_of_day
+    end
+
+    def finish
+      report_date.end_of_day
+    end
+
+    def report_body
+      params = {
+        start: start,
+        finish: finish,
+      }.transform_values { |v| ActiveRecord::Base.connection.quote(v) }
+
+      sql = format(<<-SQL, params)
+        SELECT
+          COUNT(*)
+        , sp_return_logs.ial
+        , sp_return_logs.issuer
+        , service_providers.iaa
+        FROM
+          sp_return_logs
+        LEFT JOIN
+          service_providers ON service_providers.issuer = sp_return_logs.issuer
+        WHERE
+          %{start} <= sp_return_logs.requested_at
+          AND sp_return_logs.requested_at <= %{finish}
+          AND sp_return_logs.returned_at IS NOT NULL
+        GROUP BY
+          sp_return_logs.ial
+        , sp_return_logs.issuer
+        , service_providers.iaa
+      SQL
+
+      results = transaction_with_timeout do
+        ActiveRecord::Base.connection.execute(sql)
+      end
+
+      {
+        start: start,
+        finish: finish,
+        results: results.as_json,
+      }
+    end
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -207,6 +207,14 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   callback: -> { Agreements::Reports::PartnerApiReport.new.run },
 )
 
+# Send daily auth report to S3
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
+  name: 'Daily Auth Report',
+  interval: 24 * 60 * 60, # 24 hours
+  timeout: 300,
+  callback: -> { Reports::DailyAuthsReport.new(Date.yesterday).call },
+)
+
 if IdentityConfig.store.ruby_workers_enabled
   # Queue heartbeat job to DelayedJob
   JobRunner::Runner.add_config JobRunner::JobConfiguration.new(

--- a/spec/services/reports/daily_auths_report_spec.rb
+++ b/spec/services/reports/daily_auths_report_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Reports::DailyAuthsReport do
+  subject(:report) { Reports::DailyAuthsReport.new(report_date) }
+
+  let(:report_date) { Date.new(2021, 3, 1) }
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+  end
+
+  describe '#call' do
+    it 'uploads a file to S3 based on the report date' do
+      expect(report).to receive(:upload_file_to_s3_bucket).with(
+        path: 'int/daily-auths-report/2021/2021-03-01.daily-auths-report.json',
+        body: kind_of(String),
+        content_type: 'application/json',
+      )
+
+      report.call
+    end
+
+    context 'with data' do
+      let(:timestamp) { report_date + 12.hours }
+
+      before do
+        create(:service_provider, issuer: 'a', iaa: 'iaa123')
+        create(:sp_return_log, ial: 1, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
+        create(:sp_return_log, ial: 1, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
+        create(:sp_return_log, ial: 2, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
+      end
+
+      it 'aggregates by issuer' do
+        expect(report).to receive(:upload_file_to_s3_bucket) do |path:, body:, content_type:|
+          parsed = JSON.parse(body, symbolize_names: true)
+
+          expect(parsed[:start]).to eq(report_date.beginning_of_day.as_json)
+          expect(parsed[:finish]).to eq(report_date.end_of_day.as_json)
+          expect(parsed[:results]).to match_array(
+            [
+              { count: 2, ial: 1, issuer: 'a', iaa: 'iaa123' },
+              { count: 1, ial: 2, issuer: 'a', iaa: 'iaa123' },
+            ],
+          )
+        end
+
+        report.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Aggregates sp_return_logs for a single day
* Can be run with past days to backfill to S3


Next steps:
- Figure out how to build similar daily summary for proofing rates, GPO

After deploy:
- If it looks good, backfill for as long as we have sp_return_logs table in prod
