### PR TITLE
Remove session phone attempt count initialization

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -33,7 +33,7 @@ module Idv
 
     def reset_doc_auth
       user_session.delete('idv/doc_auth')
-      user_session['idv'] = { params: {}, step_attempts: { phone: 0 } }
+      user_session['idv'] = {}
     end
 
     def cancel_document_capture_session

--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -44,7 +44,7 @@ module Idv
       end
 
       def self.session_idv(session)
-        session[:idv] ||= { params: {}, step_attempts: { phone: 0 } }
+        session[:idv] ||= {}
       end
     end
   end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -15,7 +15,6 @@ module Idv
       profile_id
       profile_step_params
       resolution_successful
-      step_attempts
     ].freeze
 
     attr_reader :current_user, :gpo_otp, :issuer
@@ -125,7 +124,7 @@ module Idv
     end
 
     def new_idv_session
-      { step_attempts: { phone: 0 } }
+      {}
     end
 
     def move_pii_to_user_session


### PR DESCRIPTION
Builds on #5339 to remove session values unused after changes proposed in that branch, left temporarily to avoid deploy issues with live sessions.

Should only be merged after deploy including #5339.

Additional context: https://github.com/18F/identity-idp/pull/5339#discussion_r696963980