### PR TITLE
LG-5101: Include billed property in TrueID response hash

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -141,7 +141,12 @@ module DocAuth
             conversation_id: conversation_id,
             reference: reference,
             vendor: 'TrueID',
+            billed: billed?,
           }
+        end
+
+        def billed?
+          !!doc_auth_result && !doc_auth_result_unknown?
         end
 
         def all_passed?
@@ -169,6 +174,10 @@ module DocAuth
 
         def doc_auth_result_attention?
           doc_auth_result == 'Attention'
+        end
+
+        def doc_auth_result_unknown?
+          doc_auth_result == 'Unknown'
         end
 
         def doc_auth_result


### PR DESCRIPTION
**Why**: So that we log and track for billing in the same way as we do with Acuant.