### PR TITLE
Remove american_date gem (LG-4628)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.9.3' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.10.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }
@@ -21,7 +21,6 @@ gem 'identity_validations', @validations_gem
 gem 'saml_idp', @saml_gem
 
 gem 'ahoy_matey', '~> 3.0'
-gem 'american_date'
 gem 'autoprefixer-rails', '~> 10.0'
 gem 'aws-sdk-kms', '~> 1.4'
 gem 'aws-sdk-ses', '~> 1.6'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.3'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.10.0' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.10.1' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.2.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 6aad84cb78541d8702ae8e48962dddeff807b5c5
-  tag: v0.9.3
+  revision: b23e2edb88d59a4d49f0332a047ddc68609bec56
+  tag: v0.10.0
   specs:
-    identity-doc-auth (0.9.3)
+    identity-doc-auth (0.10.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)
@@ -125,7 +125,6 @@ GEM
       device_detector
       geocoder (>= 1.4.5)
       safely_block (>= 0.2.1)
-    american_date (1.1.1)
     android_key_attestation (0.3.0)
     ast (2.4.2)
     autoprefixer-rails (10.2.5.1)
@@ -696,7 +695,6 @@ PLATFORMS
 
 DEPENDENCIES
   ahoy_matey (~> 3.0)
-  american_date
   autoprefixer-rails (~> 10.0)
   aws-sdk-cloudwatchlogs
   aws-sdk-eventbridge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: b23e2edb88d59a4d49f0332a047ddc68609bec56
-  tag: v0.10.0
+  revision: 2b1992d83e6a152b2234a5b71b9682d5f89635aa
+  tag: v0.10.1
   specs:
-    identity-doc-auth (0.10.0)
+    identity-doc-auth (0.10.1)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -45,7 +45,7 @@ module Idv
     end
 
     def dob_meets_min_age?
-      dob_date = DateParser.parse(dob)
+      dob_date = DateParser.parse_legacy(dob)
       today = Time.zone.today
       age = today.year - dob_date.year - ((today.month > dob_date.month ||
         (today.month == dob_date.month && today.day >= dob_date.day)) ? 0 : 1)

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -45,7 +45,7 @@ module Idv
     end
 
     def dob_meets_min_age?
-      dob_date = Date.parse(dob)
+      dob_date = DateParser.parse(dob)
       today = Time.zone.today
       age = today.year - dob_date.year - ((today.month > dob_date.month ||
         (today.month == dob_date.month && today.day >= dob_date.day)) ? 0 : 1)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -68,7 +68,7 @@ class Profile < ApplicationRecord
       pii.first_name,
       pii.last_name,
       pii.zipcode,
-      pii.dob && DateParser.parse(pii[:dob]).year,
+      pii.dob && DateParser.parse_legacy(pii[:dob]).year,
     ]
 
     return unless values.all?(&:present?)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -68,7 +68,7 @@ class Profile < ApplicationRecord
       pii.first_name,
       pii.last_name,
       pii.zipcode,
-      pii.dob && Date.parse(pii[:dob]).year,
+      pii.dob && DateParser.parse(pii[:dob]).year,
     ]
 
     return unless values.all?(&:present?)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -67,7 +67,7 @@ class OpenidConnectUserInfoPresenter
     american_date_format = IdentityConfig.store.
       dob_international_format_opt_out_list.include?(identity.service_provider)
 
-    date = Date.parse(ial2_data.dob)
+    date = DateParser.parse(ial2_data.dob)
 
     if american_date_format
       date.strftime('%m/%d/%Y')

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -67,7 +67,7 @@ class OpenidConnectUserInfoPresenter
     american_date_format = IdentityConfig.store.
       dob_international_format_opt_out_list.include?(identity.service_provider)
 
-    date = DateParser.parse(ial2_data.dob)
+    date = DateParser.parse_legacy(ial2_data.dob)
 
     if american_date_format
       date.strftime('%m/%d/%Y')

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -107,7 +107,7 @@ class AttributeAsserter
   def wrap_with_dob_formatter(getter, american_date_format:)
     proc do |principal|
       if (date_str = getter.call(principal))
