### PR TITLE
Remove old throttle rows

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,4 +5,15 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # Helper to round a Time instance to a particular interval
+  # @param [Time] time
+  # @param [Integer] interval number of seconds to round to
+  # @return [Time]
+  # @example
+  #  round_time(time: Time.zone.now, interval: 5.minutes)
+  def self.round_time(time:, interval:)
+    rounded_seconds = (time.to_i / interval.to_i) * interval.to_i
+    Time.zone.at(rounded_seconds)
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,15 +5,4 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
-
-  # Helper to round a Time instance to a particular interval
-  # @param [Time] time
-  # @param [Integer] interval number of seconds to round to
-  # @return [Time]
-  # @example
-  #  round_time(time: Time.zone.now, interval: 5.minutes)
-  def self.round_time(time:, interval:)
-    rounded_seconds = (time.to_i / interval.to_i) * interval.to_i
-    Time.zone.at(rounded_seconds)
-  end
 end

--- a/app/jobs/remove_old_throttles_job.rb
+++ b/app/jobs/remove_old_throttles_job.rb
@@ -1,0 +1,43 @@
+class RemoveOldThrottlesJob < ApplicationJob
+  queue_as :low
+
+  WINDOW = 30.days.freeze
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    perform_limit: 1,
+    key: -> do
+      rounded = ApplicationJob.round_time(time: arguments.first, interval: 30.minutes)
+      "remove-old-throttles-#{rounded.to_i}"
+    end,
+  )
+
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
+  def perform(now, limit: 1000, total_limit: 100_000)
+    max_window = Throttle::THROTTLE_CONFIG.map { |_, config| config[:attempt_window] }.max
+    total_removed = 0
+
+    loop do
+      removed_count = Throttle.
+        where('updated_at < ?', now - (WINDOW + max_window.minutes)).
+        limit(limit).
+        delete_all
+
+      total_removed += removed_count
+
+      Rails.logger.info(
+        {
+          name: 'remove_old_throttles',
+          removed_count: removed_count,
+          total_removed: total_removed,
+        }.to_json,
+      )
+
+      break if removed_count.zero?
+      break if total_removed >= total_limit
+    end
+  end
+end

--- a/app/jobs/remove_old_throttles_job.rb
+++ b/app/jobs/remove_old_throttles_job.rb
@@ -33,6 +33,7 @@ class RemoveOldThrottlesJob < ApplicationJob
           name: 'remove_old_throttles',
           removed_count: removed_count,
           total_removed: total_removed,
+          total_limit: total_limit,
         }.to_json,
       )
 

--- a/app/jobs/remove_old_throttles_job.rb
+++ b/app/jobs/remove_old_throttles_job.rb
@@ -9,7 +9,7 @@ class RemoveOldThrottlesJob < ApplicationJob
     enqueue_limit: 1,
     perform_limit: 1,
     key: -> do
-      rounded = ApplicationJob.round_time(time: arguments.first, interval: 30.minutes)
+      rounded = ApplicationJob.round_time(time: arguments.first, interval: 1.hour)
       "remove-old-throttles-#{rounded.to_i}"
     end,
   )

--- a/app/jobs/remove_old_throttles_job.rb
+++ b/app/jobs/remove_old_throttles_job.rb
@@ -9,7 +9,7 @@ class RemoveOldThrottlesJob < ApplicationJob
     enqueue_limit: 1,
     perform_limit: 1,
     key: -> do
-      rounded = ApplicationJob.round_time(time: arguments.first, interval: 1.hour)
+      rounded = TimeService.round_time(time: arguments.first, interval: 1.hour)
       "remove-old-throttles-#{rounded.to_i}"
     end,
   )

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -8,11 +8,8 @@ module AccountReset
       enqueue_limit: 1,
       perform_limit: 1,
       key: -> do
-        now = arguments.first
-        five_minutes = 5.minutes.to_i
-        rounded = (now.to_i / five_minutes) * five_minutes
-
-        "grant-requests-and-send-emails-#{rounded}"
+        rounded = ApplicationJob.round_time(time: arguments.first, interval: 5.minutes)
+        "grant-requests-and-send-emails-#{rounded.to_i}"
       end,
     )
 

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -8,7 +8,7 @@ module AccountReset
       enqueue_limit: 1,
       perform_limit: 1,
       key: -> do
-        rounded = ApplicationJob.round_time(time: arguments.first, interval: 5.minutes)
+        rounded = TimeService.round_time(time: arguments.first, interval: 5.minutes)
         "grant-requests-and-send-emails-#{rounded.to_i}"
       end,
     )

