### PR TITLE
Discard jobs due to concurrency errors

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,7 +5,4 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
-
-  # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
-  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,4 +5,7 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 end

--- a/app/jobs/gpo_daily_job.rb
+++ b/app/jobs/gpo_daily_job.rb
@@ -7,6 +7,8 @@ class GpoDailyJob < ApplicationJob
     key: -> { "gpo-daily-job-#{arguments.first}" },
   )
 
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
   # Enqueue a test letter every day, but only upload letters on working weekdays
   def perform(date)
     GpoDailyTestSender.new.run

--- a/app/jobs/gpo_daily_job.rb
+++ b/app/jobs/gpo_daily_job.rb
@@ -1,4 +1,6 @@
 class GpoDailyJob < ApplicationJob
+  queue_as :low
+
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -4,6 +4,9 @@ module Reports
   class BaseReport < ApplicationJob
     queue_as :low
 
+    # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
+    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
     private
 
     def fiscal_start_date

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -1,5 +1,7 @@
 module AccountReset
   class GrantRequestsAndSendEmails < ApplicationJob
+    queue_as :low
+
     include GoodJob::ActiveJobExtensions::Concurrency
 
     good_job_control_concurrency_with(

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -8,6 +8,8 @@ module AccountReset
       key: -> { "grant-requests-and-send-emails-#{arguments.first}" },
     )
 
+    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
     def perform(_date)
       notifications_sent = 0
       AccountResetRequest.where(

--- a/app/services/agreements/reports/partner_api_report.rb
+++ b/app/services/agreements/reports/partner_api_report.rb
@@ -9,6 +9,8 @@ module Agreements
         key: -> { "partner-api-report-#{arguments.first}" },
       )
 
+      discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
       def perform(_date)
         return unless IdentityConfig.store.enable_partner_api
 

--- a/app/services/agreements/reports/partner_api_report.rb
+++ b/app/services/agreements/reports/partner_api_report.rb
@@ -1,6 +1,8 @@
 module Agreements
   module Reports
     class PartnerApiReport < ApplicationJob
+      queue_as :low
+
       include GoodJob::ActiveJobExtensions::Concurrency
 
       good_job_control_concurrency_with(


### PR DESCRIPTION
Spotted this line in the workers.log on a worker instance in my personal env:

```
Retrying AccountReset::GrantRequestsAndSendEmails in 19 seconds, due to a GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError.
```

which makes it sound like these jobs are not being immediately discarded the way I was thinking