### PR TITLE
Adding theme-color meta tag

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
+  <meta name="theme-color" content="#112e51">
   <meta content="<%= APP_NAME %>" name="description" />
   <meta content="IE=edge" http-equiv="X-UA-Compatible" />
   <meta content="none" name="msapplication-config" />
@@ -41,7 +42,6 @@
   <link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
   <link href="/manifest.json" rel="manifest" />
   <link color="#e21c3d" href="/safari-pinned-tab.svg" rel="mask-icon" />
-  <meta content="#ffffff" name="theme-color" />
 
   <!--[if lt IE 9]>
   <%= javascript_include_tag_without_preload 'html5shiv' %>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,6 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#ffffff",
+  "theme_color": "#112e51",
   "display": "standalone"
 }


### PR DESCRIPTION
**Why**:
- Safari 15 browser and some mobile browsers on Android will start
supporting theme-color meta tag that lets browser color the window
to match the theme color of the site. This gives a more consistent
look to the site and lets login.gov implement a standard theme-color
meta tag.

**How**:
- Setting theme-color meta tag with color value as per web standard
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

<img width="935" alt="Screen Shot 2021-08-17 at 9 46 09 AM" src="https://user-images.githubusercontent.com/498669/129742530-9be80546-cb16-478e-a5aa-83286c63625c.png">
<img width="1436" alt="Screen Shot 2021-08-17 at 9 46 14 AM" src="https://user-images.githubusercontent.com/498669/129742570-975fb674-aa44-408b-b89b-241ac08151bb.png">
<img src="https://user-images.githubusercontent.com/498669/129742644-77e80aa6-7f9a-4ec6-a3b1-87de78e69128.png" />
