### PR TITLE
LG-4259: Return user to account page when canceling reauthn MFA selection

### DIFF
--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -47,6 +47,7 @@ module TwoFactorAuthentication
       TwoFactorLoginOptionsPresenter.new(
         user: current_user,
         view: view_context,
+        context: context,
         service_provider: current_sp,
         aal3_required: service_provider_mfa_policy.aal3_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -47,7 +47,7 @@ module TwoFactorAuthentication
       TwoFactorLoginOptionsPresenter.new(
         user: current_user,
         view: view_context,
-        context: context,
+        user_session_context: context,
         service_provider: current_sp,
         aal3_required: service_provider_mfa_policy.aal3_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -3,9 +3,10 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   attr_reader :user
 
-  def initialize(user:, view:, service_provider:, aal3_required:, piv_cac_required:)
+  def initialize(user:, view:, context:, service_provider:, aal3_required:, piv_cac_required:)
     @user = user
     @view = view
+    @context = context
     @service_provider = service_provider
     @aal3_required = aal3_required
     @piv_cac_required = piv_cac_required
@@ -53,6 +54,14 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def account_reset_or_cancel_link
     account_reset_token_valid? ? account_reset_cancel_link : account_reset_link
+  end
+
+  def cancel_link
+    if UserSessionContext.reauthentication_context?(@context)
+      account_path
+    else
+      sign_out_path
+    end
   end
 
   private

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -3,10 +3,17 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   attr_reader :user
 
-  def initialize(user:, view:, context:, service_provider:, aal3_required:, piv_cac_required:)
+  def initialize(
+    user:,
+    view:,
+    user_session_context:,
+    service_provider:,
+    aal3_required:,
+    piv_cac_required:
+  )
     @user = user
     @view = view
-    @context = context
+    @user_session_context = user_session_context
     @service_provider = service_provider
     @aal3_required = aal3_required
     @piv_cac_required = piv_cac_required
@@ -57,7 +64,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
   end
 
   def cancel_link
-    if UserSessionContext.reauthentication_context?(@context)
+    if UserSessionContext.reauthentication_context?(@user_session_context)
       account_path
     else
       sign_out_path

--- a/app/services/user_session_context.rb
+++ b/app/services/user_session_context.rb
@@ -7,8 +7,12 @@ class UserSessionContext
     context == DEFAULT_CONTEXT
   end
 
+  def self.reauthentication_context?(context)
+    context == REAUTHENTICATION_CONTEXT
+  end
+
   def self.authentication_context?(context)
-    context == DEFAULT_CONTEXT || context == REAUTHENTICATION_CONTEXT
+    initial_authentication_context?(context) || reauthentication_context?(context)
   end
 
   def self.confirmation_context?(context)

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -47,6 +47,6 @@
   <%= @presenter.account_reset_or_cancel_link %>
 </p>
 
-<%= render 'shared/cancel', link: destroy_user_session_path %>
+<%= render 'shared/cancel', link: @presenter.cancel_link %>
 
 <%= javascript_packs_tag_once 'webauthn-unhide-signin' %>

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -49,6 +49,20 @@ feature 'Changing authentication factor' do
           to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end
     end
+
+    context 'changing authentication methods' do
+      it 'returns user to account page if they choose to cancel' do
+        sign_in_and_2fa_user
+        travel(IdentityConfig.store.reauthn_window + 1)
+        visit manage_password_path
+        complete_2fa_confirmation_without_entering_otp
+
+        click_on t('two_factor_authentication.login_options_link_text')
+        click_on t('links.cancel')
+
+        expect(current_path).to eq account_path
+      end
+    end
   end
 
   def complete_2fa_confirmation

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -670,8 +670,8 @@ feature 'Sign in' do
     it 'signs out the user if they choose to cancel' do
       user = create(:user, :signed_up)
       signin(user.email, user.password)
-      choose_another_security_option
-
+      accept_rules_of_use_and_continue_if_displayed
+      click_link t('two_factor_authentication.login_options_link_text')
       click_on t('links.cancel')
 
       expect(current_path).to eq root_path

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -666,6 +666,19 @@ feature 'Sign in' do
   it_behaves_like 'signing in with wrong credentials', :saml
   it_behaves_like 'signing in with wrong credentials', :oidc
 
+  context 'user signs in and chooses another authentication method' do
+    it 'signs out the user if they choose to cancel' do
+      user = create(:user, :signed_up)
+      signin(user.email, user.password)
+      choose_another_security_option
+
+      click_on t('links.cancel')
+
+      expect(current_path).to eq root_path
+      expect(page).to have_content(t('devise.sessions.signed_out'))
+    end
+  end
+
   context 'user signs in with personal key, visits account page' do
     # this can happen if you submit the personal key form multiple times quickly
     it 'does not redirect to the personal key page' do

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -7,13 +7,13 @@ describe TwoFactorLoginOptionsPresenter do
   let(:view) { ActionController::Base.new.view_context }
   let(:aal3_required) { false }
   let(:piv_cac_required) { false }
-  let(:context) { UserSessionContext::DEFAULT_CONTEXT }
+  let(:user_session_context) { UserSessionContext::DEFAULT_CONTEXT }
 
   subject(:presenter) do
     TwoFactorLoginOptionsPresenter.new(
       user: user,
       view: view,
-      context: context,
+      user_session_context: user_session_context,
       service_provider: nil,
       aal3_required: false,
       piv_cac_required: false,
@@ -80,13 +80,13 @@ describe TwoFactorLoginOptionsPresenter do
     subject(:cancel_link) { presenter.cancel_link }
 
     context 'default user session context' do
-      let(:context) { UserSessionContext::DEFAULT_CONTEXT }
+      let(:user_session_context) { UserSessionContext::DEFAULT_CONTEXT }
 
       it { should eq sign_out_path }
     end
 
     context 'reauthentication user session context' do
-      let(:context) { UserSessionContext::REAUTHENTICATION_CONTEXT }
+      let(:user_session_context) { UserSessionContext::REAUTHENTICATION_CONTEXT }
 
       it { should eq account_path }
     end

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -7,11 +7,13 @@ describe TwoFactorLoginOptionsPresenter do
   let(:view) { ActionController::Base.new.view_context }
   let(:aal3_required) { false }
   let(:piv_cac_required) { false }
+  let(:context) { UserSessionContext::DEFAULT_CONTEXT }
 
   subject(:presenter) do
     TwoFactorLoginOptionsPresenter.new(
       user: user,
       view: view,
+      context: context,
       service_provider: nil,
       aal3_required: false,
       piv_cac_required: false,
@@ -71,6 +73,22 @@ describe TwoFactorLoginOptionsPresenter do
         klass == TwoFactorAuthentication::WebauthnSelectionPresenter
       end
       expect(webauthn_selection_presenters.count).to eq 1
+    end
+  end
+
+  describe '#cancel_link' do
+    subject(:cancel_link) { presenter.cancel_link }
+
+    context 'default user session context' do
+      let(:context) { UserSessionContext::DEFAULT_CONTEXT }
+
+      it { should eq sign_out_path }
+    end
+
+    context 'reauthentication user session context' do
+      let(:context) { UserSessionContext::REAUTHENTICATION_CONTEXT }
+
+      it { should eq account_path }
     end
   end
 end

--- a/spec/services/user_session_context_spec.rb
+++ b/spec/services/user_session_context_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe UserSessionContext do
   let(:confirmation) { { context: 'confirmation' } }
 
-  describe '::initial_authentication_context?' do
+  describe '.initial_authentication_context?' do
     it 'returns true when context is default context' do
       expect(
         UserSessionContext.initial_authentication_context?(UserSessionContext::DEFAULT_CONTEXT),
@@ -25,7 +25,21 @@ describe UserSessionContext do
     end
   end
 
-  describe '::authentication_context?' do
+  describe '.reauthentication_context?' do
+    it 'returns true when context is reauthn context' do
+      expect(
+        UserSessionContext.reauthentication_context?(UserSessionContext::REAUTHENTICATION_CONTEXT),
+      ).to eq true
+    end
+
+    it 'returns false when context is default context' do
+      expect(
+        UserSessionContext.reauthentication_context?(UserSessionContext::DEFAULT_CONTEXT),
+      ).to eq false
+    end
+  end
+
+  describe '.authentication_context?' do
     it 'returns true when context is default or reauth context' do
       expect(
         UserSessionContext.authentication_context?(UserSessionContext::DEFAULT_CONTEXT),
@@ -45,7 +59,7 @@ describe UserSessionContext do
     end
   end
 
-  describe '::confirmation_context?' do
+  describe '.confirmation_context?' do
     it 'returns true when context is confirmation context' do
       expect(
         UserSessionContext.confirmation_context?(UserSessionContext::CONFIRMATION_CONTEXT),

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -16,14 +16,14 @@ module Features
       expect(page).to have_content t('sign_up.email.invalid_email_alert_inline')
     end
 
-    def choose_another_security_option(option)
+    def choose_another_security_option(option = nil)
       accept_rules_of_use_and_continue_if_displayed
 
       click_link t('two_factor_authentication.login_options_link_text')
 
       expect(current_path).to eq login_two_factor_options_path
 
-      select_2fa_option(option)
+      select_2fa_option(option) if option
     end
 
     def select_2fa_option(option, **find_options)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -16,14 +16,14 @@ module Features
       expect(page).to have_content t('sign_up.email.invalid_email_alert_inline')
     end
 
-    def choose_another_security_option(option = nil)
+    def choose_another_security_option(option)
       accept_rules_of_use_and_continue_if_displayed
 
       click_link t('two_factor_authentication.login_options_link_text')
 
       expect(current_path).to eq login_two_factor_options_path
 
-      select_2fa_option(option) if option
+      select_2fa_option(option)
     end
 
     def select_2fa_option(option, **find_options)

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'two_factor_authentication/options/index.html.erb' do
     @presenter = TwoFactorLoginOptionsPresenter.new(
       user: user,
       view: view,
-      context: UserSessionContext::DEFAULT_CONTEXT,
+      user_session_context: UserSessionContext::DEFAULT_CONTEXT,
       service_provider: nil,
       aal3_required: false,
       piv_cac_required: false,

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -9,6 +9,7 @@ describe 'two_factor_authentication/options/index.html.erb' do
     @presenter = TwoFactorLoginOptionsPresenter.new(
       user: user,
       view: view,
+      context: UserSessionContext::DEFAULT_CONTEXT,
       service_provider: nil,
       aal3_required: false,
       piv_cac_required: false,
@@ -29,5 +30,11 @@ describe 'two_factor_authentication/options/index.html.erb' do
 
     expect(rendered).to have_content \
       t('two_factor_authentication.login_options_title')
+  end
+
+  it 'has a cancel link' do
+    render
+
+    expect(rendered).to have_link(t('links.cancel_account_creation'), href: sign_up_cancel_path)
   end
 end


### PR DESCRIPTION
**Why**: So that a user isn't unexpectedly signed out simply because they choose to cancel the reauthentication process.

The MFA options page is hard-coded to direct the user to sign out when they click the "Cancel" link. This makes sense when choosing MFA during sign-in, but not when reauthenticating such as when modifying account settings (edit password, etc).

Steps to reproduce:

1. Sign in
2. Wait 2 minutes
3. Click "Edit password" on account dashboard
4. Enter password when prompted
5. When prompted for MFA, click "choose another option" link
6. Click "Cancel"

Before: Signed out
After: Redirected to account page