### PR TITLE
do not always load x509 and IAL2 attributes in OIDC userinfo/token requests

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -108,7 +108,10 @@ module Users
       add_sp_cost(:digest)
       create_user_event(:sign_in_before_2fa)
       update_sp_return_logs_with_user(current_user.id)
-      update_last_sign_in_at_on_email
+      EmailAddress.update_last_sign_in_at_on_user_id_and_email(
+        user_id: current_user.id,
+        email: auth_params[:email],
+      )
       redirect_to next_url_after_valid_authentication
     end
 
@@ -148,11 +151,6 @@ module Users
       }
 
       analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)
-    end
-
-    def update_last_sign_in_at_on_email
-      email_address = current_user.email_addresses.find_with_email(params[:user][:email])
-      email_address.update!(last_sign_in_at: Time.zone.now)
     end
 
     def user_signed_in_and_not_locked_out?(user)

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -39,7 +39,7 @@ class EmailAddress < ApplicationRecord
     end
 
     def update_last_sign_in_at_on_user_id_and_email(user_id:, email:)
-      return nil if !email.is_a?(String) || email.empty?
+      return nil if email.to_s.empty?
 
       email = email.downcase.strip
       email_fingerprint = create_fingerprint(email)

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -38,6 +38,18 @@ class EmailAddress < ApplicationRecord
       find_by(email_fingerprint: email_fingerprint)
     end
 
+    def update_last_sign_in_at_on_user_id_and_email(user_id:, email:)
+      return nil if !email.is_a?(String) || email.empty?
+
+      email = email.downcase.strip
+      email_fingerprint = create_fingerprint(email)
+      # rubocop:disable Rails/SkipsModelValidations
+      EmailAddress.where(user_id: user_id, email_fingerprint: email_fingerprint).update_all(
+        last_sign_in_at: Time.zone.now,
+      )
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
     private
 
     def create_fingerprint(email)

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -46,6 +46,7 @@ class EmailAddress < ApplicationRecord
       # rubocop:disable Rails/SkipsModelValidations
       EmailAddress.where(user_id: user_id, email_fingerprint: email_fingerprint).update_all(
         last_sign_in_at: Time.zone.now,
+        updated_at: Time.zone.now,
       )
       # rubocop:enable Rails/SkipsModelValidations
     end

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -1,29 +1,31 @@
 class OpenidConnectAttributeScoper
-  VALID_SCOPES = %w[
-    address
-    email
-    openid
-    phone
-    profile
-    profile:birthdate
-    profile:name
-    profile:verified_at
-    social_security_number
+  X509_SCOPES = %w[
     x509
     x509:subject
     x509:issuer
     x509:presented
-  ].freeze
+  ]
+
+  IAL2_SCOPES = %w[
+    address
+    phone
+    profile
+    profile:name
+    profile:birthdate
+    social_security_number
+  ]
+
+  VALID_SCOPES = %w[
+    email
+    openid
+    profile:verified_at
+  ] + X509_SCOPES + IAL2_SCOPES
 
   VALID_IAL1_SCOPES = %w[
     email
     openid
     profile:verified_at
-    x509
-    x509:subject
-    x509:issuer
-    x509:presented
-  ].freeze
+  ] + X509_SCOPES
 
   ATTRIBUTE_SCOPES_MAP = {
     email: %w[email],
@@ -57,6 +59,18 @@ class OpenidConnectAttributeScoper
 
   def initialize(scope)
     @scopes = parse_scope(scope)
+  end
+
+  def ial2_scopes_requested?
+    (scopes & IAL2_SCOPES).any?
+  end
+
+  def x509_scopes_requested?
+    (scopes & X509_SCOPES).any?
+  end
+
+  def verified_at_requested?
+    scopes.include?('profile:verified_at') || scopes.include?('profile')
   end
 
   def filter(user_info)

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe OpenidConnect::UserInfoController do
 
         action
       end
+
+      it 'does not change session' do
+        action
+        expect(request.session).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
in working on #5177, I noticed some potentially extraneous KMS and database calls. Turns out we always load IAL2 profiles and PIV/CAC information (for x509 attributes), even if none of them are requested!

SAML has some similar logic around this in the [attribute asserter](https://github.com/18F/identity-idp/blob/fa22268/app/services/attribute_asserter.rb), so mostly I copied that to avoid the unnecessary database and KMS requests.