### PR TITLE
Fix ERB trailing comma errors

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -41,7 +41,6 @@ linters:
       - '*/app/views/reactivate_account/index.html.erb'
       - '*/app/views/session_timeout/_expire_session.html.erb'
       - '*/app/views/session_timeout/_ping.html.erb'
-      - '*/app/views/shared/_alert.html.erb'
       - '*/app/views/shared/_banner.html.erb'
       - '*/app/views/shared/_block_link.html.erb'
       - '*/app/views/shared/_email_languages.html.erb'

--- a/app/views/account_reset/delete_account/show.html.erb
+++ b/app/views/account_reset/delete_account/show.html.erb
@@ -15,10 +15,10 @@
   root_url,
   method: :get,
   class: 'usa-button usa-button--big usa-button--wide margin-bottom-1 personal-key-continue',
-  'data-toggle': 'modal'
+  'data-toggle': 'modal',
 ) { t('account_reset.request.no_cancel') } %>
 <%= button_to(
   account_reset_delete_account_path,
   method: :delete,
-  class: 'usa-button usa-button--unstyled'
+  class: 'usa-button usa-button--unstyled',
 ) { t('account_reset.request.yes_continue') } %>

--- a/app/views/accounts/_webauthn.html.erb
+++ b/app/views/accounts/_webauthn.html.erb
@@ -22,7 +22,7 @@
           <div class="grid-col-4 mobile-lg:grid-col-6 right-align">
             <%= link_to(
               t('account.index.webauthn_delete'),
-              webauthn_setup_delete_path(id: cfg.id)
+              webauthn_setup_delete_path(id: cfg.id),
             ) %>
           </div>
         <% end %>

--- a/app/views/idv/doc_auth/_back.html.erb
+++ b/app/views/idv/doc_auth/_back.html.erb
@@ -23,7 +23,7 @@ classes << local_assigns[:class] if local_assigns[:class]
       <%= button_to(
         path,
         method: :put,
-        class: [*classes, 'usa-button usa-button--unstyled']
+        class: [*classes, 'usa-button usa-button--unstyled'],
       ) { text } %>
     <% else %>
       <%= link_to(text, path, class: classes) %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -35,7 +35,7 @@
       url_for,
       method: :put,
       class: 'usa-button usa-button--big usa-button--wide',
-      form_class: 'link-sent-continue-button-form'
+      form_class: 'link-sent-continue-button-form',
     ) { t('forms.buttons.continue') }
   %>
 </div>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -71,7 +71,7 @@
       :doc_auth,
       url: url_for(type: :desktop),
       method: 'PUT',
-      html: { autocomplete: 'off', class: 'inline' }
+      html: { autocomplete: 'off', class: 'inline' },
     ) do %>
       <button type="submit" class="usa-button usa-button--unstyled">
         <%= t('doc_auth.info.upload_computer_link') %>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -54,7 +54,7 @@
           idv_doc_auth_step_path(step: :redo_ssn),
           method: :put,
           class: 'usa-button usa-button--unstyled',
-          'aria-label': t('doc_auth.buttons.change_ssn_label')
+          'aria-label': t('doc_auth.buttons.change_ssn_label'),
         ) { t('doc_auth.buttons.change_ssn') } %>
       </div>
     </div>  

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -61,7 +61,7 @@
         form: f,
         allowed_countries: ['US'],
         required: true,
-        class: 'margin-bottom-4'
+        class: 'margin-bottom-4',
       ) %>
   <div class="margin-y-5">
     <%= render('shared/spinner_button', action_message: t('doc_auth.info.verifying')) do %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -11,7 +11,7 @@
     selfie_image_upload_url
   ].
     compact.
-    map { |url| URI(url).tap { |uri| uri.query = nil }.to_s }
+    map { |url| URI(url).tap { |uri| uri.query = nil }.to_s },
 )
 
    session_id = flow_session[:document_capture_session_uuid]
@@ -60,7 +60,7 @@
     :doc_auth,
     url: url_for,
     method: 'PUT',
-    html: { autocomplete: 'off', class: 'margin-top-2 js-document-capture-form' }
+    html: { autocomplete: 'off', class: 'margin-top-2 js-document-capture-form' },
   ) do |f| %>
     <%# ---- Front Image ----- %>
 

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -8,7 +8,7 @@
             asset_url('us-flag.png'),
             alt: t('image_description.us_flag'),
             size: '18x12',
-            class: 'margin-right-1'
+            class: 'margin-right-1',
           ) %>
           <div class="grid-col-fill tablet:grid-col-auto">
             <p class="usa-banner__header-text">
@@ -30,7 +30,7 @@
             <%= image_tag(
               asset_url('icon-dot-gov.svg'),
               alt: 'Dot gov',
-              class: 'usa-banner__icon usa-media-block__img'
+              class: 'usa-banner__icon usa-media-block__img',
             ) %>
             <div class="usa-media-block__body">
               <p>
@@ -43,7 +43,7 @@
             <%= image_tag(
               asset_url('icon-https.svg'),
               alt: 'Https',
-              class: 'usa-banner__icon usa-media-block__img'
+              class: 'usa-banner__icon usa-media-block__img',
             ) %>
             <div class="usa-media-block__body">
               <p>

--- a/app/views/user_mailer/account_verified.html.erb
+++ b/app/views/user_mailer/account_verified.html.erb
@@ -5,7 +5,7 @@
         date: @date,
         disavowal_link: link_to(
           t('user_mailer.account_verified.disavowal_link'),
-          event_disavowal_url(disavowal_token: @disavowal_token)
+          event_disavowal_url(disavowal_token: @disavowal_token),
         ),
         contact_link: link_to(t('user_mailer.account_verified.contact_link'), MarketingSite.contact_url),
        ) %>

--- a/app/views/users/service_provider_inactive/index.html.erb
+++ b/app/views/users/service_provider_inactive/index.html.erb
@@ -18,6 +18,6 @@
   link_to(
     t('service_providers.errors.inactive.button_text', app_name: APP_NAME),
     root_path,
-    class: 'usa-button usa-button--wide usa-button--big margin-top-3'
+    class: 'usa-button usa-button--wide usa-button--big margin-top-3',
   )
 %>


### PR DESCRIPTION
**Why**: To make incremental progress toward fixing up ERBLint exclusions, so that the changes don't need to be incorporated in unrelated ticket work.

Approach, for future reference:

1. Remove [all excluded files](https://github.com/18F/identity-idp/blob/808e45bb6bb1120e547500a75c9f06111a1a79ea/.erb-lint.yml#L7-L104)
2. Replace [`inherit_from`](https://github.com/18F/identity-idp/blob/808e45bb6bb1120e547500a75c9f06111a1a79ea/.erb-lint.yml#L106-L107) with:
```
AllCops:
  DisabledByDefault: true
```
3. Copy a specific [Rubocop configuration](https://github.com/18F/identity-idp/blob/main/.rubocop.yml) to [`rubocop_config:`](https://github.com/18F/identity-idp/blob/808e45bb6bb1120e547500a75c9f06111a1a79ea/.erb-lint.yml#L105)
4. If the cop is auto-correctable, run `bundle exec erblint app/views app/components --autocorrect`
5. Restore changes from step 2 and 3 to original values
6. Find remaining files with issues by running: `make lint_erb | grep "In file:" | sed 's/^In file: /*\//' | sed 's/:.*//' | uniq | sort`
7. Use and format the result to be the new `exclude:` list