### PR TITLE
allow bootsnap in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'autoprefixer-rails', '~> 10.0'
 gem 'aws-sdk-kms', '~> 1.4'
 gem 'aws-sdk-ses', '~> 1.6'
 gem 'base32-crockford'
+gem 'bootsnap', '~> 1.9.0', require: false
 gem 'blueprinter', '~> 0.25.3'
 gem 'connection_pool'
 gem 'device_detector'
@@ -90,7 +91,6 @@ end
 
 group :development, :test do
   gem 'aws-sdk-cloudwatchlogs', require: false
-  gem 'bootsnap', '~> 1.9.0', require: false
   gem 'brakeman', require: false
   gem 'bullet', '>= 6.0.2'
   gem 'erb_lint', '~> 0.0.37', require: false

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -5,7 +5,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 begin
-  require 'bootsnap/setup' if ENV['RAILS_ENV'] != 'production' && ENV['ENABLE_BOOTSNAP'] != 'false'
+  require 'bootsnap/setup' if ENV['ENABLE_BOOTSNAP'] != 'false'
 rescue LoadError
   # bootsnap is only for dev/test
 end


### PR DESCRIPTION
This PR enables the ability to use Bootsnap in production. I have been testing this in my sandbox for a bit and haven't seen any ill effects. The primary benefit is we make multiple calls to rake tasks which load the Rails environment, and it becomes a lot faster after the first time with this change.