### PR TITLE
Add unique users per-month to issuer supplement report (LG-5319)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install python3-pip python-dev jq
-            sudo pip install awscli
+            sudo pip install awscli --ignore-installed six
       - run:
           name: Install Code Climate Test Reporter
           command: |

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -9,8 +9,10 @@ module Db
 
       module_function
 
+      # @param [Hash] iaa
+      # @param [Symbol] aggregate (one of :sum, :unique)
       # @return [PG::Result,Array]
-      def call(service_provider)
+      def call(service_provider:, aggregate:)
         return [] if !service_provider.iaa_start_date || !service_provider.iaa_end_date
 
         iaa_range = (service_provider.iaa_start_date..service_provider.iaa_end_date)
@@ -25,35 +27,68 @@ module Db
         # The subqueries create a uniform representation of data:
         # - full months from monthly_sp_auth_counts
         # - partial months by aggregating sp_return_logs
-        # The results are rows with [ial, auth_count, year_month, issuer, iaa, iaa start, iaa end]
-        union_query = [
-          *full_month_subquery(sp: service_provider, full_months: full_months),
-          *partial_month_subqueries(sp: service_provider, partial_months: partial_months),
+        # The results are rows with [user_id, ial, auth_count, year_month]
+        subquery = [
+          *full_month_subquery(issuer: issuer, full_months: full_months),
+          *partial_month_subqueries(issuer: issuer, partial_months: partial_months),
         ].join(' UNION ALL ')
 
-        ActiveRecord::Base.connection.execute(union_query)
+        select_clause = case aggregate
+        when :sum
+          <<~SQL
+            SUM(billing_month_logs.auth_count)::bigint AS total_auth_count
+          SQL
+        when :unique
+          <<~SQL
+            COUNT(DISTINCT billing_month_logs.user_id) AS unique_users
+          SQL
+        else
+          raise "unknown aggregate=#{aggregate}"
+        end
+
+        params = {
+          iaa_start_date: quote(iaa_range.begin),
+          iaa_end_date: quote(iaa_range.end),
+          iaa: quote(service_provider.iaa),
+          issuer: quote(issuer),
+          subquery: subquery,
+          select_clause: select_clause,
+        }
+
+        sql = format(<<~SQL, params)
+          WITH subquery AS (%{subquery})
+          SELECT
+            billing_month_logs.year_month
+          , billing_month_logs.ial
+          , %{iaa_start_date} AS iaa_start_date
+          , %{iaa_end_date} AS iaa_end_date
+          , %{issuer} AS issuer
+          , %{iaa} AS iaa
+          , %{select_clause}
+          FROM
+            subquery billing_month_logs
+          GROUP BY
+            billing_month_logs.year_month
+          , billing_month_logs.ial
+        SQL
+
+        ActiveRecord::Base.connection.execute(sql)
       end
 
       # @return [String]
-      def full_month_subquery(sp:, full_months:)
+      def full_month_subquery(issuer:, full_months:)
         return if full_months.blank?
         params = {
-          iaa: sp.iaa,
-          issuer: sp.issuer,
-          iaa_start_date: sp.iaa_start_date,
-          iaa_end_date: sp.iaa_end_date,
+          issuer: issuer,
           year_months: full_months.map { |r| r.begin.strftime('%Y%m') },
         }.transform_values { |value| quote(value) }
 
         full_month_subquery = format(<<~SQL, params)
           SELECT
-            monthly_sp_auth_counts.year_month
+            monthly_sp_auth_counts.user_id
+          , monthly_sp_auth_counts.year_month
           , monthly_sp_auth_counts.ial
-          , SUM(monthly_sp_auth_counts.auth_count)::bigint AS total_auth_count
-          , %{issuer} AS issuer
-          , %{iaa} AS iaa
-          , %{iaa_start_date} AS iaa_start_date
-          , %{iaa_end_date} AS iaa_end_date
+          , SUM(monthly_sp_auth_counts.auth_count)::bigint AS auth_count
           FROM
             monthly_sp_auth_counts
           WHERE
@@ -62,38 +97,34 @@ module Db
           GROUP BY
             monthly_sp_auth_counts.year_month
           , monthly_sp_auth_counts.ial
+          , monthly_sp_auth_counts.user_id
         SQL
       end
 
       # @return [Array<String>]
-      def partial_month_subqueries(sp:, partial_months:)
+      def partial_month_subqueries(issuer:, partial_months:)
         partial_months.map do |month_range|
           params = {
-            iaa: sp.iaa,
-            issuer: sp.issuer,
-            iaa_start_date: sp.iaa_start_date,
-            iaa_end_date: sp.iaa_end_date,
             range_start: month_range.begin,
             range_end: month_range.end,
+            issuer: issuer,
             year_month: month_range.begin.strftime('%Y%m'),
           }.transform_values { |value| quote(value) }
 
           format(<<~SQL, params)
             SELECT
-              %{year_month} AS year_month
+              sp_return_logs.user_id
+            , %{year_month} AS year_month
             , sp_return_logs.ial
             , COUNT(sp_return_logs.id) AS auth_count
-            , %{issuer} AS issuer
-            , %{iaa} AS iaa
-            , %{iaa_start_date} AS iaa_start_date
-            , %{iaa_end_date} AS iaa_end_date
             FROM sp_return_logs
             WHERE
                   sp_return_logs.requested_at BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer = %{issuer}
             GROUP BY
-              sp_return_logs.ial
+              sp_return_logs.user_id
+            , sp_return_logs.ial
           SQL
         end
       end

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -9,7 +9,7 @@ module Db
 
       module_function
 
-      # @param [Hash] iaa
+      # @param [ServiceProvider] service_provider
       # @param [Symbol] aggregate (one of :sum, :unique)
       # @return [PG::Result,Array]
       def call(service_provider:, aggregate:)

--- a/spec/jobs/reports/agency_invoice_issuer_supplement_report_spec.rb
+++ b/spec/jobs/reports/agency_invoice_issuer_supplement_report_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe Reports::AgencyInvoiceIssuerSupplementReport do
               year_month: '202101',
               ial1_total_auth_count: 11,
               ial2_total_auth_count: 22,
+              ial1_unique_users: 1,
+              ial2_unique_users: 1,
             },
           ],
         )


### PR DESCRIPTION
I copied logic I wrote in `UniqueMonthlyAuthCountsByIaa` which has a switch between `SUM` and `COUNT(DISTINCT user_id)`, so it didn't come from out of nothing...

I suspect this might result in some longer running queries so we may want keep an eye on this