### PR TITLE
fix which error is shown for VOIP phones

### DIFF
--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -79,9 +79,9 @@ class NewPhoneForm
 
     if @phone_info.type == :voip &&
        !FeatureManagement.voip_allowed_phones.include?(parsed_phone.e164)
-      errors.add(:phone, I18n.t('errors.messages.voip_check_error'))
-    elsif @phone_info.error
       errors.add(:phone, I18n.t('errors.messages.voip_phone'))
+    elsif @phone_info.error
+      errors.add(:phone, I18n.t('errors.messages.voip_check_error'))
     end
   rescue Aws::Pinpoint::Errors::BadRequestException
     errors.add(:phone, :improbable_phone)

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -83,7 +83,7 @@ describe 'Add a new phone number' do
     click_on "+ #{t('account.index.phone_add')}"
     fill_in :new_phone_form_phone, with: telephony_gem_voip_number
     click_continue
-    expect(page).to have_content(t('errors.messages.voip_phone'))
+    expect(page).to have_content(t('errors.messages.voip_check_error'))
   end
 
   scenario 'adding a phone in a different country', js: true do

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -225,7 +225,7 @@ describe NewPhoneForm do
 
         it 'is invalid' do
           expect(result.success?).to eq(false)
-          expect(result.errors[:phone]).to eq([I18n.t('errors.messages.voip_check_error')])
+          expect(result.errors[:phone]).to eq([I18n.t('errors.messages.voip_phone')])
         end
 
         it 'logs the type and carrier' do


### PR DESCRIPTION
Looks like we switched which error is shown for VOIP phones. We wanted to show the first when there's an error checking if it's VOIP phone, and the second when it's a VOIP phone:

```
      voip_check_error: There was an error checking your phone, please try again
      voip_phone: This number is a web-based (VOIP) phone service. Please select a
        different number and try again
```
https://github.com/18F/identity-idp/blob/main/config/locales/errors/en.yml#L104-L106

This patch switches it so we show the right error.