### PR TITLE
LG-5184: honor locale of referring page

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -62,7 +62,7 @@ module Idv
       if VendorStatus.new.any_ial2_vendor_outage?
         session[:vendor_outage_redirect] = current_step
         session[:vendor_outage_redirect_from_idv] = true
-        redirect_to vendor_outage_url
+        redirect_to VendorStatus.new.vendor_outage_url_localized
       end
     end
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -71,7 +71,7 @@ module SignUp
       return unless ial2_requested? && VendorStatus.new.any_ial2_vendor_outage?
 
       session[:vendor_outage_redirect] = CREATE_ACCOUNT
-      return redirect_to vendor_outage_url
+      return redirect_to VendorStatus.new.vendor_outage_url_localized
     end
   end
 end

--- a/app/services/vendor_status.rb
+++ b/app/services/vendor_status.rb
@@ -1,4 +1,6 @@
 class VendorStatus
+  include Rails.application.routes.url_helpers
+
   def initialize(from: nil, from_idv: nil, sp: nil)
     @from = from
     @from_idv = from_idv
@@ -7,6 +9,16 @@ class VendorStatus
 
   IAL2_VENDORS = %i[acuant lexisnexis_instant_verify lexisnexis_trueid].freeze
   ALL_VENDORS = (IAL2_VENDORS + %i[sms voice]).freeze
+
+  def vendor_outage_url_localized
+    return vendor_outage_url if I18n.locale == :en
+
+    vendor_outage_url(locale: I18n.locale)
+  end
+
+  def url_options
+    {}
+  end
 
   def vendor_outage?(vendor)
     status = case vendor

--- a/spec/services/vendor_status_spec.rb
+++ b/spec/services/vendor_status_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe VendorStatus do
+  include Rails.application.routes.url_helpers
+
   let(:from) { nil }
   let(:from_idv) { nil }
   let(:sp) { nil }
@@ -10,6 +12,17 @@ describe VendorStatus do
 
   it 'raises an error if passed an unknown vendor' do
     expect { subject.vendor_outage?(:unknown_vendor) }.to raise_error(ArgumentError)
+  end
+
+  it 'returns a localized url if locale is other than English' do
+    I18n.locale = :fr
+    expect(subject.vendor_outage_url_localized).to eq vendor_outage_url(locale: :fr)
+
+    I18n.locale = :es
+    expect(subject.vendor_outage_url_localized).to eq vendor_outage_url(locale: :es)
+
+    I18n.locale = :en
+    expect(subject.vendor_outage_url_localized).to eq vendor_outage_url
   end
 
   context 'when all vendors are operational' do


### PR DESCRIPTION
Additional PR for LG-5184 to ensure that the locale of the page redirecting to the outage page is persisted.