### PR TITLE
LG-4888: updated IAL2 error messaging

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -80,7 +80,7 @@ en:
         top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make sure
           that the flash on your camera is off and try taking new pictures.
       http:
-        image_load: There is something wrong with your image file. Please take new
+        image_load: The image file that you added is not supported. Please take new
           photos of your ID and try again.
         image_size: You image size is too large or too small. Please add images of your
           ID that are about 2025 x 1275 pixels.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -100,8 +100,8 @@ es:
           tengan reflejos. Asegúrese de que el flash de su cámara esté
           desactivado e intente tomar nuevas fotos.
       http:
-        image_load: Hay un error en su archivo de imagen. Procure tomar nuevas fotos de
-          su documento de identidad e inténtelo nuevamente.
+        image_load: El archivo de imagen que ha añadido no es compatible. Por favor,
+          tome nuevas fotos de su identificación y vuelva a intentarlo.
         image_size: El tamaño de la imagen es demasiado grande o demasiado pequeño.
           Añada imágenes de su documento de identidad de unos 2025 x 1275
           píxeles.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -105,8 +105,9 @@ fr:
           peuvent avoir des reflets. Assurez-vous que le flash de votre appareil
           photo est désactivé puis essayez de prendre de nouvelles photos.
       http:
-        image_load: Il y a un problème avec votre fichier image. Veuillez prendre de
-          nouvelles photos de votre pièce d’identité et réessayer.
+        image_load: Le fichier image que vous avez ajouté n’est pas pris en charge.
+          Veuillez prendre de nouvelles photos de votre pièce d’identité et
+          réessayer.
         image_size: La taille de votre image est trop grande ou trop petite. Veuillez
           ajouter des images de votre pièce d’identité d’environ 2025 x 1275
           pixels.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -29,8 +29,7 @@ en:
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.
       send_link_throttle: You tried too many times, please try again in %{timeout}.
-        You can also click on Start Over and choose to use your computer
-        instead.
+        You can also go back and choose to use your computer instead.
       throttled_heading: We could not verify your ID
       throttled_heading_liveness: We could not verify your ID and photo of you
       throttled_text_html: '<strong>Please try again in %{timeout}.</strong> For your

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -29,9 +29,9 @@ es:
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite de
         verificación de identidad. Póngase en contacto con su proveedor de
         servicios para obtener más información.
-      send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en
-        %{timeout}. También puedes hacer clic en comenzar de nuevo y elegir usar
-        tu computadora.
+      send_link_throttle: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
+        en %{timeout}. También puede retroceder y elegir utilizar su computadora
+        como alternativa.
       throttled_heading: No pudimos verificar la identificación
       throttled_heading_liveness: No pudimos verificar la identificación ni la foto
       throttled_text_html: '<strong>Por favor, inténtelo de nuevo en

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -33,9 +33,9 @@ fr:
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d’identité. Veuillez contacter votre fournisseur de
         services pour plus d’informations.
-      send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
-        %{timeout}. Vous pouvez également cliquer sur recommencer et choisir
-        d’utiliser votre ordinateur.
+      send_link_throttle: Vous avez essayé trop de fois, veuillez réessayer dans
+        %{timeout}. Vous pouvez également revenir en arrière et choisir
+        d’utiliser votre ordinateur à la place.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
       throttled_heading_liveness: Nous n’avons pas pu vérifier votre identité et votre photo
       throttled_text_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour


### PR DESCRIPTION
This PR is to implement content changes to two error messages in the IAL2 flow.

The send_link_throttle error text in the hybrid flow needs to be changed because it references the "Start Over" button, which no longer appears on that page. Instead, the user should go back to try uploading images with their computer.

The 438 error text is changed to avoid saying "something is wrong" with the image the user submitted, which can cause cognitive burden to the user.

 