### PR TITLE
Replace Timecop with ActiveSupport::Testing::TimeHelpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,7 +127,6 @@ group :test do
   gem 'rspec-retry'
   gem 'scss_lint', require: false
   gem 'shoulda-matchers', '~> 4.0', require: false
-  gem 'timecop'
   gem 'webdrivers', '~> 4.0'
   gem 'webmock'
   gem 'zonebie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,7 +631,6 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.4)
     tpm-key_attestation (0.10.0)
       bindata (~> 2.4)
       openssl-signature_algorithm (~> 1.0)
@@ -799,7 +798,6 @@ DEPENDENCIES
   stringex
   strong_migrations (>= 0.4.2)
   subprocess
-  timecop
   uglifier (~> 4.2)
   user_agent_parser
   valid_email (>= 0.1.3)

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -88,7 +88,7 @@ describe AccountReset::DeleteAccountController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::ACCOUNT_RESET, properties)
 
-      Timecop.travel(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days) do
         session[:granted_token] = AccountResetRequest.all[0].granted_token
         delete :delete
       end
@@ -133,7 +133,7 @@ describe AccountReset::DeleteAccountController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::ACCOUNT_RESET, properties)
 
-      Timecop.travel(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days) do
         get :show, params: { token: AccountResetRequest.all[0].granted_token }
       end
 

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -51,7 +51,7 @@ describe Idv::CaptureDocController do
 
     context 'with an expired token' do
       it 'redirects to the root url' do
-        Timecop.travel(Time.zone.now + 1.day) do
+        travel_to(Time.zone.now + 1.day) do
           get :index, params: { 'document-capture-session': session_uuid }
         end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -124,7 +124,7 @@ describe SignUp::CompletionsController do
   end
 
   describe '#update' do
-    let(:now) { Time.zone.now }
+    let(:now) { Time.zone.now.change(usec: 0) }
 
     before do
       stub_analytics
@@ -166,7 +166,8 @@ describe SignUp::CompletionsController do
           last_consented_at: now,
           clear_deleted_at: true,
         )
-        Timecop.freeze(now) do
+        freeze_time do
+          travel_to(now)
           patch :update
         end
       end
@@ -217,7 +218,8 @@ describe SignUp::CompletionsController do
           last_consented_at: now,
           clear_deleted_at: true,
         )
-        Timecop.freeze(now) do
+        freeze_time do
+          travel_to(now)
           patch :update
         end
       end

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -31,7 +31,6 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
       raw_key = PersonalKeyGenerator.new(user).create
-      old_key = user.reload.encrypted_recovery_code_digest
       stub_sign_in_before_2fa(user)
       get :show
 

--- a/spec/controllers/users/forget_all_browsers_controller_spec.rb
+++ b/spec/controllers/users/forget_all_browsers_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Users::ForgetAllBrowsersController do
     it 'updates the remember_device_revoked_at attribute for the user' do
       now = Time.zone.now
 
-      expect { Timecop.freeze(now) { subject } }.to change { user.remember_device_revoked_at.to_i }.
+      expect { freeze_time { travel_to(now); subject } }.to change { user.remember_device_revoked_at.to_i }.
         from(original_device_revoked_at.to_i).
         to(now.to_i)
     end

--- a/spec/controllers/users/forget_all_browsers_controller_spec.rb
+++ b/spec/controllers/users/forget_all_browsers_controller_spec.rb
@@ -46,7 +46,12 @@ RSpec.describe Users::ForgetAllBrowsersController do
     it 'updates the remember_device_revoked_at attribute for the user' do
       now = Time.zone.now
 
-      expect { freeze_time { travel_to(now); subject } }.to change { user.remember_device_revoked_at.to_i }.
+      expect do
+        freeze_time do
+          travel_to(now)
+          subject
+        end
+      end.to change { user.remember_device_revoked_at.to_i }.
         from(original_device_revoked_at.to_i).
         to(now.to_i)
     end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -181,9 +181,7 @@ describe Users::ResetPasswordsController, devise: true do
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
 
-        now = Time.zone.now
         freeze_time do
