### PR TITLE
Remove instances of "h1" BassCSS class

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -151,7 +151,7 @@ linters:
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent|border))?'
           - '(border|bg)-(none|black|gray|silver|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
           - 'bg-(cover|contain|center|top|right|bottom|left)'
-          - 'h([03]|00)'
+          - 'h([013]|00)'
           - 'h([01]|00)-responsive'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -39,7 +39,7 @@
     <%= t('doc_auth.info.tag') %>
   </div>
   <div class='sm-col sm-col-9'>
-    <div class='bold h1 margin-y-105'>
+    <div class="text-bold font-sans-lg margin-y-105">
       <% if liveness_checking_enabled? %>
         <%= t('doc_auth.headings.upload_from_phone_liveness_enabled') %>
       <% else %>

--- a/app/views/shared/_no_pii_banner.html.erb
+++ b/app/views/shared/_no_pii_banner.html.erb
@@ -1,3 +1,3 @@
-<div class='h1 padding-y-4 bg-secondary-darker text-white fs-12p line-height-1 center'>
+<div class="font-sans-lg padding-y-4 bg-secondary-darker text-white line-height-1 text-center">
   <%= t('idv.messages.sessions.no_pii') %>
 </div>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -9,7 +9,7 @@
     <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
       1
     </div>
-    <label class="h1 margin-right-1 inline-block margin-bottom-1 bold" for="nickname">
+    <label class="font-sans-lg margin-right-1 display-inline-block margin-bottom-1 text-bold" for="nickname">
       <%= t('instructions.mfa.piv_cac.step_1') %>
     </label>
     <div class='margin-left-6 margin-bottom-1'>
@@ -25,7 +25,7 @@
       2
     </div>
     <div class='margin-right-1 inline-block margin-bottom-2'>
-      <div class='h1 inline-block bold'>
+      <div class="font-sans-lg display-inline-block text-bold">
         <%= t('instructions.mfa.piv_cac.step_2') %>
       </div>
     </div>
@@ -36,7 +36,7 @@
       3
     </div>
     <div class='margin-right-1 inline-block'>
-      <div class='h1 inline-block bold'>
+      <div class="font-sans-lg display-inline-block text-bold">
         <%= t('instructions.mfa.piv_cac.step_3') %>
       </div>
     </div>


### PR DESCRIPTION
**Why**: Toward migration off BassCSS to design system.

The `font-sans-lg` design system utility class provides a similar font size styling effect (`1.5rem` with `h1` vs. `1.46rem` with `font-sans-lg`). In the future, we may consider avoiding these classes altogether, toward more semantic elements such as headings, or componentizing specific usage such as [process lists](https://designsystem.digital.gov/components/process-list/) (LG-4791).

**Open Questions:**

- The font size for the "Upload" step in the Figma design is `1.25rem`, which matches neither `h1` nor `font-sans-lg`. Does that font size correspond to anything meaningful (component, etc)? Would you like for it to match the design, or should the design be updated to use the design system font size token?

(cc @anniehirshman-gsa)

**Screenshots:**

Screen|Before|After
---|---|---
PIV Setup|![piv-before](https://user-images.githubusercontent.com/1779930/142218428-ec827b71-23b6-4f61-9e76-d83f442f5260.png)|![piv-after](https://user-images.githubusercontent.com/1779930/142218446-b3bb8178-c3a3-4f32-a8d7-6ab22a0f4bc6.png)
IAL2 Device Choice|![upload-before](https://user-images.githubusercontent.com/1779930/142218492-4e1f0913-3b03-451a-9edd-449c41486e63.png)|![upload-after](https://user-images.githubusercontent.com/1779930/142218490-b851e990-42fc-4fe9-a725-cf27af7da8f4.png)