### PR TITLE
Fix wrong argument for bucket name in DailyAuthsReport

### DIFF
--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -26,7 +26,7 @@ module Reports
           path: path,
           body: report_body.to_json,
           content_type: 'application/json',
-          bucket_name: bucket_name,
+          bucket: bucket_name,
         )
       end
     end

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Reports::DailyAuthsReport do
     Aws.config[:s3] = {
       stub_responses: {
         put_object: {},
-      }
+      },
     }
   end
 

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Reports::DailyAuthsReport do
       and_return(s3_report_bucket_prefix)
     allow(IdentityConfig.store).to receive(:s3_report_public_bucket_prefix).
       and_return(s3_report_public_bucket_prefix)
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        put_object: {},
+      }
+    }
   end
 
   describe '#perform' do
@@ -27,8 +33,8 @@ RSpec.describe Reports::DailyAuthsReport do
           path: 'int/daily-auths-report/2021/2021-03-01.daily-auths-report.json',
           body: kind_of(String),
           content_type: 'application/json',
-          bucket_name: bucket,
-        ).exactly(1).time
+          bucket: bucket,
+        ).exactly(1).time.and_call_original
       end
 
       report.perform(report_date)
@@ -41,9 +47,9 @@ RSpec.describe Reports::DailyAuthsReport do
         expect(report).to receive(:upload_file_to_s3_bucket).with(
           hash_including(
             path: 'int/daily-auths-report/2021/2021-03-01.daily-auths-report.json',
-            bucket_name: 'reports-bucket.1234-us-west-1',
+            bucket: 'reports-bucket.1234-us-west-1',
           ),
-        ).exactly(1).time
+        ).exactly(1).time.and_call_original
 
         report.perform(report_date)
       end
@@ -69,7 +75,7 @@ RSpec.describe Reports::DailyAuthsReport do
 
       it 'aggregates by issuer' do
         expect(report).to receive(:upload_file_to_s3_bucket).
-          exactly(2).times do |path:, body:, content_type:, bucket_name:|
+          exactly(2).times do |path:, body:, content_type:, bucket:|
             parsed = JSON.parse(body, symbolize_names: true)
 
             expect(parsed[:start]).to eq(report_date.beginning_of_day.as_json)


### PR DESCRIPTION
Big whoops, discovered in dev ([newrelic link](https://one.newrelic.com/launcher/nr1-core.explorer/?platform[accountId]=1376370&platform[filters]=Iihkb21haW4gPSAnQVBNJyBBTkQgdHlwZSA9ICdBUFBMSUNBVElPTicpIg==&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true&pane=eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThNVEEwTkRBNE1qVTQifQ==&cards[0]=eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkuZXJyb3ItdHJhY2VzIiwiZmlsdGVyU2V0TnJxbCI6IihgZXJyb3IuY2xhc3NgID0gJ0FyZ3VtZW50RXJyb3InIEFORCB0cmFuc2FjdGlvblVpTmFtZSA9ICdSZXBvcnRzOjpEYWlseUF1dGhzUmVwb3J0L2V4ZWN1dGUnKSIsInRpbWVab25lIjoiQW1lcmljYS9Mb3NfQW5nZWxlcyIsImVudGl0eUd1aWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1UQTBOREE0TWpVNCIsInRyYWNlSWQiOiI2ZmQ4YjNhNC0xNTc3LTExZWMtOWI1ZC0wMjQyYWMxMTAwMDhfNzEzMV8xODkxNiJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9LCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThNVEEwTkRBNE1qVTQifQ==&state=9c9c2b67-d0b9-3a48-d33d-8d4c0fe39db7))
