### PR TITLE
Phone Input: Fix flag image for deployed environments

### DIFF
--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -6,12 +6,12 @@
   }
 }
 
-.phone-input .iti__flag {
+lg-phone-input .iti__flag {
   background-image: image-url('intl-tel-input/build/img/flags.png');
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-  .phone-input .iti__flag {
+  lg-phone-input .iti__flag {
     background-image: image-url('intl-tel-input/build/img/flags@2x.png');
   }
 }


### PR DESCRIPTION
Regression of: #5481

**Why**: These styles are intended to override the default intl-tel-input relative-path, non-fingerprinted image path URL. Since the image is part of the Rails asset pipeline, it needs to be referenced with the image-url helper.

This style existed before #5481, but it was changed from [a bare `.iti__flag`](https://github.com/18F/identity-idp/pull/5481/files#diff-713d34477e9add11a904eed4dae8f5245cd280266b22c9772a1c131a874fc907) to one specific to the "component" being extracted. Unfortunately, it used a non-existent `.phone-input` class, intended to be scoped to the `lg-phone-input` custom element.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/137747880-b7b7650a-dc1f-40d1-9821-142bc5390042.png)|![after](https://user-images.githubusercontent.com/1779930/137747914-2fa3f663-5f5a-45d5-9387-8f38b98db95a.png)
