### PR TITLE
LG-4590: Set expiration for S3 presigned URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'public/**/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   TargetRailsVersion: 6.0
   UseCache: true
   DisabledByDefault: true

--- a/spec/helpers/aws_s3_helper_spec.rb
+++ b/spec/helpers/aws_s3_helper_spec.rb
@@ -57,6 +57,21 @@ describe 'AwsS3Helper' do
       expect { helper.s3_presigned_url(bucket_prefix: '', keyname: 'image_type') }.
         to raise_error(ArgumentError, 'bucket_prefix is required')
     end
+
+    it 'is created with an expiration' do
+      key = "#{session_uuid}-#{image_type}"
+      object = Aws::S3::Object.new(bucket_name: bucket, key: key)
+      allow(helper).to receive(:s3_object).and_return(object)
+      expect(object).to receive(:presigned_url).with(
+        kind_of(Symbol),
+        hash_including(expires_in: helper.presigned_url_expiration_in_seconds),
+      ).and_call_original
+
+      helper.s3_presigned_url(
+        bucket_prefix: prefix,
+        keyname: key,
+      )
+    end
   end
 
   describe '#s3_resource' do
@@ -69,6 +84,12 @@ describe 'AwsS3Helper' do
       it 'returns nil' do
         expect(helper.s3_resource).to be_nil
       end
+    end
+  end
+
+  describe '#presigned_url_expiration_in_seconds' do
+    it 'returns a number' do
+      expect(helper.presigned_url_expiration_in_seconds).to be_a_kind_of(Numeric)
     end
   end
 end


### PR DESCRIPTION
**Why**: To avoid a situation where the S3 URL becomes expired after 15 minutes while the user's session is still active, set the URL to expire aligning to the maximum session duration.

Reference: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Presigner.html#presigned_url-instance_method

>**`:expires_in`** (`Integer`) — default: `900` — The number of seconds before the presigned URL expires. Defaults to 15 minutes. As signature version 4 has a maximum expiry time of one week for presigned URLs, attempts to set this value to greater than one week (604800) will raise an exception.