### PR TITLE
Support IALMAX using the Comparison attribute in SAML

### DIFF
--- a/app/controllers/concerns/billable_event_trackable.rb
+++ b/app/controllers/concerns/billable_event_trackable.rb
@@ -20,14 +20,14 @@ module BillableEventTrackable
   end
 
   def create_sp_return_log(billable:)
-    ial_context = IalContext.new(
-      ial: sp_session_ial, service_provider: current_sp, user: current_user,
+    user_ial_context = IalContext.new(
+      ial: ial_context.ial, service_provider: current_sp, user: current_user,
     )
     Db::SpReturnLog.create_return(
       request_id: request_id,
       user_id: current_user.id,
       billable: billable,
-      ial: ial_context.bill_for_ial_1_or_2,
+      ial: user_ial_context.bill_for_ial_1_or_2,
       issuer: current_sp.issuer,
       requested_at: session[:session_started_at],
     )

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -122,6 +122,7 @@ module SamlIdpAuthConcern
     @ial_context ||= IalContext.new(
       ial: requested_ial_authn_context,
       service_provider: saml_request_service_provider,
+      authn_context_comparison: saml_request.requested_authn_context_comparison,
     )
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -58,6 +58,10 @@ module OpenidConnect
       @authorize_form.link_identity_to_service_provider(current_user, session.id)
     end
 
+    def ial_context
+      @authorize_form.ial_context
+    end
+
     def handle_successful_handoff
       track_events
       SpHandoffBounce::AddHandoffTimeToSession.call(sp_session)

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -100,8 +100,12 @@ class SamlIdpController < ApplicationController
   end
 
   def profile_or_identity_needs_verification_or_decryption?
-    return false unless ial_context.ial2_or_greater?
+    return false unless ial_context.ial2_or_greater? || ialmax_requested_with_ial2_user?
     profile_needs_verification? || identity_needs_verification? || identity_needs_decryption?
+  end
+
+  def ialmax_requested_with_ial2_user?
+    ial_context.ialmax_requested? && identity_needs_decryption?
   end
 
   def identity_needs_decryption?
@@ -114,7 +118,7 @@ class SamlIdpController < ApplicationController
       endpoint: remap_auth_post_path(request.env['PATH_INFO']),
       idv: identity_needs_verification?,
       finish_profile: profile_needs_verification?,
-      requested_ial: saml_request&.requested_ial_authn_context || 'none',
+      requested_ial: requested_ial,
     )
     analytics.track_event(Analytics::SAML_AUTH, analytics_payload)
   end
@@ -123,9 +127,15 @@ class SamlIdpController < ApplicationController
     return unless external_saml_request?
 
     analytics.saml_auth_request(
-      requested_ial: saml_request&.requested_ial_authn_context || 'none',
+      requested_ial: requested_ial,
       service_provider: saml_request&.issuer,
     )
+  end
+
+  def requested_ial
+    return 'ialmax' if ial_context.ialmax_requested?
+
+    saml_request&.requested_ial_authn_context || 'none'
   end
 
   def handle_successful_handoff
@@ -152,7 +162,7 @@ class SamlIdpController < ApplicationController
   end
 
   def track_events
-    analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: sp_session_ial)
+    analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: ial_context.ial)
     track_billing_events
   end
 end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -95,6 +95,10 @@ class OpenidConnectAuthorizeForm
     acr_values.filter { |acr| %r{/aal/}.match? acr }
   end
 
+  def ial_context
+    @ial_context ||= IalContext.new(ial: ial, service_provider: service_provider)
+  end
+
   def_delegators :ial_context,
                  :ial2_or_greater?,
                  :ial2_requested?,
@@ -103,10 +107,6 @@ class OpenidConnectAuthorizeForm
   private
 
   attr_reader :identity, :success
-
-  def ial_context
-    @ial_context ||= IalContext.new(ial: ial, service_provider: service_provider)
-  end
 
   def check_for_unauthorized_scope(params)
     param_value = params[:scope]

--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -1,14 +1,15 @@
 # Wraps up logic for querying the IAL level of an authorization request
 class IalContext
-  attr_reader :ial, :service_provider, :user
+  attr_reader :ial, :service_provider, :user, :authn_context_comparison
 
   # @param ial [String, Integer] IAL level as either an integer (see ::Idp::Constants::IAL2, etc)
   #   or a string see Saml::Idp::Constants contexts
   # @param service_provider [ServiceProvider, nil]
