### PR TITLE
LG-5025: Create separate throttle error screen for proof_ssn throttle type

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -10,6 +10,10 @@ module Idv
       @remaining_step_attempts = remaining_step_attempts
     end
 
+    def ssn_failure
+      render 'idv/session_errors/failure'
+    end
+
     private
 
     def remaining_step_attempts

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -26,7 +26,7 @@ module Idv
               throttle_type: :proof_ssn,
               step_name: self.class,
             )
-            redirect_to idv_session_errors_failure_url
+            redirect_to idv_session_errors_ssn_failure_url
             return
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,7 @@ Rails.application.routes.draw do
       put '/review' => 'review#create'
       get '/session/errors/warning' => 'session_errors#warning'
       get '/session/errors/failure' => 'session_errors#failure'
+      get '/session/errors/ssn_failure' => 'session_errors#ssn_failure'
       get '/session/errors/exception' => 'session_errors#exception'
       get '/session/errors/throttled' => 'session_errors#throttled'
       delete '/session' => 'sessions#destroy'

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -72,4 +72,11 @@ describe Idv::SessionErrorsController do
 
     it_behaves_like 'an idv session errors controller action'
   end
+
+  describe '#ssn_failure' do
+    let(:action) { :ssn_failure }
+    let(:template) { 'idv/session_errors/failure' }
+
+    it_behaves_like 'an idv session errors controller action'
+  end
 end

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -111,11 +111,11 @@ describe Idv::Steps::VerifyStep do
 
         step = build_step(controller)
         expect(step.call).to be_nil, 'does not enqueue a job'
-        expect(redirect(step)).to eq(idv_session_errors_failure_url)
+        expect(redirect(step)).to eq(idv_session_errors_ssn_failure_url)
 
         step2 = build_step(controller2)
         expect(step2.call).to be_nil, 'does not enqueue a job'
-        expect(redirect(step2)).to eq(idv_session_errors_failure_url)
+        expect(redirect(step2)).to eq(idv_session_errors_ssn_failure_url)
       end
     end
   end


### PR DESCRIPTION
**Why**: So that each throttle error screen corresponds to exactly one throttle type, to accommodate accurate time labels proposed in #5301 (LG-4637).