-        date = Date.parse(date_str)
+        date = DateParser.parse(date_str)
 
         if american_date_format
           date.strftime('%m/%d/%Y')

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -107,7 +107,7 @@ class AttributeAsserter
   def wrap_with_dob_formatter(getter, american_date_format:)
     proc do |principal|
       if (date_str = getter.call(principal))
-        date = DateParser.parse(date_str)
+        date = DateParser.parse_legacy(date_str)
 
         if american_date_format
           date.strftime('%m/%d/%Y')

--- a/app/services/date_parser.rb
+++ b/app/services/date_parser.rb
@@ -1,0 +1,13 @@
+module DateParser
+  AMERICAN_REGEX = %r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}.freeze
+
+  # Date parsing with a fallback for american-style Month/Day/Year
+  # since we have legacy data in PII bundles that may be stored this way
+  def self.parse(str, allow_american: true)
+    if allow_american && (m = str.match(AMERICAN_REGEX))
+      Date.parse("#{m[:year]}-#{m[:month]}-#{m[:day]}")
+    else
+      Date.parse(str)
+    end
+  end
+end

--- a/app/services/date_parser.rb
+++ b/app/services/date_parser.rb
@@ -3,8 +3,8 @@ module DateParser
 
   # Date parsing with a fallback for american-style Month/Day/Year
   # since we have legacy data in PII bundles that may be stored this way
-  def self.parse(str, allow_american: true)
-    if allow_american && (m = str.match(AMERICAN_REGEX))
+  def self.parse_legacy(str)
+    if (m = str.match(AMERICAN_REGEX))
       Date.parse("#{m[:year]}-#{m[:month]}-#{m[:day]}")
     else
       Date.parse(str)

--- a/app/services/expired_license_allower.rb
+++ b/app/services/expired_license_allower.rb
@@ -48,7 +48,8 @@ class ExpiredLicenseAllower
     !!(
       only_error_was_document_expired? &&
         response.pii_from_doc[:state_id_expiration] &&
-        (state_id_expiration = Date.parse(response.pii_from_doc[:state_id_expiration])) &&
+        # Can switch to Date.parse after next deploy
+        (state_id_expiration = DateParser.parse(response.pii_from_doc[:state_id_expiration])) &&
         state_id_expiration >= IdentityConfig.store.proofing_expired_license_after
     )
   end

--- a/app/services/expired_license_allower.rb
+++ b/app/services/expired_license_allower.rb
@@ -49,8 +49,8 @@ class ExpiredLicenseAllower
       only_error_was_document_expired? &&
         response.pii_from_doc[:state_id_expiration] &&
         # Can switch to Date.parse after next deploy
-        (state_id_expiration = DateParser.parse_legacy(response.pii_from_doc[:state_id_expiration])) &&
-        state_id_expiration >= IdentityConfig.store.proofing_expired_license_after
+        (state_id_exp = DateParser.parse_legacy(response.pii_from_doc[:state_id_expiration])) &&
+        state_id_exp >= IdentityConfig.store.proofing_expired_license_after
     )
   end
 

--- a/app/services/expired_license_allower.rb
+++ b/app/services/expired_license_allower.rb
@@ -49,7 +49,7 @@ class ExpiredLicenseAllower
       only_error_was_document_expired? &&
         response.pii_from_doc[:state_id_expiration] &&
         # Can switch to Date.parse after next deploy
-        (state_id_expiration = DateParser.parse(response.pii_from_doc[:state_id_expiration])) &&
+        (state_id_expiration = DateParser.parse_legacy(response.pii_from_doc[:state_id_expiration])) &&
         state_id_expiration >= IdentityConfig.store.proofing_expired_license_after
     )
   end

