### PR TITLE
Add missing error translations

### DIFF
--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -93,7 +93,9 @@ es:
         opción de llamada telefónica a continuación o use su clave personal.
       pwned_password: La contraseña que ingresaste no es segura. Está en una lista de
         contraseñas conocidas expuestas en violaciones de datos.
-      try_again: Por favor, inténtelo de nuevo.
+      too_short:
+        one: es muy corto (mínimo 1 caracter)
+        other: es muy corto (mínimo %{count} caracteres)
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_nameid_format: Formato de ID de nombre no autorizado
       unauthorized_service_provider: Proveedor de servicio no autorizado

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -96,6 +96,7 @@ es:
       too_short:
         one: es muy corto (mínimo 1 caracter)
         other: es muy corto (mínimo %{count} caracteres)
+      try_again: Por favor, inténtelo de nuevo.
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_nameid_format: Formato de ID de nombre no autorizado
       unauthorized_service_provider: Proveedor de servicio no autorizado

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -102,6 +102,9 @@ fr:
       pwned_password: Le mot de passe que vous avez entré n’est pas sécurisé. C’est
         dans une liste de mots de passe connus exposés dans les violations de
         données.
+      too_short:
+        one: est trop courte (le minimum est de 1 caractère)
+        other: est trop courte (le minimum est de %{count} caractères)
       try_again: Veuillez réessayer.
       unauthorized_authn_context: Contexte d’authentification non autorisé
       unauthorized_nameid_format: Format non autorisé du nom d’identification


### PR DESCRIPTION
This PR adds translations for "is too short (minimum is 1 character" and "is too short (minimum is %{count} characters" in French and Spanish. Previously, the error would appear in English regardless of the language of the page.
![Screen Shot 2021-08-06 at 2 15 36 PM](https://user-images.githubusercontent.com/17969963/128560425-041c4712-f469-4bb0-b348-0c1d3126742a.png)
![Screen Shot 2021-08-06 at 2 19 00 PM](https://user-images.githubusercontent.com/17969963/128560426-5c823c88-7a06-4efc-92a6-f678bb24aa23.png)
