### PR TITLE
Fix ServiceProviderSeeder data for certs

### DIFF
--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -12,18 +12,18 @@ class ServiceProviderSeeder
 
     service_providers.each do |issuer, config|
       next unless write_service_provider?(config)
-      ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
-        cert_pems = Array(config['certs']).map do |cert|
-          cert_path = Rails.root.join('certs', 'sp', "#{cert}.crt")
-          cert_path.read if cert_path.exist?
-        end.compact
 
+      cert_pems = Array(config['certs']).map do |cert|
+        cert_path = Rails.root.join('certs', 'sp', "#{cert}.crt")
+        cert_path.read if cert_path.exist?
+      end.compact
+
+      ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
         sp.update(
           approved: true,
           active: true,
           native: true,
           friendly_name: config['friendly_name'],
-          certs: cert_pems,
         )
       end.update!(config.except(
         'agency',
@@ -32,7 +32,7 @@ class ServiceProviderSeeder
         'uuid_priority',
         'protocol',
         'native',
-      ))
+      ).merge(certs: cert_pems))
     end
   end
 

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -139,6 +139,8 @@ test:
     iaa: 'ABC123-2020'
     iaa_start_date: '2020-01-01'
     iaa_end_date: '2020-12-31'
+    certs:
+      - 'saml_test_sp'
 
   'urn:gov:gsa:openidconnect:test':
     redirect_uris:

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -61,13 +61,16 @@ RSpec.describe ServiceProviderSeeder do
           :service_provider,
           issuer: 'http://test.host',
           acs_url: 'http://test.host/test/saml/decode_assertion_old',
+          certs: ['a', 'b'],
         )
       end
 
       it 'updates the attributes based on the current value of the yml file' do
-        expect { run }.
-          to change { ServiceProvider.from_issuer('http://test.host').acs_url }.
-          to('http://test.host/test/saml/decode_assertion')
+        expect { run }.to(
+          change { ServiceProvider.from_issuer('http://test.host').acs_url }.
+            to('http://test.host/test/saml/decode_assertion').and(
+              change { ServiceProvider.from_issuer('http://test.host').certs }.
+                to([Rails.root.join('certs', 'sp', 'saml_test_sp.crt').read])))
       end
     end
 

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe ServiceProviderSeeder do
           change { ServiceProvider.from_issuer('http://test.host').acs_url }.
             to('http://test.host/test/saml/decode_assertion').and(
               change { ServiceProvider.from_issuer('http://test.host').certs }.
-                to([Rails.root.join('certs', 'sp', 'saml_test_sp.crt').read])))
+                to([Rails.root.join('certs', 'sp', 'saml_test_sp.crt').read]),
+            ),
+        )
       end
     end
 


### PR DESCRIPTION
- find_or_create only calls its block for new records,
  so updates to existing records need to go outside the block

Eagle eye @orenyk noticed some records weren't updating the way we expected 😬 🤦 