### PR TITLE
Finer grained funnel tracking

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -15,7 +15,7 @@ class Analytics
       new_event: first_event_this_session?,
       new_session_path: first_path_visit_this_session?,
       new_session_success_state: first_success_state_this_session?,
-      success_state: success_state_token,
+      success_state: success_state_token(event),
       path: request&.path,
       user_id: attributes[:user_id] || user.uuid,
       locale: I18n.locale,
@@ -42,8 +42,9 @@ class Analytics
     @session[:events] ||= {}
     @session[:success_states] ||= {}
     if request
-      @session[:first_success_state] = !@session[:success_states].key?(success_state_token)
-      @session[:success_states][success_state_token] = true
+      token = success_state_token(event)
+      @session[:first_success_state] = !@session[:success_states].key?(token)
+      @session[:success_states][token] = true
       @session[:first_path_visit] = !@session[:paths_visited].key?(request.path)
       @session[:paths_visited][request.path] = true
     end
@@ -59,7 +60,7 @@ class Analytics
     @session[:first_success_state]
   end
 
-  def success_state_token
+  def success_state_token(event)
     "#{request.env["REQUEST_METHOD"]}:#{request&.path}:#{event}"
   end
   def first_event_this_session?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -61,7 +61,7 @@ class Analytics
   end
 
   def success_state_token(event)
-    "#{request.env["REQUEST_METHOD"]}:#{request&.path}:#{event}"
+    "#{request&.env["REQUEST_METHOD"]}:#{request&.path}:#{event}"
   end
   def first_event_this_session?
     @session[:first_event]

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -14,6 +14,8 @@ class Analytics
       event_properties: attributes.except(:user_id),
       new_event: first_event_this_session?,
       new_session_path: first_path_visit_this_session?,
+      new_session_success_state: first_success_state_this_session?,
+      success_state: success_state_token,
       path: request&.path,
       user_id: attributes[:user_id] || user.uuid,
       locale: I18n.locale,
@@ -38,7 +40,10 @@ class Analytics
   def update_session_events_and_paths_visited_for_analytics(event)
     @session[:paths_visited] ||= {}
     @session[:events] ||= {}
+    @session[:success_states] ||= {}
     if request
+      @session[:first_success_state] = !@session[:success_states].key?(success_state_token)
+      @session[:success_states][success_state_token] = true
       @session[:first_path_visit] = !@session[:paths_visited].key?(request.path)
       @session[:paths_visited][request.path] = true
     end
@@ -50,6 +55,13 @@ class Analytics
     @session[:first_path_visit]
   end
 
+  def first_success_state_this_session?
+    @session[:first_success_state]
+  end
+
+  def success_state_token
+    "#{request.env["REQUEST_METHOD"]}:#{request&.path}:#{event}"
+  end
   def first_event_this_session?
     @session[:first_event]
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -63,6 +63,7 @@ class Analytics
   def success_state_token(event)
     "#{request&.env&.dig('REQUEST_METHOD')}:#{request&.path}:#{event}"
   end
+
   def first_event_this_session?
     @session[:first_event]
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -61,7 +61,7 @@ class Analytics
   end
 
   def success_state_token(event)
-    "#{request&.env["REQUEST_METHOD"]}:#{request&.path}:#{event}"
+    "#{request&.env&.dig('REQUEST_METHOD')}:#{request&.path}:#{event}"
   end
   def first_event_this_session?
     @session[:first_event]

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -61,7 +61,7 @@ class Analytics
   end
 
   def success_state_token(event)
-    "#{request&.env&.dig('REQUEST_METHOD')}:#{request&.path}:#{event}"
+    "#{request&.env&.dig('REQUEST_METHOD')}|#{request&.path}|#{event}"
   end
 
   def first_event_this_session?

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe OpenidConnect::UserInfoController do
           'first_path_visit' => true,
           'events' => { 'OpenID Connect: bearer token authentication' => true },
           'first_event' => true,
+          'first_success_state' => true,
+          'success_states' => {'POST:/api/openid_connect/userinfo:OpenID Connect: bearer token authentication' => true},
         }
         expect(request.session.to_h).to eq(session_hash)
       end

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe OpenidConnect::UserInfoController do
           'events' => { 'OpenID Connect: bearer token authentication' => true },
           'first_event' => true,
           'first_success_state' => true,
