### PR TITLE
LG-4671: Messaging for when camera access is declined

### DIFF
--- a/app/javascript/packages/components/alert.jsx
+++ b/app/javascript/packages/components/alert.jsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
@@ -14,12 +16,13 @@
 
 /**
  * @param {AlertProps} props Props object.
+ * @param {import('react').ForwardedRef<any>} ref
  */
-function Alert({ type = 'other', className, children }) {
+function Alert({ type = 'other', className, children }, ref) {
   const classes = [`usa-alert usa-alert--${type}`, className].filter(Boolean).join(' ');
 
   return (
-    <div className={classes} role="alert">
+    <div ref={ref} className={classes} role="alert">
       <div className="usa-alert__body">
         <p className="usa-alert__text">{children}</p>
       </div>
@@ -27,4 +30,4 @@ function Alert({ type = 'other', className, children }) {
   );
 }
 
-export default Alert;
+export default forwardRef(Alert);

--- a/app/javascript/packages/components/alert.jsx
+++ b/app/javascript/packages/components/alert.jsx
@@ -11,6 +11,8 @@ import { forwardRef } from 'react';
  *
  * @prop {AlertType=} type Alert type. Defaults to "other".
  * @prop {string=} className Optional additional class names to add to element.
+ * @prop {boolean=} isFocusable Optional, whether rendered element should be focusable, as in the
+ * case where focus should be shifted programmatically to a new alert.
  * @prop {ReactNode} children Child elements.
  */
 
@@ -18,11 +20,11 @@ import { forwardRef } from 'react';
  * @param {AlertProps} props Props object.
  * @param {import('react').ForwardedRef<any>} ref
  */
-function Alert({ type = 'other', className, children }, ref) {
+function Alert({ type = 'other', className, isFocusable, children }, ref) {
   const classes = [`usa-alert usa-alert--${type}`, className].filter(Boolean).join(' ');
 
   return (
-    <div ref={ref} className={classes} role="alert">
+    <div ref={ref} className={classes} role="alert" tabIndex={isFocusable ? -1 : undefined}>
       <div className="usa-alert__body">
         <p className="usa-alert__text">{children}</p>
       </div>

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -22,6 +22,7 @@ import './acuant-capture.scss';
 /** @typedef {import('react').ReactNode} ReactNode */
 /** @typedef {import('./acuant-capture-canvas').AcuantSuccessResponse} AcuantSuccessResponse */
 /** @typedef {import('./acuant-capture-canvas').AcuantDocumentType} AcuantDocumentType */
+/** @typedef {import('./full-screen').FullScreenRefHandle} FullScreenRefHandle */
 
 /**
  * @typedef {"id"|"passport"|"none"} AcuantDocumentTypeLabel
@@ -89,6 +90,7 @@ import './acuant-capture.scss';
  *   nextValue: string|Blob|null,
  *   metadata?: ImageAnalyticsPayload
  * )=>void} onChange Callback receiving next value on change.
+ * @prop {()=>void=} onCameraAccessDeclined Camera permission declined callback.
  * @prop {'user'=} capture Facing mode of capture. If capture is not specified and a camera is
  * supported, defaults to the Acuant environment camera capture.
  * @prop {string=} className Optional additional class names.
@@ -166,6 +168,36 @@ function getImageDimensions(file) {
 }
 
 /**
+ * Pauses default focus trap behaviors for a single tick. If a focus transition occurs during this
+ * tick, the focus trap's deactivation will be overridden to prevent any default focus return, in
+ * order to avoid a race condition between the intended focus targets.
+ *
+ * @param {import('focus-trap').FocusTrap} focusTrap
+ */
+function suspendFocusTrapForAnticipatedFocus(focusTrap) {
+  // Pause trap event listeners to prevent focus from being pulled back into the trap container in
+  // response to programmatic focus transitions.
+  focusTrap.pause();
+
+  // If an element is focused while behaviors are suspended, prevent the default deactivate from
+  // attempting to return focus to any other element.
+  const originalDeactivate = focusTrap.deactivate;
+  function onFocus() {
+    focusTrap.deactivate = (deactivateOptions) =>
+      originalDeactivate({ ...deactivateOptions, returnFocus: false });
+  }
+  document.addEventListener('focusin', onFocus, true);
+
+  // After the current frame, assume that focus was not moved elsewhere, or at least resume original
+  // trap behaviors.
+  setTimeout(() => {
+    document.removeEventListener('focusin', onFocus, true);
+    focusTrap.deactivate = originalDeactivate;
+    focusTrap.unpause();
+  }, 0);
+}
+
+/**
  * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK
  * in supported devices.
  *
@@ -177,6 +209,7 @@ function AcuantCapture(
     bannerText,
     value,
     onChange = () => {},
+    onCameraAccessDeclined = () => {},
     capture,
     className,
     allowUpload = true,
@@ -195,6 +228,7 @@ function AcuantCapture(
   } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { addPageAction } = useContext(AnalyticsContext);
+  const fullScreenRef = useRef(/** @type {FullScreenRefHandle?} */ (null));
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
   const isForceUploading = useRef(false);
   const isSuppressingClickLogging = useRef(false);
@@ -403,13 +437,24 @@ function AcuantCapture(
     <div className={[className, 'document-capture-acuant-capture'].filter(Boolean).join(' ')}>
       {isCapturingEnvironment && (
         <FullScreen
+          ref={fullScreenRef}
           label={t('doc_auth.accessible_labels.document_capture_dialog')}
           onRequestClose={() => setIsCapturingEnvironment(false)}
         >
           <AcuantCaptureCanvas
             onImageCaptureSuccess={onAcuantImageCaptureSuccess}
             onImageCaptureFailure={(error) => {
-              setOwnErrorMessage(t('doc_auth.errors.camera.failed'));
+              const didDeclineAccess = error instanceof Error;
+              if (didDeclineAccess) {
+                if (fullScreenRef.current?.focusTrap) {
+                  suspendFocusTrapForAnticipatedFocus(fullScreenRef.current.focusTrap);
+                }
+
+                onCameraAccessDeclined();
+              } else {
+                setOwnErrorMessage(t('doc_auth.errors.camera.failed'));
+              }
+
               setIsCapturingEnvironment(false);
               addPageAction({
                 label: 'IdV: Image capture failed',

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -100,6 +100,16 @@ import './acuant-capture.scss';
  */
 
 /**
+ * Returns true if the given Acuant capture failure was caused by the user declining access to the
+ * camera, or false otherwise.
+ *
+ * @param {import('./acuant-capture-canvas').AcuantCaptureFailureError} error
+ *
+ * @return {boolean}
+ */
+export const isAcuantCameraAccessFailure = (error) => error instanceof Error;
+
+/**
  * Returns a human-readable document label corresponding to the given document type constant.
  *
  * @param {AcuantDocumentType} documentType
@@ -123,7 +133,7 @@ function getDocumentTypeLabel(documentType) {
  * @return {string}
  */
 export function getNormalizedAcuantCaptureFailureMessage(error) {
-  if (error instanceof Error) {
+  if (isAcuantCameraAccessFailure(error)) {
     return 'User or system denied camera access';
   }
 
@@ -444,8 +454,7 @@ function AcuantCapture(
           <AcuantCaptureCanvas
             onImageCaptureSuccess={onAcuantImageCaptureSuccess}
             onImageCaptureFailure={(error) => {
-              const didDeclineAccess = error instanceof Error;
-              if (didDeclineAccess) {
+              if (isAcuantCameraAccessFailure(error)) {
                 if (fullScreenRef.current?.focusTrap) {
                   suspendFocusTrapForAnticipatedFocus(fullScreenRef.current.focusTrap);
                 }

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx
@@ -1,0 +1,64 @@
+import AcuantCapture from './acuant-capture';
+import FormErrorMessage, { CameraAccessDeclinedError } from './form-error-message';
+import useI18n from '../hooks/use-i18n';
+
+/** @typedef {import('./form-steps').FormStepError<*>} FormStepError */
+/** @typedef {import('./form-steps').RegisterFieldCallback} RegisterFieldCallback */
+/** @typedef {import('./form-steps').OnErrorCallback} OnErrorCallback */
+
+/**
+ * @typedef DocumentSideAcuantCaptureProps
+ *
+ * @prop {'front'|'back'} side
+ * @prop {RegisterFieldCallback} registerField
+ * @prop {Blob|string|null|undefined} value
+ * @prop {(nextValues:{[key:string]: Blob|string|null|undefined})=>void} onChange Update values,
+ * merging with existing values.
+ * @prop {FormStepError[]} errors
+ * @prop {OnErrorCallback} onError
+ * @prop {string=} className
+ */
+
+/**
+ * @param {DocumentSideAcuantCaptureProps} props Props object.
+ */
+function DocumentSideAcuantCapture({
+  side,
+  registerField,
+  value,
+  onChange,
+  errors,
+  onError,
+  className,
+}) {
+  const { t } = useI18n();
+  const error = errors.find(({ field }) => field === side)?.error;
+
+  return (
+    <AcuantCapture
+      ref={registerField(side, { isRequired: true })}
+      /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
+      /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
+      label={t(`doc_auth.headings.document_capture_${side}`)}
+      /* i18n-tasks-use t('doc_auth.headings.back') */
+      /* i18n-tasks-use t('doc_auth.headings.front') */
+      bannerText={t(`doc_auth.headings.${side}`)}
+      value={value}
+      onChange={(nextValue, metadata) =>
+        onChange({
+          [side]: nextValue,
+          [`${side}_image_metadata`]: JSON.stringify(metadata),
+        })
+      }
+      onCameraAccessDeclined={() => {
+        onError(new CameraAccessDeclinedError(), { field: side });
+        onError(new CameraAccessDeclinedError());
+      }}
+      errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
+      name={side}
+      className={className}
+    />
+  );
+}
+
+export default DocumentSideAcuantCapture;

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import BlockLink from './block-link';
 import AcuantCapture from './acuant-capture';
-import FormErrorMessage from './form-error-message';
+import FormErrorMessage, { CameraAccessDeclinedError } from './form-error-message';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import ServiceProviderContext from '../context/service-provider';
@@ -41,6 +41,7 @@ function DocumentsStep({
   value = {},
   onChange = () => {},
   errors = [],
+  onError = () => {},
   registerField = () => undefined,
 }) {
   const { t, formatHTML } = useI18n();
@@ -84,6 +85,10 @@ function DocumentsStep({
                 [`${side}_image_metadata`]: JSON.stringify(metadata),
               })
             }
+            onCameraAccessDeclined={() => {
+              onError(new CameraAccessDeclinedError(), { field: side });
+              onError(new CameraAccessDeclinedError());
+            }}
             errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
             name={side}
           />

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 import BlockLink from './block-link';
-import AcuantCapture from './acuant-capture';
-import FormErrorMessage, { CameraAccessDeclinedError } from './form-error-message';
+import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import ServiceProviderContext from '../context/service-provider';
@@ -65,35 +64,17 @@ function DocumentsStep({
           })}
         </BlockLink>
       )}
-      {DOCUMENT_SIDES.map((side) => {
-        const error = errors.find(({ field }) => field === side)?.error;
-
-        return (
-          <AcuantCapture
-            key={side}
-            ref={registerField(side, { isRequired: true })}
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
-            label={t(`doc_auth.headings.document_capture_${side}`)}
-            /* i18n-tasks-use t('doc_auth.headings.back') */
-            /* i18n-tasks-use t('doc_auth.headings.front') */
-            bannerText={t(`doc_auth.headings.${side}`)}
-            value={value[side]}
-            onChange={(nextValue, metadata) =>
-              onChange({
-                [side]: nextValue,
-                [`${side}_image_metadata`]: JSON.stringify(metadata),
-              })
-            }
-            onCameraAccessDeclined={() => {
-              onError(new CameraAccessDeclinedError(), { field: side });
-              onError(new CameraAccessDeclinedError());
-            }}
-            errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
-            name={side}
-          />
-        );
-      })}
+      {DOCUMENT_SIDES.map((side) => (
+        <DocumentSideAcuantCapture
+          key={side}
+          side={side}
+          registerField={registerField}
+          value={value[side]}
+          onChange={onChange}
+          errors={errors}
+          onError={onError}
+        />
+      ))}
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/file-image.jsx
+++ b/app/javascript/packages/document-capture/components/file-image.jsx
@@ -15,7 +15,7 @@ import FileBase64CacheContext from '../context/file-base64-cache';
  */
 function FileImage({ file, alt, className }) {
   const cache = useContext(FileBase64CacheContext);
-  const [, forceRender] = useState();
+  const [, forceRender] = useState(/** @type {number=} */ (undefined));
   const imageData = cache.get(file);
   const ifStillMounted = useIfStillMounted();
 

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -8,6 +8,7 @@ import useI18n from '../hooks/use-i18n';
  * @typedef FormErrorMessageProps
  *
  * @prop {Error} error Error for which message should be generated.
+ * @prop {boolean=} isDetail Whether to use an extended description for the error, if available.
  */
 
 /**
@@ -31,7 +32,7 @@ export class CameraAccessDeclinedError extends Error {}
 /**
  * @param {FormErrorMessageProps} props Props object.
  */
-function FormErrorMessage({ error }) {
+function FormErrorMessage({ error, isDetail = false }) {
   const { t } = useI18n();
 
   if (error instanceof RequiredValueMissingError) {
@@ -39,7 +40,13 @@ function FormErrorMessage({ error }) {
   }
 
   if (error instanceof CameraAccessDeclinedError) {
-    return <>{t('doc_auth.errors.camera.blocked')}</>;
+    return (
+      <>
+        {isDetail
+          ? t('doc_auth.errors.camera.blocked_detail')
+          : t('doc_auth.errors.camera.blocked')}
+      </>
+    );
   }
 
   if (error instanceof UploadFormEntryError) {

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -24,6 +24,11 @@ const NBSP_UNICODE = '\u00A0';
 export class RequiredValueMissingError extends Error {}
 
 /**
+ * An error representing user declined access to camera.
+ */
+export class CameraAccessDeclinedError extends Error {}
+
+/**
  * @param {FormErrorMessageProps} props Props object.
  */
 function FormErrorMessage({ error }) {
@@ -31,6 +36,10 @@ function FormErrorMessage({ error }) {
 
   if (error instanceof RequiredValueMissingError) {
     return <>{t('simple_form.required.text')}</>;
+  }
+
+  if (error instanceof CameraAccessDeclinedError) {
+    return <>{t('doc_auth.errors.camera.blocked')}</>;
   }
 
   if (error instanceof UploadFormEntryError) {

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -26,17 +26,25 @@ import useIfStillMounted from '../hooks/use-if-still-mounted';
  */
 
 /**
+ * @typedef {(
+ *   field:string,
+ *   options?:Partial<FormStepRegisterFieldOptions>
+ * )=>undefined|import('react').RefCallback<HTMLElement>} RegisterFieldCallback
+ */
+
+/**
+ * @typedef {(error:Error, options?: {field?: string?})=>void} OnErrorCallback
+ */
+
+/**
  * @typedef FormStepComponentProps
  *
  * @prop {(nextValues:Partial<V>)=>void} onChange Update values, merging with existing values.
- * @prop {(error:Error, options?: {field?: string?})=>void} onError Trigger a field error.
+ * @prop {OnErrorCallback} onError Trigger a field error.
  * @prop {Partial<V>} value Current values.
  * @prop {FormStepError<V>[]} errors Current active errors.
- * @prop {(
- *   field:string,
- *   options?:Partial<FormStepRegisterFieldOptions>
- * )=>undefined|import('react').RefCallback<HTMLElement>} registerField Registers field by given
- * name, returning ref assignment function.
+ * @prop {RegisterFieldCallback} registerField Registers field by given name, returning ref
+ * assignment function.
  *
  * @template V
  */

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
@@ -15,6 +15,10 @@ import useFocusTrap from '../hooks/use-focus-trap';
  * @prop {()=>void=} onRequestClose Callback invoked when user initiates close intent.
  * @prop {string} label Accessible label for modal.
  * @prop {ReactNode} children Child elements.
+ */
+
+/**
+ * @typedef {{focusTrap: import('focus-trap').FocusTrap?}} FullScreenRefHandle
  */
 
 /**
@@ -48,16 +52,18 @@ export function useInertSiblingElements(containerRef) {
 
 /**
  * @param {FullScreenProps} props Props object.
+ * @param {import('react').ForwardedRef<FullScreenRefHandle>} ref
  */
-function FullScreen({ onRequestClose = () => {}, label, children }) {
+function FullScreen({ onRequestClose = () => {}, label, children }, ref) {
   const { t } = useI18n();
   const { getAssetPath } = useAsset();
   const containerRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const onFocusTrapDeactivate = useImmutableCallback(onRequestClose);
-  useFocusTrap(containerRef, {
+  const focusTrap = useFocusTrap(containerRef, {
     clickOutsideDeactivates: true,
     onDeactivate: onFocusTrapDeactivate,
   });
+  useImperativeHandle(ref, () => ({ focusTrap }), [focusTrap]);
   useToggleBodyClassByPresence('has-full-screen-overlay', FullScreen);
   useInertSiblingElements(containerRef);
 
@@ -77,4 +83,4 @@ function FullScreen({ onRequestClose = () => {}, label, children }) {
   );
 }
 
-export default FullScreen;
+export default forwardRef(FullScreen);

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { hasMediaAccess } from '@18f/identity-device';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
+import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import AcuantCapture from './acuant-capture';
 import BlockLink from './block-link';
 import SelfieCapture from './selfie-capture';
@@ -54,6 +55,7 @@ function ReviewIssuesStep({
   value = {},
   onChange = () => {},
   errors = [],
+  onError = () => {},
   registerField = () => undefined,
 }) {
   const { t, formatHTML } = useI18n();
@@ -70,29 +72,18 @@ function ReviewIssuesStep({
         <li>{t('doc_auth.tips.review_issues_id_text3')}</li>
         <li>{t('doc_auth.tips.review_issues_id_text4')}</li>
       </ul>
-      {DOCUMENT_SIDES.map((side) => {
-        const sideError = errors.find(({ field }) => field === side)?.error;
-
-        return (
-          <AcuantCapture
-            key={side}
-            ref={registerField(side, { isRequired: true })}
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
-            label={t(`doc_auth.headings.document_capture_${side}`)}
-            /* i18n-tasks-use t('doc_auth.headings.back') */
-            /* i18n-tasks-use t('doc_auth.headings.front') */
-            bannerText={t(`doc_auth.headings.${side}`)}
-            value={value[side]}
-            onChange={(nextValue, metadata) =>
-              onChange({ [side]: nextValue, [`${side}_image_metadata`]: JSON.stringify(metadata) })
-            }
-            className="document-capture-review-issues-step__input"
-            errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}
-            name={side}
-          />
-        );
-      })}
+      {DOCUMENT_SIDES.map((side) => (
+        <DocumentSideAcuantCapture
+          key={side}
+          side={side}
+          registerField={registerField}
+          value={value[side]}
+          onChange={onChange}
+          errors={errors}
+          onError={onError}
+          className="document-capture-review-issues-step__input"
+        />
+      ))}
       {serviceProvider.isLivenessRequired && (
         <>
           <hr className="margin-y-4" />

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -143,8 +143,10 @@ const withBackgroundEncryptedUpload = (Component) =>
       onChange(nextValuesWithUpload);
     }
 
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    return <Component {...props} onChange={onChangeWithBackgroundEncryptedUpload} />;
+    return (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <Component {...props} onError={onError} onChange={onChangeWithBackgroundEncryptedUpload} />
+    );
   };
 
 export default withBackgroundEncryptedUpload;

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -134,7 +134,7 @@ const withBackgroundEncryptedUpload = (Component) =>
               const error = new BackgroundEncryptedUploadError();
               error.baseField = key;
               error.fields = [key, `${key}_image_iv`, `${key}_image_url`];
-              onError(key, error);
+              onError(error, { field: key });
               throw error;
             });
         }

--- a/app/javascript/packages/document-capture/hooks/use-focus-trap.js
+++ b/app/javascript/packages/document-capture/hooks/use-focus-trap.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { createFocusTrap } from 'focus-trap';
 
 /** @typedef {import('focus-trap').FocusTrap} FocusTrap */
@@ -15,20 +15,22 @@ import { createFocusTrap } from 'focus-trap';
  * @param {React.MutableRefObject<FocusTrap?>} containerRef
  */
 function useFocusTrap(containerRef, options) {
-  const trapRef = useRef(/** @type {FocusTrap?} */ (null));
+  const [trap, setTrap] = useState(/** @type {FocusTrap?} */ (null));
 
   useEffect(() => {
+    let focusTrap;
     if (containerRef.current) {
-      trapRef.current = createFocusTrap(containerRef.current, options);
-      trapRef.current.activate();
+      focusTrap = createFocusTrap(containerRef.current, options);
+      focusTrap.activate();
+      setTrap(focusTrap);
     }
 
     return () => {
-      trapRef.current?.deactivate();
+      focusTrap?.deactivate();
     };
   }, []);
 
-  return trapRef;
+  return trap;
 }
 
 export default useFocusTrap;

--- a/app/javascript/packages/document-capture/hooks/use-if-still-mounted.js
+++ b/app/javascript/packages/document-capture/hooks/use-if-still-mounted.js
@@ -19,11 +19,16 @@ function useIfStillMounted() {
     };
   });
 
-  const ifStillMounted = (fn) => (...args) => {
-    if (isMounted.current) {
-      fn(...args);
-    }
-  };
+  /**
+   * @template {(...args) => any} T
+   * @param {T} fn
+   */
+  const ifStillMounted = (fn) =>
+    /** @type {T} */ ((...args) => {
+      if (isMounted.current) {
+        fn(...args);
+      }
+    });
 
   return ifStillMounted;
 }

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -11,6 +11,7 @@
 - doc_auth.buttons.upload_picture
 - doc_auth.errors.camera.failed
 - doc_auth.errors.camera.blocked
+- doc_auth.errors.camera.blocked_detail
 - doc_auth.errors.file_type.invalid
 - doc_auth.errors.general.network_error
 - doc_auth.errors.glare.failed_short

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -53,6 +53,9 @@ en:
         visible_photo_check: We couldn’t verify the photo on your ID. Try taking new pictures.
       camera:
         blocked: Your camera is blocked
+        blocked_detail: We don’t have permission to access the camera. Please check your
+          browser or system settings, reload this page, or upload a photo
+          instead.
         failed: Camera failed to start, please try again.
       dpi:
         top_msg: We couldn’t read your ID. Your image size may be too small, or your ID

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -64,6 +64,9 @@ es:
           tomar nuevas fotografías.
       camera:
         blocked: Su cámara está bloqueada
+        blocked_detail: No tenemos permiso para acceder a la cámara. Por favor,
+          compruebe la configuración de su navegador o sistema, recargue esta
+          página o suba una foto en su lugar.
         failed: No se ha podido encender la cámara, por favor, inténtelo de nuevo.
       dpi:
         top_msg: No pudimos leer su identificación. Es posible que el tamaño de su

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -67,7 +67,10 @@ fr:
         visible_photo_check: Nous n’avons pas pu vérifier la photo sur votre pièce
           d’identité. Essayez de prendre de nouvelles photos.
       camera:
-        blocked: Votre caméra est bloquée
+        blocked: Votre appareil photo est bloqué
+        blocked_detail: Nous n'avons pas la permission d'accéder à l'appareil photo.
+          Veuillez vérifier les paramètres de votre navigateur ou de votre
+          système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
       dpi:
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre

--- a/spec/javascripts/packages/components/alert-spec.jsx
+++ b/spec/javascripts/packages/components/alert-spec.jsx
@@ -23,6 +23,15 @@ describe('identity-components/alert', () => {
     expect(alert.classList.contains('my-class')).to.be.true();
   });
 
+  it('is optionally focusable', () => {
+    const { getByRole } = render(<Alert isFocusable />);
+
+    const alert = getByRole('alert');
+    alert.focus();
+
+    expect(document.activeElement).to.equal(alert);
+  });
+
   it('forwards ref', () => {
     const ref = createRef();
     const { container } = render(<Alert ref={ref} />);

--- a/spec/javascripts/packages/components/alert-spec.jsx
+++ b/spec/javascripts/packages/components/alert-spec.jsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { Alert } from '@18f/identity-components';
 import { render } from '../../support/document-capture';
 
@@ -20,5 +21,12 @@ describe('identity-components/alert', () => {
     const alert = getByRole('alert');
 
     expect(alert.classList.contains('my-class')).to.be.true();
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef();
+    const { container } = render(<Alert ref={ref} />);
+
+    expect(ref.current).to.equal(container.firstChild);
   });
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -3,6 +3,7 @@ import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import AcuantCapture, {
+  isAcuantCameraAccessFailure,
   getNormalizedAcuantCaptureFailureMessage,
 } from '@18f/identity-document-capture/components/acuant-capture';
 import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
@@ -49,6 +50,16 @@ describe('document-capture/components/acuant-capture', () => {
 
         expect(message).to.be.a('string');
       });
+    });
+  });
+
+  describe('isAcuantCameraAccessFailure', () => {
+    it('returns false if not a camera access failure', () => {
+      expect(isAcuantCameraAccessFailure('Camera not supported.')).to.be.false();
+    });
+
+    it('returns true if a camera access failure', () => {
+      expect(isAcuantCameraAccessFailure(new Error())).to.be.true();
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
@@ -58,4 +58,22 @@ describe('document-capture/components/form-error-message', () => {
 
     expect(container.childNodes).to.be.empty();
   });
+
+  describe('isDetail', () => {
+    it('returns formatted CameraAccessDeclinedError', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{
+            'doc_auth.errors.camera.blocked_detail':
+              'We don’t have permission to access the camera. Please check your browser or system' +
+              ' settings, reload this page, or upload a photo instead.',
+          }}
+        >
+          <FormErrorMessage error={new CameraAccessDeclinedError()} isDetail />
+        </I18nContext.Provider>,
+      );
+
+      expect(getByText('We don’t have permission', { exact: false })).to.be.ok();
+    });
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-error-message-spec.jsx
@@ -1,6 +1,7 @@
 import { I18nContext } from '@18f/identity-document-capture';
 import FormErrorMessage, {
   RequiredValueMissingError,
+  CameraAccessDeclinedError,
 } from '@18f/identity-document-capture/components/form-error-message';
 import { UploadFormEntryError } from '@18f/identity-document-capture/services/upload';
 import { BackgroundEncryptedUploadError } from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
@@ -40,6 +41,16 @@ describe('document-capture/components/form-error-message', () => {
       'try',
       'again.',
     ]);
+  });
+
+  it('returns formatted CameraAccessDeclinedError', () => {
+    const { getByText } = render(
+      <I18nContext.Provider value={{ 'doc_auth.errors.camera.blocked': 'Your camera is blocked' }}>
+        <FormErrorMessage error={new CameraAccessDeclinedError()} />
+      </I18nContext.Provider>,
+    );
+
+    expect(getByText('Your camera is blocked')).to.be.ok();
   });
 
   it('returns null if error is of an unknown type', () => {

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -22,7 +22,7 @@ describe('document-capture/components/form-steps', () => {
             data-is-error={errors.some(({ field }) => field === 'secondInputOne') || undefined}
             onChange={(event) => {
               if (event.target.validationMessage) {
-                onError('secondInputOne', new Error(event.target.validationMessage));
+                onError(new Error(event.target.validationMessage), { field: 'secondInputOne' });
               } else {
                 onChange({ changed: true });
                 onChange({ secondInputOne: event.target.value });
@@ -39,6 +39,9 @@ describe('document-capture/components/form-steps', () => {
               onChange({ secondInputTwo: event.target.value });
             }}
           />
+          <button type="button" onClick={() => onError(new Error())}>
+            Create Step Error
+          </button>
         </>
       ),
     },
@@ -379,5 +382,15 @@ describe('document-capture/components/form-steps', () => {
     userEvent.type(inputOne, 'one');
 
     expect(inputOne.hasAttribute('data-is-error')).to.be.true();
+  });
+
+  it('renders and moves focus to step errors', () => {
+    const steps = [STEPS[1]];
+
+    const { getByRole } = render(<FormSteps steps={steps} />);
+    const button = getByRole('button', { name: 'Create Step Error' });
+    userEvent.click(button);
+
+    expect(getByRole('alert')).to.equal(document.activeElement);
   });
 });

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, createRef } from 'react';
 import { screen } from '@testing-library/dom';
 import { render, fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
@@ -175,5 +175,12 @@ describe('document-capture/components/full-screen', () => {
     rerender(<></>);
 
     expect(document.body.classList.contains('has-full-screen-overlay')).to.be.false();
+  });
+
+  it('exposes focus trap on its ref', () => {
+    const ref = createRef();
+    render(<FullScreen ref={ref}>Content</FullScreen>);
+
+    expect(ref.current.focusTrap.deactivate).to.be.a('function');
   });
 });

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -240,8 +240,8 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           const patch = onChange.getCall(0).args[0];
           await patch.foo_image_url.catch(() => {});
           expect(onError).to.have.been.calledOnceWith(
-            'foo',
             sinon.match.instanceOf(BackgroundEncryptedUploadError),
+            { field: 'foo' },
           );
           expect(addPageAction).to.have.been.calledWith({
             label: 'IdV: document capture async upload encryption',
@@ -257,8 +257,8 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
           const patch = onChange.getCall(0).args[0];
           await patch.foo_image_url.catch(() => {});
           expect(onError).to.have.been.calledOnceWith(
-            'foo',
             sinon.match.instanceOf(BackgroundEncryptedUploadError),
+            { field: 'foo' },
           );
         });
 

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -61,10 +61,16 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
   });
 
   describe('withBackgroundEncryptedUpload', () => {
-    const Component = withBackgroundEncryptedUpload(({ onChange }) => {
+    const Component = withBackgroundEncryptedUpload(({ onChange, onError, errorOnMount }) => {
       useEffect(() => {
         onChange({ foo: 'bar', baz: 'quux' });
       }, []);
+
+      useEffect(() => {
+        if (errorOnMount) {
+          onError(new Error());
+        }
+      }, [errorOnMount]);
 
       return null;
     });
@@ -111,6 +117,13 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
       });
     });
 
+    it('passes through original onError', () => {
+      const onError = sinon.spy();
+      render(<Component onChange={() => {}} onError={onError} errorOnMount />);
+
+      expect(onError).to.have.been.calledOnce();
+    });
+
     describe('upload', () => {
       async function renderWithResponse(response) {
         const addPageAction = sinon.spy();
@@ -132,7 +145,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
               backgroundUploadURLs={{ foo: 'about:blank' }}
               backgroundUploadEncryptKey={key}
             >
-              <Component onChange={onChange} onError={onError} />)
+              <Component onChange={onChange} onError={onError} />
             </UploadContextProvider>
           </AnalyticsContext.Provider>,
         );

--- a/spec/javascripts/packages/document-capture/hooks/use-focus-trap-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-focus-trap-spec.jsx
@@ -21,12 +21,12 @@ describe('document-capture/hooks/use-focus-trap', () => {
     screen.getByTestId('outsideButton').focus();
   });
 
-  it('returns focus trap ref', () => {
+  it('returns focus trap', () => {
     const container = document.querySelector('.container');
     const { result } = renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
 
-    const trapRef = result.current;
-    expect(trapRef.current.deactivate).to.be.a('function');
+    const trap = result.current;
+    expect(trap.deactivate).to.be.a('function');
   });
 
   it('traps focus', () => {
@@ -43,8 +43,8 @@ describe('document-capture/hooks/use-focus-trap', () => {
     const container = document.querySelector('.container');
     const { result } = renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
 
-    const trapRef = result.current;
-    trapRef.current.deactivate();
+    const trap = result.current;
+    trap.deactivate();
 
     // Delay for focus return isn't configurable.
     await delay();


### PR DESCRIPTION
**Why**: As a user, I expect that if Acuant fails to start because they do not have permission to use the camera (denied either explicitly by the user, or at the system-level), the messaging clearly indicates if there's a permissions problem, so that I'm not left confused about the reason for the failure, and so that I don't waste my time repeatedly trying to "Try again" if there's a systems permissions issue.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/1779930/123301869-1d10ad00-d4ea-11eb-82e6-f871899956ab.jpg" alt="screenshot" width="300">

**Implementation Notes:**

This adds support for steps to declare their own errors. Part of the requirement from the ticket is to transition focus to the error when rendered. This proved rather difficult due to how Acuant is shown in a full-screen modal, and how the [`focus-trap` library](https://www.npmjs.com/package/focus-trap) tries to both keep focus within the modal, and return focus (after a delay) to the element which had been active when the trap was first initiated. The solution here isn't pretty, but essentially suspends the default focus trap behaviors while the camera access error is being handled, with the expectation that some focus transitions could happen in response to these errors (e.g. focusing the step alert).