### PR TITLE
Remove outdated rubocop disables

### DIFF
--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -101,7 +101,6 @@ module Proofing
           applicant.uuid
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def user_provided_data_map
           applicant_address = applicant.address
           {
@@ -112,7 +111,6 @@ module Proofing
             '//ns1:PersonBirthDate' => applicant.dob,
           }
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         def timeout
           (config.verification_request_timeout || 5).to_i

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -4,7 +4,7 @@ module Proofing
       class VerificationRequest < Request
         private
 
-        def build_request_body # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def build_request_body
           {
             Settings: {
               AccountNumber: account_number,

--- a/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
@@ -4,7 +4,7 @@ module Proofing
       class VerificationRequest < Request
         private
 
-        def build_request_body # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+        def build_request_body
           {
             Settings: {
               AccountNumber: account_number,

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -53,13 +53,11 @@ module Telephony
     attr_accessor :voice_pause_time
     attr_accessor :voice_rate
 
-    # rubocop:disable Metrics/MethodLength
     def initialize
       @adapter = :pinpoint
       @logger = Logger.new(STDOUT)
       @pinpoint = PinpointConfiguration.new
     end
-    # rubocop:enable Metrics/MethodLength
 
     def adapter
       @adapter.to_sym

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -35,7 +35,6 @@ module Telephony
 
     private
 
-    # rubocop:disable all
     def adapter
       case [Telephony.config.adapter, channel.to_sym]
       when [:pinpoint, :sms]
@@ -50,7 +49,6 @@ module Telephony
         raise "Unknown telephony adapter #{Telephony.config.adapter} for channel #{channel.to_sym}"
       end
     end
-    # rubocop:enable all
 
     def log_response(response, context:)
       extra = {

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -13,7 +13,7 @@ module Telephony
         'UNKNOWN_FAILURE' => UnknownFailureError,
       }.freeze
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength
       # @return [Response]
       def send(message:, to:, country_code:, otp: nil)
         return handle_config_failure if Telephony.config.pinpoint.sms_configs.empty?
@@ -64,7 +64,7 @@ module Telephony
         end
         response || handle_config_failure
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+      # rubocop:enable Metrics/BlockLength
 
       def phone_info(phone_number)
         return handle_config_failure if Telephony.config.pinpoint.sms_configs.empty?
@@ -131,7 +131,6 @@ module Telephony
         )
       end
 
-      # rubocop:disable Metrics/MethodLength
       def build_response(pinpoint_response, start:, finish:)
         message_response_result = pinpoint_response.message_response.result.values.first
 

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -3,7 +3,7 @@ require 'time'
 module Telephony
   module Pinpoint
     class VoiceSender
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength
       def send(message:, to:, country_code:, otp: nil)
         return handle_config_failure if Telephony.config.pinpoint.voice_configs.empty?
 
@@ -50,7 +50,7 @@ module Telephony
 
         last_error || handle_config_failure
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+      # rubocop:enable Metrics/BlockLength
 
       # @api private
       # @param [PinpointVoiceConfiguration] voice_config


### PR DESCRIPTION
I thought Rubocop warned on unnecessary disables, but I guess not. The Rubocop rules were different across repos, so we can make them closer to the IDP rules now that they're here.