### PR TITLE
Remove unused CSS utility classes

### DIFF
--- a/app/assets/stylesheets/utilities/_background.scss
+++ b/app/assets/stylesheets/utilities/_background.scss
@@ -1,8 +1,6 @@
 .bg-gray-lighter { background-color: $gray-lighter; }
 .bg-light-blue { background-color: $blue-light; }
-.bg-lighter-blue { background-color: $blue-lighter; }
 .bg-lightest-blue { background-color: $blue-lightest; }
-.bg-lightest-red { background-color: $red-lightest; }
 // scss-lint:disable ImportantRule
 .bg-white { background-color: $white !important; }
 // scss-lint:enable ImportantRule

--- a/app/assets/stylesheets/utilities/_border.scss
+++ b/app/assets/stylesheets/utilities/_border.scss
@@ -1,11 +1,5 @@
 .border-dashed { border-style: dashed; }
 
-.rounded-md { border-radius: $border-radius-md; }
 .rounded-lg { border-radius: $border-radius-lg; }
 .rounded-xl { border-radius: $border-radius-xl; }
 .rounded-xxl { border-radius: $border-radius-xxl; }
-
-@media #{$breakpoint-sm} {
-  .sm-border-none { border: 0; }
-  .sm-rounded-md { border-radius: $border-radius-md; }
-}

--- a/app/assets/stylesheets/utilities/_color.scss
+++ b/app/assets/stylesheets/utilities/_color.scss
@@ -1,3 +1,0 @@
-@media #{$breakpoint-sm} {
-  .sm-white { color: $white; }
-}

--- a/app/assets/stylesheets/utilities/_position.scss
+++ b/app/assets/stylesheets/utilities/_position.scss
@@ -1,2 +1,1 @@
-.top-n16 { top: -16px; }
 .top-n24 { top: -24px; }

--- a/app/assets/stylesheets/utilities/_space-addon.scss
+++ b/app/assets/stylesheets/utilities/_space-addon.scss
@@ -1,9 +1,0 @@
-.tablet\:padding-x-10 {
-  @include at-media(tablet) {
-    @include u-padding-x(10);
-  }
-}
-
-.margin-top-neg-3 {
-  @include u-margin-top(-3);
-}

--- a/app/assets/stylesheets/utilities/_space-misc.scss
+++ b/app/assets/stylesheets/utilities/_space-misc.scss
@@ -3,44 +3,16 @@
 .mxn-tiny { margin-left: -$space-tiny; margin-right: -$space-tiny; }
 .mb-tiny { margin-bottom: $space-tiny; }
 .ml-tiny { margin-left: $space-tiny; }
-.mr-tiny { margin-right: $space-tiny; }
 .mt-tiny { margin-top: $space-tiny; }
-.pb-tiny { padding-bottom: $space-tiny; }
 .pt-tiny { padding-top: $space-tiny; }
-.px-tiny { padding-left: $space-tiny; padding-right: $space-tiny; }
 .py-tiny { padding-bottom: $space-tiny; padding-top: $space-tiny; }
 
-.mb-12p { margin-bottom: 12px; }
-.mt-12p { margin-top: 12px; }
 .px-12p { padding-left: 12px; padding-right: 12px; }
 .py-12p { padding-bottom: 12px; padding-top: 12px; }
 
 .pl-24p { padding-left: 24px; }
 
-.mb-40p { margin-bottom: 40px; }
-
-.mtn1 { margin-top: -$space-1; }
-.mtn2 { margin-top: -$space-2; }
-.mtn3 { margin-top: -$space-3; }
-
 @media #{$breakpoint-sm} {
   .sm-mr-20p { margin-right: 20px; }
   .sm-ml-28p { margin-left: 28px; }
-  .sm-mtn2 { margin-top: -$space-2; }
-  .sm-mtn3 { margin-top: -$space-3; }
-}
-
-.margin-top-neg-4 {
-  margin-top: units(-4);
-}
-
-@include at-media('tablet') {
-  .tablet\:margin-x-neg-6 {
-    margin-left: units(-6);
-    margin-right: units(-6);
-  }
-
-  .tablet\:margin-top-neg-4 {
-    margin-top: units(-4);
-  }
 }

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -7,12 +7,6 @@ body { -webkit-font-smoothing: antialiased; }
 
 .text-decoration-none { text-decoration: none; }
 
