### PR TITLE
Set two_words_connector at locale string data

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -40,7 +40,6 @@ class UserDecorator
       current_time + lockout_time_remaining,
       true,
       highest_measures: 2,
-      two_words_connector: " #{I18n.t('datetime.dotiw.two_words_connector')} ",
     )
   end
 
@@ -60,7 +59,6 @@ class UserDecorator
       current_time + Devise.confirm_within,
       true,
       accumulate_on: :hours,
-      two_words_connector: " #{I18n.t('datetime.dotiw.two_words_connector')} ",
     )
   end
 

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -19,11 +19,7 @@ module SessionTimeoutWarningHelper
   end
 
   def time_left_in_session
-    distance_of_time_in_words(
-      session_timeout_warning,
-      0,
-      two_words_connector: " #{I18n.t('datetime.dotiw.two_words_connector')} ",
-    )
+    distance_of_time_in_words(session_timeout_warning, 0)
   end
 
   def session_modal

--- a/app/presenters/account_reset/pending_presenter.rb
+++ b/app/presenters/account_reset/pending_presenter.rb
@@ -16,7 +16,6 @@ module AccountReset
         account_reset_request.requested_at + wait_time,
         true,
         highest_measures: 2,
-        two_words_connector: " #{I18n.t('datetime.dotiw.two_words_connector')} ",
       )
     end
   end

--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -32,7 +32,6 @@ class ConfirmationEmailPresenter
       current_time + Devise.confirm_within,
       true,
       accumulate_on: :hours,
-      two_words_connector: " #{I18n.t('datetime.dotiw.two_words_connector')} ",
     )
   end
 

--- a/config/locales/dotiw/en.yml
+++ b/config/locales/dotiw/en.yml
@@ -2,4 +2,4 @@
 en:
   datetime:
     dotiw:
-      two_words_connector: and
+      two_words_connector: ' and '

--- a/config/locales/dotiw/es.yml
+++ b/config/locales/dotiw/es.yml
@@ -2,4 +2,4 @@
 es:
   datetime:
     dotiw:
-      two_words_connector: y
+      two_words_connector: ' y '

--- a/config/locales/dotiw/fr.yml
+++ b/config/locales/dotiw/fr.yml
@@ -2,4 +2,4 @@
 fr:
   datetime:
     dotiw:
-      two_words_connector: et
+      two_words_connector: ' et '


### PR DESCRIPTION
Extracted from #5301 ([context](https://github.com/18F/identity-idp/pull/5301#discussion_r690665001))

**Why**: Makes distance_of_time_in_words less error-prone and verbose, and aligns to [library documented defaults](https://github.com/radar/distance_of_time_in_words#two_words_connector). It had previously been implemented this way largely due to [limitations of YAML normalization](https://github.com/18F/identity-idp/pull/3780#discussion_r431246132) resolved by #5066.