### PR TITLE
LG-5241: Log GPO letter code resend

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -13,7 +13,10 @@ module Idv
       current_async_state = async_state
 
       if current_async_state.none?
-        analytics.track_event(Analytics::IDV_GPO_ADDRESS_VISITED)
+        analytics.track_event(
+          Analytics::IDV_GPO_ADDRESS_VISITED,
+          letter_already_sent: @presenter.letter_already_sent?,
+        )
         render :index
       elsif current_async_state.in_progress?
         render :wait

--- a/app/presenters/idv/gpo_presenter.rb
+++ b/app/presenters/idv/gpo_presenter.rb
@@ -33,6 +33,10 @@ module Idv
       current_user.decorate.gpo_mail_bounced?
     end
 
+    def letter_already_sent?
+      gpo_mail_service.any_mail_sent?
+    end
+
     def url_options
       @url_options
     end
@@ -41,10 +45,6 @@ module Idv
 
     def gpo_mail_service
       @gpo_mail_service ||= Idv::GpoMail.new(current_user)
-    end
-
-    def letter_already_sent?
-      gpo_mail_service.any_mail_sent?
     end
 
     def user_needs_address_otp_verification?


### PR DESCRIPTION
**Why**: So that we can track how often a user interacts with the "Send another letter" link on the GPO letter code entry page.