### PR TITLE
Add daily dropoffs report, for the dashboard (LG-4649)

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -9,6 +9,12 @@ module Reports
 
     private
 
+    def public_bucket_name
+      if (prefix = IdentityConfig.store.s3_report_public_bucket_prefix)
+        Identity::Hostdata.bucket_name("#{prefix}-#{Identity::Hostdata.env}")
+      end
+    end
+
     def fiscal_start_date
       now = Time.zone.now.beginning_of_day
       now.change(year: now.month >= 10 ? now.year : now.year - 1, month: 10, day: 1)

--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -31,12 +31,6 @@ module Reports
       end
     end
 
-    def public_bucket_name
-      if (prefix = IdentityConfig.store.s3_report_public_bucket_prefix)
-        Identity::Hostdata.bucket_name("#{prefix}-#{Identity::Hostdata.env}")
-      end
-    end
-
     def start
       report_date.beginning_of_day
     end

--- a/app/jobs/reports/daily_dropoffs_report.rb
+++ b/app/jobs/reports/daily_dropoffs_report.rb
@@ -1,0 +1,140 @@
+require 'csv'
+
+module Reports
+  class DailyDropoffsReport < BaseReport
+    REPORT_NAME = 'daily-dropoffs-report'
+
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
+    attr_reader :report_date
+
+    def perform(report_date)
+      @report_date = report_date
+
+      _latest, path = generate_s3_paths(REPORT_NAME, 'csv', now: report_date)
+      body = report_body
+
+      [
+        bucket_name, # default reporting bucket
+        IdentityConfig.store.s3_public_reports_enabled && public_bucket_name,
+      ].select(&:present?).
+        each do |bucket_name|
+        upload_file_to_s3_bucket(
+          path: path,
+          body: body,
+          content_type: 'text/csv',
+          bucket: bucket_name,
+        )
+      end
+    end
+
+    def start
+      report_date.beginning_of_day
+    end
+
+    def finish
+      report_date.end_of_day
+    end
+
+    def report_body
+      CSV.generate do |csv|
+        csv << %w[
+          issuer
+          friendly_name
+          iaa
+          agency
+          start
+          finish
+        ] + Db::DocAuthLog::DropOffRatesHelper::STEPS
+
+        query_results.each do |sp_result|
+          csv << [
+            sp_result['issuer'],
+            sp_result['friendly_name'],
+            sp_result['iaa'],
+            sp_result['agency'],
+            start.iso8601,
+            finish.iso8601,
+            *Db::DocAuthLog::DropOffRatesHelper::STEPS.map { |step| sp_result[step].to_i },
+          ]
+        end
+      end
+    end
+
+    def query_results
+      params = {
+        start: start,
+        finish: finish,
+      }.transform_values { |v| ActiveRecord::Base.connection.quote(v) }
+
+      sql = format(<<-SQL, params)
+        SELECT
+          NULLIF(doc_auth_logs.issuer, '') AS issuer
+        , MAX(service_providers.iaa) AS iaa
+        , MAX(service_providers.friendly_name) AS friendly_name
+        , MAX(agencies.name) AS agency
+        , COUNT(doc_auth_logs.welcome_view_at) AS welcome
+        , COUNT(doc_auth_logs.agreement_view_at) AS agreement
+        , COUNT(doc_auth_logs.upload_view_at) AS upload_option
+        , COUNT(
+            COALESCE(
+              doc_auth_logs.back_image_view_at
+            , doc_auth_logs.mobile_back_image_view_at
+            , doc_auth_logs.capture_mobile_back_image_view_at
+            , doc_auth_logs.present_cac_view_at
+            , doc_auth_logs.document_capture_view_at
+            )
+          ) AS capture_document
+        , COUNT(
+            COALESCE(
+              CASE WHEN doc_auth_logs.document_capture_submit_count > 0 THEN 1 else null END
+            , CASE WHEN doc_auth_logs.back_image_submit_count > 0 THEN 1 else null END
+            , CASE WHEN doc_auth_logs.capture_mobile_back_image_submit_count > 0 THEN 1 else null END
+            , CASE WHEN doc_auth_logs.mobile_back_image_submit_count > 0 THEN 1 else null END
+            )
+          ) AS cap_doc_submit
+        , COUNT(
+            COALESCE(
+              doc_auth_logs.ssn_view_at
+            , doc_auth_logs.enter_info_view_at
+            )
+          ) AS ssn
+        , COUNT(doc_auth_logs.verify_view_at) AS verify_info
+        , COUNT(
+            COALESCE(CASE WHEN doc_auth_logs.verify_submit_count > 0 THEN 1 else null END)
+          ) AS verify_submit
+        , COUNT(doc_auth_logs.verify_phone_view_at) AS phone
+        , COUNT(doc_auth_logs.encrypt_view_at) AS encrypt
+        , COUNT(doc_auth_logs.verified_view_at) AS personal_key
+        , COUNT(profiles.id) AS verified
+        FROM doc_auth_logs
+        LEFT JOIN
+          service_providers ON service_providers.issuer = doc_auth_logs.issuer
+        LEFT JOIN
+          agencies ON service_providers.agency_id = agencies.id
+        LEFT JOIN
+          profiles ON profiles.user_id = doc_auth_logs.user_id
+            AND profiles.verified_at IS NOT NULL
+            AND %{start} <= profiles.verified_at
+            AND profiles.verified_at <= %{finish}
+            AND profiles.active = TRUE
+
+        WHERE
+          %{start} <= doc_auth_logs.welcome_view_at
+        AND doc_auth_logs.welcome_view_at <= %{finish}
+
+        GROUP BY
+          doc_auth_logs.issuer
+      SQL
+
+      transaction_with_timeout do
+        ActiveRecord::Base.connection.execute(sql)
+      end
+    end
+  end
+end

