### PR TITLE
Clean up GrantRequestsAndSendEmails

### DIFF
--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -30,7 +30,7 @@ module AccountReset
       analytics.track_event(
         Analytics::ACCOUNT_RESET,
         event: :notifications,
-        count: notifications_sent
+        count: notifications_sent,
       )
 
       notifications_sent

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -27,17 +27,24 @@ module AccountReset
         notifications_sent += 1 if grant_request_and_send_email(arr)
       end
 
-      # TODO: rewrite analytics so that we can generate events even from
-      # background jobs where we have no request or user objects
-      # analytics.track_event(Analytics::ACCOUNT_RESET,
-      #                       event: :notifications, count: notifications_sent)
-
-      Rails.logger.info("Sent #{notifications_sent} account_reset notifications")
+      analytics.track_event(
+        Analytics::ACCOUNT_RESET,
+        event: :notifications,
+        count: notifications_sent
+      )
 
       notifications_sent
     end
 
     private
+
+    def analytics
+      @analytics ||= Analytics.new(
+        user: AnonymousUser.new,
+        request: nil,
+        sp: nil,
+      )
+    end
 
     def sql_query_for_users_eligible_to_delete_their_accounts
       <<~SQL

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -18,11 +18,11 @@ module AccountReset
 
     discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
-    def perform(_now)
+    def perform(now)
       notifications_sent = 0
       AccountResetRequest.where(
         sql_query_for_users_eligible_to_delete_their_accounts,
-        tvalue: Time.zone.now - IdentityConfig.store.account_reset_wait_period_days.days,
+        tvalue: now - IdentityConfig.store.account_reset_wait_period_days.days,
       ).order('requested_at ASC').each do |arr|
         notifications_sent += 1 if grant_request_and_send_email(arr)
       end

--- a/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
+++ b/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
@@ -11,44 +11,44 @@ describe AccountReset::GrantRequestsAndSendEmails do
 
     context 'after waiting the full wait period' do
       it 'does not send notifications when the notifications were already sent' do
-        create_account_reset_request_for(user)
-
-        after_waiting_the_full_wait_period do
-          AccountReset::GrantRequestsAndSendEmails.new.perform(now)
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
-          expect(notifications_sent).to eq(0)
+        before_waiting_the_full_wait_period(now) do
+          create_account_reset_request_for(user)
         end
+
+        AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+        expect(notifications_sent).to eq(0)
       end
 
       it 'does not send notifications when the request was cancelled' do
-        create_account_reset_request_for(user)
-        cancel_request_for(user)
-
-        after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
-          expect(notifications_sent).to eq(0)
+        before_waiting_the_full_wait_period(now) do
+          create_account_reset_request_for(user)
+          cancel_request_for(user)
         end
+
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+        expect(notifications_sent).to eq(0)
       end
 
       it 'sends notifications after a request is granted' do
-        create_account_reset_request_for(user)
-
-        after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
-
-          expect(notifications_sent).to eq(1)
+        before_waiting_the_full_wait_period(now) do
+          create_account_reset_request_for(user)
         end
+
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+
+        expect(notifications_sent).to eq(1)
       end
 
       it 'sends 2 notifications after 2 requests are granted' do
-        create_account_reset_request_for(user)
-        create_account_reset_request_for(user2)
-
-        after_waiting_the_full_wait_period do
-          notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
-
-          expect(notifications_sent).to eq(2)
+        before_waiting_the_full_wait_period(now) do
+          create_account_reset_request_for(user)
+          create_account_reset_request_for(user2)
         end
+
+        notifications_sent = AccountReset::GrantRequestsAndSendEmails.new.perform(now)
+
+        expect(notifications_sent).to eq(2)
       end
     end
 
@@ -85,9 +85,9 @@ describe AccountReset::GrantRequestsAndSendEmails do
     end
   end
 
-  def after_waiting_the_full_wait_period
+  def before_waiting_the_full_wait_period(now)
     days = IdentityConfig.store.account_reset_wait_period_days.days
-    travel_to(Time.zone.now + 1 + days) do
+    travel_to(now - 1 - days) do
       yield
     end
   end


### PR DESCRIPTION
While fixing #5324, I noticed a few things that could be cleaned up

- Send an analytics event, using an anonymous user
- Inject `now`, switch tests to set up events beforehand instead of after