### PR TITLE
LG-5141: Move zip code to its own line

### DIFF
--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -26,13 +26,15 @@
     <%= f.input :city, label: t('idv.form.city'), required: true, maxlength: 255,
                        input_html: { aria: { invalid: false }, value: @pii['city'] } %>
 
-    <div class="clearfix margin-x-neg-1">
-      <div class="sm-col sm-col-8 padding-x-1">
+    <div class="margin-x-neg-1">
+      <div class="padding-x-1">
         <%= f.input :state, collection: us_states_territories,
-                            label: t('idv.form.state'), required: true,
-                            selected: @pii['state'] %>
+                          label: t('idv.form.state'), required: true,
+                          selected: @pii['state'] %>
       </div>
-      <div class="sm-col sm-col-4 padding-x-1">
+    </div>
+    <div class="margin-x-neg-1">
+      <div class="tablet:grid-col-6 padding-x-1">
         <%# using :tel for mobile numeric keypad %>
         <%= f.input :zipcode, as: :tel,
                               label: t('idv.form.zipcode'), required: true,

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -26,21 +26,15 @@
     <%= f.input :city, label: t('idv.form.city'), required: true, maxlength: 255,
                        input_html: { aria: { invalid: false }, value: @pii['city'] } %>
 
-    <div class="margin-x-neg-1">
-      <div class="padding-x-1">
-        <%= f.input :state, collection: us_states_territories,
-                          label: t('idv.form.state'), required: true,
-                          selected: @pii['state'] %>
-      </div>
-    </div>
-    <div class="margin-x-neg-1">
-      <div class="tablet:grid-col-6 padding-x-1">
-        <%# using :tel for mobile numeric keypad %>
-        <%= f.input :zipcode, as: :tel,
-                              label: t('idv.form.zipcode'), required: true,
-                              pattern: '(\d{5}([\-]\d{4})?)',
-                              input_html: { aria: { invalid: false }, class: 'zipcode', value: @pii['zipcode'] } %>
-      </div>
+    <%= f.input :state, collection: us_states_territories,
+                        label: t('idv.form.state'), required: true,
+                        selected: @pii['state'] %>
+    <div class="tablet:grid-col-6">
+      <%# using :tel for mobile numeric keypad %>
+      <%= f.input :zipcode, as: :tel,
+                            label: t('idv.form.zipcode'), required: true,
+                            pattern: '(\d{5}([\-]\d{4})?)',
+                            input_html: { aria: { invalid: false }, class: 'zipcode', value: @pii['zipcode'] } %>
     </div>
     <div class="margin-top-0">
       <button type="submit" class="usa-button usa-button--big usa-button--wide margin-top-2">


### PR DESCRIPTION
This PR moves the zip code input to its own line per the [Figma designs](https://www.figma.com/file/g8SrhXQC67JiNaUeaDBACl/Investigate-instructions-for-zip-code-across-flows-%5BLG-4946%5D?node-id=11%3A82). This will help with a future ticket to add the error message "Enter a 5-digit or 9-digit zip code".