### PR TITLE
Fix device page 500

### DIFF
--- a/app/decorators/device_decorator.rb
+++ b/app/decorators/device_decorator.rb
@@ -15,10 +15,14 @@ DeviceDecorator = Struct.new(:device) do
 
   def nice_name
     browser = BrowserCache.parse(device.user_agent)
+    os = browser.platform.name
+    os_version = browser.platform.version&.split('.')&.first
+    os = "#{os} #{os_version}" if os_version
+
     I18n.t(
       'account.index.device',
       browser: "#{browser.name} #{browser.version}",
-      os: "#{browser.platform.name} #{browser.platform.version.split('.').first}",
+      os: os,
     )
   end
 end

--- a/spec/decorators/device_decorator_spec.rb
+++ b/spec/decorators/device_decorator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DeviceDecorator do
     end
 
     it 'does not fail if OS version cannot be parsed' do
+      # This user agent currently does not parse the OS version
       user_agent = 'Mozilla/5.0 (X11; CrOS armv7l 11316.165.0) AppleWebKit/537.36 (KHTML, '\
                    'like Gecko) Chrome/72.0.3626.122 Safari/537.36'
       device.user_agent = user_agent


### PR DESCRIPTION
Related to https://github.com/18F/identity-idp/pull/5491

It is possible we don't get a platform version, and it was leading to 500s: [NR Link](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=43200000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwidHJhY2VJZCI6IjZiNGZkMDI0LTMwNDMtMTFlYy1iMTI4LTAyNDJhYzExMDAxMl83MzUyXzMxMzE1IiwibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3IiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGcifQ==&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19&state=74426f3a-af2c-b966-a756-e461d28a6c7d)

This PR adds some checks around not attempting to split on `nil`