### PR TITLE
Update parsing of Pinpoint supported countries, send sender ID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 6.1.4'
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }
-@telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.3.0' }
+@telephony_gem ||= { github: '18f/identity-telephony', branch: 'margolis-sms-sender-id' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.7.0' }
 
 gem 'identity-hostdata', @hostdata_gem

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 6.1.4'
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.3.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }
-@telephony_gem ||= { github: '18f/identity-telephony', branch: 'margolis-sms-sender-id' }
+@telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.3.1' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.7.0' }
 
 gem 'identity-hostdata', @hostdata_gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: 7e255d9a30d605af6529ad6062b3edce00698d77
-  tag: v0.3.0
+  revision: fc61cc534d5fef392e0b81ad3a60beed0dc9555b
+  branch: margolis-sms-sender-id
   specs:
-    identity-telephony (0.3.0)
+    identity-telephony (0.3.1)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,8 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: fc61cc534d5fef392e0b81ad3a60beed0dc9555b
-  branch: margolis-sms-sender-id
+  revision: ce223b6e55e052a63d6bf731f3bd90957cb2040c
+  tag: v0.3.1
   specs:
     identity-telephony (0.3.1)
       aws-sdk-pinpoint

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -162,7 +162,7 @@ BW:
 BY:
   country_code: '375'
   name: Belarus
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
   supports_voice_unconfirmed: false
 BZ:
@@ -288,7 +288,7 @@ EE:
 EG:
   country_code: '20'
   name: Egypt
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
 ER:
   country_code: '291'
@@ -801,7 +801,7 @@ PG:
 PH:
   country_code: '63'
   name: Philippines
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
   supports_voice_unconfirmed: false
 PK:
@@ -970,7 +970,7 @@ TG:
 TH:
   country_code: '66'
   name: Thailand
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
   supports_voice_unconfirmed: false
 TJ:

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -468,7 +468,7 @@ IM:
 IN:
   country_code: '91'
   name: India
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 IQ:
   country_code: '964'
@@ -581,7 +581,7 @@ LI:
 LK:
   country_code: '94'
   name: Sri Lanka
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 LR:
   country_code: '231'
@@ -1001,7 +1001,7 @@ TO:
 TR:
   country_code: '90'
   name: Turkey
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 TT:
   country_code: '1868'

--- a/config/initializers/telephony.rb
+++ b/config/initializers/telephony.rb
@@ -10,6 +10,8 @@ Telephony.config do |c|
   c.voice_pause_time = IdentityConfig.store.voice_otp_pause_time
   c.voice_rate = IdentityConfig.store.voice_otp_speech_rate
 
+  c.sender_id = IdentityConfig.store.pinpoint_sms_sender_id
+
   IdentityConfig.store.pinpoint_sms_configs.each do |sms_json_config|
     c.pinpoint.add_sms_config do |sms|
       sms.application_id = sms_json_config['application_id']

--- a/config/pinpoint_overrides.yml
+++ b/config/pinpoint_overrides.yml
@@ -41,7 +41,6 @@ BO:
 BR:
   supports_voice: false
 BY:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 CA:
@@ -66,7 +65,6 @@ DZ:
 EC:
   supports_voice: false
 EG:
-  supports_sms: false
   supports_voice: true
 FI:
   supports_voice: false
@@ -155,7 +153,6 @@ PA:
 PE:
   supports_voice: false
 PH:
-  supports_sms: false
   supports_voice_unconfirmed: false
 PK:
   supports_voice: false
@@ -194,7 +191,6 @@ TD:
   supports_sms: true
   supports_voice: false
 TH:
-  supports_sms: false
   supports_voice_unconfirmed: false
 TJ:
   supports_voice: false

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -7,7 +7,7 @@ AD:
 AE:
   country_code: '971'
   name: United Arab Emirates (UAE)
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 AF:
   country_code: '93'
@@ -137,7 +137,7 @@ BW:
 BY:
   country_code: '375'
   name: Belarus
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 BZ:
   country_code: '501'
@@ -257,7 +257,7 @@ EE:
 EG:
   country_code: '20'
   name: Egypt
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 ER:
   country_code: '291'
@@ -437,7 +437,7 @@ IM:
 IN:
   country_code: '91'
   name: India
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 IQ:
   country_code: '964'
@@ -467,7 +467,7 @@ JM:
 JO:
   country_code: '962'
   name: Jordan
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 JP:
   country_code: '81'
@@ -507,7 +507,7 @@ KR:
 KW:
   country_code: '965'
   name: Kuwait
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 KY:
   country_code: '1345'
@@ -542,7 +542,7 @@ LI:
 LK:
   country_code: '94'
   name: Sri Lanka
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 LR:
   country_code: '231'
@@ -712,7 +712,7 @@ NL:
 'NO':
   country_code: '47'
   name: Norway
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
 NP:
   country_code: '977'
