### PR TITLE
RISC EventBridge fixes

### DIFF
--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -118,7 +118,11 @@ RSpec.describe PushNotification::HttpPush do
 
       context 'with an error from eventbridge' do
         before do
-          eventbridge_client.stub_responses(:put_events, failed_entry_count: 1, entries: [ { error_code: 'MalformedDetail', error_message: 'Detail is malformed' }])
+          eventbridge_client.stub_responses(
+            :put_events,
+            failed_entry_count: 1,
+            entries: [{ error_code: 'MalformedDetail', error_message: 'Detail is malformed' }],
+          )
         end
 
         it 'logs a warning' do


### PR DESCRIPTION
1. "detail" needs to be a JSON string, so put the JWT inside a JSON object
2. errors were getting silently swallowed, this turns them into warnings
   similar to HTTP deliver errors