### PR TITLE
Fix call to flushdb on namespaced redis, fix deprecation warning

### DIFF
--- a/spec/services/redis_rate_limiter_spec.rb
+++ b/spec/services/redis_rate_limiter_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe RedisRateLimiter do
   let(:now) { Time.zone.now }
 
   around do |ex|
-    REDIS_POOL.with { |r| r.flushdb }
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |r| r.flushdb }
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   let(:key) { 'some-unique-identifier' }


### PR DESCRIPTION
Example warning:

> Passing 'flushdb' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at identity-idp/spec/services/redis_rate_limiter_spec.rb:7:in `block (3 levels) in <top (required)>')
