### PR TITLE
Create combined IAA/issuer billing report as CSV (LG-4975)

### DIFF
--- a/app/jobs/reports/agency_invoice_issuer_supplement_report.rb
+++ b/app/jobs/reports/agency_invoice_issuer_supplement_report.rb
@@ -13,7 +13,10 @@ module Reports
       raw_results = service_providers.flat_map do |service_provider|
         transaction_with_timeout do
           Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow.call(
-            service_provider: service_provider,
+            issuer: service_provider.issuer,
+            iaa_start_date: service_provider.iaa_start_date,
+            iaa_end_date: service_provider.iaa_end_date,
+            iaa: service_provider.iaa,
           )
         end
       end

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -1,0 +1,132 @@
+require 'csv'
+
+module Reports
+  class CombinedInvoiceSupplementReport < BaseReport
+    REPORT_NAME = 'combined-invoice-supplement-report'.freeze
+
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
+    def perform(_date)
+      iaas = IaaReportingHelper.iaas
+
+      by_iaa_results = iaas.flat_map do |iaa|
+        transaction_with_timeout do
+          Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(
+            key: iaa.key,
+            issuers: iaa.issuers,
+            start_date: iaa.start_date,
+            end_date: iaa.end_date,
+          )
+        end
+      end
+
+      by_issuer_results = iaas.flat_map do |iaa|
+        iaa.issuers.flat_map do |issuer|
+          transaction_with_timeout do
+            Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow.call(
+              issuer: issuer,
+              iaa_start_date: iaa.start_date,
+              iaa_end_date: iaa.end_date,
+              iaa: iaa.key,
+            )
+          end
+        end
+      end
+
+      csv = combine_by_iaa_month(
+        by_iaa_results: by_iaa_results,
+        by_issuer_results: by_issuer_results,
+      )
+
+      save_report(REPORT_NAME, csv, extension: 'csv')
+    end
+
+    def combine_by_iaa_month(by_iaa_results:, by_issuer_results:)
+      by_iaa_and_year_month = by_iaa_results.group_by do |result|
+        [ result[:key], result[:year_month] ]
+      end
+
+      by_issuer_iaa_issuer_year_months = by_issuer_results.
+        group_by { |r| r[:iaa] }.
+        transform_values do |iaa|
+          iaa.group_by { |r| r[:issuer] }.
+            transform_values { |issuer| issuer.group_by { |r| r[:year_month] } }
+        end
+
+      # rubocop:disable Metrics/BlockLength
+      CSV.generate do |csv|
+        csv << [
+          'iaa_order_number',
+          'iaa_start_date',
+          'iaa_end_date',
+
+          'issuer',
+          'friendly_name',
+
+          'year_month',
+          'year_month_readable',
+          'dates_billed_start_date',
+          'dates_billed_end_date',
+
+          'iaa_ial1_unique_users',
+          'iaa_ial2_unique_users',
+          'iaa_ial1_plus_2_unique_users',
+          'iaa_ial2_new_unique_users',
+
+          'issuer_ial1_total_auth_count',
+          'issuer_ial2_total_auth_count',
+          'issuer_ial1_plus_2_total_auth_count',
+        ]
+
+        by_issuer_iaa_issuer_year_months.each do |iaa_key, issuer_year_months|
+          issuer_year_months.each do |issuer, year_months_data|
+            friendly_name = ServiceProvider.find_by(issuer: issuer).friendly_name
+            year_months = year_months_data.keys.sort
+
+            year_months.each do |year_month|
+              iaa_results = by_iaa_and_year_month[ [iaa_key, year_month] ]
+              issuer_results = year_months_data[year_month]
+
+              year_month_start = Date.strptime(year_month, '%Y%m')
+              iaa_start_date = Date.parse(iaa_results.first[:iaa_start_date])
+              iaa_end_date = Date.parse(iaa_results.first[:iaa_end_date])
+
+              csv << [
+                iaa_key,
+                iaa_start_date,
+                iaa_end_date,
+
+                issuer,
+                friendly_name,
+
+                year_month,
+                year_month_start.strftime('%B %Y'),
+                [year_month_start, iaa_start_date].max.to_s,
+                [year_month_start.end_of_month, iaa_end_date].min.to_s,
+
+                (ial1_unique_users = extract(iaa_results, :unique_users, ial: 1)),
+                (ial2_unique_users = extract(iaa_results, :unique_users, ial: 2)),
+                ial1_unique_users + ial2_unique_users,
+                extract(iaa_results, :new_unique_users, ial: 2),
+
+                (ial1_total_auth_count = extract(issuer_results, :total_auth_count, ial: 1)),
+                (ial2_total_auth_count = extract(issuer_results, :total_auth_count, ial: 2)),
+                ial1_total_auth_count + ial2_total_auth_count,
+              ]
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/BlockLength
+    end
+
+    def extract(arr, key, ial:)
+      arr.find { |elem| elem[:ial] == ial && elem[key] }&.dig(key) || 0
+    end
+  end
+end

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -9,19 +9,20 @@ module Db
 
       module_function
 
