### PR TITLE
Do not show "Your letter is on its way" during GPO verification before the letter has been queued

### DIFF
--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -65,7 +65,12 @@ module Idv
       @code = personal_key
       user_session[:personal_key] = @code
       idv_session.personal_key = nil
-      flash.now[:success] = t('idv.messages.confirm')
+
+      if idv_session.address_verification_mechanism == 'gpo'
+        flash.now[:success] = t('idv.messages.mail_sent')
+      else
+        flash.now[:success] = t('idv.messages.confirm')
+      end
       flash[:allow_confirmations_continue] = true
     end
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -62,9 +62,7 @@ module Idv
     end
 
     def flash_message_content
-      if idv_session.address_verification_mechanism == 'gpo'
-        t('idv.messages.mail_sent')
-      else
+      unless idv_session.address_verification_mechanism == 'gpo'
         phone_of_record_msg = ActionController::Base.helpers.content_tag(
           :strong, t('idv.messages.phone.phone_of_record')
         )

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -62,7 +62,7 @@ module Idv
     end
 
     def flash_message_content
-      unless idv_session.address_verification_mechanism == 'gpo'
+      if idv_session.address_verification_mechanism != 'gpo'
         phone_of_record_msg = ActionController::Base.helpers.content_tag(
           :strong, t('idv.messages.phone.phone_of_record')
         )

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -173,6 +173,7 @@ describe Idv::ConfirmationsController do
       it 'assigns step indicator steps with pending status' do
         get :show
 
+        expect(flash.now[:success]).to eq t('idv.messages.mail_sent')
         expect(assigns(:step_indicator_steps)).to include(
           hash_including(name: :verify_phone_or_address, status: :pending),
         )

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -226,14 +226,6 @@ describe Idv::ReviewController do
         idv_session.address_verification_mechanism = 'gpo'
       end
 
-      it 'displays a helpful flash message to the user' do
-        get :new
-
-        expect(flash.now[:success]).to eq(
-          t('idv.messages.mail_sent'),
-        )
-      end
-
       it 'shows revises steps to show pending address verification' do
         get :new
 
@@ -254,7 +246,6 @@ describe Idv::ReviewController do
       it 'displays a success message' do
         get :new
 
-        expect(flash.now[:success]).to eq t('idv.messages.mail_sent')
         expect(flash.now[:error]).to be_nil
       end
     end


### PR DESCRIPTION
Slack thread: https://gsa-tts.slack.com/archives/CEUQ9FXNJ/p1625064906009000

During identity proofing, if you choose to receive a GPO letter for address verification, you will see a `Your letter is on its way` before the letter is actually queued, leading to confusing and drop-off. This PR is a smaller fix that moves the message until after the password has been entered and the letter has been queued.

| Before | After |
------|-----
|![image](https://user-images.githubusercontent.com/1430443/123988577-bed24700-d98d-11eb-9004-84d90699783d.png)|![image](https://user-images.githubusercontent.com/1430443/123988577-bed24700-d98d-11eb-9004-84d90699783d.png)|
|![image](https://user-images.githubusercontent.com/1430443/123988768-e6291400-d98d-11eb-82d3-55dce6c91ad8.png)|![image](https://user-images.githubusercontent.com/1430443/123987736-0c9a7f80-d98d-11eb-95d0-526e79c04fe3.png)|
|![image](https://user-images.githubusercontent.com/1430443/123989056-24bece80-d98e-11eb-8ecc-28bcb67f8c0d.png)|![image](https://user-images.githubusercontent.com/1430443/123988012-43709580-d98d-11eb-931c-c0385b5ebc03.png)|
