### PR TITLE
LG-4815: retire legacy event names

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -24,8 +24,6 @@ module Flow
       if @analytics_id
         increment_step_name_counts
         analytics.track_event(analytics_submitted, result.to_h.merge(analytics_properties))
-        # keeping the old event names for backward compatibility
-        analytics.track_event(old_analytics_submitted, result.to_h.merge(analytics_properties))
       end
       register_update_step(step, result)
       if flow.json
@@ -50,8 +48,6 @@ module Flow
       if @analytics_id
         increment_step_name_counts
         analytics.track_event(analytics_visited, analytics_properties)
-        # keeping the old event names for backward compatibility
-        analytics.track_event(old_analytics_visited, analytics_properties)
       end
       Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(current_step, :view, true)
     end
@@ -129,8 +125,6 @@ module Flow
         optional_properties = result.to_h.merge(step: optional_show_step_name)
 
         analytics.track_event(analytics_optional_step, optional_properties)
-        # keeping the old event names for backward compatibility
-        analytics.track_event(old_analytics_optional_step, optional_properties)
       end
 
       if next_step.to_s != optional_step
@@ -176,18 +170,6 @@ module Flow
 
     def analytics_optional_step
       'IdV: ' + "#{@analytics_id} optional #{current_step} submitted".downcase
-    end
-
-    def old_analytics_submitted
-      @analytics_id + ' submitted'
-    end
-
-    def old_analytics_visited
-      @analytics_id + ' visited'
-    end
-
-    def old_analytics_optional_step
-      [@analytics_id, 'optional submitted'].join(' ')
     end
 
     def analytics_properties

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -131,7 +131,7 @@ describe Idv::CaptureDocController do
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).with(
-          Analytics::DOC_AUTH + ' visited', result
+          'IdV: ' + "#{Analytics::DOC_AUTH} capture_complete visited".downcase, result
         )
       end
 
@@ -142,11 +142,11 @@ describe Idv::CaptureDocController do
         get :show, params: { step: 'capture_complete' }
 
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::DOC_AUTH + ' visited',
+          'IdV: ' + "#{Analytics::DOC_AUTH} capture_complete visited".downcase,
           hash_including(step: 'capture_complete', step_count: 1),
         )
         expect(@analytics).to have_received(:track_event).ordered.with(
-          Analytics::DOC_AUTH + ' visited',
+          'IdV: ' + "#{Analytics::DOC_AUTH} capture_complete visited".downcase,
           hash_including(step: 'capture_complete', step_count: 2),
         )
       end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -85,9 +85,6 @@ describe Idv::DocAuthController do
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} welcome visited".downcase, result
       )
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::DOC_AUTH + ' visited', result
-      )
     end
 
     it 'tracks analytics for the optional step' do
@@ -99,9 +96,6 @@ describe Idv::DocAuthController do
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} optional verify_wait submitted".downcase, result
       )
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::DOC_AUTH + ' optional submitted', result
-      )
     end
 
     it 'increments the analytics step counts on subsequent submissions' do
@@ -109,11 +103,11 @@ describe Idv::DocAuthController do
       get :show, params: { step: 'welcome' }
 
       expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' visited',
+        'IdV: ' + "#{Analytics::DOC_AUTH} welcome visited".downcase,
         hash_including(step: 'welcome', step_count: 1),
       )
       expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' visited',
+        'IdV: ' + "#{Analytics::DOC_AUTH} welcome visited".downcase,
         hash_including(step: 'welcome', step_count: 2),
       )
     end
@@ -138,9 +132,6 @@ describe Idv::DocAuthController do
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} ssn submitted".downcase, result
       )
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::DOC_AUTH + ' submitted', result
-      )
     end
 
     it 'increments the analytics step counts on subsequent submissions' do
@@ -158,12 +149,6 @@ describe Idv::DocAuthController do
       put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '666-66-6666' } }
       put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
 
