### PR TITLE
Fix support for nested ViewComponent scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'uglifier', '~> 4.2'
 gem 'valid_email', '>= 0.1.3'
-gem 'view_component', '~> 2.40.0', require: 'view_component/engine'
+gem 'view_component', '~> 2.43.1', require: 'view_component/engine'
 gem 'webauthn', '~> 2.1'
 gem 'webpacker', '~> 5.1'
 gem 'xmldsig', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,7 @@ GEM
     valid_email (0.1.3)
       activemodel
       mail (>= 2.6.1)
-    view_component (2.40.0)
+    view_component (2.43.1)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     virtus (2.0.0)
@@ -784,7 +784,7 @@ DEPENDENCIES
   subprocess
   uglifier (~> 4.2)
   valid_email (>= 0.1.3)
-  view_component (~> 2.40.0)
+  view_component (~> 2.43.1)
   webauthn (~> 2.1)
   webdrivers (~> 4.0)
   webmock

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -2,8 +2,8 @@ class BaseComponent < ViewComponent::Base
   def before_render
     return if @rendered_scripts
     @rendered_scripts = true
-    if helpers.respond_to?(:render_component_script) && self.class.scripts.present?
-      helpers.render_component_script(*self.class.scripts)
+    if helpers.respond_to?(:enqueue_component_scripts) && self.class.scripts.present?
+      helpers.enqueue_component_scripts(*self.class.scripts)
     end
   end
 

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -1,14 +1,9 @@
 class BaseComponent < ViewComponent::Base
-  def render_in(view_context, &block)
-    render_scripts_in(view_context)
-    super(view_context, &block)
-  end
-
-  def render_scripts_in(view_context)
+  def before_render
     return if @rendered_scripts
     @rendered_scripts = true
-    if view_context.respond_to?(:render_component_script) && self.class.scripts.present?
-      view_context.render_component_script(*self.class.scripts)
+    if helpers.respond_to?(:render_component_script) && self.class.scripts.present?
+      helpers.render_component_script(*self.class.scripts)
     end
   end
 

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -20,7 +20,7 @@ module ScriptHelper
     nil
   end
 
-  alias_method :render_component_script, :javascript_packs_tag_once
+  alias_method :enqueue_component_scripts, :javascript_packs_tag_once
 
   def render_javascript_pack_once_tags
     return if !@scripts

--- a/spec/components/base_component_spec.rb
+++ b/spec/components/base_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BaseComponent, type: :component do
   context 'with sidecar script' do
     class ExampleComponentWithScript < BaseComponent
       def call
-        ''
+        render(NestedExampleComponentWithScript.new)
       end
 
       def self._sidecar_files(extensions)
@@ -32,8 +32,14 @@ RSpec.describe BaseComponent, type: :component do
       end
     end
 
+    class NestedExampleComponentWithScript < ExampleComponentWithScript
+      def call
+        ''
+      end
+    end
+
     it 'adds script to class variable when rendered' do
-      expect(view_context).to receive(:render_component_script).
+      expect(view_context).to receive(:render_component_script).twice.
         with('example_component_with_script')
 
       render_inline(ExampleComponentWithScript.new)

--- a/spec/components/base_component_spec.rb
+++ b/spec/components/base_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BaseComponent, type: :component do
   end
 
   it 'does nothing when rendered' do
-    expect(view_context).not_to receive(:render_component_script)
+    expect(view_context).not_to receive(:enqueue_component_scripts)
 
     render_inline(ExampleComponent.new)
   end
@@ -39,7 +39,7 @@ RSpec.describe BaseComponent, type: :component do
     end
 
     it 'adds script to class variable when rendered' do
-      expect(view_context).to receive(:render_component_script).twice.
+      expect(view_context).to receive(:enqueue_component_scripts).twice.
         with('example_component_with_script')
 
       render_inline(ExampleComponentWithScript.new)


### PR DESCRIPTION
Extracted from: #5619

**Why**: Because it's expected that a component with a "sidecar" JavaScript file will load that file, regardless whether the component is rendered as nested within another component.

Upgrades `view_component` gem from 2.40.0 to latest (2.43.1) to fix related bug where `helpers` reference was not consistent ([see v2.42.0 release notes](https://viewcomponent.org/CHANGELOG.html#2420)).