### PR TITLE
Remove whitespace from OneTimeCodeInput altered input ID

### DIFF
--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -19,10 +19,10 @@ class OneTimeCodeInput {
   }
 
   createHiddenInput() {
-    const { input, form } = this.elements;
+    const { input } = this.elements;
     const hiddenInput = /** @type {HTMLInputElement} */ (document.createElement('input'));
-    const label = form?.querySelector(`label[for="${input.id}"]`);
-    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)}`;
+    const label = input.ownerDocument.querySelector(`label[for="${input.id}"]`);
+    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)} `;
     hiddenInput.name = input.name;
     hiddenInput.value = input.value;
     hiddenInput.type = 'hidden';

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -22,7 +22,7 @@ class OneTimeCodeInput {
     const { input, form } = this.elements;
     const hiddenInput = /** @type {HTMLInputElement} */ (document.createElement('input'));
     const label = form?.querySelector(`label[for="${input.id}"]`);
-    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)} `;
+    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)}`;
     hiddenInput.name = input.name;
     hiddenInput.value = input.value;
     hiddenInput.type = 'hidden';

--- a/app/javascript/packages/one-time-code-input/index.js
+++ b/app/javascript/packages/one-time-code-input/index.js
@@ -22,7 +22,7 @@ class OneTimeCodeInput {
     const { input } = this.elements;
     const hiddenInput = /** @type {HTMLInputElement} */ (document.createElement('input'));
     const label = input.ownerDocument.querySelector(`label[for="${input.id}"]`);
-    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)} `;
+    const modifiedId = `${input.id}-${Math.floor(Math.random() * 1000000)}`;
     hiddenInput.name = input.name;
     hiddenInput.value = input.value;
     hiddenInput.type = 'hidden';

--- a/spec/javascripts/packages/one-time-code-input/index-spec.js
+++ b/spec/javascripts/packages/one-time-code-input/index-spec.js
@@ -1,14 +1,16 @@
 import OneTimeCodeInput from '@18f/identity-one-time-code-input';
-import { waitFor } from '@testing-library/dom';
+import { waitFor, screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 import { useSandbox } from '../../support/sinon';
 
 describe('OneTimeCodeInput', () => {
   const sandbox = useSandbox();
+  const labelText = 'Enter a value:';
 
   function initialize({ transport = 'sms', inForm = false } = {}) {
     const input = document.createElement('input');
+    input.id = 'input';
     if (transport) {
       input.dataset.transport = transport;
     }
@@ -19,6 +21,10 @@ describe('OneTimeCodeInput', () => {
     } else {
       document.body.appendChild(input);
     }
+    const label = document.createElement('label');
+    label.textContent = labelText;
+    label.setAttribute('for', input.id);
+    document.body.appendChild(label);
     const otcInput = new OneTimeCodeInput(document.body.querySelector('input'));
     otcInput.bind();
     return otcInput;
@@ -124,6 +130,12 @@ describe('OneTimeCodeInput', () => {
       OneTimeCodeInput.isWebOTPSupported = originalIsWebOTPSupported;
       navigator.credentials = originalCredentials;
       window.removeEventListener('submit', onSubmit);
+    });
+
+    it('is still associated by its label', () => {
+      initialize();
+
+      expect(screen.getByLabelText(labelText)).to.be.ok();
     });
 
     context('in form', () => {


### PR DESCRIPTION
**Why**: [By specification](https://html.spec.whatwg.org/multipage/dom.html#global-attributes:the-id-attribute-2), an ID "must not contain any ASCII whitespace".

It's unclear what (if anything) this affects, though it doesn't seem to be an intended behavior regardless.