### PR TITLE
Add ignored_columns to avoid "SELECT *" by default

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  # Forces ActiveRecord to select individual columns instead of SELECT *
+  self.ignored_columns = [:__fake_column__]
+
   connects_to shards: {
     default: { writing: :primary, reading: :primary },
     read_replica: {


### PR DESCRIPTION
Hat tip to @mitchellhenke and https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf

