### PR TITLE
LG-4927: include login.gov logo alt text

### DIFF
--- a/app/views/accounts/_personal_key_item_heading.html.erb
+++ b/app/views/accounts/_personal_key_item_heading.html.erb
@@ -1,4 +1,4 @@
 <div class='col'>
-  <%= image_tag asset_url('p-key.svg'), width: 16, class: 'margin-right-1 text-middle' %>
+  <%= image_tag asset_url('p-key.svg'), alt: '', width: 16, class: 'margin-right-1 text-middle' %>
 </div>
 <%= t('account.items.personal_key') %>

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -12,7 +12,7 @@
 <%= image_tag(
       asset_url('come-back.svg'),
       size: '140', class: 'block margin-x-auto',
-      alt: '' 
+      alt: ''
     ) %>
 <h2 class="center">
   <%= t('idv.titles.come_back_later') %>

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -12,6 +12,7 @@
 <%= image_tag(
       asset_url('come-back.svg'),
       size: '140', class: 'block margin-x-auto',
+      alt: '' 
     ) %>
 <h2 class="center">
   <%= t('idv.titles.come_back_later') %>

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -1,5 +1,5 @@
 <nav class='nav-branded vertical-align bg-light-blue center relative'>
-  <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: '',
+  <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: 'Login.gov',
                 class: 'inline-block text-middle') %>
   <div class='px-12p inline-block'>
     <span class='absolute top-0 bottom-0 border-right border-primary-light margin-y-1 tablet:margin-y-2'></span>

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -1,5 +1,5 @@
 <nav class='nav-branded vertical-align bg-light-blue center relative'>
-  <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: 'Login.gov',
+  <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME,
                 class: 'inline-block text-middle') %>
   <div class='px-12p inline-block'>
     <span class='absolute top-0 bottom-0 border-right border-primary-light margin-y-1 tablet:margin-y-2'></span>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -23,7 +23,7 @@
 <br>
 <br>
 <div class="sm-col sm-col-2 padding-right-2">
-  <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: '', size: '80') %>
+  <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: 'Lock Icon with red exclamation point', size: '80') %>
 </div>
 <div class="sm-col sm-col-10">
   <div class="bold margin-bottom-0">

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -23,7 +23,7 @@
 <br>
 <br>
 <div class="sm-col sm-col-2 padding-right-2">
-  <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: 'Lock Icon with red exclamation point', size: '80') %>
+  <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: '', size: '80') %>
 </div>
 <div class="sm-col sm-col-10">
   <div class="bold margin-bottom-0">


### PR DESCRIPTION
***Why***

Currently the Login.gov logo has no alt text when associated with a Service Provider. This solves that issue. 