### PR TITLE
Add remote SAML Logout endpoint

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -48,6 +48,23 @@ class SamlIdpController < ApplicationController
     handle_valid_sp_logout_request
   end
 
+  def remotelogout
+    raw_saml_request = params[:SAMLRequest]
+    return head(:bad_request) if raw_saml_request.nil?
+
+    decode_request(raw_saml_request)
+
+    track_remote_logout_event
+
+    return head(:bad_request) unless valid_saml_request?
+
+    user_id = find_user_from_session_index
+
+    return head(:bad_request) unless valid_remote_logout_user_id?(user_id)
+
+    handle_valid_sp_remote_logout_request(user_id)
+  end
+
   private
 
   def confirm_user_is_authenticated_with_fresh_mfa

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -228,6 +228,7 @@ class Analytics
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
+  REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze
   RETURN_TO_SP_CANCEL = 'Return to SP: Cancelled'.freeze
   RETURN_TO_SP_FAILURE_TO_PROOF = 'Return to SP: Failed to proof'.freeze
   RULES_OF_USE_VISIT = 'Rules Of Use Visited'.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   SamlEndpoint.suffixes.each do |suffix|
     get "/api/saml/metadata#{suffix}" => 'saml_idp#metadata', format: false
     match "/api/saml/logout#{suffix}" => 'saml_idp#logout', via: %i[get post delete]
+    match "/api/saml/remotelogout#{suffix}" => 'saml_idp#remotelogout', via: %i[get post delete]
     # JS-driven POST redirect route to preserve existing session
     post "/api/saml/auth#{suffix}" => 'saml_post#auth'
     # actual SAML handling POST route


### PR DESCRIPTION
**Why:** This will allow partners to send back-channel SAML Logout
requests instead of redirecting users as part of their logout flow. This
controller action leverages the `<SessionIndex>` element of the SAML
request to receive a user's agency UUID and uses the unique_session_id
attribute to remotely log out a user from any active session.