### PR TITLE
Avoid raising 500 when OTP verification code is nil

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -61,7 +61,7 @@ module TwoFactorAuthentication
     end
 
     def sanitized_otp_code
-      form_params[:code].strip
+      form_params[:code].to_s.strip
     end
 
     def form_params

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -373,6 +373,13 @@ describe TwoFactorAuthentication::OtpVerificationController do
               with(Analytics::MULTI_FACTOR_AUTH_SETUP, properties)
           end
         end
+
+        context 'user does not include a code parameter' do
+          it 'fails and increments attempts count' do
+            post :create, params: { otp_delivery_preference: 'sms' }
+            expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
+          end
+        end
       end
 
       context 'when user does not have an existing phone number' do


### PR DESCRIPTION
We received a submission with a missing parameter, which led to a 500. This patch coerces the parameter into a string and ensures we don't call `strip` on `nil`

[NR link](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=43200000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiZGE3MGIzMTUtMWEyZi0xMWVjLTk2MGYtMDI0MmFjMTEwMDA4XzBfMTY4NTkiLCJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThOVEl4TXpZNE5UZyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19&state=1368ddd9-4eda-dc9e-49d6-4f5950c251a6)