### PR TITLE
Fix error in job log subscriber

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -84,13 +84,19 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     ex = event.payload[:error]
     wait_seconds = event.payload[:wait]
 
-    json = {
+    json = default_attributes(event, job).merge(
       wait_ms: wait_seconds.to_i.in_milliseconds,
-    }
+    )
 
     json[:exception_class] = ex.class.name if ex
 
-    info(json.to_json)
+    if ex
+      error(json.to_json)
+    else
+      info(json.to_json)
+    end
+
+    json
   end
 
   def retry_stopped(event)

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -85,7 +85,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     wait_seconds = event.payload[:wait]
 
     json = {
-      wait_ms: wait.to_i.in_milliseconds,
+      wait_ms: wait_seconds.to_i.in_milliseconds,
     }
 
     json[:exception_class] = ex.class.name if ex


### PR DESCRIPTION
Was looking at worker logs and noticed:

```
NameError: undefined local variable or method `wait' for #<IdentityJobLogSubscriber:0x00005576f49b9270>
/srv/idp/releases/chef/lib/identity_job_log_subscriber.rb:88
```

This PR should fix that