### PR TITLE
Set reporting jobs to low priority, declare job queues

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -2,6 +2,8 @@ require 'identity/hostdata'
 
 module Reports
   class BaseReport < ApplicationJob
+    queue_as :low
+
     private
 
     def fiscal_start_date

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -3,6 +3,7 @@ if IdentityConfig.store.ruby_workers_enabled
     config.good_job.execution_mode = :external
     config.good_job.poll_interval = 5
     config.good_job.enable_cron = true
+    config.good_job.queues = 'default:5,low:1;*'
     # see config/initializers/job_configurations.rb for cron schedule
   end
 end


### PR DESCRIPTION
Problem: the daily scheduled reporting jobs went to the default queue, which blocks all our normal jobs

Solution: separate queues. I took a guess at how we want to do these, but I think that having more workers focus on default lets us push through things faster