-      # @param [ServiceProvider] service_provider
+      # @param [String] issuer
+      # @param [String] iaa
+      # @param [Date] iaa_start_date
+      # @param [Date] iaa_end_date
       # @return [PG::Result,Array]
-      def call(service_provider:)
-        return [] if !service_provider.iaa_start_date || !service_provider.iaa_end_date
+      def call(issuer:, iaa:, iaa_start_date:, iaa_end_date:)
+        return [] if !iaa_start_date || !iaa_end_date
 
-        iaa_range = (service_provider.iaa_start_date..service_provider.iaa_end_date)
+        iaa_range = (iaa_start_date..iaa_end_date)
 
         full_months, partial_months = Reports::MonthHelper.months(iaa_range).
           partition do |month_range|
             Reports::MonthHelper.full_month?(month_range)
           end
-
-        issuer = service_provider.issuer
 
         # The subqueries create a uniform representation of data:
         # - full months from monthly_sp_auth_counts
@@ -64,8 +65,8 @@ module Db
             prev_seen_users |= unique_users
 
             rows << {
-              issuer: service_provider.issuer,
-              iaa: service_provider.iaa,
+              issuer: issuer,
+              iaa: iaa,
               ial: ial,
               year_month: year_month,
               iaa_start_date: iaa_range.begin.to_s,

--- a/app/services/iaa_reporting_helper.rb
+++ b/app/services/iaa_reporting_helper.rb
@@ -9,7 +9,7 @@ module IaaReportingHelper
     :end_date,
     keyword_init: true,
   ) do
-    # ex LG123567-1
+    # ex LG123567-0001
     def key
       "#{gtc_number}-#{format('%04d', order_number)}"
     end

--- a/app/services/iaa_reporting_helper.rb
+++ b/app/services/iaa_reporting_helper.rb
@@ -1,0 +1,38 @@
+module IaaReportingHelper
+  module_function
+
+  IaaConfig = Struct.new(
+    :gtc_number,   # ex LG123567
+    :order_number, # ex 1
+    :issuers,
+    :start_date,
+    :end_date,
+    keyword_init: true,
+  ) do
+    # ex LG123567-1
+    def key
+      "#{gtc_number}-#{format('%04d', order_number)}"
+    end
+  end
+
+  # @return [Array<IaaConfig>]
+  def iaas
+    Agreements::IaaGtc.
+      includes(iaa_orders: { integration_usages: :integration }).
+      flat_map do |gtc|
+        gtc.iaa_orders.flat_map do |iaa_order|
+          issuers = iaa_order.integration_usages.map { |usage| usage.integration.issuer }
+
+          if issuers.present?
+            IaaConfig.new(
+              gtc_number: gtc.gtc_number,
+              order_number: iaa_order.order_number,
+              issuers: issuers,
+              start_date: iaa_order.start_date,
+              end_date: iaa_order.end_date,
+            )
+          end
+        end.compact
+      end
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -108,6 +108,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.today] },
       },
+      # Combined Invoice Supplement Report to S3
+      combined_invoice_supplement_report: {
+        class: 'Reports::CombinedInvoiceSupplementReport',
+        cron: cron_24h,
+        args: -> { [Time.zone.today] },
+      },
       # Total SP Costs Report to S3
       total_sp_costs: {
         class: 'Reports::TotalSpCostReport',

--- a/spec/jobs/reports/agency_invoice_iaa_supplement_report_spec.rb
+++ b/spec/jobs/reports/agency_invoice_iaa_supplement_report_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Reports::AgencyInvoiceIaaSupplementReport do
   end
 
   let(:iaa_order1) do
-    build_iaa_order(order_number: 1,  date_range: iaa1_range, iaa_gtc: gtc1)
+    build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
   end
   let(:iaa_order2) do
-    build_iaa_order(order_number: 2,  date_range: iaa2_range, iaa_gtc: gtc2)
+    build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc2)
   end
 
   # Have to do this because of invalid check when building integration usages