--- a/app/services/time_service.rb
+++ b/app/services/time_service.rb
@@ -1,0 +1,12 @@
+module TimeService
+  # Helper to round a Time instance to a particular interval
+  # @param [Time] time
+  # @param [Integer] interval number of seconds to round to
+  # @return [Time]
+  # @example
+  #   round_time(time: Time.zone.now, interval: 5.minutes)
+  def self.round_time(time:, interval:)
+    rounded_seconds = (time.to_i / interval.to_i) * interval.to_i
+    Time.zone.at(rounded_seconds)
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -3,6 +3,8 @@ require 'job_runner/job_configuration'
 
 cron_5m = '0/5 * * * *'
 interval_5m = 5 * 60
+cron_30m = '0/30 * * * *'
+interval_30m = 30 * 60
 cron_24h = '0 0 * * *'
 inteval_24h = 24 * 60 * 60
 
@@ -377,6 +379,20 @@ all_configs = {
       args: -> { [Time.zone.yesterday] },
     },
   },
+  # Removes old rows from the Throttles table
+  remove_old_throttles: {
+    job_runner: {
+      name: 'Remove Old Throttles',
+      interval: interval_30m,
+      timeout: 300,
+      callback: -> { RemoveOldThrottlesJob.new.perform(Time.zone.now) }
+    },
+    good_job: {
+      class: 'RemoveOldThrottlesJob',
+      cron: cron_30m,
+      args: -> { [Time.zone.now] },
+    },
+  }
 }
 
 if IdentityConfig.store.ruby_workers_enabled

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -3,8 +3,8 @@ require 'job_runner/job_configuration'
 
 cron_5m = '0/5 * * * *'
 interval_5m = 5 * 60
-cron_30m = '0/30 * * * *'
-interval_30m = 30 * 60
+cron_1h = '0/ * * * *'
+interval_1h = 60 * 60
 cron_24h = '0 0 * * *'
 inteval_24h = 24 * 60 * 60
 
@@ -383,13 +383,13 @@ all_configs = {
   remove_old_throttles: {
     job_runner: {
       name: 'Remove Old Throttles',
-      interval: interval_30m,
+      interval: interval_1h,
       timeout: 300,
       callback: -> { RemoveOldThrottlesJob.new.perform(Time.zone.now) }
     },
     good_job: {
       class: 'RemoveOldThrottlesJob',
-      cron: cron_30m,
+      cron: cron_1h,
       args: -> { [Time.zone.now] },
     },
   }

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -3,7 +3,7 @@ require 'job_runner/job_configuration'
 
 cron_5m = '0/5 * * * *'
 interval_5m = 5 * 60
-cron_1h = '0/ * * * *'
+cron_1h = '0 * * * *'
 interval_1h = 60 * 60
 cron_24h = '0 0 * * *'
 inteval_24h = 24 * 60 * 60

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -385,14 +385,14 @@ all_configs = {
       name: 'Remove Old Throttles',
       interval: interval_1h,
       timeout: 300,
-      callback: -> { RemoveOldThrottlesJob.new.perform(Time.zone.now) }
+      callback: -> { RemoveOldThrottlesJob.new.perform(Time.zone.now) },
     },
     good_job: {
       class: 'RemoveOldThrottlesJob',
       cron: cron_1h,
       args: -> { [Time.zone.now] },
     },
-  }
+  },
 }
 
 if IdentityConfig.store.ruby_workers_enabled

--- a/db/primary_migrate/20210830171646_add_timestamps_to_throttles.rb
+++ b/db/primary_migrate/20210830171646_add_timestamps_to_throttles.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToThrottles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :throttles, :created_at, :timestamp
+    add_column :throttles, :updated_at, :timestamp
+  end
+end