-  def initialize(ial:, service_provider:, user: nil)
-    @ial = int_ial(ial)
+  def initialize(ial:, service_provider:, user: nil, authn_context_comparison: nil)
+    @authn_context_comparison = authn_context_comparison
     @service_provider = service_provider
     @user = user
+    @ial = int_ial(ial)
   end
 
   def ial2_service_provider?
@@ -46,6 +47,19 @@ class IalContext
   private
 
   def int_ial(input)
+    return 0 if saml_ialmax?(input)
+
+    convert_ial_to_int(input)
+  end
+
+  def saml_ialmax?(input)
+    int_ial_from_request = convert_ial_to_int(input)
+    return false unless int_ial_from_request.present?
+
+    service_provider&.ial == 2 && authn_context_comparison == 'minimum' && int_ial_from_request < 2
+  end
+
+  def convert_ial_to_int(input)
     Integer(input)
   rescue TypeError # input was nil
     nil

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -441,6 +441,15 @@ describe SamlIdpController do
         },
       )
     end
+    let(:ialmax_settings) do
+      saml_settings(
+        overrides: {
+          issuer: sp1_issuer,
+          authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          authn_context_comparison: 'minimum',
+        },
+      )
+    end
 
     shared_examples 'a verified identity' do |authn_context, ial|
       let(:ial2_settings) do
@@ -601,6 +610,117 @@ describe SamlIdpController do
         generate_saml_response(user, saml_settings)
 
         expect(response).to_not be_redirect
+      end
+    end
+
+    context 'with IALMAX and the identity is already verified' do
+      let(:user) { create(:profile, :active, :verified).user }
+      let(:pii) do
+        Pii::Attributes.new_from_hash(
+          first_name: 'Some',
+          last_name: 'One',
+          ssn: '666666666',
+          zipcode: '12345',
+        )
+      end
+      let(:this_authn_request) do
+        ialmax_authnrequest = saml_authn_request_url(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            authn_context_comparison: 'minimum',
+          },
+        )
+        raw_req = CGI.unescape ialmax_authnrequest.split('SAMLRequest').last
+        SamlIdp::Request.from_deflated_request(raw_req)
+      end
+      let(:asserter) do
+        AttributeAsserter.new(
+          user: user,
+          service_provider: ServiceProvider.find_by(issuer: sp1_issuer),
+          authn_request: this_authn_request,
+          name_id_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          decrypted_pii: pii,
+          user_session: {},
+        )
+      end
+
+      before do
+        stub_sign_in(user)
+        IdentityLinker.new(user, ServiceProvider.find_by(issuer: sp1_issuer)).link_identity(ial: 2)
+        user.identities.last.update!(
+          verified_attributes: %w[email given_name family_name social_security_number address],
+        )
+        allow(subject).to receive(:attribute_asserter) { asserter }
+
+        controller.user_session[:decrypted_pii] = pii
+      end
+
+      it 'calls AttributeAsserter#build' do
+        expect(asserter).to receive(:build).at_least(:once).and_call_original
+
+        saml_get_auth(ialmax_settings)
+      end
+
+      it 'sets identity ial to 0' do
+        saml_get_auth(ialmax_settings)
+        expect(user.identities.last.ial).to eq(0)
+      end
+
+      it 'does not redirect the user to the IdV URL' do
+        saml_get_auth(ialmax_settings)
+
+        expect(response).to_not be_redirect
+      end
+
+      it 'contains verified attributes' do
+        saml_get_auth(ialmax_settings)
+
+        expect(xmldoc.attribute_node_for('address1')).to be_nil
+
+        %w[first_name last_name ssn zipcode].each do |attr|
+          node_value = xmldoc.attribute_value_for(attr)
+          expect(node_value).to eq(pii[attr])
+        end
+
+        expect(xmldoc.attribute_value_for('verified_at')).to eq(
+          user.active_profile.verified_at.iso8601,
+        )
+      end
+
+      it 'tracks IAL2 authentication events' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: 'ialmax',
+               service_provider: sp1_issuer)
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::SAML_AUTH,
+               success: true,
+               errors: {},
+               nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+               authn_context: ['http://idmanagement.gov/ns/assurance/ial/1'],
+               authn_context_comparison: 'minimum',
+               requested_ial: 'ialmax',
+               service_provider: sp1_issuer,
+               endpoint: '/api/saml/auth2022',
+               idv: false,
+               finish_profile: false)
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::SP_REDIRECT_INITIATED,
+               ial: 0)
+
+        allow(controller).to receive(:identity_needs_verification?).and_return(false)
+        saml_get_auth(ialmax_settings)
+      end
+
+      context 'profile is not in session' do
+        let(:pii) { nil }
+
+        it 'redirects to password capture if profile is verified but not in session' do
+          saml_get_auth(ialmax_settings)
+          expect(response).to redirect_to capture_password_url
+        end
       end
     end
 

