### PR TITLE
LG-4537: actually stop including the doc auth gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,12 @@ ruby '~> 2.7.3'
 gem 'rails', '~> 6.1.4'
 
 # Variables can be overridden for local dev in Gemfile-dev
-@doc_auth_gem ||= { github: '18F/identity-doc-auth', tag: 'v0.13.0' }
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }
 @telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.3.0' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.6.0' }
 
-gem 'identity-doc-auth', @doc_auth_gem
 gem 'identity-hostdata', @hostdata_gem
 gem 'identity-logging', @logging_gem
 gem 'identity-telephony', @telephony_gem

--- a/Gemfile-dev.example
+++ b/Gemfile-dev.example
@@ -14,11 +14,9 @@ FileUtils.cp("Gemfile.lock", "Gemfile-dev.lock")
 # Override the defaults in the native Gemfile. Uncomment and customize for your setup.
 # NOTE: These assume all gems are in the same directory as the IDP and named the same as the repos.
 
-# @doc_auth_gem = { path: '../identity-doc-auth' }
 # @hostdata_gem = { path: '../identity-hostdata' }
 # @idp_functions_gem = { path: '../identity-idp-functions' }
 # @logging_gem = { path: '../identity-logging' }
-# @proofer_gem = { path: '../identity-proofer-gem' }
 # @telephony_gem = { path: '../identity-telephony' }
 # @validations_gem = { path: '../identity-validations' }
 # @saml_gem = { path: '../saml_idp' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/18F/identity-doc-auth.git
-  revision: adfb1f33e72af1db4987da3dccfe26e5b1bacf1f
-  tag: v0.13.0
-  specs:
-    identity-doc-auth (0.13.0)
-      activesupport
-      faraday
-      redacted_struct (>= 1.0.0)
-
-GIT
   remote: https://github.com/18F/identity-hostdata.git
   revision: 32fc831b47d17c878381279c936014e9956fcbe7
   tag: v3.3.0
@@ -725,7 +715,6 @@ DEPENDENCIES
   hiredis
   http_accept_language
   i18n-tasks (>= 0.9.31)
-  identity-doc-auth!
   identity-hostdata!
   identity-logging!
   identity-telephony!


### PR DESCRIPTION
In #5236, I forgot to actually remove identity-doc-auth gem from the Gemfile.