### PR TITLE
LG-4637: Show accurate time remaining for IAL2 throttle screens

### DIFF
--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -6,23 +6,25 @@ module Idv
     before_action :confirm_idv_phone_step_needed
 
     def warning
-      @remaining_step_attempts = remaining_step_attempts
+      @remaining_step_attempts = throttle.remaining_count
     end
 
     def timeout
-      @remaining_step_attempts = remaining_step_attempts
+      @remaining_step_attempts = throttle.remaining_count
     end
 
     def jobfail
-      @remaining_step_attempts = remaining_step_attempts
+      @remaining_step_attempts = throttle.remaining_count
     end
 
-    def failure; end
+    def failure
+      @expires_at = throttle.expires_at
+    end
 
     private
 
-    def remaining_step_attempts
-      Throttle.for(user: idv_session.current_user, throttle_type: :idv_resolution).remaining_count
+    def throttle
+      Throttle.for(user: idv_session.current_user, throttle_type: :idv_resolution)
     end
 
     def confirm_idv_phone_step_needed

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -60,6 +60,7 @@ module Users
         throttle_type: :verify_gpo_key,
       )
 
+      @expires_at = throttle.expires_at
       render :throttled
     end
 

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -50,6 +50,7 @@ module Users
         throttle_type: :verify_personal_key,
       )
 
+      @expires_at = throttle.expires_at
       render :throttled
     end
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -22,7 +22,9 @@
         <%= t(
               'idv.failure.phone.fail_html',
               timeout: distance_of_time_in_words(
-                IdentityConfig.store.idv_attempt_window_in_hours.hours,
+                Time.zone.now,
+                [@expires_at, Time.zone.now].compact.max,
+                except: :seconds,
               ),
             ) %>
       </p>

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -21,7 +21,9 @@
         <%= t(
               'idv.failure.sessions.fail_html',
               timeout: distance_of_time_in_words(
-                IdentityConfig.store.idv_attempt_window_in_hours.hours,
+                Time.zone.now,
+                [@expires_at, Time.zone.now].compact.max,
+                except: :seconds,
               ),
             ) %>
       </p>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -23,7 +23,9 @@
         <%= t(
               'errors.doc_auth.throttled_text_html',
               timeout: distance_of_time_in_words(
-                IdentityConfig.store.acuant_attempt_window_in_minutes.minutes,
+                Time.zone.now,
+                [@expires_at, Time.zone.now].compact.max,
+                except: :seconds,
               ),
             ) %>
       </p>

--- a/app/views/users/verify_account/throttled.html.erb
+++ b/app/views/users/verify_account/throttled.html.erb
@@ -5,5 +5,13 @@
 </h1>
 
 <p>
-  <%= t('errors.verify_profile.throttled') %> <%= link_to(t('links.go_back'), account_path) %>.
+  <%= t(
+        'errors.verify_profile.throttled',
+        timeout: distance_of_time_in_words(
+          Time.zone.now,
+          [@expires_at, Time.zone.now].compact.max,
+          except: :seconds,
+        ),
+      ) %>
+  <%= link_to(t('links.go_back'), account_path) %>.
 </p>

--- a/app/views/users/verify_personal_key/throttled.html.erb
+++ b/app/views/users/verify_personal_key/throttled.html.erb
@@ -5,5 +5,13 @@
 </h1>
 
 <p>
-  <%= t('errors.verify_personal_key.throttled') %> <%= link_to(t('links.go_back'), account_path) %>.
+  <%= t(
+        'errors.verify_personal_key.throttled',
+        timeout: distance_of_time_in_words(
+          Time.zone.now,
+          [@expires_at, Time.zone.now].compact.max,
+          except: :seconds,
+        ),
+      ) %>
+  <%= link_to(t('links.go_back'), account_path) %>.
 </p>

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -48,7 +48,7 @@ en:
         before continuing. We sent you a link with instructions.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.
-      send_link_throttle: You tried too many times, please try again in 10 minutes.
+      send_link_throttle: You tried too many times, please try again in %{timeout}.
         You can also click on Start Over and choose to use your computer
         instead.
       throttled_heading: We could not verify your ID
@@ -114,9 +114,9 @@ en:
     two_factor_auth_setup:
       must_select_option: Select an authentication method.
     verify_personal_key:
-      throttled: You tried too many times, please try again in 15 minutes.
+      throttled: You tried too many times, please try again in %{timeout}.
     verify_profile:
