### PR TITLE
Try to fix flakey keepalive test

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -570,6 +570,10 @@ describe Users::SessionsController, devise: true do
   end
 
   describe 'POST /sessions/keepalive' do
+    around do |ex|
+      freeze_time { ex.run }
+    end
+
     context 'when user is present' do
       before do
         stub_sign_in


### PR DESCRIPTION
**Why**: Because the keepalive response depends on relative times, so we should freeze time during test execution to avoid off-by-X if the test takes slightly longer to complete.

Example failure: https://app.circleci.com/pipelines/github/18F/identity-idp/54398/workflows/1c09446f-0e10-4f58-8a9d-271394f69ff6/jobs/84633/parallel-runs/2