### PR TITLE
reduce lexis nexis timeout and do not retry

### DIFF
--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -14,9 +14,7 @@ class AddressProofingJob < ApplicationJob
     applicant_pii = decrypted_args[:applicant_pii]
 
     proofer_result = timer.time('address') do
-      with_retries(**faraday_retry_options) do
-        address_proofer.proof(applicant_pii)
-      end
+      address_proofer.proof(applicant_pii)
     end
 
     Db::SpCost::AddSpCost.call(

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -54,9 +54,7 @@ class ResolutionProofingJob < ApplicationJob
   # @return [CallbackLogData]
   def proof_lexisnexis_then_aamva(timer:, applicant_pii:, should_proof_state_id:, document_expired:)
     proofer_result = timer.time('resolution') do
-      with_retries(**faraday_retry_options) do
-        resolution_proofer.proof(applicant_pii)
-      end
+      resolution_proofer.proof(applicant_pii)
     end
 
     result = proofer_result.to_h

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -91,7 +91,7 @@ liveness_checking_enabled: 'false'
 logins_per_ip_track_only_mode: 'false'
 # LexisNexis #####################################################
 lexisnexis_base_url: https://www.example.com
-lexisnexis_timeout: '45'
+lexisnexis_timeout: '10'
 lexisnexis_request_mode: testing
 # Instant Verify and Phone Finder Integrations
 lexisnexis_account_id: test_account


### PR DESCRIPTION
We've had a couple issues with LN this week with periods of extremely slow responses that led to users experiencing the request timeout page.

We could extend the timeout for these paths like we do for doc auth, but the 99.9% response time for LN is under 10 seconds. I think it's preferable to tailor our request timeout to that, and show users the message that we're having internal issues rather than the 503 page.

It probably makes sense to re-evaluate bringing the retry back once async is live.

Relevant slack thread: https://gsa-tts.slack.com/archives/C0NGESUN5/p1626982530079500