### PR TITLE
LG-5231: Remove tooltip from personal key input field 

### DIFF
--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -45,6 +45,7 @@ function unsetEmptyResponse() {
   input.setAttribute('aria-invalid', 'false');
   input.classList.remove('margin-bottom-3');
   input.classList.add('margin-bottom-6');
+  input.classList.remove('usa-input--error');
 
   isInvalidForm = false;
 }
@@ -63,6 +64,8 @@ function setEmptyResponse() {
   input.setAttribute('aria-invalid', 'true');
   input.classList.remove('margin-bottom-6');
   input.classList.add('margin-bottom-3');
+  input.classList.add('usa-input--error');
+  input.focus();
 
   isInvalidForm = true;
 }

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="personal-key-confirm" class="display-none">
-  <%= render layout: '/shared/modal_layout' do %>
+  <%= render layout: 'shared/modal_layout' do %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
       <h2 class="margin-top-0 margin-bottom-2">
         <%= t('forms.personal_key.title') %>
@@ -20,7 +20,7 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <%= render 'shared/validation_message', {
           class: 'margin-bottom-2',
-          message: t('users.personal_key.invalid_error'),
+          message: t('simple_form.required.text'),
         } %>
         <div class="clearfix margin-x-neg-2">
           <div class="col col-12 sm-col-6 padding-x-2 margin-bottom-2 tablet:margin-bottom-0 tablet:display-none">

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -23,7 +23,6 @@ en:
       confirmation_error: You’ve entered an incorrect personal key.
       generated_on_html: Generated on %{date}
       header: Your personal key
-      invalid_error: Please fill out this field
       print: Print
     rules_of_use:
       check_box_to_accept: Check this box to accept the %{app_name}

--- a/config/locales/users/es.yml
+++ b/config/locales/users/es.yml
@@ -24,7 +24,6 @@ es:
       confirmation_error: Ha ingresado una clave personal incorrecta.
       generated_on_html: Generado el %{date}
       header: Su clave personal
-      invalid_error: Por favor, rellene este campo
       print: Imprima esta página
     rules_of_use:
       check_box_to_accept: Marque esta casilla para aceptar las reglas de uso de %{app_name}

--- a/config/locales/users/fr.yml
+++ b/config/locales/users/fr.yml
@@ -26,7 +26,6 @@ fr:
       confirmation_error: Vous avez entré un clé personnelle erronée.
       generated_on_html: Générée le %{date}
       header: Votre clé personnelle
-      invalid_error: Veuillez remplir ce champ
       print: Imprimer cette page
     rules_of_use:
       check_box_to_accept: Cochez cette case pour accepter les règles d’utilisation de %{app_name}


### PR DESCRIPTION
This PR removes the tooltip from the personal key field

**Why**: So we do not have to rely on the browser to show an error message if the personal key input field is empty

| Before | After |
|------- | ----- |
|  ![Before image of personal key error](https://user-images.githubusercontent.com/17969963/138505602-df024136-01c9-4c00-b4fd-c5ffd55b24f0.png) |  ![image](https://user-images.githubusercontent.com/17969963/138505025-1dc77029-a4dc-461c-ad04-ad47a185d888.png) |






