### PR TITLE
Configure i18n-tasks to look inside lib/ dir as well

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -44,8 +44,9 @@ data:
 # Find translate calls
 search:
   ## Paths or `File.find` patterns to search in:
-  # paths:
-  #  - app/
+  paths:
+   - app/
+   - lib/
 
   ## Root directories for relative keys resolution.
   relative_roots:

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'rails_helper'
 require 'i18n/tasks'
 
 module I18n


### PR DESCRIPTION
Figured out why the i18n-tasks gem thought a bunch of keys were unused