### PR TITLE
allow sending SMS only to confirmed numbers

### DIFF
--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -16,7 +16,16 @@ class PhoneNumberCapabilities
 
   def supports_sms?
     return false if country_code_data.nil?
-    country_code_data['supports_sms']
+    supports_sms = country_code_data['supports_sms']
+
+    supports_sms_unconfirmed = country_code_data.fetch(
+      'supports_sms_unconfirmed',
+      supports_sms,
+    )
+
+    supports_sms_unconfirmed || (
+      supports_sms && phone_confirmed
+    )
   end
 
   def supports_voice?

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -474,6 +474,7 @@ IQ:
   country_code: '964'
   name: Iraq
   supports_sms: true
+  supports_sms_unconfirmed: false
   supports_voice: false
 IS:
   country_code: '354'

--- a/config/pinpoint_overrides.yml
+++ b/config/pinpoint_overrides.yml
@@ -90,6 +90,8 @@ IE:
   supports_voice: false
 IL:
   supports_voice: false
+IQ:
+  supports_sms_unconfirmed: false
 IS:
   supports_voice: false
 IT:

--- a/spec/services/phone_number_capabilities_spec.rb
+++ b/spec/services/phone_number_capabilities_spec.rb
@@ -43,6 +43,12 @@ describe PhoneNumberCapabilities do
       let(:phone) { '+1 (441) 295-9644' }
       it { is_expected.to eq(true) }
     end
+
+    context 'Iraq number that is unconfirmed' do
+      let(:phone_confirmed) { false }
+      let(:phone) { '+964 (703) 555-5000' }
+      it { is_expected.to eq(false) }
+    end
   end
 
   describe '#supports_voice?' do


### PR DESCRIPTION
Follow up to #5250 to allow SMS for Iraq only for already confirmed numbers