--- a/spec/features/ialmax/saml_sign_in_spec.rb
+++ b/spec/features/ialmax/saml_sign_in_spec.rb
@@ -1,0 +1,157 @@
+require 'rails_helper'
+
+feature 'SAML IALMAX sign in' do
+  include SamlAuthHelper
+
+  context 'with an ial2 SP' do
+    context 'with an ial1 user' do
+      scenario 'piv sign in' do
+        user = user_with_piv_cac
+        visit_idp_from_saml_sp_with_ialmax
+        signin_with_piv(user)
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.to raise_exception
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(1)
+      end
+
+      scenario 'password sign in' do
+        user = create(:user, :signed_up)
+        visit_idp_from_saml_sp_with_ialmax
+        sign_in_live_with_2fa(user)
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.to raise_exception
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(1)
+      end
+    end
+
+    context 'with an ial2 user' do
+      scenario 'piv sign in' do
+        pii = { phone: '+12025555555', ssn: '111111111' }
+        user = create(:profile, :active, :verified, pii: pii).user
+        user.piv_cac_configurations.create(x509_dn_uuid: 'helloworld', name: 'My PIV Card')
+        visit_idp_from_saml_sp_with_ialmax
+        signin_with_piv(user)
+        fill_in 'user[password]', with: user.password
+        click_submit_default
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.not_to raise_exception
+        expect(xmldoc.attribute_value_for(:ssn)).to eq('111111111')
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(2)
+      end
+
+      scenario 'password sign in' do
+        pii = { phone: '+12025555555', ssn: '111111111' }
+        user = create(:profile, :active, :verified, pii: pii).user
+        visit_idp_from_saml_sp_with_ialmax
+        sign_in_live_with_2fa(user)
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.not_to raise_exception
+        expect(xmldoc.attribute_value_for(:ssn)).to eq('111111111')
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(2)
+      end
+    end
+
+    context 'with an inactive profile user' do
+      scenario 'piv sign in' do
+        user = create(:profile, :active, :verified).user
+        user.profiles.first.update!(
+          active: false,
+          deactivation_reason: :verification_cancelled,
+        )
+        user.piv_cac_configurations.create(x509_dn_uuid: 'helloworld', name: 'My PIV Card')
+        visit_idp_from_saml_sp_with_ialmax
+        signin_with_piv(user)
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.to raise_exception
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(1)
+      end
+
+      scenario 'password sign in' do
+        user = create(:profile, :active, :verified).user
+        user.profiles.first.update!(
+          active: false,
+          deactivation_reason: :verification_cancelled,
+        )
+        visit_idp_from_saml_sp_with_ialmax
+        sign_in_live_with_2fa(user)
+        click_agree_and_continue
+
+        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+        expect(xmldoc.attribute_value_for(:ial)).to eq(
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        )
+        expect { xmldoc.attribute_value_for(:ssn) }.to raise_exception
+
+        sp_return_logs = SpReturnLog.where(user_id: user.id)
+        expect(sp_return_logs.count).to eq(1)
+        expect(sp_return_logs.first.ial).to eq(1)
+      end
+    end
+  end
+
+  context 'with an ial1 SP' do
+    before do
+      ServiceProvider.
+        find_by(issuer: 'saml_sp_ial2').
+        update!(ial: 1)
+    end
+
+    scenario 'returns an ial1 responses even with an ial2 user' do
+      pii = { phone: '+12025555555', ssn: '111111111' }
+      user = create(:profile, :active, :verified, pii: pii).user
+      visit_idp_from_saml_sp_with_ialmax
+      sign_in_live_with_2fa(user)
+      click_agree_and_continue
+
+      xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+      expect(xmldoc.attribute_value_for(:ial)).to eq(
+        Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      )
+      expect { xmldoc.attribute_value_for(:ssn) }.to raise_exception
+
+      sp_return_logs = SpReturnLog.where(user_id: user.id)
+      expect(sp_return_logs.count).to eq(1)
+      expect(sp_return_logs.first.ial).to eq(1)
+    end
+  end
+end

