### PR TITLE
Make sure we don't retry stale jobs

### DIFF
--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -4,6 +4,8 @@ class AddressProofingJob < ApplicationJob
 
   queue_as :default
 
+  discard_on JobHelpers::StaleJobHelper::StaleJobError
+
   def perform(user_id:, issuer:, result_id:, encrypted_arguments:, trace_id:)
     timer = JobHelpers::Timer.new
 

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -4,6 +4,8 @@ class DocumentProofingJob < ApplicationJob
 
   queue_as :default
 
+  discard_on JobHelpers::StaleJobHelper::StaleJobError
+
   def perform(
     result_id:,
     encrypted_arguments:,

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -4,6 +4,8 @@ class ResolutionProofingJob < ApplicationJob
 
   queue_as :default
 
+  discard_on JobHelpers::StaleJobHelper::StaleJobError
+
   CallbackLogData = Struct.new(
     :result,
     :resolution_success,

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -5,4 +5,7 @@ if IdentityConfig.store.ruby_workers_enabled
     config.good_job.enable_cron = true
     # see config/initializers/job_configurations.rb for cron schedule
   end
+
+  GoodJob.retry_on_unhandled_error = false
+  GoodJob.on_thread_error = ->(exception) { NewRelic::Agent.notice_error(exception) }
 end


### PR DESCRIPTION
- StaleJobError added in #5244

I got paged in `dev` because of a lot of stale job errors, I think there was one old job that was being constantly retried. I went through proofing manually and it was fine