### PR TITLE
CORS: cache redirect uris from DB

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -93,7 +93,7 @@ module Upaya
 
           redirect_uris = Rails.cache.fetch(
             'all_service_provider_redirect_uris',
-            expires_in: 5.minutes,
+            expires_in: IdentityConfig.store.all_redirect_uris_cache_duration_minutes.minutes,
           ) do
             ServiceProvider.pluck(:redirect_uris).flatten.compact
           end

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,7 +91,14 @@ module Upaya
         origins do |source, _env|
           next if source == IdentityConfig.store.domain_name
 
-          ServiceProvider.pluck(:redirect_uris).flatten.compact.find do |uri|
+          redirect_uris = Rails.cache.fetch(
+            'all_service_provider_redirect_uris',
+            expires_in: 5.minutes,
+          ) do
+            ServiceProvider.pluck(:redirect_uris).flatten.compact
+          end
+
+          redirect_uris.find do |uri|
             split_uri = uri.split('//')
             protocol = split_uri[0]
             domain = split_uri[1].split('/')[0] if split_uri.size > 1

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -20,6 +20,7 @@ aamva_cert_enabled: 'true'
 aamva_sp_banlist_issuers: '[]'
 aamva_verification_request_timeout: '5'
 aamva_verification_url: https://example.org:12345/verification/url
+all_redirect_uris_cache_duration_minutes: '5'
 account_reset_token_valid_for_days: '1'
 account_reset_wait_period_days: '1'
 acuant_maintenance_window_start:

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -20,7 +20,7 @@ aamva_cert_enabled: 'true'
 aamva_sp_banlist_issuers: '[]'
 aamva_verification_request_timeout: '5'
 aamva_verification_url: https://example.org:12345/verification/url
-all_redirect_uris_cache_duration_minutes: '5'
+all_redirect_uris_cache_duration_minutes: '2'
 account_reset_token_valid_for_days: '1'
 account_reset_wait_period_days: '1'
 acuant_maintenance_window_start:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -72,6 +72,7 @@ class IdentityConfig
     config.add(:aamva_sp_banlist_issuers, type: :json)
     config.add(:aamva_verification_request_timeout, type: :integer)
     config.add(:aamva_verification_url)
+    config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
     config.add(:account_reset_token_valid_for_days, type: :integer)
     config.add(:account_reset_wait_period_days, type: :integer)
     config.add(:acuant_maintenance_window_start, type: :timestamp, allow_nil: true)

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'CORS headers for OpenID Connect endpoints' do
+  before { Rails.cache.clear }
+  after { Rails.cache.clear }
+
   describe 'configuration endpoint' do
     context 'origin is included in ServiceProvider redirect_uris' do
       it 'allows origin' do


### PR DESCRIPTION
This is a very hot codepath, so caching this helps us alleviate pressure on the DB