### PR TITLE
Support formatted message arguments in console.error test spy

### DIFF
--- a/spec/javascripts/support/console.js
+++ b/spec/javascripts/support/console.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import sinon from 'sinon';
+import { format } from 'util';
 
 /**
  * Chai plugin which adds chainable `logged` method, to be used in combination with
@@ -45,8 +46,8 @@ export function chaiConsoleSpy(chai, utils) {
 export function useConsoleLogSpy() {
   beforeEach(() => {
     console.unverifiedCalls = [];
-    sinon.stub(console, 'error').callsFake((message) => {
-      console.unverifiedCalls = console.unverifiedCalls.concat(message);
+    sinon.stub(console, 'error').callsFake((message, ...args) => {
+      console.unverifiedCalls = console.unverifiedCalls.concat(format(message, ...args));
     });
   });
 


### PR DESCRIPTION
Extracted from: #5590

**Why**: So that it's easier to debug the root cause of a console log, which may use format arguments to describe the callsite.

API reference: https://developer.mozilla.org/en-US/docs/Web/API/console/error

`util.format`: https://nodejs.org/api/util.html#utilformatformat-args

_Before:_

```
  1) "after each" hook for "ends on unmount":
     AssertionError: Unexpected console logging: Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s: expected [ Array(1) ] to be empty
      at Context.<anonymous> (spec/javascripts/support/console.js:55:43)
      at processImmediate (internal/timers.js:461:21)
```

_After:_

```
  1) "after each" hook for "ends on unmount":
     Unexpected console logging: Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at AcuantContextProvider (/Code/identity-idp/app/javascript/packages/document-capture/context/acuant.jsx:145:3)
    at UploadContextProvider (/Code/identity-idp/app/javascript/packages/document-capture/context/upload.jsx:98:3)
    at wrapper (/Code/identity-idp/spec/javascripts/support/document-capture.jsx:60:7): expected [ Array(1) ] to be empty
  AssertionError: Unexpected console logging: Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
      at AcuantContextProvider (app/javascript/packages/document-capture/context/acuant.jsx:145:3)
      at UploadContextProvider (app/javascript/packages/document-capture/context/upload.jsx:98:3)
      at wrapper (/Code/identity-idp/spec/javascripts/support/document-capture.jsx:60:7): expected [ Array(1) ] to be empty
      at Context.<anonymous> (spec/javascripts/support/console.js:56:43)
      at processImmediate (internal/timers.js:461:21)
```