### PR TITLE
Show a message in lower envs explaining how to use test SSNs

### DIFF
--- a/app/views/idv/doc_auth/_ssn_init.html.erb
+++ b/app/views/idv/doc_auth/_ssn_init.html.erb
@@ -16,6 +16,16 @@
   <%= new_window_link_to(t('doc_auth.instructions.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
 </p>
 
+<% if IdentityConfig.store.proofer_mock_fallback %>
+  <div class="usa-alert usa-alert--info margin-bottom-4" role="status">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <%= t('doc_auth.instructions.test_ssn') %>
+      </p>
+    </div>
+  </div>
+<% end %>
+
 <%= simple_form_for(
       :doc_auth,
       url: url_for,

--- a/app/views/idv/doc_auth/_ssn_update.html.erb
+++ b/app/views/idv/doc_auth/_ssn_update.html.erb
@@ -9,6 +9,16 @@
   <%= new_window_link_to(t('doc_auth.instructions.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
 </p>
 
+<% if IdentityConfig.store.proofer_mock_fallback %>
+  <div class="usa-alert usa-alert--info margin-bottom-4" role="status">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <%= t('doc_auth.instructions.test_ssn') %>
+      </p>
+    </div>
+  </div>
+<% end %>
+
 <%= simple_form_for(
       :doc_auth,
       url: url_for,

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -219,7 +219,7 @@ en:
       send_sms: We’ll send a text message to your device with a link.  Follow that
         link to your browser to take photos of the front and back of your ID.
       switch_back: Switch back to your computer to finish verifying your identity.
-      test_ssn: In the test environment, only SSNs that begin with “900-” are
+      test_ssn: In the test environment only SSNs that begin with “900-” are
         considered valid. Do not enter real PII in this field.
       text1: ''
       text1a: such as a phone or computer.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -219,6 +219,8 @@ en:
       send_sms: We’ll send a text message to your device with a link.  Follow that
         link to your browser to take photos of the front and back of your ID.
       switch_back: Switch back to your computer to finish verifying your identity.
+      test_ssn: In the test environment, only SSNs that begin with “900-” are
+        considered valid. Do not enter real PII in this field.
       text1: ''
       text1a: such as a phone or computer.
       text2: You will not need the card with you.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -253,6 +253,8 @@ es:
         trasera de su identificación.
       switch_back: Regrese a su computadora para continuar con la verificación de su
         identidad.
+      test_ssn: En el entorno de prueba, solo los SSN que comienzan con “900-” se
+        consideran válidos. No ingrese PII real en este campo.
       text1: ''
       text1a: como un teléfono o una computadora.
       text2: No es necesario disponer de la credencial.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -253,7 +253,7 @@ es:
         trasera de su identificación.
       switch_back: Regrese a su computadora para continuar con la verificación de su
         identidad.
-      test_ssn: En el entorno de prueba, solo los SSN que comienzan con “900-” se
+      test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” se
         consideran válidos. No ingrese PII real en este campo.
       text1: ''
       text1a: como un teléfono o una computadora.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -267,6 +267,8 @@ fr:
         ce lien vers votre navigateur pour prendre des photos du recto et du
         verso de votre identifiant.
       switch_back: Retournez sur votre ordinateur pour continuer à vérifier votre identité.
+      test_ssn: Dans l’environnement de test, seuls les SSN commençant par “900-” sont
+        considérés comme valides. N’entrez pas de vrais PII dans ce champ.
       text1: ''
       text1a: tel qu’un téléphone ou un ordinateur
       text2: Vous n’aurez pas besoin de la carte avec vous.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -267,7 +267,7 @@ fr:
         ce lien vers votre navigateur pour prendre des photos du recto et du
         verso de votre identifiant.
       switch_back: Retournez sur votre ordinateur pour continuer à vérifier votre identité.
-      test_ssn: Dans l’environnement de test, seuls les SSN commençant par “900-” sont
+      test_ssn: Dans l’environnement de test seuls les SSN commençant par “900-” sont
         considérés comme valides. N’entrez pas de vrais PII dans ce champ.
       text1: ''
       text1a: tel qu’un téléphone ou un ordinateur


### PR DESCRIPTION
**Why**: So that users in the test envs will know not to enter real SSNs and how to enter valid test SSNs