### PR TITLE
Set aria-invalid on ValidatedFieldComponent for invalid field

### DIFF
--- a/app/javascript/packages/validated-field/index.js
+++ b/app/javascript/packages/validated-field/index.js
@@ -36,6 +36,7 @@ export class ValidatedField extends HTMLElement {
     } catch {}
 
     this.input?.addEventListener('input', () => this.setErrorMessage());
+    this.input?.addEventListener('input', () => this.setInputIsValid(true));
     this.input?.addEventListener('invalid', (event) => this.toggleErrorMessage(event));
   }
 
@@ -47,7 +48,12 @@ export class ValidatedField extends HTMLElement {
    */
   toggleErrorMessage(event) {
     event.preventDefault();
-    this.setErrorMessage(this.getNormalizedValidationMessage(this.input));
+
+    const errorMessage = this.getNormalizedValidationMessage(this.input);
+    const isValid = !errorMessage;
+
+    this.setErrorMessage(errorMessage);
+    this.setInputIsValid(isValid);
   }
 
   /**
@@ -63,8 +69,16 @@ export class ValidatedField extends HTMLElement {
       this.removeChild(this.errorMessage);
       this.errorMessage = null;
     }
+  }
 
-    this.input?.classList.toggle('usa-input--error', !!message);
+  /**
+   * Sets input attributes corresponding to given validity state.
+   *
+   * @param {boolean} isValid Whether input is valid.
+   */
+  setInputIsValid(isValid) {
+    this.input?.classList.toggle('usa-input--error', !isValid);
+    this.input?.setAttribute('aria-invalid', String(!isValid));
   }
 
   /**

--- a/app/javascript/packages/validated-field/index.spec.js
+++ b/app/javascript/packages/validated-field/index.spec.js
@@ -48,6 +48,7 @@ describe('ValidatedField', () => {
     form.checkValidity();
 
     expect(input.classList.contains('usa-input--error')).to.be.true();
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
     expect(document.activeElement).to.equal(input);
     const message = getByText(element, 'This field is required');
     expect(message).to.be.ok();
@@ -82,6 +83,7 @@ describe('ValidatedField', () => {
     userEvent.type(input, '5');
 
     expect(input.classList.contains('usa-input--error')).to.be.false();
+    expect(input.getAttribute('aria-invalid')).to.equal('false');
     expect(() => getByText(element, 'This field is required')).to.throw();
   });
 
@@ -99,6 +101,7 @@ describe('ValidatedField', () => {
       userEvent.type(input, '5');
 
       expect(input.classList.contains('usa-input--error')).to.be.false();
+      expect(input.getAttribute('aria-invalid')).to.equal('false');
       expect(() => getByText(element, 'Invalid value')).to.throw();
     });
   });


### PR DESCRIPTION
**Why**: Since the component is meant to emulate (and eventually replace) the behaviors currently present in `form-validation.js`, this should include `aria-invalid` attribute setting behavior.