### PR TITLE
Apply insecure header overrides to POST and GET requests involved in redirects to SPs

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -4,7 +4,7 @@ module SignUp
 
     before_action :confirm_two_factor_authenticated
     before_action :verify_confirmed, if: :ial2?
-    before_action :apply_secure_headers_override, only: :show
+    before_action :apply_secure_headers_override, only: [:show, :update]
 
     def show
       @view_model = view_model

--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -1,10 +1,12 @@
 module Users
   class AuthorizationConfirmationController < ApplicationController
     include AuthorizationCountConcern
+    include SecureHeadersConcern
 
     before_action :ensure_sp_in_session_with_request_url, only: :show
     before_action :bump_auth_count
     before_action :confirm_two_factor_authenticated
+    before_action :apply_secure_headers_override, only: [:show]
 
     def show
       analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,7 @@ module Users
     skip_before_action :require_no_authentication, only: [:new]
     before_action :store_sp_metadata_in_session, only: [:new]
     before_action :check_user_needs_redirect, only: [:new]
-    before_action :apply_secure_headers_override, only: [:new]
+    before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
 
     def new


### PR DESCRIPTION
**Why**: The lack of the form action CSP directive on the response to POST / appears to be causing an issue with chrome on Android