### PR TITLE
LG-4690 Fix FIDO/Webauthn Sign In on Safari

### DIFF
--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -10,6 +10,9 @@ function webauthn() {
     window.location.href = href;
   }
 
+  const spinner = document.getElementById('spinner');
+  spinner.classList.remove('hidden');
+
   WebAuthn.verifyWebauthnDevice({
     userChallenge: document.getElementById('user_challenge').value,
     credentialIds: document.getElementById('credential_ids').value,

--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -22,4 +22,10 @@ function webauthn() {
     webauthnSuccessContainer.classList.remove('hidden');
   });
 }
-document.addEventListener('DOMContentLoaded', webauthn);
+
+function webauthnButton() {
+  const button = document.getElementById('webauthn-button');
+  button.addEventListener('click', webauthn);
+}
+
+document.addEventListener('DOMContentLoaded', webauthnButton);

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -28,7 +28,7 @@
       </div>
     </div>
     <p class="half-center">
-      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('forms.buttons.continue') %>">
+      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('forms.webauthn_setup.login_text') %>">
     </p>
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -18,7 +18,7 @@
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
 
   <%= content_tag :div, id: 'webauthn-auth-in-progress', data: { webauthn_not_enabled_url: login_two_factor_options_path } do %>
-    <div class="spinner" id="spinner">
+    <div class="spinner hidden" id="spinner">
       <div class="col-12 center margin-bottom-2">
         <%= image_tag(asset_url('spinner.gif'),
                 srcset: asset_url('spinner@2x.gif'),
@@ -28,7 +28,8 @@
       </div>
     </div>
     <p class="half-center">
-      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('links.continue_sign_in') %>">
+      <span class="h2"><%= t('forms.webauthn_setup.login_text') %></span>
+      <input type="button" id="webauthn-button" class="margin-top-2 usa-button usa-button--big usa-button--wide" value="<%= t('two_factor_authentication.webauthn_use_key') %>">
     </p>
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -28,7 +28,7 @@
       </div>
     </div>
     <p class="half-center">
-      <%= t('forms.webauthn_setup.login_text') %>
+      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('forms.buttons.continue') %>">
     </p>
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -28,7 +28,7 @@
       </div>
     </div>
     <p class="half-center">
-      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('forms.webauthn_setup.login_text') %>">
+      <input type="button" id="webauthn-button" class="usa-button usa-button--big usa-button--wide" value="<%= t('links.continue_sign_in') %>">
     </p>
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,5 +128,4 @@ en:
         account.  Your security key must support the FIDO standard.  You can add
         as many security keys as you want, and we recommend at least two for
         easier account recovery.
-      login_text: Press the button on your security key to sign in with login.gov
       nickname: Security key nickname

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,4 +128,5 @@ en:
         account.  Your security key must support the FIDO standard.  You can add
         as many security keys as you want, and we recommend at least two for
         easier account recovery.
+      login_text: When you are ready to authenticate, press the button
       nickname: Security key nickname

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,4 +128,5 @@ en:
         account.  Your security key must support the FIDO standard.  You can add
         as many security keys as you want, and we recommend at least two for
         easier account recovery.
+      login_text: Continue
       nickname: Security key nickname

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,5 +128,4 @@ en:
         account.  Your security key must support the FIDO standard.  You can add
         as many security keys as you want, and we recommend at least two for
         easier account recovery.
-      login_text: Continue
       nickname: Security key nickname

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -135,4 +135,5 @@ es:
         cuenta. Su clave de seguridad debe ser compatible con el estándar FIDO.
         Puede agregar tantas claves de seguridad como desee, y le recomendamos
         al menos dos para que la recuperación de la cuenta sea más fácil.
+      login_text: Cuando esté listo para autenticarse, presione el botón
       nickname: Apodo clave de seguridad

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -135,5 +135,4 @@ es:
         cuenta. Su clave de seguridad debe ser compatible con el estándar FIDO.
         Puede agregar tantas claves de seguridad como desee, y le recomendamos
         al menos dos para que la recuperación de la cuenta sea más fácil.
-      login_text: Continuar
       nickname: Apodo clave de seguridad

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -135,4 +135,5 @@ es:
         cuenta. Su clave de seguridad debe ser compatible con el estándar FIDO.
         Puede agregar tantas claves de seguridad como desee, y le recomendamos
         al menos dos para que la recuperación de la cuenta sea más fácil.
+      login_text: Continuar
       nickname: Apodo clave de seguridad

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -135,6 +135,4 @@ es:
         cuenta. Su clave de seguridad debe ser compatible con el estándar FIDO.
         Puede agregar tantas claves de seguridad como desee, y le recomendamos
         al menos dos para que la recuperación de la cuenta sea más fácil.
-      login_text: Presione el botón en su clave de seguridad para iniciar sesión con
-        login.gov
       nickname: Apodo clave de seguridad

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -139,5 +139,4 @@ fr:
         FIDO. Vous pouvez ajouter autant de clés de sécurité que vous le
         souhaitez et nous en recommandons au moins deux pour faciliter la
         récupération du compte.
-      login_text: Continuer
       nickname: Pseudo clé de sécurité

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -139,4 +139,5 @@ fr:
         FIDO. Vous pouvez ajouter autant de clés de sécurité que vous le
         souhaitez et nous en recommandons au moins deux pour faciliter la
         récupération du compte.
+      login_text: Lorsque vous êtes prêt à vous authentifier, appuyez sur le bouton
       nickname: Pseudo clé de sécurité

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -139,4 +139,5 @@ fr:
         FIDO. Vous pouvez ajouter autant de clés de sécurité que vous le
         souhaitez et nous en recommandons au moins deux pour faciliter la
         récupération du compte.
+      login_text: Continuer
       nickname: Pseudo clé de sécurité

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -139,6 +139,4 @@ fr:
         FIDO. Vous pouvez ajouter autant de clés de sécurité que vous le
         souhaitez et nous en recommandons au moins deux pour faciliter la
         récupération du compte.
-      login_text: Appuyez sur le bouton de votre clé de sécurité pour vous connecter
-        avec login.gov
       nickname: Pseudo clé de sécurité

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -164,6 +164,7 @@ en:
       question: Don’t have your security key available?
     webauthn_header_text: Connect your security key
     webauthn_piv_available: Use your PIV or CAC
+    webauthn_use_key: Use security key
     webauthn_verified:
       header: Security key verified
       info: We have verified your security key. Click continue to sign in.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -176,6 +176,7 @@ es:
       question: '¿No dispone de su llave de seguridad?'
     webauthn_header_text: Conecte su llave de seguridad
     webauthn_piv_available: Utilice su PIV o CAC
+    webauthn_use_key: Usar llave de seguridad
     webauthn_verified:
       header: Llave de seguridad verificada
       info: Hemos verificado su llave de seguridad. Haga clic en continuar para

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -180,6 +180,7 @@ fr:
       question: Vous n’avez pas votre clé de sécurité avec vous?
     webauthn_header_text: Connectez votre clé de sécurité
     webauthn_piv_available: Utilisez votre PIV ou CAC
+    webauthn_use_key: Utiliser la clé de sécurité
     webauthn_verified:
       header: Clé de sécurité vérifiée
       info: Nous avons vérifié votre clé de sécurité. Cliquez sur Continuer pour vous


### PR DESCRIPTION
**Why**: https://github.com/18F/identity-idp/issues/5132  In summary user has to trigger an action for navigator.credentials.get to work.
**How**: Add button to trigger action that used to happen onload