### PR TITLE
Handle NoMethodError on nil, in TOTP setup (LG-5290)

### DIFF
--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -43,7 +43,7 @@ module Users
       @totp_setup_form ||= TotpSetupForm.new(
         current_user,
         new_totp_secret,
-        params[:code].strip,
+        params[:code].to_s.strip,
         params[:name].to_s.strip,
       )
     end
@@ -52,8 +52,7 @@ module Users
       @presenter = SetupPresenter.new(
         current_user: current_user,
         user_fully_authenticated: user_fully_authenticated?,
-        user_opted_remember_device_cookie:
-                                                  user_opted_remember_device_cookie,
+        user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
       )
     end

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -133,6 +133,36 @@ describe Users::TotpSetupController, devise: true do
             with(Analytics::MULTI_FACTOR_AUTH_SETUP, result)
         end
       end
+
+      context 'when user presents nil code' do
+        before do
+          user = create(:user, :signed_up)
+          secret = ROTP::Base32.random_base32
+          stub_sign_in(user)
+          stub_analytics
+          allow(@analytics).to receive(:track_event)
+          subject.user_session[:new_totp_secret] = secret
+
+          patch :confirm, params: {}
+        end
+
+        it 'redirects with an error message' do
+          expect(response).to redirect_to(authenticator_setup_path)
+          expect(flash[:error]).to eq t('errors.invalid_totp')
+          expect(subject.current_user.auth_app_configurations.any?).to eq false
+
+          result = {
+            success: false,
+            errors: {},
+            totp_secret_present: true,
+            multi_factor_auth_method: 'totp',
+            auth_app_configuration_id: nil,
+          }
+
+          expect(@analytics).to have_received(:track_event).
+            with(Analytics::MULTI_FACTOR_AUTH_SETUP, result)
+        end
+      end
     end
 
     context 'user is not yet signed up' do


### PR DESCRIPTION
Spotted in NewRelic: https://onenr.io/0GbRmlvpnwy