### PR TITLE
do a production yarn install in the build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
       - image: redis:5.0.8
 
 commands:
-  bundle-yarn-install:
+  node-install:
     steps:
       - run:
           name: Switch Node.js version
@@ -42,6 +42,25 @@ commands:
             . "$NVM_DIR/nvm.sh" --install
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV;
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV;
+      - run:
+          name: Print Node.js version
+          command: node -v
+  yarn-install:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
+            - v1-identity-idp-yarn-
+      - run:
+          name: Install Yarn
+          command: yarn install --frozen-lockfile --ignore-engines --cache-folder ~/.cache/yarn
+      - save_cache:
+          key: v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+
+  bundle-install:
+    steps:
       - run: gem install bundler --version $BUNDLER_VERSION
       - restore_cache:
           keys:
@@ -54,21 +73,6 @@ commands:
           key: v2-identity-idp-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - restore_cache:
-          keys:
-            - v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
-            - v1-identity-idp-yarn-
-      - run:
-          name: Install Yarn
-          command: yarn install --frozen-lockfile --ignore-engines --cache-folder ~/.cache/yarn
-      - run:
-          name: Print Node.js version
-          command: node -v
-      - save_cache:
-          key: v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-
   # Custom version of "checkout" that checks out a SHA deployed to sha_url param
   # Adapter from https://gist.github.com/drazisil/e97dc21454120251472154de1c1b1c7b
   checkout-deployed-sha:
@@ -137,7 +141,9 @@ jobs:
     executor: ruby_browsers
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: Test Setup
           command: |
@@ -162,7 +168,9 @@ jobs:
 
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: Install AWS CLI
           command: |
@@ -221,23 +229,39 @@ jobs:
           command: |
             aws s3 sync "s3://login-gov-test-coverage/coverage/$CIRCLE_BUILD_NUM" coverage/
             ./cc-test-reporter sum-coverage --output - --parts $CIRCLE_NODE_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+  javascript_test:
+    working_directory: ~/identity-idp
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - node-install
+      - yarn-install
+      - run:
+          name: Run Tests
+          command: |
+            yarn test
+
   javascript_build:
     working_directory: ~/identity-idp
     executor: ruby_browsers
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - bundle-install
       - run:
           name: Run Tests
           command: |
-            yarn test
+            yarn install --production --frozen-lockfile
+            bundle exec rake assets:precompile
 
   lints:
     working_directory: ~/identity-idp
     executor: ruby_browsers
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: Run Lints
           command: |
@@ -251,7 +275,9 @@ jobs:
       - jq/install
       - checkout-deployed-sha:
           sha_url: https://idp.dev.identitysandbox.gov/api/deploy.json
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: 'Smoke tests'
           command: |
@@ -267,7 +293,9 @@ jobs:
       - jq/install
       - checkout-deployed-sha:
           sha_url: https://idp.int.identitysandbox.gov/api/deploy.json
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: 'Smoke tests'
           command: |
@@ -283,7 +311,9 @@ jobs:
       - jq/install
       - checkout-deployed-sha:
           sha_url: https://idp.staging.login.gov/api/deploy.json
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: 'Smoke tests'
           command: |
@@ -297,7 +327,9 @@ jobs:
       MONITOR_ENV: PROD
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: 'Smoke tests'
           command: |
@@ -308,7 +340,9 @@ jobs:
     executor: ruby_browsers
     steps:
       - checkout
-      - bundle-yarn-install
+      - node-install
+      - yarn-install
+      - bundle-install
       - run:
           name: Check current AWS Pinpoint country support
           command: |-
@@ -325,6 +359,9 @@ workflows:
           requires:
             - setup
       - javascript_build:
+          requires:
+            - setup
+      - javascript_test:
           requires:
             - setup
       - lints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,19 @@ commands:
           key: v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+  yarn-production-install:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-identity-idp-yarn-production-{{ checksum "yarn.lock" }}
+            - v1-identity-idp-yarn-production
+      - run:
+          name: Install Yarn
+          command: yarn install --production --frozen-lockfile --ignore-engines --cache-folder ~/.cache/yarn
+      - save_cache:
+          key: v1-identity-idp-yarn-production-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
 
   bundle-install:
     steps:
@@ -247,11 +260,11 @@ jobs:
     steps:
       - checkout
       - node-install
+      - yarn-production-install
       - bundle-install
       - run:
           name: Run Tests
           command: |
-            yarn install --production --frozen-lockfile
             bundle exec rake assets:precompile
 
   lints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
             - public/packs
             - public/packs-test
 
-  build:
+  ruby_test:
     executor: ruby_browsers
 
     environment:
@@ -368,7 +368,7 @@ workflows:
   release:
     jobs:
       - setup
-      - build:
+      - ruby_test:
           requires:
             - setup
       - javascript_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
             - v1-identity-idp-yarn-
       - run:
           name: Install Yarn
-          command: yarn install --ignore-engines --cache-folder ~/.cache/yarn
+          command: yarn install --frozen-lockfile --ignore-engines --cache-folder ~/.cache/yarn
       - run:
           name: Print Node.js version
           command: node -v

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ lint:
 	@echo "--- bundler-audit ---"
 	bundle exec bundler-audit check --update
 # JavaScript
-	@echo "--- lint yarn lockfile ---"
-	make lint_yarn_lockfile
 	@echo "--- eslint ---"
 	yarn run lint
 	@echo "--- typescript ---"
@@ -54,9 +52,6 @@ lint:
 
 lint_erb:
 	bundle exec erblint app/views
-
-lint_yarn_lockfile:
-	(! git diff --name-only | grep yarn.lock) || (echo "Error: Sync Yarn lockfile using 'yarn install'"; exit 1)
 
 lint_yaml: normalize_yaml
 	(! git diff --name-only | grep "^config/.*\.yml$$") || (echo "Error: Run 'make normalize_yaml' to normalize YAML"; exit 1)

--- a/deploy/build
+++ b/deploy/build
@@ -29,7 +29,7 @@ bundle install --deployment --jobs 4 \
     --binstubs "$bundle_dir/bin" \
     --without 'deploy development doc test'
 
-bundle exec yarn install
+yarn install --production --frozen-lockfile
 
 set +x
 


### PR DESCRIPTION
Ignores dev dependencies and ensures the lock file is not modified or out of sync

Deployed this change to my sandbox and the install and asset compilation still work as expected