### PR TITLE
LG-5081: trueid response date parsing

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -91,21 +91,21 @@ module DocAuth
           pii[:state_id_type] = 'drivers_license'
 
           if pii[:dob_month] && pii[:dob_day] && pii[:dob_year]
-            pii[:dob] = [
-              pii.delete(:dob_year),
-              pii.delete(:dob_month),
-              pii.delete(:dob_day),
-            ].join('-')
+            pii[:dob] = Date.new(
+              pii.delete(:dob_year).to_i,
+              pii.delete(:dob_month).to_i,
+              pii.delete(:dob_day).to_i,
+            ).to_s
           end
 
           if pii[:state_id_expiration_month] &&
              pii[:state_id_expiration_day] &&
              pii[:state_id_expiration_year]
-            pii[:state_id_expiration] = [
-              pii.delete(:state_id_expiration_year),
-              pii.delete(:state_id_expiration_month),
-              pii.delete(:state_id_expiration_day),
-            ].join('-')
+            pii[:state_id_expiration] = Date.new(
+              pii.delete(:state_id_expiration_year).to_i,
+              pii.delete(:state_id_expiration_month).to_i,
+              pii.delete(:state_id_expiration_day).to_i,
+            ).to_s
           end
 
           pii

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_2.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_2.json
@@ -185,12 +185,12 @@
       {
         "Group": "AUTHENTICATION_RESULT",
         "Name": "DOB_Month",
-        "Values": [{"Value": "10"}]
+        "Values": [{"Value": "7"}]
       },
       {
         "Group": "AUTHENTICATION_RESULT",
         "Name": "DOB_Day",
-        "Values": [{"Value": "13"}]
+        "Values": [{"Value": "1"}]
       },
       {
         "Group": "AUTHENTICATION_RESULT",
@@ -627,12 +627,12 @@
       {
         "Group": "IDAUTH_FIELD_DATA",
         "Name": "Fields_DOB_Month",
-        "Values": [{"Value": "10"}]
+        "Values": [{"Value": "7"}]
       },
       {
         "Group": "IDAUTH_FIELD_DATA",
         "Name": "Fields_DOB_Day",
-        "Values": [{"Value": "13"}]
+        "Values": [{"Value": "1"}]
       },
       {
         "Group": "IDAUTH_FIELD_DATA",

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       minimum_expected_hash = {
         first_name: 'DAVID',
         last_name: 'SAMPLE',
-        dob: '1986-10-13',
+        dob: '1986-07-01',
         state: 'MD',
       }
 


### PR DESCRIPTION
DOBs with single digit month or day were being formatted without padding to two digits. For IAL2 identity verification involving AAMVA, this malformed date fails to pass.

This PR creates a new Date object with the year, month and day and converts to an iso8061 String.