### PR TITLE
LG-4956: translate activemodel error messages

### DIFF
--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -65,17 +65,6 @@ en:
     messages:
       already_confirmed: was already confirmed, please try signing in
       blank: Please fill in this field.
-      inclusion: is not included in the list
-      too_long:
-        one: is too long (maximum is 1 character)
-        other: is too long (maximum is %{count} characters)
-      too_short:
-        one: is too short (minimum is 1 character)
-        other: is too short (minimum is %{count} characters)
-      wrong_length:
-        one: is the wrong length (should be 1 character)
-        other: is the wrong length (should be %{count} characters)
-      not_a_number: is not a number
       confirmation_code_incorrect: Incorrect code. Did you type it in correctly?
       confirmation_invalid_token: Invalid confirmation link. Either the link expired
         or you already confirmed your account.
@@ -86,6 +75,7 @@ en:
       gpo_otp_expired: Your confirmation code has expired. Please request another
         letter for a new code.
       improbable_phone: Invalid phone number. Please make sure you enter a valid phone number.
+      inclusion: is not included in the list
       invalid_calling_area: Calls to that phone number are not supported. Please try
         SMS if you have an SMS-capable phone.
       invalid_phone_number: The phone number entered is not valid.
@@ -97,6 +87,7 @@ en:
       must_have_us_country_code: Invalid phone number. Please make sure you enter a
         phone number with a U.S. country code.
       no_pending_profile: No profile is waiting for verification
+      not_a_number: is not a number
       otp_failed: Your security code failed to send.
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
@@ -108,6 +99,12 @@ en:
         select a different number and try again.
       pwned_password: The password you entered is not safe. It’s in a list of known
         passwords exposed in data breaches.
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
       try_again: Please try again.
       unauthorized_authn_context: Unauthorized authentication context
       unauthorized_nameid_format: Unauthorized nameID format
@@ -116,6 +113,9 @@ en:
       voip_phone: This number is a web-based (VOIP) phone service. Please select a
         different number and try again
       weak_password: Your password is not strong enough. %{feedback}
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
     piv_cac_setup:
       unique_name: That name is already taken. Please choose a different name.
     registration:

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -66,17 +66,6 @@ es:
     messages:
       already_confirmed: ya estaba confirmado, por favor intente iniciar una sesión
       blank: Por favor, rellenar este campo.
-      inclusion: No se incluye en la lista.
-      too_long:
-        one: es demasiado largo (el máximo es 1 carácter)
-        other: es demasiado largo (el máximo es %{count} caracteres)
-      too_short:
-        one: es demasiado corto (el mínimo es 1 carácter)
-        other: es demasiado corto (el mínimo es %{count} caracteres)
-      wrong_length:
-        one: es la longitud incorrecta (debería ser de 1 carácter)
-        other: es la longitud incorrecta (debería ser de %{count} caracteres)
-      not_a_number: no es un número
       confirmation_code_incorrect: El código es incorrecto. ¿Lo escribió correctamente?
       confirmation_invalid_token: El enlace de confirmación no es válido. El enlace
         expiró o usted ya ha confirmado su cuenta.
@@ -88,6 +77,7 @@ es:
         carta para recibir un nuevo código.
       improbable_phone: Número de teléfono no válido. Asegúrate de introducir un
         número de teléfono válido.
+      inclusion: No se incluye en la lista.
       invalid_calling_area: No se admiten llamadas a ese número de teléfono. Intenta
         enviar un SMS si tienes un teléfono que permita enviar SMS.
       invalid_phone_number: El número de teléfono ingresado no está en el formato correcto.
@@ -99,6 +89,7 @@ es:
       must_have_us_country_code: Número de teléfono no válido. Asegúrate de introducir
         un número de teléfono con un código país de EE. UU.
       no_pending_profile: Ningún perfil está esperando verificación
+      not_a_number: no es un número
       otp_failed: Se produjo un error al enviar el código de seguridad.
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
@@ -111,6 +102,12 @@ es:
         premium. Por favor, seleccione otro número e inténtelo de nuevo.
       pwned_password: La contraseña que ingresaste no es segura. Está en una lista de
         contraseñas conocidas expuestas en violaciones de datos.
