### PR TITLE
Add redis-namespace (LG-5030)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'rack-timeout', require: false
 gem 'readthis'
 gem 'redacted_struct'
 gem 'redis', '>= 3.2.0'
+gem 'redis-namespace'
 gem 'redis-session-store', '>= 0.11.3'
 gem 'retries'
 gem 'rotp', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -496,6 +496,8 @@ GEM
       redis (>= 3.0, < 5.0)
     redacted_struct (1.1.0)
     redis (4.3.1)
+    redis-namespace (1.8.1)
+      redis (>= 3.0.4)
     redis-session-store (0.11.3)
       actionpack (>= 3, < 7)
       redis (>= 3, < 5)
@@ -770,6 +772,7 @@ DEPENDENCIES
   readthis
   redacted_struct
   redis (>= 3.2.0)
+  redis-namespace
   redis-session-store (>= 0.11.3)
   retries
   rotp (~> 6.1)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -7,5 +7,8 @@ READTHIS_POOL = ConnectionPool.new(size: 10) do
 end
 
 REDIS_POOL = ConnectionPool.new(size: 10) do
-  Redis.new(url: IdentityConfig.store.redis_url)
+  Redis::Namespace.new(
+    'redis-pool',
+    redis: Redis.new(url: IdentityConfig.store.redis_url),
+  )
 end

--- a/spec/jobs/risc_delivery_job_spec.rb
+++ b/spec/jobs/risc_delivery_job_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe RiscDeliveryJob do
   around do |ex|
-    REDIS_POOL.with { |r| r.flushdb }
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |r| r.flushdb }
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   describe '#perform' do


### PR DESCRIPTION
**Why**: To migrate off of the Readthis gem without
colliding with the same keys

