### PR TITLE
Fix lintfix Makefile target to remove invalid argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ lint_yaml: normalize_yaml
 
 lintfix:
 	@echo "--- rubocop fix ---"
-	bundle exec rubocop -R -a
+	bundle exec rubocop -a
 
 brakeman:
 	bundle exec brakeman


### PR DESCRIPTION
The "-R" ("--rails") option was removed as of RuboCop 0.72.

See: https://github.com/rubocop/rubocop/releases/tag/v0.72.0