### PR TITLE
Form Validation: Limit custom validation reset to own validation

### DIFF
--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -24,7 +24,10 @@ function kebabCase(string) {
 }
 
 function resetInput(input) {
-  input.setCustomValidity('');
+  if (input.hasAttribute('data-form-validation-message')) {
+    input.setCustomValidity('');
+    input.removeAttribute('data-form-validation-message');
+  }
   input.setAttribute('aria-invalid', 'false');
   input.classList.remove('usa-input--error');
 }
@@ -56,11 +59,13 @@ function checkInputValidity(event) {
   const { I18n } = /** @type {typeof window & LoginGovGlobal} */ (window).LoginGov;
   if (input.validity.valueMissing) {
     input.setCustomValidity(I18n.t('simple_form.required.text'));
+    input.setAttribute('data-form-validation-message', '');
   } else if (input.validity.patternMismatch) {
     PATTERN_TYPES.forEach((type) => {
       if (input.classList.contains(type)) {
         // i18n-tasks-use t('idv.errors.pattern_mismatch.personal_key')
         input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${snakeCase(type)}`));
+        input.setAttribute('data-form-validation-message', '');
       }
     });
   }

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -3,7 +3,7 @@ import { loadPolyfills } from '@18f/identity-polyfill';
 /** @typedef {{t:(key:string)=>string, key:(key:string)=>string}} LoginGovI18n */
 /** @typedef {{LoginGov:{I18n:LoginGovI18n}}} LoginGovGlobal */
 
-const PATTERN_TYPES = ['personal-key', 'ssn'];
+const PATTERN_TYPES = ['personal-key'];
 
 const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').toLowerCase();
 

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 </p>
 
-<%= simple_form_for(
+<%= validated_form_for(
       @new_phone_form,
       html: { autocomplete: 'off', method: :patch },
       data: { international_phone_form: true },

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 </p>
 
-<%= simple_form_for(
+<%= validated_form_for(
       @new_phone_form,
       html: { autocomplete: 'off', method: :post },
       data: { international_phone_form: true },


### PR DESCRIPTION
Extracted from: #5619

**Why**:

- To avoid conflicts between form-validation custom validation and other custom validation which may apply to an input (e.g. a component implementation).
- For consistency of form rendering to include baseline validation (e.g. required field validation).
- To restore test coverage for remaining pattern type validation in `form-validation.js`.
- To reflect latest changes where SSN validation is handled by adjacent visible text element as of #5468.

Previously, changing the value of an input within a form subject to `form-validation.js` behavior would reset custom validity, and often introduced race conditions where a custom implementation's custom validity behavior would be unexpectedly reset.

Steps to reproduce:

1. Log in
2. On Account dashboard, click "Add phone number"
3. Enter an invalid phone number, like "513555"
4. Toggle delivery method to "Phone"

Previously, if `validated_form_for` was used in these forms, the "Submit" button would become unexpectedly enabled, since the form is valid at this point. It was valid only because despite `@18f/identity-phone-input` applying a custom validity reflecting the invalid phone number, a race condition occurred where `form-validation.js` would reset that custom validity immediately afterward. With the changes here, the reset no longer occurs, and `@18f/identity-phone-input` is put back in full control of managing custom validity.

The default required and pattern mismatch validation is trending toward eventual removal in favor of explicit error texts adjacent to the invalid input (LG-5040).