### PR TITLE
[LG-4768] Add task to generate a mapping of user IDs to agency UUIDs

### DIFF
--- a/app/services/user_id_to_agency_uuid_reporter.rb
+++ b/app/services/user_id_to_agency_uuid_reporter.rb
@@ -1,0 +1,85 @@
+require 'csv'
+
+class UserIdToAgencyUuidReporter
+  include ActiveModel::Model
+
+  def self.run(**opts)
+    new(**opts).run
+  end
+
+  validate :sp_exists
+  validate :output_file_does_not_exist
+
+  # Instantiate a new instance of the service object
+  #
+  # @attr issuer [String] the SP issuer to run the report for
+  # @attr output [String] the location where the output CSV should be written
+  def initialize(issuer:, output:)
+    @issuer = issuer
+    @sp = ServiceProvider.find_by(issuer: issuer)
+    @agency_id = sp&.agency_id
+    @output = output
+
+    raise ArgumentError.new(errors.full_messages.join('; ')) unless valid?
+  end
+
+  def run
+    rows = collect_sp_identity_info
+    rows = collect_agency_uuids(rows)
+    save_csv(rows)
+
+    rows.length
+  end
+
+  private
+
+  attr_reader :agency_id, :issuer, :output, :sp
+
+  def sp_exists
+    return if sp
+
+    errors.add(:issuer, 'must correspond to a service provider')
+  end
+
+  def output_file_does_not_exist
+    return unless File.exist?(output)
+
+    errors.add(:output, 'already exists')
+  end
+
+  def collect_sp_identity_info
+    Hash.new.tap do |records|
+      ServiceProviderIdentity.
+        select(:id, :service_provider, :user_id, :created_at).
+        find_in_batches(batch_size: 10_000) do |batch|
+          batch.each do |sp_identity|
+            if sp_identity.service_provider == issuer
+              records[sp_identity.user_id] = { created_at: sp_identity.created_at }
+            end
+          end
+        end
+    end
+  end
+
+  def collect_agency_uuids(rows)
+    user_ids = rows.keys
+    agency_identities = AgencyIdentity.
+      select(:user_id, :uuid).
+      where(user_id: user_ids, agency_id: agency_id)
+    uuid_hash = agency_identities.map { |record| [record.user_id, record.uuid] }.to_h
+
+    rows.map do |user_id, row|
+      [user_id, row.merge({uuid: uuid_hash[user_id] })]
+    end.to_h
+  end
+
+  def save_csv(rows)
+    CSV.open(output, 'w') do |csv|
+      csv << ['old_identifier', 'new_identifier', 'created_at']
+
+      rows.each do |user_id, row|
+        csv << [user_id, row[:uuid], row[:created_at]]
+      end
+    end
+  end
+end

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -43,4 +43,26 @@ namespace :partners do
       exit(-1)
     end
   end
+
+  desc 'Retrieve a mapping of agency UUIDs to user IDs given an issuer'
+  task export_user_ids_to_agency_uuids: :environment do
+    options = {
+      issuer: ENV['ISSUER'],
+      output: ENV['OUTPUT'],
+    }
+
+    if options.values.any?(&:nil?)
+      puts 'You must define the environment variables ISSUER and OUTPUT'
+      exit(-1)
+    end
+
+    begin
+      count = UserIdToAgencyUuidReporter.run(**options)
+      puts "#{count} records exported"
+      puts 'Complete!'
+    rescue ArgumentError, StandardError => e
+      puts "ERROR: #{e.message}"
+      exit(-1)
+    end
+  end
 end

--- a/spec/services/user_id_to_agency_uuid_reporter_spec.rb
+++ b/spec/services/user_id_to_agency_uuid_reporter_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe UserIdToAgencyUuidReporter do
+  let(:valid_issuer) { 'valid_issuer' }
+  let(:valid_output) { 'tmp/uuids.csv' }
+
+  # DATA
+  let!(:agency) { create(:agency) }
+  let!(:sp) { create(:service_provider, agency: agency, issuer: 'valid_issuer') }
+
+  describe '.new' do
+    it 'raises the appropriate error with invalid issuer' do
+      opts = {
+        issuer: 'invalid_issuer',
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /correspond to a service provider/)
+    end
+    it 'raises the appropriate error when the output file exists' do
+      FileUtils.touch(valid_output)
+
+      opts = {
+        issuer: valid_issuer,
+        output: valid_output,
+      }
+
+      expect { described_class.new(**opts) }.to \
+        raise_error(ArgumentError, /already exists/)
+
+      File.delete(valid_output)
+    end
+  end
+
+  describe '.run' do
+    context 'with valid inputs' do
+      let!(:user1) { create(:user, :signed_up) }
+      let!(:user2) { create(:user, :signed_up) }
+      let!(:user3) { create(:user, :signed_up) }
+      let!(:uuid1) do
+        IdentityLinker.new(user1, sp.issuer).link_identity
+        AgencyIdentity.find_by(user_id: user1.id, agency_id: agency.id).uuid
+      end
+      let!(:uuid2) do
+        IdentityLinker.new(user2, sp.issuer).link_identity
+        AgencyIdentity.find_by(user_id: user2.id, agency_id: agency.id).uuid
+      end
+      let!(:created_at1) do
+        ServiceProviderIdentity.
+          find_by(user_id: user1.id, service_provider: valid_issuer).
+          created_at
+      end
+      let!(:created_at2) do
+        ServiceProviderIdentity.
+          find_by(user_id: user2.id, service_provider: valid_issuer).
+          created_at
+      end
+
+      let(:opts) do
+        {
+          issuer: valid_issuer,
+          output: valid_output,
+        }
+      end
+
+      before(:each) do
+        IdentityLinker.new(user3, create(:service_provider).issuer).link_identity
+      end
+
+      after(:each) { File.delete(valid_output) }
+
+      it 'generates the correct csv' do
+        expected = <<~CSV
+          old_identifier,new_identifier,created_at
+          #{user1.id},#{uuid1},#{created_at1}
+          #{user2.id},#{uuid2},#{created_at2}
+        CSV
+
+        described_class.run(**opts)
+
+        expect(File.read(valid_output)).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves LG-4768

**Why:** We will need to generate these reports for impacted SPs from the recently identified SAML bug (see #5169), so it would be good for them not to be ad-hoc reports 😄 