### PR TITLE
Fix Phone Input error in Internet Explorer

### DIFF
--- a/app/javascript/packages/phone-input/index.js
+++ b/app/javascript/packages/phone-input/index.js
@@ -72,7 +72,7 @@ export class PhoneInput extends HTMLElement {
   get selectedOption() {
     const { codeInput } = this;
 
-    return codeInput && codeInput.selectedOptions[0];
+    return codeInput && codeInput.options[codeInput.selectedIndex];
   }
 
   /**

--- a/app/javascript/packs/otp-delivery-preference.js
+++ b/app/javascript/packs/otp-delivery-preference.js
@@ -82,7 +82,7 @@ function updateOTPDeliveryMethods(event) {
     return;
   }
 
-  const selectedOption = select.selectedOptions[0];
+  const selectedOption = select.options[select.selectedIndex];
   const methods = getOTPDeliveryMethods();
   setHintText();
 


### PR DESCRIPTION
**Why**: `HTMLSelectElement#selectedOptions` is not supported in Internet Explorer.

See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedOptions#browser_compatibility

NewRelic: https://onenr.io/0xZw0LMvpwv