### PR TITLE
Add custom Rubocop cop to prevent translation in smoke tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
   - ./lib/linters/localized_validation_message_linter.rb
   - ./lib/linters/mail_later_linter.rb
   - ./lib/linters/redirect_back_linter.rb
+  - ./lib/linters/translation_linter.rb
   - ./lib/linters/url_options_linter.rb
 
 AllCops:
@@ -46,6 +47,11 @@ IdentityIdp/LocalizedValidationMessageLinter:
 
 IdentityIdp/MailLaterLinter:
   Enabled: true
+
+IdentityIdp/TranslationLinter:
+  Enabled: true
+  Include:
+    - 'spec/support/monitor/**/*.rb'
 
 IdentityIdp/UrlOptionsLinter:
   Enabled: true

--- a/lib/linters/translation_linter.rb
+++ b/lib/linters/translation_linter.rb
@@ -1,0 +1,17 @@
+module RuboCop
+  module Cop
+    module IdentityIdp
+      # This lint prevents the use of Rails translation method, and is intended only to be applied
+      # on files where localization is not available (e.g. smoke tests).
+      class TranslationLinter < RuboCop::Cop::Cop
+        MSG = 'Translation is not allowed in this file'.freeze
+
+        RESTRICT_ON_SEND = [:t].freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/linters/translation_linter_spec.rb
+++ b/spec/lib/linters/translation_linter_spec.rb
@@ -1,0 +1,18 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../lib/linters/translation_linter'
+
+describe RuboCop::Cop::IdentityIdp::TranslationLinter do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:config) { RuboCop::Config.new }
+  let(:cop) { RuboCop::Cop::IdentityIdp::TranslationLinter.new(config) }
+
+  it 'registers offense when calling translate method' do
+    expect_offense(<<~RUBY)
+      t('foo.bar.baz')
+      ^^^^^^^^^^^^^^^^ Translation is not allowed in this file
+    RUBY
+  end
+end


### PR DESCRIPTION
**Why**: Since it's easy to overlook, and not otherwise caught during standard pull request CI, therefore likely to cause surprise (and Slack channel noise) when it inevitably fails post-merge.

Context: https://github.com/18F/identity-idp/pull/5650/files#r759674528