### PR TITLE
Configure USWDS "usa-hint" class for form hints

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -66,13 +66,14 @@ input::-webkit-inner-spin-button {
   }
 }
 
-.usa-hint {
-  font-style: italic;
-}
-
 // ===============================================
 // Pending upstream Login Design System revisions:
 // ===============================================
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/262
+.usa-hint {
+  font-style: italic;
+}
 
 .usa-form-group--error {
   border-left-style: none;

--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -1,8 +1,27 @@
 lg-phone-input {
   display: block;
 
+  .iti {
+    margin-top: units(1);
+  }
+
   .iti__flag {
     background-image: image-url('intl-tel-input/build/img/flags.png');
+
+    /* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
+    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+      background-image: image-url('intl-tel-input/build/img/flags@2x.png');
+    }
+  }
+
+  .iti:not(.iti--allow-dropdown) input {
+    padding-left: 36px;
+    padding-right: 6px;
+  }
+
+  .iti:not(.iti--allow-dropdown) .iti__flag-container {
+    left: 0;
+    right: auto;
   }
 }
 
@@ -11,22 +30,5 @@ lg-phone-input {
 
   .no-js & {
     display: block;
-  }
-}
-
-.iti:not(.iti--allow-dropdown) input {
-  padding-left: 36px;
-  padding-right: 6px;
-}
-
-.iti:not(.iti--allow-dropdown) .iti__flag-container {
-  left: 0;
-  right: auto;
-}
-
-/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-  lg-phone-input .iti__flag {
-    background-image: image-url('intl-tel-input/build/img/flags@2x.png');
   }
 }

--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -1,7 +1,7 @@
 lg-phone-input {
   display: block;
 
-  .iti {
+  .validated-field__input-wrapper {
     margin-top: units(1);
   }
 

--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -32,11 +32,9 @@
         :phone,
         class: 'usa-label',
       ) { t('two_factor_authentication.phone_label') } %>
-  <%= f.hint safe_join([
-        t('forms.example'),
-        ' ',
-        content_tag('span', '', class: 'phone-input__example'),
-      ]) %>
+  <%= f.hint safe_join(
+        [t('forms.example'), ' ', content_tag('span', '', class: 'phone-input__example')],
+      ) %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :phone,

--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -32,10 +32,11 @@
         :phone,
         class: 'usa-label',
       ) { t('two_factor_authentication.phone_label') } %>
-  <div class="margin-bottom-1 usa-hint js">
-    <%= t('forms.example') %>
-    <span class="phone-input__example"></span>
-  </div>
+  <%= f.hint safe_join([
+        t('forms.example'),
+        ' ',
+        content_tag('span', '', class: 'phone-input__example'),
+      ]) %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :phone,

--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -32,10 +32,12 @@
         :phone,
         class: 'usa-label',
       ) { t('two_factor_authentication.phone_label') } %>
-  <%= f.hint(capture do %>
-    <%= t('forms.example') %>
-    <span class="phone-input__example"></span>
-  <% end) %>
+  <div class="js">
+    <%= f.hint(capture do %>
+      <%= t('forms.example') %>
+      <span class="phone-input__example"></span>
+    <% end) %>
+  </div>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :phone,

--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -32,9 +32,10 @@
         :phone,
         class: 'usa-label',
       ) { t('two_factor_authentication.phone_label') } %>
-  <%= f.hint safe_join(
-        [t('forms.example'), ' ', content_tag('span', '', class: 'phone-input__example')],
-      ) %>
+  <%= f.hint(capture do %>
+    <%= t('forms.example') %>
+    <span class="phone-input__example"></span>
+  <% end) %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :phone,

--- a/app/javascript/packages/phone-input/index.spec.js
+++ b/app/javascript/packages/phone-input/index.spec.js
@@ -49,7 +49,7 @@ describe('PhoneInput', () => {
         ${!isSingleOption && !isNonUSSingleOption ? MULTIPLE_OPTIONS_HTML : ''}
       </div>
       <label class="usa-label" for="phone_form_phone">Phone number</label>
-      <div class="margin-bottom-1 usa-hint js">
+      <div class="usa-hint">
         Example:
         <span class="phone-input__example"></span>
       </div>

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -6,9 +6,7 @@ locals:
 <%= f.label :ssn, class: 'usa-label' do %>
   <%= t('idv.form.ssn_label_html') %>
 <% end %>
-<div class="usa-hint">
-  <%= t('forms.example') %> 123-45-6789
-</div>
+<%= f.hint t('forms.example') + ' 123-45-6789' %>
 <%# maxlength set and includes '-' delimiters to work around cleave bug %>
 <%= f.input(
       :ssn,

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -6,7 +6,7 @@ locals:
 <%= f.label :ssn, class: 'usa-label' do %>
   <%= t('idv.form.ssn_label_html') %>
 <% end %>
-<div class="margin-bottom-1 usa-hint">
+<div class="usa-hint">
   <%= t('forms.example') %> 123-45-6789
 </div>
 <%# maxlength set and includes '-' delimiters to work around cleave bug %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -22,7 +22,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: 'bold'
-    b.use :hint,  wrap_with: { tag: 'div', class: 'italic' }
+    b.use :hint,  wrap_with: { tag: 'div', class: 'usa-hint' }
     b.use :input, class: 'block col-12 field', error_class: 'usa-input--error'
     b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
   end


### PR DESCRIPTION
**Why**: As a step toward USWDS as the standard for form building. We don't appear to be using SimpleForm's `hint` behavior anyways as-is, but this would change the configured default to use the USWDS class, and refactors existing ad-hoc usage of USWDS to take advantage of the form builder to simplify implementation of standard defaults.

There is not intended to be any visual changes as a result of these revisions, but screenshots below show the affected code:

Screen|Screenshot
---|---
Add Phone|![Screen Shot 2021-11-30 at 9 34 53 AM](https://user-images.githubusercontent.com/1779930/144067496-bee8e168-368e-4867-b593-99f7c9a539ac.png)
Enter SSN|![Screen Shot 2021-11-30 at 9 34 35 AM](https://user-images.githubusercontent.com/1779930/144067531-f77ef6e4-29aa-4e3a-83b5-9cbeed5771d2.png)