### PR TITLE
Update brakeman

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     blueprinter (0.25.3)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
-    brakeman (5.1.1)
+    brakeman (5.1.2)
     browser (5.3.1)
     builder (3.2.4)
     bullet (6.1.5)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	@echo "--- rubocop ---"
 	bundle exec rubocop --parallel
 	@echo "--- brakeman ---"
-	bundle exec brakeman --skip-files app/services/doc_auth_router.rb
+	bundle exec brakeman
 	@echo "--- zeitwerk check ---"
 	bin/rails zeitwerk:check
 	@echo "--- bundler-audit ---"


### PR DESCRIPTION
Brakeman updated their Ruby parser, so now we can drop our exclusion of the doc_auth_router file