### PR TITLE
LG-4443: Set default liveness requirement by previous profile

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
   def liveness_checking_enabled?
     return false if !FeatureManagement.liveness_checking_enabled?
     return sp_session[:ial2_strict] if sp_session.key?(:ial2_strict)
-    !!current_user && current_user.profiles.verified.any?(&:includes_liveness_check?)
+    !!current_user&.decorate&.password_reset_profile&.includes_liveness_check?
   end
 
   def cancel_link_text

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,8 +31,9 @@ module ApplicationHelper
   end
 
   def liveness_checking_enabled?
-    FeatureManagement.liveness_checking_enabled? &&
-      (sp_session[:issuer].blank? || sp_session[:ial2_strict])
+    return false if !FeatureManagement.liveness_checking_enabled?
+    return sp_session[:ial2_strict] if sp_session.key?(:ial2_strict)
+    !!current_user && current_user.profiles.verified.any?(&:includes_liveness_check?)
   end
 
   def cancel_link_text

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -113,7 +113,9 @@ module Idv
       end
 
       def liveness_checking_enabled?
-        FeatureManagement.liveness_checking_enabled? && (no_sp? || sp_session[:ial2_strict])
+        return false if !FeatureManagement.liveness_checking_enabled?
+        return sp_session[:ial2_strict] if sp_session.key?(:ial2_srict)
+        current_user.profiles.verified.any?(&:includes_liveness_check?)
       end
 
       def create_document_capture_session(key)
@@ -132,10 +134,6 @@ module Idv
         @document_capture_session ||= DocumentCaptureSession.find_by(
           uuid: flow_session[document_capture_session_uuid_key],
         )
-      end
-
-      def no_sp?
-        sp_session[:issuer].blank?
       end
 
       def document_capture_session_uuid_key

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -115,7 +115,7 @@ module Idv
       def liveness_checking_enabled?
         return false if !FeatureManagement.liveness_checking_enabled?
         return sp_session[:ial2_strict] if sp_session.key?(:ial2_strict)
-        current_user.profiles.verified.any?(&:includes_liveness_check?)
+        !!current_user.decorate.password_reset_profile&.includes_liveness_check?
       end
 
       def create_document_capture_session(key)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -114,7 +114,7 @@ module Idv
 
       def liveness_checking_enabled?
         return false if !FeatureManagement.liveness_checking_enabled?
-        return sp_session[:ial2_strict] if sp_session.key?(:ial2_srict)
+        return sp_session[:ial2_strict] if sp_session.key?(:ial2_strict)
         current_user.profiles.verified.any?(&:includes_liveness_check?)
       end
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,6 +1,6 @@
 <%= render(
       'idv/shared/error',
-      heading: FeatureManagement.liveness_checking_enabled? && sp_session[:ial2_strict].presence ?
+      heading: liveness_checking_enabled? ?
         t('errors.doc_auth.throttled_heading_liveness') :
         t('errors.doc_auth.throttled_heading'),
       options: [

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,7 +115,7 @@ describe ApplicationHelper do
                 :profile,
                 :verified,
                 deactivation_reason: :password_reset,
-                proofing_components: { liveness_check: true }.to_json,
+                proofing_components: { liveness_check: DocAuthRouter.doc_auth_vendor }.to_json,
               ),
             ],
           )

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,21 +57,19 @@ describe ApplicationHelper do
     context 'feature enabled' do
       let(:liveness_checking_enabled) { true }
 
-      context 'sp session value set' do
-        context 'sp does not request liveness' do
-          let(:sp_session) { { ial2_strict: false } }
+      context 'sp requests no liveness' do
+        let(:sp_session) { { ial2_strict: false } }
 
-          it 'returns false' do
-            expect(helper.liveness_checking_enabled?).to eq(false)
-          end
+        it 'returns false' do
+          expect(helper.liveness_checking_enabled?).to eq(false)
         end
+      end
 
-        context 'sp requests liveness' do
-          let(:sp_session) { { ial2_strict: true } }
+      context 'sp requests liveness' do
+        let(:sp_session) { { ial2_strict: true } }
 
-          it 'returns true' do
-            expect(helper.liveness_checking_enabled?).to eq(true)
-          end
+        it 'returns true' do
+          expect(helper.liveness_checking_enabled?).to eq(true)
         end
       end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -79,8 +79,27 @@ describe ApplicationHelper do
         end
       end
 
-      context 'current user has no profiles with liveness' do
+      context 'current user has no profiles' do
         let(:current_user) { create(:user) }
+
+        it 'returns false' do
+          expect(helper.liveness_checking_enabled?).to eq(false)
+        end
+      end
+
+      context 'current user has no profiles with liveness' do
+        let(:current_user) do
+          create(
+            :user,
+            profiles: [
+              create(
+                :profile,
+                :verified,
+                deactivation_reason: :password_reset,
+              ),
+            ],
+          )
+        end
 
         it 'returns false' do
           expect(helper.liveness_checking_enabled?).to eq(false)

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -3,14 +3,11 @@ require 'rails_helper'
 describe 'idv/session_errors/throttled.html.erb' do
   let(:sp_name) { nil }
   let(:liveness_checking_enabled) { false }
-  let(:sp_session) { {} }
 
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
-    allow(FeatureManagement).to receive(:liveness_checking_enabled?).
-      and_return(liveness_checking_enabled)
-    allow(view).to receive(:sp_session).and_return(sp_session)
+    allow(view).to receive(:liveness_checking_enabled?).and_return(liveness_checking_enabled)
 
     render
   end
@@ -51,20 +48,8 @@ describe 'idv/session_errors/throttled.html.erb' do
   context 'with liveness feature enabled' do
     let(:liveness_checking_enabled) { true }
 
-    context 'without strict ial2' do
-      let(:sp_session) { {} }
-
-      it 'renders expected heading' do
-        expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
-      end
-    end
-
-    context 'with strict ial2' do
-      let(:sp_session) { { ial2_strict: true } }
-
-      it 'renders expected heading' do
-        expect(rendered).to have_text(t('errors.doc_auth.throttled_heading_liveness'))
-      end
+    it 'renders expected heading' do
+      expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
     end
   end
 end


### PR DESCRIPTION
**Why**: In environments where liveness is enabled, change default to require liveness only if explicitly requested by the SP. Absent an associated SP for the current session (e.g. password reset reverification), require selfie only if it had been checked previously.

General notes:

- The duplication between ApplicationHelper and DocAuthBaseStep isn't great. I'd initially wanted to remove this method from ApplicationHelper altogether, as it doesn't seem like something we should need to have globally available. However, we reference it in quite a few places, so it's non-trivial to move elsewhere. And it's not entirely clear where a best place for it would be. It might be nice if we could initialize this computed value at the start of the proofing flow and reference it from there (e.g. `flow_session`).