### PR TITLE
Format phone numbers for PhoneForm initial value

### DIFF
--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -49,10 +49,13 @@ module Idv
     attr_writer :phone
 
     def initial_phone_value(input_phone)
-      return input_phone if input_phone.present?
+      initial_phone = input_phone
+      initial_phone ||= begin
+        user_phone = MfaContext.new(user).phone_configurations.take&.phone
+        user_phone if valid_phone?(user_phone, phone_confirmed: true)
+      end
 
-      user_phone = MfaContext.new(user).phone_configurations.take&.phone
-      user_phone if valid_phone?(user_phone, phone_confirmed: true)
+      PhoneFormatter.format(initial_phone) if initial_phone
     end
 
     def validate_valid_phone_for_allowed_countries

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -49,12 +49,12 @@ describe Idv::PhoneForm do
       let(:phone) { '7035551234' }
       let(:user) { build_stubbed(:user, :signed_up, with: { phone: phone }) }
 
-      it 'uses the user phone number as the initial phone value' do
-        expect(subject.phone).to eq('7035551234')
+      it 'uses the formatted phone number as the initial phone value' do
+        expect(subject.phone).to eq('+1 703-555-1234')
       end
 
       context 'with supported international user phone number' do
-        let(:phone) { '+63 0905 123 4567' }
+        let(:phone) { '+63 905 123 4567' }
 
         it 'uses the user phone number as the initial phone value' do
           expect(subject.phone).to eq(phone)
@@ -84,7 +84,7 @@ describe Idv::PhoneForm do
       let(:previous_params) { { phone: '2255555000' } }
 
       it 'uses the previously submitted value as the initial phone value' do
-        expect(subject.phone).to eq('2255555000')
+        expect(subject.phone).to eq('+1 225-555-5000')
       end
     end
 


### PR DESCRIPTION
Extracted from: #5619

**Why**:

- Fixes an issue where if the phone number is used in a PhoneInputComponent (in LG-5333, and after LG-5399), the intl-tel-input library could have trouble parsing the country of an arbitrary, user-entered number value, resulting in a scenario where the flag dropdown appears as an empty gray box.
- Presumably it is easier to read a nicely-formatted phone number than a string of 6-14 numbers (cc @anniehirshman-gsa)
- It matches how the number is actually saved and sent with the attributes bundle, allowing a user to make corrections if they spot an issue
- It matches the behavior where a user's existing phone number automatically pre-fills the input

**Screenshots:**

Screenshots taken with revisions in #5619 to use PhoneInputComponent on IAL2 address verification step.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/142896882-7952d2db-828c-4020-9dca-f09317f971fe.png)|![image](https://user-images.githubusercontent.com/1779930/142896960-e3ef2737-0bd5-435b-a6a2-f60ee9132430.png)

