### PR TITLE
LG-5213: Fix alt image typo for "Back of an ID"

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -237,7 +237,7 @@ en:
       capture_troubleshooting_blurry: The photo you added is too blurry.
       capture_troubleshooting_clean: Make sure that the barcode is not damaged or
         dirty and all the information on your ID can be read.
-      capture_troubleshooting_clean_image: Back of oan ID
+      capture_troubleshooting_clean_image: Back of an ID
       capture_troubleshooting_glare: The photo you added has glare.
       capture_troubleshooting_lead: 'Here are some tips for taking a successful photo:'
       capture_troubleshooting_lighting: Make sure there is plenty of light. Indirect


### PR DESCRIPTION
**Why**: Because it's incorrect.