### PR TITLE
Preload geocoder database, to minimize timeouts

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -18,6 +18,7 @@ if Rails.env.production? && File.exist?(GEO_DATA_FILEPATH)
       file: GEO_DATA_FILEPATH,
     },
   )
+  Geocoder.search('1.2.3.4') # the datasource is lazily loaded, make sure it eager loads
 else
   Geocoder.configure(ip_lookup: :test)
   Geocoder::Lookup::Test.set_default_stub(

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -11,18 +11,18 @@ end
 
 GEO_DATA_FILEPATH = Rails.root.join(IdentityConfig.store.geo_data_file_path).freeze
 
-if !Rails.env.production? && !File.exist?(GEO_DATA_FILEPATH)
-  Geocoder.configure(ip_lookup: :test)
-  Geocoder::Lookup::Test.set_default_stub(
-    [
-      { 'city' => '', 'country' => 'United States', 'state_code' => '' },
-    ],
-  )
-else
+if Rails.env.production? && File.exist?(GEO_DATA_FILEPATH)
   Geocoder.configure(
     ip_lookup: :geoip2,
     geoip2: {
       file: GEO_DATA_FILEPATH,
     },
+  )
+else
+  Geocoder.configure(ip_lookup: :test)
+  Geocoder::Lookup::Test.set_default_stub(
+    [
+      { 'city' => '', 'country' => 'United States', 'state_code' => '' },
+    ],
   )
 end


### PR DESCRIPTION
We see a few occasional geocoder timeouts in prod while reading from disk, my hypothesis was that the Geocoder gem lazily loads its datasource.

- [Example NewRelic error](https://onenr.io/0kLwGZ6DvQ6)

In a fresh Rails console in INT, I believe I confirmed this. The first lookup is ~0.1 seconds, and subsequent lookups are at least 200x faster, no matter the order or values, so I am pretty sure the first one forces a lookup

```ruby
> timing = %w[0.0.0.0 1.2.3.4 8.8.8.8 192.168.1.1].map { |ip| Benchmark.realtime { Geocoder.search(ip) } }
=> [0.08297044999926584, 0.00040709099994273856, 0.0003728679985215422, 0.00019449899991741404]
timing[1..].map { |x| timing.first / x }
=> [203.81302954606332, 222.51963249260257, 426.58548390735075]
```


The first commit (c4e57b57169ec93ab02f709a007bb447a9ffe0e4) was just a personal preference of trying to have "positive" conditions first, which I think reads better.

The "meat" of this PR is 6d2a310477c4d984aa2f9f59424f330f98321eb2