-          travel_to(now)
           user = create(
             :user,
             :signed_up,

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -181,7 +181,9 @@ describe Users::ResetPasswordsController, devise: true do
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
 
-        Timecop.freeze(Time.zone.now) do
+        now = Time.zone.now
+        freeze_time do
+          travel_to(now)
           user = create(
             :user,
             :signed_up,

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Users::ServiceProviderRevokeController do
     subject { delete :destroy, params: { sp_id: sp_id } }
 
     it 'marks the identity as deleted and redirects' do
-      expect { Timecop.freeze(now) { subject } }.
+      expect { freeze_time { travel_to(now); subject } }.
         to change { @identity.reload.deleted_at&.to_i }.
         from(nil).to(now.to_i)
       expect(response).to redirect_to(account_connected_accounts_path)

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -61,9 +61,14 @@ RSpec.describe Users::ServiceProviderRevokeController do
     subject { delete :destroy, params: { sp_id: sp_id } }
 
     it 'marks the identity as deleted and redirects' do
-      expect { freeze_time { travel_to(now); subject } }.
-        to change { @identity.reload.deleted_at&.to_i }.
-        from(nil).to(now.to_i)
+      expect do
+        freeze_time do
+          travel_to(now)
+          subject
+        end
+      end.to change { @identity.reload.deleted_at&.to_i }.
+      from(nil).to(now.to_i)
+
       expect(response).to redirect_to(account_connected_accounts_path)
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -97,9 +97,9 @@ describe Users::SessionsController, devise: true do
         expected_time = now + 10
         session[:pinged_at] = now
 
-        Timecop.travel(Time.zone.now + 10)
-        get :active
-        Timecop.return
+        travel_to(Time.zone.now + 10) do
+          get :active
+        end
 
         expect(session[:pinged_at].to_i).to be_within(1).of(expected_time.to_i)
       end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -68,7 +68,7 @@ describe UserDecorator do
 
   describe '#lockout_time_remaining' do
     it 'returns the difference in seconds between otp drift and second_factor_locked_at' do
-      Timecop.freeze(Time.zone.now) do
+      freeze_time do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 180)
         user_decorator = UserDecorator.new(user)
         allow(IdentityConfig.store).to receive(:lockout_period_in_minutes).and_return(8)
@@ -80,7 +80,7 @@ describe UserDecorator do
 
   describe '#lockout_time_remaining_in_words' do
     it 'converts lockout_time_remaining to words representing minutes and seconds left' do
-      Timecop.freeze(Time.zone.now) do
+      freeze_time do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 181)
         user_decorator = UserDecorator.new(user)
         allow(IdentityConfig.store).to receive(:lockout_period_in_minutes).and_return(8)

--- a/spec/features/account_reset/cancel_request_spec.rb
+++ b/spec/features/account_reset/cancel_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Account Reset Request: Cancellation' do
       click_button t('account_reset.request.yes_continue')
       reset_email
 
-      Timecop.travel(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/cancel\?token/)

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -29,7 +29,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       reset_email
 
-      Timecop.travel(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)
@@ -86,7 +86,7 @@ describe 'Account Reset Request: Delete Account', email: true do
       reset_email
 
       allow(IdentityConfig.store).to receive(:push_notifications_enabled).and_return(true)
-      Timecop.travel(2.days.from_now) do
+      travel_to(2.days.from_now) do
         request = stub_push_notification_request(
           sp_push_notification_endpoint: push_notification_url,
           event_type: PushNotification::AccountPurgedEvent::EVENT_TYPE,

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -91,7 +91,7 @@ feature 'disavowing an action' do
   scenario 'attempting to disavow an event after a long time and the disavowal has expired' do
     perform_disavowable_password_reset
 
-    Timecop.travel 11.days.from_now do
+    travel_to(11.days.from_now) do
       open_last_email
       click_email_link_matching(%r{events/disavow})
 

--- a/spec/features/idv/doc_auth/agreement_step_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_step_spec.rb
@@ -82,7 +82,7 @@ feature 'doc auth welcome step' do
       end
 
       around do |ex|
-        Timecop.travel(now) { ex.run }
+        travel_to(now) { ex.run }
       end
 
       it 'renders the warning banner but no other content' do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -152,7 +152,7 @@ feature 'doc auth document capture step' do
         throttle_type: :idv_acuant,
       )
 
-      Timecop.travel(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_document_capture_step
         attach_and_submit_images
@@ -238,7 +238,7 @@ feature 'doc auth document capture step' do
         throttle_type: :idv_acuant,
       )
 
-      Timecop.travel(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_document_capture_step
         attach_and_submit_images

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -84,7 +84,7 @@ feature 'doc auth send link step' do
       throttle_type: :idv_send_link,
     )
 
-    Timecop.travel(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes) do
+    travel_to(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes) do
       fill_in :doc_auth_phone, with: '415-555-0199'
       click_idv_continue
       expect(page).to have_current_path(idv_doc_auth_link_sent_step)

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -84,7 +84,7 @@ feature 'doc auth send link step' do
       throttle_type: :idv_send_link,
     )
 
-    travel_to(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes) do
+    travel_to(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes + 1) do
       fill_in :doc_auth_phone, with: '415-555-0199'
       click_idv_continue
       expect(page).to have_current_path(idv_doc_auth_link_sent_step)

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -113,7 +113,7 @@ feature 'doc auth verify step' do
       step_name: Idv::Steps::VerifyWaitStepShow,
     )
 