-      throttled: You tried too many times, please try again in 10 minutes.
+      throttled: You tried too many times, please try again in %{timeout}.
     webauthn_setup:
       already_registered: Security key already registered. Please try a different security key.
       attestation_error: Sorry, but your security key doesn’t appear to be a FIDO

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -49,9 +49,9 @@ es:
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite de
         verificación de identidad. Póngase en contacto con su proveedor de
         servicios para obtener más información.
-      send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10
-        minutos. También puedes hacer clic en comenzar de nuevo y elegir usar tu
-        computadora.
+      send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en
+        %{timeout}. También puedes hacer clic en comenzar de nuevo y elegir usar
+        tu computadora.
       throttled_heading: No pudimos verificar la identificación
       throttled_heading_liveness: No pudimos verificar la identificación ni la foto
       throttled_text_html: '<strong>Por favor, inténtelo de nuevo en
@@ -118,9 +118,9 @@ es:
     two_factor_auth_setup:
       must_select_option: Seleccione un método de autenticación.
     verify_personal_key:
-      throttled: Lo intentaste muchas veces, vuelve a intentarlo en 15 minutos.
+      throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
     verify_profile:
-      throttled: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
+      throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
     webauthn_setup:
       already_registered: Clave de seguridad ya registrada. Por favor, intente una
         clave de seguridad diferente.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -53,8 +53,8 @@ fr:
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d’identité. Veuillez contacter votre fournisseur de
         services pour plus d’informations.
-      send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans 10
-        minutes. Vous pouvez également cliquer sur recommencer et choisir
+      send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
+        %{timeout}. Vous pouvez également cliquer sur recommencer et choisir
         d’utiliser votre ordinateur.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
       throttled_heading_liveness: Nous n’avons pas pu vérifier votre identité et votre photo
@@ -127,9 +127,9 @@ fr:
     two_factor_auth_setup:
       must_select_option: Sélectionnez une méthode d’authentification.
     verify_personal_key:
-      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans 15 minutes.
+      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
     verify_profile:
-      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans 10 minutes.
+      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
     webauthn_setup:
       already_registered: Clé de sécurité déjà enregistrée. Veuillez essayer une clé
         de sécurité différente.

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -8,9 +8,9 @@ shared_examples_for 'an idv phone errors controller action' do
   end
 
   context 'the user is authenticated and has not confirmed their phone' do
-    it 'renders the error' do
-      stub_sign_in
+    let(:user) { create(:user) }
 
+    it 'renders the error' do
       get action
 
       expect(response).to render_template(template)
@@ -18,11 +18,10 @@ shared_examples_for 'an idv phone errors controller action' do
   end
 
   context 'the user is authenticated and has confirmed their phone' do
+    let(:user) { create(:user) }
     let(:idv_session_user_phone_confirmation) { true }
 
     it 'redirects to the review url' do
-      stub_sign_in
-
       get action
 
       expect(response).to redirect_to(idv_review_url)
@@ -41,12 +40,15 @@ end
 describe Idv::PhoneErrorsController do
   let(:idv_session) { double }
   let(:idv_session_user_phone_confirmation) { false }
+  let(:user) { nil }
 
   before do
     allow(idv_session).to receive(:user_phone_confirmation).
       and_return(idv_session_user_phone_confirmation)
+    allow(idv_session).to receive(:current_user).and_return(user)
     allow(subject).to receive(:remaining_step_attempts).and_return(5)
     allow(controller).to receive(:idv_session).and_return(idv_session)
+    stub_sign_in(user) if user
   end
 
   describe '#warning' do
@@ -54,6 +56,20 @@ describe Idv::PhoneErrorsController do
     let(:template) { 'idv/phone_errors/warning' }
 
     it_behaves_like 'an idv phone errors controller action'
+
+    context 'with throttle attempts' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:throttle, user: user, throttle_type: :idv_resolution, attempts: 1)
+      end
+
+      it 'assigns remaining count' do
+        get action
+
+        expect(assigns(:remaining_step_attempts)).to be_kind_of(Numeric)
+      end
+    end
   end
 
   describe '#timeout' do
@@ -61,6 +77,20 @@ describe Idv::PhoneErrorsController do
     let(:template) { 'idv/phone_errors/timeout' }
 
     it_behaves_like 'an idv phone errors controller action'
