### PR TITLE
skip sp query if issuer is blank

### DIFF
--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -26,11 +26,12 @@ module Db
           NewRelic::Agent.notice_error(SpCostTypeError.new(token.to_s))
           return
         end
-        agency_id = (issuer.present? && ServiceProvider.find_by(issuer: issuer)&.agency_id) || 0
+        service_provider = issuer.present? ? ServiceProvider.find_by(issuer: issuer) : nil
+        agency_id = service_provider&.agency_id || 0
         current_user = User.find_by(id: user_id)
         ial_context = IalContext.new(
           ial: ial,
-          service_provider: ServiceProvider.find_by(issuer: issuer),
+          service_provider: service_provider,
           user: current_user,
         )
         ::SpCost.create(


### PR DESCRIPTION
The first `ServiceProvider.find_by(issuer: issuer)` short circuits if the issuer is blank, and we can do it for the same query later in the method.

Somewhat related question, do we need to log SP costs when no SP is present?