### PR TITLE
Block null bytes at the middleware layer

### DIFF
--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -9,9 +9,9 @@ class Utf8Sanitizer
   def call(env)
     parser = RackRequestParser.new(Rack::Request.new(env))
 
-    if has_invalid_strings(parser.values_to_check) ||
+    if contains_invalid_strings?(parser.values_to_check) ||
        params_have_null_byte?(parser.request.params) ||
-       has_null_byte?(parser.request.body)
+       contains_null_byte?(parser.request.body)
       return bad_request_and_log(invalid_utf8_event(env, parser.request))
     end
 
@@ -26,21 +26,21 @@ class Utf8Sanitizer
 
   # @param [Hash] params
   def params_have_null_byte?(params)
-    params.values.any? { |value| has_null_byte?(value) }
+    params.values.any? { |value| contains_null_byte?(value) }
   end
 
-  def has_null_byte?(param)
+  def contains_null_byte?(param)
     case param
     when Hash
-      param.values.any? { |value| has_null_byte?(value) }
+      param.values.any? { |value| contains_null_byte?(value) }
     when Array
-      param.any? { |value| has_null_byte?(value) }
+      param.any? { |value| contains_null_byte?(value) }
     when String
       param.include?("\x00")
     end
   end
 
-  def has_invalid_strings(values)
+  def contains_invalid_strings?(values)
     string_values(values).any? { |string| invalid_string?(string) }
   end
 

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -10,8 +10,7 @@ class Utf8Sanitizer
     parser = RackRequestParser.new(Rack::Request.new(env))
 
     if contains_invalid_strings?(parser.values_to_check) ||
-       params_have_null_byte?(parser.request.params) ||
-       contains_null_byte?(parser.request.body)
+       contains_null_byte?(parser.request.params)
       return bad_request_and_log(invalid_utf8_event(env, parser.request))
     end
 
@@ -23,11 +22,6 @@ class Utf8Sanitizer
   end
 
   private
-
-  # @param [Hash] params
-  def params_have_null_byte?(params)
-    params.values.any? { |value| contains_null_byte?(value) }
-  end
 
   def contains_null_byte?(param)
     case param

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -32,7 +32,7 @@ class Utf8Sanitizer
   def contains_null_byte?(param)
     case param
     when Hash
-      param.values.any? { |value| contains_null_byte?(value) }
+      param.any? { |key, value| contains_null_byte?(key) || contains_null_byte?(value) }
     when Array
       param.any? { |value| contains_null_byte?(value) }
     when String

--- a/spec/lib/utf8_sanitizer_spec.rb
+++ b/spec/lib/utf8_sanitizer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Utf8Sanitizer do
     end
 
     it 'blocks null bytes in the params' do
-      post '/test', params: { some: { value: "\x00" } }
+      post '/test', params: { some: [ 'aaa', { value: "\x00" } ] }
       expect(last_response).to be_bad_request
     end
 

--- a/spec/lib/utf8_sanitizer_spec.rb
+++ b/spec/lib/utf8_sanitizer_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Utf8Sanitizer do
+  include Rack::Test::Methods
+
+  let(:inner_app) do
+    proc { |env| [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
+  end
+
+  subject(:app) { Utf8Sanitizer.new(inner_app) }
+
+  context 'with valid strings' do
+    it 'passes through' do
+      post '/test', body: 'hiii', params: { hi: 'hiii' }
+
+      expect(last_response).to be_ok
+    end
+  end
+
+  context 'with invalid utf8' do
+    it '400s' do
+      get '/test', params: { hi: "hi \xFFFFFFFFFFFF" }
+      expect(last_response).to be_bad_request
+    end
+  end
+end

--- a/spec/lib/utf8_sanitizer_spec.rb
+++ b/spec/lib/utf8_sanitizer_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Utf8Sanitizer do
       expect(last_response).to be_bad_request
     end
 
+    it 'blocks null bytes in the keys of params' do
+      post '/test', params: { "key_\x00" => 'value' }
+      expect(last_response).to be_bad_request
+    end
+
     it 'blocks null bytes in the body' do
       post '/test', body: "\x00"
       expect(last_response).to be_bad_request

--- a/spec/lib/utf8_sanitizer_spec.rb
+++ b/spec/lib/utf8_sanitizer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Utf8Sanitizer do
       expect(last_response).to be_bad_request
     end
 
-    it 'blocks null bytes in the body' do
+    it 'blocks null bytes inside the body' do
       post '/test', body: "\x00"
       expect(last_response).to be_bad_request
     end


### PR DESCRIPTION
As part of https://github.com/18F/identity-idp/pull/5187, that removes a common method that checks for null bytes in Service Provider issuer field

So we have a few approaches:
1. keep `ServiceProvider.from_issuer` so we can check null bytes there, and hope nobody tries to send null bytes to our DB any other spot
2. block all null bytes in params
3. monkeypatch ActiveRecord to elide null bytes when writing to the DB

This goes for approach (2)

Draws inspo from: http://joshfrankel.me/blog/recursively-validate-application-requests-with-rack/