-      expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 1)
-      )
-      expect(@analytics).to have_received(:track_event).ordered.with(
-        Analytics::DOC_AUTH + ' submitted', hash_including(step: 'ssn', step_count: 2)
-      )
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} ssn submitted".downcase,
         hash_including(step: 'ssn', step_count: 1),
@@ -194,9 +179,6 @@ describe Idv::DocAuthController do
       expect(response).to redirect_to idv_doc_auth_errors_no_camera_url
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} welcome submitted".downcase, result
-      )
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::DOC_AUTH + ' submitted', result
       )
     end
   end
@@ -397,18 +379,6 @@ describe Idv::DocAuthController do
       )
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} verify_document_status submitted".downcase, {
-          errors: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
-          error_details: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
-          success: false,
-          remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
-          step: 'verify_document_status',
-          flow_path: 'standard',
-          step_count: 1,
-          pii_like_keypaths: [[:pii]],
-        }
-      )
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::DOC_AUTH + ' submitted', {
           errors: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
           error_details: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
           success: false,

--- a/spec/features/idv/doc_auth/agreement_step_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_step_spec.rb
@@ -52,12 +52,6 @@ feature 'doc auth welcome step' do
       expect(log.upload_view_at).not_to be_nil
 
       expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' visited', step: 'upload', step_count: 1
-      )
-      expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' submitted', step: 'upload', step_count: 2, success: true
-      )
-      expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} upload visited".downcase, step: 'upload', step_count: 1
       )
       expect(fake_analytics).to have_logged_event(

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -87,13 +87,6 @@ feature 'doc auth document capture step' do
 
       expect(page).to have_current_path(next_step)
       expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' submitted',
-        step: 'document_capture',
-        flow_path: 'standard',
-        doc_auth_result: 'Passed',
-        billed: true,
-      )
-      expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
         step: 'document_capture',
         flow_path: 'standard',
@@ -117,14 +110,6 @@ feature 'doc auth document capture step' do
 
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
 
-      expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' submitted',
-        step: 'document_capture',
-        flow_path: 'standard',
-        doc_auth_result: 'Passed',
-        billed: true,
-        success: false,
-      )
       expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
         step: 'document_capture',
@@ -397,7 +382,7 @@ feature 'doc auth document capture step' do
         expect(page).to have_current_path(idv_doc_auth_document_capture_step)
 
         expect(fake_analytics).to have_logged_event(
-          Analytics::DOC_AUTH + ' submitted',
+          'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
           document_expired: true,
           would_have_passed: true,
         )
@@ -412,7 +397,7 @@ feature 'doc auth document capture step' do
         expect(page).to have_current_path(next_step)
 
         expect(fake_analytics).to have_logged_event(
-          Analytics::DOC_AUTH + ' submitted',
+          'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
           document_expired: true,
         )
 

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -118,7 +118,7 @@ feature 'doc capture document capture step' do
     it 'logs events as the inherited user' do
       complete_doc_capture_steps_before_first_step(user)
       expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' visited',
+        'IdV: ' + "#{Analytics::DOC_AUTH} document_capture visited".downcase,
         step: 'document_capture',
         flow_path: 'hybrid',
       )
@@ -241,13 +241,6 @@ feature 'doc capture document capture step' do
       attach_and_submit_images
 
       expect(page).to have_current_path(next_step)
-      expect(fake_analytics).to have_logged_event(
-        Analytics::DOC_AUTH + ' submitted',
-        step: 'document_capture',
-        flow_path: 'hybrid',
-        doc_auth_result: 'Passed',
-        billed: true,
-      )
       expect(fake_analytics).to have_logged_event(
         'IdV: ' + "#{Analytics::DOC_AUTH} document_capture submitted".downcase,
         step: 'document_capture',


### PR DESCRIPTION
Retires the older `Doc Auth visited|submitted` event names.

**Why?** We moved to the more consistent naming scheme (`IdV: doc auth <step> visited|submitted`) last February. Any instances of dashboards that are still using the old names and will break can and should be updated to the new names.