### PR TITLE
[LG-4725] Add support for limited step-up AuthnContext behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 6.1.3'
 @doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.9.3' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
-@saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.1-18f' }
+@saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }
 @telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.3.0' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.6.0' }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 1b59d834efcc4df3d40db213eb4092fc4d5ff4c6
-  tag: v0.14.1-18f
+  revision: 89d93da7b45cad7f01b5335f762f5f020d40765f
+  tag: v0.14.2-18f
   specs:
-    saml_idp (0.14.1.pre.18f)
+    saml_idp (0.14.2.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -24,6 +24,7 @@ module SamlIdpAuthConcern
     @result = @saml_request_validator.call(
       service_provider: current_service_provider,
       authn_context: requested_authn_contexts,
+      authn_context_comparison: saml_request.requested_authn_context_comparison,
       nameid_format: name_id_format,
     )
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -14,6 +14,10 @@ module Saml
       IAL2_STRICT_AUTHN_CONTEXT_CLASSREF = "#{IAL_AUTHN_CONTEXT_PREFIX}/2?strict=true".freeze
       IALMAX_AUTHN_CONTEXT_CLASSREF = "#{IAL_AUTHN_CONTEXT_PREFIX}/0".freeze
 
+      PASSWORD_AUTHN_CONTEXT_CLASSREFS = %w[
+        urn:oasis:names:tc:SAML:2.0:ac:classes:Password
+        urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+      ].freeze
       DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF = 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo'.freeze
       AAL_AUTHN_CONTEXT_PREFIX = 'http://idmanagement.gov/ns/assurance/aal'.freeze
       AAL1_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/1".freeze

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -136,6 +136,93 @@ describe SamlRequestValidator do
       end
     end
 
+    context 'unsupported authn context with step up and valid sp and nameID format' do
+      it 'returns a FormResponse with success: true for Comparison=minimum' do
+        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+          sp = ServiceProvider.from_issuer('http://localhost:3000')
+          authn_context = [password_context]
+          comparison = 'minimum'
+          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
+          extra = {
+            authn_context: authn_context,
+            service_provider: sp.issuer,
+            nameid_format: name_id_format,
+          }
+
+          response = SamlRequestValidator.new.call(
+            service_provider: sp,
+            authn_context: authn_context,
+            authn_context_comparison: comparison,
+            nameid_format: name_id_format,
+          )
+
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
+      end
+
+      it 'returns a FormResponse with success: true for Comparison=better' do
+        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+          sp = ServiceProvider.from_issuer('http://localhost:3000')
+          authn_context = [password_context]
+          comparison = 'better'
+          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
+          extra = {
+            authn_context: authn_context,
+            service_provider: sp.issuer,
+            nameid_format: name_id_format,
+          }
+
+          response = SamlRequestValidator.new.call(
+            service_provider: sp,
+            authn_context: authn_context,
+            authn_context_comparison: comparison,
+            nameid_format: name_id_format,
+          )
+
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
+      end
+    end
+
+    context 'unsupported authn context without step up and valid sp and nameID format' do
+      it 'returns FormResponse with success: false for unknown authn context' do
+        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+          sp = ServiceProvider.from_issuer('http://localhost:3000')
+          authn_context = [password_context]
+          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
+          extra = {
+            authn_context: authn_context,
+            service_provider: sp.issuer,
+            nameid_format: name_id_format,
+          }
+          errors = {
+            authn_context: [t('errors.messages.unauthorized_authn_context')],
+          }
+
+          response = SamlRequestValidator.new.call(
+            service_provider: sp,
+            authn_context: authn_context,
+            nameid_format: name_id_format,
+          )
+
+          expect(response.to_h).to include(
+            success: false,
+            errors: errors,
+            error_details: hash_including(*errors.keys),
+            **extra,
+          )
+        end
+      end
+    end
+
     context 'invalid authn context and valid sp and authorized nameID format' do
       it 'returns FormResponse with success: false for unknown authn context' do
         sp = ServiceProvider.from_issuer('http://localhost:3000')

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -11,6 +11,10 @@ class FakeSamlRequest
     Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
   end
 
+  def requested_authn_context_comparison
+    'exact'
+  end
+
   def requested_authn_contexts
     [
       Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,


### PR DESCRIPTION
Resolves LG-4725

* Add PasswordProtectedTransport (non-duo version) to SamlIdp variables
* Take requested_auth_context_comparison attribute from saml request and
  pass it to the SamlRequestValidator service object during
  authentication requests
* Allow SamlRequestValidator to pass requests sending the
  PasswordProtectedTransport AuthnContext if the RequestAuthnContext
  element includes the Comparison attribute set to either "minimum" or
  "better" (section 3.3.2.2.1 of the SAML Core 2.0 spec)

Tested locally with [this SAML request](http://localhost:3000/api/saml/auth2021?SAMLRequest=lVJdj9owEPwrkd8TOx8NlRVyoqCqSFyLgFanvpyMvRyWYju1HUL%2FfU3I3b3Qu%2FbJ0np2dmZ2q7uzaqITWCeNnqI0IeiurmadP%2BoN%2FOrA%2BSgAtKNnJ6bo6H1LMe77PunzxNgnnBGS4of71ZYfQTH0Apbvg2OpnWeaA4qWiyl6PBQTMvmYsfiQ5SIuCl7GezbJ4n3JSJ6XkyJlJYp%2BPEvNgtRo6VwHy4HHhxLJ0piUcVruSErzD7QofqJobY033DSfpBZSP01RZzU1zElHNVPgqOd0O7tf0cBI91eQo192u3W8%2FrbdoWjmHFgfhs6Ndp0CuwV7khy%2Bb1YvLhvDWXM0ztOcEIJ9CA47phosgBsBj%2ByZA0WL8Cc184OL2%2B2sldduFhZxcTUG%2B7b2djSK6mrIxf5L06uw%2BqLFBTG2TRN3tRgoT1KATbhRg5irLAWeCeZZha%2BD6uprIF4u1qaR%2FHf02VjF%2FN%2Fnpkk6VKSIDwOUdtq1wOVBggh5N43p5xaYhynytgsHgutqPEcQw3GGVXg4%2B2huVMusdJcsldRSdQqN9ztC5k2wuIHDf4bxJoxTfmEN5XV4emPF5ciAB3U7y4IXY32Fb6moK3zTSD3Cx8%2F6Dw%3D%3D) - if you disable block encryption for the first SP record in the DB after a reset you can see that it is passing the `PasswordProtectedTransport:duo` AuthnContext in the response.