### PR TITLE
Additional ERB linting

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -19,7 +19,6 @@ linters:
       - '*/app/views/idv/review/*'
       - '*/app/views/idv/shared/_document_capture.html.erb'
       - '*/app/views/event_disavowal/*'
-      - '*/app/views/events/*'
       - '*/app/views/mfa_confirmation/*'
       - '*/app/views/partials/*'
       - '*/app/views/reactivate_account/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -15,7 +15,6 @@ linters:
       - '*/app/views/event_disavowal/*'
       - '*/app/views/mfa_confirmation/*'
       - '*/app/views/reactivate_account/*'
-      - '*/app/views/saml_idp/*'
       - '*/app/views/service_provider_mfa/*'
       - '*/app/views/session_timeout/*'
       - '*/app/views/shared/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -29,7 +29,6 @@ linters:
       - '*/app/views/session_timeout/*'
       - '*/app/views/shared/*'
       - '*/app/views/sign_up/*'
-      - '*/app/views/test/*'
       - '*/app/views/two_factor_authentication/*'
       - '*/app/views/user_mailer/*'
       - '*/app/views/users/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,7 +7,6 @@ linters:
     exclude:
       - '*/app/views/account_reset/*'
       - '*/app/views/accounts/*'
-      - '*/app/views/devise/*'
       - '*/app/views/idv/address/*'
       - '*/app/views/idv/come_back_later/*'
       - '*/app/views/idv/confirmations/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -43,7 +43,11 @@ linters:
         - .rubocop.yml
       Layout/InitialIndentation:
         Enabled: false
+      Layout/LineLength:
+        Enabled: false
       Layout/TrailingEmptyLines:
+        Enabled: false
+      Rails/OutputSafety:
         Enabled: false
   DeprecatedClasses:
     enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,7 +11,6 @@ linters:
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'
-      - '*/app/views/idv/otp_delivery_method/*'
       - '*/app/views/idv/otp_verification/*'
       - '*/app/views/idv/phone/*'
       - '*/app/views/idv/shared/_document_capture.html.erb'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -19,7 +19,6 @@ linters:
       - '*/app/views/service_provider_mfa/*'
       - '*/app/views/session_timeout/*'
       - '*/app/views/shared/*'
-      - '*/app/views/sign_up/*'
       - '*/app/views/two_factor_authentication/*'
       - '*/app/views/user_mailer/*'
       - '*/app/views/users/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,7 +12,6 @@ linters:
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'
-      - '*/app/views/idv/forgot_password/*'
       - '*/app/views/idv/otp_delivery_method/*'
       - '*/app/views/idv/otp_verification/*'
       - '*/app/views/idv/phone/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -14,7 +14,6 @@ linters:
       - '*/app/views/idv/otp_delivery_method/*'
       - '*/app/views/idv/otp_verification/*'
       - '*/app/views/idv/phone/*'
-      - '*/app/views/idv/review/*'
       - '*/app/views/idv/shared/_document_capture.html.erb'
       - '*/app/views/event_disavowal/*'
       - '*/app/views/mfa_confirmation/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,7 +7,6 @@ linters:
     exclude:
       - '*/app/views/account_reset/*'
       - '*/app/views/accounts/*'
-      - '*/app/views/idv/address/*'
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -18,7 +18,6 @@ linters:
       - '*/app/views/idv/phone/*'
       - '*/app/views/idv/review/*'
       - '*/app/views/idv/shared/_document_capture.html.erb'
-      - '*/app/views/forgot_password/*'
       - '*/app/views/event_disavowal/*'
       - '*/app/views/events/*'
       - '*/app/views/mfa_confirmation/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,7 +24,6 @@ linters:
       - '*/app/views/layouts/*'
       - '*/app/views/mfa_confirmation/*'
       - '*/app/views/partials/*'
-      - '*/app/views/password_capture/*'
       - '*/app/views/reactivate_account/*'
       - '*/app/views/saml_idp/*'
       - '*/app/views/service_provider_mfa/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -84,3 +84,5 @@ linters:
       - deprecated:
           - 'js-consent-form'
         suggestion: 'Rename classes that are known to be hidden by the Hush plugin'
+  SpaceAroundErbTag:
+    enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -13,7 +13,6 @@ linters:
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'
       - '*/app/views/idv/forgot_password/*'
-      - '*/app/views/idv/gpo/*'
       - '*/app/views/idv/otp_delivery_method/*'
       - '*/app/views/idv/otp_verification/*'
       - '*/app/views/idv/phone/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -8,7 +8,6 @@ linters:
       - '*/app/views/account_reset/*'
       - '*/app/views/accounts/*'
       - '*/app/views/idv/address/*'
-      - '*/app/views/idv/come_back_later/*'
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -21,7 +21,6 @@ linters:
       - '*/app/views/forgot_password/*'
       - '*/app/views/event_disavowal/*'
       - '*/app/views/events/*'
-      - '*/app/views/layouts/*'
       - '*/app/views/mfa_confirmation/*'
       - '*/app/views/partials/*'
       - '*/app/views/reactivate_account/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -23,7 +23,6 @@ linters:
       - '*/app/views/events/*'
       - '*/app/views/layouts/*'
       - '*/app/views/mfa_confirmation/*'
