### PR TITLE
LG-5140: guard against improper date data returned from LN

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -110,17 +110,6 @@ module DocAuth
 
         private
 
-        def parse_date(year:, month:, day:)
-          return nil unless year && month && day
-
-          i_year = year.to_i
-          i_month = month.to_i
-          i_day = day.to_i
-          return nil unless i_year > 0 && i_month > 0 && i_day > 0
-
-          Date.new(i_year, i_month, i_day).to_s
-        end
-
         def response_info
           @response_info ||= create_response_info
         end
@@ -254,6 +243,12 @@ module DocAuth
           end
 
           new_metrics
+        end
+
+        def parse_date(year:, month:, day:)
+          if year.to_i.positive? && month.to_i.positive? && day.to_i.positive?
+            Date.new(year.to_i, month.to_i, day.to_i).to_s
+          end
         end
       end
     end

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -85,36 +85,41 @@ module DocAuth
 
         def pii_from_doc
           return {} unless true_id_product&.dig(:IDAUTH_FIELD_DATA).present?
-
           pii = {}
           PII_INCLUDES.each do |true_id_key, idp_key|
             pii[idp_key] = true_id_product[:IDAUTH_FIELD_DATA][true_id_key]
           end
-
           pii[:state_id_type] = DocAuth::Response::ID_TYPE_SLUGS[pii[:state_id_type]]
 
-          if pii[:dob_month] && pii[:dob_day] && pii[:dob_year]
-            pii[:dob] = Date.new(
-              pii.delete(:dob_year).to_i,
-              pii.delete(:dob_month).to_i,
-              pii.delete(:dob_day).to_i,
-            ).to_s
-          end
+          dob = parse_date(
+            year: pii.delete(:dob_year),
+            month: pii.delete(:dob_month),
+            day: pii.delete(:dob_day),
+          )
+          pii[:dob] = dob if dob
 
-          if pii[:state_id_expiration_month] &&
-             pii[:state_id_expiration_day] &&
-             pii[:state_id_expiration_year]
-            pii[:state_id_expiration] = Date.new(
-              pii.delete(:state_id_expiration_year).to_i,
-              pii.delete(:state_id_expiration_month).to_i,
-              pii.delete(:state_id_expiration_day).to_i,
-            ).to_s
-          end
+          exp_date = parse_date(
+            year: pii.delete(:state_id_expiration_year),
+            month: pii.delete(:state_id_expiration_month),
+            day: pii.delete(:state_id_expiration_day),
+          )
+          pii[:state_id_expiration] = exp_date if exp_date
 
           pii
         end
 
         private
+
+        def parse_date(year:, month:, day:)
+          return nil unless year && month && day
+
+          i_year = year.to_i
+          i_month = month.to_i
+          i_day = day.to_i
+          return nil unless i_year > 0 && i_month > 0 && i_day > 0
+
+          Date.new(i_year, i_month, i_day).to_s
+        end
 
         def response_info
           @response_info ||= create_response_info

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -48,16 +48,6 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     DocAuth::LexisNexis::Config.new
   end
 
-  context 'when the dob is incorrectly parsed' do
-    let(:response) { described_class.new(success_response, false, config) }
-    let(:bad_pii) { { dob_year: 'OCR', dob_month: 'failed', dob_day: 'to parse' } }
-
-    it 'does not throw an exception when getting pii from doc' do
-      allow(response).to receive(:pii).and_return(bad_pii)
-      expect { response.pii_from_doc }.not_to raise_error(Date::Error, 'invalid date')
-    end
-  end
-
   context 'when the response is a success' do
     let(:response) { described_class.new(success_response, false, config) }
 
@@ -283,6 +273,16 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       )
       expect(output[:exception]).to be_nil
       expect(output[:doc_auth_result]).to eq('Failed')
+    end
+  end
+
+  context 'when the dob is incorrectly parsed' do
+    let(:response) { described_class.new(success_response, false, config) }
+    let(:bad_pii) { { dob_year: 'OCR', dob_month: 'failed', dob_day: 'to parse' } }
+
+    it 'does not throw an exception when getting pii from doc' do
+      allow(response).to receive(:pii).and_return(bad_pii)
+      expect { response.pii_from_doc }.not_to raise_error
     end
   end
 end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     DocAuth::LexisNexis::Config.new
   end
 
+  context 'when the dob is incorrectly parsed' do
+    let(:response) { described_class.new(success_response, false, config) }
+    let(:bad_pii) { { dob_year: 'OCR', dob_month: 'failed', dob_day: 'to parse' } }
+
+    it 'does not throw an exception when getting pii from doc' do
+      allow(response).to receive(:pii).and_return(bad_pii)
+      expect { response.pii_from_doc }.not_to raise_error(Date::Error, 'invalid date')
+    end
+  end
+
   context 'when the response is a success' do
     let(:response) { described_class.new(success_response, false, config) }
 


### PR DESCRIPTION
In testing the TrueID interface, we noticed a 500 that appears to be due to some malformed dates coming back from LexisNexis. This PR ensures that the day, month and year all parse to integers greater than 0.