### PR TITLE
Fix AccountReset::GrantRequestsAndSendEmails job locking

### DIFF
--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -7,12 +7,18 @@ module AccountReset
     good_job_control_concurrency_with(
       enqueue_limit: 1,
       perform_limit: 1,
-      key: -> { "grant-requests-and-send-emails-#{arguments.first}" },
+      key: -> do
+        now = arguments.first
+        five_minutes = 5.minutes.to_i
+        rounded = (now.to_i / five_minutes) * five_minutes
+
+        "grant-requests-and-send-emails-#{rounded}"
+      end
     )
 
     discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
-    def perform(_date)
+    def perform(_now)
       notifications_sent = 0
       AccountResetRequest.where(
         sql_query_for_users_eligible_to_delete_their_accounts,

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -13,7 +13,7 @@ module AccountReset
         rounded = (now.to_i / five_minutes) * five_minutes
 
         "grant-requests-and-send-emails-#{rounded}"
-      end
+      end,
     )
 
     discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -29,14 +29,14 @@ all_configs = {
       name: 'Account reset notice',
       interval: interval_5m,
       timeout: 4 * 60,
-      callback: -> { AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today) },
+      callback: -> { AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.now) },
       health_critical: true,
       failures_before_alarm: 2,
     },
     good_job: {
       class: 'AccountReset::GrantRequestsAndSendEmails',
       cron: cron_5m,
-      args: -> { [Time.zone.today] },
+      args: -> { [Time.zone.now] },
     },
   },
   # Send OMB Fitara report to s3

--- a/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
+++ b/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
@@ -7,13 +7,15 @@ describe AccountReset::GrantRequestsAndSendEmails do
   let(:user2) { create(:user) }
 
   describe '#perform' do
+    let(:now) { Time.zone.now }
+
     context 'after waiting the full wait period' do
       it 'does not send notifications when the notifications were already sent' do
         create_account_reset_request_for(user)
 
         after_waiting_the_full_wait_period do
-          AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+          AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
           expect(notifications_sent).to eq(0)
         end
       end
@@ -23,7 +25,7 @@ describe AccountReset::GrantRequestsAndSendEmails do
         cancel_request_for(user)
 
         after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
           expect(notifications_sent).to eq(0)
         end
       end
@@ -32,7 +34,7 @@ describe AccountReset::GrantRequestsAndSendEmails do
         create_account_reset_request_for(user)
 
         after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
 
           expect(notifications_sent).to eq(1)
         end
@@ -43,7 +45,7 @@ describe AccountReset::GrantRequestsAndSendEmails do
         create_account_reset_request_for(user2)
 
         after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
 
           expect(notifications_sent).to eq(2)
         end
@@ -54,7 +56,7 @@ describe AccountReset::GrantRequestsAndSendEmails do
       it 'does not send notifications after a request' do
         create_account_reset_request_for(user)
 
-        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
         expect(notifications_sent).to eq(0)
       end
 
@@ -62,18 +64,24 @@ describe AccountReset::GrantRequestsAndSendEmails do
         create_account_reset_request_for(user)
         cancel_request_for(user)
 
-        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
         expect(notifications_sent).to eq(0)
       end
     end
   end
 
   describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
+    it 'is the job name and the current time, rounded to the nearest 5 minutes' do
+      now = Time.zone.at(1629819000)
 
-    it 'is the job name and the date' do
-      job = AccountReset::GrantRequestsAndSendEmails.new(date)
-      expect(job.good_job_concurrency_key).to eq("grant-requests-and-send-emails-#{date}")
+      job_now = AccountReset::GrantRequestsAndSendEmails.new(now)
+      expect(job_now.good_job_concurrency_key).to eq("grant-requests-and-send-emails-#{now.to_i}")
+
+      job_plus_1m = AccountReset::GrantRequestsAndSendEmails.new(now + 1.minute)
+      expect(job_plus_1m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
+
+      job_plus_5m = AccountReset::GrantRequestsAndSendEmails.new(now + 5.minutes)
+      expect(job_plus_5m.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
     end
   end
 


### PR DESCRIPTION
- Job runs every 5 minutes, but was locking for an entire day


See [Slack thread](https://gsa-tts.slack.com/archives/C42TZ3K5H/p1629819255012500?thread_ts=1629817645.008900&cid=C42TZ3K5H)