### PR TITLE
LG-5114: Update link text to be more comprehensive

### DIFF
--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -31,7 +31,7 @@
         </div>
       </div>  
       <div class='grid-auto'>
-        <%= link_to(t('doc_auth.buttons.change_address'), idv_address_url) %>
+        <%= link_to(t('doc_auth.buttons.change_address'), idv_address_url, 'aria-label': t('doc_auth.buttons.change_address_label')) %>
       </div>        
     </div>
     <div class='grid-row padding-top-1'>
@@ -54,7 +54,7 @@
           idv_doc_auth_step_path(step: :redo_ssn),
           method: :put,
           class: 'usa-button usa-button--unstyled',
-          'aria-labelledby': 'Change social security number'
+          'aria-label': t('doc_auth.buttons.change_ssn_label')
         ) { t('doc_auth.buttons.change_ssn') } %>
       </div>
     </div>  

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -54,6 +54,7 @@
           idv_doc_auth_step_path(step: :redo_ssn),
           method: :put,
           class: 'usa-button usa-button--unstyled',
+          'aria-labelledby': 'Change social security number'
         ) { t('doc_auth.buttons.change_ssn') } %>
       </div>
     </div>  

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -11,7 +11,9 @@ en:
       status_tap_to_capture: Automatic capture disabled
     buttons:
       change_address: Change
+      change_address_label: Change address
       change_ssn: Change
+      change_ssn_label: Change Social Security Number
       continue: Continue
       start_over: Start over
       take_or_upload_picture: '<lg-take-photo>Take photo</lg-take-photo> or

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -11,7 +11,9 @@ es:
       status_tap_to_capture: Captura automática desactivada
     buttons:
       change_address: Cambio
+      change_address_label: Cambiar dirección
       change_ssn: Cambio
+      change_ssn_label: Cambiar número de Seguridad Social
       continue: Continuar
       start_over: Comenzar de nuevo
       take_or_upload_picture: '<lg-take-photo>Toma una foto</lg-take-photo> o

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -11,7 +11,9 @@ fr:
       status_tap_to_capture: Capture automatique désactivée
     buttons:
       change_address: Changement
+      change_address_label: Changement d'adresse
       change_ssn: Changement
+      change_ssn_label: Changement de numéro de sécurité sociale
       continue: Continuer
       start_over: Recommencer
       take_or_upload_picture: '<lg-take-photo>Prendre une photo</lg-take-photo> ou


### PR DESCRIPTION
This PR adds an `aria-label` to the change button/link on the "Verify your Identity" page.

**Why**:So that screen readers announce that the elements are to change address and change social security number