@@ -58,12 +58,12 @@ RSpec.describe Reports::AgencyInvoiceIaaSupplementReport do
     )
   end
 
-  let(:integration1) {
+  let(:integration1) do
     build_integration(issuer: iaa1_sp.issuer, partner_account: partner_account1)
-  }
-  let(:integration2) {
+  end
+  let(:integration2) do
     build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account2)
-  }
+  end
 
   let(:iaa1) { 'iaa1' }
   let(:iaa1_key) { "#{gtc1.gtc_number}-#{format('%04d', iaa_order1.order_number)}" }
@@ -168,19 +168,19 @@ RSpec.describe Reports::AgencyInvoiceIaaSupplementReport do
       end
 
       context 'one agreement with consecutive iaas' do
-        let(:iaa_order1) {
-          build_iaa_order(order_number: 1,  date_range: iaa1_range, iaa_gtc: gtc1)
-        }
-        let(:iaa_order2) {
-          build_iaa_order(order_number: 2,  date_range: iaa2_range, iaa_gtc: gtc1)
-        }
+        let(:iaa_order1) do
+          build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
+        end
+        let(:iaa_order2) do
+          build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc1)
+        end
 
-        let(:integration1) {
+        let(:integration1) do
           build_integration(issuer: iaa1_sp.issuer, partner_account: partner_account1)
-        }
-        let(:integration2) {
+        end
+        let(:integration2) do
           build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account1)
-        }
+        end
 
         let(:iaa2_key) { "#{gtc1.gtc_number}-#{format('%04d', iaa_order2.order_number)}" }
 
@@ -218,63 +218,6 @@ RSpec.describe Reports::AgencyInvoiceIaaSupplementReport do
 
           expect(results).to match_array(rows)
         end
-      end
-    end
-  end
-
-  describe '#iaas' do
-    before do
-      iaa_order1.integrations << integration1
-      iaa_order2.integrations << integration2
-      iaa_order1.save
-      iaa_order2.save
-    end
-
-    context 'multiple IAAs on same GTC' do
-      let(:iaa_order1) {
-        build_iaa_order(order_number: 1,  date_range: iaa1_range, iaa_gtc: gtc1)
-      }
-      let(:iaa_order2) {
-        build_iaa_order(order_number: 2,  date_range: iaa2_range, iaa_gtc: gtc1)
-      }
-
-      let(:integration2) {
-        build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account1)
-      }
-
-      let(:iaa2_key) { "#{gtc1.gtc_number}-#{format('%04d', iaa_order2.order_number)}" }
-
-      let(:iaa1_range) { Date.new(2020, 4, 15)..Date.new(2021, 4, 14) }
-      let(:iaa2_range) { Date.new(2021, 4, 14)..Date.new(2022, 4, 13) }
-
-      it 'returns both fo the IAAS with the proper key' do
-        iaas = report.iaas
-        orders = iaas.select { |obj| obj[:key].starts_with?(gtc1.gtc_number) }
-        # Expect IAAS with matching GTC to appear
-        expect(orders.count).to eq(2)
-      end
-    end
-
-    context 'IAAS on different GTCs' do
-      let(:integration1) {
-        build_integration(issuer: iaa1_sp.issuer, partner_account: partner_account1)
-      }
-      let(:integration2) {
-        build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account2)
-      }
-      let(:iaa_order1) {
-        build_iaa_order(order_number: 1,  date_range: iaa1_range, iaa_gtc: gtc1)
-      }
-      let(:iaa_order2) {
-        build_iaa_order(order_number: 2,  date_range: iaa2_range, iaa_gtc: gtc2)
-      }
-
-      it 'returns both of the IAAS with the proper key of different GTCs' do
-        iaas = report.iaas
-        gtc1_orders = iaas.select { |obj| obj[:key].starts_with?(gtc1.gtc_number) }
-        gtc2_orders = iaas.select { |obj| obj[:key].starts_with?(gtc2.gtc_number) }
-        expect(gtc1_orders.count).to eq(1)
-        expect(gtc2_orders.count).to eq(1)
       end
     end
   end

