### PR TITLE
Fix flaky DocAuthRouter tests

### DIFF
--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe DocAuthRouter do
           and_return(doc_auth_vendor_randomize_percent)
 
         results = []
-        iterations.times do |_i|
-          results.push(DocAuthRouter.doc_auth_vendor(discriminator: SecureRandom.uuid))
+        iterations.times do |i|
+          results.push(DocAuthRouter.doc_auth_vendor(discriminator: i.to_s(16)))
         end
 
         target_value = iterations*(doc_auth_vendor_randomize_percent.to_f/100)
@@ -124,8 +124,8 @@ RSpec.describe DocAuthRouter do
           and_return(doc_auth_vendor_randomize_percent)
 
         results = []
-        iterations.times do |_i|
-          client = DocAuthRouter.client(vendor_discriminator: SecureRandom.uuid).client
+        iterations.times do |i|
+          client = DocAuthRouter.client(vendor_discriminator: i.to_s(16)).client
           results.push(client.class.to_s)
         end
 


### PR DESCRIPTION
I had a test run fail due to the randomness not working out in my favor ([CircleCI link](https://app.circleci.com/pipelines/github/18F/identity-idp/61567/workflows/8263ab44-7cbc-4f3b-9495-fbf9950e8d5c/jobs/95566/parallel-runs/3?filterBy=FAILED))

Setting the random seed would allow us to be exact in the expectations of how many end up in each category if we want to go that route. I'm very open to suggestions though.

There was some discussion in the original PR here on potential for flakiness: https://github.com/18F/identity-idp/pull/5296/files#r693164038