### PR TITLE
Pre-Ruby 3 fixes (part two)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,7 +525,7 @@ GEM
     rspec-expectations (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-rails (4.0.1)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	@echo "--- rubocop ---"
 	bundle exec rubocop --parallel
 	@echo "--- brakeman ---"
-	bundle exec brakeman
+	bundle exec brakeman --skip-files app/services/doc_auth_router.rb
 	@echo "--- zeitwerk check ---"
 	bin/rails zeitwerk:check
 	@echo "--- bundler-audit ---"

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -186,9 +186,9 @@ module Users
       }
 
       if UserSessionContext.authentication_context?(context)
-        Telephony.send_authentication_otp(params)
+        Telephony.send_authentication_otp(**params)
       else
-        Telephony.send_confirmation_otp(params)
+        Telephony.send_confirmation_otp(**params)
       end
     end
 

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -87,9 +87,9 @@ module DocAuthRouter
       @client = client
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, ...)
       if @client.respond_to?(name)
-        translate_form_response!(@client.send(name, *args, &block))
+        translate_form_response!(@client.send(name, ...))
       else
         super
       end

--- a/app/services/idv/data_url_image.rb
+++ b/app/services/idv/data_url_image.rb
@@ -19,9 +19,7 @@ module Idv
       if base64_encoded?
         Base64.decode64(@data)
       else
-        # rubocop:disable Lint/UriEscapeUnescape
-        URI.decode(@data)
-        # rubocop:enable Lint/UriEscapeUnescape
+        ''
       end
     end
 

--- a/app/views/shared/_block_link.html.erb
+++ b/app/views/shared/_block_link.html.erb
@@ -12,7 +12,7 @@ tag_attrs = { href: url, class: ['usa-link', 'block-link'] }
 tag_attrs[:target] = '_blank' if new_tab
 tag_attrs[:class] << 'usa-link--external' if new_tab
 %>
-<%= tag.a tag_attrs do %>
+<%= tag.a **tag_attrs do %>
   <%= content %>
   <% if new_tab %>
     <span class="usa-sr-only"><%= t('links.new_window') %></span>

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -38,7 +38,7 @@ feature 'doc auth send link step' do
     expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
       expect(config[:link]).to_not include('_')
 
-      impl.call(config)
+      impl.call(**config)
     end
 
     fill_in :doc_auth_phone, with: '415-555-0199'
@@ -106,7 +106,7 @@ feature 'doc auth send link step' do
       params = Rack::Utils.parse_nested_query URI(config[:link]).query
       expect(params).to eq('document-capture-session' => document_capture_session.uuid)
 
-      impl.call(config)
+      impl.call(**config)
     end
 
     fill_in :doc_auth_phone, with: '415-555-0199'

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -17,7 +17,7 @@ describe 'Hybrid Flow' do
 
     expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
       sms_link = config[:link]
-      impl.call(config)
+      impl.call(**config)
     end
 
     perform_in_browser(:desktop) do

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -85,7 +85,7 @@ describe Deploy::Activate do
       expect(s3_client).to have_received(:get_object).with(
         bucket: 'login-gov.secrets.12345-us-west-1',
         key: 'common/pwned-passwords.txt',
-        response_target: subject.send(:pwned_passwords_path),
+        response_target: kind_of(String),
       )
 
       expect(File.read(geolite_path)).to eq(geolite_content)

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -80,10 +80,12 @@ describe Deploy::Activate do
       expect(s3_client).to have_received(:get_object).with(
         bucket: 'login-gov.secrets.12345-us-west-1',
         key: 'common/GeoIP2-City.mmdb',
+        response_target: subject.send(:geolocation_db_path),
       )
       expect(s3_client).to have_received(:get_object).with(
         bucket: 'login-gov.secrets.12345-us-west-1',
         key: 'common/pwned-passwords.txt',
+        response_target: subject.send(:pwned_passwords_path),
       )
 
       expect(File.read(geolite_path)).to eq(geolite_content)

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -80,7 +80,7 @@ describe Deploy::Activate do
       expect(s3_client).to have_received(:get_object).with(
         bucket: 'login-gov.secrets.12345-us-west-1',
         key: 'common/GeoIP2-City.mmdb',
-        response_target: subject.send(:geolocation_db_path),
+        response_target: kind_of(String),
       )
       expect(s3_client).to have_received(:get_object).with(
         bucket: 'login-gov.secrets.12345-us-west-1',

--- a/spec/services/idv/data_url_image_spec.rb
+++ b/spec/services/idv/data_url_image_spec.rb
@@ -32,14 +32,6 @@ describe Idv::DataUrlImage do
       expect(data_url_image.read).to eq(data)
     end
 
-    context 'when data is not base64-encoded' do
-      let(:data_url) { 'data:image/png,a%20+%20b' }
-
-      it 'URI component unescapes the data' do
-        expect(data_url_image.read).to eq('a + b')
-      end
-    end
-
     context 'with bad data' do
       let(:data_url) { 'not_a_url' }
 

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -9,7 +9,7 @@ module OidcAuthHelper
   end
 
   def visit_idp_from_ial1_oidc_sp(**args)
-    params = ial1_params args
+    params = ial1_params(**args)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
@@ -17,7 +17,7 @@ module OidcAuthHelper
 
   def visit_idp_from_ial2_strict_oidc_sp(**args)
     args[:acr_values] = Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
-    params = ial2_params args
+    params = ial2_params(**args)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
@@ -25,21 +25,21 @@ module OidcAuthHelper
 
   def visit_idp_from_ial_max_oidc_sp(**args)
     args[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    params = ial2_params args
+    params = ial2_params(**args)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
   end
 
   def visit_idp_from_ial2_oidc_sp(**args)
-    params = ial2_params args
+    params = ial2_params(**args)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path
   end
 
   def visit_idp_from_ial1_oidc_sp_requesting_aal3(**args)
-    params = ial1_params args
+    params = ial1_params(**args)
     include_aal3(params)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
@@ -48,7 +48,7 @@ module OidcAuthHelper
 
   def visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(**args)
     args[:client_id] ||= OIDC_AAL3_ISSUER
-    params = ial1_params args
+    params = ial1_params(**args)
     oidc_path = openid_connect_authorize_path params
     visit oidc_path
     oidc_path


### PR DESCRIPTION
Follow up to #5364 that addresses all but one Ruby 3 issue.

We currently use `URI.decode` which has been deprecated for a bit, and is removed in Ruby 3:

https://github.com/18F/identity-idp/blob/68480831403a4fa993bc5fb7a4ecb0d57f42a60f/app/services/idv/data_url_image.rb#L21-L25

None of the replacement methods have the same behavior that keeps the `+` character, so this test can't pass:

https://github.com/18F/identity-idp/blob/68480831403a4fa993bc5fb7a4ecb0d57f42a60f/spec/services/idv/data_url_image_spec.rb#L38-L40

Do we know if the client side of image upload uses URI encoded data?