+
+    context 'with throttle attempts' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:throttle, user: user, throttle_type: :idv_resolution, attempts: 1)
+      end
+
+      it 'assigns remaining count' do
+        get action
+
+        expect(assigns(:remaining_step_attempts)).to be_kind_of(Numeric)
+      end
+    end
   end
 
   describe '#jobfail' do
@@ -68,6 +98,20 @@ describe Idv::PhoneErrorsController do
     let(:template) { 'idv/phone_errors/jobfail' }
 
     it_behaves_like 'an idv phone errors controller action'
+
+    context 'with throttle attempts' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:throttle, user: user, throttle_type: :idv_resolution, attempts: 1)
+      end
+
+      it 'assigns remaining count' do
+        get action
+
+        expect(assigns(:remaining_step_attempts)).to be_kind_of(Numeric)
+      end
+    end
   end
 
   describe '#failure' do
@@ -75,5 +119,19 @@ describe Idv::PhoneErrorsController do
     let(:template) { 'idv/phone_errors/failure' }
 
     it_behaves_like 'an idv phone errors controller action'
+
+    context 'while throttled' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:throttle, :with_throttled, user: user, throttle_type: :idv_resolution)
+      end
+
+      it 'assigns expiration time' do
+        get action
+
+        expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+    end
   end
 end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -64,6 +64,20 @@ describe Idv::SessionErrorsController do
     let(:template) { 'idv/session_errors/warning' }
 
     it_behaves_like 'an idv session errors controller action'
+
+    context 'with throttle attempts' do
+      before do
+        user = create(:user)
+        stub_sign_in(user)
+        create(:throttle, user: user, throttle_type: :idv_resolution, attempts: 1)
+      end
+
+      it 'assigns remaining count' do
+        get action
+
+        expect(assigns(:remaining_step_attempts)).to be_kind_of(Numeric)
+      end
+    end
   end
 
   describe '#failure' do
@@ -71,6 +85,20 @@ describe Idv::SessionErrorsController do
     let(:template) { 'idv/session_errors/failure' }
 
     it_behaves_like 'an idv session errors controller action'
+
+    context 'while throttled' do
+      before do
+        user = create(:user)
+        stub_sign_in(user)
+        create(:throttle, :with_throttled, user: user, throttle_type: :idv_resolution)
+      end
+
+      it 'assigns expiration time' do
+        get action
+
+        expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+    end
   end
 
   describe '#ssn_failure' do
@@ -78,5 +106,46 @@ describe Idv::SessionErrorsController do
     let(:template) { 'idv/session_errors/failure' }
 
     it_behaves_like 'an idv session errors controller action'
+
+    context 'while throttled' do
+      let(:ssn) { '666666666' }
+
+      before do
+        stub_sign_in
+        create(
+          :throttle,
+          target: Pii::Fingerprinter.fingerprint(ssn),
+          throttle_type: :proof_ssn,
+        )
+        controller.user_session['idv/doc_auth'] = { 'pii_from_doc' => { 'ssn' => ssn } }
+      end
+
+      it 'assigns expiration time' do
+        get action
+
+        expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+    end
+  end
+
+  describe '#throttled' do
+    let(:action) { :throttled }
+    let(:template) { 'idv/session_errors/throttled' }
+
+    it_behaves_like 'an idv session errors controller action'
+
+    context 'while throttled' do
+      before do
+        user = create(:user)
+        stub_sign_in(user)
+        create(:throttle, :with_throttled, user: user, throttle_type: :idv_acuant)
+      end
+
+      it 'assigns expiration time' do
+        get action
+
+        expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+    end
   end
 end

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -138,7 +138,7 @@ describe Users::VerifyPersonalKeyController do
           throttle_type: :verify_personal_key,
         ).once
 
-        max_attempts, = Throttle.config_values(:verify_personal_key)
+        max_attempts = Throttle.max_attempts(:verify_personal_key)
         (max_attempts + 1).times { post :create, params: { personal_key: bad_key } }
 
         expect(response).to render_template(:throttled)

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -37,22 +37,21 @@ shared_examples 'verification step max attempts' do |step, sp|
       first(:link, t('links.sign_out')).click
       reattempt_interval = (IdentityConfig.store.idv_attempt_window_in_hours + 1).hours
 
-      travel(reattempt_interval) do
-        visit_idp_from_sp_with_ial2(:oidc)
-        sign_in_live_with_2fa(user)
+      travel(reattempt_interval)
+      visit_idp_from_sp_with_ial2(:oidc)
+      sign_in_live_with_2fa(user)
 
