### PR TITLE
LG-4611: Replace state id type

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -73,6 +73,7 @@ module Idv
       )
       response.extra.merge!(extra_attributes)
       response.extra[:state] = response.pii_from_doc[:state]
+      response.extra[:state_id_type] = response.pii_from_doc[:state_id_type]
 
       update_analytics(response)
 

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -78,6 +78,7 @@ class DocumentProofingJob < ApplicationJob
       Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
       proofer_result.to_h.merge(
         state: proofer_result.pii_from_doc[:state],
+        state_id_type: proofer_result.pii_from_doc[:state_id_type],
         async: true,
         remaining_attempts: remaining_attempts,
         client_image_metrics: image_metadata,

--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -27,7 +27,7 @@ module DocAuth
         VALUE.each do |key, value|
           hash[value] = @name_to_value[key]
         end
-        hash[:state_id_type] = convert_id_type(hash[:state_id_type])
+        hash[:state_id_type] = DocAuth::Response::ID_TYPE_SLUGS[hash[:state_id_type]]
         hash[:dob] = convert_date(hash[:dob])
         hash[:state_id_expiration] = convert_date(hash[:state_id_expiration])
         hash
@@ -41,17 +41,6 @@ module DocAuth
         return if !match || !match[:milliseconds]
 
         Time.zone.at(match[:milliseconds].to_f / 1000).utc.to_date.to_s
-      end
-
-      def convert_id_type(state_id_type)
-        case state_id_type
-        when 'Identification Card'
-          'state_id_card'
-        when 'Permit'
-          'drivers_permit'
-        when 'Drivers License'
-          'drivers_license'
-        end
       end
 
       private

--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -13,6 +13,7 @@ module DocAuth
         'Document Number' => :state_id_number,
         'Issuing State Code' => :state_id_jurisdiction,
         'Expiration Date' => :state_id_expiration,
+        'Document Class Name' => :state_id_type,
       }.freeze
 
       def initialize(id_data_fields)
@@ -26,7 +27,7 @@ module DocAuth
         VALUE.each do |key, value|
           hash[value] = @name_to_value[key]
         end
-        hash[:state_id_type] = 'drivers_license'
+        hash[:state_id_type] = convert_id_type(hash[:state_id_type])
         hash[:dob] = convert_date(hash[:dob])
         hash[:state_id_expiration] = convert_date(hash[:state_id_expiration])
         hash
@@ -40,6 +41,17 @@ module DocAuth
         return if !match || !match[:milliseconds]
 
         Time.zone.at(match[:milliseconds].to_f / 1000).utc.to_date.to_s
+      end
+
+      def convert_id_type(state_id_type)
+        case state_id_type
+        when 'Identification Card'
+          'state_id_card'
+        when 'Permit'
+          'drivers_permit'
+        when 'Drivers License'
+          'drivers_license'
+        end
       end
 
       private

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -92,7 +92,7 @@ module DocAuth
             pii[idp_key] = true_id_product[:IDAUTH_FIELD_DATA][true_id_key]
           end
 
-          pii[:state_id_type] = convert_id_type(pii[:state_id_type])
+          pii[:state_id_type] = DocAuth::Response::ID_TYPE_SLUGS[pii[:state_id_type]]
 
           if pii[:dob_month] && pii[:dob_day] && pii[:dob_year]
             pii[:dob] = [
@@ -178,17 +178,6 @@ module DocAuth
         def true_id_product
           products[:TrueID] if products.present?
         end
-
-        def convert_id_type(state_id_type)
-          case state_id_type
-          when 'Identification Card'
-            'state_id_card'
-          when 'Permit'
-            'drivers_permit'
-          when 'Drivers License'
-            'drivers_license'
-          end
-        end 
 
         def parsed_alerts
           return @new_alerts if defined?(@new_alerts)

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -41,6 +41,7 @@ module DocAuth
           'Fields_xpirationDate_Day' => :state_id_expiration_day, # this is NOT a typo
           'Fields_ExpirationDate_Month' => :state_id_expiration_month,
           'Fields_ExpirationDate_Year' => :state_id_expiration_year,
+          'Fields_DocumentClassName' => :state_id_type,
         }.freeze
         attr_reader :config
 
@@ -91,7 +92,7 @@ module DocAuth
             pii[idp_key] = true_id_product[:IDAUTH_FIELD_DATA][true_id_key]
           end
 
