### PR TITLE
echo deploy.json response to debug SHA checkout errors in smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,9 @@ commands:
       - run:
           name: Custom Checkout of Deployed SHA
           command: |
-            DEPLOYED_SHA=$(curl --silent << parameters.sha_url >> | jq -r '.git_sha')
+            SHA_RESPONSE=$(curl --silent << parameters.sha_url >>)
+            echo "Response: $SHA_RESPONSE"
+            DEPLOYED_SHA=$(echo ${SHA_RESPONSE} | jq -r '.git_sha')
 
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"


### PR DESCRIPTION
We get pretty infrequent smoke test errors in the form of:

```
parse error: Invalid numeric literal at line 1, column 7
```

This adds an echo to print the response to see what went wrong