### PR TITLE
Shallow clone identity-idp-config

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -42,7 +42,7 @@ module Deploy
       )
       checkout_dir = File.join(root, idp_config_checkout_name)
 
-      cmd = ['git', 'clone', private_git_repo_url, checkout_dir]
+      cmd = ['git', 'clone', '--depth', '1', '--branch', 'main', private_git_repo_url, checkout_dir]
       logger.info('+ ' + cmd.join(' '))
       Subprocess.check_call(cmd)
     end


### PR DESCRIPTION
Similar to https://github.com/18F/identity-devops/pull/3765, but for `identity-idp-config`

We really only care about the most recent version, so we may as well limit our download to that. I tested in my sandbox and everything works as expected. Tagged all of the partnerships engineers as this does have some effect on service provider config loading.

From a deployed instance with this patch:

```
root@idp-i-01749cc0308ae7963:/srv/idp/current# cd /srv/idp/current/identity-idp-config/
root@idp-i-01749cc0308ae7963:/srv/idp/current/identity-idp-config# git log
commit db068af98c8e6f700e411d2d9f24a5e4850cca5c (grafted, HEAD -> main, origin/main, origin/HEAD)
Author: Tianna Woodson <tianna24@vt.edu>
Date:   Thu Sep 9 14:51:58 2021 -0400

    [LGN0000385 ] Add new Order for HHS (#488)

    * Add new Order for HHS

    * Update approved apps

    * Fix comments
root@idp-i-01749cc0308ae7963:/srv/idp/current/identity-idp-config#
```