### PR TITLE
Add TamperResult to Acuant logging.

### DIFF
--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -43,6 +43,7 @@ module DocAuth
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,
             image_metrics: processed_image_metrics,
+            tamper_result: parsed_response_body&.dig('TamperResult')
           }
         end
 

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -21,6 +21,11 @@ module DocAuth
           DocAuth::Acuant::ResultCodes.from_int(parsed_response_body['Result'])
         end
 
+        def tamper_result_code
+          # TamperResult uses the same Acuant Enum as Result
+          DocAuth::Acuant::ResultCodes.from_int(parsed_response_body&.dig('TamperResult'))
+        end
+
         def pii_from_doc
           DocAuth::Acuant::PiiFromDoc.new(parsed_response_body).call
         end
@@ -43,7 +48,7 @@ module DocAuth
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,
             image_metrics: processed_image_metrics,
-            tamper_result: parsed_response_body&.dig('TamperResult'),
+            tamper_result: tamper_result_code&.name,
           }
         end
 

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -43,7 +43,7 @@ module DocAuth
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,
             image_metrics: processed_image_metrics,
-            tamper_result: parsed_response_body&.dig('TamperResult')
+            tamper_result: parsed_response_body&.dig('TamperResult'),
           }
         end
 

--- a/spec/fixtures/acuant_responses/get_results_response_failure.json
+++ b/spec/fixtures/acuant_responses/get_results_response_failure.json
@@ -214,5 +214,7 @@
     "IsTrial": false,
     "Name": "Dev Test iProov",
     "StorePII": false
-  }
+  },
+  "TamperResult": 1,
+  "TamperSensitivity": 0
 }

--- a/spec/fixtures/acuant_responses/get_results_response_success.json
+++ b/spec/fixtures/acuant_responses/get_results_response_success.json
@@ -1830,5 +1830,7 @@
     "IsTrial": false,
     "Name": "Dev GSA iProov",
     "StorePII": false
-  }
+  },
+  "TamperResult": 1,
+  "TamperSensitivity": 0
 }

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             processed_alerts: { failed: [], passed: [] },
             success: true,
             exception: nil,
+            tamper_result: nil,
           )
 
           expect(job_analytics).to have_logged_event(
@@ -151,6 +152,7 @@ RSpec.describe DocumentProofingJob, type: :job do
               front: front_image_metadata,
               back: back_image_metadata,
             },
+            tamper_result: nil,
           )
 
           expect(result.pii_from_doc).to eq(applicant_pii)
@@ -181,6 +183,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             },
             success: true,
             exception: nil,
+            tamper_result: nil,
           )
 
           expect(job_analytics).to have_logged_event(
@@ -207,6 +210,7 @@ RSpec.describe DocumentProofingJob, type: :job do
               front: front_image_metadata,
               back: back_image_metadata,
             },
+            tamper_result: nil,
           )
 
           expect(result.pii_from_doc).to eq(applicant_pii)

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         ),
         image_metrics: a_hash_including(:back, :front),
         alert_failure_count: 2,
-        tamper_result: 1,
+        tamper_result: 'Passed',
       }
 
       processed_alerts = response_hash[:processed_alerts]

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         ),
         image_metrics: a_hash_including(:back, :front),
         alert_failure_count: 2,
+        tamper_result: 1,
       }
 
       processed_alerts = response_hash[:processed_alerts]


### PR DESCRIPTION
Small addition to the Acuant logging payload. TamperResult was added by Acuant awhile back, but we never added it to logging.