-.lower { text-transform: lowercase; }
-
-.ls-0 { letter-spacing: 0; }
-.ls-05 { letter-spacing: .5px; }
-.ls-5 { letter-spacing: 5px; }
-
 .fs-12p { font-size: 12px; }
 .fs-13p { font-size: 13px; }
 .fs-20p { font-size: 20px; }
@@ -23,11 +17,7 @@ body { -webkit-font-smoothing: antialiased; }
 }
 
 .line-height-1 { line-height: $line-height-1; }
-.line-height-2 { line-height: $line-height-2; }
-.line-height-3 { line-height: $line-height-3; }
 .line-height-4 { line-height: $line-height-4; }
-
-.underline { text-decoration: underline; }
 
 // given how similar & coupled these are, single line preferred
 // scss-lint:disable SingleLinePerSelector, SpaceBeforeBrace

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -1,9 +1,5 @@
 // supplemental utility classes
 
-.w-60p { width: 60px; }
-
-.no-hover-decoration:hover { text-decoration: none; }
-
 .hidden { display: none; }
 
 .truncate-inline {
@@ -40,22 +36,8 @@ html.js .no-js {
 }
 
 @media #{$breakpoint-sm} {
-  // scss-lint:disable ImportantRule
-  .sm-display-inline-block { display: inline-block !important; }
-  // scss-lint:enable ImportantRule
-
-  .sm-maxw-190p { max-width: 190px; }
-  .sm-maxw-250p { max-width: 250px; }
-
   .sm-left-align { text-align: left; }
   .sm-right-align { text-align: right; }
-}
-
-.recommended {
-  color: $olive-dark;
-  float: right;
-  font-weight: bold;
-  text-align: right;
 }
 
 .half-center {

--- a/app/assets/stylesheets/utilities/all.scss
+++ b/app/assets/stylesheets/utilities/all.scss
@@ -1,8 +1,6 @@
 @import 'background';
 @import 'border';
-@import 'color';
 @import 'position';
-@import 'space-addon';
 @import 'space-misc';
 @import 'typography';
 @import 'util';

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -18,8 +18,6 @@ $caps-letter-spacing: 1px !default;
 
 $line-height-0: .75 !default; // For when a tighter-than-normal leading is desired.
 $line-height-1: 1 !default;
-$line-height-2: 1.3 !default;
-$line-height-3: 1.75 !default;
 $line-height-4: 2 !default;
 
 $h1: 1.3125rem !default;

--- a/app/assets/stylesheets/variables/_colors.scss
+++ b/app/assets/stylesheets/variables/_colors.scss
@@ -1,14 +1,12 @@
 $aqua: #7fdbff !default;
 $blue: #0071bb !default;
 $blue-light: #ebf3fa !default;
-$blue-lighter: #ecfcff !default;
 $blue-lightest: #f2f9ff !default;
 $blue-mid: #1c5899;
 $navy: #112e51 !default;
 $teal: #00bfe7 !default;
 $green: #68e380 !default;
 $olive: #3d9970 !default;
-$olive-dark: #2d8960 !default;
 $lime: #01ff70 !default;
 $yellow: #e1ce28 !default;
 $orange: #ff851b !default;

--- a/vendor/assets/stylesheets/basscss/_typography.scss
+++ b/vendor/assets/stylesheets/basscss/_typography.scss
@@ -2,8 +2,6 @@
 // Converted Variables
 
 $line-height-1: 1 !default;
-$line-height-2: 1.125 !default;
-$line-height-3: 1.25 !default;
 $line-height-4: 1.5 !default;
 $letter-spacing: 1 !default;
 $caps-letter-spacing: .2em !default;
@@ -41,10 +39,6 @@ $bold-font-weight: bold !default;
 .break-word { word-wrap: break-word }
 
 .line-height-1 { line-height: $line-height-1 }
-
-.line-height-2 { line-height: $line-height-2 }
-
-.line-height-3 { line-height: $line-height-3 }
 
 .line-height-4 { line-height: $line-height-4 }
 


### PR DESCRIPTION
**Why**:

- Moves us toward design system utilities, removing temptation of use for developers and facilitating future substitution work.
- Reduces size of stylesheets, producing smaller bundle sizes for users (faster page loads) and lower mental overhead for developers.