### PR TITLE
Daily Auths Report: only one query once per destination

### DIFF
--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -16,6 +16,7 @@ module Reports
       @report_date = report_date
 
       _latest, path = generate_s3_paths(REPORT_NAME, 'json', now: report_date)
+      body = report_body.to_json
 
       [
         bucket_name, # default reporting bucket
@@ -24,7 +25,7 @@ module Reports
         each do |bucket_name|
         upload_file_to_s3_bucket(
           path: path,
-          body: report_body.to_json,
+          body: body,
           content_type: 'application/json',
           bucket: bucket_name,
         )

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Reports::DailyAuthsReport do
         ).exactly(1).time.and_call_original
       end
 
+      expect(report).to receive(:report_body).and_call_original.once
+
       report.perform(report_date)
     end
 


### PR DESCRIPTION
the `report_body` is not memoized, so it would issue the query twice :yikes: