### PR TITLE
Run ERBLint on ViewComponent markup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:
 	bundle exec scss-lint
 
 lint_erb:
-	bundle exec erblint app/{views,components}
+	bundle exec erblint app/views app/components
 
 lint_yaml: normalize_yaml
 	(! git diff --name-only | grep "^config/.*\.yml$$") || (echo "Error: Run 'make normalize_yaml' to normalize YAML"; exit 1)


### PR DESCRIPTION
**Why**: Because these ERB files live outside app/views, but should still be subject to linting.