### PR TITLE
Add index to sp_return_logs to speed up reporting queries

### DIFF
--- a/db/primary_migrate/20211206205035_add_issuer_returned_at_index_to_sp_return_logs.rb
+++ b/db/primary_migrate/20211206205035_add_issuer_returned_at_index_to_sp_return_logs.rb
@@ -1,0 +1,11 @@
+class AddIssuerReturnedAtIndexToSpReturnLogs < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :sp_return_logs,
+      %i[issuer requested_at],
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_04_174749) do
+ActiveRecord::Schema.define(version: 2021_12_06_205035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -569,6 +569,7 @@ ActiveRecord::Schema.define(version: 2021_11_04_174749) do
     t.integer "user_id"
     t.datetime "returned_at"
     t.boolean "billable"
+    t.index ["issuer", "requested_at"], name: "index_sp_return_logs_on_issuer_and_requested_at"
     t.index ["request_id"], name: "index_sp_return_logs_on_request_id", unique: true
     t.index ["requested_at"], name: "index_sp_return_logs_on_requested_at"
     t.index ["user_id", "requested_at"], name: "index_sp_return_logs_on_user_id_and_requested_at"


### PR DESCRIPTION
**Note**: My goal is to deploy this index as a patch release (today?) so that it if goes poorly, we can revert it and clean it up well before the scheduled Thursday deploy

**Background**:
We're getting consistent timeouts in the new, Combined IAA report see below is one of the queries that's timing out (inside of `TotalMonthlyAuthCountsWithinIaaWindow`)

The `sp_return_logs` table is very big, and even using the `requested_at` index still yields too many rows, so our current hypothesis is that a new index would help to speed things up, assuming the query planner doesn't pick the wrong one.


```sql
SELECT
sp_return_logs.user_id
, '202109' AS year_month
, sp_return_logs.ial
, COUNT(sp_return_logs.id) AS auth_count
FROM sp_return_logs
WHERE
sp_return_logs.requested_at BETWEEN '2021-09-01' AND '2021-09-29'
AND sp_return_logs.returned_at IS NOT NULL
AND sp_return_logs.issuer = '...'
GROUP BY
sp_return_logs.user_id
, sp_return_logs.ial
```