### PR TITLE
Do not allow redirects via Referer to external hosts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ require:
   - rubocop-performance
   - ./lib/linters/url_options_linter.rb
   - ./lib/linters/localized_validation_message_linter.rb
+  - ./lib/linters/redirect_back_linter.rb
 
 AllCops:
   Exclude:
@@ -46,6 +47,9 @@ IdentityIdp/UrlOptionsLinter:
   Enabled: true
   Exclude:
     - 'spec/**/*.rb'
+
+IdentityIdp/RedirectBackLinter:
+  Enabled: true
 
 Layout/AccessModifierIndentation:
   Enabled: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,7 +221,7 @@ class ApplicationController < ActionController::Base
       user_signed_in: user_signed_in?,
     )
     flash[:error] = t('errors.invalid_authenticity_token')
-    redirect_back fallback_location: new_user_session_url
+    redirect_back fallback_location: new_user_session_url, allow_other_host: false
   end
 
   def user_fully_authenticated?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -100,7 +100,7 @@ module Users
       analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN, controller: controller_info)
       sign_out
       flash[:error] = t('errors.invalid_authenticity_token')
-      redirect_back fallback_location: new_user_session_url
+      redirect_back fallback_location: new_user_session_url, allow_other_host: false
     end
 
     def check_user_needs_redirect

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -105,7 +105,7 @@ module Users
         redirect_to_otp_verification_with_error
       else
         flash[:error] = telephony_error.friendly_message
-        redirect_back(fallback_location: account_url)
+        redirect_back(fallback_location: account_url, allow_other_host: false)
       end
     end
 

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -61,7 +61,7 @@ module Users
       return if params[:two_factor_options_form].present?
 
       flash[:error] = t('errors.two_factor_auth_setup.must_select_option')
-      redirect_back(fallback_location: two_factor_options_path)
+      redirect_back(fallback_location: two_factor_options_path, allow_other_host: false)
     end
 
     def confirm_user_needs_2fa_setup

--- a/lib/linters/redirect_back_linter.rb
+++ b/lib/linters/redirect_back_linter.rb
@@ -1,0 +1,51 @@
+module RuboCop
+  module Cop
+    module IdentityIdp
+      # This lint ensures `redirect_back` is called with
+      # the fallback_location option and allow_other_host set to false.
+      # This is to prevent open redirects via the Referer header.
+      #
+      # @example
+      #   #bad
+      #   redirect_back
+      #   redirect_back '/'
+      #   redirect_back allow_other_host: false
+      #
+      #   #good
+      #   redirect_back fallback_location: '/', allow_other_host: false
+      #
+      class RedirectBackLinter < RuboCop::Cop::Cop
+        MSG = 'Please set a fallback_location and the allow_other_host parameter to false'.freeze
+
+        RESTRICT_ON_SEND = [:redirect_back]
+
+        def_node_matcher :redirect_back_matcher, <<~PATTERN
+          (send nil? :redirect_back $...)
+        PATTERN
+
+        def on_send(node)
+          add_offense(node, location: :expression) && return if node.arguments.empty?
+
+          sets_fallback_location, sets_allow_other_host_false = false
+          redirect_back_matcher(node) do |arguments|
+            arguments.first.pairs.each do |pair|
+              if pair.key.sym_type? && pair.key.source == 'fallback_location' &&
+                 !pair.value.source.nil?
+                sets_fallback_location = true
+              end
+
+              if pair.key.sym_type? && pair.key.source == 'allow_other_host' &&
+                 pair.value.false_type?
+                sets_allow_other_host_false = true
+              end
+            end
+          end
+
+          return if sets_fallback_location && sets_allow_other_host_false
+
+          add_offense(node, location: :expression)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -101,14 +101,24 @@ describe ApplicationController do
       expect(subject.current_user).to be_present
     end
 
-    it 'redirects back to referer if present' do
-      referer = 'http://example.com/sign_up/enter_email?request_id=123'
+    it 'redirects back to referer if present and is not external' do
+      referer = login_piv_cac_url
 
       request.env['HTTP_REFERER'] = referer
 
       get :index
 
       expect(response).to redirect_to(referer)
+    end
+
+    it 'redirects back to home page if present and referer is external' do
+      referer = 'http://testing.example.com'
+
+      request.env['HTTP_REFERER'] = referer
+
+      get :index
+
+      expect(response).to redirect_to(new_user_session_url)
     end
   end
 

--- a/spec/lib/linters/redirect_back_linter_spec.rb
+++ b/spec/lib/linters/redirect_back_linter_spec.rb
@@ -1,0 +1,38 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../lib/linters/redirect_back_linter'
+
+describe RuboCop::Cop::IdentityIdp::RedirectBackLinter do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:config) { RuboCop::Config.new }
+  let(:cop) { RuboCop::Cop::IdentityIdp::RedirectBackLinter.new(config) }
+
+  it 'registers offenses when calling redirect_back with no arguments' do
+    expect_offense(<<~RUBY)
+      redirect_back
+      ^^^^^^^^^^^^^ Please set a fallback_location and the allow_other_host parameter to false
+    RUBY
+  end
+
+  it 'registers offenses when calling redirect_back with only fallback location' do
+    expect_offense(<<~RUBY)
+      redirect_back fallback_location: '/'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please set a fallback_location and the allow_other_host parameter to false
+    RUBY
+  end
+
+  it 'registers offenses when calling redirect_back with only allow_other_host set to false' do
+    expect_offense(<<~RUBY)
+      redirect_back allow_other_host: false
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please set a fallback_location and the allow_other_host parameter to false
+    RUBY
+  end
+
+  it 'registers no offense when including Rails url_helpers and defining url_options' do
+    expect_no_offenses(<<~RUBY)
+      redirect_back fallback_location: '/', allow_other_host: false
+    RUBY
+  end
+end


### PR DESCRIPTION
This changeset was deployed earlier today to patch the vulnerability before disclosing it.

Previously, an attacker could redirect users to malicious external sites by rewriting the Referer header during the request/response cycle. These changes prevent redirects to external sites and falling back to a specified page (usually root) if it is attempted.

`redirect_back` uses the Referer header to redirect back to the previous page, but Rails does not yet support globally preventing external host redirects, so I've also added a Rubocop that will fail if we try to do a `redirect_back` without disabling external hosts and including a fallback location.