### PR TITLE
Do not check Redis for SP request if string is blank

### DIFF
--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -24,7 +24,7 @@ class ServiceProviderRequestProxy
   end
 
   def self.find_by(uuid:)
-    return unless uuid
+    return if uuid.blank?
     obj = REDIS_POOL.with { |client| client.read(key(uuid)) }
     obj ? hash_to_spr(obj, uuid) : nil
   end


### PR DESCRIPTION
Minor optimization to avoid hitting Redis unnecessarily. When checking for an SP request, the uuid defaults to `""`, not `nil`, which leads to a lot of Redis queries like this:

```
1625233088.659499 [0 127.0.0.1:65419] "get" "spr:"
```

This PR changes the logic to also skip if the query if the uuid is an empty string.