--- a/spec/presenters/saml_request_presenter_spec.rb
+++ b/spec/presenters/saml_request_presenter_spec.rb
@@ -8,19 +8,68 @@ describe SamlRequestPresenter do
         allow(FakeSamlRequest).to receive(:new).and_return(request)
         allow(request).to receive(:requested_authn_contexts).
           and_return([Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF])
+        allow(request).to receive(:requested_authn_context_comparison).and_return('exact')
+        allow(request).to receive(:requested_ial_authn_context).
+          and_return(Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF)
 
         parser = instance_double(SamlRequestParser)
         allow(SamlRequestParser).to receive(:new).with(request).and_return(parser)
         allow(parser).to receive(:requested_attributes).and_return(nil)
 
         all_attributes = %w[
-          email first_name middle_name last_name dob ssn verified_at
+          email all_emails first_name last_name dob ssn verified_at
           phone address1 address2 city state zipcode foo
         ]
         service_provider = ServiceProvider.new(attribute_bundle: all_attributes)
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 
-        expect(presenter.requested_attributes).to eq(%i[email verified_at])
+        expect(presenter.requested_attributes).to eq(%i[email all_emails verified_at])
+      end
+    end
+
+    context 'with no requested context and IAL2 SP' do
+      it 'returns SP attribute_bundle' do
+        request = instance_double(FakeSamlRequest)
+        allow(FakeSamlRequest).to receive(:new).and_return(request)
+        allow(request).to receive(:requested_authn_contexts).
+          and_return([])
+        allow(request).to receive(:requested_authn_context_comparison).and_return('exact')
+        allow(request).to receive(:requested_ial_authn_context).
+          and_return(nil)
+
+        parser = instance_double(SamlRequestParser)
+        allow(SamlRequestParser).to receive(:new).with(request).and_return(parser)
+        allow(parser).to receive(:requested_attributes).and_return(nil)
+
+        sp_attributes = %w[email first_name last_name ssn zipcode]
+        service_provider = ServiceProvider.new(attribute_bundle: sp_attributes, ial: 2)
+        presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
+
+        expect(presenter.requested_attributes).to eq(
+          %i[email given_name family_name social_security_number address],
+        )
+      end
+    end
+
+    context 'with no requested context and IAL1 SP' do
+      it 'returns permitted attribute_bundle' do
+        request = instance_double(FakeSamlRequest)
+        allow(FakeSamlRequest).to receive(:new).and_return(request)
+        allow(request).to receive(:requested_authn_contexts).
+          and_return([])
+        allow(request).to receive(:requested_authn_context_comparison).and_return('exact')
+        allow(request).to receive(:requested_ial_authn_context).
+          and_return(nil)
+
+        parser = instance_double(SamlRequestParser)
+        allow(SamlRequestParser).to receive(:new).with(request).and_return(parser)
+        allow(parser).to receive(:requested_attributes).and_return(nil)
+
+        sp_attributes = %w[email first_name last_name ssn zipcode all_emails]
+        service_provider = ServiceProvider.new(attribute_bundle: sp_attributes, ial: 1)
+        presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
+
+        expect(presenter.requested_attributes).to eq(%i[email all_emails])
       end
     end
 
@@ -34,12 +83,12 @@ describe SamlRequestPresenter do
 
         service_provider = ServiceProvider.new(
           attribute_bundle: %w[
-            email first_name middle_name last_name dob foo ssn phone verified_at
+            email first_name last_name dob foo ssn phone verified_at
           ],
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
         valid_attributes = %i[
-          email given_name name family_name birthdate social_security_number phone verified_at
+          email given_name family_name birthdate social_security_number phone verified_at
         ]
 
         expect(presenter.requested_attributes).to eq(valid_attributes)

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -10,8 +10,16 @@ RSpec.describe IalContext do
     )
   end
   let(:user) { nil }
+  let(:authn_context_comparison) { nil }
 
-  subject(:ial_context) { IalContext.new(ial: ial, service_provider: service_provider, user: user) }
+  subject(:ial_context) do
+    IalContext.new(
+      ial: ial,
+      service_provider: service_provider,
+      user: user,
+      authn_context_comparison: authn_context_comparison,
+    )
+  end
 
   describe '#ial' do
     context 'with an integer input' do
