### PR TITLE
LG-3880: Remove BassCSS "colors" module

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -47,6 +47,7 @@ linters:
     enabled: true
     rule_set:
       - deprecated:
+          - (black|gray|silver|white|aqua|blue|navy|teal|green|olive|lime|yellow|orange|red|fuchsia|purple|maroon|color-inherit|muted)
           - 'align-(top|middle|bottom|baseline)'
           - '(left)-align'
           - 'justify'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -47,7 +47,7 @@ linters:
     enabled: true
     rule_set:
       - deprecated:
-          - (black|gray|silver|white|aqua|blue|navy|teal|green|olive|lime|yellow|orange|red|fuchsia|purple|maroon|color-inherit|muted)
+          - (black|silver|white|aqua|blue|navy|teal|green|olive|lime|yellow|orange|red|fuchsia|purple|maroon|color-inherit|muted)
           - 'align-(top|middle|bottom|baseline)'
           - '(left)-align'
           - 'justify'

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -13,7 +13,6 @@
 @import 'basscss-sass/positions';
 @import 'basscss-sass/grid';
 @import 'basscss-sass/flex-object';
-@import 'basscss-sass/colors';
 @import 'basscss-sass/background-colors';
 @import 'basscss-sass/background-images';
 @import 'basscss-sass/border-colors';

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -9,7 +9,7 @@
 
   <ul class='list-reset'>
     <li class='padding-top-2 padding-bottom-1'>
-      <div class='inline-block margin-right-2 text-top circle-number bg-blue white'>
+      <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
         <%= step += 1 %>
       </div>
       <div class='margin-right-1 inline-block'>
@@ -24,7 +24,7 @@
     </li>
     <% if liveness_checking_enabled? %>
       <li class='padding-top-2 padding-bottom-1'>
-        <div class='inline-block margin-right-2 text-top circle-number bg-blue white'>
+        <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
           <%= step += 1 %>
         </div>
         <div class='margin-right-1 inline-block'>
@@ -40,7 +40,7 @@
     <% end %>
     <li class='padding-top-2 padding-bottom-1'>
       <div class="grid-row">
-        <div class='inline-block margin-right-2 text-top circle-number bg-blue white'>
+        <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
           <%= step += 1 %>
         </div>
         <div class='grid-col-10'>
@@ -56,7 +56,7 @@
     </li>
     <li class='padding-top-2 padding-bottom-1'>
       <div class="grid-row">
-        <div class='grid-col-2 margin-right-2 text-top circle-number bg-blue white'>
+        <div class='grid-col-2 margin-right-2 text-top circle-number bg-blue text-white'>
           <%= step += 1 %>
         </div>
         <div class='grid-col-10'>

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -28,7 +28,7 @@
       <div class="radio">
         <%= radio_button_tag 'otp_delivery_preference', :sms, false, class: :otp_delivery_preference_sms %>
         <span class="indicator mt-tiny"></span>
-        <span class="blue bold fs-20p">
+        <span class="text-primary bold fs-20p">
           <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
         </span>
         <div class="regular gray-dark fs-10p mb-tiny">
@@ -40,7 +40,7 @@
       <div class="radio">
         <%= radio_button_tag 'otp_delivery_preference', :voice, false, class: :otp_delivery_preference_voice %>
         <span class="indicator mt-tiny"></span>
-        <span class="blue bold fs-20p">
+        <span class="text-primary bold fs-20p">
           <%= t('two_factor_authentication.otp_delivery_preference.voice') %>
         </span>
         <div class="regular gray-dark fs-10p mb-tiny">

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -4,7 +4,7 @@
   </h2>
   <div class="margin-top-6 margin-bottom-6 padding-x-0 tablet:padding-x-1 padding-y-2 center bg-white border-width-2px separator-text bg-pk-box">
     <%- code.split('-').each do |word|
-      -%><div class="inline fs-20p bold navy"
+      -%><div class="inline fs-20p bold text-primary-darker"
         ><code class="monospace" data-personal-key="word"
           ><%= word
         %></code

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -8,7 +8,7 @@
     <div class='tablet:display-none border-bottom border-primary-light'>
       <div class='container cntnr-wide padding-y-1 padding-x-2 desktop:padding-x-0 h5'>
         <div class='i18n-mobile-toggle flex flex-align-center flex-justify-center'>
-            <button class='block text-decoration-none blue fs-13p language-mobile-button' aria-expanded='false'>
+            <button class='block text-decoration-none text-primary fs-13p language-mobile-button' aria-expanded='false'>
               <%= image_tag asset_url('globe-blue.svg'), width: 12,
               class: 'margin-right-1', alt: '', 'aria-hidden': 'true' %><%= t('i18n.language') %><span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
             </button>