+      too_long:
+        one: es demasiado largo (el máximo es 1 carácter)
+        other: es demasiado largo (el máximo es %{count} caracteres)
+      too_short:
+        one: es demasiado corto (el mínimo es 1 carácter)
+        other: es demasiado corto (el mínimo es %{count} caracteres)
       try_again: Por favor, inténtelo de nuevo.
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_nameid_format: Formato de ID de nombre no autorizado
@@ -120,6 +117,9 @@ es:
       voip_phone: Este número corresponde a un servicio de telefonía basado en la web
         (VoIP). Por favor, seleccione un número diferente e inténtelo de nuevo.
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
+      wrong_length:
+        one: es la longitud incorrecta (debería ser de 1 carácter)
+        other: es la longitud incorrecta (debería ser de %{count} caracteres)
     piv_cac_setup:
       unique_name: El nombre ya fue escogido. Por favor, elija un nombre diferente.
     registration:

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -71,17 +71,6 @@ fr:
     messages:
       already_confirmed: a déjà été confirmé, veuillez essayer de vous connecter
       blank: Veuillez remplir ce champ.
-      inclusion: N'est pas inclus dans la liste
-      too_long:
-        one: Est trop long (maximum de 1 caractère)
-        other: est trop long (le maximum est de %{count} caractères)
-      too_short:
-        one: est trop court (1 caractère minimum)
-        other: est trop court (le minimum est de %{count} caractères)
-      wrong_length:
-        one: n'est pas de la bonne longueur (devrait être de 1 caractère)
-        other: n'est pas de la bonne longueur (devrait être %{count} caractères)
-      not_a_number: N'est pas un nombre
       confirmation_code_incorrect: Code non valide. L’avez-vous inscrit correctement?
       confirmation_invalid_token: Lien de confirmation non valide. Le lien est expiré
         ou vous avez déjà confirmé votre compte.
@@ -94,6 +83,7 @@ fr:
         autre lettre afin d’obtenir un nouveau code.
       improbable_phone: Numéro de téléphone non valide. Veillez à saisir un numéro de
         téléphone valide.
+      inclusion: N'est pas inclus dans la liste
       invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en
         charge. Veuillez essayer par SMS si vous possédez un téléphone disposant
         de cette fonction.
@@ -106,6 +96,7 @@ fr:
       must_have_us_country_code: Numéro de téléphone non valide. Veuillez vous assurer
         de saisir un numéro de téléphone avec un code pays des États-Unis.
       no_pending_profile: Aucun profil en attente de vérification
+      not_a_number: N'est pas un nombre
       otp_failed: Échec de l’envoi de votre code de sécurité.
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
@@ -120,6 +111,12 @@ fr:
       pwned_password: Le mot de passe que vous avez entré n’est pas sécurisé. C’est
         dans une liste de mots de passe connus exposés dans les violations de
         données.
+      too_long:
+        one: Est trop long (maximum de 1 caractère)
+        other: est trop long (le maximum est de %{count} caractères)
+      too_short:
+        one: est trop court (1 caractère minimum)
+        other: est trop court (le minimum est de %{count} caractères)
       try_again: Veuillez réessayer.
       unauthorized_authn_context: Contexte d’authentification non autorisé
       unauthorized_nameid_format: Format non autorisé du nom d’identification
@@ -129,6 +126,9 @@ fr:
       voip_phone: Ce numéro est un service téléphonique basé sur le Web (Voix sur IP).
         Veuillez sélectionner un autre numéro et réessayer
       weak_password: Votre mot de passe n’est pas assez fort. %{feedback}
+      wrong_length:
+        one: n'est pas de la bonne longueur (devrait être de 1 caractère)
+        other: n'est pas de la bonne longueur (devrait être %{count} caractères)
     piv_cac_setup:
       unique_name: Ce nom est déjà pris. Veuillez choisir un autre nom.
     registration:


### PR DESCRIPTION
This was a response to https://github.com/18F/identity-idp/pull/5267#pullrequestreview-725543616. currently Translated the most likely error messages, (too long, too short, wrong length and inclusion) on activemodel. I can also translate the rest of the ones on that list but I felt that a lot of those were not likely. 