### PR TITLE
LG-5100 Log vendor for all docauth responses

### DIFF
--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -121,7 +121,7 @@ module DocAuth
           success: false,
           errors: error,
           exception: exception,
-          extra: { vendor: 'Acuant' }
+          extra: { vendor: 'Acuant' },
         )
       end
 

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -116,10 +116,10 @@ module DocAuth
         DocAuth::RequestError.new(message, http_response.status)
       end
 
-      def create_error_response(error, exception)
+      def create_error_response(errors, exception)
         DocAuth::Response.new(
           success: false,
-          errors: error,
+          errors: errors,
           exception: exception,
           extra: { vendor: 'Acuant' },
         )

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -116,6 +116,15 @@ module DocAuth
         DocAuth::RequestError.new(message, http_response.status)
       end
 
+      def create_error_response(error, exception)
+        DocAuth::Response.new(
+          success: false,
+          errors: error,
+          exception: exception,
+          extra: { vendor: 'Acuant' }
+        )
+      end
+
       def handle_expected_http_error(http_response)
         error = case http_response.status
           when 438
@@ -126,11 +135,7 @@ module DocAuth
             Errors::IMAGE_SIZE_FAILURE
         end
 
-        DocAuth::Response.new(
-          success: false,
-          errors: { general: [error] },
-          exception: create_http_exception(http_response),
-        )
+        create_error_response({ general: [error] }, create_http_exception(http_response))
       end
 
       def handle_invalid_response(http_response)
@@ -140,11 +145,7 @@ module DocAuth
 
       def handle_connection_error(exception)
         send_exception_notification(exception)
-        DocAuth::Response.new(
-          success: false,
-          errors: { network: true },
-          exception: exception,
-        )
+        create_error_response({ network: true }, exception)
       end
 
       def send_exception_notification(exception, custom_params = {})

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -54,6 +54,7 @@ module DocAuth
           success: false,
           errors: { network: true },
           exception: exception,
+          extra: { vendor: 'TrueID' },
         )
       end
 

--- a/spec/services/doc_auth/acuant/request_spec.rb
+++ b/spec/services/doc_auth/acuant/request_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe DocAuth::Acuant::Request do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(network: true)
         expect(response.exception).to be_a(Faraday::ConnectionFailed)
+        expect(response.extra).to include(vendor: 'Acuant')
       end
     end
 

--- a/spec/services/doc_auth/acuant/request_spec.rb
+++ b/spec/services/doc_auth/acuant/request_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe DocAuth::Acuant::Request do
 
         expect_failed_response(response)
         expect(response.errors).to eq(general: [DocAuth::Errors::IMAGE_LOAD_FAILURE])
+        expect(response.extra).to include(vendor: 'Acuant')
       end
 
       it 'it produces a 439 error' do
@@ -172,6 +173,7 @@ RSpec.describe DocAuth::Acuant::Request do
 
         expect_failed_response(response)
         expect(response.errors).to eq(general: [DocAuth::Errors::PIXEL_DEPTH_FAILURE])
+        expect(response.extra).to include(vendor: 'Acuant')
       end
 
       it 'it produces a 440 error' do
@@ -185,6 +187,7 @@ RSpec.describe DocAuth::Acuant::Request do
 
         expect_failed_response(response)
         expect(response.errors).to eq(general: [DocAuth::Errors::IMAGE_SIZE_FAILURE])
+        expect(response.extra).to include(vendor: 'Acuant')
       end
     end
   end

--- a/spec/services/doc_auth/lexis_nexis/request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/request_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe DocAuth::LexisNexis::Request do
           response = subject.fetch
 
           expect(response.class).to eq(DocAuth::Response)
+          expect(response.extra).to include(vendor: 'TrueID')
         end
 
         it 'includes information on the error' do

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     it 'excludes pii fields from logging' do
       expect(response.extra_attributes.keys).to_not include(*described_class::PII_EXCLUDES)
     end
+
+    it 'excludes unnecessary raw Alert data from logging' do
+      expect(response.extra_attributes.keys.any? { |key| key.start_with?('Alert_') }).to eq(false)
+    end
   end
 
   context 'when the barcode can not be read' do

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
     it 'is a successful result' do
       expect(response.successful_result?).to eq(true)
+      expect(response.to_h[:vendor]).to eq('TrueID')
     end
     it 'has no error messages' do
       expect(response.error_messages).to be_empty
@@ -75,6 +76,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
     it 'includes expiration' do
       expect(response.pii_from_doc).to include(state_id_expiration: '2099-10-15')
+    end
+
+    it 'excludes pii fields from logging' do
+      expect(response.extra_attributes.keys).to_not include(*described_class::PII_EXCLUDES)
     end
   end
 
@@ -131,6 +136,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:general]).to contain_exactly(
         DocAuth::Errors::GENERAL_ERROR_LIVENESS,
       )
+      expect(output[:vendor]).to eq('TrueID')
     end
 
     it 'it produces appropriate errors with liveness and everything failing' do
@@ -152,6 +158,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(network: true)
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
+      expect(output[:vendor]).to eq('TrueID')
     end
 
     it 'it produces reasonable output for internal application error' do
@@ -168,6 +175,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS])
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info, :exception)
+      expect(output[:vendor]).to eq('TrueID')
     end
 
     it 'it produces reasonable output for a malformed TrueID response' do


### PR DESCRIPTION
LG-5100 Make sure vendor is logged for all submission responses and some minor refactors to clean up.