### PR TITLE
Configure Capybara to always click checkbox label

### DIFF
--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -267,11 +267,11 @@ feature 'doc auth verify step' do
       expect(page).to have_text('6**-**-***4')
       expect(page).not_to have_text('666-66-1234')
 
-      check t('forms.ssn.show'), allow_label_click: true
+      check t('forms.ssn.show')
       expect(page).to have_text('666-66-1234')
       expect(page).not_to have_text('6**-**-***4')
 
-      uncheck t('forms.ssn.show'), allow_label_click: true
+      uncheck t('forms.ssn.show')
       expect(page).to have_text('6**-**-***4')
       expect(page).not_to have_text('666-66-1234')
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -687,7 +687,7 @@ feature 'Sign in' do
       expect(button[:class]).to include('usa-button--disabled')
 
       # This checkbox element has a non-standard id for the accept-terms-button JS
-      check 'user_terms_accepted', allow_label_click: true
+      check 'user_terms_accepted'
 
       button = find_button(t('forms.buttons.continue'))
       expect(button[:class]).to_not include('usa-button--disabled')

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -42,6 +42,7 @@ Capybara.server = :puma, { Silent: true }
 Capybara.default_max_wait_time = (ENV['CAPYBARA_WAIT_TIME_SECONDS'] || '0.5').to_f
 Capybara::Screenshot.autosave_on_failure = false
 Capybara.asset_host = ENV['RAILS_ASSET_HOST'] || 'http://localhost:3000'
+Capybara.automatic_label_click = true # USWDS styles native checkbox/radio as offscreen
 
 Capybara.register_driver(:mobile_rack_test) do |app|
   user_agent_string = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) ' \

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -6,7 +6,7 @@ module Features
 
     def sign_up_with(email)
       visit sign_up_email_path
-      check t('sign_up.terms'), allow_label_click: true
+      check t('sign_up.terms')
       fill_in t('forms.registration.labels.email'), with: email
       click_button t('forms.buttons.submit.default')
     end
@@ -270,7 +270,7 @@ module Features
 
     def accept_rules_of_use_and_continue_if_displayed
       return unless current_path == rules_of_use_path
-      check :user_terms_accepted, allow_label_click: true
+      check :user_terms_accepted
       click_button t('forms.buttons.continue')
     end
 
@@ -468,7 +468,7 @@ module Features
     end
 
     def submit_form_with_valid_email(email = 'test@test.com')
-      check t('sign_up.terms'), allow_label_click: true
+      check t('sign_up.terms')
       fill_in t('forms.registration.labels.email'), with: email
       click_button t('forms.buttons.submit.default')
     end

--- a/spec/support/monitor/monitor_idp_steps.rb
+++ b/spec/support/monitor/monitor_idp_steps.rb
@@ -24,7 +24,7 @@ module MonitorIdpSteps
   # @return [String] email address for the account
   def create_new_account_up_until_password(email_address = random_email_address)
     fill_in 'user_email', with: email_address
-    check 'user_terms_accepted', allow_label_click: true
+    check 'user_terms_accepted'
     click_on 'Submit'
     confirmation_link = monitor.check_for_confirmation_link
     visit confirmation_link
@@ -59,7 +59,7 @@ module MonitorIdpSteps
     click_on 'Sign in'
 
     if current_path == '/rules_of_use'
-      check 'user_terms_accepted', allow_label_click: true
+      check 'user_terms_accepted'
       click_button 'Continue'
     end
 

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -9,7 +9,7 @@ module MonitorIdvSteps
     click_on 'Continue'
 
     expect(page).to have_current_path('/verify/doc_auth/agreement')
-    check 'ial2_consent_given', visible: :all, allow_label_click: true
+    check 'ial2_consent_given'
     expect(page).to have_button('Continue', disabled: :all)
 
     click_on 'Continue'


### PR DESCRIPTION
**Why**: To avoid developer confusion when [`Capybara::Node::Actions#check`](https://rubydoc.info/github/jnicklas/capybara/master/Capybara%2FNode%2FActions:check) fails when called on a USWDS checkbox, since USWDS styles replace the native checkbox with a stylized pseudo-element, and the native element is placed offscreen. This requires "allow_label_click" option to be passed. Since we can assume most checkboxes/radios should be USWDS checkboxes/radios, set this as the default behavior.

See: https://rubydoc.info/github/jnicklas/capybara/master/Capybara#configure-class_method