### PR TITLE
LG-4149: pick up the latest version of identity-doc-auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.12.0' }
+@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.13.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: 27efe0fc8188da2911e2bc349e59cb3f4257fad2
-  tag: v0.12.0
+  revision: adfb1f33e72af1db4987da3dccfe26e5b1bacf1f
+  tag: v0.13.0
   specs:
-    identity-doc-auth (0.12.0)
+    identity-doc-auth (0.13.0)
       activesupport
       faraday
       redacted_struct (>= 1.0.0)


### PR DESCRIPTION
Both LG-4149 and LG-4837 made updates to the doc auth gem v0.13.0, and this update simply pulls them into the IDP.