### PR TITLE
Increase TOTP secret length from 80 bits to 160 bits

### DIFF
--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -15,7 +15,7 @@ module UserOtpMethods
   end
 
   def generate_totp_secret
-    ROTP::Base32.random_base32(16)
+    ROTP::Base32.random_base32(32)
   end
 
   def authenticate_direct_otp(code)

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -15,7 +15,7 @@ module UserOtpMethods
   end
 
   def generate_totp_secret
-    ROTP::Base32.random_base32(32)
+    ROTP::Base32.random(20)
   end
 
   def authenticate_direct_otp(code)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe User do
     it 'generates a secret 16 characters long' do
       user = build(:user)
       secret = user.generate_totp_secret
-      expect(secret.length).to eq 16
+      expect(secret.length).to eq 32
     end
   end
 


### PR DESCRIPTION
**Why**: [RFC 4226](https://datatracker.ietf.org/doc/html/rfc4226) specifies that the length should meet or exceed 128 bits.