### PR TITLE
Sync package.json engines to nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=12",
+    "node": ">=12.22",
     "npm": "6.x.x"
   },
   "workspaces": [


### PR DESCRIPTION
**Why**: So that we're consistent in the version we're expecting.

Related Slack discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1635359140050500

This will exit with an error when not matching an expected version:

```
$ yarn
error upaya@0.0.1: The engine "node" is incompatible with this module. Expected version ">=12.22". Got "12.13.1"
```

NVMRC reference:

https://github.com/18F/identity-idp/blob/1ae2c215ff7dd125f564d7d430a9492b5c35d87d/.nvmrc#L1