### PR TITLE
LG-5167:Remove 'selfie' from directions in IDP

### DIFF
--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -40,7 +40,7 @@ en:
         <li>Your ID does not have any damaged barcodes</li>
         <li>Your ID represents 80% of the overall image</li>
         <li>Your ID is against a solid, dark background</li>
-        <li>Your selfie is taken in a well-lit area with a plain background</li>
+        <li>Your picture is taken in a well-lit area with a plain background</li>
         <li>You are not wearing a hat or glasses, and your head is fully visible</li>
         </ul>
       document_verification_timeout: The server took too long to respond. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -40,7 +40,7 @@ es:
         <li>Su identificación no tiene ningún código de barras dañado</li>
         <li>Su identificación representa el 80% de la imagen general</li>
         <li>Su identificación está contra un fondo sólido y oscuro</li>
-        <li>Su selfie se toma en un área bien iluminada con un fondo liso</li>
+        <li>La foto se hace en un espacio bien iluminado y con un fondo uniforme</li>
         <li>No lleva puesto un sombrero o anteojos, y su cabeza es completamente visible</li>
         </ul>
       document_verification_timeout: El servidor tardó demasiado en responder. Inténtalo de nuevo.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -43,7 +43,7 @@ fr:
         <li>Votre identifiant n’a pas de code à barres endommagé</li>
         <li>Votre pièce d’identité représente 80% de l’image globale</li>
         <li>Votre pièce d’identité est sur un fond sombre et uni</li>
-        <li>Votre selfie est pris dans une zone bien éclairée avec un arrière-plan uni</li>
+        <li>Votre photo est prise dans un endroit bien éclairé avec un fond uni</li>
         <li>Vous ne portez pas de chapeau ni de lunettes et votre tête est entièrement visible</li>
         </ul>
       document_verification_timeout: Le serveur a mis trop de temps à répondre. Veuillez réessayer.


### PR DESCRIPTION
This PR changes "Your selfie is taken in a well-lit area with a plain background" to "Your **picture** is taken in a well-lit area with a plain background"

**Why:** To avoid using idioms in the IdP

_screenshot to come_