### PR TITLE
LG-5262: Add logging to continue button on letter wait page

### DIFF
--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -33,7 +33,7 @@
     <% if decorated_session.sp_name.present? %>
       <%= link_to(
             t('idv.buttons.continue_plain'),
-            return_to_sp_cancel_path,
+            return_to_sp_cancel_path(location: :come_back_later),
             class: 'usa-button usa-button--big usa-button--wide',
           ) %>
     <% else %>

--- a/spec/views/idv/come_back_later/show.html.erb_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.erb_spec.rb
@@ -14,7 +14,7 @@ describe 'idv/come_back_later/show.html.erb' do
       render
       expect(rendered).to have_link(
         t('idv.buttons.continue_plain'),
-        href: return_to_sp_cancel_path,
+        href: return_to_sp_cancel_path(location: :come_back_later),
       )
     end
 


### PR DESCRIPTION
**Why**: So that we can track user progression through the flow.

**Implementation Notes:**

This approach simply takes advantage of existing "location" logging parameter support on the rendered `return_to_sp_cancel_path` link, such that we could query link clicks as `filter name = 'Return to SP: Cancelled' and properties.event_properties.location = 'come_back_later'`. An alternative could be to create a new controller action in `ComeBackLaterController` for the redirect logic, and log an explicit new event.