### PR TITLE
Revert changes to IDV personal key generation

### DIFF
--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -21,10 +21,16 @@ module Idv
     end
 
     def download
-      code = personal_key
+      personal_key = user_session[:personal_key]
 
-      analytics.track_event(Analytics::IDV_DOWNLOAD_PERSONAL_KEY, success: code.present?)
-      send_data "#{code}\r\n", filename: 'personal_key.txt'
+      analytics.track_event(Analytics::IDV_DOWNLOAD_PERSONAL_KEY, success: personal_key.present?)
+
+      if personal_key.present?
+        data = personal_key + "\r\n"
+        send_data data, filename: 'personal_key.txt'
+      else
+        head :bad_request
+      end
     end
 
     private
@@ -67,6 +73,8 @@ module Idv
 
     def finish_idv_session
       @code = personal_key
+      user_session[:personal_key] = @code
+      idv_session.personal_key = nil
 
       if idv_session.address_verification_mechanism == 'gpo'
         flash.now[:success] = t('idv.messages.mail_sent')
@@ -77,7 +85,7 @@ module Idv
     end
 
     def personal_key
-      user_session[:personal_key] ||= generate_personal_key
+      idv_session.personal_key || generate_personal_key
     end
 
     def generate_personal_key

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -14,6 +14,7 @@ module Idv
       profile_confirmation
       profile_id
       profile_step_params
+      personal_key
       resolution_successful
     ].freeze
 
@@ -50,6 +51,7 @@ module Idv
       profile = profile_maker.save_profile
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
+      self.personal_key = profile.personal_key
     end
 
     def cache_encrypted_pii(password)


### PR DESCRIPTION
(#5230)

This reverts commit 57308972fd615821a84dd51943923a195ec0190f

---

these changes resulted in double-generation of personal keys, so the personal key shown to the user does not work to recover PII

- We will need to find a way to find affected users, and come up with a flow for them to re-generate their personal keys