### PR TITLE
fix 500 from nil options

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -18,6 +18,7 @@ class ServiceProviderSessionDecorator
   end
 
   def custom_alert(section)
+    return if sp.help_text.nil?
     language = I18n.locale.to_s
     alert = sp.help_text.dig(section, language)
     format(alert, sp_name: sp_name, sp_create_link: sp_create_link) if alert.present?

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -147,7 +147,7 @@ module DocAuth
         )
       end
 
-      def send_exception_notification(exception, custom_params = nil)
+      def send_exception_notification(exception, custom_params = {})
         return if exception.is_a?(DocAuth::RequestError) &&
                   HANDLED_HTTP_CODES.include?(exception.error_code)
         NewRelic::Agent.notice_error(exception, custom_params)

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe ServiceProviderSessionDecorator do
       end
     end
 
+    context 'sp has a nil custom alert' do
+      let(:sp) { build(:service_provider, help_text: nil) }
+
+      it 'returns nil' do
+        expect(subject.custom_alert('sign_in')).
+          to be_nil
+      end
+    end
+
     context 'sp has a blank custom alert' do
       let(:sp) { build_stubbed(:service_provider, :with_blank_help_text) }
 

--- a/spec/services/doc_auth/acuant/request_spec.rb
+++ b/spec/services/doc_auth/acuant/request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe DocAuth::Acuant::Request do
           )
 
         expect(NewRelic::Agent).to receive(:notice_error).
-          with(DocAuth::RequestError, nil).once
+          with(DocAuth::RequestError, {}).once
 
         expect(NewRelic::Agent).to receive(:notice_error).
           with(anything, hash_including(:retry)).twice


### PR DESCRIPTION
New Relic calls `.has_key?` on the options passed in, which makes the nil default raise an error ([New Relic error](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=86400000&platformVersion=release-2986&env=production&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJ0YWJsZSIsInByaW1hcnlGYWNldCI6ImVycm9yLmNsYXNzIiwiZmlsdGVycyI6W3sia2V5IjoiZXJyb3IuZXhwZWN0ZWQiLCJ2YWx1ZSI6Im5vdCB0cnVlIn0seyJrZXkiOiJlcnJvci5jbGFzcyIsInZhbHVlIjoiTm9NZXRob2RFcnJvciIsImxpa2UiOmZhbHNlfV0sIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUd1aWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5USXhNelk0TlRnIn0&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19))

It's also possible for `help_text` to be nil, and calling `dig` on it will raise an error