### PR TITLE
Add timestamps columns throttles table

### DIFF
--- a/db/primary_migrate/20210830171646_add_timestamps_to_throttles.rb
+++ b/db/primary_migrate/20210830171646_add_timestamps_to_throttles.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToThrottles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :throttles, :created_at, :timestamp
+    add_column :throttles, :updated_at, :timestamp
+  end
+end

--- a/db/primary_migrate/20210830171713_add_index_on_updated_at_to_throttles.rb
+++ b/db/primary_migrate/20210830171713_add_index_on_updated_at_to_throttles.rb
@@ -1,0 +1,7 @@
+class AddIndexOnUpdatedAtToThrottles < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :throttles, [:updated_at], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_17_200558) do
+ActiveRecord::Schema.define(version: 2021_08_30_171713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -599,7 +599,10 @@ ActiveRecord::Schema.define(version: 2021_08_17_200558) do
     t.integer "attempts", default: 0
     t.integer "throttled_count"
     t.string "target"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["target", "throttle_type"], name: "index_throttles_on_target_and_throttle_type"
+    t.index ["updated_at"], name: "index_throttles_on_updated_at"
     t.index ["user_id", "throttle_type"], name: "index_throttles_on_user_id_and_throttle_type"
   end
 


### PR DESCRIPTION
**Why**: Prep work for LG-5008, so we can delete old throttles.
Without these columns, it's more difficult to tell how old a row
is.