### PR TITLE
LG-4796: Set Acuant cropping mode by image source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.11.0' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.12.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.2-18f' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: bfac07129eceb5193f38ef6dde2a864a724940b9
-  tag: v0.11.0
+  revision: 27efe0fc8188da2911e2bc349e59cb3f4257fad2
+  tag: v0.12.0
   specs:
-    identity-doc-auth (0.11.0)
+    identity-doc-auth (0.12.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -72,6 +72,7 @@ module Idv
         back_image: back.read,
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
+        cropping_mode: cropping_mode,
       )
       response.extra.merge!(extra_attributes)
       response.extra[:state] = response.pii_from_doc[:state]
@@ -118,6 +119,14 @@ module Idv
 
     def liveness_checking_enabled?
       @liveness_checking_enabled
+    end
+
+    def cropping_mode
+      if acuant_sdk_capture?
+        IdentityDocAuth::CroppingModes::NONE
+      else
+        IdentityDocAuth::CroppingModes::ALWAYS
+      end
     end
 
     def front
@@ -192,8 +201,13 @@ module Idv
       )
     end
 
+    def acuant_sdk_capture?
+      image_metadata.dig(:front, :source) == 'acuant' &&
+        image_metadata.dig(:back, :source) == 'acuant'
+    end
+
     def image_metadata
-      params.permit(:front_image_metadata, :back_image_metadata).
+      @image_metadata ||= params.permit(:front_image_metadata, :back_image_metadata).
         to_h.
         transform_values do |str|
           JSON.parse(str)

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -49,8 +49,8 @@ module Idv
           verify_document_capture_session,
           liveness_checking_enabled: liveness_checking_enabled?,
           trace_id: amzn_trace_id,
+          image_metadata: image_metadata,
           analytics_data: {
-            client_image_metrics: image_metadata,
             browser_attributes: @flow.analytics.browser_attributes,
           },
         )

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -41,8 +41,13 @@ module Idv
       )
     end
 
-    def proof_document(document_capture_session, liveness_checking_enabled:, trace_id:,
-                       analytics_data:)
+    def proof_document(
+      document_capture_session,
+      liveness_checking_enabled:,
+      trace_id:,
+      image_metadata:,
+      analytics_data:
+    )
       encrypted_arguments = Encryption::Encryptors::SessionEncryptor.new.encrypt(
         { document_arguments: @applicant }.to_json,
       )
@@ -52,6 +57,7 @@ module Idv
         liveness_checking_enabled: liveness_checking_enabled,
         result_id: document_capture_session.result_id,
         trace_id: trace_id,
+        image_metadata: image_metadata,
         analytics_data: analytics_data,
       )
     end

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -67,6 +67,7 @@ module Idv
           back_image: back_image.read,
           selfie_image: selfie_image&.read,
           liveness_checking_enabled: liveness_checking_enabled?,
+          cropping_mode: IdentityDocAuth::CroppingModes::ALWAYS, # No-JS flow doesn't use Acuant SDK
         )
         # DP: should these cost recordings happen in the doc_auth_client?
         add_costs(result)

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -73,6 +73,11 @@ feature 'doc auth document capture step' do
     end
 
     it 'proceeds to the next page with valid info and logs analytics info' do
+      expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
+        to receive(:post_images).
+        with(hash_including(cropping_mode: IdentityDocAuth::CroppingModes::ALWAYS)).
+        and_call_original
+
       attach_and_submit_images
 
       expect(page).to have_current_path(next_step)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -215,5 +215,63 @@ RSpec.describe Idv::ApiImageUploadForm do
         expect(response.errors[:doc_pii]).to eq('bad')
       end
     end
+
+    describe 'cropping mode' do
+      let(:source) { nil }
+      let(:front_image_metadata) do
+        { width: 40, height: 40, mimeType: 'image/png', source: source }.to_json
+      end
+      let(:back_image_metadata) do
+        { width: 20, height: 20, mimeType: 'image/png', source: source }.to_json
+      end
+      let(:cropping_mode) { nil }
+
+      before do
+        expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
+          to receive(:post_images).
+          with(hash_including(cropping_mode: cropping_mode)).
+          and_call_original
+      end
+
+      context 'manual uploads' do
+        let(:source) { 'upload' }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          form.submit
+        end
+      end
+
+      context 'mixed sources' do
+        let(:source) { 'upload' }
+        let(:back_image_metadata) do
+          { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
+        end
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          form.submit
+        end
+      end
+
+      context 'acuant images' do
+        let(:source) { 'acuant' }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::NONE }
+
+        it 'sets cropping mode to none' do
+          form.submit
+        end
+      end
+
+      context 'malformed image metadata' do
+        let(:source) { 'upload' }
+        let(:front_image_metadata) { nil.to_json }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          form.submit
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe DocumentProofingJob, type: :job do
   let(:back_image_iv) { SecureRandom.random_bytes(12) }
   let(:selfie_image_iv) { SecureRandom.random_bytes(12) }
   let(:trace_id) { SecureRandom.uuid }
+  let(:source) { nil }
+  let(:front_image_metadata) { { mimeType: 'image/png', source: source } }
+  let(:back_image_metadata) { { mimeType: 'image/png', source: source } }
+  let(:image_metadata) { { front: front_image_metadata, back: back_image_metadata } }
   let(:liveness_checking_enabled) { true }
 
   let(:applicant_pii) do
@@ -58,6 +62,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         liveness_checking_enabled: liveness_checking_enabled,
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
+        image_metadata: image_metadata,
         analytics_data: {},
       )
 
@@ -74,6 +79,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         liveness_checking_enabled: liveness_checking_enabled,
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
+        image_metadata: image_metadata,
         analytics_data: {},
       )
     end
@@ -223,6 +229,60 @@ RSpec.describe DocumentProofingJob, type: :job do
         expect(a_request(:get, front_image_url)).to have_been_made
         expect(a_request(:get, back_image_url)).to have_been_made
         expect(a_request(:get, selfie_image_url)).to have_been_made
+      end
+    end
+
+    describe 'cropping mode' do
+      let(:source) { nil }
+      let(:front_image_metadata) { { mimeType: 'image/png', source: source } }
+      let(:back_image_metadata) { { mimeType: 'image/png', source: source } }
+      let(:cropping_mode) { nil }
+
+      before do
+        expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
+          to receive(:post_images).
+          with(hash_including(cropping_mode: cropping_mode)).
+          and_call_original
+      end
+
+      context 'manual uploads' do
+        let(:source) { 'upload' }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          perform
+        end
+      end
+
+      context 'mixed sources' do
+        let(:source) { 'upload' }
+        let(:back_image_metadata) do
+          { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
+        end
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          perform
+        end
+      end
+
+      context 'acuant images' do
+        let(:source) { 'acuant' }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::NONE }
+
+        it 'sets cropping mode to none' do
+          perform
+        end
+      end
+
+      context 'malformed image metadata' do
+        let(:source) { 'upload' }
+        let(:front_image_metadata) { nil }
+        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+
+        it 'sets cropping mode to always' do
+          perform
+        end
       end
     end
   end


### PR DESCRIPTION
Depends on: https://github.com/18F/identity-doc-auth/pull/26

**Why**: The "automatic" cropping mode currently used is not recommended and may return more "Unknown" results. Instead, set cropping mode to one or the other of "None" or "Always" based on whether the image was captured using Acuant SDK (where cropping is assumed).