### PR TITLE
LG-4263: log state with aamva results

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -32,7 +32,7 @@ module Idv
         doc_pii_response = validate_pii_from_doc(client_response) if client_response.success?
       end
 
-      return determine_response(
+      determine_response(
         form_response: form_response,
         client_response: client_response,
         doc_pii_response: doc_pii_response,

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -43,7 +43,9 @@ module Idv
         idv_session['resolution_successful'] = 'phone'
       end
 
-      def idv_result_to_form_response(idv_result)
+      def idv_result_to_form_response(idv_result:, state: nil)
+        state_id = idv_result.dig(:context, :stages, :state_id)
+        state_id[:state] = state if state && state_id
         FormResponse.new(
           success: idv_success(idv_result),
           errors: idv_errors(idv_result),

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -28,7 +28,10 @@ module Idv
 
       def async_state_done(current_async_state)
         add_proofing_costs(current_async_state.result)
-        form_response = idv_result_to_form_response(current_async_state.result)
+        form_response = idv_result_to_form_response(
+          idv_result: current_async_state.result,
+          state: flow_session[:pii_from_doc][:state],
+        )
         if form_response.success?
           response = check_ssn(flow_session[:pii_from_doc]) if form_response.success?
           form_response = form_response.merge(response)

--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -126,10 +126,6 @@ module Proofing
         end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
-        def uuid
-          SecureRandom.uuid
-        end
-
         def timeout
           (config.verification_request_timeout || 5).to_i
         end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -183,7 +183,7 @@ feature 'doc auth verify step' do
     end
   end
 
-  context 'when the user lives in an AAMVA unsupported state' do
+  context 'when the user does not live in an AAMVA supported state' do
     it 'does not perform the state ID check' do
       agent = instance_double(Idv::Agent)
       allow(Idv::Agent).to receive(:new).and_return(agent)


### PR DESCRIPTION
This PR includes the state with the logged aamva data. There aren't existing unit tests for the verify_wait_step_show so testing this is much more work than doing the work. Future work to write unit specs should be considered.