### PR TITLE
support local-only install in build script via environment variables

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -20,6 +20,7 @@ id
 which bundle
 # default bundle directory to shared directory
 : ${BUNDLE_DIR=/srv/idp/shared/bundle}
+: ${IDP_LOCAL_DEPENDENCIES=false}
 
 # use system libxml2, not the one vendored with nokogiri
 bundle config build.nokogiri --use-system-libraries
@@ -27,10 +28,16 @@ bundle config set --local deployment 'true'
 bundle config set --local path $BUNDLE_DIR
 bundle config set --local without 'deploy development doc test'
 
-bundle install --jobs 4
-bundle binstubs --all
+if [ "$IDP_LOCAL_DEPENDENCIES" == "true" ]
+then
+  bundle install --jobs 4 --local
+  yarn install --production --frozen-lockfile --offline
+else
+  bundle install --jobs 4
+  yarn install --production --frozen-lockfile
+fi
 
-yarn install --production --frozen-lockfile
+bundle binstubs --all
 
 set +x
 


### PR DESCRIPTION
Allows the instance build process to tell the IDP to only attempt to install Ruby/JS dependencies from local sources (artifact) without making any HTTP requests.

[bundle install](https://bundler.io/v2.2/man/bundle-install.1.html)'s `--local` option:

>Do not attempt to connect to rubygems.org. Instead, Bundler will use the gems already present in Rubygems' cache or in vendor/cache. Note that if an appropriate platform-specific gem exists on rubygems.org it will not be found.

[yarn install](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-offline)'s `--offline` option:

>Run yarn install in offline mode.

dev-ops changes are in https://github.com/18F/identity-devops/pull/3778