### PR TITLE
Improve React component display names

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -94,9 +94,10 @@ export function isValidForAccepts(mimeType, accept) {
 }
 
 /**
- * @type {import('react').ForwardRefExoticComponent<FileInputProps & ReactRefAttributes>}
+ * @param {FileInputProps} props Props object.
+ * @param {import('react').ForwardedRef<any>} ref
  */
-const FileInput = forwardRef((props, ref) => {
+function FileInput(props, ref) {
   const {
     label,
     hint,
@@ -284,6 +285,6 @@ const FileInput = forwardRef((props, ref) => {
       </div>
     </div>
   );
-});
+}
 
-export default FileInput;
+export default forwardRef(FileInput);

--- a/app/javascript/packages/document-capture/context/acuant.jsx
+++ b/app/javascript/packages/document-capture/context/acuant.jsx
@@ -85,6 +85,8 @@ const AcuantContext = createContext({
   endpoint: /** @type {string?} */ (null),
 });
 
+AcuantContext.displayName = 'AcuantContext';
+
 /**
  * @param {AcuantContextProviderProps} props Props object.
  */

--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -32,4 +32,6 @@ const AnalyticsContext = createContext(
   }),
 );
 
+AnalyticsContext.displayName = 'AnalyticsContext';
+
 export default AnalyticsContext;

--- a/app/javascript/packages/document-capture/context/asset.js
+++ b/app/javascript/packages/document-capture/context/asset.js
@@ -2,4 +2,6 @@ import { createContext } from 'react';
 
 const AssetContext = createContext({});
 
+AssetContext.displayName = 'AssetContext';
+
 export default AssetContext;

--- a/app/javascript/packages/document-capture/context/device.js
+++ b/app/javascript/packages/document-capture/context/device.js
@@ -8,4 +8,6 @@ import { createContext } from 'react';
 
 const DeviceContext = createContext(/** @type {DeviceContext} */ ({ isMobile: false }));
 
+DeviceContext.displayName = 'DeviceContext';
+
 export default DeviceContext;

--- a/app/javascript/packages/document-capture/context/file-base64-cache.js
+++ b/app/javascript/packages/document-capture/context/file-base64-cache.js
@@ -2,4 +2,6 @@ import { createContext } from 'react';
 
 const FileBase64CacheContext = createContext(/** @type {WeakMap<Blob,string>} */ (new WeakMap()));
 
+FileBase64CacheContext.displayName = 'FileBase64CacheContext';
+
 export default FileBase64CacheContext;

--- a/app/javascript/packages/document-capture/context/i18n.js
+++ b/app/javascript/packages/document-capture/context/i18n.js
@@ -2,4 +2,6 @@ import { createContext } from 'react';
 
 const I18nContext = createContext({});
 
+I18nContext.displayName = 'I18nContext';
+
 export default I18nContext;

--- a/app/javascript/packages/document-capture/context/index.js
+++ b/app/javascript/packages/document-capture/context/index.js
@@ -1,0 +1,10 @@
+export { default as AssetContext } from './asset';
+export { default as I18nContext } from './i18n';
+export { default as DeviceContext } from './device';
+export { default as AcuantContext, Provider as AcuantContextProvider } from './acuant';
+export { default as UploadContext, Provider as UploadContextProvider } from './upload';
+export {
+  default as ServiceProviderContext,
+  Provider as ServiceProviderContextProvider,
+} from './service-provider';
+export { default as AnalyticsContext } from './analytics';

--- a/app/javascript/packages/document-capture/context/service-provider.jsx
+++ b/app/javascript/packages/document-capture/context/service-provider.jsx
@@ -21,6 +21,8 @@ const ServiceProviderContext = createContext(
   }),
 );
 
+ServiceProviderContext.displayName = 'ServiceProviderContext';
+
 /**
  * @typedef ServiceProviderContextProviderProps
  *

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -10,6 +10,8 @@ const UploadContext = createContext({
   backgroundUploadEncryptKey: /** @type {CryptoKey=} */ (undefined),
 });
 
+UploadContext.displayName = 'UploadContext';
+
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -149,8 +149,8 @@ const withBackgroundEncryptedUpload = (Component) => {
     );
   }
 
