### PR TITLE
Update HeartbeatJob to log queue metrics

### DIFF
--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -2,6 +2,17 @@ class HeartbeatJob < ApplicationJob
   queue_as :default
 
   def perform
+    Rails.logger.info(
+      {
+        name: 'queue_metric.good_job',
+        # borrowed from: https://github.com/bensheldon/good_job/blob/main/engine/app/controllers/good_job/dashboards_controller.rb#L35
+        num_finished: GoodJob::Job.finished.count,
+        num_unfinished: GoodJob::Job.unfinished.count,
+        num_running: GoodJob::Job.running.count,
+        num_errors: GoodJob::Job.where.not(error: nil).count,
+      }.to_json,
+    )
+
     true
   end
 end

--- a/spec/jobs/heartbeat_job_spec.rb
+++ b/spec/jobs/heartbeat_job_spec.rb
@@ -7,5 +7,20 @@ RSpec.describe HeartbeatJob, type: :job do
 
       expect(result).to eq true
     end
+
+    it 'logs goodjob queue metrics' do
+      expect(Rails.logger).to receive(:info) do |str|
+        msg = JSON.parse(str, symbolize_names: true)
+        expect(msg).to eq(
+          name: 'queue_metric.good_job',
+          num_finished: 0,
+          num_unfinished: 0,
+          num_running: 0,
+          num_errors: 0,
+        )
+      end
+
+      HeartbeatJob.new.perform
+    end
   end
 end


### PR DESCRIPTION
This is just an idea, very open to better places to put this

We don't have any examples I've seen of submitting Cloudwatch metrics directly, so I opted to go with a Rails.logger like we do for the Faraday metrics

We also don't have a consistent place to submit these (inside each job might be a little much) but a ~5 minute check on these seems not too bad?

The queries come from the GoodJob dashboard so I hope they are not too taxing on the DB