-      - '*/app/views/pages/*'
       - '*/app/views/partials/*'
       - '*/app/views/password_capture/*'
       - '*/app/views/reactivate_account/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,7 +11,6 @@ linters:
       - '*/app/views/idv/confirmations/*'
       - '*/app/views/idv/capture_doc/*'
       - '*/app/views/idv/doc_auth/*'
-      - '*/app/views/idv/otp_verification/*'
       - '*/app/views/idv/phone/*'
       - '*/app/views/idv/shared/_document_capture.html.erb'
       - '*/app/views/event_disavowal/*'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -20,7 +20,6 @@ linters:
       - '*/app/views/idv/shared/_document_capture.html.erb'
       - '*/app/views/event_disavowal/*'
       - '*/app/views/mfa_confirmation/*'
-      - '*/app/views/partials/*'
       - '*/app/views/reactivate_account/*'
       - '*/app/views/saml_idp/*'
       - '*/app/views/service_provider_mfa/*'

--- a/app/views/accounts/_event_item.html.erb
+++ b/app/views/accounts/_event_item.html.erb
@@ -6,6 +6,6 @@
     <%= event.last_sign_in_location_and_ip %>
   </div>
   <div class="mobile-lg:grid-col-6 padding-x-1 sm-right-align">
-    <%=  local_time(event.happened_at, t('time.formats.event_timestamp')) %>
+    <%= local_time(event.happened_at, t('time.formats.event_timestamp')) %>
   </div>
 </div>

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -22,7 +22,7 @@
         </div>
       </div>
       <div class="desktop:display-none display-flex flex-row flex-justify-end">
-        <%= link_to t('links.sign_out'), destroy_user_session_path, class: 'margin-top-105 margin-right-2'%>
+        <%= link_to t('links.sign_out'), destroy_user_session_path, class: 'margin-top-105 margin-right-2' %>
         <% if enable_mobile_nav %>
           <button class="usa-menu-btn"><%= t('account.navigation.menu') %></button>
         <% end %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,18 +4,20 @@
   <%= t('headings.passwords.change') %>
 </h1>
 
-<%= validated_form_for(@reset_password_form,
-    url: user_password_path,
-    html: { autocomplete: 'off',
-            method: :put }) do |f| %>
+<%= validated_form_for(
+      @reset_password_form,
+      url: user_password_path,
+      html: { autocomplete: 'off',
+              method: :put },
+    ) do |f| %>
   <%= f.input :reset_password_token, as: :hidden %>
   <%= f.full_error :reset_password_token %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
-              input_html: { class: 'password-toggle' } %>
+                         input_html: { class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'usa-button--big margin-bottom-4' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>
 
-<%=  javascript_packs_tag_once 'pw-strength' %>
+<%= javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,9 +11,11 @@
   <%= t('instructions.password.forgot') %>
 </p>
 
-<%= validated_form_for(@password_reset_email_form,
-                       url: user_password_path,
-                       html: { autocomplete: 'off', method: :post }) do |f| %>
+<%= validated_form_for(
+      @password_reset_email_form,
+      url: user_password_path,
+      html: { autocomplete: 'off', method: :post },
+    ) do |f| %>
   <%= f.input :email,
               required: true,
               input_html: { autocorrect: 'off',

--- a/app/views/devise/sessions/_return_to_service_provider.html.erb
+++ b/app/views/devise/sessions/_return_to_service_provider.html.erb
@@ -1,8 +1,10 @@
 <div class='sm-col padding-y-1 tablet:padding-0'>
   <%= link_to(
-    "‹ #{t('links.back_to_sp',
-    sp: decorated_session.sp_name)}",
-    return_to_sp_cancel_path,
-    class: 'inline-block text-bottom',
-  ) %>
+        "‹ #{t(
+          'links.back_to_sp',
+          sp: decorated_session.sp_name,
+        )}",
+        return_to_sp_cancel_path,
+        class: 'inline-block text-bottom',
+      ) %>
 </div>

--- a/app/views/devise/sessions/bounced.html.erb
+++ b/app/views/devise/sessions/bounced.html.erb
@@ -3,8 +3,11 @@
   <%= t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
 </h1>
 <p class='margin-top-2 margin-bottom-2'>
-  <%= t('instructions.sp_handoff_bounced', sp_name: @sp_name,
-      sp_link: @sp_link.blank? ? @sp_name : link_to(@sp_name, @sp_link)) %>
+  <%= t(
+        'instructions.sp_handoff_bounced',
+        sp_name: @sp_name,
+        sp_link: @sp_link.blank? ? @sp_name : link_to(@sp_name, @sp_link),
+      ) %>
 </p>
 <div class='margin-top-4'>
   <%= link_to t('instructions.mfa.piv_cac.back_to_sign_in'), root_url, class: 'usa-button' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,10 +16,11 @@
 <%= render 'shared/sp_alert' %>
 
 <%= validated_form_for(
-  resource,
-  as: resource_name,
-  url: session_path(resource_name),
-  html: { autocomplete: 'off' }) do |f|
+      resource,
+      as: resource_name,
+      url: session_path(resource_name),
+      html: { autocomplete: 'off' },
+    ) do |f|
 %>
   <%= f.input :email,
               label: t('account.index.email'),
