### PR TITLE
Fix flakey backup codes spec

### DIFF
--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -55,7 +55,7 @@ feature 'Backup codes' do
       click_continue
 
       generated_at = user.backup_code_configurations.
-                     order(created_at: :asc).last.created_at.
+                     order(created_at: :asc).first.created_at.
                      in_time_zone('UTC')
       formatted_generated_at = l(generated_at, format: t('time.formats.event_timestamp'))
 


### PR DESCRIPTION
**Why**: To match actual logic of the view, in case the set of backup codes aren't all created in a timeframe before the next minute elapses.

View logic:

https://github.com/18F/identity-idp/blob/3a3dac6ae701d4d56a3735a07afd78341074cd8f/app/view_models/account_show.rb#L33-L35

Example failing build: https://app.circleci.com/pipelines/github/18F/identity-idp/51886/workflows/c48b25c2-c872-4aba-86c5-fa33ff42757a/jobs/81045/parallel-runs/1