### PR TITLE
Allow configurable bundle directory in deploy step

### DIFF
--- a/deploy/activate
+++ b/deploy/activate
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # This script is called by identity-devops cookbooks as part of the deployment
-# process. It fetches the latest application.yml from S3 to ensure the app is
-# properly configured.
+# process. It fetches identity-idp-config and large data files like pwned passwords and
+# GeoIP from S3.
 
 set -euo pipefail
 

--- a/deploy/build
+++ b/deploy/build
@@ -19,12 +19,12 @@ env
 id
 which bundle
 # default bundle directory to shared directory
-: ${BUNDLE_DIRECTORY=/srv/idp/shared/bundle}
+: ${BUNDLE_DIR=/srv/idp/shared/bundle}
 
 # use system libxml2, not the one vendored with nokogiri
 bundle config build.nokogiri --use-system-libraries
 bundle config set --local deployment 'true'
-bundle config set --local path $BUNDLE_DIRECTORY
+bundle config set --local path $BUNDLE_DIR
 bundle config set --local without 'deploy development doc test'
 
 bundle install --jobs 4

--- a/deploy/build
+++ b/deploy/build
@@ -18,16 +18,17 @@ env
 
 id
 which bundle
-
-bundle_dir=/srv/idp/shared
+# default bundle directory to shared directory
+: ${BUNDLE_DIRECTORY=/srv/idp/shared/bundle}
 
 # use system libxml2, not the one vendored with nokogiri
 bundle config build.nokogiri --use-system-libraries
+bundle config set --local deployment 'true'
+bundle config set --local path $BUNDLE_DIRECTORY
+bundle config set --local without 'deploy development doc test'
 
-bundle install --deployment --jobs 4 \
-    --path "$bundle_dir/bundle" \
-    --binstubs "$bundle_dir/bin" \
-    --without 'deploy development doc test'
+bundle install --jobs 4
+bundle binstubs --all
 
 yarn install --production --frozen-lockfile
 


### PR DESCRIPTION
This change is to facilitate some changes infrastructure-side in how we cache and install dependencies. It also includes fixing the deprecated bundle behavior.

It should not affect the current behavior of a deployment, and I've deployed this change to my sandbox to confirm that the logs show it using the same directory and re-using some of the gems already in the shared bundle cache.

Logs from a build step with this patch:

<details>
<summary>Log</summary>

