### PR TITLE
Remove domready for script initialization

### DIFF
--- a/app/javascript/app/components/index.js
+++ b/app/javascript/app/components/index.js
@@ -1,9 +1,8 @@
 import { accordion, banner, navigation, skipnav } from 'identity-style-guide';
-import domready from 'domready';
 import Modal from './modal';
 
 window.LoginGov = window.LoginGov || {};
 window.LoginGov.Modal = Modal;
 
 const components = [accordion, banner, navigation, skipnav];
-domready(() => components.forEach((component) => component.on()));
+components.forEach((component) => component.on());

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.6.0",
     "clipboard": "^2.0.6",
-    "domready": "^1.0.8",
     "fast-glob": "^3.2.7",
     "focus-trap": "^6.2.3",
     "identity-style-guide": "^6.2.0",


### PR DESCRIPTION
**Why**: JavaScript are always rendered last on the page, so at that point all markup we care about is already present.

Benefits:

- Marginally quicker time-to-initialize, since there would be a small delay between script execution and DOMContentLoaded
- Reduce JavaScript bundle size
- Fewer dependencies reduces maintenance burden