### PR TITLE
Remove temporary routes for SP redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,8 +250,6 @@ Rails.application.routes.draw do
     get '/redirect/return_to_sp/cancel' => 'redirect/return_to_sp#cancel', as: :return_to_sp_cancel
     get '/redirect/return_to_sp/failure_to_proof' => 'redirect/return_to_sp#failure_to_proof', as: :return_to_sp_failure_to_proof
     get '/redirect/help_center' => 'redirect/help_center#show', as: :help_center_redirect
-    get '/return_to_sp/cancel' => redirect('/redirect/return_to_sp/cancel') # Temporary: Remove after RC169
-    get '/return_to_sp/failure_to_proof' => redirect('/redirect/return_to_sp/failure_to_proof') # Temporary: Remove after RC169
 
     match '/sign_out' => 'sign_out#destroy', via: %i[get post delete]
 


### PR DESCRIPTION
Previously: #5662 ([discussion](https://github.com/18F/identity-idp/pull/5662#discussion_r762137156))

**Why**: Because they exist only as a stopgap for mid-deploy routing, they are no longer needed as of RC169.

**Do not merge until after RC169 is fully deployed.**