### PR TITLE
Add configuration to turn off agreements data seeding if desired

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -196,6 +196,7 @@ rules_of_use_updated_at: '2021-05-21T00:00:00Z'
 s3_public_reports_enabled: 'false'
 s3_reports_enabled: 'false'
 saml_secret_rotation_enabled: 'false'
+seed_agreements_data: 'true'
 service_provider_request_ttl_hours: '24'
 session_check_delay: '30'
 session_check_frequency: '30'
@@ -345,6 +346,7 @@ production:
   saml_endpoint_configs: '[]'
   scrypt_cost: 10000$8$1$
   secret_key_base:
+  seed_agreements_data: 'false'
   session_encryption_key:
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:int"]'
   sps_over_quota_limit_notify_email_list: '[]'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,13 @@ ServiceProviderSeeder.new.run
 AgencySeeder.new.run
 
 # add partnerships / agreements data, note that the order matters!
-Agreements::PartnerAccountStatusSeeder.new.run
-Agreements::PartnerAccountSeeder.new.run
-Agreements::IaaGtcSeeder.new.run
-Agreements::IntegrationStatusSeeder.new.run
-Agreements::IntegrationSeeder.new.run
-Agreements::IaaOrderSeeder.new.run
+if IdentityConfig.store.seed_agreements_data
+  puts '=== Seeding agreements data ===' # rubocop:disable Rails/Output
+
+  Agreements::PartnerAccountStatusSeeder.new.run
+  Agreements::PartnerAccountSeeder.new.run
+  Agreements::IaaGtcSeeder.new.run
+  Agreements::IntegrationStatusSeeder.new.run
+  Agreements::IntegrationSeeder.new.run
+  Agreements::IaaOrderSeeder.new.run
+end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -282,6 +282,7 @@ class IdentityConfig
     config.add(:saml_secret_rotation_enabled, type: :boolean)
     config.add(:scrypt_cost, type: :string)
     config.add(:secret_key_base, type: :string)
+    config.add(:seed_agreements_data, type: :boolean)
     config.add(:service_provider_request_ttl_hours, type: :integer)
     config.add(:session_check_delay, type: :integer)
     config.add(:session_check_frequency, type: :integer)


### PR DESCRIPTION
**Why:** https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1636035938073500

We need to make sure we turn this setting on in production `application.yml` before deploying.