### PR TITLE
Fix IDV in IE (LG-4526)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,8 +28,15 @@ class ApplicationController < ActionController::Base
   prepend_before_action :add_new_relic_trace_attributes
   prepend_before_action :session_expires_at
   prepend_before_action :set_locale
+  prepend_before_action :set_x_request_url
   before_action :disable_caching
   before_action :cache_issuer_in_cookie
+
+  # Workaround that helps our JS fetch polyfill. See:
+  # https://www.npmjs.com/package/whatwg-fetch#user-content-obtaining-the-response-url
+  def set_x_request_url
+    response.headers['X-Request-URL'] = request.url
+  end
 
   def session_expires_at
     return if @skip_session_expiration || @skip_session_load

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -90,7 +90,20 @@ export class FormStepsWait {
       body: new window.FormData(form),
     });
 
-    this.handleResponse(response);
+    if ('polyfill' in window.fetch) {
+      // The fetch polyfill is implemented using XMLHttpRequest, which suffers from an issue where a
+      // Content-Type header from a POST is carried into a redirected GET, which is exactly the flow
+      // we are handling here. The current version of Rack neither handles nor provides easy insight
+      // into an empty-bodied (GET) multi-part form. This will change in Rack 3 with the addition of
+      // the Rack::Multipart::EmptyContentError class. In the meantime, only allow non-polyfilled
+      // fetch environmnents to handle the initial response.
+      //
+      // See: https://github.com/whatwg/fetch/issues/609
+      // See: https://github.com/rack/rack/issues/1603
+      this.poll();
+    } else {
+      this.handleResponse(response);
+    }
   }
 
   /**

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -106,6 +106,9 @@ export class FormStepsWait {
         this.scheduleNextPollFetch();
       } else {
         const message = getPageErrorMessage(dom);
+        console.log("====");
+        console.log(response.url);
+        console.log("=====");
         const isSamePage = new URL(response.url).pathname === window.location.pathname;
         if (message && isSamePage) {
           this.renderError(message);

--- a/app/javascript/packs/form-steps-wait.jsx
+++ b/app/javascript/packs/form-steps-wait.jsx
@@ -106,9 +106,6 @@ export class FormStepsWait {
         this.scheduleNextPollFetch();
       } else {
         const message = getPageErrorMessage(dom);
-        console.log("====");
-        console.log(response.url);
-        console.log("=====");
         const isSamePage = new URL(response.url).pathname === window.location.pathname;
         if (message && isSamePage) {
           this.renderError(message);

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -30,7 +30,6 @@ describe ApplicationController do
     end
   end
 
-
   describe '#cache_issuer_in_cookie' do
     controller do
       def index

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,21 @@ describe ApplicationController do
     end
   end
 
+  describe '#set_x_request_url' do
+    controller do
+      def index
+        render plain: 'Hello'
+      end
+    end
+
+    it 'sets the X-Request-URL header' do
+      get :index
+
+      expect(response.headers['X-Request-URL']).to eq('http://www.example.com/anonymous')
+    end
+  end
+
+
   describe '#cache_issuer_in_cookie' do
     controller do
       def index


### PR DESCRIPTION
The issue is that `response.url` comes back blank in our `fetch` polyfill (used here), so the Verify and Address steps that poll end up failing.

https://github.com/18F/identity-idp/blob/02d60d09ba99d9712a56c9c56063efe386c45b11/app/javascript/packs/form-steps-wait.jsx#L109

So the polyfill authors recommend this workaround https://www.npmjs.com/package/whatwg-fetch#user-content-obtaining-the-response-url

Confirmed this works in my personal sandbox