### PR TITLE
Add additional error handling in RiscDeliveryJob (LG-5130)

### DIFF
--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -1,9 +1,14 @@
 class RiscDeliveryJob < ApplicationJob
   queue_as :low
 
-  retry_on Faraday::TimeoutError,
-           Faraday::ConnectionFailed,
-           Faraday::SSLError,
+  NETWORK_ERRORS = [
+    Faraday::TimeoutError,
+    Faraday::ConnectionFailed,
+    Faraday::SSLError,
+    Errno::ECONNREFUSED,
+  ].freeze
+
+  retry_on *NETWORK_ERRORS,
            wait: :exponentially_longer,
            attempts: 5
   retry_on RedisRateLimiter::LimitError,
@@ -41,8 +46,7 @@ class RiscDeliveryJob < ApplicationJob
         }.to_json,
       )
     end
-  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::SSLError,
-         RedisRateLimiter::LimitError => err
+  rescue *NETWORK_ERRORS, RedisRateLimiter::LimitError => err
     raise err if !inline?
 
     Rails.logger.warn(
@@ -69,7 +73,7 @@ class RiscDeliveryJob < ApplicationJob
   end
 
   def faraday
-    Faraday.new do |f|
+    @faraday ||= Faraday.new do |f|
       f.request :instrumentation, name: 'request_log.faraday'
       f.adapter :net_http
       f.options.timeout = 3

--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -8,9 +8,11 @@ class RiscDeliveryJob < ApplicationJob
     Errno::ECONNREFUSED,
   ].freeze
 
-  retry_on *NETWORK_ERRORS,
-           wait: :exponentially_longer,
-           attempts: 5
+  retry_on(
+    *NETWORK_ERRORS,
+    wait: :exponentially_longer,
+    attempts: 5,
+  )
   retry_on RedisRateLimiter::LimitError,
            wait: :exponentially_longer,
            attempts: 10


### PR DESCRIPTION
- Add handling for ERRNO:EConnRefused (this repros when trying something like `localhost:9999` that does not exist
- Added tests to confirm behavior for non-200 responses (just warn)
