### PR TITLE
Convert bin/activate to rake task

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-load File.expand_path('../lib/deploy/activate.rb', File.dirname(__FILE__))
-
-Deploy::Activate.new.run

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -2,7 +2,7 @@
 
 # The defaults set in this file are used as the basis for configuration in all
 # production and development environments. On deployed EC2 servers, we run
-# bin/activate to generate the final application.yml using this file for
+# deploy/activate to generate the final application.yml using this file for
 # defaults and deep merging any overrides set in the application.yml from the
 # app secrets S3 bucket. Deployed EC2 servers always set RAILS_ENV=production,
 # so they will use values from top-level and from the production block.

--- a/deploy/activate
+++ b/deploy/activate
@@ -15,8 +15,7 @@ set -x
 id
 which bundle
 
-bundle exec bin/activate
-bundle exec rake db:check_for_pending_migrations
+bundle exec rake deploy:activate db:check_for_pending_migrations
 
 set +x
 

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -104,10 +104,6 @@ module Deploy
       @secrets_s3 ||= Identity::Hostdata.secrets_s3(s3_client: s3_client, logger: logger)
     end
 
-    def ec2_data
-      @ec2_data ||= Identity::Hostdata::EC2.load
-    end
-
     def default_logger
       logger = Logger.new(STDOUT)
       logger.progname = 'deploy/activate'

--- a/lib/tasks/activate.rake
+++ b/lib/tasks/activate.rake
@@ -1,0 +1,7 @@
+namespace :deploy do
+  desc 'Run activate script'
+  task activate: :environment do
+    require_relative '../deploy/activate'
+    Deploy::Activate.new.run
+  end
+end

--- a/lib/tasks/activate.rake
+++ b/lib/tasks/activate.rake
@@ -1,9 +1,9 @@
 namespace :deploy do
   desc 'Run activate script'
-  # rubocop:disable [Rails/EnvironmentRakeTask] or something
+  # rubocop:disable Rails/RakeEnvironment
   task :activate do
-  # rubocop:enable [Rails/EnvironmentRakeTask] or something
     require_relative '../deploy/activate'
     Deploy::Activate.new.run
   end
+  # rubocop:enable Rails/RakeEnvironment
 end

--- a/lib/tasks/activate.rake
+++ b/lib/tasks/activate.rake
@@ -1,6 +1,8 @@
 namespace :deploy do
   desc 'Run activate script'
-  task activate: :environment do
+  # rubocop:disable [Rails/EnvironmentRakeTask] or something
+  task :activate do
+  # rubocop:enable [Rails/EnvironmentRakeTask] or something
     require_relative '../deploy/activate'
     Deploy::Activate.new.run
   end


### PR DESCRIPTION
Most of our build setup scripts are implemented as rake tasks that are called from scripts, with the exception of `activate`. This moves activate into a rake task and combines it into a single `bundle exec rake` so the bundle only has to be exec-ed once.