### PR TITLE
[LG-5273] Disable brittle validation for IntegrationUsages

### DIFF
--- a/app/models/agreements/integration_usage.rb
+++ b/app/models/agreements/integration_usage.rb
@@ -12,7 +12,9 @@ class Agreements::IntegrationUsage < ApplicationRecord
   validates :integration, presence: true
   validates :integration_id, uniqueness: { scope: :iaa_order_id }
 
-  validate :integration_and_order_have_same_account
+  # DISABLED 2021-10-20 due to unforeseen edge case where we transfer an
+  # integration from one account to another
+  # validate :integration_and_order_have_same_account
 
   private
 

--- a/spec/models/agreements/integration_usage_spec.rb
+++ b/spec/models/agreements/integration_usage_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Agreements::IntegrationUsage, type: :model do
     it { is_expected.to validate_presence_of(:integration) }
     it { is_expected.to validate_uniqueness_of(:integration_id).scoped_to(:iaa_order_id) }
 
-    it 'validates that the IAA Order and Integration belong to the same account' do
+    xit 'validates that the IAA Order and Integration belong to the same account' do
       subject.iaa_order = create(:iaa_order)
       expect(subject).not_to be_valid
     end


### PR DESCRIPTION
Resolves LG-5273

This was causing our config seeders to fail due to an edge case where an
integration was moved to a different account.

More context [here](https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1634671608025600)