### PR TITLE
LG-4959: add uuid_prefix to reference sent to LexisNexis

### DIFF
--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -60,7 +60,8 @@ class DocumentProofingJob < ApplicationJob
           selfie_image: selfie_image || '',
           image_source: image_source(image_metadata),
           liveness_checking_enabled: liveness_checking_enabled,
-          applicant: applicant,
+          user_uuid: applicant&.fetch(:uuid, SecureRandom.uuid),
+          uuid_prefix: applicant&.fetch(:uuid_prefix, nil),
         )
       end
     end

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -24,15 +24,17 @@ class DocumentProofingJob < ApplicationJob
     decrypted_args = JSON.parse(
       Encryption::Encryptors::SessionEncryptor.new.decrypt(encrypted_arguments),
       symbolize_names: true,
-    )[:document_arguments]
+    )
+    document_args = decrypted_args[:document_arguments]
+    applicant = decrypted_args[:applicant_pii]
 
-    encryption_key = Base64.decode64(decrypted_args[:encryption_key].to_s)
-    front_image_iv = Base64.decode64(decrypted_args[:front_image_iv].to_s)
-    back_image_iv = Base64.decode64(decrypted_args[:back_image_iv].to_s)
-    selfie_image_iv = Base64.decode64(decrypted_args[:selfie_image_iv].to_s)
-    front_image_url = decrypted_args[:front_image_url]
-    back_image_url = decrypted_args[:back_image_url]
-    selfie_image_url = decrypted_args[:selfie_image_url]
+    encryption_key = Base64.decode64(document_args[:encryption_key].to_s)
+    front_image_iv = Base64.decode64(document_args[:front_image_iv].to_s)
+    back_image_iv = Base64.decode64(document_args[:back_image_iv].to_s)
+    selfie_image_iv = Base64.decode64(document_args[:selfie_image_iv].to_s)
+    front_image_url = document_args[:front_image_url]
+    back_image_url = document_args[:back_image_url]
+    selfie_image_url = document_args[:selfie_image_url]
 
     front_image = decrypt_from_s3(
       timer: timer, name: :front, url: front_image_url, iv: front_image_iv, key: encryption_key,
@@ -58,6 +60,7 @@ class DocumentProofingJob < ApplicationJob
           selfie_image: selfie_image || '',
           image_source: image_source(image_metadata),
           liveness_checking_enabled: liveness_checking_enabled,
+          applicant: applicant,
         )
       end
     end

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -26,7 +26,8 @@ class DocumentProofingJob < ApplicationJob
       symbolize_names: true,
     )
     document_args = decrypted_args[:document_arguments]
-    applicant = decrypted_args[:applicant_pii]
+    user_uuid = decrypted_args.fetch(:user_uuid, nil)
+    uuid_prefix = decrypted_args.fetch(:uuid_prefix, nil)
 
     encryption_key = Base64.decode64(document_args[:encryption_key].to_s)
     front_image_iv = Base64.decode64(document_args[:front_image_iv].to_s)
@@ -60,8 +61,8 @@ class DocumentProofingJob < ApplicationJob
           selfie_image: selfie_image || '',
           image_source: image_source(image_metadata),
           liveness_checking_enabled: liveness_checking_enabled,
-          user_uuid: applicant&.fetch(:uuid, SecureRandom.uuid),
-          uuid_prefix: applicant&.fetch(:uuid_prefix, nil),
+          user_uuid: user_uuid,
+          uuid_prefix: uuid_prefix,
         )
       end
     end

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -58,7 +58,8 @@ module DocAuth
         back_image:,
         selfie_image:,
         image_source:,
-        liveness_checking_enabled: nil
+        liveness_checking_enabled: nil,
+        applicant: nil
       )
         document_response = create_document(image_source: image_source)
         return document_response unless document_response.success?

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -59,7 +59,8 @@ module DocAuth
         selfie_image:,
         image_source:,
         liveness_checking_enabled: nil,
