### PR TITLE
Use deterministic issuer names for ordered tests

### DIFF
--- a/app/jobs/reports/agreement_summary_report.rb
+++ b/app/jobs/reports/agreement_summary_report.rb
@@ -30,7 +30,7 @@ module Reports
         ]
 
         IaaReportingHelper.iaas.each do |iaa|
-          ServiceProvider.where(issuer: iaa.issuers).each do |service_provider|
+          ServiceProvider.where(issuer: iaa.issuers).order(:issuer).each do |service_provider|
             csv << [
               iaa.gtc_number,
               iaa.order_number,

--- a/spec/jobs/reports/agreement_summary_report_spec.rb
+++ b/spec/jobs/reports/agreement_summary_report_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Reports::AgreementSummaryReport do
     end
 
     context 'with iaa data' do
-      let(:sp1) { create(:service_provider, friendly_name: 'aaa') }
-      let(:sp2) { create(:service_provider, friendly_name: 'bbb') }
+      let(:sp1) { create(:service_provider, issuer: 'aaa', friendly_name: 'App A') }
+      let(:sp2) { create(:service_provider, issuer: 'bbb', friendly_name: 'App B') }
 
       let(:partner_account) { build(:partner_account) }
 


### PR DESCRIPTION
Background:
- Issuers are generated by `SecureRandom.uuid` in factories: https://github.com/18F/identity-idp/blob/62ed7b475aa72a98b0ba0ff865b9bcfd7225a22b/spec/factories/service_providers.rb#L7
- We're now sorting by issuers as of this PR: https://github.com/18F/identity-idp/pull/5669/files#diff-dff005bc5b24ed4b3d86658e47c5a0ce9028e780f9282be6ed60a65f4c02d5c8R30

So to make the build reliable, I am giving this test (that depends on row order) consistent issuers