### PR TITLE
LG-5073: add location to "Get Help at SP" link on welcome page

### DIFF
--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -88,7 +88,7 @@
             new_tab: true,
           },
           decorated_session.sp_name && {
-            url: idv_doc_auth_return_to_sp_path,
+            url: idv_doc_auth_return_to_sp_path(location: 'welcome'),
             text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
             new_tab: true,
           },

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -88,7 +88,7 @@
             new_tab: true,
           },
           decorated_session.sp_name && {
-            url: idv_doc_auth_return_to_sp_path(location: 'welcome'),
+            url: idv_doc_auth_return_to_sp_path(location: 'missing_items'),
             text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
             new_tab: true,
           },

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -30,7 +30,7 @@ feature 'doc auth welcome step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::RETURN_TO_SP_FAILURE_TO_PROOF,
       step: 'welcome',
-      location: 'welcome',
+      location: 'missing_items',
     )
   end
 

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -30,6 +30,7 @@ feature 'doc auth welcome step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::RETURN_TO_SP_FAILURE_TO_PROOF,
       step: 'welcome',
+      location: 'welcome',
     )
   end
 


### PR DESCRIPTION
Adds a location parameter for the "Get help at..." link on the IAL2 welcome page to ensure we have an accurate number for Cancel