### PR TITLE
Normalize newlines in Pinpoint supported countries script

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -66,7 +66,7 @@ class PinpointSupportedCountries
       select { |sms_config| sms_config['ISO code'] }. # skip section rows
       map do |sms_config|
         iso_code = sms_config['ISO code']
-        supports_sms = case trim_trailing_digits_spaces(sms_config['Supports sender IDs'])
+        supports_sms = case trim_digits_spaces(sms_config['Supports sender IDs'])
         when 'Registration required'
           SENDER_ID_COUNTRIES.include?(iso_code)
         else
@@ -75,7 +75,7 @@ class PinpointSupportedCountries
 
         CountrySupport.new(
           iso_code: iso_code,
-          name: trim_trailing_digits_spaces(sms_config['Country or region']),
+          name: trim_digits_spaces(sms_config['Country or region']),
           supports_sms: supports_sms,
         )
       end
@@ -85,7 +85,7 @@ class PinpointSupportedCountries
   def voice_support
     TableConverter.new(download(PINPOINT_VOICE_URL)).convert.map do |voice_config|
       CountrySupport.new(
-        name: trim_trailing_digits_spaces(
+        name: trim_digits_spaces(
           voice_config['Country or Region'], # Yes, it is capitalized differently :[
         ),
         supports_voice: true,
@@ -145,8 +145,8 @@ class PinpointSupportedCountries
     }[name]
   end
 
-  def trim_trailing_digits_spaces(str)
-    str.gsub(/[\d\s]+$/, '')
+  def trim_digits_spaces(str)
+    str.gsub(/\s{2,}/, ' ').gsub(/[\d\s]+$/, '')
   end
 
   def digits_only?(str)

--- a/spec/lib/pinpoint_supported_countries_spec.rb
+++ b/spec/lib/pinpoint_supported_countries_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe PinpointSupportedCountries do
           <td>Registration required<sup><a href="#sms-support-note-1">1</a></sup></td>
           <td></td>
         </tr>
+        <tr>
+          <td>Cayman
+             Islands
+          </td>
+          <td>KY</td>
+          <td>No</td>
+          <td>No</td>
+        </tr>
       </table>
     HTML
   end
@@ -76,6 +84,11 @@ RSpec.describe PinpointSupportedCountries do
           <td>Yes</td>
           <td>No</td>
         </tr>
+        <tr>
+          <td>Cayman Islands</td>
+          <td>No</td>
+          <td>No</td>
+        </tr>
       </table>
     HTML
   end
@@ -98,6 +111,11 @@ RSpec.describe PinpointSupportedCountries do
           name: Belarus
           supports_sms: true
           supports_voice: false
+        KY:
+          country_code: '1345'
+          name: Cayman Islands
+          supports_sms: true
+          supports_voice: true
       STR
     end
   end
@@ -109,6 +127,7 @@ RSpec.describe PinpointSupportedCountries do
         PinpointSupportedCountries::CountrySupport.new(iso_code: 'AR', name: 'Argentina', supports_sms: true),
         PinpointSupportedCountries::CountrySupport.new(iso_code: 'AU', name: 'Australia', supports_sms: true),
         PinpointSupportedCountries::CountrySupport.new(iso_code: 'BY', name: 'Belarus', supports_sms: true),
+        PinpointSupportedCountries::CountrySupport.new(iso_code: 'KY', name: 'Cayman Islands', supports_sms: true),
       ]
     end
     # rubocop:enable Layout/LineLength
@@ -126,12 +145,15 @@ RSpec.describe PinpointSupportedCountries do
   end
 
   describe '#voice_support' do
+    # rubocop:disable Layout/LineLength
     it 'parses the voice page from poinpoint an array of configs' do
       expect(countries.voice_support).to eq [
         PinpointSupportedCountries::CountrySupport.new(name: 'Argentina', supports_voice: true),
         PinpointSupportedCountries::CountrySupport.new(name: 'Australia', supports_voice: true),
+        PinpointSupportedCountries::CountrySupport.new(name: 'Cayman Islands', supports_voice: true),
       ]
     end
+    # rubocop:enable Layout/LineLength
   end
 
   describe '#load_country_dialing_codes' do
@@ -141,6 +163,7 @@ RSpec.describe PinpointSupportedCountries do
         PinpointSupportedCountries::CountryDialingCode.new(country_code: '54', iso_code: 'AR', name: 'Argentina', supports_sms: true, supports_voice: true),
         PinpointSupportedCountries::CountryDialingCode.new(country_code: '61', iso_code: 'AU', name: 'Australia', supports_sms: true, supports_voice: true),
         PinpointSupportedCountries::CountryDialingCode.new(country_code: '375', iso_code: 'BY', name: 'Belarus', supports_sms: true, supports_voice: false),
+        PinpointSupportedCountries::CountryDialingCode.new(country_code: '1345', iso_code: 'KY', name: 'Cayman Islands', supports_sms: true, supports_voice: true),
       ]
     end
     # rubocop:enable Layout/LineLength


### PR DESCRIPTION
**Why**: So that inconsistencies between voice and SMS markup are tolerated and correctly combined / mapped.