### PR TITLE
Remove unused abbreviation styles

### DIFF
--- a/app/assets/stylesheets/components/_abbr.scss
+++ b/app/assets/stylesheets/components/_abbr.scss
@@ -1,4 +1,0 @@
-// normalize.css adds a text underline by default
-// scss-lint:disable QualifyingElement
-abbr[title] { text-decoration: none; }
-// scss-lint:enable QualifyingElement

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -1,5 +1,4 @@
 @import 'general';
-@import 'abbr';
 @import 'account-header';
 @import 'banner';
 @import 'block-link';


### PR DESCRIPTION
**Why**: Because they're unused.

The styles themselves are very old, introduced in #73. While the pull request hadn't specifically implemented any `abbr` elements, it's likely they were targeted at "required" asterisks which were removed as of #4855. From what I can tell, we do not render any `abbr` currently in the IdP. The default styles with text underline would be desirable for any future usage, an example of which can be seen [on the developer site](https://developers.login.gov/security-events/) ([screenshot](https://user-images.githubusercontent.com/1779930/134213324-980cc51f-f453-44cb-84f3-6960a21d3f42.png)).