--- a/spec/services/date_parser_spec.rb
+++ b/spec/services/date_parser_spec.rb
@@ -1,56 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe DateParser do
-  describe '.parse' do
-    subject(:parse) { DateParser.parse(str, allow_american: allow_american) }
+  describe '.parse_legacy' do
+    subject(:parse) { DateParser.parse_legacy(str) }
 
-    context 'with allow_american: false' do
-      let(:allow_american) { false }
+    context 'with an american style date' do
+      let(:str) { '12/31/1970' }
 
-      context 'with an american style date' do
-        let(:str) { '12/31/1970' }
-
-        it 'blows up' do
-          expect { parse }.to raise_error
-        end
-      end
-
-      context 'with an international style date' do
-        let(:str) { '1970-12-31' }
-
-        it { is_expected.to eq(Date.new(1970, 12, 31)) }
-      end
-
-      context 'with something that is not a date' do
-        let(:str) { 'aaa' }
-
-        it 'blows up' do
-          expect { parse }.to raise_error
-        end
-      end
+      it { is_expected.to eq(Date.new(1970, 12, 31)) }
     end
 
-    context 'with allow_american: true' do
-      let(:allow_american) { true }
+    context 'with an international style date' do
+      let(:str) { '1970-12-31' }
 
-      context 'with an american style date' do
-        let(:str) { '12/31/1970' }
+      it { is_expected.to eq(Date.new(1970, 12, 31)) }
+    end
 
-        it { is_expected.to eq(Date.new(1970, 12, 31)) }
-      end
+    context 'with something that is not a date' do
+      let(:str) { 'aaa' }
 
-      context 'with an international style date' do
-        let(:str) { '1970-12-31' }
-
-        it { is_expected.to eq(Date.new(1970, 12, 31)) }
-      end
-
-      context 'with something that is not a date' do
-        let(:str) { 'aaa' }
-
-        it 'blows up' do
-          expect { parse }.to raise_error
-        end
+      it 'blows up' do
+        expect { parse }.to raise_error
       end
     end
   end

--- a/spec/services/date_parser_spec.rb
+++ b/spec/services/date_parser_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe DateParser do
+  describe '.parse' do
+    subject(:parse) { DateParser.parse(str, allow_american: allow_american) }
+
+    context 'with allow_american: false' do
+      let(:allow_american) { false }
+
+      context 'with an american style date' do
+        let(:str) { '12/31/1970' }
+
+        it 'blows up' do
+          expect { parse }.to raise_error
+        end
+      end
+
+      context 'with an international style date' do
+        let(:str) { '1970-12-31' }
+
+        it { is_expected.to eq(Date.new(1970, 12, 31)) }
+      end
+
+      context 'with something that is not a date' do
+        let(:str) { 'aaa' }
+
+        it 'blows up' do
+          expect { parse }.to raise_error
+        end
+      end
+    end
+
+    context 'with allow_american: true' do
+      let(:allow_american) { true }
+
+      context 'with an american style date' do
+        let(:str) { '12/31/1970' }
+
+        it { is_expected.to eq(Date.new(1970, 12, 31)) }
+      end
+
+      context 'with an international style date' do
+        let(:str) { '1970-12-31' }
+
+        it { is_expected.to eq(Date.new(1970, 12, 31)) }
+      end
+
+      context 'with something that is not a date' do
+        let(:str) { 'aaa' }
+
+        it 'blows up' do
+          expect { parse }.to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/services/date_parser_spec.rb
+++ b/spec/services/date_parser_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe DateParser do
       it { is_expected.to eq(Date.new(1970, 12, 31)) }
     end
 
+    context 'single digit american date month and year' do
+      let(:str) { '2/1/1970' }
+
+      it { is_expected.to eq(Date.new(1970, 2, 1)) }
+    end
+
     context 'with an international style date' do
       let(:str) { '1970-12-31' }
 


### PR DESCRIPTION
* Add DateParser class to parse legacy persisted data

(Branched off https://github.com/18F/identity-idp/pull/5157, I think I want that merged before this gets merged, but they can also go together I think)