### PR TITLE
Respect the ForceAuthn attribute in SAML AuthnRequests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.1.4'
 # Variables can be overridden for local dev in Gemfile-dev
 @hostdata_gem ||= { github: '18F/identity-hostdata', tag: 'v3.4.0' }
 @logging_gem ||= { github: '18F/identity-logging', tag: 'v0.1.0' }
-@saml_gem ||= { github: '18F/saml_idp', tag: 'v0.14.3-18f' }
+@saml_gem ||= { github: '18F/saml_idp', tag: '0.15.0-18f' }
 @validations_gem ||= { github: '18F/identity-validations', tag: 'v0.7.1' }
 
 gem 'identity-hostdata', @hostdata_gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,10 +25,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: cf2ec293aa2c12e8679adfa7d6807a8d77814f4c
-  tag: v0.14.3-18f
+  revision: 2180ccf2230c7d42046a5acaca52a0cf0b821f4f
+  tag: 0.15.0-18f
   specs:
-    saml_idp (0.14.3.pre.18f)
+    saml_idp (0.15.0.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -6,12 +6,22 @@ module SamlIdpAuthConcern
     # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :validate_saml_request, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
+    # this must take place _before_ the store_saml_request action or the SAML
+    # request is cleared (along with the rest of the session) when the user is
+    # signed out
+    before_action :sign_out_if_forceauthn_is_true_and_user_is_signed_in, only: :auth
     before_action :store_saml_request, only: :auth
     before_action :check_sp_active, only: :auth
     # rubocop:enable Rails/LexicallyScopedActionFilter
   end
 
   private
+
+  def sign_out_if_forceauthn_is_true_and_user_is_signed_in
+    return unless user_signed_in? && saml_request.force_authn?
+
+    sign_out unless sp_session[:request_url] == request.original_url
+  end
 
   def check_sp_active
     return if current_service_provider&.active?

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -407,6 +407,19 @@ describe SamlIdpController do
       end
     end
 
+    context 'ForceAuthn set to true' do
+      it 'signs the user out if a session is active' do
+        user = create(:user, :signed_up)
+        sign_in(user)
+        generate_saml_response(user, saml_settings(overrides: { force_authn: true }))
+
+        # would be 200 if the user's session persists
+        expect(response.status).to eq(302)
+        # implicit test of request storage since request_id would be missing otherwise
+        expect(response.location).to match(%r{#{root_url}\?request_id=.+})
+      end
+    end
+
     context 'service provider is inactive' do
       it 'responds with an error page' do
         user = create(:user, :signed_up)

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -46,6 +46,10 @@ class FakeSamlRequest
     '123'
   end
 
+  def force_authn?
+    false
+  end
+
   def authn_request?
     true
   end


### PR DESCRIPTION
The SAML specification (section 3.4.1) includes an attribute
`ForceAuthn` for the `AuthnRequest` element that can be used by an SP to
require that a user be authenticated again, rather than relying on a
previous security context. This change allows the IdP to respect that
attribute and force authentication when an SP includes
`ForceAuthn='true'` in the SAML request.

Blocked on https://github.com/18F/saml_idp/pull/50