### PR TITLE
LG-4837: Set Acuant sensor type parameter by image source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.12.0' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.13.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 27efe0fc8188da2911e2bc349e59cb3f4257fad2
-  tag: v0.12.0
+  revision: adfb1f33e72af1db4987da3dccfe26e5b1bacf1f
+  tag: v0.13.0
   specs:
-    identity-doc-auth (0.12.0)
+    identity-doc-auth (0.13.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -72,7 +72,7 @@ module Idv
         back_image: back.read,
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
-        cropping_mode: cropping_mode,
+        image_source: image_source,
       )
       response.extra.merge!(extra_attributes)
       response.extra[:state] = response.pii_from_doc[:state]
@@ -121,11 +121,11 @@ module Idv
       @liveness_checking_enabled
     end
 
-    def cropping_mode
+    def image_source
       if acuant_sdk_capture?
-        IdentityDocAuth::CroppingModes::NONE
+        IdentityDocAuth::ImageSources::ACUANT_SDK
       else
-        IdentityDocAuth::CroppingModes::ALWAYS
+        IdentityDocAuth::ImageSources::UNKNOWN
       end
     end
 

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -51,7 +51,7 @@ class DocumentProofingJob < ApplicationJob
           front_image: front_image,
           back_image: back_image,
           selfie_image: selfie_image || '',
-          cropping_mode: cropping_mode(image_metadata),
+          image_source: image_source(image_metadata),
           liveness_checking_enabled: liveness_checking_enabled,
         )
       end
@@ -99,11 +99,11 @@ class DocumentProofingJob < ApplicationJob
     @encryption_helper ||= JobHelpers::EncryptionHelper.new
   end
 
-  def cropping_mode(image_metadata)
+  def image_source(image_metadata)
     if acuant_sdk_capture?(image_metadata)
-      IdentityDocAuth::CroppingModes::NONE
+      IdentityDocAuth::ImageSources::ACUANT_SDK
     else
-      IdentityDocAuth::CroppingModes::ALWAYS
+      IdentityDocAuth::ImageSources::UNKNOWN
     end
   end
 

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -67,7 +67,7 @@ module Idv
           back_image: back_image.read,
           selfie_image: selfie_image&.read,
           liveness_checking_enabled: liveness_checking_enabled?,
-          cropping_mode: IdentityDocAuth::CroppingModes::ALWAYS, # No-JS flow doesn't use Acuant SDK
+          image_source: IdentityDocAuth::ImageSources::UNKNOWN, # No-JS flow doesn't use Acuant SDK
         )
         # DP: should these cost recordings happen in the doc_auth_client?
         add_costs(result)

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -75,7 +75,7 @@ feature 'doc auth document capture step' do
     it 'proceeds to the next page with valid info and logs analytics info' do
       expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
         to receive(:post_images).
-        with(hash_including(cropping_mode: IdentityDocAuth::CroppingModes::ALWAYS)).
+        with(hash_including(image_source: IdentityDocAuth::ImageSources::UNKNOWN)).
         and_call_original
 
       attach_and_submit_images

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
-    describe 'cropping mode' do
+    describe 'image source' do
       let(:source) { nil }
       let(:front_image_metadata) do
         { width: 40, height: 40, mimeType: 'image/png', source: source }.to_json
@@ -224,20 +224,20 @@ RSpec.describe Idv::ApiImageUploadForm do
       let(:back_image_metadata) do
         { width: 20, height: 20, mimeType: 'image/png', source: source }.to_json
       end
-      let(:cropping_mode) { nil }
+      let(:image_source) { nil }
 
       before do
         expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
           to receive(:post_images).
-          with(hash_including(cropping_mode: cropping_mode)).
+          with(hash_including(image_source: image_source)).
           and_call_original
       end
 
       context 'manual uploads' do
         let(:source) { 'upload' }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           form.submit
         end
       end
@@ -247,18 +247,18 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:back_image_metadata) do
           { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
         end
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           form.submit
         end
       end
 
       context 'acuant images' do
         let(:source) { 'acuant' }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::NONE }
+        let(:image_source) { IdentityDocAuth::ImageSources::ACUANT_SDK }
 
-        it 'sets cropping mode to none' do
+        it 'sets image source to acuant sdk' do
           form.submit
         end
       end
@@ -266,9 +266,9 @@ RSpec.describe Idv::ApiImageUploadForm do
       context 'malformed image metadata' do
         let(:source) { 'upload' }
         let(:front_image_metadata) { nil.to_json }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           form.submit
         end
       end

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -232,24 +232,24 @@ RSpec.describe DocumentProofingJob, type: :job do
       end
     end
 
-    describe 'cropping mode' do
+    describe 'image source' do
       let(:source) { nil }
       let(:front_image_metadata) { { mimeType: 'image/png', source: source } }
       let(:back_image_metadata) { { mimeType: 'image/png', source: source } }
-      let(:cropping_mode) { nil }
+      let(:image_source) { nil }
 
       before do
         expect_any_instance_of(IdentityDocAuth::Mock::DocAuthMockClient).
           to receive(:post_images).
-          with(hash_including(cropping_mode: cropping_mode)).
+          with(hash_including(image_source: image_source)).
           and_call_original
       end
 
       context 'manual uploads' do
         let(:source) { 'upload' }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           perform
         end
       end
@@ -259,18 +259,18 @@ RSpec.describe DocumentProofingJob, type: :job do
         let(:back_image_metadata) do
           { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
         end
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           perform
         end
       end
 
       context 'acuant images' do
         let(:source) { 'acuant' }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::NONE }
+        let(:image_source) { IdentityDocAuth::ImageSources::ACUANT_SDK }
 
-        it 'sets cropping mode to none' do
+        it 'sets image source to acuant sdk' do
           perform
         end
       end
@@ -278,9 +278,9 @@ RSpec.describe DocumentProofingJob, type: :job do
       context 'malformed image metadata' do
         let(:source) { 'upload' }
         let(:front_image_metadata) { nil }
-        let(:cropping_mode) { IdentityDocAuth::CroppingModes::ALWAYS }
+        let(:image_source) { IdentityDocAuth::ImageSources::UNKNOWN }
 
-        it 'sets cropping mode to always' do
+        it 'sets image source to unknown' do
           perform
         end
       end


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5219, https://github.com/18F/identity-doc-auth/pull/27

**Why**: We currently hard-code this value as "Mobile" sensor, which could be causing higher failure rates for images not captured using the Acuant SDK. Instead, set "Mobile" only if the image source is Acuant SDK, otherwise "Unknown".