--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -1,6 +1,12 @@
 class DocAuthLog < ApplicationRecord
   belongs_to :user
 
+  # rubocop:disable Rails/InverseOf
+  belongs_to :service_provider,
+             foreign_key: 'issuer',
+             primary_key: 'issuer'
+  # rubocop:enable Rails/InverseOf
+
   def self.verified_users_count
     Profile.where.not(verified_at: nil).count
   end

--- a/app/services/db/doc_auth_log/drop_off_rates_helper.rb
+++ b/app/services/db/doc_auth_log/drop_off_rates_helper.rb
@@ -1,8 +1,19 @@
 module Db
   module DocAuthLog
     module DropOffRatesHelper
-      STEPS = %w[welcome agreement capture_document cap_doc_submit ssn verify_info
-                 verify_submit phone encrypt personal_key verified].freeze
+      STEPS = %w[
+        welcome
+        agreement
+        capture_document
+        cap_doc_submit
+        ssn
+        verify_info
+        verify_submit
+        phone
+        encrypt
+        personal_key
+        verified
+      ].freeze
 
       private
 

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -379,6 +379,20 @@ all_configs = {
       args: -> { [Time.zone.yesterday] },
     },
   },
+  # Send daily dropoff report to S3
+  daily_dropoffs: {
+    job_runner: {
+      name: 'Daily Dropoff Report',
+      interval: inteval_24h,
+      timeout: 300,
+      callback: -> { Reports::DailyDropoffsReport.new.perform(Time.zone.yesterday) },
+    },
+    good_job: {
+      class: 'Reports::DailyDropoffsReport',
+      cron: cron_24h,
+      args: -> { [Time.zone.yesterday] },
+    },
+  },
   # Removes old rows from the Throttles table
   remove_old_throttles: {
     job_runner: {

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -379,10 +379,10 @@ all_configs = {
       args: -> { [Time.zone.yesterday] },
     },
   },
-  # Send daily dropoff report to S3
+  # Send daily dropoffs report to S3
   daily_dropoffs: {
     job_runner: {
-      name: 'Daily Dropoff Report',
+      name: 'Daily Dropoffs Report',
       interval: inteval_24h,
       timeout: 300,
       callback: -> { Reports::DailyDropoffsReport.new.perform(Time.zone.yesterday) },

--- a/spec/factories/doc_auth_logs.rb
+++ b/spec/factories/doc_auth_logs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :doc_auth_log do
+  end
+end

--- a/spec/jobs/reports/daily_dropoffs_report_spec.rb
+++ b/spec/jobs/reports/daily_dropoffs_report_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe Reports::DailyDropoffsReport do
+  subject(:report) { Reports::DailyDropoffsReport.new }
+
+  let(:report_date) { Date.new(2021, 3, 1) }
+  let(:s3_public_reports_enabled) { true }
+  let(:s3_report_bucket_prefix) { 'reports-bucket' }
+  let(:s3_report_public_bucket_prefix) { 'public-reports-bucket' }
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+    allow(Identity::Hostdata).to receive(:aws_account_id).and_return('1234')
+    allow(Identity::Hostdata).to receive(:aws_region).and_return('us-west-1')
+    allow(IdentityConfig.store).to receive(:s3_public_reports_enabled).
+      and_return(s3_public_reports_enabled)
+    allow(IdentityConfig.store).to receive(:s3_report_bucket_prefix).
+      and_return(s3_report_bucket_prefix)
+    allow(IdentityConfig.store).to receive(:s3_report_public_bucket_prefix).
+      and_return(s3_report_public_bucket_prefix)
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        put_object: {},
+      },
+    }
+  end
+  describe '#perform' do
+    it 'uploads a file to S3 based on the report date' do
+      ['reports-bucket.1234-us-west-1', 'public-reports-bucket-int.1234-us-west-1'].each do |bucket|
+        expect(report).to receive(:upload_file_to_s3_bucket).with(
+          path: 'int/daily-dropoffs-report/2021/2021-03-01.daily-dropoffs-report.csv',
+          body: kind_of(String),
+          content_type: 'text/csv',
+          bucket: bucket,
+        ).exactly(1).time.and_call_original
+      end
+
+      expect(report).to receive(:report_body).and_call_original.once
+
+      report.perform(report_date)
+    end
+
+    context 'when s3 public reports are disabled' do
+      let(:s3_public_reports_enabled) { false }
+
+      it 'only uploads to one bucket' do
+        expect(report).to receive(:upload_file_to_s3_bucket).with(
+          hash_including(
+            path: 'int/daily-dropoffs-report/2021/2021-03-01.daily-dropoffs-report.csv',
+            bucket: 'reports-bucket.1234-us-west-1',
+          ),
+        ).exactly(1).time.and_call_original
+
+        report.perform(report_date)
+      end
+    end
+
+    context 'with data' do
+      let(:timestamp) { report_date + 12.hours }
+
+      let(:agency) { create(:agency, name: 'The Agency') }
+      let(:service_provider) do
+        create(
+          :service_provider,
+          issuer: 'issuer1',
+          iaa: 'iaa123',
+          friendly_name: 'The App',
+          agency: agency,
+        )
+      end
+
+      before do
+        started_user = create(:user)
+        last_step_user = create(:user)
+        verified_user = create(:user)
+
+        create(
+          :doc_auth_log,
+          user: started_user,
+          service_provider: service_provider,
+          welcome_view_at: timestamp,
+        )
+
+        # going through all the funnel steps
+        [last_step_user, verified_user].each do |user|
+          create(
+            :doc_auth_log,
+            user: user,
+            service_provider: service_provider,
+            agreement_view_at: timestamp,
+            welcome_view_at: timestamp,
+            document_capture_view_at: timestamp,
+            document_capture_submit_count: 1,
+            ssn_view_at: timestamp,
+            verify_view_at: timestamp,
+            verify_submit_count: 1,
+            verify_phone_view_at: timestamp,
+            encrypt_view_at: timestamp,
+            verified_view_at: timestamp,
+          )
+        end
+
+        create(:profile, user: verified_user, verified_at: timestamp, active: true)
+      end
+
+      it 'aggregates by issuer' do
+        expect(report).to receive(:upload_file_to_s3_bucket).
+          exactly(2).times do |path:, body:, content_type:, bucket:|
+            csv = CSV.parse(body, headers: true)
+
+            row = csv.first
+
+            expect(row['issuer']).to eq(service_provider.issuer)
+            expect(row['friendly_name']).to eq(service_provider.friendly_name)
+            expect(row['iaa']).to eq(service_provider.iaa)
+            expect(row['agency']).to eq(agency.name)
+            expect(row['start']).to eq(report_date.beginning_of_day.iso8601)
+            expect(row['finish']).to eq(report_date.end_of_day.iso8601)
+
+            # all 3 users started
+            expect(row['welcome'].to_i).to eq(3)
+
+            # 2 users went through the full funnel
+            expect(row['agreement'].to_i).to eq(2)
+            expect(row['capture_document'].to_i).to eq(2)
+            expect(row['cap_doc_submit'].to_i).to eq(2)
+            expect(row['ssn'].to_i).to eq(2)
+            expect(row['verify_info'].to_i).to eq(2)
+            expect(row['verify_submit'].to_i).to eq(2)
+            expect(row['phone'].to_i).to eq(2)
+            expect(row['encrypt'].to_i).to eq(2)
+            expect(row['personal_key'].to_i).to eq(2)
+
+            # only 1 user verified
+            expect(row['verified'].to_i).to eq(1)
+          end
+
+        report.perform(report_date)
+      end
+    end
+  end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+end


### PR DESCRIPTION
This is a new report that is based heavily on the existing DropoffHelper classes

## Examples

New report looks like:

```csv
issuer,friendly_name,iaa,agency,start,finish,welcome,agreement,capture_document,cap_doc_submit,ssn,verify_info,verify_submit,phone,encrypt,personal_key,verified
issuer1,The App,iaa123,The Agency,2021-03-01T00:00:00+01:00,2021-03-01T23:59:59+01:00,3,2,2,2,2,2,2,2,2,2,1
issuer2,The Other App,iaa123,The Agency,2021-03-01T00:00:00+01:00,2021-03-01T23:59:59+01:00,5,4,3,2,1,0,0,0,0,0,0
```

The existing reports look like:

```
Sprint
'09-09-2021' <= date user starts doc auth < '09-23-2021'

                step  users %users dropoff
             welcome 120960   100%      6%
           agreement 113265    94%      7%
    capture_document 105000    87%     17%
      cap_doc_submit  87634    72%     19%
                 ssn  70887    59%      0%
         verify_info  70647    58%      0%
       verify_submit  70350    58%     11%
               phone  62484    52%      6%
             encrypt  58684    49%      3%
        personal_key  56891    47%      6%
            verified  53549    44%      0%
```

## Differences

### One Day at a Time

Similar to the Daily Auths Report, I wanted a report that could:
- Be re-run for an individual day (in case we need to fix old days)
- Have results that can be easily post-processed and combined

### Only counts!

1. Counts can be added up and summed across days
2. Percents are easily calculated when rendering

This eliminates the need for separate classes based on time range, since getting a bigger time range just means combining in additional files from other days.

### Don't Separate Overall vs Blanket 

The key difference between overall and blanket is where we start counting. The only difference between the two is that "100%" starts at the image submit step. Given this, showing a dashboard of Blanket just means dropping the first 3 steps, which is straightforward post processing step

### CSV format (vs JSON)


We needed something that parsed more easily than the existing text tables. A common option is JSON but I decided to make the new report a CSV since it maps very closely to a table/spreadsheet. 

Yes, technically JSON can capture this too, but JSON doesn't easily map to column order the way CSV does.

I did have a version of this in JSON with a nested array of steps like this, but honestly it was a hassle when working with on a dashboard:
```json
{
  "issuer": "issuer1",
  ...
  "steps": [
    { "name": "welcome", "count": 5 },
    ...
    { "name": "verified", "count": 1 }
  ]
}
```

### Implementation Notes

Unfortunately the existing [DropOffHelper](https://github.com/18F/identity-idp/blob/main/app/services/db/doc_auth_log/drop_off_rates_helper.rb) is very tied to its output format, so there was no way to extract the logic I needed. I was able to share the steps array.

None of the existing classes, or their shared mixin, mapped to this behavior easily 

For reference that's [8 reports](https://github.com/18F/identity-idp/tree/main/app/services/db/doc_auth_log):
`{Blanket,Overall}DropOffRates{AllSps,PerSp}{AllTime,InRange}`

So this adds one new class, and if we like this direction, maybe we can consider removing some of the older ones