### PR TITLE
Include git tag and sha in logs and events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,8 +44,15 @@ class ApplicationController < ActionController::Base
   # for lograge
   def append_info_to_payload(payload)
     payload[:user_id] = analytics_user.uuid unless @skip_session_load
-    payload[:git_sha] = IdentityConfig::GIT_SHA if IdentityConfig::GIT_SHA
-    payload[:git_tag] = IdentityConfig::GIT_TAG if IdentityConfig::GIT_TAG
+
+    payload[:git_sha] = IdentityConfig::GIT_SHA
+    if IdentityConfig::GIT_TAG.present?
+      payload[:git_tag] = IdentityConfig::GIT_TAG
+    else
+      payload[:git_branch] = IdentityConfig::GIT_BRANCH
+    end
+
+    payload
   end
 
   attr_writer :analytics

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,6 +44,8 @@ class ApplicationController < ActionController::Base
   # for lograge
   def append_info_to_payload(payload)
     payload[:user_id] = analytics_user.uuid unless @skip_session_load
+    payload[:git_sha] = IdentityConfig::GIT_SHA if IdentityConfig::GIT_SHA
+    payload[:git_tag] = IdentityConfig::GIT_TAG if IdentityConfig::GIT_TAG
   end
 
   attr_writer :analytics

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -42,13 +42,18 @@ class Analytics
   attr_reader :user, :request, :sp, :ahoy
 
   def request_attributes
-    {
+    attributes = {
       user_ip: request.remote_ip,
       hostname: request.host,
       pid: Process.pid,
       service_provider: sp,
       trace_id: request.headers['X-Amzn-Trace-Id'],
-    }.merge!(browser_attributes)
+    }
+
+    attributes[:git_sha] = IdentityConfig::GIT_SHA if IdentityConfig::GIT_SHA
+    attributes[:git_tag] = IdentityConfig::GIT_TAG if IdentityConfig::GIT_TAG
+
+    attributes.merge!(browser_attributes)
   end
 
   def browser

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -50,8 +50,12 @@ class Analytics
       trace_id: request.headers['X-Amzn-Trace-Id'],
     }
 
-    attributes[:git_sha] = IdentityConfig::GIT_SHA if IdentityConfig::GIT_SHA
-    attributes[:git_tag] = IdentityConfig::GIT_TAG if IdentityConfig::GIT_TAG
+    attributes[:git_sha] = IdentityConfig::GIT_SHA
+    if IdentityConfig::GIT_TAG.present?
+      attributes[:git_tag] = IdentityConfig::GIT_TAG
+    else
+      attributes[:git_branch] = IdentityConfig::GIT_BRANCH
+    end
 
     attributes.merge!(browser_attributes)
   end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -1,6 +1,7 @@
 class IdentityConfig
   GIT_SHA = `git rev-parse HEAD`.chomp
   GIT_TAG = `git tag --points-at HEAD`.chomp.split("\n").first
+  GIT_BRANCH = `git rev-parse --abbrev-ref HEAD`.chomp
 
   class << self
     attr_reader :store

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -1,4 +1,7 @@
 class IdentityConfig
+  GIT_SHA = `git rev-parse HEAD`.chomp
+  GIT_TAG = `git tag --points-at HEAD`.chomp.split("\n").first
+
   class << self
     attr_reader :store
   end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -1,5 +1,5 @@
 class IdentityConfig
-  GIT_SHA = `git rev-parse HEAD`.chomp
+  GIT_SHA = `git rev-parse --short=8 HEAD`.chomp
   GIT_TAG = `git tag --points-at HEAD`.chomp.split("\n").first
   GIT_BRANCH = `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -125,6 +125,7 @@ describe ApplicationController do
 
       expect(payload).to eq(
         user_id: user.uuid,
+        git_sha: IdentityConfig::GIT_SHA,
       )
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -126,6 +126,7 @@ describe ApplicationController do
       expect(payload).to eq(
         user_id: user.uuid,
         git_sha: IdentityConfig::GIT_SHA,
+        git_branch: IdentityConfig::GIT_BRANCH,
       )
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -120,7 +120,12 @@ describe ApplicationController do
       allow(controller).to receive(:analytics_user).and_return(user)
     end
 
-    it 'adds user_uuid to the lograge output' do
+    it 'adds user_uuid and git metadata to the lograge output' do
+      stub_const(
+        'IdentityConfig::GIT_BRANCH',
+        'my branch',
+      )
+
       controller.append_info_to_payload(payload)
 
       expect(payload).to eq(

--- a/spec/features/account_reset/cancel_request_spec.rb
+++ b/spec/features/account_reset/cancel_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Account Reset Request: Cancellation' do
       click_button t('account_reset.request.yes_continue')
       reset_email
 
-      travel_to(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days + 1) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/cancel\?token/)

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -29,7 +29,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       reset_email
 
-      travel_to(Time.zone.now + 2.days) do
+      travel_to(Time.zone.now + 2.days + 1) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)
@@ -86,7 +86,7 @@ describe 'Account Reset Request: Delete Account', email: true do
       reset_email
 
       allow(IdentityConfig.store).to receive(:push_notifications_enabled).and_return(true)
-      travel_to(2.days.from_now) do
+      travel_to(2.days.from_now + 1) do
         request = stub_push_notification_request(
           sp_push_notification_endpoint: push_notification_url,
           event_type: PushNotification::AccountPurgedEvent::EVENT_TYPE,

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -39,6 +39,7 @@ describe Analytics do
         user_id: current_user.uuid,
         locale: I18n.locale,
         git_sha: IdentityConfig::GIT_SHA,
+        git_branch: IdentityConfig::GIT_BRANCH,
       }
 
       expect(ahoy).to receive(:track).
@@ -56,6 +57,7 @@ describe Analytics do
         user_id: tracked_user.uuid,
         locale: I18n.locale,
         git_sha: IdentityConfig::GIT_SHA,
+        git_branch: IdentityConfig::GIT_BRANCH,
       }
 
       expect(ahoy).to receive(:track).
@@ -106,6 +108,7 @@ describe Analytics do
         user_id: current_user.uuid,
         locale: locale,
         git_sha: IdentityConfig::GIT_SHA,
+        git_branch: IdentityConfig::GIT_BRANCH,
       }
 
       expect(ahoy).to receive(:track).

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -38,6 +38,7 @@ describe Analytics do
         event_properties: {},
         user_id: current_user.uuid,
         locale: I18n.locale,
+        git_sha: IdentityConfig::GIT_SHA,
       }
 
       expect(ahoy).to receive(:track).
@@ -54,6 +55,7 @@ describe Analytics do
         event_properties: {},
         user_id: tracked_user.uuid,
         locale: I18n.locale,
+        git_sha: IdentityConfig::GIT_SHA,
       }
 
       expect(ahoy).to receive(:track).
@@ -103,6 +105,7 @@ describe Analytics do
         event_properties: {},
         user_id: current_user.uuid,
         locale: locale,
+        git_sha: IdentityConfig::GIT_SHA,
       }
 
       expect(ahoy).to receive(:track).

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -34,6 +34,11 @@ describe Analytics do
 
   describe '#track_event' do
     it 'identifies the user and sends the event to the backend' do
+      stub_const(
+        'IdentityConfig::GIT_BRANCH',
+        'my branch',
+      )
+
       analytics_hash = {
         event_properties: {},
         user_id: current_user.uuid,


### PR DESCRIPTION
This is a precursor to a better way of observing deploys go out.

I realize it's kind of uncouth to run `git` during the load of the application, but it will ideally be replaced by something like system environment variables in the future.