### PR TITLE
LG-4992: Switch over inputs to button instead of links

### DIFF
--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -27,7 +27,10 @@
   <%= f.input :resend, as: :hidden, wrapper: false %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>
-  <%= f.button :submit, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
+  <%= button_to(
+      user_password_path,
+      class: 'usa-button usa-button--unstyled ml-tiny',
+    ) { t('links.resend')} %></p>
 
   <% link = link_to(
        t('notices.forgot_password.use_diff_email.link'),

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -17,7 +17,7 @@
   </div>
   <hr/>
   <div class='right'>
-    <%= link_to(t('doc_auth.buttons.change_address'), idv_address_url) %>
+    <%= button_to(idv_address_url, method: :get, class: 'usa-button usa-button--unstyled') { t('doc_auth.buttons.change_address') } %>
   </div>
   <div>
     <%= "#{t('doc_auth.forms.address1')}: #{flow_session[:pii_from_doc][:address1]}" %>

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -25,12 +25,15 @@
 <%= validated_form_for @resend_email_confirmation_form,
                        html: { class: 'margin-bottom-2' },
                        url: sign_up_register_path do |f| %>
-
+  
   <%= f.input :email, as: :hidden, wrapper: false %>
   <%= f.input :resend, as: :hidden, wrapper: false %>
   <%= f.input :request_id, as: :hidden, wrapper: false %>
   <p><%= t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start') %>
-  <%= f.button :submit, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
+  <%= button_to(
+      sign_up_register_path,
+      class: 'usa-button usa-button--unstyled ml-tiny',
+    ) { t('links.resend')} %></p>
 
   <% link = link_to(
        t('notices.use_diff_email.link'),


### PR DESCRIPTION
***Why?**

For accessibility purposes in the IAL2 flow we should have all the things that are acting like inputs improperly will change to buttons. 