--- a/db/primary_migrate/20210830171713_add_index_on_updated_at_to_throttles.rb
+++ b/db/primary_migrate/20210830171713_add_index_on_updated_at_to_throttles.rb
@@ -1,0 +1,7 @@
+class AddIndexOnUpdatedAtToThrottles < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :throttles, [:updated_at], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_17_200558) do
+ActiveRecord::Schema.define(version: 2021_08_30_171713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -599,7 +599,10 @@ ActiveRecord::Schema.define(version: 2021_08_17_200558) do
     t.integer "attempts", default: 0
     t.integer "throttled_count"
     t.string "target"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["target", "throttle_type"], name: "index_throttles_on_target_and_throttle_type"
+    t.index ["updated_at"], name: "index_throttles_on_updated_at"
     t.index ["user_id", "throttle_type"], name: "index_throttles_on_user_id_and_throttle_type"
   end
 

--- a/spec/factories/throttles.rb
+++ b/spec/factories/throttles.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :throttle do
+    throttle_type { :idv_acuant }
+
     trait :with_throttled do
       attempts { 9999 }
       attempted_at { Time.zone.now }

--- a/spec/jobs/remove_old_throttles_job_spec.rb
+++ b/spec/jobs/remove_old_throttles_job_spec.rb
@@ -38,17 +38,17 @@ RSpec.describe RemoveOldThrottlesJob do
   end
 
   describe '#good_job_concurrency_key' do
-    it 'is the job name and the current time, rounded to the nearest 30 minutes' do
+    it 'is the job name and the current time, rounded to the nearest hour' do
       now = Time.zone.at(1629819000)
 
       job_now = RemoveOldThrottlesJob.new(now)
       expect(job_now.good_job_concurrency_key).to eq("remove-old-throttles-#{now.to_i}")
 
-      job_plus_15m = RemoveOldThrottlesJob.new(now + 15.minutes)
-      expect(job_plus_15m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
-
       job_plus_30m = RemoveOldThrottlesJob.new(now + 30.minutes)
-      expect(job_plus_30m.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
+      expect(job_plus_30m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
+
+      job_plus_1h = RemoveOldThrottlesJob.new(now + 1.hour)
+      expect(job_plus_1h.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
     end
   end
 end

--- a/spec/jobs/remove_old_throttles_job_spec.rb
+++ b/spec/jobs/remove_old_throttles_job_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe RemoveOldThrottlesJob do
+  let(:limit) { 1 }
+  let(:total_limit) { 10 }
+  let(:now) { Time.zone.now }
+
+  subject(:job) { RemoveOldThrottlesJob.new }
+
+  describe '#perform' do
+    subject(:perform) { job.perform(now, limit: limit, total_limit: total_limit) }
+
+    it 'deletes throttles that are older than WINDOW' do
+      old_throttle = create(:throttle, target: SecureRandom.hex, updated_at: now - 45.days)
+      new_throttle = create(:throttle, target: SecureRandom.hex, updated_at: now)
+
+      perform
+
+      expect(Throttle.all.map(&:id)).to match_array([new_throttle.id])
+    end
+
+    # This can be removed after the updated_at column has been deployed for 30+ days
+    it 'does not delete legacy rows with updated_at: nil' do
+      legacy_throttle = create(:throttle, target: SecureRandom.hex, updated_at: nil)
+
+      perform
+
+      expect(legacy_throttle.reload).to be
+    end
+
+    it 'stops after total_limit jobs' do
+      (total_limit + 1).times do
+        create(:throttle, target: SecureRandom.hex, updated_at: now - 45.days)
+      end
+
+      expect { perform }.to(change { Throttle.count }.to(1))
+    end
+  end
+
+  describe '#good_job_concurrency_key' do
+    it 'is the job name and the current time, rounded to the nearest 30 minutes' do
+      now = Time.zone.at(1629819000)
+
+      job_now = RemoveOldThrottlesJob.new(now)
+      expect(job_now.good_job_concurrency_key).to eq("remove-old-throttles-#{now.to_i}")
+
+      job_plus_15m = RemoveOldThrottlesJob.new(now + 15.minutes)
+      expect(job_plus_15m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
+
+      job_plus_30m = RemoveOldThrottlesJob.new(now + 30.minutes)
+      expect(job_plus_30m.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
+    end
+  end
+end

--- a/spec/jobs/remove_old_throttles_job_spec.rb
+++ b/spec/jobs/remove_old_throttles_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RemoveOldThrottlesJob do
 
   describe '#good_job_concurrency_key' do
     it 'is the job name and the current time, rounded to the nearest hour' do
-      now = Time.zone.at(1629819000)
+      now = Time.zone.at(1629817200)
 
       job_now = RemoveOldThrottlesJob.new(now)
       expect(job_now.good_job_concurrency_key).to eq("remove-old-throttles-#{now.to_i}")

--- a/spec/services/time_service_spec.rb
+++ b/spec/services/time_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TimeService do
+  describe '.round_time' do
+    it 'returns a Time instance rounded to the nearest interval' do
+      time = Time.zone.at(0)
+
+      rounded_time = TimeService.round_time(time: time, interval: 5.minutes)
+      expect(rounded_time).to eq(time)
+
+      plus_3m_rounded = TimeService.round_time(time: time + 3.minutes, interval: 5.minutes)
+      expect(plus_3m_rounded).to eq(time)
+
+      plus_5m_rounded = TimeService.round_time(time: time + 5.minutes, interval: 5.minutes)
+      expect(plus_5m_rounded).to_not eq(time)
+      expect(plus_5m_rounded.to_i).to eq((time + 5.minutes).to_i)
+    end
+  end
+end


### PR DESCRIPTION
This adds a job that will delete old Throttle rows, based on `updated_at`

Unfortunately, most rows will not have `updated_at` because that was just added in https://github.com/18F/identity-idp/pull/5352, so this job will no-op for about 30 days until it has rows old enough to delete