### PR TITLE
Make the no PII banner comically large

### DIFF
--- a/app/views/shared/_no_pii_banner.html.erb
+++ b/app/views/shared/_no_pii_banner.html.erb
@@ -1,3 +1,3 @@
-<div class='padding-y-1 bg-secondary-darker text-white fs-12p line-height-1 center'>
+<div class='h1 padding-y-4 bg-secondary-darker text-white fs-12p line-height-1 center'>
   <%= t('idv.messages.sessions.no_pii') %>
 </div>


### PR DESCRIPTION
**Why**: To help ensure that people see it and don't enter PII

Screenshot:
![image](https://user-images.githubusercontent.com/963654/141871372-27bb8267-a22d-475d-9c2c-52ff4911a34a.png)
