### PR TITLE
Always set GoodJob initializer config, even when workers disabled

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -7,8 +7,10 @@ if IdentityConfig.store.ruby_workers_enabled
     config.good_job.queues = IdentityConfig.store.good_job_queues
     # see config/initializers/job_configurations.rb for cron schedule
   end
-
-  GoodJob.active_record_parent_class = 'WorkerJobApplicationRecord'
-  GoodJob.retry_on_unhandled_error = false
-  GoodJob.on_thread_error = ->(exception) { NewRelic::Agent.notice_error(exception) }
 end
+
+# Configure GoodJob even if it's not enabled, to avoid errors if the good_job process is started,
+# such as in local development.
+GoodJob.active_record_parent_class = 'WorkerJobApplicationRecord'
+GoodJob.retry_on_unhandled_error = false
+GoodJob.on_thread_error = ->(exception) { NewRelic::Agent.notice_error(exception) }


### PR DESCRIPTION
**Why**: Avoid errors in local development with ruby_workers_enabled: false since we start good_job process, even if the application won't be configured to use it.

Context: https://gsa-tts.slack.com/archives/C0NGESUN5/p1630086894061900