-          pii[:state_id_type] = 'drivers_license'
+          pii[:state_id_type] = convert_id_type(pii[:state_id_type])
 
           if pii[:dob_month] && pii[:dob_day] && pii[:dob_year]
             pii[:dob] = [
@@ -177,6 +178,17 @@ module DocAuth
         def true_id_product
           products[:TrueID] if products.present?
         end
+
+        def convert_id_type(state_id_type)
+          case state_id_type
+          when 'Identification Card'
+            'state_id_card'
+          when 'Permit'
+            'drivers_permit'
+          when 'Drivers License'
+            'drivers_license'
+          end
+        end 
 
         def parsed_alerts
           return @new_alerts if defined?(@new_alerts)

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -2,6 +2,12 @@ module DocAuth
   class Response
     attr_reader :errors, :exception, :extra, :pii_from_doc
 
+    ID_TYPE_SLUGS = {
+      'Identification Card' => 'state_id_card',
+      'Permit' => 'drivers_permit',
+      'Drivers License' => 'drivers_license',
+    }
+
     def initialize(success:, errors: {}, exception: nil, extra: {}, pii_from_doc: {})
       @success = success
       @errors = errors.to_h

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -239,6 +239,7 @@ describe Idv::ImageUploadsController do
           exception: nil,
           doc_auth_result: 'Passed',
           state: 'MT',
+          state_id_type: 'drivers_license',
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
           client_image_metrics: {
@@ -264,6 +265,7 @@ describe Idv::ImageUploadsController do
         let(:first_name) { 'FAKEY' }
         let(:last_name) { 'MCFAKERSON' }
         let(:state) { 'ND' }
+        let(:state_id_type) { 'drivers_license' }
         let(:dob) { '10/06/1938' }
 
         before do
@@ -277,6 +279,7 @@ describe Idv::ImageUploadsController do
                 first_name: first_name,
                 last_name: last_name,
                 state: state,
+                state_id_type: state_id_type,
                 dob: dob,
               },
             ),
@@ -306,6 +309,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               doc_auth_result: 'Passed',
               state: 'ND',
+              state_id_type: 'drivers_license',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -354,6 +358,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               doc_auth_result: 'Passed',
               state: 'Maryland',
+              state_id_type: 'drivers_license',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -402,6 +407,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               doc_auth_result: 'Passed',
               state: 'ND',
+              state_id_type: 'drivers_license',
               user_id: user.uuid,
               remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
               client_image_metrics: {
@@ -474,6 +480,7 @@ describe Idv::ImageUploadsController do
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
           state: nil,
+          state_id_type: nil,
           exception: nil,
           async: false,
           client_image_metrics: {
@@ -524,6 +531,7 @@ describe Idv::ImageUploadsController do
           billed: true,
           doc_auth_result: 'Caution',
           state: nil,
+          state_id_type: nil,
           exception: nil,
           user_id: user.uuid,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           billed: true,
           remaining_attempts: IdentityConfig.store.acuant_max_attempts - 1,
           state: 'MT',
+          state_id_type: 'drivers_license',
           user_id: document_capture_session.user.uuid,
           client_image_metrics: {
             front: JSON.parse(front_image_metadata, symbolize_names: true),

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             alert_failure_count: 0,
             image_metrics: {},
             state: 'MT',
+            state_id_type: 'drivers_license',
             async: true,
             remaining_attempts: IdentityConfig.store.acuant_max_attempts,
             client_image_metrics: {
@@ -196,6 +197,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             alert_failure_count: 0,
             image_metrics: {},
             state: 'MT',
+            state_id_type: 'drivers_license',
             async: true,
             remaining_attempts: IdentityConfig.store.acuant_max_attempts,
             face_match_results: { is_match: true, match_score: nil },

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe DocumentProofingJob, type: :job do
       ssn: '123456789',
       phone: '18888675309',
       state: 'MT',
+      state_id_type: 'drivers_license',
     }
   end
 

--- a/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
+++ b/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DocAuth::Acuant::PiiFromDoc do
         state_id_expiration: '2022-10-24',
         state_id_number: 'DOE-84-1165',
         state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
+        state_id_type: 'state_id_card',
       )
     end
   end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         state_id_expiration: '2022-10-24',
         state_id_number: 'DOE-84-1165',
         state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
+        state_id_type: 'state_id_card',
       )
     end
   end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         last_name: 'SAMPLE',
         dob: '1986-10-13',
         state: 'MD',
+        state_id_type: 'drivers_license',
       }
 
       expect(response.pii_from_doc).to include(minimum_expected_hash)
@@ -99,6 +100,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         last_name: 'SAMPLE',
         dob: '1986-10-13',
         state: 'MD',
+        state_id_type: 'drivers_license',
       }
 
       expect(response.pii_from_doc).to include(minimum_expected_hash)


### PR DESCRIPTION
*Why?* 

We need to move to logging the Id type properly sent back to us by Acuant. Right now we just hard coded it to drivers license. 
