### PR TITLE
LG-4143: Include reference in InstantVerify result

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -63,6 +63,7 @@ class ResolutionProofingJob < ApplicationJob
     resolution_success = proofer_result.success?
 
     result[:transaction_id] = proofer_result.transaction_id
+    result[:reference] = proofer_result.reference
 
     exception = proofer_result.exception.inspect if proofer_result.exception
     result[:timed_out] = proofer_result.timed_out?
@@ -79,6 +80,7 @@ class ResolutionProofingJob < ApplicationJob
           success: proofer_result.success?,
           timed_out: proofer_result.timed_out?,
           transaction_id: proofer_result.transaction_id,
+          reference: proofer_result.reference,
         },
       },
     }
@@ -147,9 +149,11 @@ class ResolutionProofingJob < ApplicationJob
         success: lexisnexis_result.success?,
         timed_out: lexisnexis_result.timed_out?,
         transaction_id: lexisnexis_result.transaction_id,
+        reference: lexisnexis_result.reference,
       }
 
       result[:transaction_id] = lexisnexis_result.transaction_id
+      result[:reference] = lexisnexis_result.reference
       result[:timed_out] = lexisnexis_result.timed_out?
       result[:exception] = lexisnexis_result.exception.inspect if lexisnexis_result.exception
     end

--- a/app/services/proofing/lexis_nexis/proofer.rb
+++ b/app/services/proofing/lexis_nexis/proofer.rb
@@ -31,6 +31,7 @@ module Proofing
       def proof_applicant(applicant, result)
         response = send_verification_request(applicant)
         result.transaction_id = response.conversation_id
+        result.reference = response.reference
         return if response.verification_status == 'passed'
 
         response.verification_errors.each do |key, error_message|

--- a/app/services/proofing/mock/resolution_mock_client.rb
+++ b/app/services/proofing/mock/resolution_mock_client.rb
@@ -12,6 +12,7 @@ module Proofing
       UNVERIFIABLE_ZIP_CODE = '00000'
       NO_CONTACT_SSN = '000-00-0000'
       TRANSACTION_ID = 'resolution-mock-transaction-id-123'
+      REFERENCE = 'aaa-bbb-ccc'
 
       proof do |applicant, result|
         first_name = applicant[:first_name]
@@ -34,6 +35,7 @@ module Proofing
         end
 
         result.transaction_id = TRANSACTION_ID
+        result.reference = REFERENCE
       end
     end
   end

--- a/app/services/proofing/result.rb
+++ b/app/services/proofing/result.rb
@@ -1,14 +1,22 @@
 module Proofing
   class Result
     attr_reader :exception
-    attr_accessor :context, :transaction_id
+    attr_accessor :context, :transaction_id, :reference
 
-    def initialize(errors: {}, messages: Set.new, context: {}, exception: nil, transaction_id: nil)
+    def initialize(
+      errors: {},
+      messages: Set.new,
+      context: {},
+      exception: nil,
+      transaction_id: nil,
+      reference: nil
+    )
       @errors = errors
       @messages = messages
       @context = context
       @exception = exception
       @transaction_id = transaction_id
+      @reference = reference
     end
 
     # rubocop:disable Style/OptionalArguments

--- a/spec/services/proofing/result_spec.rb
+++ b/spec/services/proofing/result_spec.rb
@@ -137,4 +137,15 @@ describe Proofing::Result do
       end
     end
   end
+
+  describe 'reference' do
+    context 'when provided' do
+      it 'is present' do
+        reference = SecureRandom.uuid
+        result = Proofing::Result.new
+        result.reference = reference
+        expect(result.reference).to eq(reference)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -1,6 +1,7 @@
 shared_examples 'a lexisnexis proofer' do
   let(:verification_status) { 'passed' }
   let(:conversation_id) { 'foo' }
+  let(:reference) { SecureRandom.uuid }
   let(:verification_errors) { {} }
   let(:result) { Proofing::Result.new }
 
@@ -8,6 +9,7 @@ shared_examples 'a lexisnexis proofer' do
     response = instance_double(Proofing::LexisNexis::Response)
     allow(response).to receive(:verification_status).and_return(verification_status)
     allow(response).to receive(:conversation_id).and_return(conversation_id)
+    allow(response).to receive(:reference).and_return(reference)
     allow(response).to receive(:verification_errors).and_return(verification_errors)
 
     allow(verification_request).to receive(:send).and_return(response)
@@ -24,6 +26,7 @@ shared_examples 'a lexisnexis proofer' do
         expect(result.success?).to eq(true)
         expect(result.errors).to be_empty
         expect(result.transaction_id).to eq(conversation_id)
+        expect(result.reference).to eq(reference)
       end
     end
 
@@ -42,6 +45,7 @@ shared_examples 'a lexisnexis proofer' do
           Discovery: ['another test error'],
         )
         expect(result.transaction_id).to eq(conversation_id)
+        expect(result.reference).to eq(reference)
       end
     end
   end


### PR DESCRIPTION
**Why**: So that it is included in logging and we can associate requests with responses.