### PR TITLE
Update GpoDailyTestSender to warn, not error when missing configs

### DIFF
--- a/app/services/gpo_daily_test_sender.rb
+++ b/app/services/gpo_daily_test_sender.rb
@@ -3,7 +3,7 @@ class GpoDailyTestSender
   def run
     if valid_designated_receiver_pii?
       GpoConfirmationMaker.new(
-        pii: designated_receiver_pii,
+        pii: IdentityConfig.store.gpo_designated_receiver_pii,
         issuer: nil,
         profile_id: -1, # profile_id can't be null on GpoConfirmationCode
         otp: otp_from_date,
@@ -25,14 +25,9 @@ class GpoDailyTestSender
     date.strftime('%b%d_%Y').upcase
   end
 
-  # @return [Hash]
-  def designated_receiver_pii
-    @designated_receiver_pii ||= (IdentityConfig.store.gpo_designated_receiver_pii || {})
-  end
-
   def valid_designated_receiver_pii?
     %i[first_name last_name address1 city state zipcode].all? do |key|
-      designated_receiver_pii[key].present?
+      IdentityConfig.store.gpo_designated_receiver_pii[key].present?
     end
   end
 end

--- a/app/services/gpo_daily_test_sender.rb
+++ b/app/services/gpo_daily_test_sender.rb
@@ -9,10 +9,13 @@ class GpoDailyTestSender
         otp: otp_from_date,
       ).perform
     else
-      raise 'missing valid designated receiver pii'
+      Rails.logger.warn(
+        {
+          source: 'GpoDailyTestSender',
+          message: 'missing valid designated receiver pii, not enqueueing a test sender',
+        }.to_json,
+      )
     end
-  rescue => err
-    NewRelic::Agent.notice_error(err)
   end
 
   # @return [String] 10-digit OTP from the date
@@ -24,7 +27,7 @@ class GpoDailyTestSender
 
   # @return [Hash]
   def designated_receiver_pii
-    @designated_receiver_pii ||= IdentityConfig.store.gpo_designated_receiver_pii
+    @designated_receiver_pii ||= (IdentityConfig.store.gpo_designated_receiver_pii || {})
   end
 
   def valid_designated_receiver_pii?

--- a/spec/services/gpo_daily_test_sender_spec.rb
+++ b/spec/services/gpo_daily_test_sender_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GpoDailyTestSender do
     end
 
     context 'when attempting handle the designated reciver renders an error' do
-      let(:designated_receiver_pii) { nil }
+      let(:designated_receiver_pii) { {} }
 
       it 'does not create gpo records' do
         expect { sender.run }.
@@ -50,12 +50,6 @@ RSpec.describe GpoDailyTestSender do
 
         expect { sender.run }.to_not raise_error
       end
-    end
-  end
-
-  describe '#designated_receiver_pii' do
-    it 'parses PII from the application config' do
-      expect(sender.designated_receiver_pii).to eq(designated_receiver_pii)
     end
   end
 


### PR DESCRIPTION
**Why**: Remove useless exceptions in lower envs