@@ -35,19 +36,19 @@
   <div class='margin-bottom-4'>
     <%= submit_tag t('links.next'), class: 'usa-button usa-button--primary usa-button--full-width margin-bottom-2' %>
     <%= link_to(
-      t('links.create_account'),
-      sign_up_email_url(request_id: @request_id),
-      class: 'text-decoration-none usa-button usa-button--outline usa-button--full-width'
-    ) %>
+          t('links.create_account'),
+          sign_up_email_url(request_id: @request_id),
+          class: 'text-decoration-none usa-button usa-button--outline usa-button--full-width',
+        ) %>
   </div>
 <% end %>
 <% if @ial && desktop_device? %>
   <div class='margin-x-neg-1 margin-y-4'>
     <%= link_to(
-      t('account.login.piv_cac'),
-      login_piv_cac_url,
-      class: 'padding-x-1'
-    ) %>
+          t('account.login.piv_cac'),
+          login_piv_cac_url,
+          class: 'padding-x-1',
+        ) %>
   </div>
 <% end %>
 <% if decorated_session.sp_name %>
@@ -60,10 +61,10 @@
 
 <div class='margin-x-neg-1 margin-y-1'>
   <%= link_to(
-    t('links.passwords.forgot'),
-    new_user_password_url(request_id: @request_id),
-    class: 'padding-x-1',
-  ) %>
+        t('links.passwords.forgot'),
+        new_user_password_url(request_id: @request_id),
+        class: 'padding-x-1',
+      ) %>
 </div>
 
 <% if ial2_requested? %>
@@ -71,10 +72,14 @@
 <% end %>
 
 <p class="margin-y-1">
-  <%= new_window_link_to(t('notices.privacy.security_and_privacy_practices'),
-                         MarketingSite.security_and_privacy_practices_url) %>
+  <%= new_window_link_to(
+        t('notices.privacy.security_and_privacy_practices'),
+        MarketingSite.security_and_privacy_practices_url,
+      ) %>
 </p>
 <p class="margin-y-1">
-  <%= new_window_link_to(t('notices.privacy.privacy_act_statement'),
-                         MarketingSite.privacy_act_statement_url) %>
+  <%= new_window_link_to(
+        t('notices.privacy.privacy_act_statement'),
+        MarketingSite.privacy_act_statement_url,
+      ) %>
 </p>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -11,8 +11,8 @@
         <%= t('instructions.password.strength.intro') %>
       </span>
       <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
-        forbidden: local_assigns[:forbidden_passwords],
-      } %>
+            forbidden: local_assigns[:forbidden_passwords],
+          } %>
     </div>
     <div class='h6'>
       <div id='pw-strength-feedback' class='italic'>

--- a/app/views/forgot_password/_resend_alert.html.erb
+++ b/app/views/forgot_password/_resend_alert.html.erb
@@ -1,5 +1,5 @@
 <%= render 'shared/alert', {
-  type: 'success',
-  class: 'margin-bottom-4',
-  message: t('notices.forgot_password.resend_email_success'),
-} %>
+      type: 'success',
+      class: 'margin-bottom-4',
+      message: t('notices.forgot_password.resend_email_success'),
+    } %>

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -29,8 +29,10 @@
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>
   <%= f.button :submit, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
 
-  <% link = link_to(t('notices.forgot_password.use_diff_email.link'),
-           sign_up_email_path(request_id: request_id)) %>
+  <% link = link_to(
+       t('notices.forgot_password.use_diff_email.link'),
+       sign_up_email_path(request_id: request_id),
+     ) %>
   <p><%= t('notices.forgot_password.use_diff_email.text_html', link: link) %></p>
   <p><%= t('instructions.forgot_password.close_window') %></p>
 <% end %>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-    current_step: :verify_info,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_info,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
 <% title t('titles.doc_auth.verify') %>
@@ -14,28 +14,30 @@
 </h1>
 
 <div class="margin-top-4 margin-bottom-4">
-  <%= validated_form_for(:idv_form, url: idv_address_path, method: 'POST',
-                         html: {autocomplete: 'off', class: 'margin-top-2'}) do |f| %>
+  <%= validated_form_for(
+        :idv_form, url: idv_address_path, method: 'POST',
+                   html: {autocomplete: 'off', class: 'margin-top-2'}
+      ) do |f| %>
 
     <%= f.input :address1, label: t('idv.form.address1'), wrapper_html: {class: 'margin-bottom-1'},
-                required: true, maxlength: 255, input_html: { aria: { invalid: false }, value: @pii['address1'] } %>
+                           required: true, maxlength: 255, input_html: { aria: { invalid: false }, value: @pii['address1'] } %>
     <%= f.input :address2, label: t('idv.form.address2'), required: false, maxlength: 255,
-                input_html: { value: @pii['address2'] } %>
+                           input_html: { value: @pii['address2'] } %>
     <%= f.input :city, label: t('idv.form.city'), required: true, maxlength: 255,
-                input_html: { aria: { invalid: false }, value: @pii['city'] } %>
+                       input_html: { aria: { invalid: false }, value: @pii['city'] } %>
 
     <div class="clearfix margin-x-neg-1">
       <div class="sm-col sm-col-8 padding-x-1">
         <%= f.input :state, collection: us_states_territories,
-                    label: t('idv.form.state'), required: true,
-                    selected: @pii['state'] %>
+                            label: t('idv.form.state'), required: true,
+                            selected: @pii['state'] %>
       </div>
       <div class="sm-col sm-col-4 padding-x-1">
         <%# using :tel for mobile numeric keypad %>
         <%= f.input :zipcode, as: :tel,