```
              + which bundle
              /opt/ruby_build/shims/bundle
              + : /srv/idp/shared/bundle
              + bundle config build.nokogiri --use-system-libraries
              + bundle config set --local deployment true
              + bundle config set --local path /srv/idp/shared/bundle
              + bundle config set --local without 'deploy development doc test'
              + bundle install --jobs 4
              Fetching gem metadata from https://rubygems.org/.......
              Fetching https://github.com/18f/identity-telephony.git
              Fetching rake 13.0.6
              Installing rake 13.0.6
              Using concurrent-ruby 1.1.9
              Using minitest 5.14.4
              Using zeitwerk 2.4.2
              Using builder 3.2.4
              Using erubi 1.10.0
              Using mini_portile2 2.5.3
              Using racc 1.5.2
              Using crass 1.0.6
              Using rack 2.2.3
              Using websocket-extensions 0.1.5
              Using marcel 1.0.1
              Fetching nio4r 2.5.8
              Using public_suffix 4.0.6
              Using device_detector 1.0.5
              Using geocoder 1.6.7
              Using errbase 0.2.0
              Using android_key_attestation 0.3.0
              Fetching mini_mime 1.1.1
              Using execjs 2.8.1
              Using awrence 1.2.1
              Using aws-eventstream 1.1.0
              Using aws-partitions 1.411.0
              Using jmespath 1.4.0
              Using base32-crockford 0.1.0
              Using bindata 2.4.10
              Using blueprinter 0.25.3
              Using bundler 2.2.26
              Using cbor 0.5.9.6
              Using bcrypt 3.1.16
              Using chunky_png 1.4.0
              Using connection_pool 2.2.5
              Using openssl 2.2.0
              Using orm_adapter 0.5.0
              Using method_source 1.0.0
              Using thor 1.1.0
              Using multipart-post 2.1.1
              Using ruby2_keywords 0.0.2
              Using ffi 1.15.3
              Using foundation_emails 2.2.1.0
              Using raabro 1.4.0
              Using hashie 4.1.0
              Using hiredis 0.6.3
              Using htmlentities 4.3.4
              Using http_accept_language 2.1.1
              Using identity_validations 0.7.0 from https://github.com/18F/identity-validations.git (at v0.7.0@85ee335)
              Using jwt 2.2.3
              Using local_time 2.1.0
              Using systemu 2.6.5
              Using maxminddb 0.1.22
              Using net-ssh 5.2.0
              Using newrelic_rpm 6.14.0
              Using pg 1.2.3
              Using phonelib 0.6.51
              Using pkcs11 0.3.3
              Using profanity_filter 0.1.1
              Using rack-headers_filter 0.0.1
              Using rack-timeout 0.6.0
              Using raise-if-root 0.0.2
              Using redacted_struct 1.1.0
              Using redis 4.3.1
              Using retries 0.0.5
              Using rexml 3.2.5
              Using rotp 6.2.0
              Fetching rqrcode_core 1.2.0
              Using ruby-progressbar 1.11.0
              Using tilt 2.0.10
              Using secure_headers 6.3.2
              Using securecompare 1.0.0
              Using semantic_range 3.0.0
              Using stringex 2.8.5
              Using subprocess 1.5.4
              Using user_agent_parser 2.7.0
              Using zxcvbn 0.1.7
              Using i18n 1.8.10
              Using tzinfo 2.0.4
              Using nokogiri 1.11.7 (x86_64-linux)
              Using rack-test 1.1.0
              Using warden 1.2.9
              Using request_store 1.5.0
              Using sprockets 4.0.2
              Using rack-attack 6.5.0
              Using rack-cors 1.1.1
              Using rack-proxy 0.7.0
              Using websocket-driver 0.7.5
              Installing nio4r 2.5.8 with native extensions
              Using addressable 2.8.0
              Using safely_block 0.3.0
              Using autoprefixer-rails 10.2.5.1
              Installing rqrcode_core 1.2.0
              Using uglifier 4.2.0
              Installing mini_mime 1.1.1
              Using aws-sigv4 1.2.2
              Using openssl-signature_algorithm 1.1.1
              Using faraday 1.1.0
              Using ffi-compiler 1.0.1
              Using sassc 2.4.0
              Using safety_net_attestation 0.4.0
              Using macaddr 1.7.2
              Using net-sftp 2.1.2
              Fetching redis-namespace 1.8.1
              Fetching activesupport 6.1.4.1
              Installing redis-namespace 1.8.1
              Fetching loofah 2.12.0
              Using et-orbi 1.2.4
              Using ruby-saml 1.12.2
              Using xmldsig 0.6.6
              Using xmlmapper 0.7.3
              Using css_parser 1.9.0
              Using aws-sdk-core 3.110.0
              Using cose 1.2.0
              Using uuid 2.3.9
              Using scrypt 3.0.7
              Using tpm-key_attestation 0.10.0
              Fetching rqrcode 2.1.0
              Installing loofah 2.12.0
              Installing activesupport 6.1.4.1
              Installing rqrcode 2.1.0
              Using mail 2.7.1
              Using aws-sdk-kms 1.40.0
              Using aws-sdk-pinpoint 1.48.0
              Using aws-sdk-pinpointsmsvoice 1.21.0
              Using aws-sdk-ses 1.36.0
              Using premailer 1.15.0
              Using webauthn 2.5.0
              Using aws-sdk-s3 1.87.0
              Using identity-telephony 0.4.0 from https://github.com/18f/identity-telephony.git (at v0.4.0@b73e77c)
              Using rails-dom-testing 2.0.3
              Fetching rails-html-sanitizer 1.4.2
              Fetching globalid 0.5.2
              Fetching fugit 1.5.1
              Fetching activemodel 6.1.4.1
              Installing rails-html-sanitizer 1.4.2
              Installing globalid 0.5.2
              Installing fugit 1.5.1
              Installing activemodel 6.1.4.1
              Using ahoy_matey 3.1.0
              Using dotiw 5.1.0
              Using saml_idp 0.14.3.pre.18f from https://github.com/18F/saml_idp.git (at v0.14.3-18f@cf2ec29)
              Using identity-hostdata 3.4.0 from https://github.com/18F/identity-hostdata.git (at v3.4.0@c69cca2)
              Fetching actionview 6.1.4.1
              Fetching activejob 6.1.4.1
              Using valid_email 0.1.3
              Fetching activerecord 6.1.4.1
              Using xmlenc 0.7.1
              Installing activejob 6.1.4.1
              Installing actionview 6.1.4.1
              Installing activerecord 6.1.4.1
              Fetching actionpack 6.1.4.1
              Installing actionpack 6.1.4.1
              Using strong_migrations 0.7.4
              Fetching actioncable 6.1.4.1
              Fetching actionmailer 6.1.4.1
              Fetching activestorage 6.1.4.1
              Fetching railties 6.1.4.1
              Installing actionmailer 6.1.4.1
              Installing actioncable 6.1.4.1
              Installing activestorage 6.1.4.1
              Installing railties 6.1.4.1
              Using sprockets-rails 3.2.2
              Using redis-session-store 0.11.3
              Using simple_form 5.1.0
              Using exception_notification 4.4.3
              Using premailer-rails 1.11.1
              Fetching actiontext 6.1.4.1
              Fetching actionmailbox 6.1.4.1
              Installing actiontext 6.1.4.1
              Installing actionmailbox 6.1.4.1
              Using responders 3.0.1
              Fetching good_job 2.0.2
              Using lograge 0.11.2
              Using sassc-rails 2.1.2
              Using webpacker 5.3.0
              Using devise 4.8.0
              Fetching rails 6.1.4.1
              Installing rails 6.1.4.1
              Using identity-logging 0.1.0 from https://github.com/18F/identity-logging.git (at v0.1.0@7a341c9)
              Using safe_target_blank 1.0.2
              Installing good_job 2.0.2
              Bundle complete! 109 Gemfile dependencies, 156 gems now installed.
              Gems in the groups 'deploy', 'development', 'doc' and 'test' were not installed.
              Bundled gems are installed into `/srv/idp/shared/bundle`
              + bundle binstubs --all
              + yarn install --production --frozen-lockfile
              yarn install v1.22.5
              [1/5] Validating package.json...
              [2/5] Resolving packages...
              [3/5] Fetching packages...
              info fsevents@2.3.2: The platform "linux" is incompatible with this module.
              info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
              info fsevents@1.2.13: The platform "linux" is incompatible with this module.
              info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
              [4/5] Linking dependencies...
              warning " > source-map-loader@1.1.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
              warning " > webpack-dev-server@3.11.1" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
              warning "webpack-dev-server > webpack-dev-middleware@3.7.2" has unmet peer dependency "webpack@^4.0.0".
              warning " > @18f/identity-rails-i18n-webpack-plugin@1.0.0" has unmet peer dependency "webpack@*".
              [5/5] Building fresh packages...
              Done in 44.00s.
```

</details>