### PR TITLE
LG-4576: add class name to ignore accessibility-form.js

### DIFF
--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -250,7 +250,7 @@ function FormSteps({
   const isLastStep = stepIndex + 1 === steps.length;
 
   return (
-    <form ref={formRef} onSubmit={toNextStep}>
+    <form ref={formRef} className="read-after-submit" onSubmit={toNextStep}>
       {Object.keys(values).length > 0 && <PromptOnNavigate />}
       <FormStepsContext.Provider value={{ isLastStep, canContinueToNextStep, onPageTransition }}>
         <Form


### PR DESCRIPTION
*Why?*
Looks like we enabled a way to disable this if we add class name 'read-after-submit' to the form. I added it and I do not see aria-hidden=true to the body anymore.  
https://github.com/18F/identity-idp/blob/main/app/javascript/app/accessible-forms.js#L12