### PR TITLE
Add flow path to post doc capture submission events (LG-5257)

### DIFF
--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -12,10 +12,11 @@ module Idv
 
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:, analytics:)
+    def initialize(params, liveness_checking_enabled:, analytics:, flow_path: nil)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
       @analytics = analytics
+      @flow_path = flow_path
     end
 
     def submit
@@ -26,6 +27,7 @@ module Idv
         errors: errors,
         extra: {
           remaining_attempts: remaining_attempts,
+          flow_path: @flow_path,
         },
       )
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -205,7 +205,11 @@ module Idv
       update_funnel(client_response)
       track_event(
         Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
-        client_response.to_h.merge(client_image_metrics: image_metadata, async: false),
+        client_response.to_h.merge(
+          client_image_metrics: image_metadata,
+          async: false,
+          flow_path: params[:flow_path],
+        ),
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -102,6 +102,7 @@ module Idv
         remaining_attempts: remaining_attempts,
         user_id: user_uuid,
         pii_like_keypaths: [[:pii]],
+        flow_path: params[:flow_path],
       }
     end
 

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -7,6 +7,7 @@ import DocumentsStep, { documentsStepValidator } from './documents-step';
 import SelfieStep, { selfieStepValidator } from './selfie-step';
 import ReviewIssuesStep, { reviewIssuesStepValidator } from './review-issues-step';
 import ServiceProviderContext from '../context/service-provider';
+import UploadContext from '../context/upload';
 import Submission from './submission';
 import SubmissionStatus from './submission-status';
 import { RetrySubmissionError } from './submission-complete';
@@ -54,6 +55,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
   const [submissionError, setSubmissionError] = useState(/** @type {Error=} */ (undefined));
   const { t } = useI18n();
   const serviceProvider = useContext(ServiceProviderContext);
