### PR TITLE
LG-4737: Include attempts in Acuant SDK analytics

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -45,6 +45,7 @@ import './acuant-capture.scss';
  * @prop {string?} mimeType Mime type, or null if unknown.
  * @prop {ImageSource} source Method by which image was added.
  * @prop {number=} attempt Total number of attempts at this point.
+ * @prop {number} size Size of image, in bytes.
  */
 
 /**
@@ -213,6 +214,17 @@ function suspendFocusTrapForAnticipatedFocus(focusTrap) {
   }, 0);
 }
 
+export function getDecodedBase64ByteSize(data) {
+  let bytes = 0.75 * data.length;
+
+  let i = data.length;
+  while (data[--i] === '=') {
+    bytes--;
+  }
+
+  return bytes;
+}
+
 /**
  * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK
  * in supported devices.
@@ -280,11 +292,11 @@ function AcuantCapture(
   /**
    * Returns an analytics payload, decorated with common values.
    *
-   * @template {ImageAnalyticsPayload} P
+   * @template P
    *
    * @param {P} payload
    *
-   * @return {P & { attempt: number }}
+   * @return {P}
    */
   function getAddAttemptAnalyticsPayload(payload) {
     const enhancedPayload = { ...payload, attempt };
@@ -308,6 +320,7 @@ function AcuantCapture(
         height,
         mimeType: nextValue.type,
         source: 'upload',
+        size: nextValue.size,
       });
 
       addPageAction({
@@ -450,6 +463,7 @@ function AcuantCapture(
       sharpnessScoreThreshold: sharpnessThreshold,
       isAssessedAsBlurry,
       assessment,
+      size: getDecodedBase64ByteSize(nextCapture.image.data),
     });
 
     addPageAction({

--- a/app/javascript/packages/document-capture/hooks/use-counter.js
+++ b/app/javascript/packages/document-capture/hooks/use-counter.js
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+/**
+ * @param {number=} initialCount Optional initial count.
+ *
+ * @return {[count: number, incrementCount: () => void]}
+ */
+function useCounter(initialCount = 0) {
+  const [count, setCount] = useState(initialCount);
+
+  const incrementCount = () => setCount((prevCount) => prevCount + 1);
+
+  return [count, incrementCount];
+}
+
+export default useCounter;

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -308,6 +308,7 @@ describe('document-capture/components/acuant-capture', () => {
           sharpnessScoreThreshold: sinon.match.number,
           source: 'acuant',
           width: sinon.match.number,
+          attempt: sinon.match.number,
         }),
       );
       await expect(window.AcuantCameraUI.end).to.eventually.be.called();
@@ -431,6 +432,7 @@ describe('document-capture/components/acuant-capture', () => {
           assessment: 'glare',
           sharpness: 100,
           width: 1748,
+          attempt: sinon.match.number,
         },
       });
 
@@ -483,6 +485,7 @@ describe('document-capture/components/acuant-capture', () => {
           assessment: 'blurry',
           sharpness: 49,
           width: 1748,
+          attempt: sinon.match.number,
         },
       });
 
@@ -584,6 +587,7 @@ describe('document-capture/components/acuant-capture', () => {
           assessment: 'blurry',
           sharpness: 49,
           width: 1748,
+          attempt: sinon.match.number,
         },
       });
     });
@@ -813,6 +817,7 @@ describe('document-capture/components/acuant-capture', () => {
         mimeType: 'image/jpeg',
         source: 'upload',
         width: sinon.match.number,
+        attempt: sinon.match.number,
       },
     });
   });
@@ -860,6 +865,32 @@ describe('document-capture/components/acuant-capture', () => {
       payload: {
         source: 'upload',
       },
+    });
+  });
+
+  it('logs attempts', async () => {
+    const addPageAction = sinon.stub();
+    const { getByLabelText } = render(
+      <AnalyticsContext.Provider value={{ addPageAction }}>
+        <AcuantContextProvider sdkSrc="about:blank">
+          <AcuantCapture label="Image" name="test" />
+        </AcuantContextProvider>
+      </AnalyticsContext.Provider>,
+    );
+
+    const input = getByLabelText('Image');
+    userEvent.upload(input, validUpload);
+
+    await expect(addPageAction).to.eventually.be.calledWith({
+      label: 'IdV: test image added',
+      payload: sinon.match({ attempt: 1 }),
+    });
+
+    userEvent.upload(input, validUpload);
+
+    await expect(addPageAction).to.eventually.be.calledWith({
+      label: 'IdV: test image added',
+      payload: sinon.match({ attempt: 2 }),
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -5,6 +5,7 @@ import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import AcuantCapture, {
   isAcuantCameraAccessFailure,
   getNormalizedAcuantCaptureFailureMessage,
+  getDecodedBase64ByteSize,
 } from '@18f/identity-document-capture/components/acuant-capture';
 import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
@@ -25,6 +26,15 @@ const ACUANT_CAPTURE_SUCCESS_RESULT = {
   glare: 100,
   sharpness: 100,
 };
+
+describe('getDecodedBase64ByteSize', () => {
+  it('returns the decoded byte size', () => {
+    const original = 'Hello World';
+    const encoded = window.btoa(original);
+
+    expect(getDecodedBase64ByteSize(encoded)).to.equal(original.length);
+  });
+});
 
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
@@ -309,6 +319,7 @@ describe('document-capture/components/acuant-capture', () => {
           source: 'acuant',
           width: sinon.match.number,
           attempt: sinon.match.number,
+          size: sinon.match.number,
         }),
       );
       await expect(window.AcuantCameraUI.end).to.eventually.be.called();
@@ -433,6 +444,7 @@ describe('document-capture/components/acuant-capture', () => {
           sharpness: 100,
           width: 1748,
           attempt: sinon.match.number,
+          size: sinon.match.number,
         },
       });
 
@@ -486,6 +498,7 @@ describe('document-capture/components/acuant-capture', () => {
           sharpness: 49,
           width: 1748,
           attempt: sinon.match.number,
+          size: sinon.match.number,
         },
       });
 
@@ -588,6 +601,7 @@ describe('document-capture/components/acuant-capture', () => {
           sharpness: 49,
           width: 1748,
           attempt: sinon.match.number,
+          size: sinon.match.number,
         },
       });
     });
@@ -818,6 +832,7 @@ describe('document-capture/components/acuant-capture', () => {
         source: 'upload',
         width: sinon.match.number,
         attempt: sinon.match.number,
+        size: sinon.match.number,
       },
     });
   });

--- a/spec/javascripts/packages/document-capture/hooks/use-counter-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-counter-spec.jsx
@@ -1,0 +1,33 @@
+import { act } from 'react-test-renderer';
+import { renderHook } from '@testing-library/react-hooks';
+import useCounter from '@18f/identity-document-capture/hooks/use-counter';
+
+describe('document-capture/hooks/use-counter', () => {
+  it('defaults to 0', () => {
+    const { result } = renderHook(() => useCounter());
+
+    const [count] = result.current;
+
+    expect(count).to.be.equal(0);
+  });
+
+  it('accepts optional initial count', () => {
+    const { result } = renderHook(() => useCounter(1));
+
+    const [count] = result.current;
+
+    expect(count).to.be.equal(1);
+  });
+
+  it('increments by one', () => {
+    const { result } = renderHook(() => useCounter());
+
+    const [, incrementCount] = result.current;
+
+    act(incrementCount);
+
+    const [count] = result.current;
+
+    expect(count).to.equal(1);
+  });
+});


### PR DESCRIPTION
**Why**: To have a better understanding of how many attempts that users are making before submitting images, so that we can get a better idea of burden users are experiencing.