### PR TITLE
fix NullServiceProvider method call

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -39,7 +39,7 @@ module SamlIdpAuthConcern
   end
 
   def specified_name_id_format
-    if recognized_name_id_format? || current_service_provider.use_legacy_name_id_behavior?
+    if recognized_name_id_format? || current_service_provider.use_legacy_name_id_behavior
       saml_request.name_id_format
     end
   end


### PR DESCRIPTION
it only implements `use_legacy_name_id_behavior`, not `use_legacy_name_id_behavior?`