@@ -757,7 +757,7 @@ PG:
 PH:
   country_code: '63'
   name: Philippines
-  supports_sms: true
+  supports_sms: false
   supports_voice: true
 PK:
   country_code: '92'
@@ -792,7 +792,7 @@ PY:
 QA:
   country_code: '974'
   name: Qatar
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 RE:
   country_code: '262'
@@ -812,7 +812,7 @@ RS:
 RU:
   country_code: '7'
   name: Russia
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 RW:
   country_code: '250'
@@ -822,7 +822,7 @@ RW:
 SA:
   country_code: '966'
   name: Saudi Arabia
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 SB:
   country_code: '677'
@@ -912,7 +912,7 @@ TG:
 TH:
   country_code: '66'
   name: Thailand
-  supports_sms: true
+  supports_sms: false
   supports_voice: true
 TJ:
   country_code: '992'
@@ -942,7 +942,7 @@ TO:
 TR:
   country_code: '90'
   name: Turkey
-  supports_sms: true
+  supports_sms: false
   supports_voice: false
 TT:
   country_code: '1868'
@@ -1007,7 +1007,7 @@ VI:
 VN:
   country_code: '84'
   name: Vietnam
-  supports_sms: true
+  supports_sms: false
   supports_voice: true
 VU:
   country_code: '678'

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -137,7 +137,7 @@ BW:
 BY:
   country_code: '375'
   name: Belarus
-  supports_sms: false
+  supports_sms: true
   supports_voice: false
 BZ:
   country_code: '501'
@@ -257,7 +257,7 @@ EE:
 EG:
   country_code: '20'
   name: Egypt
-  supports_sms: false
+  supports_sms: true
   supports_voice: false
 ER:
   country_code: '291'
@@ -912,7 +912,7 @@ TG:
 TH:
   country_code: '66'
   name: Thailand
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
 TJ:
   country_code: '992'

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -757,7 +757,7 @@ PG:
 PH:
   country_code: '63'
   name: Philippines
-  supports_sms: false
+  supports_sms: true
   supports_voice: true
 PK:
   country_code: '92'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -202,6 +202,7 @@ class IdentityConfig
     config.add(:phone_setups_per_ip_period, type: :integer)
     config.add(:pii_lock_timeout_in_minutes, type: :integer)
     config.add(:pinpoint_sms_configs, type: :json)