-        applicant: nil
+        user_uuid: nil,
+        uuid_prefix: nil
       )
         document_response = create_document(image_source: image_source)
         return document_response unless document_response.success?

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -34,11 +34,13 @@ module DocAuth
         selfie_image:,
         liveness_checking_enabled: nil,
         image_source: nil,
-        applicant: nil
+        user_uuid: nil,
+        uuid_prefix: nil
       )
         Requests::TrueIdRequest.new(
           config: config,
-          applicant: applicant,
+          user_uuid: user_uuid,
+          uuid_prefix: uuid_prefix,
           front_image: front_image,
           back_image: back_image,
           selfie_image: selfie_image,

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -33,10 +33,12 @@ module DocAuth
         back_image:,
         selfie_image:,
         liveness_checking_enabled: nil,
-        image_source: nil
+        image_source: nil,
+        applicant: nil
       )
         Requests::TrueIdRequest.new(
           config: config,
+          applicant: applicant,
           front_image: front_image,
           back_image: back_image,
           selfie_image: selfie_image,

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -1,10 +1,11 @@
 module DocAuth
   module LexisNexis
     class Request
-      attr_reader :config
+      attr_reader :config, :applicant
 
-      def initialize(config:)
+      def initialize(config:, applicant: nil)
         @config = config
+        @applicant = applicant
       end
 
       def fetch
@@ -123,9 +124,17 @@ module DocAuth
         }
       end
 
-      # AM: Need to account for the uuid-prefix when folding in the lexisnexis gem.
       def uuid
-        SecureRandom.uuid
+        return SecureRandom.uuid unless applicant
+
+        uuid = applicant.fetch(:uuid, SecureRandom.uuid)
+        uuid_prefix = applicant[:uuid_prefix]
+
+        if uuid_prefix.present?
+          "#{uuid_prefix}:#{uuid}"
+        else
+          uuid
+        end
       end
 
       def username

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -1,11 +1,12 @@
 module DocAuth
   module LexisNexis
     class Request
-      attr_reader :config, :applicant
+      attr_reader :config, :user_uuid, :uuid_prefix
 
-      def initialize(config:, applicant: nil)
+      def initialize(config:, user_uuid: nil, uuid_prefix: nil)
         @config = config
-        @applicant = applicant
+        @user_uuid = user_uuid
+        @uuid_prefix = uuid_prefix
       end
 
       def fetch
@@ -125,10 +126,9 @@ module DocAuth
       end
 
       def uuid
-        return SecureRandom.uuid unless applicant
+        return SecureRandom.uuid unless user_uuid
 
-        uuid = applicant.fetch(:uuid, SecureRandom.uuid)
-        uuid_prefix = applicant[:uuid_prefix]
+        uuid = user_uuid
 
         if uuid_prefix.present?
           "#{uuid_prefix}:#{uuid}"

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -6,14 +6,15 @@ module DocAuth
 
         def initialize(
           config:,
-          applicant:,
+          user_uuid:,
+          uuid_prefix:,
           front_image:,
           back_image:,
           selfie_image: nil,
           liveness_checking_enabled: nil,
           image_source: nil
         )
-          super(config: config, applicant: applicant)
+          super(config: config, user_uuid: user_uuid, uuid_prefix: uuid_prefix)
           @front_image = front_image
           @back_image = back_image
           @selfie_image = selfie_image

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -6,13 +6,14 @@ module DocAuth
 
         def initialize(
           config:,
+          applicant:,
           front_image:,
           back_image:,
           selfie_image: nil,
           liveness_checking_enabled: nil,
           image_source: nil
         )
-          super(config: config)
+          super(config: config, applicant: applicant)
           @front_image = front_image
           @back_image = back_image
           @selfie_image = selfie_image

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -61,7 +61,8 @@ module DocAuth
         selfie_image:,
         liveness_checking_enabled: nil,
         image_source: nil,
-        applicant: nil
+        user_uuid: nil,
+        uuid_prefix: nil
       )
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -60,7 +60,8 @@ module DocAuth
         back_image:,
         selfie_image:,
         liveness_checking_enabled: nil,
