### PR TITLE
Fix queue syntax for good_job

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -78,7 +78,7 @@ event_disavowal_expiration_hours: '240'
 exception_recipients: user1@example.com,user2@example.com
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 good_job_max_threads: '5'
-good_job_queues: 'default:5,low:1;*'
+good_job_queues: 'default:5;low:1;*'
 gpo_designated_receiver_pii: '{}'
 hide_phone_mfa_signup: 'false'
 identity_pki_disabled: 'false'


### PR DESCRIPTION
This reverts commit 26cc476f6fc6a91cccbf09f3443c0a786f6a814d,
which in turn reverts b07ef999eb572e887020586cb22ff3f7d3547833

I think this is causing errors in DM because we're parsing the string incorrectly

See: https://github.com/bensheldon/good_job#optimize-queues-threads-and-processes