### PR TITLE
Remove personal key section from account reset template

### DIFF
--- a/app/views/account_reset/request/show.html.erb
+++ b/app/views/account_reset/request/show.html.erb
@@ -5,38 +5,6 @@
 <p class='mt-tiny margin-bottom-0'>
   <%= t('account_reset.request.info').html_safe %>
 </p>
-<% if current_user&.encrypted_recovery_code_digest&.present? %>
-  <br/>
-
-  <h4 class='margin-y-0'><%= t('account_reset.request.personal_key') %></h4>
-
-  <p class='mt-tiny margin-bottom-0'>
-    <%= t('account_reset.request.personal_key_info') %>
-  </p>
-
-  <hr/>
-
-  <%= render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX' %>
-
-  <div class='margin-bottom-4 right-align'>
-    <%= link_to(
-      t('users.personal_key.print'),
-      '#',
-      data: { print: true },
-      class: 'usa-button usa-button--outline margin-top-2 ico ico-print',
-    ) %>
-  </div>
-  <hr/>
-  <p class='mt-tiny margin-bottom-0'>
-    <%= t(
-      'account_reset.request.personal_key_trailer',
-      link: link_to(
-        t('account_reset.request.access_your_account'),
-        login_two_factor_personal_key_url),
-      ).html_safe %>
-  </p>
-<% end %>
-
 <br/>
 
 <h4 class='margin-y-0'><%= t('account_reset.request.delete_account') %></h4>

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -37,7 +37,6 @@ en:
         <strong>%{interval}</strong>, you will receive an email with
         instructions to complete the deletion.
     request:
-      access_your_account: access your account
       are_you_sure: Are you sure you don’t have access to any of your authentication methods?
       delete_account: Delete your account
       delete_account_info: Deleting your existing account and creating a new one will
@@ -53,10 +52,5 @@ en:
         option. <br><br> We can’t undo an account delete, so please verify if
         you have another authentication method you can use instead.
       no_cancel: No, cancel
-      personal_key: Do you have your personal key?
-      personal_key_info: Your personal key is a 16 character code that was given to
-        you at account creation as a recovery method–see example below.
-      personal_key_trailer: If you have your personal key, you can use it to %{link}
-        instead of resetting.
       title: Account deletion and reset
       yes_continue: Yes, continue deletion.

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -38,7 +38,6 @@ es:
         <strong>%{interval}</strong>, recibirá un correo electrónico con
         instrucciones para completar la eliminación.
     request:
-      access_your_account: acceder a tu cuenta
       are_you_sure: '¿Estás seguro de que no tienes acceso a ninguno de tus métodos de
         seguridad?'
       delete_account: Eliminar su cuenta
@@ -57,11 +56,5 @@ es:
         cuenta, así que por favor asegúrese de no tener otra opción de seguridad
         que puede usar.
       no_cancel: No, cancelar
-      personal_key: '¿Tienes tu clave personal?'
-      personal_key_info: Su clave personal es un código de 16 caracteres que se le dio
-        a en la creación de la cuenta como método de recuperación; consulte el
-        ejemplo a continuación.
-      personal_key_trailer: Si tiene su clave personal, puede usarla en %{link} en
-        lugar de restablecer.
       title: Eliminación y restablecimiento de cuenta
       yes_continue: Sí, continúa la eliminación.

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -38,7 +38,6 @@ fr:
         Dans <strong>%{interval}</strong>, vous recevrez un e-mail avec des
         instructions pour terminer la suppression.
     request:
-      access_your_account: accéder à votre compte
       are_you_sure: Êtes-vous sûr de n’avoir accès à aucune de vos méthodes de sécurité?
       delete_account: Supprimer votre compte
       delete_account_info: Supprimer votre compte existant et en créer un nouveau vous
@@ -56,11 +55,5 @@ fr:
         assurez-vous que vous n’avez pas une autre option de sécurité que vous
         pouvez utiliser à la place.
       no_cancel: Non, annuler
-      personal_key: Avez-vous votre clé personnelle?
-      personal_key_info: Votre clé personnelle est un code de 16 caractères qui a été
-        donné à vous à la création de compte comme une méthode de récupération -
-        voir l’exemple ci-dessous.
-      personal_key_trailer: Si vous avez votre clé personnelle, vous pouvez l’utiliser
-        pour %{link} au lieu de réinitialiser.
       title: Suppression de compte et réinitialisation
       yes_continue: Oui, continuez la suppression.

--- a/spec/views/account_reset/request/show.html.erb_spec.rb
+++ b/spec/views/account_reset/request/show.html.erb_spec.rb
@@ -16,18 +16,4 @@ describe 'account_reset/request/show.html.erb' do
     render
     expect(rendered).to have_button t('account_reset.request.yes_continue')
   end
-
-  it 'shows personal key info when a user has a personal key' do
-    render
-    expect(rendered).to have_content(t('account_reset.request.personal_key'))
-  end
-
-  it 'does not show personal key info when a user does not have a personal key' do
-    user = view.current_user
-    user.encrypted_recovery_code_digest = ''
-    user.save
-
-    render
-    expect(rendered).to_not have_content(t('account_reset.request.personal_key'))
-  end
 end


### PR DESCRIPTION
We don't allow using the personal key as a second factor any longer, so we shouldn't include content about it in this template as it is confusing for people.


Screenshot of current template before these changes:

![image](https://user-images.githubusercontent.com/1430443/137995498-42f3e241-1211-46de-abf7-035e0ee686c8.png)

After:

![image](https://user-images.githubusercontent.com/1430443/138108769-4b578df6-8a5e-4544-ae96-84f9c4ef8c7d.png)