-                    label: t('idv.form.zipcode'), required: true,
-                    pattern: '(\d{5}([\-]\d{4})?)',
-                    input_html: { aria: { invalid: false }, class: 'zipcode', value: @pii['zipcode'] } %>
+                              label: t('idv.form.zipcode'), required: true,
+                              pattern: '(\d{5}([\-]\d{4})?)',
+                              input_html: { aria: { invalid: false }, class: 'zipcode', value: @pii['zipcode'] } %>
       </div>
     </div>
     <div class="margin-top-0">

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -1,16 +1,18 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
-      step[:name] == :secure_account ? step.merge(status: :complete) : step
-    end,
-    current_step: :verify_phone_or_address,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
+          step[:name] == :secure_account ? step.merge(status: :complete) : step
+        end,
+        current_step: :verify_phone_or_address,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
-<%= image_tag(asset_url('come-back.svg'),
-              size: '140', class: 'block margin-x-auto') %>
+<%= image_tag(
+      asset_url('come-back.svg'),
+      size: '140', class: 'block margin-x-auto',
+    ) %>
 <h2 class="center">
   <%= t('idv.titles.come_back_later') %>
 </h2>
@@ -26,13 +28,17 @@
   </p>
   <div class="center">
     <% if decorated_session.sp_name.present? %>
-      <%= link_to(t('idv.buttons.continue_plain'),
-                  return_to_sp_cancel_path,
-                  class: 'usa-button usa-button--big usa-button--wide') %>
+      <%= link_to(
+            t('idv.buttons.continue_plain'),
+            return_to_sp_cancel_path,
+            class: 'usa-button usa-button--big usa-button--wide',
+          ) %>
     <% else %>
-      <%= link_to(t('idv.buttons.continue_plain'),
-                  account_path,
-                  class: 'usa-button usa-button--big usa-button--wide') %>
+      <%= link_to(
+            t('idv.buttons.continue_plain'),
+            account_path,
+            class: 'usa-button usa-button--big usa-button--wide',
+          ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -49,7 +49,7 @@
           </div>
           <br/>
           <div class="margin-top-1">
-            <%= t('doc_auth.instructions.text2')  %>
+            <%= t('doc_auth.instructions.text2') %>
           </div>
         </div>
       </div>

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -15,9 +15,9 @@
 
 <div class='margin-top-4'>
   <%= link_to t('idv.forgot_password.try_again'), idv_review_path,
-    class: 'usa-button usa-button--big usa-button--wide' %>
+              class: 'usa-button usa-button--big usa-button--wide' %>
 </div>
 <div class='margin-top-2'>
   <%= button_to t('idv.forgot_password.reset_password'), idv_forgot_password_path,
-    method: :post, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>
+                method: :post, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>
 </div>

--- a/app/views/idv/gpo/_new_address.html.erb
+++ b/app/views/idv/gpo/_new_address.html.erb
@@ -1,24 +1,27 @@
-<%=  validated_form_for(:idv_form, url: idv_gpo_path, method: 'POST',
-                        html: { autocomplete: 'off', class: 'margin-top-2' }) do |f| %>
+<%= validated_form_for(
+      :idv_form,
+      url: idv_gpo_path, method: 'POST',
+      html: { autocomplete: 'off', class: 'margin-top-2' }
+    ) do |f| %>
 
   <%= f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'margin-bottom-1' },
-                required: true, input_html: { aria: { invalid: false } }, maxlength: 255 %>
+                         required: true, input_html: { aria: { invalid: false } }, maxlength: 255 %>
   <%= f.input :address2, label: t('idv.form.address2'), required: false, maxlength: 255 %>
   <%= f.input :city, label: t('idv.form.city'), required: true, maxlength: 255 %>
 
   <div class="clearfix margin-x-neg-1">
     <div class="sm-col sm-col-8 padding-x-1">
       <%= f.input :state, collection: us_states_territories,
-                    label: t('idv.form.state'), required: true,
-                    prompt: '- Select -' %>
+                          label: t('idv.form.state'), required: true,
+                          prompt: '- Select -' %>
     </div>
 
     <div class="sm-col sm-col-4 padding-x-1">
       <%# using :tel for mobile numeric keypad %>
       <%= f.input :zipcode, as: :tel,
-                    label: t('idv.form.zipcode'), required: true,
-                    pattern: '(\d{5}([\-]\d{4})?)',
-                    input_html: { class: 'zipcode' } %>
+                            label: t('idv.form.zipcode'), required: true,
+                            pattern: '(\d{5}([\-]\d{4})?)',
+                            input_html: { class: 'zipcode' } %>
     </div>
   </div>
   <div class="margin-top-0">

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-    current_step: :verify_phone_or_address,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_phone_or_address,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
 <div class="margin-top-neg-2">

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-    current_step: :verify_phone_or_address,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_phone_or_address,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
 <% title t('titles.doc_auth.otp_delivery') %>
@@ -17,9 +17,11 @@
 </p>
 
 
-<%= form_tag(idv_otp_delivery_method_url,
-             autocomplete: 'off', class: 'margin-top-4',
-             method: :put) do |f| %>
+<%= form_tag(
+      idv_otp_delivery_method_url,
+      autocomplete: 'off', class: 'margin-top-4',
+      method: :put
+    ) do |f| %>
 
   <fieldset class="margin-bottom-4 padding-0 border-none">
     <label class="btn-border col-12 margin-bottom-1">

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
-    current_step: :verify_phone_or_address,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_phone_or_address,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
 <% title t('titles.enter_2fa_code') %>
