### PR TITLE
Add git SHA to NewRelic traces

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -28,6 +28,7 @@ class Analytics
       user_ip: request&.remote_ip,
       service_provider: sp,
       event_name: event,
+      git_sha: IdentityConfig::GIT_SHA,
     )
   end
 


### PR DESCRIPTION
so we can tie errors to boxes during a canary deploy