### PR TITLE
Add language attribute to language dropdown links

### DIFF
--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const mobileDropdown = document.querySelector('.i18n-mobile-dropdown');
   const desktopLink = document.querySelector('.i18n-desktop-toggle > button');
   const desktopDropdown = document.querySelector('.i18n-desktop-dropdown');
+  const currentLanguage = document.querySelector('html').lang;
+  const urlLinks = document.querySelectorAll('a.language');
 
   function addListenerMulti(el, s, fn) {
     s.split(' ').forEach((e) => el.addEventListener(e, fn, false));
@@ -30,6 +32,16 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  function removeLanguageAttribute() {
+    urlLinks.forEach((link) => {
+      if (link.lang === currentLanguage) {
+        link.removeAttribute('lang');
+      }
+    });
+  }
+
+  removeLanguageAttribute();
 
   if (desktopLink) {
     languagePicker(desktopLink, desktopDropdown);

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -5,8 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const mobileDropdown = document.querySelector('.i18n-mobile-dropdown');
   const desktopLink = document.querySelector('.i18n-desktop-toggle > button');
   const desktopDropdown = document.querySelector('.i18n-desktop-dropdown');
-  const currentLanguage = document.querySelector('html').lang;
-  const urlLinks = document.querySelectorAll('a.language');
 
   function addListenerMulti(el, s, fn) {
     s.split(' ').forEach((e) => el.addEventListener(e, fn, false));
@@ -32,16 +30,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-
-  function removeLanguageAttribute() {
-    urlLinks.forEach((link) => {
-      if (link.lang === currentLanguage) {
-        link.removeAttribute('lang');
-      }
-    });
-  }
-
-  removeLanguageAttribute();
 
   if (desktopLink) {
     languagePicker(desktopLink, desktopDropdown);

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -19,7 +19,7 @@
       <ul class='list-reset margin-bottom-0 white center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none blue fs-13p' %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none blue fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -61,8 +61,8 @@
                   <li class='border-bottom border-navy'>
                     <%= link_to t("i18n.locale.#{locale}"),
                       sanitized_requested_url.merge(locale: locale),
-                      class: 'block pl-24p padding-y-2 text-decoration-none white language',
-                      lang: locale %>
+                      class: 'block pl-24p padding-y-2 text-decoration-none white',
+                      lang: locale == I18n.locale ? nil : locale %>
                   </li>
                 <% end %>
               </ul>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -61,7 +61,8 @@
                   <li class='border-bottom border-navy'>
                     <%= link_to t("i18n.locale.#{locale}"),
                       sanitized_requested_url.merge(locale: locale),
-                      class: 'block pl-24p padding-y-2 text-decoration-none white' %>
+                      class: 'block pl-24p padding-y-2 text-decoration-none white language',
+                      lang: locale %>
                   </li>
                 <% end %>
               </ul>


### PR DESCRIPTION
This ticket adds the language attribute to language link text that is in different language.

**Why**

To follow accessibility best practices: Any text that is in a different language should be annotated with the `lang` attribute