### PR TITLE
Add `alternate_email` prop to OIDC userinfo

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -101,14 +101,14 @@ module SignUp
       "#{pii[:first_name]} #{pii[:last_name]}"
     end
 
-    def email
-      EmailContext.new(current_user).last_sign_in_email_address.email
+    def emails
+      current_user.confirmed_email_addresses.map(&:email).join(', ')
     end
 
     def displayable_attributes
       return pii_to_displayable_attributes if user_session['decrypted_pii'].present?
       {
-        email: email,
+        email: emails,
         verified_at: verified_at,
         x509_subject: current_user.piv_cac_configurations.first&.x509_dn_uuid,
         x509_issuer: current_user.piv_cac_configurations.first&.x509_issuer,
@@ -147,7 +147,7 @@ module SignUp
         address: address,
         birthdate: dob,
         phone: PhoneFormatter.format(pii[:phone].to_s),
-        email: email,
+        email: emails,
         verified_at: verified_at,
         x509_subject: current_user.piv_cac_configurations.first&.x509_dn_uuid,
         x509_issuer: current_user.piv_cac_configurations.first&.x509_issuer,

--- a/app/decorators/email_context.rb
+++ b/app/decorators/email_context.rb
@@ -9,6 +9,10 @@ class EmailContext
     user.confirmed_email_addresses.order('last_sign_in_at DESC NULLS LAST').first
   end
 
+  def alternate_email_addresses
+    user.confirmed_email_addresses.excluding(last_sign_in_email_address)
+  end
+
   def email_address_count
     user.email_addresses.count
   end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -13,6 +13,7 @@ class OpenidConnectUserInfoPresenter
       sub: uuid_from_sp_identity(identity),
       iss: root_url,
       email: email_from_sp_identity(identity),
+      alternate_emails: alternate_emails_from_sp_identity(identity),
       email_verified: true,
     }
 
@@ -35,6 +36,10 @@ class OpenidConnectUserInfoPresenter
 
   def email_from_sp_identity(identity)
     EmailContext.new(identity.user).last_sign_in_email_address.email
+  end
+
+  def alternate_emails_from_sp_identity(identity)
+    EmailContext.new(identity.user).alternate_email_addresses.map(&:email)
   end
 
   def ial2_attributes

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -30,6 +30,7 @@ class OpenidConnectAttributeScoper
   ATTRIBUTE_SCOPES_MAP = {
     email: %w[email],
     email_verified: %w[email],
+    alternate_emails: %w[email],
     address: %w[address],
     phone: %w[phone],
     phone_verified: %w[phone],
@@ -45,7 +46,7 @@ class OpenidConnectAttributeScoper
 
   SCOPE_ATTRIBUTE_MAP = {}.tap do |scope_attribute_map|
     ATTRIBUTE_SCOPES_MAP.each do |attribute, scopes|
-      next [] if attribute.match?(/_verified$/)
+      next [] if attribute.match?(/_verified$/) || attribute == 'alternate_emails'
       scopes.each do |scope|
         scope_attribute_map[scope] ||= []
         scope_attribute_map[scope] << attribute

--- a/spec/decorators/email_context_spec.rb
+++ b/spec/decorators/email_context_spec.rb
@@ -20,4 +20,25 @@ describe EmailContext do
       expect(subject.last_sign_in_email_address).to eq(last_sign_in_email_address)
     end
   end
+
+  describe '#alternate_email_addresses' do
+    it 'returns all of a users emails except the last sign in email' do
+      last_sign_in_email_address = create(:email_address, user: user, last_sign_in_at: 1.day.ago)
+      other_sign_in_email = create(:email_address, user: user, last_sign_in_at: 2.days.ago)
+      never_sign_in_email = create(:email_address, user: user, last_sign_in_at: nil)
+
+      email_addresses = subject.alternate_email_addresses
+
+      expect(email_addresses).to_not include(last_sign_in_email_address)
+      expect(email_addresses).to include(other_sign_in_email)
+      expect(email_addresses).to include(never_sign_in_email)
+    end
+
+    it 'returns an empty array if the user only has one email' do
+      last_sign_in_email_address = user.email_addresses.first
+      last_sign_in_email_address.update!(last_sign_in_at: 1.day.ago)
+
+      expect(subject.alternate_email_addresses).to eq([])
+    end
+  end
 end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         expect(user_info[:iss]).to eq(root_url)
         expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
         expect(user_info[:email_verified]).to eq(true)
+        expect(user_info[:alternate_emails]).to eq([])
       end
     end
 
@@ -138,6 +139,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             aggregate_failures do
               expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
               expect(user_info[:email_verified]).to eq(true)
+              expect(user_info[:alternate_emails]).to eq([])
               expect(user_info[:given_name]).to eq(nil)
               expect(user_info[:family_name]).to eq(nil)
               expect(user_info[:birthdate]).to eq(nil)

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe OpenidConnectAttributeScoper do
         iss: 'https://login.gov',
         email: 'foo@example.com',
         email_verified: true,
+        alternate_emails: ['bar@example.com'],
         given_name: 'John',
         family_name: 'Jones',
         birthdate: '1970-01-01',
@@ -76,6 +77,7 @@ RSpec.describe OpenidConnectAttributeScoper do
       it 'includes the email and email_verified attributes' do
         expect(filtered[:email]).to be_present
         expect(filtered[:email_verified]).to eq(true)
+        expect(filtered[:alternate_emails]).to be_present
       end
     end
 


### PR DESCRIPTION
**Why**: So that if SPs have users with multiple email addresses, they can access those email addresses

This is a proposal for dealing with:

a.) A feature request from SPs to be able to see all of a user's email addresses
b.) A feature request from SPs to have a mechanism for selecting email addresses when a user signs in with a PIV (i.e. without an email)

Users with multiple email addresses will have the email addresses they did not use to sign in under an `alternate_emails` property. Users with only one email address will have an empty array there:

![image](https://user-images.githubusercontent.com/963654/134726244-309ea049-5223-4fa0-9527-4915313817c6.png)

Additionally, I updated the consent screen to demonstrate that all of the user's email addresses are being shared. We should likely make this change anyway given that we may share a user's alternate email with an SP if they use it to sign in:

![image](https://user-images.githubusercontent.com/963654/134726345-ebc1cc9f-1145-4bba-99b8-a2c9ecf18a69.png)