--- a/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
@@ -1,0 +1,210 @@
+require 'rails_helper'
+
+RSpec.describe Reports::CombinedInvoiceSupplementReport do
+  subject(:report) { Reports::CombinedInvoiceSupplementReport.new }
+
+  let(:partner_account1) { create(:partner_account) }
+  let(:partner_account2) { create(:partner_account) }
+  let(:gtc1) do
+    create(
+      :iaa_gtc,
+      gtc_number: 'gtc1234',
+      partner_account: partner_account1,
+      start_date: iaa1_range.begin,
+      end_date: iaa1_range.end,
+    )
+  end
+
+  let(:gtc2) do
+    create(
+      :iaa_gtc,
+      gtc_number: 'gtc5678',
+      partner_account: partner_account2,
+      start_date: iaa2_range.begin,
+      end_date: iaa2_range.end,
+    )
+  end
+
+  let(:iaa_order1) do
+    build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
+  end
+  let(:iaa_order2) do
+    build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc2)
+  end
+
+  # Have to do this because of invalid check when building integration usages
+  let!(:iaa_orders) do
+    [
+      iaa_order1,
+      iaa_order2,
+    ]
+  end
+
+  let!(:iaa1_sp) do
+    create(
+      :service_provider,
+      iaa: iaa1,
+      iaa_start_date: iaa1_range.begin,
+      iaa_end_date: iaa1_range.end,
+    )
+  end
+
+  let!(:iaa2_sp1) do
+    create(
+      :service_provider,
+      iaa: iaa2,
+      iaa_start_date: iaa2_range.begin,
+      iaa_end_date: iaa2_range.end,
+    )
+  end
+  let!(:iaa2_sp2) do
+    create(
+      :service_provider,
+      iaa: iaa2,
+      iaa_start_date: iaa2_range.begin,
+      iaa_end_date: iaa2_range.end,
+    )
+  end
+
+  let(:iaa1) { 'iaa1' }
+  let(:iaa1_range) { Date.new(2020, 4, 15)..Date.new(2021, 4, 14) }
+  let(:inside_iaa1) { iaa1_range.begin + 1.day }
+
+  let(:iaa2) { 'iaa2' }
+  let(:iaa2_range) { Date.new(2020, 9, 1)..Date.new(2021, 8, 30) }
+  let(:inside_iaa2) { iaa2_range.begin + 1.day }
+
+  describe '#perform' do
+    it 'is empty with no data' do
+      csv = CSV.parse(report.perform(Time.zone.today), headers: true)
+      expect(csv).to be_empty
+    end
+
+    context 'with data' do
+      let(:user1) { create(:user) }
+      let(:user2) { create(:user) }
+
+      before do
+        iaa_order1.integrations << build_integration(
+          issuer: iaa1_sp.issuer,
+          partner_account: partner_account1,
+        )
+        iaa_order2.integrations << build_integration(
+          issuer: iaa2_sp1.issuer,
+          partner_account: partner_account2,
+        )
+        iaa_order2.integrations << build_integration(
+          issuer: iaa2_sp2.issuer,
+          partner_account: partner_account2,
+        )
+        iaa_order1.save
+        iaa_order2.save
+
+        create(
+          :sp_return_log,
+          user_id: user1.id,
+          issuer: iaa1_sp.issuer,
+          ial: 1,
+          requested_at: inside_iaa1,
+          returned_at: inside_iaa1,
+        )
+
+        # 1 unique user in month 1 at IAA 2 sp 1 @ IAL 2
+        create(
+          :monthly_sp_auth_count,
+          user_id: user1.id,
+          auth_count: 1,
+          ial: 2,
+          issuer: iaa2_sp1.issuer,
+          year_month: inside_iaa2.strftime('%Y%m'),
+        )
+
+        # 1 unique user in month 1 at IAA 2 sp 2 @ IAL 2
+        create(
+          :monthly_sp_auth_count,
+          user_id: user2.id,
+          auth_count: 1,
+          ial: 2,
+          issuer: iaa2_sp2.issuer,
+          year_month: inside_iaa2.strftime('%Y%m'),
+        )
+      end
+
+      it 'generates a report by iaa + order number and issuer and year month' do
+        csv = CSV.parse(report.perform(Time.zone.today), headers: true)
+
+        row = csv.first
+        expect(row['iaa_order_number']).to eq('gtc1234-0001')
+        expect(row['iaa_start_date']).to eq('2020-04-15')
+        expect(row['iaa_end_date']).to eq('2021-04-14')
+
+        expect(row['issuer']).to eq(iaa1_sp.issuer)
+        expect(row['friendly_name']).to eq(iaa1_sp.friendly_name)
+
+        expect(row['year_month']).to eq('202004')
+        expect(row['year_month_readable']).to eq('April 2020')
+        expect(row['dates_billed_start_date']).to eq('2020-04-15')
+        expect(row['dates_billed_end_date']).to eq('2020-04-30')
+
+        expect(row['iaa_ial1_unique_users'].to_i).to eq(1)
+        expect(row['iaa_ial2_unique_users'].to_i).to eq(0)
+        expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(1)
+        expect(row['iaa_ial2_new_unique_users'].to_i).to eq(0)
+
+        expect(row['issuer_ial1_total_auth_count'].to_i).to eq(1)
+        expect(row['issuer_ial2_total_auth_count'].to_i).to eq(0)
+        expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(1)
+
+        row = csv[1]
+        expect(row['iaa_order_number']).to eq('gtc5678-0002')
+        expect(row['iaa_start_date']).to eq('2020-09-01')
+        expect(row['iaa_end_date']).to eq('2021-08-30')
+
+        expect(row['issuer']).to eq(iaa2_sp1.issuer)
+        expect(row['friendly_name']).to eq(iaa2_sp1.friendly_name)
+
+        expect(row['year_month']).to eq('202009')
+        expect(row['year_month_readable']).to eq('September 2020')
+        expect(row['dates_billed_start_date']).to eq('2020-09-01')
+        expect(row['dates_billed_end_date']).to eq('2020-09-30')
+
+        expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
+        expect(row['iaa_ial2_unique_users'].to_i).to eq(2)
+        expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(2)
+        expect(row['iaa_ial2_new_unique_users'].to_i).to eq(2)
+
+        expect(row['issuer_ial1_total_auth_count'].to_i).to eq(0)
+        expect(row['issuer_ial2_total_auth_count'].to_i).to eq(1)
+        expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(1)
+      end
+    end
+  end
+
+  def build_iaa_order(order_number:, date_range:, iaa_gtc:)
+    create(
+      :iaa_order,
+      order_number: order_number,
+      start_date: date_range.begin,
+      end_date: date_range.end,
+      iaa_gtc: iaa_gtc,
+    )
+  end
+
+  def build_integration(issuer:, partner_account:)
+    create(
+      :integration,
+      issuer: issuer,
+      partner_account: partner_account,
+    )
+  end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+end

