### PR TITLE
Send doc auth warnings to events.log (LG-4799)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.10.1' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', branch: 'margolis-warning-not-exception' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', branch: 'margolis-warning-not-exception' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.11.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 2b1992d83e6a152b2234a5b71b9682d5f89635aa
-  tag: v0.10.1
+  revision: 4b6e5831b8473d62fa0d47429eb0c17a2e6e3c40
+  branch: margolis-warning-not-exception
   specs:
-    identity-doc-auth (0.10.1)
+    identity-doc-auth (0.11.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 4b6e5831b8473d62fa0d47429eb0c17a2e6e3c40
-  branch: margolis-warning-not-exception
+  revision: bfac07129eceb5193f38ef6dde2a864a724940b9
+  tag: v0.11.0
   specs:
     identity-doc-auth (0.11.0)
       activesupport

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -155,7 +155,9 @@ module Idv
     end
 
     def doc_auth_client
-      @doc_auth_client ||= DocAuthRouter.client
+      @doc_auth_client ||= DocAuthRouter.client(
+        warn_notifier: proc { |attrs| track_event(Analytics::DOC_AUTH_WARNING, attrs) },
+      )
     end
 
     def as_readable(image_key)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -84,6 +84,7 @@ class Analytics
   AUTHENTICATION_CONFIRMATION = 'Authentication Confirmation'.freeze
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended
   DOC_AUTH_ASYNC = 'Doc Auth Async'.freeze
+  DOC_AUTH_WARNING = 'Doc Auth Warning'.freeze
   DOCUMENT_CAPTURE_SESSION_OVERWRITTEN = 'Document Capture Session Overwritten'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_DELETION_REQUEST = 'Email Deletion Requested'.freeze

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -144,7 +144,8 @@ module DocAuthRouter
     end
   end
 
-  def self.client
+  # @param [Proc,nil] warn_notifier proc takes a hash, and should log that hash to events.log
+  def self.client(warn_notifier: nil)
     case doc_auth_vendor
     when 'acuant'
       DocAuthErrorTranslatorProxy.new(
@@ -157,6 +158,7 @@ module DocAuthRouter
           passlive_url: IdentityConfig.store.acuant_passlive_url,
           timeout: IdentityConfig.store.acuant_timeout,
           exception_notifier: method(:notify_exception),
+          warn_notifier: warn_notifier,
           dpi_threshold: IdentityConfig.store.doc_auth_error_dpi_threshold,
           sharpness_threshold: IdentityConfig.store.doc_auth_error_sharpness_threshold,
           glare_threshold: IdentityConfig.store.doc_auth_error_glare_threshold,
@@ -175,6 +177,7 @@ module DocAuthRouter
           trueid_username: IdentityConfig.store.lexisnexis_trueid_username,
           timeout: IdentityConfig.store.lexisnexis_timeout,
           exception_notifier: method(:notify_exception),
+          warn_notifier: warn_notifier,
           locale: I18n.locale,
           dpi_threshold: IdentityConfig.store.doc_auth_error_dpi_threshold,
           sharpness_threshold: IdentityConfig.store.doc_auth_error_sharpness_threshold,
@@ -182,7 +185,11 @@ module DocAuthRouter
         ),
       )
     when 'mock'
-      DocAuthErrorTranslatorProxy.new(IdentityDocAuth::Mock::DocAuthMockClient.new)
+      DocAuthErrorTranslatorProxy.new(
+        IdentityDocAuth::Mock::DocAuthMockClient.new(
+          warn_notifier: warn_notifier,
+        ),
+      )
     else
       raise "#{doc_auth_vendor} is not a valid doc auth vendor"
     end

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -58,7 +58,11 @@ module Idv
       def post_images
         return throttled_response if throttled_else_increment
 
-        result = DocAuthRouter.client.post_images(
+        result = DocAuthRouter.client(
+          warn_notifier: proc do |attrs|
+            @flow.analytics.track_event(Analytics::DOC_AUTH_WARNING, attrs)
+          end,
+        ).post_images(
           front_image: front_image.read,
           back_image: back_image.read,
           selfie_image: selfie_image&.read,

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -215,6 +215,24 @@ feature 'doc capture document capture step' do
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
     end
 
+    it 'logs a warning event when there are unknown errors in the response' do
+      Tempfile.create(['ia2_mock', '.yml']) do |yml_file|
+        yml_file.rewind
+        yml_file.puts <<~YAML
+          failed_alerts:
+          - name: Some Made Up Error
+        YAML
+        yml_file.close
+
+        attach_file 'doc_auth_front_image', yml_file.path
+        attach_file 'doc_auth_back_image', yml_file.path
+        attach_file 'doc_auth_selfie_image', yml_file.path
+        click_idv_continue
+      end
+
+      expect(fake_analytics).to have_logged_event(Analytics::DOC_AUTH_WARNING, {})
+    end
+
     it 'proceeds to the next page with valid info and logs analytics info' do
       attach_and_submit_images
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
+    context 'image data returns unknown errors' do
+      let(:back_image) do
+        Rack::Test::UploadedFile.new(StringIO.new(<<~YAML), original_filename: 'ial2.yml')
+          failed_alerts:
+          - name: Some Made Up Error
+        YAML
+      end
+
+      it 'logs a doc auth warning' do
+        form.submit
+
+        expect(fake_analytics).to have_logged_event(Analytics::DOC_AUTH_WARNING, {})
+      end
+    end
+
     context 'invalid metadata shape' do
       let(:back_image_metadata) { '{' }
 

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe DocumentProofingJob, type: :job do
       let(:doc_auth_client) { instance_double(IdentityDocAuth::Acuant::AcuantClient) }
 
       before do
-        allow(instance).to receive(:doc_auth_client).and_return(doc_auth_client)
+        allow(instance).to receive(:build_doc_auth_client).and_return(doc_auth_client)
 
         expect(doc_auth_client).to receive(:post_images).
           and_return(IdentityDocAuth::Response.new(success: false, exception: RuntimeError.new))


### PR DESCRIPTION
- Before, these would be reported as exceptions to
  NewRelic, which could be noisy, since they are not
  necessarily critical.

- This, along with 18f/identity-doc-auth#25, updates
  to add a new warning_notifier config option we can pass
  around.