### PR TITLE
Remove configuration files for unused gems

### DIFF
--- a/.bummr-build.sh
+++ b/.bummr-build.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-bundle exec rspec --fail-fast

--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,6 +1,0 @@
-speedups:
-  # Disabled because argument is actually faster.
-  # See https://github.com/DamirSvrtan/fasterer/issues/37
-  fetch_with_argument_vs_block: false
-  # In UserDecorator#recent_events, sort is faster
-  sort_vs_sort_by: false


### PR DESCRIPTION
Previously: #4481

**Why**: Because we don't use these gems anymore, we should no longer have need for configuration files.