@@ -16,10 +16,10 @@
       </div>
     </div>
     <div class='i18n-mobile-dropdown tablet:display-none display-none'>
-      <ul class='list-reset margin-bottom-0 white center'>
+      <ul class='list-reset margin-bottom-0 text-white center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none blue fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>
@@ -29,7 +29,7 @@
     <div class='flex flex-align-center flex-justify-center'>
       <div class='flex flex-auto flex-first'>
         <div class="tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none white h6 margin-right-1 tablet:display-none',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 tablet:display-none',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
               width: 20, alt: '' %>
@@ -37,7 +37,7 @@
         </div>
 
         <div class="display-none tablet:display-block">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none white h6 margin-right-1 usa-link--alt',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 usa-link--alt',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
               width: 20, class: 'margin-right-1', alt: '' %>
@@ -51,17 +51,17 @@
         <% if show_language_dropdown %>
           <ul class='list-reset display-none tablet:display-block margin-bottom-0'>
             <li class="i18n-desktop-toggle flex margin-y-1 margin-x-2 relative">
-              <button class='white text-decoration-none border border-blue radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
+              <button class='text-white text-decoration-none border border-blue radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
                 <%= image_tag asset_url('globe-white.svg'), width: 12,
                 class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
                 <span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
               </button>
-              <ul class="i18n-desktop-dropdown list-reset margin-bottom-0 white display-none">
+              <ul class="i18n-desktop-dropdown list-reset margin-bottom-0 text-white display-none">
                 <% I18n.available_locales.each do |locale| %>
                   <li class='border-bottom border-navy'>
                     <%= link_to t("i18n.locale.#{locale}"),
                       sanitized_requested_url.merge(locale: locale),
-                      class: 'block pl-24p padding-y-2 text-decoration-none white',
+                      class: 'block pl-24p padding-y-2 text-decoration-none text-white',
                       lang: locale == I18n.locale ? nil : locale %>
                   </li>
                 <% end %>
@@ -72,20 +72,20 @@
 
         <div class="display-flex tablet:display-none">
           <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
-                                class: 'caps h6 blue text-decoration-none margin-right-2') %>
+                                class: 'caps h6 text-primary text-decoration-none margin-right-2') %>
           <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
-                                class: 'caps h6 blue text-decoration-none margin-right-2') %>
+                                class: 'caps h6 text-primary text-decoration-none margin-right-2') %>
           <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                                class: 'caps h6 blue text-decoration-none margin-right-2') %>
+                                class: 'caps h6 text-primary text-decoration-none margin-right-2') %>
         </div>
 
         <div class="display-none tablet:display-flex">
           <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
-                                class: 'caps h6 white text-decoration-none margin-right-2 usa-link--alt') %>
+                                class: 'caps h6 text-white text-decoration-none margin-right-2 usa-link--alt') %>
           <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
-                                class: 'caps h6 white text-decoration-none margin-right-2 usa-link--alt') %>
+                                class: 'caps h6 text-white text-decoration-none margin-right-2 usa-link--alt') %>
           <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                                class: 'caps h6 white text-decoration-none margin-right-2 usa-link--alt') %>
+                                class: 'caps h6 text-white text-decoration-none margin-right-2 usa-link--alt') %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_no_pii_banner.html.erb
+++ b/app/views/shared/_no_pii_banner.html.erb
@@ -1,3 +1,3 @@
-<div class='padding-y-1 bg-maroon white fs-12p line-height-1 center'>
+<div class='padding-y-1 bg-maroon text-white fs-12p line-height-1 center'>
   <%= t('idv.messages.sessions.no_pii') %>
 </div>

--- a/app/views/sign_up/registrations/_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_registration_heading.html.erb
@@ -1,3 +1,3 @@
-<h1 class='margin-bottom-4 blue regular'>
+<h1 class='margin-bottom-4 text-primary regular'>
   <%= t('headings.create_account_without_sp') %>
 </h1>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,4 +1,4 @@
-<h1 class='margin-bottom-4 blue regular'>
+<h1 class='margin-bottom-4 text-primary regular'>
   <strong>
     <%= decorated_session.sp_name %>
   </strong>

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -26,7 +26,7 @@
                     index.zero?,
                     class: option.html_class.to_s) %>
               <span class="indicator mt-tiny"></span>
-              <span class="blue bold fs-20p">
+              <span class="text-primary bold fs-20p">
                 <%= option.label %>
               </span>
               <div class="regular gray-dark fs-10p mb-tiny">

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -47,7 +47,7 @@
                         class: 'margin-y-2 margin-left-2 margin-right-1 margin-left-0' %>
       <%= label_tag 'remember_device',
                     t('forms.messages.remember_device'),
