### PR TITLE
use ActiveRecord::Base connection instead of ApplicationRecord for reports

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -31,7 +31,7 @@ module Reports
       # connections mid-test, so we just skip for now :[
       return yield if rails_env.test?
 
-      ApplicationRecord.connected_to(role: :reading, shard: :read_replica) do
+      ActiveRecord::Base.connected_to(role: :reading, shard: :read_replica) do
         ActiveRecord::Base.transaction do
           quoted_timeout = ActiveRecord::Base.connection.quote(report_timeout)
           ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")


### PR DESCRIPTION
This should address the issue with reports sometimes using the primary database instead of the read replica. Specifically, if a report constructs a SQL query with a string instead of interacting with the database via ActiveRecord, it would use the primary database. Ex:

https://github.com/18F/identity-idp/blob/4a6aea4b0ddaea87414854dd64d3276b69ceb24e/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb#L96