+  const { flowPath } = useContext(UploadContext);
 
   /**
    * Clears error state and sets form values for submission.
@@ -66,8 +68,12 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
   }
 
   const submissionFormValues = useMemo(
-    () => (formValues && isAsyncForm ? except(formValues, 'front', 'back', 'selfie') : formValues),
-    [isAsyncForm, formValues],
+    () =>
+      formValues && {
+        ...(isAsyncForm ? except(formValues, 'front', 'back', 'selfie') : formValues),
+        flow_path: flowPath,
+      },
+    [isAsyncForm, formValues, flowPath],
   );
 
   let initialActiveErrors;

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -12,7 +12,8 @@ class DocumentProofingJob < ApplicationJob
     trace_id:,
     liveness_checking_enabled:,
     image_metadata:,
-    analytics_data:
+    analytics_data:,
+    flow_path:
   )
     timer = JobHelpers::Timer.new
 
@@ -83,6 +84,7 @@ class DocumentProofingJob < ApplicationJob
         attempts: throttle.attempts,
         remaining_attempts: throttle.remaining_count,
         client_image_metrics: image_metadata,
+        flow_path: flow_path,
       ).merge(analytics_data),
     )
   ensure

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -14,7 +14,7 @@ class ResolutionProofingJob < ApplicationJob
   )
 
   def perform(result_id:, encrypted_arguments:, trace_id:, should_proof_state_id:,
-              dob_year_only:, document_expired:, flow_path: nil)
+              dob_year_only:, document_expired:)
     timer = JobHelpers::Timer.new
 
     raise_stale_job! if stale_job?(enqueued_at)

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -14,7 +14,7 @@ class ResolutionProofingJob < ApplicationJob
   )
 
   def perform(result_id:, encrypted_arguments:, trace_id:, should_proof_state_id:,
-              dob_year_only:, document_expired:)
+              dob_year_only:, document_expired:, flow_path: nil)
     timer = JobHelpers::Timer.new
 
     raise_stale_job! if stale_job?(enqueued_at)

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -26,6 +26,7 @@ module Idv
           params,
           liveness_checking_enabled: liveness_checking_enabled?,
           analytics: @flow.analytics,
+          flow_path: flow_path,
         )
       end
 

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -60,6 +60,7 @@ module Idv
           analytics_data: {
             browser_attributes: @flow.analytics.browser_attributes,
           },
+          flow_path: flow_path,
         )
 
         nil

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -45,7 +45,10 @@ module Idv
 
         @flow.analytics.track_event(
           Analytics::IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION,
-          doc_pii_form_result.to_h.merge(remaining_attempts: remaining_attempts),
+          doc_pii_form_result.to_h.merge(
+            remaining_attempts: remaining_attempts,
+            flow_path: flow_path,
+          ),
         )
 
         delete_async

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -24,7 +24,6 @@ module Idv
         trace_id: trace_id,
         result_id: document_capture_session.result_id,
         document_expired: document_expired,
-        flow_path: flow_path,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -60,7 +60,8 @@ module Idv
       liveness_checking_enabled:,
       trace_id:,
       image_metadata:,
-      analytics_data:
+      analytics_data:,
+      flow_path:
     )
       encrypted_arguments = Encryption::Encryptors::SessionEncryptor.new.encrypt(
         @applicant.to_json,
@@ -73,6 +74,7 @@ module Idv
         trace_id: trace_id,
         image_metadata: image_metadata,
         analytics_data: analytics_data,
+        flow_path: flow_path,
       )
     end
   end

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -9,7 +9,7 @@ module Idv
       should_proof_state_id:,
       trace_id:,
       document_expired:,
-      flow_path:
+      flow_path: 'standard'
     )
       document_capture_session.create_proofing_session
 
@@ -61,7 +61,7 @@ module Idv
       trace_id:,
       image_metadata:,
       analytics_data:,
-      flow_path:
+      flow_path: 'standard'
     )
       encrypted_arguments = Encryption::Encryptors::SessionEncryptor.new.encrypt(
         @applicant.to_json,

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -8,7 +8,8 @@ module Idv
       document_capture_session,
       should_proof_state_id:,
       trace_id:,
-      document_expired:
+      document_expired:,
+      flow_path:
     )
       document_capture_session.create_proofing_session
 
@@ -23,6 +24,7 @@ module Idv
         trace_id: trace_id,
         result_id: document_capture_session.result_id,
         document_expired: document_expired,
+        flow_path: flow_path,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -180,7 +180,7 @@ module Idv
         doc_auth_log.save!
       end
 
-      delegate :idv_session, :session, to: :@flow
+      delegate :idv_session, :session, :flow_path, to: :@flow
     end
   end
 end

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -42,6 +42,7 @@ module Idv
           should_proof_state_id: should_use_aamva?(pii_from_doc),
           trace_id: amzn_trace_id,
           document_expired: document_expired,
+          flow_path: flow_path,
         )
       end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -14,6 +14,7 @@ describe Idv::ImageUploadsController do
         back_image_metadata: '{"glare":99.99}',
         selfie: DocAuthImageFixtures.selfie_image_multipart,
         document_capture_session_uuid: document_capture_session.uuid,
+        flow_path: 'standard',
       }
     end
     let(:json) { JSON.parse(response.body, symbolize_names: true) }
@@ -51,6 +52,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).not_to receive(:track_event).with(
@@ -105,6 +107,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).not_to receive(:track_event).with(
@@ -203,6 +206,7 @@ describe Idv::ImageUploadsController do
           attempts: IdentityConfig.store.doc_auth_max_attempts,
           remaining_attempts: 0,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).not_to receive(:track_event).with(
@@ -236,6 +240,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -256,6 +261,7 @@ describe Idv::ImageUploadsController do
             back: { glare: 99.99 },
           },
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -266,6 +272,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         action
@@ -312,6 +319,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -332,6 +340,7 @@ describe Idv::ImageUploadsController do
                 back: { glare: 99.99 },
               },
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -347,6 +356,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             action
@@ -367,6 +377,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -387,6 +398,7 @@ describe Idv::ImageUploadsController do
                 back: { glare: 99.99 },
               },
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -402,6 +414,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             action
@@ -422,6 +435,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -442,6 +456,7 @@ describe Idv::ImageUploadsController do
                 back: { glare: 99.99 },
               },
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -457,6 +472,7 @@ describe Idv::ImageUploadsController do
               attempts: 1,
               remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
               pii_like_keypaths: [[:pii]],
+              flow_path: 'standard',
             )
 
             action
@@ -501,6 +517,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -521,6 +538,7 @@ describe Idv::ImageUploadsController do
             back: { glare: 99.99 },
           },
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         action
@@ -555,6 +573,7 @@ describe Idv::ImageUploadsController do
           attempts: 1,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -577,6 +596,7 @@ describe Idv::ImageUploadsController do
             back: { glare: 99.99 },
           },
           pii_like_keypaths: [[:pii]],
+          flow_path: 'standard',
         )
 
         action

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -182,6 +182,7 @@ feature 'doc auth verify step' do
         should_proof_state_id: true,
         document_expired: nil,
         trace_id: anything,
+        flow_path: 'standard',
       )
     end
   end
@@ -211,6 +212,7 @@ feature 'doc auth verify step' do
         should_proof_state_id: false,
         document_expired: nil,
         trace_id: anything,
+        flow_path: 'standard',
       )
       expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
     end
@@ -237,6 +239,7 @@ feature 'doc auth verify step' do
         should_proof_state_id: false,
         document_expired: nil,
         trace_id: anything,
+        flow_path: 'standard',
       )
     end
   end

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -344,6 +344,7 @@ describe('document-capture/components/document-capture', () => {
             'back_image_metadata',
             'selfie_image_iv',
             'selfie_image_url',
+            'flow_path',
           ]);
 
           return Promise.resolve({ success: true, isPending: true });

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         trace_id: trace_id,
         image_metadata: image_metadata,
         analytics_data: {},
+        flow_path: 'standard',
       )
 
       result = document_capture_session.load_doc_auth_async_result
@@ -84,6 +85,7 @@ RSpec.describe DocumentProofingJob, type: :job do
         trace_id: trace_id,
         image_metadata: image_metadata,
         analytics_data: {},
+        flow_path: 'standard',
       )
     end
 

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -61,6 +61,7 @@ describe Idv::Steps::VerifyStep do
           should_proof_state_id: anything,
           trace_id: amzn_trace_id,
           document_expired: nil,
+          flow_path: 'standard',
         )
 
       step.call


### PR DESCRIPTION
Our logging for flow path don't include flow path for `IdV: doc auth image upload form submitted`, `IdV: doc auth image upload vendor submitted`, and `IdV: doc auth image upload vendor pii validation`. 

By not having this we can't differentiate in the logs between hybrid and normal flow for these events.