### PR TITLE
Pass around Pii::Attributes around instead of a string (LG-5294)

### DIFF
--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -30,8 +30,7 @@ module Users
     end
 
     def decrypted_pii
-      pii = reactivate_account_session.decrypted_pii
-      @_decrypted_pii ||= Pii::Attributes.new_from_json(pii)
+      @_decrypted_pii ||= reactivate_account_session.decrypted_pii
     end
 
     def handle_success(result)

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -29,6 +29,7 @@ module Users
       redirect_to root_url
     end
 
+    # @return [Pii::Attributes, nil]
     def decrypted_pii
       @_decrypted_pii ||= reactivate_account_session.decrypted_pii
     end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -28,7 +28,7 @@ module Users
 
         analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED, result.to_h)
         if result.success?
-          handle_success(decrypted_pii_json: personal_key_form.decrypted_pii_json)
+          handle_success(decrypted_pii: personal_key_form.decrypted_pii)
         else
           handle_failure(result)
         end
@@ -61,9 +61,10 @@ module Users
       reactivate_account_session.start
     end
 
-    def handle_success(decrypted_pii_json:)
+    # @param [Pii::Attributes] decrypted_pii
+    def handle_success(decrypted_pii:)
       analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION)
-      reactivate_account_session.store_decrypted_pii(decrypted_pii_json)
+      reactivate_account_session.store_decrypted_pii(decrypted_pii)
       redirect_to verify_password_url
     end
 

--- a/app/forms/verify_personal_key_form.rb
+++ b/app/forms/verify_personal_key_form.rb
@@ -22,18 +22,15 @@ class VerifyPersonalKeyForm
     FormResponse.new(success: valid?, errors: errors, extra: extra)
   end
 
-  def decrypted_pii_json
-    decrypted_pii&.to_json
+  # @return [Pii::Attributes,nil]
+  def decrypted_pii
+    @_pii ||= password_reset_profile.recover_pii(personal_key)
   end
 
   private
 
   def password_reset_profile
     user.decorate.password_reset_profile
-  end
-
-  def decrypted_pii
-    @_pii ||= password_reset_profile.recover_pii(personal_key)
   end
 
   def validate_personal_key

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -40,12 +40,14 @@ class Profile < ApplicationRecord
     Pii::Attributes.new_from_json(decrypted_json)
   end
 
+  # @return [Pii::Attributes]
   def recover_pii(personal_key)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
     decrypted_recovery_json = encryptor.decrypt(encrypted_pii_recovery, user_uuid: user.uuid)
     Pii::Attributes.new_from_json(decrypted_recovery_json)
   end
 
+  # @param [Pii::Attributes] pii
   def encrypt_pii(pii, password)
     encrypt_ssn_fingerprint(pii)
     encrypt_compound_pii_fingerprint(pii)
@@ -54,6 +56,7 @@ class Profile < ApplicationRecord
     encrypt_recovery_pii(pii)
   end
 
+  # @param [Pii::Attributes] pii
   def encrypt_recovery_pii(pii)
     personal_key = personal_key_generator.create
     encryptor = Encryption::Encryptors::PiiEncryptor.new(
@@ -63,6 +66,7 @@ class Profile < ApplicationRecord
     @personal_key = personal_key
   end
 
+  # @param [Pii::Attributes] pii
   def self.build_compound_pii(pii)
     values = [
       pii.first_name,

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -24,17 +24,22 @@ class ReactivateAccountSession
     session[SESSION_KEY] = generate_session
   end
 
+  # Stores PII as a string in the session
+  # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:personal_key] = true
-    reactivate_account_session[:pii] = pii
+    reactivate_account_session[:pii] = pii.to_json
   end
 
   def personal_key?
     reactivate_account_session[:personal_key]
   end
 
+  # Parses string into PII struct
+  # @return [Pii::Attributes, nil]
   def decrypted_pii
-    reactivate_account_session[:pii]
+    json_str = reactivate_account_session[:pii]
+    Pii::Attributes.new_from_json(json_str) if json_str
   end
 
   private

--- a/spec/forms/verify_personal_key_form_spec.rb
+++ b/spec/forms/verify_personal_key_form_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe VerifyPersonalKeyForm do
 
       it 'exposes the decrypted_pii as a separate attribute' do
         form.submit
-        expect(form.decrypted_pii_json).to be_present
-        expect(JSON.parse(form.decrypted_pii_json, symbolize_names: true)).
-          to include(ssn: '123456789')
+        expect(form.decrypted_pii).to be_present
+        expect(form.decrypted_pii.ssn).to eq('123456789')
       end
     end
 

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -41,14 +41,14 @@ describe ReactivateAccountSession do
 
   describe '#suspend' do
     it 'sets the reactivate account object back to its defaults' do
-      pii = {}
+      pii = Pii::Attributes.new(first_name: 'Test')
 
       @reactivate_account_session.start
       @reactivate_account_session.store_decrypted_pii(pii)
 
       expect(@reactivate_account_session.started?).to be(true)
       expect(@reactivate_account_session.personal_key?).to be(true)
-      expect(@reactivate_account_session.decrypted_pii).to be(pii)
+      expect(@reactivate_account_session.decrypted_pii).to eq(pii)
 
       @reactivate_account_session.suspend
 
@@ -60,11 +60,11 @@ describe ReactivateAccountSession do
 
   describe '#store_decrypted_pii' do
     it 'stores the supplied object in the session and toggles `personal_key` flag' do
-      pii = {}
+      pii = Pii::Attributes.new(first_name: 'Test')
       @reactivate_account_session.store_decrypted_pii(pii)
       account_reactivation_obj = user_session[:reactivate_account]
       expect(account_reactivation_obj[:personal_key]).to be(true)
-      expect(account_reactivation_obj[:pii]).to eq(pii)
+      expect(account_reactivation_obj[:pii]).to eq(pii.to_json)
     end
   end
 
@@ -85,7 +85,7 @@ describe ReactivateAccountSession do
     end
 
     it 'returns the pii stored in the session' do
-      pii = {}
+      pii = Pii::Attributes.new(first_name: 'Test')
       @reactivate_account_session.store_decrypted_pii(pii)
 
       expect(@reactivate_account_session.decrypted_pii).to eq(pii)


### PR DESCRIPTION
- Minimize chances of accidental logging by using redacted struct