--- a/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
+++ b/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow do
   describe '.call' do
     subject(:result) do
       Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow.call(
-        service_provider: service_provider,
+        issuer: service_provider.issuer,
+        iaa_start_date: service_provider.iaa_start_date,
+        iaa_end_date: service_provider.iaa_end_date,
+        iaa: service_provider.iaa,
       )
     end
 

--- a/spec/services/iaa_reporting_helper_spec.rb
+++ b/spec/services/iaa_reporting_helper_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+RSpec.describe IaaReportingHelper do
+  let(:partner_account1) { create(:partner_account) }
+  let(:partner_account2) { create(:partner_account) }
+  let(:gtc1) do
+    create(
+      :iaa_gtc,
+      gtc_number: 'gtc1234',
+      partner_account: partner_account1,
+      start_date: iaa1_range.begin,
+      end_date: iaa1_range.end,
+    )
+  end
+
+  let(:gtc2) do
+    create(
+      :iaa_gtc,
+      gtc_number: 'gtc5678',
+      partner_account: partner_account2,
+      start_date: iaa2_range.begin,
+      end_date: iaa2_range.end,
+    )
+  end
+
+  let(:iaa_order1) do
+    build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
+  end
+  let(:iaa_order2) do
+    build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc2)
+  end
+
+  let(:integration1) do
+    build_integration(issuer: iaa1_sp.issuer, partner_account: partner_account1)
+  end
+  let(:integration2) do
+    build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account2)
+  end
+
+  # Have to do this because of invalid check when building integration usages
+  let!(:iaa_orders) do
+    [
+      iaa_order1,
+      iaa_order2,
+    ]
+  end
+
+  let(:iaa1) { 'iaa1' }
+  let(:iaa1_key) { "#{gtc1.gtc_number}-#{format('%04d', iaa_order1.order_number)}" }
+  let(:iaa1_range) { Date.new(2020, 4, 15)..Date.new(2021, 4, 14) }
+
+  let(:iaa2) { 'iaa2' }
+  let(:iaa2_key) { "#{gtc2.gtc_number}-#{format('%04d', iaa_order2.order_number)}" }
+  let(:iaa2_range) { Date.new(2020, 9, 1)..Date.new(2021, 8, 30) }
+
+  let!(:iaa1_sp) do
+    create(
+      :service_provider,
+      iaa: iaa1,
+      iaa_start_date: iaa1_range.begin,
+      iaa_end_date: iaa1_range.end,
+    )
+  end
+
+  let!(:iaa2_sp) do
+    create(
+      :service_provider,
+      iaa: iaa2,
+      iaa_start_date: iaa2_range.begin,
+      iaa_end_date: iaa2_range.end,
+    )
+  end
+
+  def build_iaa_order(order_number:, date_range:, iaa_gtc:)
+    create(
+      :iaa_order,
+      order_number: order_number,
+      start_date: date_range.begin,
+      end_date: date_range.end,
+      iaa_gtc: iaa_gtc,
+    )
+  end
+
+  def build_integration(issuer:, partner_account:)
+    create(
+      :integration,
+      issuer: issuer,
+      partner_account: partner_account,
+    )
+  end
+
+  describe '#iaas' do
+    before do
+      iaa_order1.integrations << integration1
+      iaa_order2.integrations << integration2
+      iaa_order1.save
+      iaa_order2.save
+    end
+
+    context 'multiple IAAs on same GTC' do
+      let(:iaa_order1) do
+        build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
+      end
+      let(:iaa_order2) do
+        build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc1)
+      end
+
+      let(:integration2) do
+        build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account1)
+      end
+
+      let(:iaa2_key) { "#{gtc1.gtc_number}-#{format('%04d', iaa_order2.order_number)}" }
+
+      let(:iaa1_range) { Date.new(2020, 4, 15)..Date.new(2021, 4, 14) }
+      let(:iaa2_range) { Date.new(2021, 4, 14)..Date.new(2022, 4, 13) }
+
+      it 'returns both fo the IAAS with the proper key' do
+        iaas = IaaReportingHelper.iaas
+        orders = iaas.select { |obj| obj.gtc_number == gtc1.gtc_number }
+        # Expect IAAS with matching GTC to appear
+        expect(orders.count).to eq(2)
+      end
+    end
+
+    context 'IAAS on different GTCs' do
+      let(:integration1) do
+        build_integration(issuer: iaa1_sp.issuer, partner_account: partner_account1)
+      end
+      let(:integration2) do
+        build_integration(issuer: iaa2_sp.issuer, partner_account: partner_account2)
+      end
+      let(:iaa_order1) do
+        build_iaa_order(order_number: 1, date_range: iaa1_range, iaa_gtc: gtc1)
+      end
+      let(:iaa_order2) do
+        build_iaa_order(order_number: 2, date_range: iaa2_range, iaa_gtc: gtc2)
+      end
+
+      it 'returns both of the IAAS with the proper key of different GTCs' do
+        iaas = IaaReportingHelper.iaas
+        gtc1_orders = iaas.select { |obj| obj.gtc_number == gtc1.gtc_number }
+        gtc2_orders = iaas.select { |obj| obj.gtc_number == gtc2.gtc_number }
+        expect(gtc1_orders.count).to eq(1)
+        expect(gtc2_orders.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
See JIRA for example spreadsheet that billing team requested that this implements

- Extracts out GTC to IAA logic from old reports
- Repurposes old reporting classes
- Builds a CSV! (much easier to parse as a spreadsheet than JSON)