### PR TITLE
LG-4502: Consider async result for stored doc capture result

### DIFF
--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -105,7 +105,9 @@ module Idv
       end
 
       def stored_result
-        @stored_document_capture_session_result ||= document_capture_session&.load_result
+        return @stored_result if defined?(@stored_result)
+        @stored_result = document_capture_session&.load_result ||
+                         document_capture_session&.load_doc_auth_async_result
       end
 
       def request_should_use_stored_result?


### PR DESCRIPTION
**Why**: The result may be loaded via `load_result` or `load_doc_auth_async_result` depending on whether async doc capture is enabled.

Without these changes, the user can still proceed to the next step because VerifyDocumentStatusAction#async_state_done will mark the step as complete, but the field validation result from DocumentCaptureStep#form_submit will cause a validation message "This field is required" to be shown on the next screen. The validation is remarking on the absence of front_image and back_image form fields.

Before|After
---|---
![Screen Shot 2021-08-03 at 9 40 13 AM](https://user-images.githubusercontent.com/1779930/128025495-c338602d-c5b2-4290-930c-898a8b064d3f.png)|![Screen Shot 2021-08-03 at 9 39 33 AM](https://user-images.githubusercontent.com/1779930/128025508-f0f4a501-27d9-4314-999d-d9a121f20f20.png)

Precedent: https://github.com/18F/identity-idp/blob/1b75022/app/controllers/idv/capture_doc_status_controller.rb#L40-L44