### PR TITLE
Remove unused CSSLint configuration

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,1 +1,0 @@
---exclude-list=./vendor/assets/stylesheets,./node_modules


### PR DESCRIPTION
**Why**: Because it's no longer used. It was added in #6 as part of CodeClimate checks, which was later removed in #3825.