@@ -22,14 +22,14 @@
     <div class="grid-col-12 tablet:grid-col-6">
       <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
       <%= render(
-        'shared/one_time_code_input',
-        name: :code,
-        value: @code,
-        required: true,
-        autofocus: true,
-        numeric: false,
-        class: 'col-12 margin-bottom-5',
-      ) %>
+            'shared/one_time_code_input',
+            name: :code,
+            value: @code,
+            required: true,
+            autofocus: true,
+            numeric: false,
+            class: 'col-12 margin-bottom-5',
+          ) %>
       <%= submit_tag t('forms.buttons.submit.default'),
                      class: 'usa-button usa-button--big usa-button--full-width' %>
     </div>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-    steps: @step_indicator_steps,
-    current_step: :secure_account,
-    locale_scope: 'idv',
-    class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  } %>
+        steps: @step_indicator_steps,
+        current_step: :secure_account,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      } %>
 <% end %>
 
 <% title t('idv.titles.review') %>
@@ -17,21 +17,27 @@
   <%= t('idv.messages.sessions.review_message') %>
 </p>
 
-<%= new_window_link_to(t('idv.messages.sessions.read_more_encrypt'),
-                       MarketingSite.security_url)%>
+<%= new_window_link_to(
+      t('idv.messages.sessions.read_more_encrypt'),
+      MarketingSite.security_url,
+    ) %>
 
-<%= validated_form_for(current_user, url: idv_review_path,
-                       html: { autocomplete: 'off', method: :put }) do |f| %>
+<%= validated_form_for(
+      current_user, url: idv_review_path,
+                    html: { autocomplete: 'off', method: :put }
+    ) do |f| %>
   <%= f.input :password, label: t('idv.form.password'), required: true,
-              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
+                         input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div class="right-align margin-top-neg-2 margin-bottom-6">
-    <%= t('idv.forgot_password.link_html',
-          link: link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1')) %>
+    <%= t(
+          'idv.forgot_password.link_html',
+          link: link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1'),
+        ) %>
 
   </div>
   <%= accordion('review-verified-info', t('idv.messages.review.intro')) do %>
     <%= render 'shared/pii_review', pii: @applicant,
-               phone: PhoneFormatter.format(@applicant[:phone]) %>
+                                    phone: PhoneFormatter.format(@applicant[:phone]) %>
   <% end %>
 
   <%= f.button(

--- a/app/views/layouts/account_side_nav.html.erb
+++ b/app/views/layouts/account_side_nav.html.erb
@@ -10,9 +10,9 @@
   <div class="top-banner grid-row grid-gap margin-bottom-4">
     <div class="grid-offset-3 grid-col-3">
       <%= image_tag(
-        asset_path('user-access.svg'),
-        alt: '',
-      ) %>
+            asset_path('user-access.svg'),
+            alt: '',
+          ) %>
     </div>
     <div class="grid-col-5">
       <div>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -1,12 +1,12 @@
 <% if local_assigns.dig(:step_indicator, :steps).presence %>
   <% content_for(:pre_flash_content) do %>
     <%= render(
-      'shared/step_indicator',
-      locale_scope: flow_namespace,
-      steps: step_indicator[:steps],
-      current_step: step_indicator[:current_step],
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4'
-    ) %>
+          'shared/step_indicator',
+          locale_scope: flow_namespace,
+          steps: step_indicator[:steps],
+          current_step: step_indicator[:current_step],
+          class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+        ) %>
   <% end %>
 <% end %>
 <% content_for(:content) { render(template: step_template, locals: local_assigns) } %>

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -43,10 +43,10 @@
                                 <tr>
                                   <th>
                                     <%= image_tag(
-                                      attachments['logo.png'].url,
-                                      size: '142x19',
-                                      style: 'width: 142px; height: 19px;',
-                                    ) %>
+                                          attachments['logo.png'].url,
+                                          size: '142x19',
+                                          style: 'width: 142px; height: 19px;',
+                                        ) %>
                                   </th>
                                   <th class="expander"></th>
                                 </tr>
@@ -101,17 +101,17 @@
                                         <th>
                                           <p>
                                             <%= (t('mailer.no_reply') + ' ' + t(
-                                              'mailer.help',
-                                              link: link_to(
-                                                MarketingSite.nice_help_url,
-                                                MarketingSite.help_url,
-                                              ),
-                                              app: link_to(
-                                                APP_NAME,
-                                                IdentityConfig.store.mailer_domain_name,
-                                                style: 'text-decoration: none;',
-                                              ),
-                                            )).html_safe %>
+                                                  'mailer.help',
+                                                  link: link_to(
+                                                    MarketingSite.nice_help_url,
+                                                    MarketingSite.help_url,
+                                                  ),
+                                                  app: link_to(
+                                                    APP_NAME,
+                                                    IdentityConfig.store.mailer_domain_name,
+                                                    style: 'text-decoration: none;',
+                                                  ),
+                                                )).html_safe %>
                                           </p>
                                         </th>
                                       </tr>
