### PR TITLE
Bring back a default cert, to fix NoMethodErrors on nil

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -158,8 +158,10 @@ module SamlIdpAuthConcern
     if query_params[:skip_encryption].present? && current_service_provider&.skip_encryption_allowed
       nil
     elsif current_service_provider&.encrypt_responses?
+      cert = saml_request.service_provider.matching_cert ||
+             current_service_provider&.ssl_certs&.first
       {
-        cert: saml_request.service_provider.matching_cert,
+        cert: cert,
         block_encryption: current_service_provider&.block_encryption,
         key_transport: 'rsa-oaep-mgf1p',
       }


### PR DESCRIPTION
Previously: #5220

[NewRelic link](https://one.newrelic.com/launcher/nr1-core.explorer?platform%5BaccountId%5D=1376370&platform%5BtimeRange%5D%5Bduration%5D=1800000&platformVersion=release-2886&env=production&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJ0YWJsZSIsIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUd1aWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1UQTBOREV3TURZMSJ9&sidebars%5B0%5D=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TVRBME5ERXdNRFkxIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ)