### PR TITLE
Fix Rubocop DynamicFindBy excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -738,10 +738,8 @@ Rails/Delegate:
   Enabled: false
 
 Rails/DynamicFindBy:
-  Include:
-    - tests/features/**/*.rb
-  AllowedMethods:
-    - find_by_id
+  Exclude:
+    - spec/features/**/*.rb
 
 Rails/FilePath:
   Enabled: false


### PR DESCRIPTION
**Why**: The configuration was intended to allow the Capybara "page.find_by_id" method within feature specs. However, this wasn't working correctly for several reasons:

- "Include" should have been "Exclude", to exempt feature specs while still enforcing elsewhere.
- "AllowedMethods" is still called "Whitelist" in the version of Rubocop we use, so it was emitting a warning about invalid configuration.
- The "Include" path was wrong, since we have our tests in "spec", not "tests"

The result of these is that the rule was not being applied _anywhere_, since it was only including files that don't actually exist in the project.