### PR TITLE
add styling for validation errors to IdP

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -105,14 +105,20 @@ input::-webkit-inner-spin-button {
   }
 }
 
+// Remove/refactor once LGDS v6.3 is released
+
+.usa-error-message,
 .usa-success-message {
   @include u-padding-y(.5);
-  background-image: url(image-path('alert/success.svg'));
-  background-position: 0 center;
+  background-position: 0 .5em;
   background-repeat: no-repeat;
-  background-size: 1rem;
-  color: color('success');
-  display: block;
+  background-size: units($icon-size);
   font-weight: font-weight('bold');
   padding-left: 1.5rem;
+}
+
+.usa-success-message {
+  background-image: url(image-path('alert/success.svg'));
+  color: color('success');
+  display: block;
 }


### PR DESCRIPTION
This PR adjusts the styling of the exclamation mark/checkmark to align to the top. This is so that all errors can be aligned with the first line of a validation message.

Error state
![image](https://user-images.githubusercontent.com/17969963/139497675-bfdb7afe-e6e8-499e-b50e-b92fb4174643.png)

Success state
![image](https://user-images.githubusercontent.com/17969963/139497983-f7cac285-6a59-4fe2-b8af-0a7ab160fb6b.png)

Note:
- This change has been implemented in the design system, but it has not been released as of the creation of this PR. Once the design system has been updated, we will refactor the styles accordingly.