### PR TITLE
[LG-5267] Add error message when testing IAL2 with invalid YAML

### DIFF
--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -101,7 +101,11 @@ module DocAuth
           { general: ["YAML data should have been a hash, got #{data.class}"] }
         end
       rescue Psych::SyntaxError
-        {}
+        if uploaded_file.ascii_only? # don't want this error for images
+          { general: ['invalid YAML file'] }
+        else
+          {}
+        end
       end
 
       def pii_from_doc

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -208,6 +208,26 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
       end
     end
 
+    context 'with a malformed yaml file' do
+      let(:input) do
+        # the lack of a space after the "phone" key makes this invalid
+        <<~YAML
+          document:
+            dob: 2000-01-01
+            phone:+1 234-567-8901
+        YAML
+      end
+
+      it 'returns a result with the appopriate error' do
+        response = builder.call
+
+        expect(response.success?).to eq(false)
+        expect(response.errors).to eq(general: ['invalid YAML file'])
+        expect(response.exception).to eq(nil)
+        expect(response.pii_from_doc).to eq({})
+      end
+    end
+
     context 'with a yaml file containing a passing result' do
       subject(:builder) {
         config = DocAuth::Mock::Config.new(


### PR DESCRIPTION
Resolves LG-5267

**Why:** if a user uploads a bad YAML file we don't give them any indication of that fact. See [Slack](https://gsa-tts.slack.com/archives/C0NGESUN5/p1634183975192200?thread_ts=1634140550.177200&cid=C0NGESUN5) for some more context.

This PR adds an exit condition to mock doc auth with an error for any text files that are uploaded that are not parsable as YAML.