### PR TITLE
Account Header: Add height attribute to logo image

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,7 +11,6 @@ linters:
       - '*/app/views/accounts/_connected_app.html.erb'
       - '*/app/views/accounts/_emails.html.erb'
       - '*/app/views/accounts/_identity_item.html.erb'
-      - '*/app/views/accounts/_nav_auth.html.erb'
       - '*/app/views/accounts/_password_reset.html.erb'
       - '*/app/views/accounts/_pending_profile_bounced_gpo.html.erb'
       - '*/app/views/accounts/_pending_profile_gpo.html.erb'

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -2,15 +2,16 @@
   <div class="container tablet:padding-x-2 tablet:padding-y-4">
     <div class="clearfix">
       <div class="margin-y-105 margin-left-2 tablet:margin-0 col col-4">
-        <%= link_to root_path do %>
-          <%= image_tag(
+        <%= link_to(
+              image_tag(
                 asset_url('logo.svg'),
                 alt: APP_NAME,
                 class: 'text-bottom',
                 width: 170,
                 height: 23,
-              ) %>
-        <% end %>
+              ),
+              root_path,
+            ) %>
       </div>
       <div class="col col-8 padding-right-1 display-none desktop:display-flex flex-justify-end">
         <div class="margin-right-1 truncate-inline">

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -2,10 +2,15 @@
   <div class="container tablet:padding-x-2 tablet:padding-y-4">
     <div class="clearfix">
       <div class="margin-y-105 margin-left-2 tablet:margin-0 col col-4">
-        <%= link_to image_tag(asset_url('logo.svg'),
-                              alt: APP_NAME,
-                              class: 'text-bottom',
-                              width: 170), root_path %>
+        <%= link_to root_path do %>
+          <%= image_tag(
+                asset_url('logo.svg'),
+                alt: APP_NAME,
+                class: 'text-bottom',
+                width: 170,
+                height: 23,
+              ) %>
+        <% end %>
       </div>
       <div class="col col-8 padding-right-1 display-none desktop:display-flex flex-justify-end">
         <div class="margin-right-1 truncate-inline">


### PR DESCRIPTION
**Why**: To fix visual appearance in IE11 due to SVG scaling.

Before|After
---|---
![Screen Shot 2021-09-28 at 2 42 33 PM](https://user-images.githubusercontent.com/1779930/135155990-76a349a7-8c2f-47c7-8c13-569db233b714.png)|![Screen Shot 2021-09-28 at 2 42 56 PM](https://user-images.githubusercontent.com/1779930/135155995-4b1c70e4-a9b2-431d-8c23-4168cec5f63f.png)
