### PR TITLE
LG-4963: Send link page, emphasis for text

### DIFF
--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -14,7 +14,7 @@
 
 <p class='mt-tiny margin-bottom-4'><%= t('doc_auth.info.take_picture') %></p>
 
-<p class='mt-tiny margin-bottom-4 bold'><%= t('doc_auth.info.camera_required') %></p>
+<p class='mt-tiny margin-bottom-4'><strong><%= t('doc_auth.info.camera_required') %></strong></p>
 
 <p class='mt-tiny margin-bottom-4'><%= t('doc_auth.instructions.send_sms') %></p>
 

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -26,8 +26,8 @@
   <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: '', size: '80') %>
 </div>
 <div class="sm-col sm-col-10">
-  <div class="bold margin-bottom-0">
-    <%= t('instructions.personal_key.email_title') %>
+  <div class="margin-bottom-0">
+    <p><strong><%= t('instructions.personal_key.email_title') %></strong></p>
   </div>
   <p><%= t('instructions.personal_key.email_body') %></p>
 </div>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -26,9 +26,9 @@
   <%= image_tag(asset_url('alert/icon-lock-alert-important.svg'), alt: '', size: '80') %>
 </div>
 <div class="sm-col sm-col-10">
-  <div class="margin-bottom-0">
-    <p><strong><%= t('instructions.personal_key.email_title') %></strong></p>
-  </div>
+  <p class="margin-bottom-0">
+    <strong><%= t('instructions.personal_key.email_title') %></strong>
+  </p>
   <p><%= t('instructions.personal_key.email_body') %></p>
 </div>
 <br>


### PR DESCRIPTION
This PR adds the `<strong>` element to bolded text in the IAL2 flow

**Why**: To make sure that we are following accessibility best practices.

- End result: "User agents can then make the structure perceivable to the user, for example using a different visual presentation for different types of structures or by using a different voice or pitch in an auditory presentation."

Note: There are areas across the IAL1 flow that should also be updated. This PR specifically addresses the items that were highlighted during the [IAL2 accessibility audit](https://docs.google.com/spreadsheets/d/1GeotAc3zqed0WiQIibPNsZKZ8yIlhKpHSW-gQ9IO3Jg/edit#gid=1982542849)