@@ -142,16 +142,16 @@
                                         <th>
                                           <p>
                                             <%= link_to(
-                                              t('mailer.about', app: APP_NAME),
-                                              MarketingSite.base_url,
-                                              style: 'text-decoration: underline;',
-                                            ).html_safe %>
+                                                  t('mailer.about', app: APP_NAME),
+                                                  MarketingSite.base_url,
+                                                  style: 'text-decoration: underline;',
+                                                ).html_safe %>
                                             &nbsp;&nbsp;|&nbsp;&nbsp;
                                             <%= link_to(
-                                              t('mailer.privacy_policy'),
-                                              MarketingSite.security_and_privacy_practices_url,
-                                              style: 'text-decoration: underline;',
-                                            ).html_safe %>
+                                                  t('mailer.privacy_policy'),
+                                                  MarketingSite.security_and_privacy_practices_url,
+                                                  style: 'text-decoration: underline;',
+                                                ).html_safe %>
                                           </p>
                                         </th>
                                         <th class="expander"></th>

--- a/app/views/pages/page_took_too_long.html.erb
+++ b/app/views/pages/page_took_too_long.html.erb
@@ -16,7 +16,7 @@
           <div class="masthead clearfix">
             <div class="inner">
                 <%= image_tag asset_url('logo-white.svg'), width: 150, alt: APP_NAME,
-                  class: 'masthead-brand' %>
+                                                           class: 'masthead-brand' %>
             </div>
           </div>
           <div class="inner cover">

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -13,7 +13,9 @@
   </div>
 
   <div class="center h5 margin-top-8 margin-bottom-1 padding-top-1 padding-bottom-2 fs-12p">
-    <%= t('users.personal_key.generated_on_html',
-          date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y'))) %>
+    <%= t(
+          'users.personal_key.generated_on_html',
+          date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
+        ) %>
   </div>
 </div>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -4,13 +4,15 @@
   <%= t('headings.passwords.confirm') %>
 </h1>
 
-<%= validated_form_for(current_user,
-                       as: :user,
-                       url: capture_password_url,
-                       method: :post,
-                       html: { autocomplete: 'off' }) do |f| %>
+<%= validated_form_for(
+      current_user,
+      as: :user,
+      url: capture_password_url,
+      method: :post,
+      html: { autocomplete: 'off' },
+    ) do |f| %>
   <%= f.input :password, label: t('account.index.password'), required: true,
-              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
+                         input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div>
     <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
   </div>

--- a/app/views/shared/_accordion.html.erb
+++ b/app/views/shared/_accordion.html.erb
@@ -1,9 +1,9 @@
 <div class="usa-accordion usa-accordion--bordered">
-  <<%= options.fetch(:heading_level, 'div')%> class="usa-accordion__heading">
+  <<%= options.fetch(:heading_level, 'div') %> class="usa-accordion__heading">
     <button type="button" class="usa-accordion__button" aria-expanded="false" aria-controls="<%= target_id %>">
       <%= header_text %>
     </button>
-  </<%= options.fetch(:heading_level, 'div')%>>
+  </<%= options.fetch(:heading_level, 'div') %>>
   <div id="<%= target_id %>" class="usa-accordion__container">
     <div class="usa-accordion__content usa-prose">
       <%= yield %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -17,9 +17,9 @@
     </div>
     <div class='i18n-mobile-dropdown tablet:display-none display-none'>
       <ul class='list-reset margin-bottom-0 white center'>
-        <%  I18n.available_locales.each do |locale| %>
+        <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none blue fs-13p'%>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none blue fs-13p' %>
           </li>
         <% end %>
       </ul>

--- a/app/views/sign_up/completions/_show_sp.html.erb
+++ b/app/views/sign_up/completions/_show_sp.html.erb
@@ -1,15 +1,19 @@
 <p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
-  <%= t('help_text.requested_attributes.intro_html',
-      app_name: APP_NAME,
-      sp: content_tag(:strong, decorated_session.sp_name)) %>
+  <%= t(
+        'help_text.requested_attributes.intro_html',
+        app_name: APP_NAME,
+        sp: content_tag(:strong, decorated_session.sp_name),
+      ) %>
 </p>
 <div class='tablet:margin-left-1 tablet:margin-right-1' >
   <%= render 'sign_up/completions/requested_attributes', requested_attributes: @view_model.requested_attributes_sorted %>
 </div>
 <p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
-  <%= t('help_text.requested_attributes.outro_html',
+  <%= t(
+        'help_text.requested_attributes.outro_html',
         app_name: APP_NAME,
-        sp: content_tag(:strong, decorated_session.sp_name)) %>
+        sp: content_tag(:strong, decorated_session.sp_name),
+      ) %>
 </p>
 <p>
   <div class="center">

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -1,7 +1,7 @@
 <% title @view_model.title %>
 <div class="clearfix col-10 sm-col-12 margin-x-auto">
   <div class="center">
-    <%= image_tag asset_url(@view_model.image_name), width: 140, alt: '', class: 'margin-bottom-2'  %>
+    <%= image_tag asset_url(@view_model.image_name), width: 140, alt: '', class: 'margin-bottom-2' %>
   </div>
 
   <h1 class="margin-bottom-2 margin-y-0 tablet:margin-right-1 tablet:margin-left-1 center">

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -3,9 +3,11 @@
 <h1 class='margin-y-0'>
   <%= t('headings.confirmations.new') %>
 </h1>
-<%= validated_form_for(@resend_email_confirmation_form,
-                       url: sign_up_register_path,
-                       html: { autocomplete: 'off', method: :post }) do |f| %>
+<%= validated_form_for(
+      @resend_email_confirmation_form,
+      url: sign_up_register_path,
+      html: { autocomplete: 'off', method: :post },
+    ) do |f| %>
   <%= f.input :email,
               label: t('forms.registration.labels.email'),
               required: true,

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -2,10 +2,10 @@
 
 <% if @resend_confirmation %>
   <%= render 'shared/alert', {
-    type: 'success',
-    class: 'margin-bottom-4',
-    message: t('notices.resend_confirmation_email.success'),
-  } %>
+        type: 'success',
+        class: 'margin-bottom-4',
+        message: t('notices.resend_confirmation_email.success'),
+      } %>
 <% end %>
 
 <div class="margin-top-neg-2">
