### PR TITLE
Document capture interstitial heading announced multiple times

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -118,22 +118,20 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
 
   return submissionFormValues &&
     (!submissionError || submissionError instanceof RetrySubmissionError) ? (
-    <SuspenseErrorBoundary
-      fallback={
-        <>
-          <PromptOnNavigate />
-          <SubmissionInterstitial autoFocus />
-        </>
-      }
-      onError={setSubmissionError}
-      handledError={submissionError}
-    >
-      {submissionError instanceof RetrySubmissionError ? (
-        <SubmissionStatus />
-      ) : (
-        <Submission payload={submissionFormValues} />
-      )}
-    </SuspenseErrorBoundary>
+    <>
+      <SubmissionInterstitial autoFocus />
+      <SuspenseErrorBoundary
+        fallback={<PromptOnNavigate />}
+        onError={setSubmissionError}
+        handledError={submissionError}
+      >
+        {submissionError instanceof RetrySubmissionError ? (
+          <SubmissionStatus />
+        ) : (
+          <Submission payload={submissionFormValues} />
+        )}
+      </SuspenseErrorBoundary>
+    </>
   ) : (
     <>
       {submissionError && !(submissionError instanceof UploadFormEntriesError) && (

--- a/app/javascript/packages/document-capture/components/submission-complete.jsx
+++ b/app/javascript/packages/document-capture/components/submission-complete.jsx
@@ -48,12 +48,7 @@ function SubmissionComplete({ resource }) {
     return () => window.clearTimeout(sleepTimeout.current);
   }
 
-  return (
-    <>
-      <CallbackOnMount onMount={handleResponse} />
-      <SubmissionInterstitial />
-    </>
-  );
+  return <CallbackOnMount onMount={handleResponse} />;
 }
 
 export default SubmissionComplete;

--- a/app/javascript/packages/document-capture/components/submission-complete.jsx
+++ b/app/javascript/packages/document-capture/components/submission-complete.jsx
@@ -1,5 +1,4 @@
 import { useState, useContext, useRef } from 'react';
-import SubmissionInterstitial from './submission-interstitial';
 import CallbackOnMount from './callback-on-mount';
 import UploadContext from '../context/upload';
 

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { waitFor } from '@testing-library/dom';
 import useAsync from '@18f/identity-document-capture/hooks/use-async';
 import { UploadContextProvider } from '@18f/identity-document-capture';
@@ -7,9 +6,11 @@ import SubmissionComplete, {
 } from '@18f/identity-document-capture/components/submission-complete';
 import SuspenseErrorBoundary from '@18f/identity-document-capture/components/suspense-error-boundary';
 import { render, useDocumentCaptureForm } from '../../../support/document-capture';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/submission-complete-step', () => {
   const onSubmit = useDocumentCaptureForm();
+  const sandbox = useSandbox();
 
   let response;
 
@@ -43,10 +44,10 @@ describe('document-capture/components/submission-complete-step', () => {
   });
 
   it('retries on pending success as configured by upload context poll interval', async () => {
-    const onError = sinon.spy();
+    const onError = sandbox.stub();
     response = { success: true, isPending: true };
 
-    const { findByText } = render(
+    render(
       <UploadContextProvider statusPollInterval={0}>
         <SuspenseErrorBoundary fallback={null} onError={onError}>
           <TestComponent />
@@ -54,29 +55,24 @@ describe('document-capture/components/submission-complete-step', () => {
       </UploadContextProvider>,
     );
 
-    expect(onError.called).to.be.false();
-    await findByText('doc_auth.headings.interstitial');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onError.calledOnce).to.be.true();
+    await expect(onError).to.eventually.be.called();
     expect(onError.getCall(0).args[0]).to.be.instanceOf(RetrySubmissionError);
     expect(console).to.have.loggedError(/^Error: Uncaught/);
     expect(console).to.have.loggedError(/React will try to recreate this component/);
   });
 
-  it('does not retry on pending success if poll interval is not configured', async () => {
-    const onError = sinon.spy();
+  it.skip('does not retry on pending success if poll interval is not configured', () => {
+    sandbox.stub(window, 'setTimeout');
+    response = { success: true, isPending: true };
 
-    const { findByText } = render(
+    render(
       <UploadContextProvider>
-        <SuspenseErrorBoundary fallback={null} onError={onError}>
+        <SuspenseErrorBoundary fallback={null}>
           <TestComponent />
         </SuspenseErrorBoundary>
       </UploadContextProvider>,
     );
 
-    expect(onError.called).to.be.false();
-    await findByText('doc_auth.headings.interstitial');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onError.called).to.be.false();
+    expect(window.setTimeout).not.to.have.been.called();
   });
 });

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -61,9 +61,21 @@ describe('document-capture/components/submission-complete-step', () => {
     expect(console).to.have.loggedError(/React will try to recreate this component/);
   });
 
-  it.skip('does not retry on pending success if poll interval is not configured', () => {
+  it('does not retry on pending success if poll interval is not configured', (done) => {
     sandbox.stub(window, 'setTimeout');
-    response = { success: true, isPending: true };
+
+    response = {
+      success: true,
+      get isPending() {
+        // When pending is checked, ensure that it's not followed-up with a scheduling of a timeout.
+        setTimeout(() => {
+          expect(window.setTimeout).not.to.have.been.called();
+          done();
+        }, 0);
+
+        return true;
+      },
+    };
 
     render(
       <UploadContextProvider>
@@ -72,7 +84,5 @@ describe('document-capture/components/submission-complete-step', () => {
         </SuspenseErrorBoundary>
       </UploadContextProvider>,
     );
-
-    expect(window.setTimeout).not.to.have.been.called();
   });
 });


### PR DESCRIPTION
This ticket removes the re-rendering of the `<SubmissionInterstitial>` component from the document capture and submission complete screen.

**Why**: So that a screen reader does not re-read "We are processing your images" multiple times