### PR TITLE
Remove unused BassCSS responsive white space module

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -13,4 +13,3 @@
 @import 'basscss-sass/positions';
 @import 'basscss-sass/grid';
 @import 'basscss-sass/flex-object';
-@import 'basscss-sass/responsive-white-space';


### PR DESCRIPTION
**Why**: Because none of these classes are currently in use.

I noticed that all classes in this file are already covered by banned ERBLint deprecated class pattern.

https://github.com/18F/identity-idp/blob/70f46e021b291101075f60417f48f87a1c45d488/.erb-lint.yml#L131

https://regex101.com/r/nl5J6U/1

Source: https://github.com/basscss/basscss-sass/blob/v3.0.0/_responsive-white-space.scss