### PR TITLE
Remove code for usajobs.gov in smoke tests (LG-4816)

### DIFF
--- a/spec/features/monitor/create_account_spec.rb
+++ b/spec/features/monitor/create_account_spec.rb
@@ -83,10 +83,7 @@ RSpec.describe 'smoke test: create account' do
 
     click_on 'Agree and continue'
 
-    if oidc_sp_is_usajobs?
-      expect(page).to have_content('Welcome ')
-      expect(current_url).to match(%r{https://.*usajobs\.gov})
-    elsif monitor.remote?
+    if monitor.remote?
       expect(page).to have_content('OpenID Connect Sinatra Example')
       expect(current_url).to match(%r{https://(sp|\w+-identity)-oidc-sinatra})
     else

--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
 
       click_on 'Agree and continue' if on_consent_screen?
 
-      if oidc_sp_is_usajobs?
-        expect(page).to have_content('Welcome ')
-        expect(current_url).to match(%r{https://.*usajobs\.gov})
-      elsif monitor.remote?
+      if monitor.remote?
         expect(page).to have_content('OpenID Connect Sinatra Example')
         expect(current_url).to match(%r{https://(sp|\w+-identity)-oidc-sinatra})
       else

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -30,6 +30,8 @@ module MonitorSpSteps
   end
 
   def log_out_from_oidc_sp
+    return unless monitor.remote?
+
     click_on 'Log out'
   end
 

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -31,8 +31,6 @@ module MonitorSpSteps
 
   def log_out_from_oidc_sp
     click_on 'Log out'
-
-    return unless monitor.remote?
   end
 
   def log_out_from_saml_sp

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -1,15 +1,7 @@
 module MonitorSpSteps
-  def oidc_sp_is_usajobs?
-    monitor.config.oidc_sp_url.to_s.match(/usajobs\.gov/)
-  end
-
   def visit_idp_from_oidc_sp
     visit monitor.config.oidc_sp_url
-    if oidc_sp_is_usajobs?
-      click_link 'Sign In', href: '/Applicant/Profile/Dashboard'
-    else
-      find(:css, '.sign-in-bttn').click
-    end
+    find(:css, '.sign-in-bttn').click
 
     expect(page).to have_content(
       'is using Login.gov to allow you to sign in to your account safely and securely.',
@@ -38,8 +30,6 @@ module MonitorSpSteps
   end
 
   def log_out_from_oidc_sp
-    return unless oidc_sp_is_usajobs?
-
     within('.usajobs-home__title') do
       click_link 'Sign Out'
     end

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -30,12 +30,9 @@ module MonitorSpSteps
   end
 
   def log_out_from_oidc_sp
-    within('.usajobs-home__title') do
-      click_link 'Sign Out'
-    end
+    click_on 'Log out'
 
     return unless monitor.remote?
-    expect(current_url).to match(%r{https://login.(uat.)?usajobs.gov/externalloggedout})
   end
 
   def log_out_from_saml_sp


### PR DESCRIPTION
**Why**: We have our own sample apps deploy now,
so we can reduce external dependencies

--

I already updated CircleCI to use our apps for smoke tests in staging and prod, luckily the code we already had works for them, this is just cleaning up old, now-unused, code