### PR TITLE
LG-4935: Add alt text to selfie image

### DIFF
--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -189,9 +189,17 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
               </button>
             </div>
             {value instanceof window.Blob ? (
-              <FileImage file={value} alt={t('doc_auth.accessible_labels.selfie_alt_text')} className="selfie-capture__preview-image" />
+              <FileImage
+                file={value}
+                alt={t('doc_auth.accessible_labels.selfie_alt_text')}
+                className="selfie-capture__preview-image"
+              />
             ) : (
-              <img src={value} alt={t('doc_auth.accessible_labels.selfie_alt_text')} className="selfie-capture__preview-image" />
+              <img
+                src={value}
+                alt={t('doc_auth.accessible_labels.selfie_alt_text')}
+                className="selfie-capture__preview-image"
+              />
             )}
           </>
         ) : (

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -189,9 +189,9 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
               </button>
             </div>
             {value instanceof window.Blob ? (
-              <FileImage file={value} alt="" className="selfie-capture__preview-image" />
+              <FileImage file={value} alt={t('doc_auth.accessible_labels.selfie_alt_text')} className="selfie-capture__preview-image" />
             ) : (
-              <img src={value} alt="" className="selfie-capture__preview-image" />
+              <img src={value} alt={t('doc_auth.accessible_labels.selfie_alt_text')} className="selfie-capture__preview-image" />
             )}
           </>
         ) : (

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -5,6 +5,7 @@ en:
       camera_video_capture_instructions: We will automatically take the picture
       camera_video_capture_label: Viewfinder with frame to center your ID
       document_capture_dialog: Document capture
+      selfie_alt_text: Your uploaded image
       status_align: Align document in frame
       status_capturing: Taking photo in three seconds
       status_move_closer: Move camera closer to document

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -5,7 +5,7 @@ en:
       camera_video_capture_instructions: We will automatically take the picture
       camera_video_capture_label: Viewfinder with frame to center your ID
       document_capture_dialog: Document capture
-      selfie_alt_text: Your uploaded image
+      selfie_alt_text: An uploaded image
       status_align: Align document in frame
       status_capturing: Taking photo in three seconds
       status_move_closer: Move camera closer to document

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -5,7 +5,7 @@ es:
       camera_video_capture_instructions: Tomaremos la foto automáticamente
       camera_video_capture_label: Visor con encuadre para centrar tu documento
       document_capture_dialog: Captura del documento
-      selfie_alt_text: Your uploaded image
+      selfie_alt_text: Una foto subida
       status_align: Alinea el documento dentro del encuadre
       status_capturing: La foto se tomará en tres segundos
       status_move_closer: Acerca la cámara al documento

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -5,6 +5,7 @@ es:
       camera_video_capture_instructions: Tomaremos la foto automáticamente
       camera_video_capture_label: Visor con encuadre para centrar tu documento
       document_capture_dialog: Captura del documento
+      selfie_alt_text: Your uploaded image
       status_align: Alinea el documento dentro del encuadre
       status_capturing: La foto se tomará en tres segundos
       status_move_closer: Acerca la cámara al documento

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -5,7 +5,7 @@ fr:
       camera_video_capture_instructions: Nous prendrons automatiquement la photo
       camera_video_capture_label: Viseur avec cadre pour centrer votre pièce d'identité
       document_capture_dialog: Capture du document
-      selfie_alt_text: Your uploaded image
+      selfie_alt_text: Une photo téléversée
       status_align: Alignez le document dans le cadre
       status_capturing: Prise de photo en trois secondes
       status_move_closer: Rapprochez l'appareil photo du document

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -5,6 +5,7 @@ fr:
       camera_video_capture_instructions: Nous prendrons automatiquement la photo
       camera_video_capture_label: Viseur avec cadre pour centrer votre pièce d'identité
       document_capture_dialog: Capture du document
+      selfie_alt_text: Your uploaded image
       status_align: Alignez le document dans le cadre
       status_capturing: Prise de photo en trois secondes
       status_move_closer: Rapprochez l'appareil photo du document


### PR DESCRIPTION
This PR adds alt text to the user's selfie image

**Why**: The selfie is a meaningful image and should have an alt text associated with it so that the user knows what it is.