### PR TITLE
Increase report timeout, mark as long running

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -2,7 +2,7 @@ require 'identity/hostdata'
 
 module Reports
   class BaseReport < ApplicationJob
-    queue_as :low
+    queue_as :long_running
 
     # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
     discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -329,6 +329,7 @@ production:
   recurring_jobs_disabled_names: "[]"
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379
+  report_timeout: 1_000_000
   ruby_workers_cron_enabled: 'false'
   ruby_workers_idv_enabled: 'false'
   s3_report_bucket_prefix: login-gov.reports


### PR DESCRIPTION
I had to re-run the `Reports::AgencyInvoiceIaaSupplementReport` report (since it has been failing out), and this was the config that I needed to get it there. A few queries took close to 100,000ms, but the when I set the timeout to 100k, queries still got canclled

A more ideal fix would obviously be to optimize the underlying queries, but I think this is acceptable in the meantime:
- the queries run against a read replica
- they're already run in background jobs
- we've been missing reports for weeks/months

Also updates the report base class to be the `long_running` queue, because that means we won't alert on long running jobs for it... because they are expected to take a long time