### PR TITLE
Skip select account screen on return visits

### DIFF
--- a/app/controllers/concerns/billable_event_trackable.rb
+++ b/app/controllers/concerns/billable_event_trackable.rb
@@ -53,4 +53,11 @@ module BillableEventTrackable
       "auth_counted_#{issuer}"
     end
   end
+
+  def first_visit_for_sp?
+    issuer = sp_session[:issuer]
+
+    # check if the user has visited this SP at either IAL1 or IAL2 in this session
+    !user_session["auth_counted_#{issuer}ial1"] && !user_session["auth_counted_#{issuer}"]
+  end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -21,7 +21,9 @@ module OpenidConnect
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
       link_identity_to_service_provider
-      return redirect_to(user_authorization_confirmation_url) if auth_count == 1
+      if auth_count == 1 && first_visit_for_sp?
+        return redirect_to(user_authorization_confirmation_url)
+      end
       handle_successful_handoff
     end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -23,7 +23,9 @@ class SamlIdpController < ApplicationController
     capture_analytics
     return redirect_to_verification_url if profile_or_identity_needs_verification_or_decryption?
     return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
-    return redirect_to(user_authorization_confirmation_url) if auth_count == 1
+    if auth_count == 1 && first_visit_for_sp?
+      return redirect_to(user_authorization_confirmation_url)
+    end
     link_identity_from_session_data
     handle_successful_handoff
   end

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -56,6 +56,19 @@ feature 'OIDC Authorization Confirmation' do
       expect(current_url).to match('http://localhost:7654/auth/result')
     end
 
+    it 'does not show the confirmation page if a user is visiting the same SP' do
+      second_email = create(:email_address, user: user1)
+      sign_in_user(user1, second_email.email)
+
+      # first visit
+      visit_idp_from_ial1_oidc_sp
+      continue_as(second_email.email)
+
+      # second visit
+      visit_idp_from_ial1_oidc_sp
+      expect(current_url).to match('http://localhost:7654/auth/result')
+    end
+
     it 'does not render an error if a user goes back after opting to switch accounts' do
       sign_in_user(user1)
       visit_idp_from_ial1_oidc_sp

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -71,6 +71,19 @@ feature 'SAML Authorization Confirmation' do
       expect(current_path).to eq(new_user_session_path)
     end
 
+    it 'does not render the confirmation screen on a return visit to the SP' do
+      second_email = create(:email_address, user: user1)
+      sign_in_user(user1, second_email.email)
+
+      # first visit
+      visit request_url
+      continue_as(second_email.email)
+
+      # second visit
+      visit request_url
+      expect(current_url).to eq(request_url)
+    end
+
     it 'redirects to the account page with no sp in session' do
       sign_in_user(user1)
       visit user_authorization_confirmation_path


### PR DESCRIPTION
**Why:** this doesn't make sense for the step up flows since it's disruptive to users.

Currently, when a user authenticates with an active Login.gov session,
they are taken to an account selection screen as per the OIDC spec. In
order to provide a more seamless "step-up" flow from IAL1 to IAL2, we
are going to only take a user to that screen on their first visit to a
given SP, and skip it on subsequent visits.