### PR TITLE
LG-4991: Improve phone OTP disabling behavior

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -49,7 +49,7 @@ module TwoFactorAuthentication
       return if capabilities.supports_voice?
 
       flash[:error] = t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: capabilities.unsupported_location,
       )
       redirect_to login_two_factor_url(otp_delivery_preference: 'sms', reauthn: reauthn?)

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -57,6 +57,14 @@ function setHintText(
 }
 
 /**
+ * Returns true if all inputs are disabled, or false otherwise.
+ *
+ * @param {HTMLInputElement[]} inputs
+ * @return {boolean}
+ */
+const isAllDisabled = (inputs) => inputs.every((input) => input.disabled);
+
+/**
  * Returns the next non-disabled input in the set of inputs, if one exists.
  *
  * @param {HTMLInputElement[]} inputs
@@ -86,6 +94,14 @@ const updateOTPDeliveryMethods = () => {
       }
     }
   });
+
+  if (isAllDisabled(methods)) {
+    const location = selectedInternationCodeOption().dataset.countryName;
+    const hintText = I18n.t(
+      'two_factor_authentication.otp_delivery_preference.no_supported_options',
+    ).replace('%{location}', location);
+    setHintText(hintText);
+  }
 };
 
 const internationalCodeFromPhone = (phone) => {

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -68,17 +68,15 @@ const isAllDisabled = (inputs) => inputs.every((input) => input.disabled);
  * Returns the next non-disabled input in the set of inputs, if one exists.
  *
  * @param {HTMLInputElement[]} inputs
- * @param {number} index
  * @return {HTMLInputElement=}
  */
