### PR TITLE
[LG-4734] Fix handling of unsupported NameID formats

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -35,7 +35,17 @@ module SamlIdpAuthConcern
   end
 
   def name_id_format
-    @name_id_format ||= saml_request.name_id_format || default_name_id_format
+    @name_id_format ||= specified_name_id_format || default_name_id_format
+  end
+
+  def specified_name_id_format
+    if recognized_name_id_format? || current_service_provider.use_legacy_name_id_behavior?
+      saml_request.name_id_format
+    end
+  end
+
+  def recognized_name_id_format?
+    Saml::Idp::Constants::VALID_NAME_ID_FORMATS.include?(saml_request.name_id_format)
   end
 
   def default_name_id_format

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -41,6 +41,7 @@ class NullServiceProvider
     signed_response_message_requested
     sp_initiated_login_url
     updated_at
+    use_legacy_name_id_behavior
   ].freeze
 
   COLUMNS.each do |col|

--- a/db/migrate/20210622182910_add_use_legacy_name_id_behavior_to_s_ps.rb
+++ b/db/migrate/20210622182910_add_use_legacy_name_id_behavior_to_s_ps.rb
@@ -1,0 +1,6 @@
+class AddUseLegacyNameIdBehaviorToSPs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_providers, :use_legacy_name_id_behavior, :boolean
+    change_column_default :service_providers, :use_legacy_name_id_behavior, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_145845) do
+ActiveRecord::Schema.define(version: 2021_06_22_182910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -564,6 +564,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_145845) do
     t.integer "default_aal"
     t.string "certs", array: true
     t.boolean "email_nameid_format_allowed", default: false
+    t.boolean "use_legacy_name_id_behavior", default: false
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -27,6 +27,7 @@ module Saml
 
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'.freeze
       NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
+      VALID_NAME_ID_FORMATS = [NAME_ID_FORMAT_PERSISTENT, NAME_ID_FORMAT_EMAIL].freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 


### PR DESCRIPTION
Resolves LG-4734

* Add use_legacy_name_id_behavior attribute to service_providers to
  preserve current behavior for impacted SPs
* Update the SamlIdpAuthConcern to only pass through supported NameID
  formats and otherwise use the default (except for currently impacted
  SPs)