### PR TITLE
Remove redundant entries in pinpoint_overrides.yml

### DIFF
--- a/config/pinpoint_overrides.yml
+++ b/config/pinpoint_overrides.yml
@@ -1,5 +1,4 @@
 AE:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 AO:
@@ -97,7 +96,6 @@ IT:
 JM:
   supports_voice: false
 JO:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 JP:
@@ -112,7 +110,6 @@ KI:
   supports_sms: true
   supports_voice: false
 KW:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 KY:
@@ -144,7 +141,6 @@ MY:
 NI:
   supports_voice: false
 'NO':
-  supports_sms: true
   supports_voice: false
 NZ:
   supports_voice: false
@@ -166,17 +162,14 @@ PW:
   supports_sms: true
   supports_voice: false
 QA:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 RO:
   supports_voice: false
 RU:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 SA:
-  supports_sms: false
   supports_voice: true
   supports_voice_unconfirmed: false
 SI:
@@ -208,7 +201,6 @@ VC:
 VE:
   supports_voice: false
 VN:
-  supports_sms: false
   supports_voice_unconfirmed: false
 ZA:
   supports_voice: false


### PR DESCRIPTION
I noticed in #5291 that we had some redundant overrides for pinpoint, ex some configs that were the same as what we parsed from the support docs

1. I believe the overrides may have come from poor parsing (since the docs changed how the document sender ID requirements)
2. Now that we have updated the parsing we can remove these

This is what I ran to help enumerate the dupes, maybe worth turning into a script and linting on it the same way we do with the country support?

```ruby
require 'yaml'
original = YAML.load_file('config/pinpoint_supported_countries.yml')
overrides = YAML.load_file('config/pinpoint_overrides.yml')

redundant = []
overrides.each { |country, vals| (original[country] || {}).each { |k, v| redundant << [country, k, v] if vals[k] == v } }

redundant
# =>
[["AE", "supports_sms", false],
 ["JO", "supports_sms", false],
 ["KW", "supports_sms", false],
 ["NO", "supports_sms", true],
 ["QA", "supports_sms", false],
 ["RU", "supports_sms", false],
 ["SA", "supports_sms", false],
 ["VN", "supports_sms", false]]

```