### PR TITLE
Add Rails Mailer previews

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,6 +1,6 @@
 SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/BlockLength
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
-  config.x_frame_options = 'DENY'
+  config.x_frame_options = Rails.env.development? ? 'ALLOWALL' : 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,136 @@
+class UserMailerPreview < ActionMailer::Preview
+  def email_confirmation_instructions
+    UserMailer.email_confirmation_instructions(
+      User.first,
+      'foo@bar.gov',
+      SecureRandom.hex,
+      request_id: SecureRandom.uuid,
+      instructions: I18n.t(
+        'user_mailer.email_confirmation_instructions.first_sentence.forgot_password',
+        app_name: APP_NAME,
+      ),
+    )
+  end
+
+  def unconfirmed_email_instructions
+    UserMailer.unconfirmed_email_instructions(
+      User.first,
+      'foo@bar.gov',
+      SecureRandom.hex,
+      request_id: SecureRandom.uuid,
+      instructions: I18n.t(
+        'user_mailer.email_confirmation_instructions.first_sentence.forgot_password',
+        app_name: APP_NAME,
+      ),
+    )
+  end
+
+  def signup_with_your_email
+    UserMailer.signup_with_your_email(User.first, 'foo@bar.gov')
+  end
+
+  def reset_password_instructions
+    UserMailer.reset_password_instructions(User.first, 'foo@bar.gov', token: SecureRandom.hex)
+  end
+
+  def password_changed
+    UserMailer.password_changed(User.first, EmailAddress.first, disavowal_token: SecureRandom.hex)
+  end
+
+  def phone_added
+    UserMailer.phone_added(User.first, EmailAddress.first, disavowal_token: SecureRandom.hex)
+  end
+
+  def account_does_not_exist
+    UserMailer.account_does_not_exist('foo@bar.gov', SecureRandom.uuid)
+  end
+
+  def personal_key_sign_in
+    UserMailer.personal_key_sign_in(User.first, 'foo@bar.gov', disavowal_token: SecureRandom.hex)
+  end
+
+  def new_device_sign_in
+    UserMailer.new_device_sign_in(
+      user: User.first,
+      email_address: EmailAddress.first,
+      date: 'February 25, 2019 15:02',
+      location: 'Washington, DC',
+      disavowal_token: SecureRandom.hex,
+    )
+  end
+
+  def personal_key_regenerated
+    UserMailer.personal_key_regenerated(User.first, 'foo@bar.gov')
+  end
+
+  def account_reset_request
+    UserMailer.account_reset_request(
+      User.first, EmailAddress.first, User.first.build_account_reset_request
+    )
+  end
+
+  def account_reset_granted
+    UserMailer.account_reset_granted(
+      User.first, EmailAddress.first, User.first.build_account_reset_request
+    )
+  end
+
+  def account_reset_complete
+    UserMailer.account_reset_complete(User.first, EmailAddress.first)
+  end
+
+  def account_reset_cancel
+    UserMailer.account_reset_cancel(User.first, EmailAddress.first)
+  end
+
+  def please_reset_password
+    UserMailer.please_reset_password(User.first, 'foo@bar.gov')
+  end
+
+  def doc_auth_desktop_link_to_sp
+    UserMailer.doc_auth_desktop_link_to_sp(User.first, 'foo@bar.gov', 'Example App', '/')
+  end
+
+  def letter_reminder
+    UserMailer.letter_reminder(User.first, 'foo@bar.gov')
+  end
+
+  def add_email
+    UserMailer.add_email(User.first, 'foo@bar.gov', SecureRandom.hex)
+  end
+
+  def email_added
+    UserMailer.email_added(User.first, 'foo@bar.gov')
+  end
+
+  def email_deleted
+    UserMailer.email_deleted(User.first, 'foo@bar.gov')
+  end
+
+  def add_email_associated_with_another_account
+    UserMailer.add_email_associated_with_another_account('foo@bar.gov')
+  end
+
+  def sps_over_quota_limit
+    UserMailer.sps_over_quota_limit('foo@bar.gov')
+  end
+
+  def deleted_user_accounts_report
+    UserMailer.deleted_user_accounts_report(
+      email: 'foo@bar.gov',
+      name: 'my name',
+      issuers: %w[issuer1 issuer2],
+      data: 'data',
+    )
+  end
+
+  def account_verified
+    UserMailer.account_verified(
+      User.first,
+      EmailAddress.first,
+      date_time: DateTime.now,
+      sp_name: 'Example App',
+      disavowal_token: SecureRandom.hex,
+    )
+  end
+end

--- a/spec/mailers/previews/user_mailer_preview_spec.rb
+++ b/spec/mailers/previews/user_mailer_preview_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require_relative './user_mailer_preview'
+
+RSpec.describe UserMailerPreview do
+  UserMailerPreview.instance_methods(false).each do |mailer_method|
+    describe "##{mailer_method}" do
+      before { create(:user) }
+
+      it 'generates a preview without blowing up' do
+        expect { UserMailerPreview.new.public_send(mailer_method) }.to_not raise_error
+      end
+    end
+  end
+
+  it 'has a preview method for each mailer method' do
+    mailer_methods = UserMailer.instance_methods(false)
+    preview_methods = UserMailerPreview.instance_methods(false)
+    expect(mailer_methods - preview_methods).to be_empty
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -112,8 +112,8 @@ describe UserMailer, type: :mailer do
   end
 
   describe '#new_device_sign_in' do
-    date = 'Washington, DC'
-    location = 'February 25, 2019 15:02'
+    date = 'February 25, 2019 15:02'
+    location = 'Washington, DC'
     disavowal_token = 'asdf1234'
     let(:mail) do
       UserMailer.new_device_sign_in(


### PR DESCRIPTION
I wanted a way to investigate https://github.com/18F/identity-idp/pull/5498#discussion_r728972613, so I remembered this nifty Rails feature: [mailer previews](https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails)!

1. go to http://localhost:3000/rails/mailers
2. click a mailer, see a preview!

lets us do cool things like check the plain-text equivalent and see in other languages

| description | screenshot |
| --- | ---- |
| list of mailers | <img width="412" alt="Screen Shot 2021-10-14 at 9 48 20 AM" src="https://user-images.githubusercontent.com/458784/137361838-edc4d967-ff98-42a4-9bfd-3931c88e1462.png"> |
| individual preview | <img width="1210" alt="Screen Shot 2021-10-14 at 9 49 03 AM" src="https://user-images.githubusercontent.com/458784/137361843-c78d8c24-d32d-4b49-b0bd-6f3b222f5e95.png"> |




