### PR TITLE
Configure smoke tests for automatic label click

### DIFF
--- a/spec/monitor_spec_helper.rb
+++ b/spec/monitor_spec_helper.rb
@@ -21,6 +21,7 @@ end
 
 Capybara.javascript_driver = :chrome
 Capybara.default_max_wait_time = 10
+Capybara.automatic_label_click = true # USWDS styles native checkbox/radio as offscreen
 
 Dir['spec/support/monitor/**/*.rb'].sort.each { |file| require File.expand_path(file) }
 


### PR DESCRIPTION
Previously: https://github.com/18F/identity-idp/pull/5385

Smoke tests use a separate configuration for Capybara, so it needs to be set as well.