### PR TITLE
Ensure SAML POST requests preserve an existing session

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -187,6 +187,7 @@ module SamlIdpAuthConcern
 
   def request_url
     url = URI.parse request.original_url
+    url.path = remap_auth_post_path(url.path)
     query_params = Rack::Utils.parse_nested_query url.query
     unless query_params['SAMLRequest']
       orig_saml_request = saml_request.options[:get_params][:SAMLRequest]
@@ -199,5 +200,12 @@ module SamlIdpAuthConcern
 
     url.query = Rack::Utils.build_query(query_params).presence
     url.to_s
+  end
+
+  def remap_auth_post_path(path)
+    path_match = path.match(%r{/api/saml/authpost(?<year>\d{4})})
+    return path unless path_match.present?
+
+    "/api/saml/auth#{path_match[:year]}"
   end
 end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -76,7 +76,7 @@ class SamlIdpController < ApplicationController
 
   def capture_analytics
     analytics_payload = @result.to_h.merge(
-      endpoint: request.env['PATH_INFO'],
+      endpoint: remap_auth_post_path(request.env['PATH_INFO']),
       idv: identity_needs_verification?,
       finish_profile: profile_needs_verification?,
     )

--- a/app/controllers/saml_post_controller.rb
+++ b/app/controllers/saml_post_controller.rb
@@ -1,0 +1,14 @@
+class SamlPostController < ApplicationController
+  after_action -> { request.session_options[:skip] = true }, only: :auth
+  skip_before_action :verify_authenticity_token
+
+  def auth
+    path_year = request.path[-4..-1]
+    path_method = "api_saml_authpost#{path_year}_url"
+    action_url = Rails.application.routes.url_helpers.send(path_method)
+
+    form_params = params.permit(:SAMLRequest, :RelayState, :SigAlg, :Signature)
+
+    render locals: { action_url: action_url, form_params: form_params }, layout: false
+  end
+end

--- a/app/services/saml_endpoint.rb
+++ b/app/services/saml_endpoint.rb
@@ -55,7 +55,7 @@ class SamlEndpoint
     @suffix ||= begin
       suffixes = self.class.endpoint_configs.map { |config| config[:suffix] }
       suffixes.find do |suffix|
-        request.path.match(/(metadata|auth|logout)#{suffix}$/)
+        request.path.match(/(metadata|auth(post)?|logout)#{suffix}$/)
       end
     end
   end

--- a/app/views/saml_post/auth.html.erb
+++ b/app/views/saml_post/auth.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_packs_with_chunks_tag 'saml-post' %>
+  </head>
+  <body>
+    <div class="container tablet:padding-y-6">
+      <div class="card margin-x-auto sm-col-6">
+        <h1 class="margin-y-0">
+          <%= t('saml_idp.shared.saml_post_binding.heading') %>
+        </h1>
+
+        <p>
+          <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+        </p>
+
+        <%= form_tag action_url, id: 'saml-post-binding' do %>
+          <% form_params.each do |key, val| %>
+            <%= hidden_field_tag(key, val) %>
+          <% end %>
+          <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
+        <% end %>
+      </div>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
   SamlEndpoint.suffixes.each do |suffix|
     get "/api/saml/metadata#{suffix}" => 'saml_idp#metadata', format: false
     match "/api/saml/logout#{suffix}" => 'saml_idp#logout', via: %i[get post delete]
-    match "/api/saml/auth#{suffix}" => 'saml_idp#auth', via: %i[get post]
+    # JS-driven POST redirect route to preserve existing session
+    post "/api/saml/auth#{suffix}" => 'saml_post#auth'
+    # actual SAML handling POST route
+    post "/api/saml/authpost#{suffix}" => 'saml_idp#auth'
+    get "/api/saml/auth#{suffix}" => 'saml_idp#auth'
   end
 
   post '/api/service_provider' => 'service_provider#update'

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -565,10 +565,17 @@ describe SamlIdpController do
           ial2: false,
           ial2_strict: false,
           ialmax: false,
-          request_url: @stored_request_url,
+          request_url: @stored_request_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
         )
+      end
+
+      it 'correctly sets the request URL' do
+        post :auth, params: { 'SAMLRequest' => @saml_request }
+        session_request_url = session[:sp][:request_url]
+
+        expect(session_request_url).to match(%r{/api/saml/auth\d{4}})
       end
     end
 
@@ -589,7 +596,7 @@ describe SamlIdpController do
           ial2: false,
           ial2_strict: false,
           ialmax: false,
-          request_url: @saml_request.request.original_url,
+          request_url: @saml_request.request.original_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
         )

--- a/spec/controllers/saml_post_controller_spec.rb
+++ b/spec/controllers/saml_post_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe SamlPostController do
+  describe 'POST /api/saml/auth' do
+    render_views
+    include ActionView::Helpers::FormTagHelper
+
+    let(:form_action_regex) { /<form.+action=".+\/api\/saml\/authpost\d{4}.+"/ }
+    let(:saml_request) { 'abc123' }
+    let(:relay_state) { 'def456' }
+    let(:sig_alg) { 'aes256' }
+    let(:signature) { 'xyz789' }
+
+    it 'renders the appropriate form' do
+      post :auth, params: {
+        'SAMLRequest' => saml_request,
+        'RelayState' => relay_state,
+        'SigAlg' => sig_alg,
+        'Signature' => signature,
+      }
+
+      expect(response.body).to match(form_action_regex)
+      expect(response.body).to match(hidden_field_tag('SAMLRequest', saml_request))
+      expect(response.body).to match(hidden_field_tag('RelayState', relay_state))
+      expect(response.body).to match(hidden_field_tag('SigAlg', sig_alg))
+      expect(response.body).to match(hidden_field_tag('Signature', signature))
+    end
+
+    it 'does not render extra parameters' do
+      post :auth, params: { 'Foo' => 'bar' }
+
+      expect(response.body).not_to match(hidden_field_tag('Foo', 'bar'))
+    end
+  end
+end

--- a/spec/requests/saml_post_spec.rb
+++ b/spec/requests/saml_post_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'SAML POST handling', type: :request do
+  include SamlAuthHelper
+
+  describe 'POST /api/saml/auth' do
+    let(:cookie_regex) { /\A(?<cookie>\w+)=/ }
+
+    it 'does not set a session cookie' do
+      post saml_settings.idp_sso_target_url
+      new_cookies = response.header['Set-Cookie'].split("\n").map do |c|
+        cookie_regex.match(c)[:cookie]
+      end
+
+      expect(new_cookies).not_to include('_upaya_session')
+    end
+  end
+end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -187,8 +187,8 @@ module SamlAuthHelper
 
   def post_saml_authn_request(settings = saml_settings, params = {})
     saml_authn_params = authn_request_post_params(settings, params)
-    response = page.driver.post(saml_settings.idp_sso_target_url, saml_authn_params)
-    visit response.location
+    page.driver.post(saml_settings.idp_sso_target_url, saml_authn_params)
+    click_button(t('forms.buttons.submit.default'))
   end
 
   def login_and_confirm_sp(user)


### PR DESCRIPTION
Currently, an external POST request to the IdP will not have access to
an existing session since the cookie is blocked due to `SameSite=Lax`.
This results in users with an active session having to sign in again if
sent back to the IdP with a POST SAML request.

However, if the POST request comes _from_ the IdP the session will be
available in that request. Therefore, this commit inserts a new action
within our SAML POST handling that captures the SAML parameters of the
original POST request, populates a form with them (with appropriate CSRF
handling), and then submits that form with JS to create an "internal"
POST request with access to the session. This new action skips session
handling so it does not override an existing IdP session cookie.