### PR TITLE
Configure auto-updates for identity-style-guide

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: 'identity-style-guide'


### PR DESCRIPTION
**Why**: To reduce confusion and maintenance overhead incurred by version drift, to simplify the sync process, and to take advantage of the latest features and bug fixes as quickly as they're made available.

Reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates#enabling-github-dependabot-version-updates

Per [configuration options](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem), `npm` is the correct "ecosystem" even though we use Yarn.

h/t @zachmargolis for [suggestion](https://github.com/18F/identity-style-guide/pull/254#pullrequestreview-767017227)