-        expect(page).to_not have_content(t("idv.failure.#{step_locale_key}.heading"))
-        expect(current_url).to eq(idv_doc_auth_step_url(step: :welcome))
+      expect(page).to_not have_content(t("idv.failure.#{step_locale_key}.heading"))
+      expect(current_url).to eq(idv_doc_auth_step_url(step: :welcome))
 
-        complete_all_doc_auth_steps
-        click_idv_continue
-        fill_in 'Password', with: user.password
-        click_idv_continue
-        click_acknowledge_personal_key
-        click_agree_and_continue
+      complete_all_doc_auth_steps
+      click_idv_continue
+      fill_in 'Password', with: user.password
+      click_idv_continue
+      click_acknowledge_personal_key
+      click_agree_and_continue
 
-        expect(current_url).to start_with('http://localhost:7654/auth/result')
-      end
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
     end
 
     scenario 'user sees the failure screen' do

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -14,6 +14,10 @@ shared_examples 'verification step max attempts' do |step, sp|
   end
 
   context 'after completing the max number of attempts' do
+    around do |ex|
+      freeze_time { ex.run }
+    end
+
     before do
       perfom_maximum_allowed_idv_step_attempts { fill_out_phone_form_fail }
     end

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -4,10 +4,16 @@ describe 'idv/phone_errors/failure.html.erb' do
   let(:sp_name) { 'Example SP' }
   let(:timeout_hours) { 6 }
 
+  around do |ex|
+    freeze_time { ex.run }
+  end
+
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
+
+    @expires_at = Time.zone.now + timeout_hours.hours
 
     render
   end

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -4,10 +4,16 @@ describe 'idv/session_errors/failure.html.erb' do
   let(:sp_name) { 'Example SP' }
   let(:timeout_hours) { 6 }
 
+  around do |ex|
+    freeze_time { ex.run }
+  end
+
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
+
+    @expires_at = Time.zone.now + timeout_hours.hours
 
     render
   end


### PR DESCRIPTION
**Why**: As a user, I expect that if I encounter an error screen informing me that I am unable to proceed due to too many attempts, the text on the page will let me know when I can try again, so that I know when to return to try again, and so that I'm not waiting longer than necessary if I can try again sooner than the text would otherwise imply.

**Screenshot:**

Screen|Before|After
---|---|---
Session Error|![Screen Shot 2021-08-17 at 3 17 37 PM](https://user-images.githubusercontent.com/1779930/129787520-3a570a20-6995-4bfe-95ac-52f5b8fa1f44.png)|![Screen Shot 2021-08-17 at 3 17 25 PM](https://user-images.githubusercontent.com/1779930/129787519-60a62b57-6d29-40e3-ac97-3d22121bf61d.png)
SSN Error|![Screen Shot 2021-08-17 at 3 17 37 PM](https://user-images.githubusercontent.com/1779930/129787520-3a570a20-6995-4bfe-95ac-52f5b8fa1f44.png)|![Screen Shot 2021-08-31 at 8 41 40 AM](https://user-images.githubusercontent.com/1779930/131507607-92449573-3e2a-4ace-9fee-ed62845b65df.png)
Phone Error|![Screen Shot 2021-08-31 at 8 59 12 AM](https://user-images.githubusercontent.com/1779930/131507634-ba31b40b-f146-47d2-a0fb-984f737ec789.png)|![Screen Shot 2021-08-31 at 9 00 07 AM](https://user-images.githubusercontent.com/1779930/131507647-ccb9a835-a899-4b68-a3ae-328782ae4cf3.png)
Send Link|![localhost_3000_verify_doc_auth_send_link](https://user-images.githubusercontent.com/1779930/130249003-2b8a04d5-41f4-4876-8f31-940d8e2dca8b.png)|![localhost_3000_verify_doc_auth_send_link (1)](https://user-images.githubusercontent.com/1779930/130249016-3c20bbca-e8bf-40fc-9a64-53babda365a3.png)
GPO Verify|![localhost_3000_account_verify](https://user-images.githubusercontent.com/1779930/130249038-d184d487-9899-4d56-952d-27a9ed04110a.png)|![localhost_3000_account_verify (2)](https://user-images.githubusercontent.com/1779930/130249456-84fbddc2-b5b6-4486-8d5d-72a691bac83c.png)