### PR TITLE
Add in agency name, app friendly name to daily auths report

### DIFF
--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -44,10 +44,14 @@ module Reports
         , sp_return_logs.ial
         , sp_return_logs.issuer
         , service_providers.iaa
+        , MAX(service_providers.friendly_name) AS friendly_name
+        , MAX(agencies.name) AS agency
         FROM
           sp_return_logs
         LEFT JOIN
           service_providers ON service_providers.issuer = sp_return_logs.issuer
+        LEFT JOIN
+          agencies ON service_providers.agency_id = agencies.id
         WHERE
           %{start} <= sp_return_logs.requested_at
           AND sp_return_logs.requested_at <= %{finish}

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Reports::DailyAuthsReport do
                 issuer: 'a',
                 iaa: 'iaa123',
                 friendly_name: 'The App',
-                agency: 'The Agency'
+                agency: 'The Agency',
               },
               {
                 count: 1,
@@ -60,7 +60,7 @@ RSpec.describe Reports::DailyAuthsReport do
                 issuer: 'a',
                 iaa: 'iaa123',
                 friendly_name: 'The App',
-                agency: 'The Agency'
+                agency: 'The Agency',
               },
             ],
           )

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -23,8 +23,16 @@ RSpec.describe Reports::DailyAuthsReport do
     context 'with data' do
       let(:timestamp) { report_date + 12.hours }
 
+      let(:agency) { create(:agency, name: 'The Agency') }
+
       before do
-        create(:service_provider, issuer: 'a', iaa: 'iaa123')
+        create(
+          :service_provider,
+          issuer: 'a',
+          iaa: 'iaa123',
+          friendly_name: 'The App',
+          agency: agency,
+        )
         create(:sp_return_log, ial: 1, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
         create(:sp_return_log, ial: 1, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
         create(:sp_return_log, ial: 2, issuer: 'a', requested_at: timestamp, returned_at: timestamp)
@@ -38,8 +46,22 @@ RSpec.describe Reports::DailyAuthsReport do
           expect(parsed[:finish]).to eq(report_date.end_of_day.as_json)
           expect(parsed[:results]).to match_array(
             [
-              { count: 2, ial: 1, issuer: 'a', iaa: 'iaa123' },
-              { count: 1, ial: 2, issuer: 'a', iaa: 'iaa123' },
+              {
+                count: 2,
+                ial: 1,
+                issuer: 'a',
+                iaa: 'iaa123',
+                friendly_name: 'The App',
+                agency: 'The Agency'
+              },
+              {
+                count: 1,
+                ial: 2,
+                issuer: 'a',
+                iaa: 'iaa123',
+                friendly_name: 'The App',
+                agency: 'The Agency'
+              },
             ],
           )
         end


### PR DESCRIPTION
I originally included this in https://github.com/18F/identity-idp/pull/5313, but that will wait on our bucket to be set up, so I think this can go in sooner