@@ -135,8 +143,24 @@ RSpec.describe IalContext do
       it { expect(ial_context.ialmax_requested?).to eq(true) }
     end
 
-    context 'when ial 1 is requested' do
+    context 'when ial 1 is requested without Comparison=minimum and ial 2 SP' do
       let(:ial) { Idp::Constants::IAL1 }
+      let(:authn_context_comparison) { 'exact' }
+      let(:sp_ial) { 2 }
+      it { expect(ial_context.ialmax_requested?).to eq(false) }
+    end
+
+    context 'when ial 1 is requested with Comparison=minimum and ial 2 SP' do
+      let(:ial) { Idp::Constants::IAL1 }
+      let(:authn_context_comparison) { 'minimum' }
+      let(:sp_ial) { 2 }
+      it { expect(ial_context.ialmax_requested?).to eq(true) }
+    end
+
+    context 'when ial 1 is requested with Comparison=minimum and ial 1 SP' do
+      let(:ial) { Idp::Constants::IAL1 }
+      let(:authn_context_comparison) { 'minimum' }
+      let(:sp_ial) { 1 }
       it { expect(ial_context.ialmax_requested?).to eq(false) }
     end
 
@@ -268,9 +292,21 @@ RSpec.describe IalContext do
   end
 
   describe '#ial2_requested?' do
-    context 'when ialmax is requested' do
+    context 'when ialmax is requested without a user' do
       let(:ial) { Idp::Constants::IAL_MAX }
       it { expect(ial_context.ial2_requested?).to eq(false) }
+    end
+
+    context 'when ialmax is requested with a user with no profile' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) { create(:user, :signed_up) }
+      it { expect(ial_context.ial2_requested?).to eq(false) }
+    end
+
+    context 'when ialmax is requested with a user with a verified profile' do
+      let(:ial) { Idp::Constants::IAL_MAX }
+      let(:user) { create(:profile, :active, :verified).user }
+      it { expect(ial_context.ial2_requested?).to eq(true) }
     end
 
     context 'when ial 1 is requested' do
@@ -291,18 +327,6 @@ RSpec.describe IalContext do
     context 'when the SP is nil' do
       let(:service_provider) { nil }
       let(:ial) { Idp::Constants::IAL2 }
-      it { expect(ial_context.ial2_requested?).to eq(true) }
-    end
-
-    context 'when ial max and the user has proofed for ial2' do
-      let(:ial) { Idp::Constants::IAL_MAX }
-      let(:user) do
-        create(
-          :user,
-          :signed_up,
-          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
-        )
-      end
       it { expect(ial_context.ial2_requested?).to eq(true) }
     end
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -310,6 +310,19 @@ module SamlAuthHelper
     )
   end
 
+  def visit_idp_from_saml_sp_with_ialmax
+    visit_saml_authn_request_url(
+      overrides: {
+        issuer: 'saml_sp_ial2',
+        authn_context: [
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}ssn",
+        ],
+        authn_context_comparison: 'minimum',
+      },
+    )
+  end
+
   def visit_idp_from_oidc_sp_with_ialmax
     state = SecureRandom.hex
     client_id = 'urn:gov:gsa:openidconnect:sp:server'

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -346,6 +346,11 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
 
   fill_in_password_and_submit(user.password)
 
+  # needed because the SP default attribute bundle includes the zip_code
+  # attribute which wasn't originally requested, so consent is required
+  expect(page).to have_current_path(sign_up_completed_path)
+  click_agree_and_continue
+
   if javascript_enabled?
     expect(current_path).to eq(test_saml_decode_assertion_path)
   else


### PR DESCRIPTION
Detailed description TBD

Tested locally using https://github.com/18F/identity-saml-sinatra, with small modifications to app.rb to set the `Comparison` attribute to `minimum`. Before testing, I modified the SP record to set the default attribute bundle to include IAL2 attributes. The following scenarios were tested:

1. Send authentication request at `IAL1`, sign in with un-proofed user ==> response back at IAL1 with only IAL1 attributes
2. Send authentication request at `IAL2`, sign in with un-proofed user ==> sent through proofing flow
3. Send authentication request at `IAL1`, sign in with proofed user ==> response back at IAL2 with default attribute bundle

I have some controller tests for this use case that appear to all pass, but this is desperately in need of tests across the board.

**EDIT 2022-01-18:** Feature tests added and should cover all use cases (IAL1 vs IAL2 user, PIV vs password auth). Probably needs a few more unit tests before it will be good to go.