### PR TITLE
Fix smoke tests to not worry about curly/straight quotes

### DIFF
--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
   end
 
   def on_consent_screen?
-    page.has_content?("been a year since you gave us consent") ||
+    page.has_content?('been a year since you gave us consent') ||
       page.has_content?('You are now signing in for the first time')
   end
 end

--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
   end
 
   def on_consent_screen?
-    page.has_content?("It's been a year since you gave us consent") ||
+    page.has_content?("been a year since you gave us consent") ||
       page.has_content?('You are now signing in for the first time')
   end
 end


### PR DESCRIPTION
**Scenario**: the smoke test accounts are running against the the 1-year consent page

- We have code to handle this scenario, but only with a straight quote
- As of #4954 we started using curly quotes in copy, so this messes up the code

**Solution**: remove "it's" from the copy we check for

<img width="689" alt="Screen Shot 2021-07-09 at 11 13 30 AM" src="https://user-images.githubusercontent.com/458784/125120103-db196680-e0a6-11eb-902d-56ce777285d2.png">
