### PR TITLE
Throw an error at boot if good_job does not have '*' queue (LG-5352)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,12 @@ module Upaya
     config.good_job.queues = IdentityConfig.store.good_job_queues
     # see config/initializers/job_configurations.rb for cron schedule
 
+    includes_star_queue = config.good_job.queues.split(';').any? do |name_threads|
+      name, threads = name_threads.split(':', 2)
+      name == '*'
+    end
+    raise 'good_job.queues does not contain *, but it should' if !includes_star_queue
+
     GoodJob.active_record_parent_class = 'WorkerJobApplicationRecord'
     GoodJob.retry_on_unhandled_error = false
     GoodJob.on_thread_error = ->(exception) { NewRelic::Agent.notice_error(exception) }


### PR DESCRIPTION
Sample error running locally:

```
11:57:37 web.1         | bundler: failed to load command: rackup (.rbenv/versions/2.7/bin/rackup)
11:57:37 web.1         | identity-idp/config/application.rb:61:in `<class:Application>': good_job.queues does not contain *, but it should (RuntimeError)
```
