### PR TITLE
LG-4940: Address parsing issues

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -84,6 +84,16 @@ input::-webkit-inner-spin-button {
 
 .checkbox {
   display: block;
+
+  .indicator {
+    background-color: $white;
+    border: $border-width solid $blue;
+    border-radius: .25rem;
+  }
+
+  input:checked ~ .indicator {
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgOCA4IiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA4IDgiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTYuNCwxTDUuNywxLjdMMi45LDQuNUwyLjEsMy43TDEuNCwzTDAsNC40bDAuNywwLjdsMS41LDEuNWwwLjcsMC43bDAuNy0wLjdsMy41LTMuNWwwLjctMC43TDYuNCwxTDYuNCwxeiINCgkvPg0KPC9zdmc+DQo=);
+  }
 }
 
 // wtf-forms.css
@@ -145,22 +155,12 @@ input::-webkit-inner-spin-button {
   color: $white;
 }
 
-.checkbox .indicator {
-  background-color: $white;
-  border: $border-width solid $blue;
-  border-radius: .25rem;
-}
-
 .indicator-checked::before {
   color: #fff;
   content: '\2713';
   font-size: 11px;
   font-weight: bold;
   line-height: .8em;
-}
-
-.checkbox input:checked ~ .indicator {
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgOCA4IiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA4IDgiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTYuNCwxTDUuNywxLjdMMi45LDQuNUwyLjEsMy43TDEuNCwzTDAsNC40bDAuNywwLjdsMS41LDEuNWwwLjcsMC43bDAuNy0wLjdsMy41LTMuNWwwLjctMC43TDYuNCwxTDYuNCwxeiINCgkvPg0KPC9zdmc+DQo=);
 }
 
 .radio .indicator {

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -82,6 +82,10 @@ input::-webkit-inner-spin-button {
   }
 }
 
+.checkbox {
+  display: block;
+}
+
 // wtf-forms.css
 .checkbox,
 .radio {

--- a/app/javascript/app/pw-toggle.js
+++ b/app/javascript/app/pw-toggle.js
@@ -10,11 +10,11 @@ function togglePw() {
       const el = `
         <div class="top-n24 right-0 absolute">
           <label class="btn-border" for="pw-toggle-${i}">
-            <div class="checkbox">
+            <span class="checkbox">
               <input id="pw-toggle-${i}" type="checkbox">
               <span class="indicator"></span>
               ${I18n.t('forms.passwords.show')}
-            </div>
+            </span>
           </label>
         </div>`;
       input.insertAdjacentHTML('afterend', el);

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -11,11 +11,11 @@ function formatSSNFieldAndLimitLength() {
       const el = `
         <div class="mt1 right">
           <label class="btn-border" for="ssn-toggle-${i}">
-            <div class="checkbox">
+            <span class="checkbox">
               <input id="ssn-toggle-${i}" type="checkbox">
               <span class="indicator"></span>
               ${I18n.t('forms.ssn.show')}
-            </div>
+            </span>
           </label>
         </div>`;
       input.insertAdjacentHTML('afterend', el);

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,12 +14,11 @@
 <%= validated_form_for(
       @password_reset_email_form,
       url: user_password_path,
-      html: { autocomplete: 'off', method: :post },
+      html: { method: :post },
     ) do |f| %>
   <%= f.input :email,
               required: true,
-              input_html: { autocorrect: 'off',
-                            aria: { invalid: false, describedby: 'email-description' } } %>
+              input_html: { aria: { invalid: false, describedby: 'email-description' } } %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-top-2' %>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,11 +14,12 @@
 <%= validated_form_for(
       @password_reset_email_form,
       url: user_password_path,
-      html: { method: :post },
+      html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <%= f.input :email,
               required: true,
-              input_html: { aria: { invalid: false, describedby: 'email-description' } } %>
+              input_html: { autocorrect: 'off',
+                            aria: { invalid: false, describedby: 'email-description' } } %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-top-2' %>
 <% end %>

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -21,12 +21,12 @@
                        html: { autocomplete: 'off', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
   <br/>
   <label class="margin-top-neg-1 margin-bottom-4" for="ial2_consent_given">
-    <div class="checkbox">
+    <span class="checkbox">
       <%= check_box_tag :ial2_consent_given, true, false %>
       <span class="indicator"></span>
       <%= t('doc_auth.instructions.consent') %>
       <%= new_window_link_to t('doc_auth.instructions.learn_more'), 'https://login.gov/policy/' %>
-    </div>
+    </span>
   </label>
   <%= f.button :button, t('doc_auth.buttons.continue'), type: :submit,
                class: 'usa-button--big usa-button--wide' %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -29,7 +29,6 @@
           <div class="usa-banner__guidance tablet:grid-col-6">
             <%= image_tag(
               asset_url('icon-dot-gov.svg'),
-              role: 'img',
               alt: 'Dot gov',
               class: 'usa-banner__icon usa-media-block__img'
             ) %>
@@ -43,7 +42,6 @@
           <div class="usa-banner__guidance tablet:grid-col-6">
             <%= image_tag(
               asset_url('icon-https.svg'),
-              role: 'img',
               alt: 'Https',
               class: 'usa-banner__icon usa-media-block__img'
             ) %>

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -7,12 +7,12 @@
       <%= t('two_factor_authentication.otp_make_default_number.instruction') %>
     </p>
     <label class="btn-border col-8">
-      <div class="checkbox">
+      <span class="checkbox">
         <%= check_box_tag 'edit_phone_form[make_default_number]',
             :otp_make_default_number, @edit_phone_form.default_phone_configuration? %>
         <span class="indicator"></span>
         <%= t('two_factor_authentication.otp_make_default_number.label') %>
-      </div>
+      </span>
     </label>
   </fieldset>
 </div>

--- a/app/views/users/shared/_otp_make_default_number.html.erb
+++ b/app/views/users/shared/_otp_make_default_number.html.erb
@@ -12,12 +12,12 @@
       <%= t('two_factor_authentication.otp_make_default_number.instruction') %>
     </p>
     <label class="btn-border col-8">
-      <div class="checkbox">
+      <span class="checkbox">
         <%= check_box_tag form_name_label,
             :otp_make_default_number, form_obj.otp_make_default_number %>
         <span class="indicator"></span>
         <%= t('two_factor_authentication.otp_make_default_number.label') %>
-      </div>
+      </span>
     </label>
   </fieldset>
 </div>


### PR DESCRIPTION
This ticket addresses parsing issues that were found during the audit of the IAL2 flow.

Why: Parsing is all about writing a clean code “HTML, CSS OR JavaScript” in a manner that is understood by browsers & assistive technologies. If the code is not written according to standards it can break the user experience of the application & assistive technology users will have a lot of problems to deal with. ([Source](https://www.digitala11y.com/understanding-sc-4-1-1-parsing/))

Note: the only warning that is not addressed is `Attribute aria-required is unnecessary for elements that have attribute required.`. My theory on is that if an input field is marked as required, the `aria-required` attribute is also created. If anyone has any thoughts on this theory, I am open to hearing any discussion about this.