### PR TITLE
Create geo_data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Gemfile-dev.lock
 /docs/security/opencontrols
 /fixtures
 /geo_data/*
+!/geo_data/.gitkeep
 /identity-idp-config
 /keys
 /kitchen/cookbooks


### PR DESCRIPTION
This creates the `geo_data` directory with a `.gitkeep` file in it so that there is a blank directory available on a fresh clone. 

The goal is to make it easier to symlink or copy data into the `geo_data` directory during the deploy process without having to create or check that the directory already exists.