+    config.add(:pinpoint_sms_sender_id, type: :string, allow_nil: true)
     config.add(:pinpoint_voice_configs, type: :json)
     config.add(:piv_cac_service_url)
     config.add(:piv_cac_verify_token_secret)

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -11,7 +11,10 @@ class PinpointSupportedCountries
 
   # The list of countries where we have our sender ID registered
   SENDER_ID_COUNTRIES = %w[
+    BY
+    EG
     PH
+    TH
   ].to_set.freeze
 
   CountrySupport = Struct.new(

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -9,6 +9,9 @@ class PinpointSupportedCountries
   PINPOINT_SMS_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html'.freeze
   PINPOINT_VOICE_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-voice-countries.html'.freeze
 
+  # The list of countries where we have our sender ID registered
+  SENDER_ID_COUNTRIES = %w[].to_set.freeze
+
   CountrySupport = Struct.new(
     :iso_code,
     :name,
@@ -56,12 +59,18 @@ class PinpointSupportedCountries
       convert.
       select { |sms_config| sms_config['ISO code'] }. # skip section rows
       map do |sms_config|
+        iso_code = sms_config['ISO code']
+        supports_sms = case trim_trailing_digits_spaces(sms_config['Supports sender IDs'])
+        when 'Registration required'
+          SENDER_ID_COUNTRIES.include?(iso_code)
+        else
+          true
+        end
+
         CountrySupport.new(
-          iso_code: sms_config['ISO code'],
+          iso_code: iso_code,
           name: trim_trailing_digits_spaces(sms_config['Country or region']),
-          # The list is of supported countries, but ones that are 'Yes1' require sender IDs,
-          # which we do not have (so we do not support them)
-          supports_sms: sms_config['Supports sender IDs'] != 'Yes1',
+          supports_sms: supports_sms,
         )
       end
   end

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -10,7 +10,9 @@ class PinpointSupportedCountries
   PINPOINT_VOICE_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-voice-countries.html'.freeze
 
   # The list of countries where we have our sender ID registered
-  SENDER_ID_COUNTRIES = %w[].to_set.freeze
+  SENDER_ID_COUNTRIES = %w[
+    PH
+  ].to_set.freeze
 
   CountrySupport = Struct.new(
     :iso_code,

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -584,11 +584,15 @@ feature 'Sign in' do
     end
   end
 
+  # For these tests, we need to have a country that is supports_sms: true, supports_vocie: false
+  let(:unsupported_country_phone_number) { '+354 611 1234' }
+  let(:unsupported_country_name) { 'Iceland' }
+
   context 'user tries to visit /login/two_factor/voice with an unsupported phone' do
     it 'displays an error message but does not send another SMS' do
       user = create(
         :user, :signed_up,
-        otp_delivery_preference: 'sms', with: { phone: '+91 1234567890' }
+        otp_delivery_preference: 'sms', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
       visit login_two_factor_path(otp_delivery_preference: 'voice', reauthn: false)
@@ -599,7 +603,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India',
+        location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end
@@ -609,7 +613,7 @@ feature 'Sign in' do
     it 'displays an error message but does not send another SMS' do
       user = create(
         :user, :signed_up,
-        otp_delivery_preference: 'sms', with: { phone: '+91 1234567890' }
+        otp_delivery_preference: 'sms', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
       visit otp_send_path(
@@ -622,7 +626,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India',
+        location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end
@@ -632,7 +636,7 @@ feature 'Sign in' do
     it 'displays an error message but does not send another SMS' do
       user = create(
         :user, :signed_up,
-        otp_delivery_preference: 'voice', with: { phone: '+91 1234567890' }
+        otp_delivery_preference: 'voice', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
       visit otp_send_path(
@@ -645,7 +649,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India',
+        location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end

--- a/spec/lib/pinpoint_supported_countries_spec.rb
+++ b/spec/lib/pinpoint_supported_countries_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PinpointSupportedCountries do
         <tr>
           <td>Belarus</td>
           <td>BY</td>
-          <td>Yes<sup><a href="#sms-support-note-1">1</a></sup></td>
+          <td>Registration required<sup><a href="#sms-support-note-1">1</a></sup></td>
           <td></td>
         </tr>
       </table>
@@ -112,6 +112,17 @@ RSpec.describe PinpointSupportedCountries do
       ]
     end
     # rubocop:enable Layout/LineLength
+
+    context 'when we have a sender ID for a country' do
+      before do
+        stub_const('PinpointSupportedCountries::SENDER_ID_COUNTRIES', Set['BY'])
+      end
+
+      it 'is supported' do
+        belarus = countries.sms_support.find { |c| c.iso_code == 'BY' }
+        expect(belarus.supports_sms).to eq(true)
+      end
+    end
   end
 
   describe '#voice_support' do

--- a/spec/lib/pinpoint_supported_countries_spec.rb
+++ b/spec/lib/pinpoint_supported_countries_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe PinpointSupportedCountries do
         BY:
           country_code: '375'
           name: Belarus
-          supports_sms: false
+          supports_sms: true
           supports_voice: false
       STR
     end
@@ -108,19 +108,19 @@ RSpec.describe PinpointSupportedCountries do
       expect(countries.sms_support).to eq [
         PinpointSupportedCountries::CountrySupport.new(iso_code: 'AR', name: 'Argentina', supports_sms: true),
         PinpointSupportedCountries::CountrySupport.new(iso_code: 'AU', name: 'Australia', supports_sms: true),
-        PinpointSupportedCountries::CountrySupport.new(iso_code: 'BY', name: 'Belarus', supports_sms: false),
+        PinpointSupportedCountries::CountrySupport.new(iso_code: 'BY', name: 'Belarus', supports_sms: true),
       ]
     end
     # rubocop:enable Layout/LineLength
 
-    context 'when we have a sender ID for a country' do
+    context 'when we do not have a sender ID for a country that requires one' do
       before do
-        stub_const('PinpointSupportedCountries::SENDER_ID_COUNTRIES', Set['BY'])
+        stub_const('PinpointSupportedCountries::SENDER_ID_COUNTRIES', [])
       end
 
       it 'is supported' do
         belarus = countries.sms_support.find { |c| c.iso_code == 'BY' }
-        expect(belarus.supports_sms).to eq(true)
+        expect(belarus.supports_sms).to eq(false)
       end
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe PinpointSupportedCountries do
       expect(countries.load_country_dialing_codes).to eq [
         PinpointSupportedCountries::CountryDialingCode.new(country_code: '54', iso_code: 'AR', name: 'Argentina', supports_sms: true, supports_voice: true),
         PinpointSupportedCountries::CountryDialingCode.new(country_code: '61', iso_code: 'AU', name: 'Australia', supports_sms: true, supports_voice: true),
-        PinpointSupportedCountries::CountryDialingCode.new(country_code: '375', iso_code: 'BY', name: 'Belarus', supports_sms: false, supports_voice: false),
+        PinpointSupportedCountries::CountryDialingCode.new(country_code: '375', iso_code: 'BY', name: 'Belarus', supports_sms: true, supports_voice: false),
       ]
     end
     # rubocop:enable Layout/LineLength


### PR DESCRIPTION
Builds on: https://github.com/18F/identity-telephony/pull/50

- I found out that AWS changed the format of "sender ID supported" SMS supported countries table, so I updated the script to handle and our test fixtures
- For now it seems like we just have one sender ID rather than a per-country one

Going to deploy to my personal env to make sure adding a sender ID doesn't break anything