### PR TITLE
Try to avoid 500s caused by database race conditions

### DIFF
--- a/app/services/account_reset/create_request.rb
+++ b/app/services/account_reset/create_request.rb
@@ -20,7 +20,7 @@ module AccountReset
     attr_reader :user
 
     def create_request
-      request = AccountResetRequest.find_or_create_by(user: user)
+      request = AccountResetRequest.create_or_find_by(user: user)
       request.update!(
         request_token: SecureRandom.uuid,
         requested_at: Time.zone.now,

--- a/app/services/account_reset/grant_request.rb
+++ b/app/services/account_reset/grant_request.rb
@@ -20,7 +20,7 @@ module AccountReset
     private
 
     def account_reset_request
-      AccountResetRequest.find_or_create_by(user_id: @user_id)
+      AccountResetRequest.create_or_find_by(user_id: @user_id)
     end
   end
 end

--- a/app/services/db/proofing_component/add.rb
+++ b/app/services/db/proofing_component/add.rb
@@ -19,8 +19,9 @@ module Db
 
       def self.call(user_id, token, value)
         return unless user_id
-        proofing_cost = ::ProofingComponent.find_or_create_by(user_id: user_id)
         return unless TOKEN_ALLOWLIST.index(token.to_sym)
+
+        proofing_cost = ::ProofingComponent.create_or_find_by(user_id: user_id)
         proofing_cost[token] = value
         proofing_cost.save
       end

--- a/app/services/db/proofing_cost/add_user_proofing_cost.rb
+++ b/app/services/db/proofing_cost/add_user_proofing_cost.rb
@@ -17,7 +17,7 @@ module Db
 
       def self.call(user_id, token)
         return unless user_id
-        proofing_cost = ::ProofingCost.find_or_create_by(user_id: user_id)
+        proofing_cost = ::ProofingCost.create_or_find_by(user_id: user_id)
         unless TOKEN_ALLOWLIST.include?(token.to_sym)
           NewRelic::Agent.notice_error(ProofingCostTypeError.new(token.to_s))
           return

--- a/app/services/db/service_provider_quota_limit/update_from_report.rb
+++ b/app/services/db/service_provider_quota_limit/update_from_report.rb
@@ -4,7 +4,7 @@ module Db
       def self.call(report_data)
         report_data.each do |rec|
           ::ServiceProviderQuotaLimit.
-            find_or_create_by(issuer: rec['issuer'], ial: 2)&.
+            create_or_find_by(issuer: rec['issuer'], ial: 2)&.
             update!(percent_full: rec['percent_ial2_quota'])
         end
       end

--- a/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
+++ b/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
@@ -77,7 +77,7 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
     end
 
     it 'does not fail when _count field is null' do
-      proofing_cost = ::ProofingCost.find_or_create_by(user_id: user_id)
+      proofing_cost = ::ProofingCost.create_or_find_by(user_id: user_id)
       proofing_cost.acuant_front_image_count = nil
       proofing_cost.save
 

--- a/spec/support/account_reset_helper.rb
+++ b/spec/support/account_reset_helper.rb
@@ -1,6 +1,6 @@
 module AccountResetHelper
   def create_account_reset_request_for(user)
-    request = AccountResetRequest.find_or_create_by(user: user)
+    request = AccountResetRequest.create_or_find_by(user: user)
     request_token = SecureRandom.uuid
     request.update!(
       request_token: request_token,


### PR DESCRIPTION
`find_or_create_by` is subject to race conditions if a unique query runs more than one at a time

`create_or_find_by` flips it so it attempts to create first, and if a unique constraint database exception occurs, it then does a select to get that row.

[Example New Relic error](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=604800000&pane=eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThOVEl4TXpZNE5UZyJ9&cards[0]=eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkuZXJyb3ItdHJhY2VzIiwiZmlsdGVyU2V0TnJxbCI6IihgZXJyb3IuY2xhc3NgID0gJ0FjdGl2ZVJlY29yZDo6UmVjb3JkTm90VW5pcXVlJyBBTkQgdHJhbnNhY3Rpb25VaU5hbWUgPSAnVXNlcnM6OlJlc2V0UGFzc3dvcmRzQ29udHJvbGxlciN1cGRhdGUnKSIsInRpbWVab25lIjoiQW1lcmljYS9DaGljYWdvIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJ0cmFjZUlkIjoiN2QwZDg2YjctMDRhZS0xMWVjLWIyOTMtMDI0MmFjMTEwMDBhXzBfMjkyMzIifQ==&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19&state=7cf21acf-d598-517e-2d13-2cb6468b86a7)