### PR TITLE
Remove unused document capture notice text

### DIFF
--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -80,13 +80,8 @@ module Idv
 
       def handle_document_verification_failure(response)
         mark_step_incomplete(:document_capture)
-        notice = if liveness_checking_enabled?
-                   { notice: I18n.t('errors.doc_auth.document_capture_info_with_selfie_html') }
-                 else
-                   { notice: I18n.t('errors.doc_auth.document_capture_info_html') }
-                 end
         log_document_error(response)
-        extra = response.to_h.merge(notice)
+        extra = response.to_h
         failure(response.first_error_message, extra)
       end
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -23,26 +23,6 @@ en:
       consent_form: Before you can continue, you must give us permission. Please check
         the box below and then click continue.
       document_capture_cancelled: You have cancelled uploading photos of your ID on your phone.
-      document_capture_info_html: |-
-        <div class="bold">Please check that:</div>
-        <ul>
-        <li>Images are clear (not blurry) and in focus</li>
-        <li>No glare, shadow or reflection is present</li>
-        <li>Your ID does not have any damaged barcodes</li>
-        <li>Your ID represents 80% of the overall image</li>
-        <li>Your ID is against a solid, dark background</li>
-        </ul>
-      document_capture_info_with_selfie_html: |-
-        <div class="bold">Please check that:</div>
-        <ul>
-        <li>Images are clear (not blurry) and in focus</li>
-        <li>No glare, shadow or reflection is present</li>
-        <li>Your ID does not have any damaged barcodes</li>
-        <li>Your ID represents 80% of the overall image</li>
-        <li>Your ID is against a solid, dark background</li>
-        <li>Your picture is taken in a well-lit area with a plain background</li>
-        <li>You are not wearing a hat or glasses, and your head is fully visible</li>
-        </ul>
       document_verification_timeout: The server took too long to respond. Please try again.
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -23,26 +23,6 @@ es:
       consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a
         continuación y luego haga clic en continuar.
       document_capture_cancelled: Ha cancelado la carga de fotos de su identificación en este teléfono.
-      document_capture_info_html: |-
-        <div class="bold">Por favor verifique que:</div>
-        <ul>
-        <li>Las imágenes son claras (no borrosas) y enfocadas</li>
-        <li>No hay reflejos, sombras o reflejos</li>
-        <li>Su identificación no tiene ningún código de barras dañado</li>
-        <li>Su identificación representa el 80% de la imagen general</li>
-        <li>Su identificación está contra un fondo sólido y oscuro</li>
-        </ul>
-      document_capture_info_with_selfie_html: |-
-        <div class="bold">Por favor verifique que:</div>
-        <ul>
-        <li>Las imágenes son claras (no borrosas) y enfocadas</li>
-        <li>No hay reflejos, sombras o reflejos</li>
-        <li>Su identificación no tiene ningún código de barras dañado</li>
-        <li>Su identificación representa el 80% de la imagen general</li>
-        <li>Su identificación está contra un fondo sólido y oscuro</li>
-        <li>La foto se hace en un espacio bien iluminado y con un fondo uniforme</li>
-        <li>No lleva puesto un sombrero o anteojos, y su cabeza es completamente visible</li>
-        </ul>
       document_verification_timeout: El servidor tardó demasiado en responder. Inténtalo de nuevo.
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -26,26 +26,6 @@ fr:
         Veuillez cocher la case ci-dessous puis cliquez sur continuer.
       document_capture_cancelled: Vous avez annulé le téléchargement de vos photos
         d'identité sur votre téléphone.
-      document_capture_info_html: |-
-        <div class="bold">Veuillez vérifier que:</div>
-        <ul>
-        <li>Les images sont claires (non floues) et nettes</li>
-        <li>Aucun éblouissement, ombre ou reflet n’est présent</li>
-        <li>Votre identifiant n’a pas de code à barres endommagé</li>
-        <li>Votre pièce d’identité représente 80% de l’image globale</li>
-        <li>Votre pièce d’identité est sur un fond sombre et uni</li>
-        </ul>
-      document_capture_info_with_selfie_html: |-
-        <div class="bold">Veuillez vérifier que:</div>
-        <ul>
-        <li>Images are clear (not blurry) and in focus</li>
-        <li>Aucun éblouissement, ombre ou reflet n’est présent</li>
-        <li>Votre identifiant n’a pas de code à barres endommagé</li>
-        <li>Votre pièce d’identité représente 80% de l’image globale</li>
-        <li>Votre pièce d’identité est sur un fond sombre et uni</li>
-        <li>Votre photo est prise dans un endroit bien éclairé avec un fond uni</li>
-        <li>Vous ne portez pas de chapeau ni de lunettes et votre tête est entièrement visible</li>
-        </ul>
       document_verification_timeout: Le serveur a mis trop de temps à répondre. Veuillez réessayer.
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé


### PR DESCRIPTION
**Why**: Because they're never actually presented to the user, who will instead see the message derived from the failing response.

Also helps for a few points of general cleanup:

- `bold` is a BassCSS class and is deprecated in favor of design system.
- Per https://github.com/18F/identity-idp/pull/5565#issuecomment-958146515, these sorts of notice content with embedded HTML may need to be opted-in to `html_safe`, so this eliminates one point of update.

This logic is only used for the no-JavaScript document capture. In practice, what happens is that the same error message which would be presented in the React application is presented to no-JavaScript.

Example:

![image](https://user-images.githubusercontent.com/1779930/139949595-3b7a52b1-f944-4136-858f-86b1f16726ff.png)

If you follow the flow of logic, you can see that the `failure` method does capture this as "extra", but that extra is not used for presenting a notice, and in-fact doesn't appear to be used for much of anything at all:

https://github.com/18F/identity-idp/blob/759408a0e65dc6a1a1add2c03310ebabf9ec7ea9/app/services/flow/base_step.rb#L53-L58

https://github.com/18F/identity-idp/blob/759408a0e65dc6a1a1add2c03310ebabf9ec7ea9/app/services/flow/flow_state_machine.rb#L28-L34

The actual error message is pulled from the `flow_session[:error_message]`:

https://github.com/18F/identity-idp/blob/759408a0e65dc6a1a1add2c03310ebabf9ec7ea9/app/views/idv/doc_auth/_error_messages.html.erb#L6

Originally: #3929

cc @anniehirshman-gsa in case you're aware of these messages being intended to be shown anywhere.