-  const { displayName = Component.name } = Component;
-  ComposedComponent.displayName = `WithBackgroundEncryptedUpload(${displayName})`;
+  const { displayName: originalDisplayName = Component.name } = Component;
+  ComposedComponent.displayName = `WithBackgroundEncryptedUpload(${originalDisplayName})`;
 
   return ComposedComponent;
 };

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -8,11 +8,6 @@ import AnalyticsContext from '../context/analytics';
  */
 
 /**
- * @typedef {import('react').FC<V>} FC
- * @template V
- */
-
-/**
  * An error representing a failure to complete encrypted upload of image.
  */
 export class BackgroundEncryptedUploadError extends Error {

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -8,6 +8,11 @@ import AnalyticsContext from '../context/analytics';
  */
 
 /**
+ * @typedef {import('react').FC<V>} FC
+ * @template V
+ */
+
+/**
  * An error representing a failure to complete encrypted upload of image.
  */
 export class BackgroundEncryptedUploadError extends Error {
@@ -61,11 +66,11 @@ export async function encrypt(key, iv, value) {
   );
 }
 
-const withBackgroundEncryptedUpload = (Component) =>
+const withBackgroundEncryptedUpload = (Component) => {
   /**
    * @param {Pick<FormStepComponentProps<Record<string,any>>, 'onChange'|'onError'>} props
    */
-  ({ onChange, onError, ...props }) => {
+  function ComposedComponent({ onChange, onError, ...props }) {
     const { backgroundUploadURLs, backgroundUploadEncryptKey } = useContext(UploadContext);
     const { addPageAction, noticeError } = useContext(AnalyticsContext);
 
@@ -147,6 +152,12 @@ const withBackgroundEncryptedUpload = (Component) =>
       // eslint-disable-next-line react/jsx-props-no-spreading
       <Component {...props} onError={onError} onChange={onChangeWithBackgroundEncryptedUpload} />
     );
-  };
+  }
+
+  const { displayName = Component.name } = Component;
+  ComposedComponent.displayName = `WithBackgroundEncryptedUpload(${displayName})`;
+
+  return ComposedComponent;
+};
 
 export default withBackgroundEncryptedUpload;

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -149,8 +149,9 @@ const withBackgroundEncryptedUpload = (Component) => {
     );
   }
 
-  const { displayName: originalDisplayName = Component.name } = Component;
-  ComposedComponent.displayName = `WithBackgroundEncryptedUpload(${originalDisplayName})`;
+  ComposedComponent.displayName = `WithBackgroundEncryptedUpload(${
+    Component.displayName || Component.name
+  })`;
 
   return ComposedComponent;
 };

--- a/app/javascript/packages/document-capture/index.js
+++ b/app/javascript/packages/document-capture/index.js
@@ -1,8 +1,2 @@
 export { default as DocumentCapture } from './components/document-capture';
-export { default as AssetContext } from './context/asset';
-export { default as I18nContext } from './context/i18n';
-export { default as DeviceContext } from './context/device';
-export { Provider as AcuantContextProvider } from './context/acuant';
-export { Provider as UploadContextProvider } from './context/upload';
-export { Provider as ServiceProviderContextProvider } from './context/service-provider';
-export { default as AnalyticsContext } from './context/analytics';
+export * from './context';

--- a/spec/javascripts/packages/document-capture/context/index-spec.js
+++ b/spec/javascripts/packages/document-capture/context/index-spec.js
@@ -1,0 +1,9 @@
+import * as exported from '@18f/identity-document-capture/context';
+
+describe('document-capture/context/index', () => {
+  it('assigns display name for each exported context', () => {
+    Object.entries(exported)
+      .filter(([exportedName]) => exportedName.endsWith('Context'))
+      .forEach(([, Context]) => expect(Context).to.have.property('displayName'));
+  });
+});

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -61,7 +61,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
   });
 
   describe('withBackgroundEncryptedUpload', () => {
-    const Component = withBackgroundEncryptedUpload(({ onChange, onError, errorOnMount }) => {
+    function OriginalComponent({ onChange, onError, errorOnMount }) {
       useEffect(() => {
         onChange({ foo: 'bar', baz: 'quux' });
       }, []);
@@ -73,7 +73,8 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
       }, [errorOnMount]);
 
       return null;
-    });
+    }
+    const Component = withBackgroundEncryptedUpload(OriginalComponent);
 
     describe('encrypt', () => {
       it('resolves to AES-GCM encrypted data from string value', async () => {
@@ -122,6 +123,10 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
       render(<Component onChange={() => {}} onError={onError} errorOnMount />);
 
       expect(onError).to.have.been.calledOnce();
+    });
+
+    it('maintains and decorates the original component display name', () => {
+      expect(Component.displayName).to.equal('WithBackgroundEncryptedUpload(OriginalComponent)');
     });
 
     describe('upload', () => {


### PR DESCRIPTION
**Why**: So that developers can better visualize the component hierarchy using [React dev tools](https://github.com/facebook/react/tree/main/packages/react-devtools).

Related:

- https://reactjs.org/docs/context.html#contextdisplayname
- https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging

Before|After
---|---
![Screen Shot 2021-06-30 at 9 51 57 AM](https://user-images.githubusercontent.com/1779930/123978492-e6291400-d98d-11eb-97db-a769dd0e8c33.png)|![Screen Shot 2021-06-30 at 10 27 19 AM](https://user-images.githubusercontent.com/1779930/123978500-e75a4100-d98d-11eb-809f-24f29358a943.png)
