### PR TITLE
Remove unnecessary ESLint core-modules setting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,17 +61,6 @@
     "require-await": "error"
   },
   "settings": {
-    "import/core-modules": [
-      "app/components/index",
-      "app/utils/index",
-      "app/pw-toggle",
-      "app/form-field-format",
-      "app/radio-btn",
-      "app/print-personal-key",
-      "app/utils/ms-formatter",
-      "app/phone-internationalization",
-      "app/i18n-dropdown"
-    ],
     "import/internal-regex": "^@18f/identity-"
   },
   "overrides": [


### PR DESCRIPTION
**Why**: It was previously added in #1363 to resolve a compatibility issue with CodeClimate, but we no longer use CodeClimate to run ESLint as of #3923. Continuing to include it risks falling out of sync and could be a source of confusion for developers.

The [setting itself](https://github.com/import-js/eslint-plugin-import#importcore-modules) is meant to allow raw imports of specific package names, but the way these files are referenced is by file path:

https://github.com/18F/identity-idp/blob/f0e850d639eee236f749ed006ef9f585b85c70eb/app/javascript/packs/application.js#L1-L10