### PR TITLE
Update SimpleForm configuration to use design system error styling

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -43,24 +43,6 @@ textarea {
   }
 }
 
-// error states
-.has-error input {
-  background-position: center right $form-field-padding-x;
-  background-repeat: no-repeat;
-  background-size: 1rem 1rem;
-  border-color: $red;
-
-  &.date,
-  &.select {
-    background-image: none;
-  }
-
-  &:focus {
-    border-color: $red;
-    box-shadow: 0 0 0 2px rgba($red, .5);
-  }
-}
-
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
@@ -83,10 +65,6 @@ input::-webkit-inner-spin-button {
   }
 }
 
-.usa-input--error.field:invalid {
-  @include u-border($theme-input-state-border-width, 'error');
-}
-
 .usa-hint {
   font-style: italic;
 }
@@ -105,8 +83,16 @@ input::-webkit-inner-spin-button {
   }
 }
 
-// Remove/refactor once LGDS v6.3 is released
+// Upstream: https://github.com/18F/identity-style-guide/pull/275
+.usa-input--error {
+  &,
+  // Temporary: Remove after LG-3877 (with BassCSS "color-forms")
+  &.field:invalid {
+    border-color: color('error');
+  }
+}
 
+// Upstream: https://github.com/18F/identity-style-guide/pull/265
 .usa-error-message,
 .usa-success-message {
   @include u-padding-y(.5);
@@ -117,6 +103,7 @@ input::-webkit-inner-spin-button {
   padding-left: 1.5rem;
 }
 
+// Upstream: https://github.com/18F/identity-style-guide/pull/265
 .usa-success-message {
   background-image: url(image-path('alert/success.svg'));
   color: color('success');

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -14,8 +14,7 @@ SimpleForm.setup do |config|
 
   config.wrappers :vertical_form,
                   tag: 'div',
-                  class: 'margin-bottom-4',
-                  error_class: 'has-error' do |b|
+                  class: 'margin-bottom-4' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -24,8 +23,8 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'bold'
     b.use :hint,  wrap_with: { tag: 'div', class: 'italic' }
-    b.use :input, class: 'block col-12 field'
-    b.use :error, wrap_with: { tag: 'div', class: 'mt-tiny h6 text-error error-message' }
+    b.use :input, class: 'block col-12 field', error_class: 'usa-input--error'
+    b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
   end
 
   config.default_wrapper = :vertical_form


### PR DESCRIPTION
Extracted from: #5619
Related upstream PR: 18f/identity-style-guide#275

**Why**:

- For improved consistency of presentation of error messages in the application
- Favoring design system over redundant, ad-hoc implementations
- Unblocking new behaviors in #5619 where form-level `has-error` class error styling would take precedence over field-level validity state styling

**Screenshots:**

Before|After
---|---
![Screen Shot 2021-11-22 at 9 33 17 AM](https://user-images.githubusercontent.com/1779930/142880414-2df1bba5-5643-40c2-bdbf-47f316f41a87.png)|![Screen Shot 2021-11-22 at 9 29 43 AM](https://user-images.githubusercontent.com/1779930/142880441-c4e8761c-7487-4f19-b836-18a1a42ab69a.png)

**Testing Instructions:**

1. From root page, click "Create an account"
2. Enter "example@example" as email address
3. Click checkbox to confirm Rules of Use
4. Click "Submit"
5. Observe error message

**Notes:**

For the most part, these error messages are not seen too often by end-users, due to client-side validation, both custom and browser native validation.