-        image_source: nil
+        image_source: nil,
+        applicant: nil
       )
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -44,9 +44,10 @@ module Idv
           'encryption_key', 'front_image_iv', 'back_image_iv', 'selfie_image_iv', 'front_image_url',
           'back_image_url', 'selfie_image_url'
         ).to_h
-        applicant_pii = flow_session[:pii_from_doc]
+        applicant_pii = flow_session.fetch(:pii_from_doc, {})
         applicant = {
-          applicant_pii: applicant_pii,
+          user_uuid: applicant_pii[:uuid],
+          uuid_prefix: applicant_pii[:uuid_prefix],
           document_arguments: document_attributes,
         }
 

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -44,8 +44,13 @@ module Idv
           'encryption_key', 'front_image_iv', 'back_image_iv', 'selfie_image_iv', 'front_image_url',
           'back_image_url', 'selfie_image_url'
         ).to_h
+        applicant_pii = flow_session[:pii_from_doc]
+        applicant = {
+          applicant_pii: applicant_pii,
+          document_arguments: document_attributes,
+        }
 
-        Idv::Agent.new(document_attributes).proof_document(
+        Idv::Agent.new(applicant).proof_document(
           verify_document_capture_session,
           liveness_checking_enabled: liveness_checking_enabled?,
           trace_id: amzn_trace_id,

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -49,7 +49,7 @@ module Idv
       analytics_data:
     )
       encrypted_arguments = Encryption::Encryptors::SessionEncryptor.new.encrypt(
-        { document_arguments: @applicant }.to_json,
+        @applicant.to_json,
       )
 
       DocumentProofingJob.perform_later(

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -57,6 +57,7 @@ module Idv
         flow_session[:pii_from_doc] = response.pii_from_doc.merge(
           uuid: current_user.uuid,
           phone: current_user.phone_configurations.take&.phone,
+          uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
         )
         if response.respond_to?(:extra)
           # Sync flow: DocAuth::Response

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
   let(:base_url) { 'https://lexis.nexis.example.com' }
   let(:path) { "/restws/identity/v3/accounts/#{account_id}/workflows/#{workflow}/conversations" }
   let(:full_url) { base_url + path }
+  let(:applicant) { { uuid: SecureRandom.uuid, uuid_prefix: '123' } }
   let(:config) do
     DocAuth::LexisNexis::Config.new(
       trueid_account_id: account_id,
@@ -26,6 +27,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       selfie_image: DocAuthImageFixtures.selfie_image,
       liveness_checking_enabled: liveness_checking_enabled,
       image_source: image_source,
+      applicant: applicant,
     )
   end
 

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       selfie_image: DocAuthImageFixtures.selfie_image,
       liveness_checking_enabled: liveness_checking_enabled,
       image_source: image_source,
-      applicant: applicant,
+      user_uuid: applicant[:uuid],
+      uuid_prefix: applicant[:uuid_prefix],
     )
   end
 


### PR DESCRIPTION
When we send data to LexisNexis, we provide a reference id. For phone finder and instant verify, we prefixed the id (the user's uuid) with the SP app id, so that we could differentiate requests by SP. This PR adds the same functionality to trueid requests.

To do this, we had to capture both the uuid and uuid_prefix, and pass them through a string of classes to get them into the request. To best follow the logic, review the diffs in the following order:

| file | change |
|-|-|
| app/services/idv/steps/doc_auth_base_step.rb | adds uuid_prefix to flow_session[:pii_from_doc] |
| app/services/idv/actions/verify_document_action.rb | combines the pii and doc attributes in the applicant |
| app/services/idv/agent.rb | encrypts the applicant data |
| app/jobs/document_proofing_job.rb | decrypts the applicant data and passes the applicant to the client |
| app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb | passes the applicant to the request |
| app/services/doc_auth/lexis_nexis/requests/true_id_request.rb | passes the applicant to the base class |
| app/services/doc_auth/lexis_nexis/request.rb | uses the applicant to construct the prefixed uuid passed as the Reference in the api call to LN |