-const getNextEnabledInput = (inputs, index) =>
-  [...inputs.slice(index + 1), ...inputs.slice(0, index)].find((input) => !input.disabled);
+const getFirstEnabledInput = (inputs) => inputs.find((input) => !input.disabled);
 
 const updateOTPDeliveryMethods = () => {
   const methods = getOTPDeliveryMethods();
   setHintText();
 
-  methods.forEach((method, index) => {
+  methods.forEach((method) => {
     const delivery = method.value;
     const isSupported = isDeliveryOptionSupported(delivery);
     method.disabled = !isSupported;
@@ -87,7 +85,7 @@ const updateOTPDeliveryMethods = () => {
 
       if (method.checked) {
         method.checked = false;
-        const nextEnabledInput = getNextEnabledInput(methods, index);
+        const nextEnabledInput = getFirstEnabledInput(methods);
         if (nextEnabledInput) {
           nextEnabledInput.checked = true;
         }

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -10,39 +10,82 @@ const selectedInternationCodeOption = () => {
   return /** @type {HTMLOptionElement} */ (dropdown.item(dropdown.selectedIndex));
 };
 
+/**
+ * @return {HTMLInputElement[]}
+ */
+const getOTPDeliveryMethods = () =>
+  Array.from(document.querySelectorAll('.js-otp-delivery-preference'));
+
+/**
+ * Returns true if the delivery option is valid for the selected option, or false otherwise.
+ *
+ * @param {string} delivery
+ * @return {boolean}
+ */
+const isDeliveryOptionSupported = (delivery) =>
+  selectedInternationCodeOption().getAttribute(`data-supports-${delivery}`) !== 'false';
+
+/**
+ * @param {string} delivery
+ * @return {string=}
+ */
+function getHintTextForDisabledDeliveryOption(delivery) {
+  // i18n-tasks-use t('two_factor_authentication.otp_delivery_preference.voice_unsupported')
+  // i18n-tasks-use t('two_factor_authentication.otp_delivery_preference.sms_unsupported')
+  let hintText = I18n.t(
+    `two_factor_authentication.otp_delivery_preference.${delivery}_unsupported`,
+  );
+
+  if (hintText) {
+    const location = selectedInternationCodeOption().dataset.countryName;
+    hintText = hintText.replace('%{location}', location);
+  }
+
+  return hintText;
+}
+
+/**
+ * @param {string=} hintText
+ */
+function setHintText(
+  hintText = I18n.t('two_factor_authentication.otp_delivery_preference.instruction'),
+) {
+  const hintElement = document.querySelector('#otp_delivery_preference_instruction');
+  if (hintElement) {
+    hintElement.textContent = hintText;
+  }
+}
+
+/**
+ * Returns the next non-disabled input in the set of inputs, if one exists.
+ *
+ * @param {HTMLInputElement[]} inputs
+ * @param {number} index
+ * @return {HTMLInputElement=}
+ */
+const getNextEnabledInput = (inputs, index) =>
+  [...inputs.slice(index + 1), ...inputs.slice(0, index)].find((input) => !input.disabled);
+
 const updateOTPDeliveryMethods = () => {
-  const phoneRadio = /** @type {HTMLInputElement?} */ (document.querySelector(
-    '[data-international-phone-form] .otp_delivery_preference_voice',
-  ));
-  const smsRadio = /** @type {HTMLInputElement?} */ (document.querySelector(
-    '[data-international-phone-form] .otp_delivery_preference_sms',
-  ));
+  const methods = getOTPDeliveryMethods();
+  setHintText();
 
-  if (!(phoneRadio && smsRadio)) {
-    return;
-  }
+  methods.forEach((method, index) => {
+    const delivery = method.value;
+    const isSupported = isDeliveryOptionSupported(delivery);
+    method.disabled = !isSupported;
+    if (!isSupported) {
+      setHintText(getHintTextForDisabledDeliveryOption(delivery));
 
-  const deliveryMethodHint = /** @type {HTMLElement} */ (document.querySelector(
-    '#otp_delivery_preference_instruction',
-  ));
-  const selectedOption = selectedInternationCodeOption();
-
-  const supportsSms = selectedOption.dataset.supportsSms === 'true';
-  const supportsVoice = selectedOption.dataset.supportsVoice === 'true';
-
-  smsRadio.disabled = !supportsSms;
-  phoneRadio.disabled = !supportsVoice;
-
-  if (supportsVoice) {
-    deliveryMethodHint.innerText = I18n.t(
-      'two_factor_authentication.otp_delivery_preference.instruction',
-    );
-  } else {
-    smsRadio.click();
-    deliveryMethodHint.innerText = I18n.t(
-      'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-    ).replace('%{location}', selectedOption.dataset.countryName);
-  }
+      if (method.checked) {
+        method.checked = false;
+        const nextEnabledInput = getNextEnabledInput(methods, index);
+        if (nextEnabledInput) {
+          nextEnabledInput.checked = true;
+        }
+      }
+    }
+  });
 };
 
 const internationalCodeFromPhone = (phone) => {

--- a/app/validators/otp_delivery_preference_validator.rb
+++ b/app/validators/otp_delivery_preference_validator.rb
@@ -25,7 +25,7 @@ module OtpDeliveryPreferenceValidator
     errors.add(
       :phone,
       I18n.t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: phone_number_capabilities.unsupported_location,
       ),
     )

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -28,7 +28,7 @@
           'otp_delivery_preference',
           :sms,
           false,
-          class: 'otp_delivery_preference_sms usa-radio__input usa-radio__input--tile',
+          class: 'usa-radio__input usa-radio__input--tile',
         ) %>
     <label for="otp_delivery_preference_sms" class="usa-radio__label">
       <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
@@ -41,7 +41,7 @@
           'otp_delivery_preference',
           :voice,
           false,
-          class: 'otp_delivery_preference_voice usa-radio__input usa-radio__input--tile',
+          class: 'usa-radio__input usa-radio__input--tile',
         ) %>
     <label for="otp_delivery_preference_voice" class="usa-radio__label">
       <%= t('two_factor_authentication.otp_delivery_preference.voice') %>

--- a/app/views/users/edit_phone/_delivery_preference_selection.html.erb
+++ b/app/views/users/edit_phone/_delivery_preference_selection.html.erb
@@ -12,7 +12,7 @@
               'edit_phone_form[delivery_preference]',
               :sms,
               @edit_phone_form.delivery_preference_sms?,
-              class: 'otp_delivery_preference_sms usa-radio__input usa-radio__input--bordered',
+              class: 'usa-radio__input usa-radio__input--bordered',
             ) %>
         <label
           class="usa-radio__label width-full"
@@ -22,7 +22,7 @@
               'edit_phone_form[delivery_preference]',
               :voice,
               @edit_phone_form.delivery_preference_voice?,
-              class: 'otp_delivery_preference_voice usa-radio__input usa-radio__input--bordered',
+              class: 'usa-radio__input usa-radio__input--bordered',
             ) %>
         <label
           class="usa-radio__label"

--- a/app/views/users/shared/_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.erb
@@ -19,7 +19,7 @@
               form_name_label,
               :sms,
               form_obj.delivery_preference_sms?,
-              class: 'otp_delivery_preference_sms usa-radio__input usa-radio__input--bordered',
+              class: 'js-otp-delivery-preference usa-radio__input usa-radio__input--bordered',
             ) %>
         <label class="usa-radio__label width-full" for="<%= form_name_tag_sms %>">
           <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
@@ -30,7 +30,7 @@
               form_name_label,
               :voice,
               form_obj.delivery_preference_voice?,
-              class: 'otp_delivery_preference_voice usa-radio__input usa-radio__input--bordered',
+              class: 'js-otp-delivery-preference usa-radio__input usa-radio__input--bordered',
             ) %>
         <label class="usa-radio__label width-full" for="<%= form_name_tag_voice %>">
           <%= t('two_factor_authentication.otp_delivery_preference.voice') %>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -85,10 +85,11 @@ en:
     otp_delivery_preference:
       instruction: You can change this selection the next time you sign in. If you
         entered a landline, please select “Phone call” below.
-      phone_unsupported: We’re unable to make phone calls to people in %{location} at this time.
       sms: Text message (SMS)
+      sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: How should we send you a code?
       voice: Phone call
+      voice_unsupported: We’re unable to make phone calls to people in %{location} at this time.
     otp_make_default_number:
       instruction: Please check the box below if you want this to be the default phone
         number you receive text messages or phone calls.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -85,6 +85,7 @@ en:
     otp_delivery_preference:
       instruction: You can change this selection the next time you sign in. If you
         entered a landline, please select “Phone call” below.
+      no_supported_options: We’re unable to verify phone numbers from %{location} at this time.
       sms: Text message (SMS)
       sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: How should we send you a code?

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -91,6 +91,7 @@ es:
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     otp_delivery_preference:
       instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
+      no_supported_options: We’re unable to verify phone numbers from %{location} at this time.
       sms: Mensaje de texto (SMS, sigla en inglés)
       sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: '¿Cómo deberíamos enviarle un código?'

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -91,10 +91,11 @@ es:
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     otp_delivery_preference:
       instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
-      phone_unsupported: En este momento no podemos realizar llamadas a personas en %{location}.
       sms: Mensaje de texto (SMS, sigla en inglés)
+      sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: '¿Cómo deberíamos enviarle un código?'
       voice: Llamada telefónica
+      voice_unsupported: En este momento no podemos realizar llamadas a personas en %{location}.
     otp_make_default_number:
       instruction: Marque la casilla a continuación si desea que este sea el teléfono
         predeterminado número que recibe mensajes de texto o llamadas

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -91,12 +91,15 @@ es:
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     otp_delivery_preference:
       instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
-      no_supported_options: We’re unable to verify phone numbers from %{location} at this time.
+      no_supported_options: En estos momentos no podemos verificar números telefónicos
+        a personas de %{location}.
       sms: Mensaje de texto (SMS, sigla en inglés)
-      sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
+      sms_unsupported: En estos momentos no podemos enviar mensajes de texto a
+        personas de %{location}.
       title: '¿Cómo deberíamos enviarle un código?'
       voice: Llamada telefónica
-      voice_unsupported: En este momento no podemos realizar llamadas a personas en %{location}.
+      voice_unsupported: En estos momentos no podemos realizar llamadas telefónicas a
+        personas de %{location}.
     otp_make_default_number:
       instruction: Marque la casilla a continuación si desea que este sea el teléfono
         predeterminado número que recibe mensajes de texto o llamadas

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -91,11 +91,12 @@ fr:
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
-      phone_unsupported: Nous ne sommes pas en mesure de passer des appels
-        téléphoniques aux personnes situées à %{location} pour le moment.
       sms: Message texte (SMS)
+      sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: Comment devrions-nous vous envoyer un code?
       voice: Appel téléphonique
+      voice_unsupported: Nous ne sommes pas en mesure de passer des appels
+        téléphoniques aux personnes situées à %{location} pour le moment.
     otp_make_default_number:
       instruction: Veuillez cocher la case ci-dessous si vous voulez que ce soit le
         téléphone par défaut. numéro que vous recevez des messages texte ou des

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -91,13 +91,15 @@ fr:
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
-      no_supported_options: We’re unable to verify phone numbers from %{location} at this time.
+      no_supported_options: Nous ne sommes pas en mesure de vérifier les numéros de
+        téléphone de %{location} pour le moment.
       sms: Message texte (SMS)
-      sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
+      sms_unsupported: Nous ne sommes pas en mesure d’envoyer des SMS aux personnes se
+        trouvant en %{location} pour le moment.
       title: Comment devrions-nous vous envoyer un code?
       voice: Appel téléphonique
       voice_unsupported: Nous ne sommes pas en mesure de passer des appels
-        téléphoniques aux personnes situées à %{location} pour le moment.
+        téléphoniques aux personnes se trouvant en %{location} pour le moment.
     otp_make_default_number:
       instruction: Veuillez cocher la case ci-dessous si vous voulez que ce soit le
         téléphone par défaut. numéro que vous recevez des messages texte ou des

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -91,6 +91,7 @@ fr:
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
+      no_supported_options: We’re unable to verify phone numbers from %{location} at this time.
       sms: Message texte (SMS)
       sms_unsupported: We’re unable to send text messages to people in %{location} at this time.
       title: Comment devrions-nous vous envoyer un code?

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -44,13 +44,13 @@ describe Users::PhoneSetupController do
         errors: {
           phone: [
             t('errors.messages.improbable_phone'),
-            t('two_factor_authentication.otp_delivery_preference.phone_unsupported', location: ''),
+            t('two_factor_authentication.otp_delivery_preference.voice_unsupported', location: ''),
           ],
         },
         error_details: {
           phone: [
             :improbable_phone,
-            t('two_factor_authentication.otp_delivery_preference.phone_unsupported', location: ''),
+            t('two_factor_authentication.otp_delivery_preference.voice_unsupported', location: ''),
           ],
         },
         otp_delivery_preference: 'sms',

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -49,7 +49,7 @@ feature 'Two Factor Authentication' do
 
         expect(current_path).to eq phone_setup_path
         expect(page).to have_content t(
-          'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+          'two_factor_authentication.otp_delivery_preference.voice_unsupported',
           location: 'Bahamas',
         )
 
@@ -78,6 +78,64 @@ feature 'Two Factor Authentication' do
         expect(page.find('#new_phone_form_international_code', visible: false).value).to eq 'JP'
       end
 
+      scenario 'updates enabled delivery options based on deliverability to the country', :js do
+        sign_in_before_2fa
+        select_2fa_option(:phone)
+
+        option_with_none_disabled = page.find('.international-code > :nth-child(1)', visible: :all)
+        option_with_none_disabled.execute_script('this.dataset.supportsVoice = "true"')
+        option_with_none_disabled.execute_script('this.dataset.supportsSms = "true"')
+        option_with_disabled_voice = page.find('.international-code > :nth-child(2)', visible: :all)
+        option_with_disabled_voice.execute_script('this.dataset.supportsVoice = "false"')
+        option_with_disabled_voice.execute_script('this.dataset.supportsSms = "true"')
+        option_with_disabled_sms = page.find('.international-code > :nth-child(3)', visible: :all)
+        option_with_disabled_sms.execute_script('this.dataset.supportsVoice = "true"')
+        option_with_disabled_sms.execute_script('this.dataset.supportsSms = "false"')
+        option_with_all_disabled = page.find('.international-code > :nth-child(4)', visible: :all)
+        option_with_all_disabled.execute_script('this.dataset.supportsVoice = "false"')
+        option_with_all_disabled.execute_script('this.dataset.supportsSms = "false"')
+
+        sms_radio = page.find('.js-otp-delivery-preference[value="sms"]', visible: :all)
+        voice_radio = page.find('.js-otp-delivery-preference[value="voice"]', visible: :all)
+
+        expect(sms_radio).to match_css(':checked')
+
+        select_country_and_type_phone_number(country: option_with_disabled_sms['value'].downcase)
+        expect(page).to have_content(
+          t(
+            'two_factor_authentication.otp_delivery_preference.sms_unsupported',
+            location: option_with_disabled_sms['data-country-name'],
+          ),
+        )
+        expect(sms_radio).not_to match_css(':checked')
+        expect(voice_radio).to match_css(':checked')
+
+        select_country_and_type_phone_number(country: option_with_disabled_voice['value'].downcase)
+        expect(page).to have_content(
+          t(
+            'two_factor_authentication.otp_delivery_preference.voice_unsupported',
+            location: option_with_disabled_voice['data-country-name'],
+          ),
+        )
+        expect(sms_radio).to match_css(':checked')
+        expect(voice_radio).not_to match_css(':checked')
+
+        select_country_and_type_phone_number(country: option_with_all_disabled['value'].downcase)
+        expect(page).to have_content(
+          t(
+            'two_factor_authentication.otp_delivery_preference.voice_unsupported',
+            location: option_with_all_disabled['data-country-name'],
+          ),
+        )
+        expect(sms_radio).not_to match_css(':checked')
+        expect(voice_radio).not_to match_css(':checked')
+
+        select_country_and_type_phone_number(country: option_with_none_disabled['value'].downcase)
+        expect(page).to have_content(
+          t('two_factor_authentication.otp_delivery_preference.instruction'),
+        )
+      end
+
       scenario 'allows a user to continue typing even if a number is invalid', :js do
         sign_in_before_2fa
         select_2fa_option(:phone)
@@ -100,7 +158,7 @@ feature 'Two Factor Authentication' do
     find('#new_phone_form_phone')
   end
 
-  def select_country_and_type_phone_number(country:, number:)
+  def select_country_and_type_phone_number(country:, number: '')
     find('.iti__flag').click
     find(".iti__country[data-country-code='#{country}']").click
     phone_field.send_keys(number)

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -123,7 +123,7 @@ feature 'Two Factor Authentication' do
         select_country_and_type_phone_number(country: option_with_all_disabled['value'].downcase)
         expect(page).to have_content(
           t(
-            'two_factor_authentication.otp_delivery_preference.voice_unsupported',
+            'two_factor_authentication.otp_delivery_preference.no_supported_options',
             location: option_with_all_disabled['data-country-name'],
           ),
         )

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -559,7 +559,7 @@ feature 'Sign in' do
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: 'Australia',
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
@@ -577,7 +577,7 @@ feature 'Sign in' do
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: 'Algeria',
       )
       expect(user.reload.otp_delivery_preference).to eq 'voice'
@@ -602,7 +602,7 @@ feature 'Sign in' do
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
@@ -625,7 +625,7 @@ feature 'Sign in' do
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
       expect(page).to have_content t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
@@ -648,7 +648,7 @@ feature 'Sign in' do
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
-        'two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        'two_factor_authentication.otp_delivery_preference.voice_unsupported',
         location: unsupported_country_name,
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'


### PR DESCRIPTION
**Why**:

- So that we consistently show a hint text for both situations of SMS or Voice being unavailable in a country.
- So that if the selected option is disabled after changing countries, the other option becomes selected as long as it is not also disabled.

**Testing Instructions:**

1. Log in
2. Click "Add a phone number" in the account dashboard sidebar
3. Observe: Both options are enabled, SMS is selected
4. Change country to Vietnam
5. Observe: SMS is disabled, Voice is now the selected option, hint text indicates SMS unavailable to Vietnam.
6. Change country to Canada
7. Observe: Voice is disabled, SMS Is now the selected option, hint text indicates Voice unavailable to Canada.
8. Change country to Algeria
9. Observe: Both options are disabled, neither is selected, hint text indicates one or the other being disabled (pending [verbiage feedback](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1632920875022700)).