### PR TITLE
LG-3880: Remove BassCSS "background-colors" module

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -104,7 +104,7 @@ linters:
           - '((sm|md|lg)-)?hide'
           - '(sm|md|lg)-show'
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent|border))?'
-          - 'border-(none|black|gray|silver|white|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
+          - '(border|bg)-(none|black|gray|silver|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
           - 'h3'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -13,7 +13,6 @@
 @import 'basscss-sass/positions';
 @import 'basscss-sass/grid';
 @import 'basscss-sass/flex-object';
-@import 'basscss-sass/background-colors';
 @import 'basscss-sass/background-images';
 @import 'basscss-sass/color-forms-dark';
 @import 'basscss-sass/color-input-range';

--- a/app/assets/stylesheets/utilities/_background.scss
+++ b/app/assets/stylesheets/utilities/_background.scss
@@ -1,10 +1,6 @@
 .bg-gray-lighter { background-color: $gray-lighter; }
 .bg-light-blue { background-color: $blue-light; }
 .bg-lightest-blue { background-color: $blue-lightest; }
-// scss-lint:disable ImportantRule
-.bg-white { background-color: $white !important; }
-// scss-lint:enable ImportantRule
-
 
 @media #{$breakpoint-sm} {
   .sm-bg-light-blue { background-color: $blue-light; }

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -9,7 +9,7 @@
 
   <ul class='list-reset'>
     <li class='padding-top-2 padding-bottom-1'>
-      <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
+      <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
         <%= step += 1 %>
       </div>
       <div class='margin-right-1 inline-block'>
@@ -24,7 +24,7 @@
     </li>
     <% if liveness_checking_enabled? %>
       <li class='padding-top-2 padding-bottom-1'>
-        <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
+        <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
           <%= step += 1 %>
         </div>
         <div class='margin-right-1 inline-block'>
@@ -40,7 +40,7 @@
     <% end %>
     <li class='padding-top-2 padding-bottom-1'>
       <div class="grid-row">
-        <div class='inline-block margin-right-2 text-top circle-number bg-blue text-white'>
+        <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
           <%= step += 1 %>
         </div>
         <div class='grid-col-10'>
@@ -56,7 +56,7 @@
     </li>
     <li class='padding-top-2 padding-bottom-1'>
       <div class="grid-row">
-        <div class='grid-col-2 margin-right-2 text-top circle-number bg-blue text-white'>
+        <div class='grid-col-2 margin-right-2 text-top circle-number bg-primary text-white'>
           <%= step += 1 %>
         </div>
         <div class='grid-col-10'>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -1,8 +1,8 @@
-<div class="bg-light-blue bg-personal-key">
+<div class="bg-personal-key">
   <h2 class="center margin-top-1 padding-top-1 fs-20p">
     <%= t('users.personal_key.header') %>
   </h2>
-  <div class="margin-top-6 margin-bottom-6 padding-x-0 tablet:padding-x-1 padding-y-2 center bg-white border-width-2px separator-text bg-pk-box">
+  <div class="margin-top-6 margin-bottom-6 padding-x-0 tablet:padding-x-1 padding-y-2 center border-width-2px separator-text bg-pk-box">
     <%- code.split('-').each do |word|
       -%><div class="inline"
         ><strong><code class="separator-text__code monospace" data-personal-key="word"

--- a/app/views/shared/_no_pii_banner.html.erb
+++ b/app/views/shared/_no_pii_banner.html.erb
@@ -1,3 +1,3 @@
-<div class='padding-y-1 bg-maroon text-white fs-12p line-height-1 center'>
+<div class='padding-y-1 bg-secondary-darker text-white fs-12p line-height-1 center'>
   <%= t('idv.messages.sessions.no_pii') %>
 </div>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -6,7 +6,7 @@
 <%= form_tag(submit_new_piv_cac_url) do %>
 <ul class='list-reset'>
   <li class='padding-top-0 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
       1
     </div>
     <label class="h1 margin-right-1 inline-block margin-bottom-1 bold" for="nickname">
