### PR TITLE
Fix CodeCoverage in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install python3-pip python-dev jq
-            sudo pip install awscli
+            sudo pip install awscli --ignore-installed six
       - run:
           name: Install Code Climate Test Reporter
           command: |


### PR DESCRIPTION
(cherry picked from commit e3943af3e5a08718c83a6e368bab37906659a657)

I Googled the error and just copied this StackOverflow answer: https://stackoverflow.com/a/59669110

Discovered that on https://github.com/18F/identity-idp/pull/5592, the tests kept failing, this fixed them