-          'success_states' => {'POST:/api/openid_connect/userinfo:OpenID Connect: bearer token authentication' => true},
+          'success_states' => {
+            'POST:/api/openid_connect/userinfo:OpenID Connect: bearer token authentication' => true,
+          },
         }
         expect(request.session.to_h).to eq(session_hash)
       end

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe OpenidConnect::UserInfoController do
           'first_event' => true,
           'first_success_state' => true,
           'success_states' => {
-            'POST:/api/openid_connect/userinfo:OpenID Connect: bearer token authentication' => true,
+            'POST|/api/openid_connect/userinfo|OpenID Connect: bearer token authentication' => true,
           },
         }
         expect(request.session.to_h).to eq(session_hash)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -23,6 +23,7 @@ describe Analytics do
   let(:current_user) { build_stubbed(:user, uuid: '123') }
   let(:request) { FakeRequest.new }
   let(:path) { 'fake_path' }
+  let(:success_state) {':fake_path:Trackable Event'}
 
   subject(:analytics) do
     Analytics.new(
@@ -48,6 +49,8 @@ describe Analytics do
         git_sha: IdentityConfig::GIT_SHA,
         git_branch: IdentityConfig::GIT_BRANCH,
         new_session_path: true,
+        new_session_success_state: true,
+        success_state: success_state,
         new_event: true,
         path: path,
       }
@@ -66,6 +69,8 @@ describe Analytics do
         git_sha: IdentityConfig::GIT_SHA,
         git_branch: IdentityConfig::GIT_BRANCH,
         new_session_path: nil,
+        new_session_success_state: nil,
+        success_state: success_state,
         new_event: nil,
         path: path,
       }
@@ -86,6 +91,8 @@ describe Analytics do
         locale: I18n.locale,
         git_sha: IdentityConfig::GIT_SHA,
         git_branch: IdentityConfig::GIT_BRANCH,
+        new_session_success_state: true,
+        success_state: success_state,
         new_session_path: true,
         new_event: true,
         path: path,
@@ -124,6 +131,8 @@ describe Analytics do
         new_session_path: true,
         new_event: true,
         path: path,
+        new_session_success_state: true,
+        success_state: success_state,
       }
 
       expect(ahoy).to receive(:track).

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -23,7 +23,7 @@ describe Analytics do
   let(:current_user) { build_stubbed(:user, uuid: '123') }
   let(:request) { FakeRequest.new }
   let(:path) { 'fake_path' }
-  let(:success_state) { 'GET:fake_path:Trackable Event' }
+  let(:success_state) { 'GET|fake_path|Trackable Event' }
 
   subject(:analytics) do
     Analytics.new(

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -23,7 +23,7 @@ describe Analytics do
   let(:current_user) { build_stubbed(:user, uuid: '123') }
   let(:request) { FakeRequest.new }
   let(:path) { 'fake_path' }
-  let(:success_state) {':fake_path:Trackable Event'}
+  let(:success_state) { 'GET:fake_path:Trackable Event' }
 
   subject(:analytics) do
     Analytics.new(

--- a/spec/support/fake_request.rb
+++ b/spec/support/fake_request.rb
@@ -24,4 +24,8 @@ class FakeRequest
   def path
     'fake_path'
   end
+
+  def env
+    {'REQUEST_METHOD': 'GET'}
+  end
 end

--- a/spec/support/fake_request.rb
+++ b/spec/support/fake_request.rb
@@ -26,6 +26,6 @@ class FakeRequest
   end
 
   def env
-    {'REQUEST_METHOD': 'GET'}
+    { 'REQUEST_METHOD' => 'GET' }
   end
 end


### PR DESCRIPTION
**Why**: Current funnel stats track by event.  However events are reused in different contexts at different endpoints.  Rather than parse other state markers for each which is highly brittle simply create a new success state token that combines endpoint/path, event, and verb.  This will give us finer grain tracking and allow us to track subfunnels.  ie 'POST:/api/openid_connect/userinfo:OpenID Connect: bearer token authentication'