### PR TITLE
LG-4149: allow a separate config for trueid timeout

### DIFF
--- a/app/services/doc_auth/lexis_nexis/config.rb
+++ b/app/services/doc_auth/lexis_nexis/config.rb
@@ -9,6 +9,7 @@ module DocAuth
       :trueid_noliveness_workflow,
       :trueid_password,
       :trueid_username,
+      :trueid_timeout, # optional
       :timeout, # optional
       :warn_notifier, # optional
       :locale,
@@ -20,9 +21,10 @@ module DocAuth
         :account_id,
         :base_url,
         :request_mode,
+        :timeout,
         :trueid_liveness_workflow,
         :trueid_noliveness_workflow,
-        :timeout,
+        :trueid_timeout,
         :locale,
         :dpi_threshold,
         :sharpness_threshold,

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -89,7 +89,6 @@ module DocAuth
       end
 
       def faraday_request_params
-        timeout = config.timeout&.to_i || 45
         { open_timeout: timeout, timeout: timeout }
       end
 
@@ -151,6 +150,10 @@ module DocAuth
 
       def request_mode
         config.request_mode
+      end
+
+      def timeout
+        config.timeout&.to_i || 45
       end
     end
   end

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -73,6 +73,10 @@ module DocAuth
         def metric_name
           'lexis_nexis_doc_auth_true_id'
         end
+
+        def timeout
+          config.trueid_timeout&.to_i || 45
+        end
       end
     end
   end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -174,6 +174,7 @@ module DocAuthRouter
           trueid_noliveness_workflow: IdentityConfig.store.lexisnexis_trueid_noliveness_workflow,
           trueid_password: IdentityConfig.store.lexisnexis_trueid_password,
           trueid_username: IdentityConfig.store.lexisnexis_trueid_username,
+          trueid_timeout: IdentityConfig.store.lexisnexis_trueid_timeout,
           timeout: IdentityConfig.store.lexisnexis_timeout,
           warn_notifier: warn_notifier,
           locale: I18n.locale,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -104,6 +104,7 @@ lexisnexis_instant_verify_workflow: customers.gsa.instant.verify.workflow
 lexisnexis_trueid_account_id: '12345'
 lexisnexis_trueid_username: test_username
 lexisnexis_trueid_password: test_password
+lexisnexis_trueid_timeout: '60'
 lexisnexis_trueid_liveness_workflow: customers.gsa.instant.verify.workflow
 lexisnexis_trueid_noliveness_workflow: customers.gsa.instant.verify.workflow
 ###################################################################

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -155,6 +155,7 @@ class IdentityConfig
     config.add(:lexisnexis_trueid_password, type: :string)
     config.add(:lexisnexis_trueid_liveness_workflow, type: :string)
     config.add(:lexisnexis_trueid_noliveness_workflow, type: :string)
+    config.add(:lexisnexis_trueid_timeout, type: :integer)
     config.add(:liveness_checking_enabled, type: :boolean)
     config.add(:lockout_period_in_minutes, type: :integer)
     config.add(:log_to_stdout, type: :boolean)


### PR DESCRIPTION
Why: the current `lexisnexis_timeout` used for phone finder and instant verify is set to 10 seconds. The call to true_id requires a greater timeout, so this PR will add another config entry for `lexisnexis_trueid_timeout`