### PR TITLE
LG-5042 Fix TrueID error message for responses without failure details.

### DIFF
--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -68,7 +68,7 @@ module DocAuth
           response_info: response_info,
         )
 
-        return DocAuth.wrapped_general_error(liveness_enabled)
+        return self.class.wrapped_general_error(liveness_enabled)
       # if the alert_error_count is 1 it is just passed along
       elsif alert_error_count > 1
         # Simplify multiple errors into a single error for the user
@@ -76,17 +76,17 @@ module DocAuth
         if error_fields.length == 1
           case error_fields.first
           when ID
-            errors[ID] = Set[DocAuth.general_error(false)]
+            errors[ID] = Set[self.class.general_error(false)]
           when FRONT
             errors[FRONT] = Set[Errors::MULTIPLE_FRONT_ID_FAILURES]
           when BACK
             errors[BACK] = Set[Errors::MULTIPLE_BACK_ID_FAILURES]
           end
         elsif error_fields.length > 1
-          return DocAuth.wrapped_general_error(liveness_enabled) if error_fields.include?(SELFIE)
+          return self.class.wrapped_general_error(liveness_enabled) if error_fields.include?(SELFIE)
 
           # If we don't have a selfie error don't give the message suggesting retaking selfie.
-          return DocAuth.wrapped_general_error(false)
+          return self.class.wrapped_general_error(false)
         end
       end
 
@@ -183,13 +183,13 @@ module DocAuth
 
       unknown_fail_count
     end
-  end
 
-  def self.general_error(liveness_enabled)
-    liveness_enabled ? Errors::GENERAL_ERROR_LIVENESS : Errors::GENERAL_ERROR_NO_LIVENESS
-  end
+    def self.general_error(liveness_enabled)
+      liveness_enabled ? Errors::GENERAL_ERROR_LIVENESS : Errors::GENERAL_ERROR_NO_LIVENESS
+    end
 
-  def self.wrapped_general_error(liveness_enabled)
-    { general: [DocAuth.general_error(liveness_enabled)] }
+    def self.wrapped_general_error(liveness_enabled)
+      { general: [ErrorGenerator.general_error(liveness_enabled)] }
+    end
   end
 end

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -59,10 +59,7 @@ module DocAuth
           if true_id_product&.dig(:AUTHENTICATION_RESULT).present?
             ErrorGenerator.new(config).generate_doc_auth_errors(response_info)
           elsif true_id_product.present?
-            general_error = @liveness_checking_enabled ?
-              Errors::GENERAL_ERROR_LIVENESS : Errors::GENERAL_ERROR_NO_LIVENESS
-
-            { general: [general_error] }
+            DocAuth.wrapped_general_error(@liveness_checking_enabled)
           else
             { network: true } # return a generic technical difficulties error to user
           end

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -59,7 +59,7 @@ module DocAuth
           if true_id_product&.dig(:AUTHENTICATION_RESULT).present?
             ErrorGenerator.new(config).generate_doc_auth_errors(response_info)
           elsif true_id_product.present?
-            DocAuth.wrapped_general_error(@liveness_checking_enabled)
+            ErrorGenerator.wrapped_general_error(@liveness_checking_enabled)
           else
             { network: true } # return a generic technical difficulties error to user
           end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -160,12 +160,12 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
     end
 
-    it 'it produces reasonable output for an empty TrueID failure' do
+    it 'it produces reasonable output for a TrueID failure without details' do
       output = described_class.new(failure_response_empty, false, config).to_h
 
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS])
-      expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
+      expect(output).to include(:lexis_nexis_status, :lexis_nexis_info, :exception)
     end
 
     it 'it produces reasonable output for a malformed TrueID response' do

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -145,9 +145,6 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
   context 'when response is unexpected' do
     it 'it produces reasonable output for communications error' do
-      expect(NewRelic::Agent).to receive(:notice_error).
-        with(anything, custom_params: hash_including(:response_info)).once
-
       output = described_class.new(communications_error_response, false, config).to_h
 
       expect(output[:success]).to eq(false)
@@ -156,9 +153,6 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     it 'it produces reasonable output for internal application error' do
-      expect(NewRelic::Agent).to receive(:notice_error).
-        with(anything, custom_params: hash_including(:response_info)).once
-
       output = described_class.new(internal_application_error_response, false, config).to_h
 
       expect(output[:success]).to eq(false)
@@ -167,20 +161,14 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     it 'it produces reasonable output for an empty TrueID failure' do
-      expect(NewRelic::Agent).to receive(:notice_error).
-        with(anything, custom_params: hash_including(:response_info)).once
-
       output = described_class.new(failure_response_empty, false, config).to_h
 
       expect(output[:success]).to eq(false)
-      expect(output[:errors]).to eq(network: true)
+      expect(output[:errors]).to eq(general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS])
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
     end
 
     it 'it produces reasonable output for a malformed TrueID response' do
-      expect(NewRelic::Agent).to receive(:notice_error).
-        with(anything).once
-
       output = described_class.new(failure_response_malformed, false, config).to_h
 
       expect(output[:success]).to eq(false)


### PR DESCRIPTION
Change how we handle TrueID failures where no details are provided. These we now understand encompass Acuant HTTP responses like 438/439/440 so returning a technical difficulties message is not correct.