### PR TITLE
skip session load on 404

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
+  prepend_before_action :skip_session_load
+  prepend_before_action :skip_session_expiration
   skip_before_action :verify_authenticity_token
-  before_action :skip_session_expiration
   skip_before_action :disable_caching
 
   def page_not_found

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -23,6 +23,14 @@ describe PagesController do
 
       expect(response).to render_template(layout: false)
     end
+
+    it 'does not load session' do
+      routes.draw { get 'foo' => 'pages#page_not_found' }
+
+      get :page_not_found
+
+      expect(session).to be_empty
+    end
   end
 
   describe 'content expiry' do


### PR DESCRIPTION
It looks like we were attempting to skip the session load, but it does not appear to have been working. Sort of a followup to #5177 