-                    class: 'blue margin-bottom-0' %>
+                    class: 'text-primary margin-bottom-0' %>
     </span>
   </div>
 <% end %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -26,7 +26,7 @@
                       class: 'margin-right-1 margin-left-2' %>
     <%= label_tag 'remember_device',
                   t('forms.messages.remember_device'),
-                  class: 'blue margin-right-2' %>
+                  class: 'text-primary margin-right-2' %>
   </div>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
 <% end %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -52,7 +52,7 @@
       <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'margin-y-2 margin-left-2 margin-right-1' %>
       <%= label_tag 'remember_device',
         t('forms.messages.remember_device'),
-        class: 'blue mt-1p' %>
+        class: 'text-primary mt-1p' %>
     </div>
     <%= submit_tag t('forms.buttons.continue'),
         class: 'usa-button usa-button--big usa-button--wide margin-y-4' %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -6,7 +6,7 @@
 <%= form_tag(submit_new_piv_cac_url) do %>
 <ul class='list-reset'>
   <li class='padding-top-0 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
       1
     </div>
     <label class="h1 margin-right-1 inline-block margin-bottom-1 bold" for="nickname">
@@ -21,7 +21,7 @@
     <hr>
   </li>
   <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
       2
     </div>
     <div class='margin-right-1 inline-block margin-bottom-2'>
@@ -32,7 +32,7 @@
     <hr>
   </li>
   <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
       3
     </div>
     <div class='margin-right-1 inline-block'>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -8,7 +8,7 @@
   <ul class="list-reset">
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue white">1</div>
+        <div class="margin-right-1 inline-block circle-number bg-blue text-white">1</div>
         <div class="inline-block bold" id="totp-nickname"><%= t('forms.totp_setup.totp_step_1') %></div>
         <div class="inline-block margin-left-4"><%= t('forms.totp_setup.totp_step_1a') %></div>
       </div>
@@ -22,12 +22,12 @@
       </div>
     </li>
     <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-right-1 inline-block circle-number bg-blue white">2</div>
+      <div class="margin-right-1 inline-block circle-number bg-blue text-white">2</div>
       <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_2') %></div>
     </li>
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue white">3</div>
+        <div class="margin-right-1 inline-block circle-number bg-blue text-white">3</div>
         <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_3') %></div>
       </div>
       <div class="sm-col-9 sm-ml-28p">
@@ -49,7 +49,7 @@
     </li>
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue white">4</div>
+        <div class="margin-right-1 inline-block circle-number bg-blue text-white">4</div>
         <div class="inline-block bold" id="totp-label"><%= t('forms.totp_setup.totp_step_4') %></div>
       </div>
       <div class="sm-col-9 sm-ml-28p">

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -26,7 +26,7 @@
           <div class="radio">
             <%= radio_button_tag('two_factor_options_form[selection]', option.type) %>
             <span class="indicator mt-tiny"></span>
-            <span class="blue bold fs-20p"><%= option.label %></span>
+            <span class="text-primary bold fs-20p"><%= option.label %></span>
             <div class="regular gray-dark fs-10p margin-top-0 mb-tiny"><%= option.info %></div>
           </div>
           <% if option.security_level && @presenter.show_security_level? %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -29,7 +29,7 @@
        <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'margin-y-2 margin-left-2 margin-right-1' %>
        <%= label_tag 'remember_device',
          t('forms.messages.remember_device'),
-         class: 'blue mt-1p' %>
+         class: 'text-primary mt-1p' %>
      </div>
      <%= submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'hidden' %>
    <% end %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -25,7 +25,7 @@ SimpleForm.setup do |config|
     b.use :label, class: 'bold'
     b.use :hint,  wrap_with: { tag: 'div', class: 'italic' }
     b.use :input, class: 'block col-12 field'
-    b.use :error, wrap_with: { tag: 'div', class: 'mt-tiny h6 red error-message' }
+    b.use :error, wrap_with: { tag: 'div', class: 'mt-tiny h6 text-error error-message' }
   end
 
   config.default_wrapper = :vertical_form


### PR DESCRIPTION
**Why**: To improve page load speed by reducing CSS bundle size, to eliminate developer confusion by choice of styling, to improve developer experience by reducing SASS compilation times, to standardize on design system styles, and to attach semantics to brand "primary" color as possibly changing over time and not fixed to specific colors.

Reference for removal: https://github.com/basscss/basscss-sass/blob/v3.0.0/_colors.scss