### PR TITLE
remove checks for SAML 2019/2020 artifacts

### DIFF
--- a/config/initializers/app_artifacts.rb
+++ b/config/initializers/app_artifacts.rb
@@ -1,10 +1,6 @@
 require 'app_artifacts'
 
 AppArtifacts.setup do |store|
-  store.add_artifact(:saml_2019_cert, '/%<env>s/saml2019.crt')
-  store.add_artifact(:saml_2019_key, '/%<env>s/saml2019.key.enc')
-  store.add_artifact(:saml_2020_cert, '/%<env>s/saml2020.crt')
-  store.add_artifact(:saml_2020_key, '/%<env>s/saml2020.key.enc')
   store.add_artifact(:saml_2021_cert, '/%<env>s/saml2021.crt')
   store.add_artifact(:saml_2021_key, '/%<env>s/saml2021.key.enc')
 


### PR DESCRIPTION
Since we're (finally!) retiring the 2019 and 2020 SAML certs, these files [were removed from the `build-keys` file in `identity-devops`](https://github.com/18F/identity-devops/pull/3611/files), so they're no longer copied from `dev` when running `create-sandbox`. As a result, however, the IdP deploy/activate fails on new hosts -- in a new sandbox -- trying to obtain those artifacts.

This PR takes care of things on the application side, removing them from the list of artifacts to obtain during initialization.

Addresses https://github.com/18F/identity-devops/issues/3165