### PR TITLE
Increase number of email checks for smoke tests

### DIFF
--- a/spec/support/monitor/monitor_email_helper.rb
+++ b/spec/support/monitor/monitor_email_helper.rb
@@ -68,7 +68,7 @@ class MonitorEmailHelper
     end.to_s
   end
 
-  def check_and_sleep(count: 10, sleep_duration: 3)
+  def check_and_sleep(count: 15, sleep_duration: 3)
     count.times do
       result = yield
 


### PR DESCRIPTION
* Should add ~15 seconds more every time we check

Would love to see if we can log IDs on the IDP side and some sort of received timestamp in S3 so we can see what our actual email delivery delays are