-    travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now) do
+    travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
       click_idv_continue

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -113,7 +113,7 @@ feature 'doc auth verify step' do
       step_name: Idv::Steps::VerifyWaitStepShow,
     )
 
-    Timecop.travel(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now) do
+    travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now) do
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
       click_idv_continue

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -74,7 +74,7 @@ feature 'doc auth welcome step' do
       let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
 
       around do |ex|
-        Timecop.travel(now) { ex.run }
+        travel_to(now) { ex.run }
       end
 
       it 'renders the warning banner but no other content' do

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -288,7 +288,7 @@ feature 'doc capture document capture step' do
 
       DocAuth::Mock::DocAuthMockClient.reset!
 
-      Timecop.travel(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
         complete_doc_capture_steps_before_first_step(user)
         attach_and_submit_images
 
@@ -374,7 +374,7 @@ feature 'doc capture document capture step' do
 
       DocAuth::Mock::DocAuthMockClient.reset!
 
-      Timecop.travel(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
         complete_doc_capture_steps_before_first_step(user)
         attach_and_submit_images
 

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -288,7 +288,7 @@ feature 'doc capture document capture step' do
 
       DocAuth::Mock::DocAuthMockClient.reset!
 
-      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now + 1) do
         complete_doc_capture_steps_before_first_step(user)
         attach_and_submit_images
 
@@ -374,7 +374,7 @@ feature 'doc capture document capture step' do
 
       DocAuth::Mock::DocAuthMockClient.reset!
 
-      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now) do
+      travel_to(IdentityConfig.store.acuant_attempt_window_in_minutes.minutes.from_now + 1) do
         complete_doc_capture_steps_before_first_step(user)
         attach_and_submit_images
 

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -102,7 +102,7 @@ feature 'phone otp rate limiting', :idv_job do
     Throttle.where(throttle_type: :idv_acuant).destroy_all
 
     retry_minutes = IdentityConfig.store.lockout_period_in_minutes + 1
-    Timecop.travel retry_minutes.minutes.from_now do
+    travel_to(retry_minutes.minutes.from_now) do
       start_idv_from_sp
       complete_idv_steps_before_phone_otp_verification_step(user)
 

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -34,7 +34,7 @@ feature 'phone otp verification step spec' do
     start_idv_from_sp
     complete_idv_steps_before_phone_otp_verification_step
 
-    Timecop.travel(expiration_minutes.minutes.from_now) do
+    travel_to(expiration_minutes.minutes.from_now) do
       fill_in_code_with_last_phone_otp
       click_button t('forms.buttons.submit.default')
 

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -176,7 +176,7 @@ feature 'adding email address' do
 
     Capybara.reset_session!
 
-    Timecop.travel 25.hours.from_now do
+    travel_to(25.hours.from_now) do
       click_on_link_in_confirmation_email
       expect(page).to have_current_path(root_path)
       expect(page).to_not have_content(t('devise.confirmations.confirmed_but_sign_in'))

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -50,7 +50,7 @@ describe 'OpenID Connect' do
 
     it 'succeeds in forcing login with prompt login and prior session' do
       user = oidc_end_client_secret_jwt(prompt: 'login')
-      Timecop.travel((IdentityConfig.store.sp_handoff_bounce_max_seconds + 1).seconds.from_now) do
+      travel_to((IdentityConfig.store.sp_handoff_bounce_max_seconds + 1).seconds.from_now) do
         oidc_end_client_secret_jwt(prompt: 'login', user: user)
       end
     end

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -24,10 +24,10 @@ describe 'signing in with remember device and idling on the sign in page' do
     visit_idp_from_sp_with_ial1(:oidc)
     request_id = ServiceProviderRequestProxy.last.uuid
 
-    Timecop.travel(Devise.timeout_in + 1.minute) do
+    travel(Devise.timeout_in + 1.minute) do
       # Simulate being idle on the sign in page long enough for the session to
-      # be deleted from Redis, but since Redis doesn't respect Timecop, we need
-      # to expire the session manually.
+      # be deleted from Redis, but since Redis doesn't respect ActiveSupport::Testing::TimeHelpers,
+      # we need to expire the session manually.
       session_store.send(:destroy_session_from_sid, session_cookie.value)
       # Simulate refreshing the page with JS to avoid a CSRF error
       visit new_user_session_url(request_id: request_id)

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
 
   context "#{protocol}: signing in" do
     it "does not require MFA before #{expiration_time.inspect}" do
