### PR TITLE
Do not raise during RISC job if server returns SSL error

### DIFF
--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -3,6 +3,7 @@ class RiscDeliveryJob < ApplicationJob
 
   retry_on Faraday::TimeoutError,
            Faraday::ConnectionFailed,
+           Faraday::SSLError,
            wait: :exponentially_longer,
            attempts: 5
   retry_on RedisRateLimiter::LimitError,
@@ -40,7 +41,8 @@ class RiscDeliveryJob < ApplicationJob
         }.to_json,
       )
     end
-  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, RedisRateLimiter::LimitError => err
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::SSLError,
+         RedisRateLimiter::LimitError => err
     raise err if !inline?
 
     Rails.logger.warn(


### PR DESCRIPTION
This currently results in a 500 to end users that are resetting their password or doing something else that generates an event. Instead, we should rescue and retry on these errors.

[SSL NR Link](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=43200000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiM2U1ODI2YmMtMWEzMi0xMWVjLTk2MGYtMDI0MmFjMTEwMDA4XzBfMjQ4OTMiLCJmaWx0ZXJzIjpbeyJrZXkiOiJlcnJvci5leHBlY3RlZCIsInZhbHVlIjoibm90IHRydWUifSx7ImtleSI6ImVycm9yLmNsYXNzIiwidmFsdWUiOiJGYXJhZGF5OjpTU0xFcnJvciIsImxpa2UiOmZhbHNlfV0sIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUd1aWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5USXhNelk0TlRnIn0=&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19&state=4b002bb7-fb86-30e7-a2f2-6f2e715b6a72)