### PR TITLE
LG-3880: Remove BassCSS "border-colors" module

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -104,7 +104,7 @@ linters:
           - '((sm|md|lg)-)?hide'
           - '(sm|md|lg)-show'
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent|border))?'
-          - 'border-(none|black|gray|white|aqua|orange|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
+          - 'border-(none|black|gray|silver|white|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
           - 'h3'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -15,7 +15,6 @@
 @import 'basscss-sass/flex-object';
 @import 'basscss-sass/background-colors';
 @import 'basscss-sass/background-images';
-@import 'basscss-sass/border-colors';
 @import 'basscss-sass/color-forms-dark';
 @import 'basscss-sass/color-input-range';
 @import 'basscss-sass/color-progress';

--- a/app/views/account_reset/confirm_delete_account/show.html.erb
+++ b/app/views/account_reset/confirm_delete_account/show.html.erb
@@ -1,5 +1,5 @@
 <% title t('account_reset.confirm_delete_account.title') %>
-<div class="margin-y-2 padding-4 tablet:padding-x-6 border border-red rounded-xl relative">
+<div class="margin-y-2 padding-4 tablet:padding-x-6 border border-error rounded-xl relative">
   <%= image_tag(asset_url('alert/fail-x.svg'),
                 size: '48x48',
                 alt: '',

--- a/app/views/account_reset/confirm_request/show.html.erb
+++ b/app/views/account_reset/confirm_request/show.html.erb
@@ -11,7 +11,7 @@
 </p>
 
 <div class="width-10">
-  <hr class="margin-y-4 border-width-05 border-teal">
+  <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
 <% if sms_phone %>

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -14,7 +14,7 @@
             <strong><%= greeting %></strong>
           </p>
         </div>
-        <div class="border-silver border-left">
+        <div class="border-base-darker border-left">
           <p class="margin-0">
             <%= link_to t('links.sign_out'), destroy_user_session_path,
                         class: 'padding-left-1' %>

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -16,7 +16,7 @@
 </p>
 
 <div class="width-10">
-  <hr class="margin-y-4 border-width-05 border-teal">
+  <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
 <%= validated_form_for @view_model.password_reset_email_form,

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -18,7 +18,7 @@
   <%= t('idv.titles.come_back_later') %>
 </h2>
 
-<div class="margin-top-2 padding-4 col-12 center border-box border border-teal rounded-xl">
+<div class="margin-top-2 padding-4 col-12 center border-box border rounded-xl">
   <p>
     <%= t('idv.messages.come_back_later', app: APP_NAME) %>
     <% if decorated_session.sp_name.present? %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -51,14 +51,14 @@
         <% if show_language_dropdown %>
           <ul class='list-reset display-none tablet:display-block margin-bottom-0'>
             <li class="i18n-desktop-toggle flex margin-y-1 margin-x-2 relative">
-              <button class='text-white text-decoration-none border border-blue radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
+              <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
                 <%= image_tag asset_url('globe-white.svg'), width: 12,
                 class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
                 <span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
               </button>
               <ul class="i18n-desktop-dropdown list-reset margin-bottom-0 text-white display-none">
                 <% I18n.available_locales.each do |locale| %>
-                  <li class='border-bottom border-navy'>
+                  <li class='border-bottom border-primary-darker'>
                     <%= link_to t("i18n.locale.#{locale}"),
                       sanitized_requested_url.merge(locale: locale),
                       class: 'block pl-24p padding-y-2 text-decoration-none text-white',

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -19,7 +19,7 @@
 </p>
 
 <div class="width-10">
-  <hr class="margin-y-4 border-width-05 border-teal">
+  <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
 <%= validated_form_for @resend_email_confirmation_form,

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -19,7 +19,7 @@
 </p>
 
 <div class="width-10">
-  <hr class="margin-y-4 border-width-05 border-teal">
+  <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
 <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -1,6 +1,6 @@
 <div class="relative">
   <%= form_tag create_verify_personal_key_path, id: 'verify-key', method: 'post', name: 'verify-key' do %>
-    <div class="padding-top-6 padding-x-1 tablet:padding-x-8 key-badge border border-dashed border-red rounded-xl">
+    <div class="padding-top-6 padding-x-1 tablet:padding-x-8 key-badge border border-dashed border-secondary rounded-xl">
       <h3 class="margin-top-0 margin-bottom-2">
         <%= t('forms.personal_key.title') %>
       </h3>


### PR DESCRIPTION
**Why**: To improve page load speed by reducing CSS bundle size, to eliminate developer confusion by choice of styling, to improve developer experience by reducing SASS compilation times, to standardize on design system styles, and to attach semantics to states rather than specific colors (e.g. red -> error, teal -> info).

Reference for removal: https://github.com/basscss/basscss-sass/blob/v3.0.0/_border-colors.scss

Design system color reference: https://design.login.gov/utilities/color/

Implementation notes:

- Specific colors weren't always being applied correctly, due to the fact that USWDS "border" class would reset BassCSS border colors. This wasn't always noticeable when USWDS offered a border color class by the same name (e.g. border-red), but not all colors had a USWDS equivalent (e.g. border-teal). There was one instance of a "border-teal" affected by this where no color was actually being applied, on the IAL2 GPO "Come Back Later" screen. The changes proposed here adhere to Figma designs.
- border-silver was replaced with border-base-darker, based on Figma designs.