### PR TITLE
Show correct email address in authorization confirmation screen

### DIFF
--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -11,6 +11,7 @@ module Users
     def show
       analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION)
       @sp = ServiceProvider.find_by(issuer: sp_session[:issuer])
+      @email = EmailContext.new(current_user).last_sign_in_email_address.email
     end
 
     def update

--- a/app/views/users/authorization_confirmation/show.html.erb
+++ b/app/views/users/authorization_confirmation/show.html.erb
@@ -24,7 +24,7 @@
             <%= t("help_text.requested_attributes.email") %>
           </span>
           <span class='padding-left-2'>
-            <%= current_user.email %>
+            <%= @email %>
           </span>
         </li>
       </ul>

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -31,12 +31,14 @@ feature 'OIDC Authorization Confirmation' do
       user1
     end
 
-    it 'it confirms the user wants to continue to the SP after signing in again' do
-      sign_in_user(user1)
+    it 'it confirms the user wants to continue to SP with signin email after signing in again' do
+      second_email = create(:email_address, user: user1)
+      sign_in_user(user1, second_email.email)
       visit_idp_from_ial1_oidc_sp
       expect(current_url).to match(user_authorization_confirmation_path)
+      expect(page).to have_content second_email.email
 
-      continue_as(user1.email)
+      continue_as(second_email.email)
       expect(current_url).to match('http://localhost:7654/auth/result')
     end
 

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -32,14 +32,15 @@ feature 'SAML Authorization Confirmation' do
       user1
     end
 
-    it 'it confirms the user wants to continue to the SP after signing in again' do
-      sign_in_user(user1)
+    it 'it confirms the user wants to continue to SP with signin email after signing in again' do
+      second_email = create(:email_address, user: user1)
+      sign_in_user(user1, second_email.email)
 
       visit request_url
-
       expect(current_url).to match(user_authorization_confirmation_path)
-      continue_as(user1.email)
+      expect(page).to have_content second_email.email
 
+      continue_as(second_email.email)
       expect(current_url).to eq(request_url)
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -171,8 +171,9 @@ module Features
       user
     end
 
-    def sign_in_user(user = create(:user))
-      signin(user.email_addresses.first.email, user.password)
+    def sign_in_user(user = create(:user), email = nil)
+      email ||= user.email_addresses.first.email
+      signin(email, user.password)
       user
     end
 


### PR DESCRIPTION
The authorization screen shows `current_user.email`, but that's not the one we send to the SP. This PR corrects it to show the email that will be sent to the SP.

![image](https://user-images.githubusercontent.com/1430443/141514091-adb3ed8e-55ca-440d-befb-1e38e8251bb2.png)
