### PR TITLE
YAML normalization: Fix non-HTML fragment smart punctuation replacement

### DIFF
--- a/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
+++ b/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
@@ -9,8 +9,8 @@ import smartquotes from 'smartquotes';
  */
 export function replaceInHTMLContent(html, replacer) {
   return html.replace(
-    /([^<]*)(<.*?>)/g,
-    (_match, text, tag) => (text ? replacer(text) : text) + tag,
+    /([^<]*)(<.*?>)?/g,
+    (_match, text, tag) => (text ? replacer(text) : text) + (tag || ''),
   );
 }
 

--- a/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
+++ b/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
@@ -10,7 +10,7 @@ import smartquotes from 'smartquotes';
 export function replaceInHTMLContent(html, replacer) {
   return html.replace(
     /([^<]*)(<.*?>)?/g,
-    (_match, text, tag) => (text ? replacer(text) : text) + (tag || ''),
+    (_match, text, tag = '') => (text ? replacer(text) : text) + tag,
   );
 }
 

--- a/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.spec.js
+++ b/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.spec.js
@@ -2,15 +2,15 @@ import { replaceInHTMLContent, ellipses } from './smart-punctuation.js';
 
 describe('replaceInHTMLContent', () => {
   it('replaces in html content', () => {
-    const string = '<div>This is a failure</div>';
-    const result = replaceInHTMLContent(string, (match) => match.replace('failure', 'success'));
-    const expected = '<div>This is a success</div>';
+    const string = 'bad<div>bad</div>bad';
+    const result = replaceInHTMLContent(string, (match) => match.replace('bad', 'good'));
+    const expected = 'good<div>good</div>good';
 
     expect(result).to.equal(expected);
   });
 
   it('does not replace in html tags', () => {
-    const string = '<div data-div-type="div">div<div>div</div>div</div>';
+    const string = 'div<div data-div-type="div">div<div>div</div>div</div>div';
     const result = replaceInHTMLContent(string, (match) => match.replace('div', ''));
     const expected = '<div data-div-type="div"><div></div></div>';
 

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -171,7 +171,7 @@ en:
       privacy_html: '%{app_name} is a secure, government website that adheres to the
         highest standards in data protection. We only use your data to verify
         your identity. %{link} about our privacy and security measures.'
-      secure_account: We'll encrypt your account with your password. Encryption means
+      secure_account: We’ll encrypt your account with your password. Encryption means
         your data is protected and only you will be able to access or change
         your information.
       ssn: We need your Social Security number to validate your name, date of birth
@@ -191,7 +191,7 @@ en:
         state-issued ID. Then, you’ll take a photo of yourself to confirm that
         you are the owner of the ID.
       upload_no_image_storage: We do not store images you upload. We only verify your identity.
-      verify_identity: We'll ask for your personal information to verify your identity
+      verify_identity: We’ll ask for your personal information to verify your identity
         against public records.
       verifying: Verifying…
       welcome_html: '%{sp_name} needs to make sure you are you — not someone

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -3,12 +3,12 @@ fr:
   doc_auth:
     accessible_labels:
       camera_video_capture_instructions: Nous prendrons automatiquement la photo
-      camera_video_capture_label: Viseur avec cadre pour centrer votre pièce d'identité
+      camera_video_capture_label: Viseur avec cadre pour centrer votre pièce d’identité
       document_capture_dialog: Capture du document
       selfie_alt_text: Une photo téléversée
     buttons:
       change_address: Changement
-      change_address_label: Changement d'adresse
+      change_address_label: Changement d’adresse
       change_ssn: Changement
       change_ssn_label: Changement de numéro de sécurité sociale
       continue: Continuer
@@ -67,7 +67,7 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
       camera:
         blocked: Votre appareil photo est bloqué
-        blocked_detail: Nous n'avons pas la permission d'accéder à l'appareil photo.
+        blocked_detail: Nous n’avons pas la permission d’accéder à l’appareil photo.
           Veuillez vérifier les paramètres de votre navigateur ou de votre
           système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
@@ -106,13 +106,13 @@ fr:
           photo est désactivé puis essayez de prendre de nouvelles photos.
       http:
         image_load: Il y a un problème avec votre fichier image. Veuillez prendre de
-          nouvelles photos de votre pièce d'identité et réessayer.
+          nouvelles photos de votre pièce d’identité et réessayer.
         image_size: La taille de votre image est trop grande ou trop petite. Veuillez
-          ajouter des images de votre pièce d'identité d'environ 2025 x 1275
+          ajouter des images de votre pièce d’identité d’environ 2025 x 1275
           pixels.
-        pixel_depth: La profondeur de pixel de votre fichier image n'est pas supportée.
-          Veuillez prendre de nouvelles photos de votre pièce d'identité et
-          réessayer. La profondeur de pixel de l'image prise en charge est de 24
+        pixel_depth: La profondeur de pixel de votre fichier image n’est pas supportée.
+          Veuillez prendre de nouvelles photos de votre pièce d’identité et
+          réessayer. La profondeur de pixel de l’image prise en charge est de 24
           bits RGB.
       no_camera:
         explanation: Pour continuer, connectez-vous à votre compte %{app_name} sur tout
@@ -150,7 +150,7 @@ fr:
       address: Mettre à jour votre adresse postale
       back: Verso
       capture_complete: Nous avons vérifié votre carte d’identité délivrée par l’État
-      capture_troubleshooting_tips: Vous rencontrez des difficultés pour ajouter votre pièce d'identité?
+      capture_troubleshooting_tips: Vous rencontrez des difficultés pour ajouter votre pièce d’identité?
       document_capture: Ajoutez votre carte d’identité délivrée par l’État
       document_capture_back: Verso de votre carte d’identité
       document_capture_front: Recto de votre carte d’identité
@@ -215,7 +215,7 @@ fr:
       ssn: Nous avons besoin de votre numéro de sécurité sociale pour valider votre
         nom, date de naissance et adresse. Votre numéro de sécurité sociale est
         crypté. Avec votre accord, nous partageons ce informations auprès de
-        l'agence gouvernementale à laquelle vous essayez d'accéder pour vérifier
+        l’agence gouvernementale à laquelle vous essayez d’accéder pour vérifier
         votre identité.
       tag: Recommandation
       take_picture: Utilisez l’appareil photo sur votre téléphone portable et
@@ -238,8 +238,8 @@ fr:
       verify_identity: Nous vous demanderons vos informations personnelles afin de
         vérifier votre identité par rapport aux registres publics.
       verifying: Vérification…
-      welcome_html: "%{sp_name} doit s'assurer que vous êtes bien vous, et non
-        quelqu'un qui se fait passer pour vous."
+      welcome_html: '%{sp_name} doit s’assurer que vous êtes bien vous, et non
+        quelqu’un qui se fait passer pour vous.'
     instructions:
       bullet1: Votre carte d’identité émise par l’État
       bullet1a: Un appareil équipé d’une caméra
@@ -273,7 +273,7 @@ fr:
       text1: ''
       text1a: tel qu’un téléphone ou un ordinateur
       text2: Vous n’aurez pas besoin de la carte avec vous.
-      text3: Il n'est pas nécessaire que vous soyez le titulaire principal du compte
+      text3: Il n’est pas nécessaire que vous soyez le titulaire principal du compte
         de votre forfait téléphonique. Si votre numéro de téléphone ne
         fonctionne pas, nous pouvons vous envoyer un code de vérification par
         courrier.
@@ -282,7 +282,7 @@ fr:
       capture_troubleshooting_blurry: La photo que vous avez ajoutée est trop floue.
       capture_troubleshooting_clean: Assurez-vous que le code-barres ne soit pas
         endommagé ou sale et que toutes les informations figurant sur votre
-        pièce d'identité soient lisibles.
+        pièce d’identité soient lisibles.
       capture_troubleshooting_clean_image: Verso de la carte d’identité
       capture_troubleshooting_glare: La photo que vous avez ajoutée est éblouissante.
       capture_troubleshooting_lead: 'Voici quelques conseils pour réussir votre photo:'
@@ -291,7 +291,7 @@ fr:
         éblouissements, les ombres et les reflets.
       capture_troubleshooting_lighting_image: Soleil avec nuage
       capture_troubleshooting_surface: Prenez une photo sur une surface plane avec un
-        fond sombre. Assurez-vous que les bords de votre pièce d'identité soient
+        fond sombre. Assurez-vous que les bords de votre pièce d’identité soient
         dégagés.
       capture_troubleshooting_surface_image: Recto de la carte d’identité
       document_capture_header_text: 'Pour obtenir les meilleurs résultats:'

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -25,7 +25,7 @@ fr:
       consent_form: Avant de pouvoir continuer, vous devez nous donner la permission.
         Veuillez cocher la case ci-dessous puis cliquez sur continuer.
       document_capture_cancelled: Vous avez annulé le téléchargement de vos photos
-        d'identité sur votre téléphone.
+        d’identité sur votre téléphone.
       document_verification_timeout: Le serveur a mis trop de temps à répondre. Veuillez réessayer.
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé
@@ -63,7 +63,7 @@ fr:
         autre lettre afin d’obtenir un nouveau code.
       improbable_phone: Numéro de téléphone non valide. Veillez à saisir un numéro de
         téléphone valide.
-      inclusion: N'est pas inclus dans la liste
+      inclusion: N’est pas inclus dans la liste
       invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en
         charge. Veuillez essayer par SMS si vous possédez un téléphone disposant
         de cette fonction.
@@ -76,7 +76,7 @@ fr:
       must_have_us_country_code: Numéro de téléphone non valide. Veuillez vous assurer
         de saisir un numéro de téléphone avec un code pays des États-Unis.
       no_pending_profile: Aucun profil en attente de vérification
-      not_a_number: N'est pas un nombre
+      not_a_number: N’est pas un nombre
       otp_failed: Échec de l’envoi de votre code de sécurité.
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
@@ -107,8 +107,8 @@ fr:
         Veuillez sélectionner un autre numéro et réessayer
       weak_password: Votre mot de passe n’est pas assez fort. %{feedback}
       wrong_length:
-        one: n'est pas de la bonne longueur (devrait être de 1 caractère)
-        other: n'est pas de la bonne longueur (devrait être %{count} caractères)
+        one: n’est pas de la bonne longueur (devrait être de 1 caractère)
+        other: n’est pas de la bonne longueur (devrait être %{count} caractères)
     piv_cac_setup:
       unique_name: Ce nom est déjà pris. Veuillez choisir un autre nom.
     registration:
@@ -129,7 +129,7 @@ fr:
       attestation_error: Désolé, votre clé de sécurité ne semble pas être une clé de
         sécurité FIDO. Veuillez vérifier que votre appareil est répertorié sur
         https://fidoalliance.org/certification/fido-certified-products/. Si vous
-        pensez qu'il s'agit d'une erreur de notre part, veuillez contacter
+        pensez qu’il s’agit d’une erreur de notre part, veuillez contacter
         %{link}.
       general_error: Une erreur s’est produite lors de l’ajout de votre clé de
         sécurité physique. Veuillez réessayer.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -14,11 +14,11 @@ fr:
     cancel:
       headings:
         confirmation:
-          hybrid: Vous avez annulé le téléchargement de vos photos d'identité sur ce
+          hybrid: Vous avez annulé le téléchargement de vos photos d’identité sur ce
             téléphone
         prompt:
           hybrid: Êtes-vous sûr de vouloir annuler le téléchargement de vos photos
-            d'identité sur ce téléphone?
+            d’identité sur ce téléphone?
       warnings:
         hybrid: Si vous annulez maintenant, vous serez invité à retourner sur votre
           ordinateur pour continuer à vérifier votre identité.
@@ -55,8 +55,8 @@ fr:
         fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de
           vérifier votre numéro de téléphone en ligne.'
-        heading: Nous n'avons pas pu faire correspondre ce numéro de téléphone à
-          d'autres enregistrements
+        heading: Nous n’avons pas pu faire correspondre ce numéro de téléphone à
+          d’autres enregistrements
         jobfail: Un problème s’est produit et nous ne pouvons pas traiter votre demande
           pour le moment. Veuillez réessayer.
         timeout: Notre demande de vérification de vos renseignements a expiré. Veuillez
@@ -88,7 +88,7 @@ fr:
     form:
       address1: Adresse
       address2: Adresse (optional)
-      city: Ville une lettre contenant un code.'
+      city: Ville une lettre contenant un code.′
       password: Mot de passe
       phone: Numéro de téléphone
       ssn_label_html: Numéro de sécurité sociale
@@ -120,7 +120,7 @@ fr:
       confirm: Vous avez crypté vos données vérifiées
       gpo:
         address_on_file: Nous enverrons une lettre avec un code de confirmation à
-          l'adresse que vous avez indiquée à l'étape précédente.
+          l’adresse que vous avez indiquée à l’étape précédente.
         new_address: Nous vous enverrons une lettre avec un code de confirmation à
           l’adresse que vous spécifiez.
         resend: Envoyez-moi une autre lettre
@@ -143,7 +143,7 @@ fr:
           numéro différent.'
         phone_of_record: numéro de téléphone enregistré
         rules:
-          - être un plan téléphonique associé à votre nom. Il n'est pas
+          - être un plan téléphonique associé à votre nom. Il n’est pas
             nécessaire que vous soyez le titulaire principal du compte.
           - pas un téléphone virtuel (comme Google Voice ou Skype)
           - un numéro américain
@@ -192,10 +192,10 @@ fr:
       options:
         change_phone_number: Utiliser un autre numéro de téléphone
         contact_support: Contacter le service d’assistance de %{app_name}
-        doc_capture_tips: Plus de conseils pour ajouter des photos de votre carte d'identité
+        doc_capture_tips: Plus de conseils pour ajouter des photos de votre carte d’identité
         get_help_at_sp: Demandez de l’aide à %{sp_name}
         learn_more_address_verification_options: En savoir plus sur la vérification par téléphone ou par courrier
         learn_more_verify_by_mail: En savoir plus sur la vérification de votre adresse par courrier
         learn_more_verify_by_phone: En savoir plus sur la vérification de votre numéro de téléphone
-        supported_documents: Voir la liste des pièces d'identité acceptées et délivrées par l'État
+        supported_documents: Voir la liste des pièces d’identité acceptées et délivrées par l’État
         verify_by_mail: Vérifiez plutôt votre adresse par courrier

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -3,24 +3,24 @@ en:
   telephony:
     account_reset_cancellation_notice: Your request to delete your %{app_name} account has been cancelled.
     account_reset_notice: As requested, your %{app_name} account will be deleted in
-      24 hours. Don't want to delete your account? Sign in to your %{app_name}
+      24 hours. Don’t want to delete your account? Sign in to your %{app_name}
       account to cancel.
     authentication_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don’t share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
         passcode is, %{code}, This code expires in %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don’t share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
         passcode is, %{code}, This code expires in %{expiration} minutes.
-    doc_auth_link: "%{link} You've requested to verify your identity on a mobile
-      phone.  Please take a photo of your state issued ID."
+    doc_auth_link: '%{link} You’ve requested to verify your identity on a mobile
+      phone.  Please take a photo of your state issued ID.'
     error:
       friendly_message:
         duplicate_endpoint: The phone number entered is not valid.
@@ -30,14 +30,14 @@ en:
         invalid_phone_number: The phone number entered is not valid.
         opt_out: The phone number entered has opted out of text messages.
         permanent_failure: The phone number entered is not valid.
-        sms_unsupported: The phone number entered doesn't support text messaging. Try
+        sms_unsupported: The phone number entered doesn’t support text messaging. Try
           the Phone call option.
         temporary_failure: We are experiencing technical difficulties.  Please try again later.
         throttled: That number is experiencing high message volume.  Please try again
           later.
         timeout: The server took too long to respond. Please try again.
         unknown_failure: We are experiencing technical difficulties.  Please try again later.
-        voice_unsupported: Invalid phone number. Check that you've entered the correct
+        voice_unsupported: Invalid phone number. Check that you’ve entered the correct
           country code or area code.
     personal_key_regeneration_notice: A new personal key has been issued for your
       %{app_name} account. If this wasn’t you, reset your password.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -21,21 +21,21 @@ fr:
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
         %{code}, de nouveau, votre code de sécurité est, %{code}, Ce code
         expirera dans %{expiration} minutes.
-    doc_auth_link: "%{link} Vous avez demandé à vérifier votre identité sur un
-      téléphone mobile. S'il vous plaît prendre une photo de votre identité
-      émise par l'état"
+    doc_auth_link: '%{link} Vous avez demandé à vérifier votre identité sur un
+      téléphone mobile. S’il vous plaît prendre une photo de votre identité
+      émise par l’état'
     error:
       friendly_message:
-        duplicate_endpoint: Le numéro de téléphone entré n'est pas valide.
-        generic: Échec de l'envoi de votre code de sécurité.
+        duplicate_endpoint: Le numéro de téléphone entré n’est pas valide.
+        generic: Échec de l’envoi de votre code de sécurité.
         invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en
           charge. Veuillez essayer par SMS si vous possédez un téléphone
           disposant de cette fonction.
-        invalid_phone_number: Le numéro de téléphone saisi n'est pas valide.
+        invalid_phone_number: Le numéro de téléphone saisi n’est pas valide.
         opt_out: Le numéro de téléphone entré a désactivé les messages texte.
-        permanent_failure: Le numéro de téléphone entré n'est pas valide.
+        permanent_failure: Le numéro de téléphone entré n’est pas valide.
         sms_unsupported: Le numéro de téléphone saisi ne prend pas en charge les
-          messages textuels. Veuillez essayer l'option d'appel téléphonique.
+          messages textuels. Veuillez essayer l’option d’appel téléphonique.
         temporary_failure: Nous rencontrons des difficultés techniques. Veuillez
           réessayer plus tard.
         throttled: Ce nombre connaît un volume de messages élevé. Veuillez réessayer
@@ -46,7 +46,7 @@ fr:
         voice_unsupported: Numéro de téléphone invalide. Vérifiez que vous avez entré le
           bon indicatif international ou régional.
     personal_key_regeneration_notice: Une nouvelle clé personnelle a été émise pour
-      votre compte %{app_name}. Si vous ne l'avez pas demandée, réinitialisez
+      votre compte %{app_name}. Si vous ne l’avez pas demandée, réinitialisez
       votre mot de passe.
     personal_key_sign_in_notice: Votre clé personnelle a été utilisée pour vous
       connecter à votre compte %{app_name}. Si ce n’était pas vous, changez

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -11,15 +11,15 @@ fr:
       show: Choisissez un mot de passe
     doc_auth:
       address: Mettez à jour votre adresse postale
-      doc_capture: Ajoutez votre pièce d'identité
+      doc_capture: Ajoutez votre pièce d’identité
       get_started: Commençons
       link_sent: Lien envoyé
       otp_delivery: Recevez un code de sécurité
       processing_images: Traitement de vos images
       ssn: Entrez votre numéro de sécurité sociale
       switch_back: Retournez sur votre ordinateur
-      take_photo: Prenez des photos de votre pièce d'identité avec un téléphone
-      upload: Vérifiez votre pièce d'identité
+      take_photo: Prenez des photos de votre pièce d’identité avec un téléphone
+      upload: Vérifiez votre pièce d’identité
       verify: Vérifiez votre identité
       verify_info: Vérifiez vos informations
     edit_info:
@@ -32,8 +32,8 @@ fr:
       phone_verification: Numéro de téléphone non vérifié
     forget_all_browsers: Oubliez tous les navigateurs
     idv:
-      cancellation_prompt: Annulez la vérification d'identité
-      cancelled: La vérification d'identité est annulée
+      cancellation_prompt: Annulez la vérification d’identité
+      cancelled: La vérification d’identité est annulée
       come_back_soon: Revenez bientôt
       enter_security_code: Entrez votre code de sécurité
       get_letter: Obtenez une lettre

--- a/config/locales/vendor_outage/fr.yml
+++ b/config/locales/vendor_outage/fr.yml
@@ -4,32 +4,32 @@ fr:
     alerts:
       phone:
         default: Nous ne pouvons pas vérifier les téléphones pour le moment. Veuillez
-          utiliser une autre méthode d'authentification si vous en avez une, ou
+          utiliser une autre méthode d’authentification si vous en avez une, ou
           réessayez plus tard.
         idv: Nous ne pouvons pas vérifier les téléphones pour le moment. Veuillez
           réessayer plus tard ou vérifier votre adresse par la poste.
       sms:
         default: Nous ne pouvons pas envoyer de messages texte (SMS) pour le moment.
           Vous pouvez obtenir un code par appel téléphonique ou choisir une
-          autre méthode d'authentification si vous en avez un.
+          autre méthode d’authentification si vous en avez un.
         idv: Nous ne pouvons pas envoyer de messages texte (SMS) pour le moment. Vous
           pouvez obtenir un code par téléphone ou vérifier votre adresse par la
           poste.
       voice:
-        default: Nous ne pouvons pas envoyer d'appels téléphoniques pour le moment. Vous
+        default: Nous ne pouvons pas envoyer d’appels téléphoniques pour le moment. Vous
           pouvez obtenir un code par message texte (SMS) ou choisir une autre
-          méthode d'authentification si vous en avez une.
-        idv: Nous ne pouvons pas envoyer d'appels téléphoniques pour le moment. Vous
+          méthode d’authentification si vous en avez une.
+        idv: Nous ne pouvons pas envoyer d’appels téléphoniques pour le moment. Vous
           pouvez obtenir un code par message texte (SMS), ou vérifier votre
           adresse par la poste.
     blocked:
       idv:
         generic: Nous rencontrons des difficultés techniques et ne pouvons pas vérifier
           votre identité pour le moment. Veuillez réessayer plus tard.
-        with_sp: "%{service_provider} doit s'assurer que c'est bien vous — et non
-          quelqu'un qui se fait passer pour vous. Malheureusement, nous
+        with_sp: '%{service_provider} doit s’assurer que c’est bien vous — et non
+          quelqu’un qui se fait passer pour vous. Malheureusement, nous
           rencontrons des difficultés techniques et ne pouvons pas vérifier
-          votre identité pour le moment. Veuillez réessayer plus tard."
+          votre identité pour le moment. Veuillez réessayer plus tard.'
         without_sp: L’agence à laquelle vous essayez d’accéder doit s’assurer qu’il
           s’agit bien de vous, et non de quelqu’un qui se fait passer pour vous.
           Malheureusement, nous rencontrons des difficultés techniques et ne
@@ -42,4 +42,4 @@ fr:
           réessayer plus tard ou vérifier votre adresse par la poste.
     get_updates: Obtenir des mises à jour
     get_updates_on_status_page: Obtenez des mises à jour sur notre page de statut
-    working: "Nous travaillons à la résolution d'une erreur"
+    working: 'Nous travaillons à la résolution d’une erreur'

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -88,9 +88,13 @@ RSpec.describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS' do
-        message = "Login.gov: Your security code is 123456. "\
-                  "It expires in 5 minutes. Don't share this "\
-                  "code with anyone.\n\n@login.gov #123456"
+        message = t(
+          'telephony.authentication_otp.sms',
+          app_name: APP_NAME,
+          code: otp,
+          expiration: expiration,
+          domain: domain,
+        )
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(
@@ -105,9 +109,13 @@ RSpec.describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Pinpoint SMS' do
-        message = "Login.gov: Your security code is 123456. It "\
-        "expires in 5 minutes. Don't share this code with anyone."\
-        "\n\n@login.gov #123456"
+        message = t(
+          'telephony.confirmation_otp.sms',
+          app_name: APP_NAME,
+          code: otp,
+          expiration: expiration,
+          domain: domain,
+        )
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5617/files#r752657699

**Why**: So that we're normalizing YAML consistently.

The previous regular expression would match content up to and within HTML tags, but would not match in cases where the string contains no HTML, or where text occurred _after_ an HTML tag.