### PR TITLE
LG-4812: dont maintain button spinner when validation error

### DIFF
--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -82,7 +82,6 @@ export class FormStepsWait {
 
     const { form } = this.elements;
     const { action, method } = form;
-    console.log(form)
     // Clear error, if present.
     this.renderError('');
 

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -71,6 +71,7 @@ export class FormStepsWait {
 
   bind() {
     this.elements.form.addEventListener('submit', (event) => this.handleSubmit(event));
+    this.elements.form.addEventListener('invalid', () => this.stopSpinner(), true);
   }
 
   /**
@@ -81,7 +82,7 @@ export class FormStepsWait {
 
     const { form } = this.elements;
     const { action, method } = form;
-
+    console.log(form)
     // Clear error, if present.
     this.renderError('');
 

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -170,10 +170,9 @@ describe('FormStepsWait', () => {
       });
       it('stops spinner', (done) => {
         new FormStepsWait(form).bind();
-        
-        fireEvent.invalid(form);
-        expect(form.checkValidity()).to.be.false();
         form.addEventListener('spinner.stop', () => done());
+
+        fireEvent.invalid(input);
       });
     });
 

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -7,7 +7,6 @@ import {
   isPollingPage,
   getPageErrorMessage,
 } from '../../../app/javascript/packs/form-steps-wait';
-import { expect } from 'chai';
 
 const POLL_PAGE_MARKUP = '<meta content="1" http-equiv="refresh">Example';
 const NON_POLL_PAGE_MARKUP = 'Example';
@@ -160,7 +159,6 @@ describe('FormStepsWait', () => {
     });
 
     context('invalid input', () => {
-
       let form;
       let input;
       beforeEach(() => {

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -7,6 +7,7 @@ import {
   isPollingPage,
   getPageErrorMessage,
 } from '../../../app/javascript/packs/form-steps-wait';
+import { expect } from 'chai';
 
 const POLL_PAGE_MARKUP = '<meta content="1" http-equiv="refresh">Example';
 const NON_POLL_PAGE_MARKUP = 'Example';
@@ -86,6 +87,7 @@ describe('FormStepsWait', () => {
         data-alert-target="#alert-target"
       >
         <div id="alert-target"></div>
+        <input type="text" id="text-name" aria-label="foo">
         <input type="hidden" name="foo" value="bar">
       </form>
     `;
@@ -154,6 +156,24 @@ describe('FormStepsWait', () => {
           const alert = await findByRole(form, 'alert');
           expect(alert.textContent).to.equal(errorMessage);
         });
+      });
+    });
+
+    context('invalid input', () => {
+
+      let form;
+      let input;
+      beforeEach(() => {
+        form = createForm({ action, method });
+        input = form.querySelector('#text-name');
+        input.setAttribute('required', '');
+      });
+      it('stops spinner', (done) => {
+        new FormStepsWait(form).bind();
+        
+        fireEvent.invalid(form);
+        expect(form.checkValidity()).to.be.false();
+        form.addEventListener('spinner.stop', () => done());
       });
     });
 


### PR DESCRIPTION
**Why**
Currently users are seeing a weird functionality where the button spinner still spins when the phone number validation fails for the input, this will make it so on form errors it will not keep spinning the buttons. 

**How**

Form will now check to see when its invalid and when it is via an input it will stop the spinner from spinning .