### PR TITLE
LG-5142: remove tiff, bmp as options for document upload

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -484,7 +484,7 @@ function AcuantCapture(
         bannerText={bannerText}
         invalidTypeText={t('doc_auth.errors.file_type.invalid')}
         fileUpdatedText={t('doc_auth.info.image_updated')}
-        accept={isMockClient ? undefined : ['image/jpeg', 'image/png', 'image/bmp', 'image/tiff']}
+        accept={isMockClient ? undefined : ['image/jpeg', 'image/png', 'image/bmp']}
         capture={capture}
         value={value}
         errorMessage={ownErrorMessage ?? errorMessage}

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -484,7 +484,7 @@ function AcuantCapture(
         bannerText={bannerText}
         invalidTypeText={t('doc_auth.errors.file_type.invalid')}
         fileUpdatedText={t('doc_auth.info.image_updated')}
-        accept={isMockClient ? undefined : ['image/jpeg', 'image/png', 'image/bmp']}
+        accept={isMockClient ? undefined : ['image/jpeg', 'image/png']}
         capture={capture}
         value={value}
         errorMessage={ownErrorMessage ?? errorMessage}

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -65,7 +65,7 @@ en:
           your ID is too small or blurry in the photos. Make sure your ID is
           large within the image frame and try taking new pictures.
       file_type:
-        invalid: This file type is not accepted, please choose a JPG, PNG, or BMP file.
+        invalid: This file type is not accepted, please choose a JPG or PNG file.
       general:
         liveness: We couldn’t verify your ID and photo of yourself. Try taking new
           pictures.
@@ -231,7 +231,7 @@ en:
       welcome: 'To verify your identity, you will need:'
     tips:
       document_capture_header_text: 'For best results:'
-      document_capture_hint: Must be a JPG, PNG, or BMP
+      document_capture_hint: Must be a JPG or PNG
       document_capture_id_text1: Use a dark background
       document_capture_id_text2: Take the photo on a flat surface
       document_capture_id_text3: Do not use the flash on your camera

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -65,8 +65,7 @@ en:
           your ID is too small or blurry in the photos. Make sure your ID is
           large within the image frame and try taking new pictures.
       file_type:
-        invalid: This file type is not accepted, please choose a JPG, PNG, BMP, or TIFF
-          file.
+        invalid: This file type is not accepted, please choose a JPG, PNG, or BMP file.
       general:
         liveness: We couldn’t verify your ID and photo of yourself. Try taking new
           pictures.
@@ -232,7 +231,7 @@ en:
       welcome: 'To verify your identity, you will need:'
     tips:
       document_capture_header_text: 'For best results:'
-      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
+      document_capture_hint: Must be a JPG, PNG, or BMP
       document_capture_id_text1: Use a dark background
       document_capture_id_text2: Take the photo on a flat surface
       document_capture_id_text3: Do not use the flash on your camera

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -80,8 +80,7 @@ es:
           identificación ocupe un gran espacio dentro del marco de la imagen e
           intente tomar nuevas fotos.
       file_type:
-        invalid: Ese formato no es admitido, por favor elija un archivo JPG, PNG, BMP, o
-          TIFF.
+        invalid: Ese formato no es admitido, por favor elija un archivo JPG, PNG, o BMP.
       general:
         liveness: No pudimos verificar su documento de identidad y su foto. Intente
           tomar nuevas fotografías.
@@ -269,7 +268,7 @@ es:
       welcome: 'Deberá contar con lo siguiente para verificar su identidad:'
     tips:
       document_capture_header_text: 'Para obtener los mejores resultados:'
-      document_capture_hint: Debe ser un JPG, BMP, PNG o TIFF
+      document_capture_hint: Debe ser un JPG, PNG, o BMP
       document_capture_id_text1: Use un fondo oscuro
       document_capture_id_text2: Tome la foto en una superficie plana
       document_capture_id_text3: No use el flash de su cámara

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -80,7 +80,7 @@ es:
           identificación ocupe un gran espacio dentro del marco de la imagen e
           intente tomar nuevas fotos.
       file_type:
-        invalid: Ese formato no es admitido, por favor elija un archivo JPG, PNG, o BMP.
+        invalid: Ese formato no es admitido, por favor elija un archivo JPG o PNG.
       general:
         liveness: No pudimos verificar su documento de identidad y su foto. Intente
           tomar nuevas fotografías.
@@ -268,7 +268,7 @@ es:
       welcome: 'Deberá contar con lo siguiente para verificar su identidad:'
     tips:
       document_capture_header_text: 'Para obtener los mejores resultados:'
-      document_capture_hint: Debe ser un JPG, PNG, o BMP
+      document_capture_hint: Debe ser un JPG o PNG
       document_capture_id_text1: Use un fondo oscuro
       document_capture_id_text2: Tome la foto en una superficie plana
       document_capture_id_text3: No use el flash de su cámara

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -85,7 +85,7 @@ fr:
           dans le cadre de l’image puis essayez de prendre des nouvelles photos.
       file_type:
         invalid: Ce type de fichier n’est pas accepté, veuillez choisir un fichier JPG,
-          PNG, BMP ou TIFF.
+          PNG ou BMP.
       general:
         liveness: Nous n’avons pas pu vérifier votre pièce d’identité et votre photo.
           Essayez de prendre de nouvelles photos.
@@ -284,7 +284,7 @@ fr:
       welcome: 'Pour vérifier votre identité, vous aurez besoin de:'
     tips:
       document_capture_header_text: 'Pour obtenir les meilleurs résultats:'
-      document_capture_hint: Doit être un JPG, BMP, PNG ou TIFF
+      document_capture_hint: Doit être un JPG, PNG ou BMP
       document_capture_id_text1: Utilisez un fond sombre
       document_capture_id_text2: Prenez la photo sur une surface plane
       document_capture_id_text3: N’utilisez pas le flash de votre appareil photo

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -84,8 +84,8 @@ fr:
           la taille de votre pièce d’identité est grande et qu’elle est située
           dans le cadre de l’image puis essayez de prendre des nouvelles photos.
       file_type:
-        invalid: Ce type de fichier n’est pas accepté, veuillez choisir un fichier JPG,
-          PNG ou BMP.
+        invalid: Ce type de fichier n’est pas accepté, veuillez choisir un fichier JPG
+          ou PNG.
       general:
         liveness: Nous n’avons pas pu vérifier votre pièce d’identité et votre photo.
           Essayez de prendre de nouvelles photos.
@@ -284,7 +284,7 @@ fr:
       welcome: 'Pour vérifier votre identité, vous aurez besoin de:'
     tips:
       document_capture_header_text: 'Pour obtenir les meilleurs résultats:'
-      document_capture_hint: Doit être un JPG, PNG ou BMP
+      document_capture_hint: Doit être un JPG ou PNG
       document_capture_id_text1: Utilisez un fond sombre
       document_capture_id_text2: Prenez la photo sur une surface plane
       document_capture_id_text3: N’utilisez pas le flash de votre appareil photo

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -790,7 +790,7 @@ describe('document-capture/components/acuant-capture', () => {
 
     const input = getByLabelText('Image');
 
-    expect(input.getAttribute('accept')).to.equal('image/jpeg,image/png,image/bmp,image/tiff');
+    expect(input.getAttribute('accept')).to.equal('image/jpeg,image/png,image/bmp');
   });
 
   it('logs metrics for manual upload', async () => {

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -790,7 +790,7 @@ describe('document-capture/components/acuant-capture', () => {
 
     const input = getByLabelText('Image');
 
-    expect(input.getAttribute('accept')).to.equal('image/jpeg,image/png,image/bmp');
+    expect(input.getAttribute('accept')).to.equal('image/jpeg,image/png');
   });
 
   it('logs metrics for manual upload', async () => {


### PR DESCRIPTION
Looking at data over the past four weeks, we found that BMP and TIFF image submissions make up a tiny fraction of all submissions, and of those the success rate is much lower than the overall success rate.

Specifically, out of 418693 total submissions:
* BMP: 115 submissions (0.027%) with 14 successes (12.17%)
* TIFF: 370 submissions (0.088%) with 39 successes (10.54%)

Another reason to drop support is just the increased file size, e.g., in testing with my drivers license, starting with the jpg version and converting from that to other image types, my file sizes were as follows:
* JPG: 2.2 MB
* BMP: 36.6 MB or scaled to 50%: 9.1 MB
* TIFF: 48.8 MB or scaled to 50%: 12.3 MB