### PR TITLE
LG-1926: Bumped idp-telephony version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 6.1.4'
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.4.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
 @saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }
-@telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.4.2' }
+@telephony_gem ||= { github: '18f/identity-telephony', tag: 'v0.4.3' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.7.1' }
 
 gem 'identity-hostdata', @hostdata_gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: 723162e7cd4fe69c3a112d218bf89f69c80849bc
-  tag: v0.4.2
+  revision: 531298a2f89da3980f1e53be420065d6ff441fd6
+  tag: v0.4.3
   specs:
-    identity-telephony (0.4.2)
+    identity-telephony (0.4.3)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n


### PR DESCRIPTION
This is to get the shortened copy (160 chars or under) for SMS replies.