### PR TITLE
return bad token error when token is not a string

### DIFF
--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -57,6 +57,7 @@ module PivCacService
     end
 
     def token_decoded(token)
+      return { 'error' => 'token.bad' } unless token.is_a?(String)
       return decode_test_token(token) if token.start_with?('TEST:')
       return { 'error' => 'service.disabled' } if FeatureManagement.identity_pki_disabled?
       res = token_response(token)

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -105,6 +105,14 @@ describe PivCacService do
             expect(test_url).to eq link
           end
         end
+
+        context 'when given a non-String token' do
+          it 'returns bad token error' do
+            expect(PivCacService.decode_token(1)).to eq(
+              'error' => 'token.bad',
+            )
+          end
+        end
       end
 
       describe 'when configured to contact piv_cac service for local development' do


### PR DESCRIPTION
Can trigger a 500 for fun by passing in a non-string via parameters, ex: https://idp.int.identitysandbox.gov/login/piv_cac?token[token]=oops