### PR TITLE
Disable SMS for Iraq

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -473,7 +473,7 @@ IN:
 IQ:
   country_code: '964'
   name: Iraq
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 IS:
   country_code: '354'

--- a/config/pinpoint_overrides.yml
+++ b/config/pinpoint_overrides.yml
@@ -92,6 +92,8 @@ IL:
   supports_voice: false
 IS:
   supports_voice: false
+IQ:
+  supports_sms: false
 IT:
   supports_voice: false
 JM:

--- a/config/pinpoint_overrides.yml
+++ b/config/pinpoint_overrides.yml
@@ -90,10 +90,10 @@ IE:
   supports_voice: false
 IL:
   supports_voice: false
-IS:
-  supports_voice: false
 IQ:
   supports_sms: false
+IS:
+  supports_voice: false
 IT:
   supports_voice: false
 JM:

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -712,7 +712,7 @@ NL:
 'NO':
   country_code: '47'
   name: Norway
-  supports_sms: true
+  supports_sms: false
   supports_voice: true
 NP:
   country_code: '977'

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -712,7 +712,7 @@ NL:
 'NO':
   country_code: '47'
   name: Norway
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
 NP:
   country_code: '977'


### PR DESCRIPTION
**Why**: We are observing a large amount of SMS spam going to Iraq