### PR TITLE
LG-5115:Refactor the check/select box behavior across the IAL2 flow

### DIFF
--- a/app/javascript/packs/ial2-consent-button.js
+++ b/app/javascript/packs/ial2-consent-button.js
@@ -1,13 +1,16 @@
 function toggleButton() {
   const continueButton = document.querySelector('button[type="submit"]');
   const checkbox = document.querySelector('input[name="ial2_consent_given"]');
+  const errorMessage = document.querySelector('.js-consent-form-alert');
 
   function sync() {
     continueButton.classList.toggle('usa-button--disabled', !checkbox.checked);
+    errorMessage.classList.toggle('display-none', checkbox.getAttribute('aria-invalid') !== 'true');
   }
 
   sync();
   checkbox.addEventListener('change', sync);
+  checkbox.addEventListener('invalid', sync);
 }
 
 document.addEventListener('DOMContentLoaded', toggleButton);

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -35,7 +35,7 @@
       <%= new_window_link_to t('doc_auth.instructions.learn_more'), MarketingSite.security_and_privacy_practices_url %>
     </label>
     <div class="usa-error-message usa-error-message--with-icon display-if-invalid" role="alert">
-      <%= t('sign_up.agree_to_rules_of_use_and_continue') %>
+      <%= t('forms.validation.required_checkbox') %>
     </div>
   </div>
   <%= f.button :button, t('doc_auth.buttons.continue'), type: :submit,

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -1,12 +1,14 @@
 <% title t('titles.doc_auth.verify') %>
 
-<% if flow_session[:error_message] %>
-  <%= render 'shared/alert', {
-    type: 'error',
-    class: 'margin-bottom-4',
-    message: flow_session[:error_message],
-  } %>
-<% end %>
+<%= render 'shared/alert', {
+  type: 'error',
+  class: [
+    'js-consent-form-alert',
+    'margin-bottom-4',
+    flow_session[:error_message].blank? && 'display-none',
+  ].select(&:present?),
+  message: flow_session[:error_message].presence || t('errors.doc_auth.consent_form'),
+} %>
 
 <h1><%= t('doc_auth.headings.lets_go') %></h1>
 <p><%= t('doc_auth.info.lets_go') %></p>
@@ -19,16 +21,23 @@
                        url: url_for,
                        method: 'put',
                        html: { autocomplete: 'off', class: 'margin-top-2 js-consent-continue-form' } do |f| %>
-  <%= check_box_tag(
-        :ial2_consent_given,
-        true,
-        false,
-        class: 'usa-checkbox__input',
-      ) %>
-  <label class="usa-checkbox__label margin-bottom-4" for="ial2_consent_given">
-    <%= t('doc_auth.instructions.consent') %>
-    <%= new_window_link_to t('doc_auth.instructions.learn_more'), MarketingSite.security_and_privacy_practices_url %>
-  </label>
+  <div class="margin-bottom-4">
+    <%= check_box_tag(
+          :ial2_consent_given,
+          true,
+          false,
+          class: 'usa-checkbox__input',
+          required: true,
+          aria: {invalid: false}
+        ) %>
+    <label class="usa-checkbox__label" for="ial2_consent_given">
+      <%= t('doc_auth.instructions.consent') %>
+      <%= new_window_link_to t('doc_auth.instructions.learn_more'), MarketingSite.security_and_privacy_practices_url %>
+    </label>
+    <div class="usa-error-message usa-error-message--with-icon display-if-invalid" role="alert">
+      <%= t('sign_up.agree_to_rules_of_use_and_continue') %>
+    </div>
+  </div>
   <%= f.button :button, t('doc_auth.buttons.continue'), type: :submit,
                class: 'usa-button--big usa-button--wide' %>
 <% end %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -52,7 +52,7 @@
         <%= new_window_link_to(t('titles.rules_of_use'), MarketingSite.rules_of_use_url) %>
       </label>
       <div class="usa-error-message usa-error-message--with-icon display-if-invalid" role="alert">
-        <%= t('sign_up.agree_to_rules_of_use_and_continue') %>
+        <%= t('forms.validation.required_checkbox') %>
       </div>
     </div>
 

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -112,6 +112,8 @@ en:
       try_again: Use another phone number
     two_factor_choice:
       legend: Select an option to secure your account
+    validation:
+      required_checkbox: Please check this box to continue
     verify_profile:
       instructions: Enter the ten-character code in the letter we sent you.
       name: Confirmation code

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -119,6 +119,8 @@ es:
       try_again: Use otro número de teléfono.
     two_factor_choice:
       legend: Seleccione una opción para proteger su cuenta
+    validation:
+      required_checkbox: Marque esta casilla para continuar
     verify_profile:
       instructions: Ingrese el código de 10 caracteres que le enviamos en la carta.
       name: Código de confirmación

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -120,6 +120,8 @@ fr:
       try_again: Utilisez un autre numéro de téléphone
     two_factor_choice:
       legend: Sélectionnez une option pour sécuriser votre compte
+    validation:
+      required_checkbox: Veuillez cocher cette case pour continuer
     verify_profile:
       instructions: Entrez le code à dix caractères qui se trouve dans la lettre que
         nous vous avons envoyée.

--- a/config/locales/sign_up/en.yml
+++ b/config/locales/sign_up/en.yml
@@ -2,7 +2,6 @@
 en:
   sign_up:
     agree_and_continue: Agree and continue
-    agree_to_rules_of_use_and_continue: Please check this box to continue
     cancel:
       success: Your account has been deleted. We did not save your information.
       warning_header: 'If you cancel now:'

--- a/config/locales/sign_up/es.yml
+++ b/config/locales/sign_up/es.yml
@@ -2,7 +2,6 @@
 es:
   sign_up:
     agree_and_continue: Aceptar y continuar
-    agree_to_rules_of_use_and_continue: Marque esta casilla para continuar
     cancel:
       success: Su cuenta ha sido eliminada. No guardamos su información.
       warning_header: 'Si cancela ahora:'

--- a/config/locales/sign_up/fr.yml
+++ b/config/locales/sign_up/fr.yml
@@ -2,7 +2,6 @@
 fr:
   sign_up:
     agree_and_continue: Acceptez et continuez
-    agree_to_rules_of_use_and_continue: Veuillez cocher cette case pour continuer
     cancel:
       success: Le dossier contenant votre information a été effacé
       warning_header: 'Si vous annulez maintenant:'


### PR DESCRIPTION
This PR adds a "please check this box to continue" warning to the doc auth agreement page.

**Why**: So that users are error messages are more consistent and easily identifiable to the user.

Before | After 
--- | --- |
![image](https://user-images.githubusercontent.com/17969963/133844566-c9e3afbd-6881-40d8-82dd-792402456524.png) | ![image](https://user-images.githubusercontent.com/17969963/133844891-34507ae9-84f3-417a-9986-77c357a7dfe4.png)