@@ -32,14 +32,18 @@
   <p><%= t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start') %>
   <%= f.button :submit, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
 
-  <% link = link_to(t('notices.use_diff_email.link'),
-           sign_up_email_path(request_id: params[:request_id])) %>
+  <% link = link_to(
+       t('notices.use_diff_email.link'),
+       sign_up_email_path(request_id: params[:request_id]),
+     ) %>
   <p><%= t('notices.use_diff_email.text_html', link: link) %></p>
   <p><%= t('devise.registrations.close_window') %></p>
 
   <% if FeatureManagement.enable_load_testing_mode? %>
-    <%= link_to('CONFIRM NOW',
-      sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
-      id: 'confirm-now') %>
+    <%= link_to(
+          'CONFIRM NOW',
+          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
+          id: 'confirm-now',
+        ) %>
   <% end %>
 <% end %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -7,13 +7,15 @@
 <p class="margin-top-2 margin-bottom-0" id="password-description">
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
 </p>
-<%= validated_form_for(@password_form,
-                       url: sign_up_create_password_path,
-                       method: :post,
-                       html: { autocomplete: 'off' }) do |f| %>
+<%= validated_form_for(
+      @password_form,
+      url: sign_up_create_password_path,
+      method: :post,
+      html: { autocomplete: 'off' },
+    ) do |f| %>
   <%= f.input :password, required: true,
-              input_html: { aria: { invalid: false, describedby: 'password-description' },
-                            class: 'password-toggle' } %>
+                         input_html: { aria: { invalid: false, describedby: 'password-description' },
+                                       class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>

--- a/app/views/sign_up/registrations/_required_pii_accordion.html.erb
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.erb
@@ -1,6 +1,8 @@
 <p class="clearfix">
-  <%= image_tag(asset_url('get-started/ID.svg'),
-                size: '40', alt: '', class: 'mt-tiny col col-1') %>
+  <%= image_tag(
+        asset_url('get-started/ID.svg'),
+        size: '40', alt: '', class: 'mt-tiny col col-1',
+      ) %>
   <span class="col col-11 padding-left-2">
     <%= t('idv.index.id.need_html') %>
   </span>
@@ -9,36 +11,46 @@
 <div class="margin-top-2">
   <%= accordion('you-will-need', t('devise.registrations.start.accordion')) do %>
     <p class="clearfix">
-      <%= image_tag(asset_url('get-started/email-password.svg'),
-                    size: '40', alt: '', class: 'mt-tiny col col-1') %>
+      <%= image_tag(
+            asset_url('get-started/email-password.svg'),
+            size: '40', alt: '', class: 'mt-tiny col col-1',
+          ) %>
       <span class="col col-11 padding-left-2">
         <%= t('devise.registrations.start.bullet_1_html') %>
       </span>
     </p>
     <p class="clearfix">
-      <%= image_tag(asset_url('get-started/2FA.svg'), size: '40', alt: '',
-                  class: 'mt-tiny col col-1') %>
+      <%= image_tag(
+            asset_url('get-started/2FA.svg'), size: '40', alt: '',
+                                              class: 'mt-tiny col col-1'
+          ) %>
       <span class="col col-11 padding-left-2">
         <%= t('devise.registrations.start.bullet_2_html') %>
       </span>
     </p>
     <p class="clearfix">
-      <%= image_tag(asset_url('get-started/personal-details.svg'),
-                  size: '40', alt: '', class: 'mt-tiny col col-1') %>
+      <%= image_tag(
+            asset_url('get-started/personal-details.svg'),
+            size: '40', alt: '', class: 'mt-tiny col col-1',
+          ) %>
       <span class="col col-11 padding-left-2">
         <%= t('devise.registrations.start.bullet_3_html') %>
       </span>
     </p>
     <p class="clearfix">
-      <%= image_tag(asset_url('get-started/personal-details.svg'),
-                  size: '40', alt: '', class: 'mt-tiny col col-1') %>
+      <%= image_tag(
+            asset_url('get-started/personal-details.svg'),
+            size: '40', alt: '', class: 'mt-tiny col col-1',
+          ) %>
       <span class="col col-11 padding-left-2">
         <%= t('devise.registrations.start.bullet_4_html') %>
       </span>
     </p>
     <p class="clearfix">
-      <%= image_tag(asset_url('get-started/financial.svg'),
-                  size: '40', alt: '', class: 'mt-tiny col col-1') %>
+      <%= image_tag(
+            asset_url('get-started/financial.svg'),
+            size: '40', alt: '', class: 'mt-tiny col col-1',
+          ) %>
       <span class="col col-11 padding-left-2">
         <%= t('devise.registrations.start.bullet_5_html') %>
       </span>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -3,21 +3,23 @@
 <%= render 'shared/sp_alert' %>
 
 <%= render 'shared/alert', {
-  type: 'error',
-  class: 'email-invalid-alert margin-bottom-4 display-none',
-  message: t('sign_up.email.invalid_email_alert_head'),
-} %>
+      type: 'error',
+      class: 'email-invalid-alert margin-bottom-4 display-none',
+      message: t('sign_up.email.invalid_email_alert_head'),
+    } %>
 
 <h1 class='margin-y-0'><%= t('titles.registrations.new') %></h1>
 
 <div class='margin-bottom-6'>