-      Timecop.travel(expiration_time.from_now - 1.day) do
+      travel_to(expiration_time.from_now - 1.day) do
         visit_idp_from_sp_with_ial1(protocol)
         sign_in_user(user)
 
@@ -16,7 +16,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
     end
 
     it "does require MFA after #{expiration_time.inspect}" do
-      Timecop.travel(expiration_time.from_now + 1.day) do
+      travel_to(expiration_time.from_now + 1.day) do
         visit_idp_from_sp_with_ial1(protocol)
         sign_in_user(user)
 
@@ -33,7 +33,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
 
   context "#{protocol}: visiting while already signed in" do
     it "does not require MFA before #{expiration_time.inspect}" do
-      Timecop.travel(expiration_time.from_now - 1.day) do
+      travel_to(expiration_time.from_now - 1.day) do
         sign_in_user(user)
         visit_idp_from_sp_with_ial1(protocol)
 
@@ -42,7 +42,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
     end
 
     it "does require MFA after #{expiration_time.inspect}" do
-      Timecop.travel(expiration_time.from_now + 1.day) do
+      travel_to(expiration_time.from_now + 1.day) do
         if expiration_time == 30.days
           sign_in_live_with_2fa(user)
           visit_idp_from_sp_with_ial1(protocol)

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -39,7 +39,7 @@ describe 'Remembering a TOTP device' do
 
   context 'update totp' do
     after do
-      Timecop.return
+      travel_back
     end
 
     def remember_device_and_sign_out_user
@@ -47,7 +47,7 @@ describe 'Remembering a TOTP device' do
       visit account_two_factor_authentication_path
       page.find('.remove-auth-app').click # Delete
       click_on t('account.index.totp_confirm_delete')
-      Timecop.travel 5.seconds.from_now # Travel past the revoked at date from disabling the device
+      travel_to(10.seconds.from_now) # Travel past the revoked at date from disabling the device
       click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
       fill_in :code, with: totp_secret_from_page
       check :remember_device

--- a/spec/features/reports/omb_fitara_report_spec.rb
+++ b/spec/features/reports/omb_fitara_report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'OMB Fitara compliance officer runs report' do
   it 'works in july' do
-    Timecop.travel Date.new(2019, 7, 2) do
+    travel_to(Date.new(2019, 7, 2)) do
       visit sign_up_email_path
       sign_up_and_2fa_ial1_user
 
@@ -12,7 +12,7 @@ feature 'OMB Fitara compliance officer runs report' do
   end
 
   it 'works in december' do
-    Timecop.travel Date.new(2019, 12, 2) do
+    travel_to(Date.new(2019, 12, 2)) do
       visit sign_up_email_path
       sign_up_and_2fa_ial1_user
 
@@ -22,7 +22,7 @@ feature 'OMB Fitara compliance officer runs report' do
   end
 
   it 'works in january' do
-    Timecop.travel Date.new(2019, 1, 2) do
+    travel_to(Date.new(2019, 1, 2)) do
       visit sign_up_email_path
       sign_up_and_2fa_ial1_user
 
@@ -37,7 +37,7 @@ feature 'OMB Fitara compliance officer runs report' do
     it 'generates paths with date or latest prefix' do
       expect(Identity::Hostdata).to receive(:env).and_return('ci')
 
