### PR TITLE
LG-5193: Use PhoneInputComponent on IAL2 hybrid link send step

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -31,7 +31,6 @@ linters:
       - '*/app/views/idv/doc_auth/link_sent.html.erb'
       - '*/app/views/idv/doc_auth/no_camera.html.erb'
       - '*/app/views/idv/doc_auth/upload.html.erb'
-      - '*/app/views/idv/doc_auth/send_link.html.erb'
       - '*/app/views/idv/doc_auth/verify.html.erb'
       - '*/app/views/idv/doc_auth/verify_wait.html.erb'
       - '*/app/views/idv/phone/new.html.erb'

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -2,41 +2,32 @@
 
 <% if flow_session[:error_message] %>
   <%= render 'shared/alert', {
-    type: 'error',
-    class: 'margin-bottom-4',
-    message: flow_session[:error_message],
-  } %>
+        type: 'error',
+        class: 'margin-bottom-4',
+        message: flow_session[:error_message],
+      } %>
 <% end %>
 
 <h1>
   <%= t('doc_auth.headings.take_picture') %>
 </h1>
 
-<p class='mt-tiny margin-bottom-4'><%= t('doc_auth.info.take_picture') %></p>
+<p><%= t('doc_auth.info.take_picture') %></p>
 
-<p class='mt-tiny margin-bottom-4'><strong><%= t('doc_auth.info.camera_required') %></strong></p>
+<p class="margin-y-4"><strong><%= t('doc_auth.info.camera_required') %></strong></p>
 
-<p class='mt-tiny margin-bottom-4'><%= t('doc_auth.instructions.send_sms') %></p>
+<p><%= t('doc_auth.instructions.send_sms') %></p>
 
-<%= validated_form_for(:doc_auth, url: url_for, method: 'PUT',
-        html: { autocomplete: 'off', class: 'margin-top-2' }) do |f| %>
-  <div class='clearfix margin-x-neg-1'>
-    <div class='sm-col sm-col-8 padding-x-1'>
-      <!-- using :phone for mobile numeric keypad -->
-      <%= f.label :phone, label: t('idv.form.phone'), class: 'bold' %>
-      <%= f.input(
-        :phone,
-        required: true,
-        input_html: { aria: { invalid: false }, class: 'sm-col-8' },
-        label: false,
-        wrapper_html: { class: 'margin-right-2' }
-      ) %>
-    </div>
-  </div>
-  <div class='margin-top-0'>
-    <button type='submit' class='usa-button usa-button--big usa-button--wide'>
-      <%= t('forms.buttons.continue') %>
-    </button>
-  </div>
+<%= validated_form_for(
+      :doc_auth,
+      url: url_for,
+      method: 'PUT',
+      html: { autocomplete: 'off', class: 'margin-top-4' },
+    ) do |f| %>
+  <%= render PhoneInputComponent.new(form: f, required: true) %>
+  <div class="usa-error-message margin-bottom-4 display-none" role="alert"></div>
+  <button class="margin-top-1 usa-button usa-button--big usa-button--wide">
+    <%= t('forms.buttons.continue') %>
+  </button>
 <% end %>
 <%= render 'idv/doc_auth/back', action: 'cancel_send_link' %>


### PR DESCRIPTION
Related: #5481, #5490

**Why**: To bring consistency to how we present international phone number input fields, since we now [support international numbers for the IAL2 hybrid flow](https://github.com/18F/identity-idp/pull/5490).

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/137496403-d14fdcaa-68f5-47e2-a789-3ef70537de37.png)|![after](https://user-images.githubusercontent.com/1779930/137496376-4f2df7df-8c20-4d98-a96f-3a12a65bb639.png)