@@ -21,7 +21,7 @@
     <hr>
   </li>
   <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
       2
     </div>
     <div class='margin-right-1 inline-block margin-bottom-2'>
@@ -32,7 +32,7 @@
     <hr>
   </li>
   <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-blue text-white'>
+    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
       3
     </div>
     <div class='margin-right-1 inline-block'>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -8,7 +8,7 @@
   <ul class="list-reset">
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue text-white">1</div>
+        <div class="margin-right-1 inline-block circle-number bg-primary text-white">1</div>
         <div class="inline-block bold" id="totp-nickname"><%= t('forms.totp_setup.totp_step_1') %></div>
         <div class="inline-block margin-left-4"><%= t('forms.totp_setup.totp_step_1a') %></div>
       </div>
@@ -22,12 +22,12 @@
       </div>
     </li>
     <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-right-1 inline-block circle-number bg-blue text-white">2</div>
+      <div class="margin-right-1 inline-block circle-number bg-primary text-white">2</div>
       <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_2') %></div>
     </li>
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue text-white">3</div>
+        <div class="margin-right-1 inline-block circle-number bg-primary text-white">3</div>
         <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_3') %></div>
       </div>
       <div class="sm-col-9 sm-ml-28p">
@@ -49,7 +49,7 @@
     </li>
     <li class="padding-y-2 border-top border-primary-light">
       <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-blue text-white">4</div>
+        <div class="margin-right-1 inline-block circle-number bg-primary text-white">4</div>
         <div class="inline-block bold" id="totp-label"><%= t('forms.totp_setup.totp_step_4') %></div>
       </div>
       <div class="sm-col-9 sm-ml-28p">


### PR DESCRIPTION
**Why**: To improve page load speed by reducing CSS bundle size, to eliminate developer confusion by choice of styling, to improve developer experience by reducing SASS compilation times, to standardize on design system colors and semantics, and to resolve broken visual appearances for backgrounds.

Reference for removal: https://github.com/basscss/basscss-sass/blob/v3.0.0/_border-colors.scss

Design system color reference: https://design.login.gov/utilities/color/

Page Element|Before|After
---|---|---
No PII Banner|![Screen Shot 2021-09-21 at 10 52 39 AM](https://user-images.githubusercontent.com/1779930/134195382-14ed7ab3-09d8-419e-8949-e9424f454662.png)|![Screen Shot 2021-09-21 at 10 52 16 AM](https://user-images.githubusercontent.com/1779930/134195422-a512fd99-3102-4aca-9924-97d7d79eea44.png)
Process List|![Screen Shot 2021-09-21 at 10 51 53 AM](https://user-images.githubusercontent.com/1779930/134195499-48c38ee6-74c4-4790-b039-d8862b12edac.png)|![Screen Shot 2021-09-21 at 10 51 21 AM](https://user-images.githubusercontent.com/1779930/134195532-f3f0520c-885d-419e-9a26-b7e888420add.png)
IAL2 Personal Key|![Screen Shot 2021-09-21 at 10 49 23 AM](https://user-images.githubusercontent.com/1779930/134195594-a5d6b335-b2ea-4a86-b611-3471b022a7ff.png)|![Screen Shot 2021-09-21 at 10 49 47 AM](https://user-images.githubusercontent.com/1779930/134195621-6db71a08-8e07-463d-b943-fc7aec0cf3fe.png)

Implementation notes:

- The "No PII Banner" maroon color has no direct equivalent. `secondary-darker` was selected as being visually-similar.
- `bg-blue` was replaced with `bg-primary`. This has a visual difference which is intended and expected: Originally we used `bg-blue` from BassCSS and overrode the color to our "primary" blue color. When USWDS was introduced, its `bg-blue` of the same name took priority over BassCSS, but applied a different color. The `bg-primary` is also correct per Figma designs.