### PR TITLE
Try disabling Webpacker compile for test environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,7 @@ jobs:
             cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
             bundle exec rake db:create db:migrate --trace
             bundle exec rake db:seed
+            ruby -i -pe 'gsub(/^(\s+)compile: true$/, "\\1compile: false")' config/webpacker.yml
       - attach_workspace:
           at: .
       - run:

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
 
 test:
   <<: *default
-  compile: false
+  compile: true
 
   # Compile test packs to a separate directory
   public_output_path: packs-test

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -51,10 +51,9 @@ development:
     watch_options:
       ignored: /node_modules\/(?!@18f\/identity-)/
 
-
 test:
   <<: *default
-  compile: true
+  compile: false
 
   # Compile test packs to a separate directory
   public_output_path: packs-test


### PR DESCRIPTION
**Why**: In CI, [we already precompile assets before running tests](https://github.com/18F/identity-idp/blob/5d1b84cb0b6b7040a08d7e9efa45e24ea9e4a886/.circleci/config.yml#L125-L128), so as with disabling this `compile` setting in production, in theory we may see speedup by disabling on-demand compilation.

This may not be shippable as-is, since we may still want on-demand compilation for tests run in local development. Currently testing to see if there's enough noticeable difference to warrant further exploration.