### PR TITLE
LG-4953: update language for password

### DIFF
--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -14,7 +14,7 @@
       html: { autocomplete: 'off' },
     ) do |f| %>
   <%= f.input :password, required: true,
-                         label: t('idv.form.password'),
+                         label: t('forms.password'),
                          input_html: { aria: { invalid: false, describedby: 'password-description' },
                                        class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -14,6 +14,7 @@
       html: { autocomplete: 'off' },
     ) do |f| %>
   <%= f.input :password, required: true,
+                         label: t('idv.form.password'),
                          input_html: { aria: { invalid: false, describedby: 'password-description' },
                                        class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -55,6 +55,7 @@ en:
       file_updated: File updated
     messages:
       remember_device: Remember this browser
+    password: Password
     passwords:
       edit:
         buttons:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -60,6 +60,7 @@ es:
       file_updated: Archivo actualizado
     messages:
       remember_device: Recuerde este navegador
+    password: Contraseña
     passwords:
       edit:
         buttons:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -61,6 +61,7 @@ fr:
       file_updated: Fichier mis à jour
     messages:
       remember_device: Enregistrer ce navigateur
+    password: Mot de passe
     passwords:
       edit:
         buttons:

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -494,12 +494,12 @@ module Features
     end
 
     def submit_form_with_invalid_password
-      fill_in 'Password', with: 'invalid'
+      fill_in t('forms.password'), with: 'invalid'
       click_button t('forms.buttons.continue')
     end
 
     def submit_form_with_valid_password(password = VALID_PASSWORD)
-      fill_in 'Password', with: password
+      fill_in t('forms.password'), with: password
       click_button t('forms.buttons.continue')
     end
 

--- a/spec/views/sign_up/passwords/new.html.erb_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.erb_spec.rb
@@ -16,6 +16,10 @@ describe 'sign_up/passwords/new.html.erb' do
     expect(rendered).to have_content(t('forms.confirmation.show_hdr'))
   end
 
+  it 'renders the proper Password label' do
+    expect(rendered).to have_content(t('forms.password'))
+  end
+
   it 'renders the proper help text' do
     expect(rendered).to have_content(
       t('instructions.password.info.lead', min_length: Devise.password_length.first),


### PR DESCRIPTION
*Why?* 

Language has been updated. now password is translated properly. 
![Screen Shot 2021-09-02 at 12 24 59 PM](https://user-images.githubusercontent.com/23225522/131914769-41cae845-289c-41c0-bb6a-1e7a9c4244f9.png)
![Screen Shot 2021-09-02 at 12 25 34 PM](https://user-images.githubusercontent.com/23225522/131914772-e9ce66c3-f1fe-4069-b57b-aca060188f86.png)
![Screen Shot 2021-09-02 at 12 25 59 PM](https://user-images.githubusercontent.com/23225522/131914773-92c363fa-468d-41dc-80fc-5d4cf2b00772.png)
