### PR TITLE
LG-4737: Include attempts in vendor submitted payload

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -98,6 +98,7 @@ module Idv
 
     def extra_attributes
       @extra_attributes ||= {
+        attempts: attempts,
         remaining_attempts: remaining_attempts,
         user_id: user_uuid,
         pii_like_keypaths: [[:pii]],
@@ -105,8 +106,11 @@ module Idv
     end
 
     def remaining_attempts
-      return nil unless document_capture_session
-      throttle.remaining_count
+      throttle.remaining_count if document_capture_session
+    end
+
+    def attempts
+      throttle.attempts if document_capture_session
     end
 
     def determine_response(form_response:, client_response:, doc_pii_response:)

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -72,7 +72,7 @@ class DocumentProofingJob < ApplicationJob
       pii: proofer_result.pii_from_doc,
     )
 
-    remaining_attempts = Throttle.for(user: user, throttle_type: :idv_doc_auth).remaining_count
+    throttle = Throttle.for(user: user, throttle_type: :idv_doc_auth)
 
     analytics.track_event(
       Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
@@ -80,7 +80,8 @@ class DocumentProofingJob < ApplicationJob
         state: proofer_result.pii_from_doc[:state],
         state_id_type: proofer_result.pii_from_doc[:state_id_type],
         async: true,
-        remaining_attempts: remaining_attempts,
+        attempts: throttle.attempts,
+        remaining_attempts: throttle.remaining_count,
         client_image_metrics: image_metadata,
       ).merge(analytics_data),
     )

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -48,6 +48,7 @@ describe Idv::ImageUploadsController do
             front: [:blank],
           },
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -101,6 +102,7 @@ describe Idv::ImageUploadsController do
             front: [I18n.t('doc_auth.errors.not_a_file')],
           },
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -198,6 +200,7 @@ describe Idv::ImageUploadsController do
             limit: [I18n.t('errors.doc_auth.throttled_heading')],
           },
           user_id: user.uuid,
+          attempts: IdentityConfig.store.doc_auth_max_attempts,
           remaining_attempts: 0,
           pii_like_keypaths: [[:pii]],
         )
@@ -230,6 +233,7 @@ describe Idv::ImageUploadsController do
           success: true,
           errors: {},
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -245,6 +249,7 @@ describe Idv::ImageUploadsController do
           state: 'MT',
           state_id_type: 'drivers_license',
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           client_image_metrics: {
             front: { glare: 99.99 },
@@ -258,6 +263,7 @@ describe Idv::ImageUploadsController do
           success: true,
           errors: {},
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -303,6 +309,7 @@ describe Idv::ImageUploadsController do
               success: true,
               errors: {},
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -318,6 +325,7 @@ describe Idv::ImageUploadsController do
               state: 'ND',
               state_id_type: 'drivers_license',
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               client_image_metrics: {
                 front: { glare: 99.99 },
@@ -336,6 +344,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.alerts.full_name_check')],
               },
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -355,6 +364,7 @@ describe Idv::ImageUploadsController do
               success: true,
               errors: {},
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -370,6 +380,7 @@ describe Idv::ImageUploadsController do
               state: 'Maryland',
               state_id_type: 'drivers_license',
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               client_image_metrics: {
                 front: { glare: 99.99 },
@@ -388,6 +399,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.general.no_liveness')],
               },
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -407,6 +419,7 @@ describe Idv::ImageUploadsController do
               success: true,
               errors: {},
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -422,6 +435,7 @@ describe Idv::ImageUploadsController do
               state: 'ND',
               state_id_type: 'drivers_license',
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               client_image_metrics: {
                 front: { glare: 99.99 },
@@ -440,6 +454,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.alerts.birth_date_checks')],
               },
               user_id: user.uuid,
+              attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
             )
@@ -483,6 +498,7 @@ describe Idv::ImageUploadsController do
           success: true,
           errors: {},
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -494,6 +510,7 @@ describe Idv::ImageUploadsController do
             front: [I18n.t('doc_auth.errors.general.multiple_front_id_failures')],
           },
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           state: nil,
           state_id_type: nil,
@@ -535,6 +552,7 @@ describe Idv::ImageUploadsController do
           success: true,
           errors: {},
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
         )
@@ -552,6 +570,7 @@ describe Idv::ImageUploadsController do
           state_id_type: nil,
           exception: nil,
           user_id: user.uuid,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           client_image_metrics: {
             front: { glare: 99.99 },

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           exception: nil,
           doc_auth_result: 'Passed',
           billed: true,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           state: 'MT',
           state_id_type: 'drivers_license',
@@ -149,6 +150,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           exception: nil,
           doc_auth_result: 'Passed',
           billed: true,
+          attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           user_id: document_capture_session.user.uuid,
           client_image_metrics: {

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             state: 'MT',
             state_id_type: 'drivers_license',
             async: true,
+            attempts: 0,
             remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
             client_image_metrics: {
               front: front_image_metadata,
@@ -202,6 +203,7 @@ RSpec.describe DocumentProofingJob, type: :job do
             state: 'MT',
             state_id_type: 'drivers_license',
             async: true,
+            attempts: 0,
             remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
             face_match_results: { is_match: true, match_score: nil },
             selfie_liveness_results: {


### PR DESCRIPTION
**Why**: So that we can easily determine number of attempts to assess user burden, especially in matching to client-side analytics (#5463), and so that the numbers can be interpreted irregardless changes to the configured maximum attempts.

Relevant Slack conversation: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1633109940058200