### PR TITLE
LG-4575: accessiblility issue where no file selected still shows after adding file. 

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -168,6 +168,9 @@ function FileInput(props, ref) {
     const file = /** @type {FileList} */ (event.target.files)[0];
     if (file) {
       if (isValidForAccepts(file.type, accept)) {
+        if (inputRef.current) { 
+          inputRef.current.title = file.name;
+        }
         onChange(file);
       } else {
         const nextOwnErrorMessage = invalidTypeText ?? t('errors.file_input.invalid_type');


### PR DESCRIPTION
***Why? ***

Currently when a file is added to file upload. we still show "no file chosen." 

Before: 
![Screen Shot 2021-12-08 at 11 56 35 AM](https://user-images.githubusercontent.com/23225522/145250301-ac2aebf7-bedd-4076-8004-1543c995fe1e.png)

After: 
![Screen Shot 2021-12-08 at 11 57 34 AM](https://user-images.githubusercontent.com/23225522/145250431-82e01c56-bed7-4b2f-b41a-62b40bedb106.png)
