### PR TITLE
Fix for react troubleshooting component heading style

### DIFF
--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -12,19 +12,19 @@ import { BlockLink } from '@18f/identity-components';
  * @typedef TroubleshootingOptionsProps
  *
  * @prop {'h1'|'h2'|'h3'|'h4'|'h5'|'h6'=} headingTag
- * @prop {string} headingText
+ * @prop {string} heading
  * @prop {TroubleshootingOption[]} options
  */
 
 /**
  * @param {TroubleshootingOptionsProps} props
  */
-function TroubleshootingOptions({ headingTag = 'h2', headingText, options }) {
+function TroubleshootingOptions({ headingTag = 'h2', heading, options }) {
   const HeadingTag = headingTag;
 
   return (
     <section className="troubleshooting-options">
-      <HeadingTag className="troubleshooting-options__heading">{headingText}</HeadingTag>
+      <HeadingTag className="troubleshooting-options__heading">{heading}</HeadingTag>
       <ul className="troubleshooting-options__options">
         {options.map(({ url, text, isExternal }) => (
           <li key={url}>

--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -11,17 +11,20 @@ import { BlockLink } from '@18f/identity-components';
 /**
  * @typedef TroubleshootingOptionsProps
  *
- * @prop {string} heading
+ * @prop {string} headingTag
+ * @prop {string} headingText
  * @prop {TroubleshootingOption[]} options
  */
 
 /**
  * @param {TroubleshootingOptionsProps} props
  */
-function TroubleshootingOptions({ heading, options }) {
+function TroubleshootingOptions({ headingTag = 'h2', headingText, options }) {
+  const HeadingTag = headingTag;
+
   return (
     <section className="troubleshooting-options">
-      <h2>{heading}</h2>
+      <HeadingTag className="troubleshooting-options__heading">{headingText}</HeadingTag>
       <ul className="troubleshooting-options__options">
         {options.map(({ url, text, isExternal }) => (
           <li key={url}>

--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -11,7 +11,7 @@ import { BlockLink } from '@18f/identity-components';
 /**
  * @typedef TroubleshootingOptionsProps
  *
- * @prop {string=} headingTag
+ * @prop {'h1'|'h2'|'h3'|'h4'|'h5'|'h6'=} headingTag
  * @prop {string} headingText
  * @prop {TroubleshootingOption[]} options
  */

--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -11,7 +11,7 @@ import { BlockLink } from '@18f/identity-components';
 /**
  * @typedef TroubleshootingOptionsProps
  *
- * @prop {string} headingTag
+ * @prop {string=} headingTag
  * @prop {string} headingText
  * @prop {TroubleshootingOption[]} options
  */

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -3,11 +3,22 @@ import TroubleshootingOptions from './troubleshooting-options';
 
 describe('TroubleshootingOptions', () => {
   it('renders a given heading', () => {
-    const { getByRole } = render(<TroubleshootingOptions headingText="Need help?" options={[]} />);
+    const { getByRole, getByText } = render(
+      <TroubleshootingOptions headingText="Need help?" options={[]} />,
+    );
 
     const heading = getByRole('heading');
 
+    expect(getByText('Need help?').tagName).to.be.equal('H2');
     expect(heading.textContent).to.equal('Need help?');
+  });
+
+  it('renders a given headingTag', () => {
+    const { getByText } = render(
+      <TroubleshootingOptions headingTag="h3" headingText="Test Header" options={[]} />,
+    );
+
+    expect(getByText('Test Header').tagName).to.be.equal('H3');
   });
 
   it('renders given options', () => {

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -3,13 +3,11 @@ import TroubleshootingOptions from './troubleshooting-options';
 
 describe('TroubleshootingOptions', () => {
   it('renders a given heading', () => {
-    const { getByRole, getByText } = render(
-      <TroubleshootingOptions heading="Need help?" options={[]} />,
-    );
+    const { getByRole } = render(<TroubleshootingOptions heading="Need help?" options={[]} />);
 
     const heading = getByRole('heading');
 
-    expect(getByText('Need help?').tagName).to.be.equal('H2');
+    expect(heading.tagName).to.be.equal('H2');
     expect(heading.textContent).to.equal('Need help?');
   });
 

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -4,7 +4,7 @@ import TroubleshootingOptions from './troubleshooting-options';
 describe('TroubleshootingOptions', () => {
   it('renders a given heading', () => {
     const { getByRole, getByText } = render(
-      <TroubleshootingOptions headingText="Need help?" options={[]} />,
+      <TroubleshootingOptions heading="Need help?" options={[]} />,
     );
 
     const heading = getByRole('heading');
@@ -15,7 +15,7 @@ describe('TroubleshootingOptions', () => {
 
   it('renders a given headingTag', () => {
     const { getByText } = render(
-      <TroubleshootingOptions headingTag="h3" headingText="Test Header" options={[]} />,
+      <TroubleshootingOptions headingTag="h3" heading="Test Header" options={[]} />,
     );
 
     expect(getByText('Test Header').tagName).to.be.equal('H3');
@@ -24,7 +24,7 @@ describe('TroubleshootingOptions', () => {
   it('renders given options', () => {
     const { getAllByRole } = render(
       <TroubleshootingOptions
-        headingText=""
+        heading=""
         options={[
           { text: <>Option 1</>, url: 'https://example.com/1', isExternal: true },
           { text: 'Option 2', url: 'https://example.com/2' },

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -3,7 +3,7 @@ import TroubleshootingOptions from './troubleshooting-options';
 
 describe('TroubleshootingOptions', () => {
   it('renders a given heading', () => {
-    const { getByRole } = render(<TroubleshootingOptions heading="Need help?" options={[]} />);
+    const { getByRole } = render(<TroubleshootingOptions headingText="Need help?" options={[]} />);
 
     const heading = getByRole('heading');
 
@@ -13,7 +13,7 @@ describe('TroubleshootingOptions', () => {
   it('renders given options', () => {
     const { getAllByRole } = render(
       <TroubleshootingOptions
-        heading=""
+        headingText=""
         options={[
           { text: <>Option 1</>, url: 'https://example.com/1', isExternal: true },
           { text: 'Option 2', url: 'https://example.com/2' },

--- a/app/javascript/packages/document-capture/components/warning.jsx
+++ b/app/javascript/packages/document-capture/components/warning.jsx
@@ -54,7 +54,7 @@ function Warning({
       )}
       {troubleshootingOptions && (
         <TroubleshootingOptions
-          headingText={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
+          heading={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
           options={troubleshootingOptions}
         />
       )}

--- a/app/javascript/packages/document-capture/components/warning.jsx
+++ b/app/javascript/packages/document-capture/components/warning.jsx
@@ -54,7 +54,7 @@ function Warning({
       )}
       {troubleshootingOptions && (
         <TroubleshootingOptions
-          heading={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
+          headingText={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
           options={troubleshootingOptions}
         />
       )}

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -89,7 +89,7 @@
 
   <%= render(
         'shared/troubleshooting_options',
-        heading_level: :h3,
+        heading_tag: :h3,
         heading: t('idv.troubleshooting.headings.missing_required_items'),
         options: [
           {

--- a/app/views/shared/_troubleshooting_options.html.erb
+++ b/app/views/shared/_troubleshooting_options.html.erb
@@ -1,15 +1,15 @@
 <%#
 locals:
-* heading_level: Tag name for heading. Does not affect visual appearance. Defaults to :h2.
+* heading_tag: Tag name for heading. Does not affect visual appearance. Defaults to :h2.
 * heading: Heading text.
 * options: List of link options to display, as an array of hashes with `url`, `text`, `external` values.
 * class: Additional class names to add to wrapper element.
 %>
 <% if local_assigns[:options].presence %>
-  <% heading_level = local_assigns[:heading_level] || :h2 %>
+  <% heading_tag = local_assigns[:heading_tag] || :h2 %>
   <% classes = ['troubleshooting-options', *local_assigns[:class]] %>
   <%= tag.section class: classes do %>
-    <%= content_tag(heading_level, heading, class: 'troubleshooting-options__heading') %>
+    <%= content_tag(heading_tag, heading, class: 'troubleshooting-options__heading') %>
     <ul class="troubleshooting-options__options">
       <% options.each do |option| %>
         <li>

--- a/spec/views/shared/_troubleshooting_options.html.erb_spec.rb
+++ b/spec/views/shared/_troubleshooting_options.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'shared/_troubleshooting_options.html.erb' do
   let(:heading) { '' }
-  let(:heading_level) { nil }
+  let(:heading_tag) { nil }
   let(:options) { [{ text: 'One', url: '#one' }, { text: 'Two', url: '#two' }] }
   let(:classes) { nil }
 
@@ -10,7 +10,7 @@ describe 'shared/_troubleshooting_options.html.erb' do
     render(
       'shared/troubleshooting_options',
       heading: heading,
-      heading_level: heading_level,
+      heading_tag: heading_tag,
       options: options,
       class: classes,
     )
@@ -24,17 +24,17 @@ describe 'shared/_troubleshooting_options.html.erb' do
     end
   end
 
-  describe 'heading_level' do
+  describe 'heading_tag' do
     context 'omitted' do
-      it 'renders with default heading_level h2' do
+      it 'renders with default heading_tag h2' do
         expect(rendered).to have_css('h2')
       end
     end
 
     context 'given' do
-      let(:heading_level) { :h3 }
+      let(:heading_tag) { :h3 }
 
-      it 'renders with custom heading_level' do
+      it 'renders with custom heading_tag' do
         expect(rendered).to have_css('h3')
       end
     end


### PR DESCRIPTION
There was a styling bug in the TroubleShooting React component. So after a quick discussion the missing style class was added and the ability to customize the header tag in the component was introduced. This brings the react troubleshooting component in line with the ruby implementation.