### PR TITLE
LG-4959: alternate pathway to get uuid_prefix in

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -23,6 +23,7 @@ module Idv
         liveness_checking_enabled: liveness_checking_enabled?,
         issuer: sp_session[:issuer].to_s,
         analytics: analytics,
+        uuid_prefix: current_sp&.app_id,
       )
     end
   end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -11,12 +11,13 @@ module Idv
     validate :validate_images
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:, issuer:, analytics: nil)
+    def initialize(params, liveness_checking_enabled:, issuer:, analytics: nil, uuid_prefix: nil)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
       @issuer = issuer
       @analytics = analytics
       @readable = {}
+      @uuid_prefix = uuid_prefix
     end
 
     def submit
@@ -41,7 +42,7 @@ module Idv
 
     private
 
-    attr_reader :params, :analytics, :issuer, :form_response
+    attr_reader :params, :analytics, :issuer, :form_response, :uuid_prefix
 
     def throttled_else_increment
       return unless document_capture_session
@@ -70,6 +71,8 @@ module Idv
         selfie_image: selfie&.read,
         liveness_checking_enabled: liveness_checking_enabled?,
         image_source: image_source,
+        user_uuid: user_uuid,
+        uuid_prefix: uuid_prefix,
       )
       response.extra.merge!(extra_attributes)
       response.extra[:state] = response.pii_from_doc[:state]


### PR DESCRIPTION
Found another code pathway that needs to pass the uuid_prefix through to the TrueID request. This is simply a patch to #5323 