### PR TITLE
LG-5213: Add additional logging for capture tips display, dismiss

### DIFF
--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -7,7 +7,7 @@ import { createContext } from 'react';
  *
  * @property {string=} key Short, camel-cased, dot-namespaced key describing event.
  * @property {string} label Long-form, human-readable label describing event action.
- * @property {Payload} payload Additional payload arguments to log with action.
+ * @property {Payload=} payload Additional payload arguments to log with action.
  */
 
 /**


### PR DESCRIPTION
**Why**: As per AC of LG-5213, we want logging data to be available indicating when the pre-submission troubleshooting tips are displayed, and for when they are dismissed (when the user clicks "Try again").