### PR TITLE
Backout reuse doc auth sessions

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -186,9 +186,8 @@ module Idv
       return if idv_session.idv_gpo_document_capture_session_uuid
       idv_session.previous_gpo_step_params = profile_params.to_h
 
-      document_capture_session = DocumentCaptureSession.create_by_user_id(
-        current_user.id,
-        analytics,
+      document_capture_session = DocumentCaptureSession.create(
+        user_id: current_user.id,
         issuer: sp_session[:issuer],
         ial2_strict: sp_session[:ial2_strict],
         requested_at: Time.zone.now,

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -69,11 +69,7 @@ module Idv
     end
 
     def step
-      @_step ||= Idv::PhoneStep.new(
-        idv_session: idv_session,
-        trace_id: amzn_trace_id,
-        analytics: analytics,
-      )
+      @_step ||= Idv::PhoneStep.new(idv_session: idv_session, trace_id: amzn_trace_id)
     end
 
     def step_params

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -3,18 +3,6 @@ class DocumentCaptureSession < ApplicationRecord
 
   belongs_to :user
 
-  def self.create_by_user_id(user_id, analytics, hash = {})
-    reuse_session = DocumentCaptureSession.find_by(user_id: user_id)
-    if reuse_session
-      reuse_session.reset(analytics)
-    else
-      reuse_session = DocumentCaptureSession.create(user_id: user_id)
-    end
-    reuse_session.assign_attributes(hash)
-    reuse_session.save!
-    reuse_session
-  end
-
   def load_result
     EncryptedRedisStructStorage.load(result_id, type: DocumentCaptureSessionResult)
   end
@@ -90,26 +78,6 @@ class DocumentCaptureSession < ApplicationRecord
     return true unless requested_at
     (requested_at + IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes) <
       Time.zone.now
-  end
-
-  def reset(analytics)
-    alert_if_session_in_use(analytics)
-
-    self.result_id = nil
-    self.requested_at = nil
-    self.ial2_strict = nil
-    self.issuer = nil
-    self.cancelled_at = nil
-  end
-
-  def alert_if_session_in_use(analytics)
-    return unless session_in_use?
-
-    analytics.track_event(Analytics::DOCUMENT_CAPTURE_SESSION_OVERWRITTEN)
-  end
-
-  def session_in_use?
-    self.created_at && !self.result_id && !self.cancelled_at
   end
 
   private

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -119,7 +119,6 @@ class Analytics
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended
   DOC_AUTH_ASYNC = 'Doc Auth Async'.freeze
   DOC_AUTH_WARNING = 'Doc Auth Warning'.freeze
-  DOCUMENT_CAPTURE_SESSION_OVERWRITTEN = 'Document Capture Session Overwritten'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_DELETION_REQUEST = 'Email Deletion Requested'.freeze
   EMAIL_LANGUAGE_VISITED = 'Email Language: Visited'.freeze

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -1,7 +1,6 @@
 module Idv
   class PhoneStep
-    def initialize(idv_session:, trace_id:, analytics:)
-      @analytics = analytics
+    def initialize(idv_session:, trace_id:)
       self.idv_session = idv_session
       @trace_id = trace_id
     end
@@ -52,9 +51,8 @@ module Idv
 
     def proof_address
       return if idv_session.idv_phone_step_document_capture_session_uuid
-      document_capture_session = DocumentCaptureSession.create_by_user_id(
-        idv_session.current_user.id,
-        @analytics,
+      document_capture_session = DocumentCaptureSession.create(
+        user_id: idv_session.current_user.id,
         requested_at: Time.zone.now,
       )
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -134,9 +134,8 @@ module Idv
       end
 
       def create_document_capture_session(key)
-        document_capture_session = DocumentCaptureSession.create_by_user_id(
-          user_id,
-          @flow.analytics,
+        document_capture_session = DocumentCaptureSession.create(
+          user_id: user_id,
           issuer: sp_session[:issuer],
           ial2_strict: sp_session[:ial2_strict],
         )

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -26,11 +26,7 @@ describe Idv::CaptureDocController do
 
   describe '#index' do
     let!(:session_uuid) do
-      DocumentCaptureSession.create_by_user_id(
-        user.id,
-        @analytics,
-        requested_at: Time.zone.now,
-      ).uuid
+      DocumentCaptureSession.create!(requested_at: Time.zone.now).uuid
     end
 
     context 'with no session' do

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -416,7 +416,7 @@ describe Idv::DocAuthController do
 
   def mock_document_capture_step
     stub_sign_in(user)
-    DocumentCaptureSession.create_by_user_id(user.id, @analytics, result_id: 1, uuid: 'foo')
+    DocumentCaptureSession.create(user_id: user.id, result_id: 1, uuid: 'foo')
     allow_any_instance_of(Flow::BaseFlow).to \
       receive(:flow_session).and_return(
         'document_capture_session_uuid' => 'foo',

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -97,9 +97,8 @@ describe Idv::PhoneController do
     it 'shows waiting interstitial if async process is in progress' do
       # having a document capture session with PII but without results will trigger
       # in progress behavior
-      document_capture_session = DocumentCaptureSession.create_by_user_id(
-        user.id,
-        @analytics,
+      document_capture_session = DocumentCaptureSession.create(
+        user_id: user.id,
         requested_at: Time.zone.now,
       )
       document_capture_session.create_proofing_session

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DocumentProofingJob, type: :job do
   let(:user) { create(:user) }
   let(:analytics) { FakeAnalytics.new }
   let(:document_capture_session) do
-    DocumentCaptureSession.create_by_user_id(user.id, analytics, result_id: SecureRandom.hex)
+    DocumentCaptureSession.create(user_id: user.id, result_id: SecureRandom.hex)
   end
 
   describe '.perform_later' do

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe DocumentCaptureSession do
-  let(:fake_analytics) { FakeAnalytics.new }
-  let(:user) { create(:user, :signed_up) }
   let(:doc_auth_response) do
     DocAuth::Response.new(
       success: true,
@@ -71,30 +69,6 @@ describe DocumentCaptureSession do
 
         expect(record.expired?).to eq(false)
       end
-    end
-  end
-
-  describe '.create_by_user_id' do
-    it 'triggers an analytics event if an attempt is made to try to overwrite a session in use' do
-      DocumentCaptureSession.create_by_user_id(user.id, fake_analytics)
-      DocumentCaptureSession.create_by_user_id(user.id, fake_analytics)
-      expect(fake_analytics).
-        to have_logged_event(Analytics::DOCUMENT_CAPTURE_SESSION_OVERWRITTEN, {})
-    end
-
-    it 'does not trigger an analytics event upon first use' do
-      DocumentCaptureSession.create_by_user_id(user.id, fake_analytics)
-      expect(fake_analytics).
-        to_not have_logged_event(Analytics::DOCUMENT_CAPTURE_SESSION_OVERWRITTEN, {})
-    end
-
-    it 'does not trigger an analytics event upon reuse' do
-      session = DocumentCaptureSession.create_by_user_id(user.id, fake_analytics)
-      session.result_id = 'foo'
-      session.save!
-      DocumentCaptureSession.create_by_user_id(user.id, fake_analytics)
-      expect(fake_analytics).
-        to_not have_logged_event(Analytics::DOCUMENT_CAPTURE_SESSION_OVERWRITTEN, {})
     end
   end
 end

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -31,13 +31,11 @@ describe Idv::PhoneStep do
     Proofing::Mock::AddressMockClient::PROOFER_TIMEOUT_PHONE_NUMBER
   end
   let(:trace_id) { SecureRandom.uuid }
-  let(:analytics) { FakeAnalytics.new }
 
   subject {
     described_class.new(
       idv_session: idv_session,
       trace_id: trace_id,
-      analytics: analytics,
     )
   }
 

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -16,6 +16,7 @@ describe Idv::Steps::VerifyStep do
       'controller',
       session: { sp: { issuer: service_provider.issuer } },
       current_user: user,
+      analytics: FakeAnalytics.new,
       url_options: {},
       request: double(
         'request',

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -16,7 +16,6 @@ describe Idv::Steps::VerifyStep do
       'controller',
       session: { sp: { issuer: service_provider.issuer } },
       current_user: user,
-      analytics: FakeAnalytics.new,
       url_options: {},
       request: double(
         'request',


### PR DESCRIPTION
**Why**: We are seeing a lot of reuse session events probably due to jobs not finishing and retries. Need to prevent a job from starting before one finishes or allow the latest to rewrite a previous one.  Reverts this https://github.com/18F/identity-idp/pull/5113