-  <%= validated_form_for(@register_user_email_form,
-      html: { autocomplete: 'off' },
-      url: sign_up_register_path) do |f| %>
+  <%= validated_form_for(
+        @register_user_email_form,
+        html: { autocomplete: 'off' },
+        url: sign_up_register_path,
+      ) do |f| %>
     <%= f.input :email,
                 label: t('forms.registration.labels.email'),
                 required: true,
-                input_html: { autocorrect: "off", aria: { invalid: false } } %>
+                input_html: { autocorrect: 'off', aria: { invalid: false } } %>
 
     <span class='email-invalid-alert-inline usa-error-message margin-top-neg-3 margin-bottom-3 display-none' role='alert'>
       <%= t('sign_up.email.invalid_email_alert_inline') %>
@@ -29,11 +31,13 @@
       </legend>
 
       <p class="margin-bottom-4">
-        <%= t('account.email_language.languages_list',
+        <%= t(
+              'account.email_language.languages_list',
               app_name: APP_NAME,
               list: I18n.available_locales.
                 map { |locale| t("account.email_language.name.#{locale}") }.
-                to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} ")) %>
+                to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} "),
+            ) %>
       </p>
 
       <%= render partial: 'shared/email_languages',
@@ -54,20 +58,24 @@
 
     <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
     <%= f.button :button, t('forms.buttons.submit.default'), type: :submit,
-                 class: 'usa-button--big grid-col-8 mobile-lg:grid-col-6' %>
+                                                             class: 'usa-button--big grid-col-8 mobile-lg:grid-col-6' %>
 <% end %>
 </div>
 
 <%= render 'shared/cancel', link: decorated_session.cancel_link_url %>
 
 <p class='margin-top-2'>
-  <%= new_window_link_to(t('notices.privacy.security_and_privacy_practices'),
-                         MarketingSite.security_and_privacy_practices_url) %>
+  <%= new_window_link_to(
+        t('notices.privacy.security_and_privacy_practices'),
+        MarketingSite.security_and_privacy_practices_url,
+      ) %>
 </p>
 
 <p>
-  <%= new_window_link_to(t('notices.privacy.privacy_act_statement'),
-                         MarketingSite.privacy_act_statement_url) %>
+  <%= new_window_link_to(
+        t('notices.privacy.privacy_act_statement'),
+        MarketingSite.privacy_act_statement_url,
+      ) %>
 </p>
 
 

--- a/app/views/test/saml_test/decode_response.html.erb
+++ b/app/views/test/saml_test/decode_response.html.erb
@@ -27,7 +27,7 @@
             <% xml_doc = Base64.encode64(response.document.to_s) %>
             <%= link_to 'Open in New Window',
                         "data:text/xml;charset=utf-8;base64,#{xml_doc}",
-                        target: '_blank'%>
+                        target: '_blank', rel: 'noopener noreferrer' %>
           </td>
         </tr>
         <tr>
@@ -37,7 +37,7 @@
               <% xml_doc = Base64.encode64(response.decrypted_document.to_s) %>
               <%= link_to 'Open in New Window',
                           "data:text/xml;charset=utf-8;base64,#{xml_doc}",
-                          target: '_blank' %>
+                          target: '_blank', rel: 'noopener noreferrer' %>
             </td>
           <% else %>
             <td>Document not encrypted</td>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -21,7 +21,7 @@
   <%= render 'users/shared/phone_number_edit', f: f %>
 
   <%= render 'users/shared/otp_delivery_preference_selection',
-             form_obj: @new_phone_form%>
+             form_obj: @new_phone_form %>
 
   <%= link_to t('two_factor_authentication.mobile_terms_of_service'),
               MarketingSite.messaging_practices_url,
@@ -29,7 +29,7 @@
 
   <% if TwoFactorAuthentication::PhonePolicy.new(current_user).enabled? %>
     <%= render 'users/shared/otp_make_default_number',
-               form_obj: @new_phone_form%>
+               form_obj: @new_phone_form %>
   <% end %>
   <%= f.button :submit, t('forms.buttons.send_security_code'), class: 'usa-button--big usa-button--wide' %>
 <% end %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 <div class='margin-top-6'>
-  <%=  accordion('review-verified-info', t('idv.messages.review.intro')) do %>
+  <%= accordion('review-verified-info', t('idv.messages.review.intro')) do %>
     <%= render 'shared/pii_review', pii: @decrypted_pii, phone: @decrypted_pii[:phone] %>
   <% end %>
 </div>


### PR DESCRIPTION
I enabled the `SpaceAroundErbTag` rule, and disabled `Layout/LineLength` and `Rails/OutputSafety`. erb-lint suggests a list of [rules to disable](https://github.com/Shopify/erb-lint#rubocop), and those are on it. Everything changed was an automatic correction.