-      Timecop.travel Date.new(2018, 1, 2) do
+      travel_to(Date.new(2018, 1, 2)) do
         expect(Reports::OmbFitaraReport.new.send(:generate_s3_paths, report_name, 'json')).
           to eq(
             ['ci/omb-fitara-report/latest.omb-fitara-report.json',

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -223,10 +223,10 @@ feature 'saml api' do
       end
 
       it 'redirects to root' do
-        Timecop.travel(Devise.timeout_in + 1.second)
-        visit api_saml_logout2021_url
-        expect(page.current_path).to eq('/')
-        Timecop.return
+        travel(Devise.timeout_in + 1.second) do
+          visit api_saml_logout2021_url
+          expect(page.current_path).to eq('/')
+        end
       end
     end
   end

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -42,7 +42,7 @@ feature 'Session Timeout' do
       sign_in_and_2fa_user
 
       timeout_in_minutes = IdentityConfig.store.session_total_duration_timeout_in_minutes.to_i
-      Timecop.travel (timeout_in_minutes + 1).minutes.from_now do
+      travel_to((timeout_in_minutes + 1).minutes.from_now) do
         visit account_path
 
         expect(page).to have_current_path(root_path)

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -7,11 +7,11 @@ feature 'Changing authentication factor' do
     before do
       user # Sign up the user
       reauthn_date = (IdentityConfig.store.reauthn_window + 1).seconds.from_now
-      Timecop.travel reauthn_date
+      travel_to(reauthn_date)
     end
 
     after do
-      Timecop.return
+      travel_back
     end
 
     scenario 'editing password' do
@@ -32,22 +32,21 @@ feature 'Changing authentication factor' do
         phone_configuration = MfaContext.new(user).phone_configurations.first
         old_phone = phone_configuration.phone
 
-        Timecop.travel(IdentityConfig.store.reauthn_window + 1) do
-          visit manage_phone_path(id: phone_configuration)
-          complete_2fa_confirmation_without_entering_otp
-          click_link t('links.two_factor_authentication.get_another_code')
+        travel(IdentityConfig.store.reauthn_window + 1)
+        visit manage_phone_path(id: phone_configuration)
+        complete_2fa_confirmation_without_entering_otp
+        click_link t('links.two_factor_authentication.get_another_code')
 
-          expect(Telephony).to have_received(:send_authentication_otp).with(
-            otp: user.reload.direct_otp,
-            to: old_phone,
-            expiration: 10,
-            channel: :sms,
-            domain: IdentityConfig.store.domain_name,
-          )
+        expect(Telephony).to have_received(:send_authentication_otp).with(
+          otp: user.reload.direct_otp,
+          to: old_phone,
+          expiration: 10,
+          channel: :sms,
+          domain: IdentityConfig.store.domain_name,
+        )
 
-          expect(current_path).
-            to eq login_two_factor_path(otp_delivery_preference: 'sms')
-        end
+        expect(current_path).
+          to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end
     end
   end
@@ -92,7 +91,7 @@ feature 'Changing authentication factor' do
   describe 'attempting to bypass current password entry' do
     it 'does not allow bypassing this step' do
       sign_in_and_2fa_user
-      Timecop.travel(IdentityConfig.store.reauthn_window + 1) do
+      travel(IdentityConfig.store.reauthn_window + 1) do
         visit manage_password_path
         expect(current_path).to eq user_password_confirm_path
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -321,7 +321,7 @@ feature 'Two Factor Authentication' do
       Db::AuthAppConfiguration.create(user, secret, nil, 'foo')
       otp = generate_totp_code(secret)
 
-      Timecop.freeze do
+      freeze_time do
         sign_in_user(user)
         fill_in 'code', with: otp
         click_submit_default

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -230,12 +230,12 @@ feature 'Sign in' do
     visit account_path
     expect(current_path).to eq account_path
 
-    Timecop.travel(Devise.timeout_in + 1.minute)
+    travel(Devise.timeout_in + 1.minute)
 
     visit account_path
     expect(current_path).to eq root_path
 
-    Timecop.return
+    travel_back
   end
 
   scenario 'user session cookie has no explicit expiration time (dies with browser exit)' do
@@ -334,10 +334,10 @@ feature 'Sign in' do
       user = sign_in_and_2fa_user
       click_link(t('links.sign_out'), match: :first)
 
-      Timecop.travel(Devise.timeout_in + 1.minute) do
+      travel(Devise.timeout_in + 1.minute) do
         expect(page).to_not have_content(t('forms.buttons.continue'))
 
-        # Redis doesn't respect Timecop so expire session manually.
+        # Redis doesn't respect ActiveSupport::Testing::TimeHelpers, so expire session manually.
         session_store.send(:destroy_session_from_sid, session_cookie.value)
 
         fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -269,7 +269,7 @@ feature 'Sign Up' do
         confirmation_token: 'foo', uuid: 'foo', email: email,
         confirmation_sent_at: Time.zone.now
       )
-      Timecop.travel 1.year.from_now do
+      travel_to(1.year.from_now) do
         visit sign_up_email_path
         submit_form_with_valid_email(email)
         click_confirmation_link_in_email(email)

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -83,7 +83,7 @@ describe 'totp management' do
       click_button 'Submit'
 
       # simulate user delay. totp has a 30 second time step
-      Timecop.travel 30.seconds.from_now do
+      travel_to(30.seconds.from_now) do
         click_link "+ #{t('account.index.auth_app_add')}", href: authenticator_setup_url
 
         secret = find('#qr-code').text

--- a/spec/features/visitors/bad_password_spec.rb
+++ b/spec/features/visitors/bad_password_spec.rb
@@ -16,7 +16,7 @@ feature 'Visitor signs in with bad passwords and gets locked out' do
       fill_in_credentials_and_submit(bad_email, bad_password)
       expect(page).to have_content(t('errors.sign_in.bad_password_limit'))
     end
-    Timecop.travel IdentityConfig.store.max_bad_passwords_window_in_seconds.seconds.from_now do
+    travel_to(IdentityConfig.store.max_bad_passwords_window_in_seconds.seconds.from_now) do
       fill_in_credentials_and_submit(bad_email, bad_password)
       expect(page).to have_content(error_message)
     end

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -90,7 +90,7 @@ feature 'Email confirmation during sign up' do
       click_email_link_matching(/confirmation_token/)
       expect(page).to have_current_path(sign_up_enter_password_path, ignore_query: true)
 
-      Timecop.travel 48.hours.from_now do
+      travel_to(48.hours.from_now) do
         sign_up_with(email)
         open_last_email
         click_email_link_matching(/confirmation_token/)

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -259,7 +259,7 @@ feature 'Password Recovery' do
     expect(unread_emails_for(email).size).to eq(max_attempts)
 
     window_in_minutes = IdentityConfig.store.reset_password_email_window_in_minutes + 1
-    Timecop.travel(Time.zone.now + window_in_minutes.minutes) do
+    travel_to(Time.zone.now + window_in_minutes.minutes) do
       submit_email_for_password_reset(email)
       expect(unread_emails_for(email).size).to eq(max_attempts + 1)
     end

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -34,7 +34,7 @@ feature 'Visit requests confirmation instructions again during sign up' do
     expect(unread_emails_for(user.email).size).to eq(max_attempts)
 
     window_in_minutes = IdentityConfig.store.reg_unconfirmed_email_window_in_minutes + 1
-    Timecop.travel(Time.zone.now + window_in_minutes.minutes) do
+    travel_to(Time.zone.now + window_in_minutes.minutes) do
       submit_resend_email_confirmation(email)
       expect(unread_emails_for(user.email).size).to eq(max_attempts + 1)
     end

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -81,7 +81,7 @@ feature 'Visitor signs up with email address' do
     expect(unread_emails_for(email).size).to eq(starting_count + max_attempts)
 
     window_in_minutes = IdentityConfig.store.reg_unconfirmed_email_window_in_minutes + 1
-    Timecop.travel(Time.zone.now + window_in_minutes.minutes) do
+    travel_to(Time.zone.now + window_in_minutes.minutes) do
       sign_up_with(email)
       expect(unread_emails_for(email).size).to eq(starting_count + max_attempts + 1)
     end

--- a/spec/jobs/reports/iaa_billing_report_spec.rb
+++ b/spec/jobs/reports/iaa_billing_report_spec.rb
@@ -109,11 +109,11 @@ describe Reports::IaaBillingReport do
     Agreements::IntegrationUsage.delete_all
     Agreements::Integration.delete_all
     ServiceProvider.delete_all
-    Timecop.travel now
+    travel_to(now)
   end
 
   after do
-    Timecop.return
+    travel_back
   end
 
   it 'works with no SPs' do

--- a/spec/jobs/reports/sp_user_quotas_report_spec.rb
+++ b/spec/jobs/reports/sp_user_quotas_report_spec.rb
@@ -28,7 +28,7 @@ describe Reports::SpUserQuotasReport do
     )
     results = [{ issuer: issuer, app_id: app_id, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
-    Timecop.travel Date.new(year, month, day) do
+    travel_to(Date.new(year, month, day)) do
       expect(subject.perform(Time.zone.today)).to eq(results)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
 
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
   config.include AbstractController::Translation

--- a/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
+++ b/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
@@ -79,7 +79,7 @@ describe AccountReset::GrantRequestsAndSendEmails do
 
   def after_waiting_the_full_wait_period
     days = IdentityConfig.store.account_reset_wait_period_days.days
-    Timecop.travel(Time.zone.now + days) do
+    travel_to(Time.zone.now + 1 + days) do
       yield
     end
   end

--- a/spec/services/funnel/registration/range_registered_count_spec.rb
+++ b/spec/services/funnel/registration/range_registered_count_spec.rb
@@ -48,7 +48,7 @@ describe Funnel::Registration::RangeRegisteredCount do
   end
 
   def register_user(year, month, day)
-    Timecop.travel Date.new(year, month, day) do
+    travel_to Date.new(year, month, day) do
       user = create(:user)
       user_id = user.id
       Funnel::Registration::Create.call(user_id)

--- a/spec/services/funnel/registration/range_submitted_count_spec.rb
+++ b/spec/services/funnel/registration/range_submitted_count_spec.rb
@@ -48,7 +48,7 @@ describe Funnel::Registration::RangeSubmittedCount do
   end
 
   def submit_user(year, month, day)
-    Timecop.travel Date.new(year, month, day) do
+    travel_to Date.new(year, month, day) do
       user = create(:user)
       user_id = user.id
       Funnel::Registration::Create.call(user_id)

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe IdTokenBuilder do
   end
 
   describe '#id_token' do
-    subject(:id_token) { freeze_time; travel_to(now); builder.id_token }
+    subject(:id_token) { builder.id_token }
 
     let(:decoded_id_token) do
       JWT.decode(

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe IdTokenBuilder do
   end
 
   describe '#id_token' do
-    subject(:id_token) { Timecop.freeze(now) { builder.id_token } }
+    subject(:id_token) { freeze_time; travel_to(now); builder.id_token }
 
     let(:decoded_id_token) do
       JWT.decode(

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -43,7 +43,7 @@ describe Idv::SendPhoneConfirmationOtp do
       it 'sends an sms' do
         allow(Telephony).to receive(:send_confirmation_otp).and_call_original
 
-        result = Timecop.freeze(now) { subject.call }
+        result = travel_to(now) { subject.call }
 
         expect(result.success?).to eq(true)
 
@@ -69,7 +69,7 @@ describe Idv::SendPhoneConfirmationOtp do
       it 'makes a phone call' do
         allow(Telephony).to receive(:send_confirmation_otp).and_call_original
 
-        result = Timecop.freeze(now) { subject.call }
+        result = travel_to(now) { subject.call }
 
         expect(result.success?).to eq(true)
 

--- a/spec/services/phone_confirmation/confirmaton_session_spec.rb
+++ b/spec/services/phone_confirmation/confirmaton_session_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe PhoneConfirmation::ConfirmationSession do
 
       expect(otp_object.expired?).to eq(false)
 
-      Timecop.travel 9.minutes.from_now do
+      travel_to 9.minutes.from_now do
         expect(otp_object.expired?).to eq(false)
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe PhoneConfirmation::ConfirmationSession do
     it 'returns true if the OTP is expired' do
       otp_object = described_class.start(phone: '+1 (225) 123-4567', delivery_method: :sms)
 
-      Timecop.travel 11.minutes.from_now do
+      travel_to 11.minutes.from_now do
         expect(otp_object.expired?).to eq(true)
       end
     end

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -33,7 +33,7 @@ shared_examples 'verification step max attempts' do |step, sp|
       first(:link, t('links.sign_out')).click
       reattempt_interval = (IdentityConfig.store.idv_attempt_window_in_hours + 1).hours
 
-      Timecop.travel reattempt_interval do
+      travel_to reattempt_interval do
         visit_idp_from_sp_with_ial2(:oidc)
         sign_in_live_with_2fa(user)
 

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -33,7 +33,7 @@ shared_examples 'verification step max attempts' do |step, sp|
       first(:link, t('links.sign_out')).click
       reattempt_interval = (IdentityConfig.store.idv_attempt_window_in_hours + 1).hours
 
-      travel_to reattempt_interval do
+      travel(reattempt_interval) do
         visit_idp_from_sp_with_ial2(:oidc)
         sign_in_live_with_2fa(user)
 

--- a/spec/support/shared_examples/phone/otp_confirmation.rb
+++ b/spec/support/shared_examples/phone/otp_confirmation.rb
@@ -25,7 +25,7 @@ shared_examples 'phone otp confirmation' do |delivery_method|
 
   it 'renders an error if the OTP has expired' do
     visit_otp_confirmation(delivery_method)
-    Timecop.travel 11.minutes.from_now do
+    travel_to(11.minutes.from_now) do
       fill_in :code, with: last_otp(delivery_method)
       click_submit_default
       expect(page).to have_content(t('two_factor_authentication.invalid_otp'))

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -58,7 +58,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
   end
 
   def expect_rate_limitting_to_expire
-    Timecop.travel 6.minutes.from_now do
+    travel_to(6.minutes.from_now) do
       visit root_path
 
       signin(user.email, user.password || Features::SessionHelper::VALID_PASSWORD)

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -10,11 +10,10 @@ shared_examples 'remember device' do
 
     days_to_travel = (IdentityConfig.store.remember_device_expiration_hours_aal_1 + 1).
       hours.from_now
-    Timecop.travel days_to_travel do
-      sign_in_user(user)
+    travel_to(days_to_travel)
+    sign_in_user(user)
 
-      expect_mfa_to_be_required_for_user(user)
-    end
+    expect_mfa_to_be_required_for_user(user)
   end
 
   it 'requires 2FA on sign in for another user' do

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -42,9 +42,6 @@ shared_examples 'signing in as IAL1 with piv/cac' do |sp|
 end
 
 shared_examples 'visiting 2fa when fully authenticated' do |sp|
-  before { freeze_time; travel_to(Time.zone.now) }
-  after { travel_back }
-
   it 'redirects to SP after visiting a 2fa screen when fully authenticated', email: true do
     ial1_sign_in_with_personal_key_goes_to_sp(sp)
 
@@ -63,9 +60,6 @@ shared_examples 'visiting 2fa when fully authenticated' do |sp|
 end
 
 shared_examples 'signing in as IAL2 with personal key' do |sp|
-  before { freeze_time; travel_to(Time.zone.now) }
-  after { travel_back }
-
   it 'does not present personal key as an MFA option', :email do
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
     pii = { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' }
@@ -100,9 +94,6 @@ shared_examples 'signing in as IAL2 with piv/cac' do |sp|
 end
 
 shared_examples 'signing in as IAL1 with personal key after resetting password' do |sp|
-  before { freeze_time; travel_to(Time.zone.now) }
-  after { travel_back }
-
   it 'redirects to SP', email: true do
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
 
@@ -204,28 +195,25 @@ def personal_key_for_ial2_user(user, pii)
 end
 
 def ial1_sign_in_with_personal_key_goes_to_sp(sp)
-  freeze_time do
-    travel_to(Time.zone.now)
-    user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
-    old_personal_key = PersonalKeyGenerator.new(user).create
+  user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
+  old_personal_key = PersonalKeyGenerator.new(user).create
 
-    Capybara.reset_sessions!
+  Capybara.reset_sessions!
 
-    visit_idp_from_sp_with_ial1(sp)
-    fill_in_credentials_and_submit(user.email, 'Val!d Pass w0rd')
-    choose_another_security_option('personal_key')
-    enter_personal_key(personal_key: old_personal_key)
-    click_submit_default
-    click_agree_and_continue
+  visit_idp_from_sp_with_ial1(sp)
+  fill_in_credentials_and_submit(user.email, 'Val!d Pass w0rd')
+  choose_another_security_option('personal_key')
+  enter_personal_key(personal_key: old_personal_key)
+  click_submit_default
+  click_agree_and_continue
 
-    expect(current_url).to eq @saml_authn_request if sp == :saml
+  expect(current_url).to eq @saml_authn_request if sp == :saml
 
-    return unless sp == :oidc
+  return unless sp == :oidc
 
-    redirect_uri = URI(current_url)
+  redirect_uri = URI(current_url)
 
-    expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-  end
+  expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
 end
 
 def ial1_sign_in_with_piv_cac_goes_to_sp(sp)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -42,8 +42,8 @@ shared_examples 'signing in as IAL1 with piv/cac' do |sp|
 end
 
 shared_examples 'visiting 2fa when fully authenticated' do |sp|
-  before { Timecop.freeze Time.zone.now }
-  after { Timecop.return }
+  before { freeze_time; travel_to(Time.zone.now) }
+  after { travel_back }
 
   it 'redirects to SP after visiting a 2fa screen when fully authenticated', email: true do
     ial1_sign_in_with_personal_key_goes_to_sp(sp)
@@ -63,8 +63,8 @@ shared_examples 'visiting 2fa when fully authenticated' do |sp|
 end
 
 shared_examples 'signing in as IAL2 with personal key' do |sp|
-  before { Timecop.freeze Time.zone.now }
-  after { Timecop.return }
+  before { freeze_time; travel_to(Time.zone.now) }
+  after { travel_back }
 
   it 'does not present personal key as an MFA option', :email do
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
@@ -100,8 +100,8 @@ shared_examples 'signing in as IAL2 with piv/cac' do |sp|
 end
 
 shared_examples 'signing in as IAL1 with personal key after resetting password' do |sp|
-  before { Timecop.freeze Time.zone.now }
-  after { Timecop.return }
+  before { freeze_time; travel_to(Time.zone.now) }
+  after { travel_back }
 
   it 'redirects to SP', email: true do
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
@@ -204,7 +204,8 @@ def personal_key_for_ial2_user(user, pii)
 end
 
 def ial1_sign_in_with_personal_key_goes_to_sp(sp)
-  Timecop.freeze Time.zone.now do
+  freeze_time do
+    travel_to(Time.zone.now)
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
     old_personal_key = PersonalKeyGenerator.new(user).create
 

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -160,7 +160,7 @@ describe 'devise/sessions/new.html.erb' do
     end
 
     around do |ex|
-      Timecop.travel(now) { ex.run }
+      travel_to(now) { ex.run }
     end
 
     it 'renders the warning banner and the normal form' do

--- a/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
@@ -68,7 +68,7 @@ describe 'idv/doc_auth/welcome.html.erb' do
     end
 
     around do |ex|
-      Timecop.travel(now) { ex.run }
+      travel_to(now) { ex.run }
     end
 
     it 'renders the warning banner but no other content' do


### PR DESCRIPTION
Replaces Timecop with ActiveSupport's very similar `TimeHelpers`. There were also some issues with Timecop in #5301.

This PR also removes time travel travel from some specs where it seemed unnecessary.