### PR TITLE
LG-5261: Add cancel page logging to "Go Back" button

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -8,8 +8,14 @@ module Idv
     def new
       properties = ParseControllerFromReferer.new(request.referer).call
       analytics.track_event(Analytics::IDV_CANCELLATION, properties.merge(step: params[:step]))
-      @go_back_path = go_back_path || idv_path
+      self.session_go_back_path = go_back_path || idv_path
       @hybrid_session = hybrid_session?
+    end
+
+    def update
+      return unless params.key?(:cancel)
+      analytics.track_event(Analytics::IDV_CANCELLATION_GO_BACK, step: params[:step])
+      redirect_to session_go_back_path || idv_path
     end
 
     def destroy
@@ -46,6 +52,22 @@ module Idv
 
     def document_capture_session
       DocumentCaptureSession.find_by(uuid: document_capture_session_uuid)
+    end
+
+    def session_go_back_path=(path)
+      if hybrid_session?
+        session[:go_back_path] = path
+      else
+        idv_session.go_back_path = path
+      end
+    end
+
+    def session_go_back_path
+      if hybrid_session?
+        session[:go_back_path]
+      else
+        idv_session.go_back_path
+      end
     end
   end
 end

--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -13,9 +13,12 @@ module Idv
     end
 
     def update
-      return unless params.key?(:cancel)
-      analytics.track_event(Analytics::IDV_CANCELLATION_GO_BACK, step: params[:step])
-      redirect_to session_go_back_path || idv_path
+      if params.key?(:cancel)
+        analytics.track_event(Analytics::IDV_CANCELLATION_GO_BACK, step: params[:step])
+        redirect_to session_go_back_path || idv_path
+      else
+        render :new
+      end
     end
 
     def destroy

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -149,6 +149,7 @@ class Analytics
   IDV_BASIC_INFO_SUBMITTED_FORM = 'IdV: basic info form submitted'.freeze
   IDV_BASIC_INFO_SUBMITTED_VENDOR = 'IdV: basic info vendor submitted'.freeze
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
+  IDV_CANCELLATION_GO_BACK = 'IdV: cancellation go back'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -3,6 +3,7 @@ module Idv
     VALID_SESSION_ATTRIBUTES = %i[
       address_verification_mechanism
       applicant
+      go_back_path
       idv_phone_step_document_capture_session_uuid
       idv_gpo_document_capture_session_uuid
       vendor_phone_confirmation

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -13,7 +13,8 @@
         },
         action_secondary: {
           text: t('links.go_back'),
-          url: @go_back_path,
+          url: idv_cancel_path(step: params[:step], cancel: true),
+          method: :put,
         },
       },
     ) do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,6 +285,7 @@ Rails.application.routes.draw do
       get '/session/errors/throttled' => 'session_errors#throttled'
       delete '/session' => 'sessions#destroy'
       get '/cancel/' => 'cancellations#new', as: :cancel
+      put '/cancel' => 'cancellations#update'
       delete '/cancel' => 'cancellations#destroy'
       get '/address' => 'address#new'
       post '/address' => 'address#update'

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -8,6 +8,12 @@ describe Idv::CancellationsController do
   end
 
   describe '#new' do
+    let(:go_back_path) { '/path/to/return' }
+
+    before do
+      allow(controller).to receive(:go_back_path).and_return(go_back_path)
+    end
+
     it 'tracks the event in analytics when referer is nil' do
       stub_sign_in
       stub_analytics
@@ -57,6 +63,12 @@ describe Idv::CancellationsController do
 
         expect(response).to render_template(:new)
       end
+
+      it 'stores go back path' do
+        get :new
+
+        expect(session[:go_back_path]).to eq(go_back_path)
+      end
     end
 
     context 'when regular session' do
@@ -68,6 +80,12 @@ describe Idv::CancellationsController do
         get :new
 
         expect(response).to render_template(:new)
+      end
+
+      it 'stores go back path' do
+        get :new
+
+        expect(controller.user_session[:idv][:go_back_path]).to eq(go_back_path)
       end
     end
   end

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -90,6 +90,54 @@ describe Idv::CancellationsController do
     end
   end
 
+  describe '#update' do
+    before do
+      stub_sign_in
+      stub_analytics
+    end
+
+    context 'without cancel param' do
+      it 'renders new template' do
+        put :update
+
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'with cancel param' do
+      it 'logs cancellation go back' do
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::IDV_CANCELLATION_GO_BACK,
+          step: 'first',
+        )
+
+        put :update, params: { step: 'first', cancel: 'true' }
+      end
+
+      it 'redirects to idv_path' do
+        put :update, params: { cancel: 'true' }
+
+        expect(response).to redirect_to idv_url
+      end
+
+      context 'with go back path stored in session' do
+        let(:go_back_path) { '/path/to/return' }
+
+        before do
+          allow(controller).to receive(:user_session).and_return(
+            idv: { go_back_path: go_back_path },
+          )
+        end
+
+        it 'redirects to go back path' do
+          put :update, params: { cancel: 'true' }
+
+          expect(response).to redirect_to go_back_path
+        end
+      end
+    end
+  end
+
   describe '#destroy' do
     it 'tracks an analytics event' do
       stub_sign_in

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -32,10 +32,31 @@ feature 'doc capture document capture step' do
     click_on t('links.cancel')
 
     expect(page).to have_text(t('idv.cancel.headings.prompt.hybrid'))
+    expect(fake_analytics).to have_logged_event(
+      Analytics::IDV_CANCELLATION,
+      step: 'document_capture',
+    )
 
     click_on t('forms.buttons.cancel')
 
     expect(page).to have_text(t('idv.cancel.headings.confirmation.hybrid'))
+    expect(fake_analytics).to have_logged_event(
+      Analytics::IDV_CANCELLATION_CONFIRMED,
+      step: 'document_capture',
+    )
+  end
+
+  it 'goes back to the right place when clicking "go back" after cancelling' do
+    complete_doc_capture_steps_before_first_step(user)
+
+    click_on t('links.cancel')
+    click_on t('links.go_back')
+
+    expect(page).to have_current_path(idv_capture_doc_document_capture_step)
+    expect(fake_analytics).to have_logged_event(
+      Analytics::IDV_CANCELLATION_GO_BACK,
+      step: 'document_capture',
+    )
   end
 
   it 'advances original session once complete' do

--- a/spec/views/idv/cancellations/new.html.erb_spec.rb
+++ b/spec/views/idv/cancellations/new.html.erb_spec.rb
@@ -3,18 +3,16 @@ require 'rails_helper'
 describe 'idv/cancellations/new.html.erb' do
   let(:hybrid_session) { false }
   let(:params) { ActionController::Parameters.new }
-  let(:go_back_path) { root_url }
 
   before do
     assign(:hybrid_session, hybrid_session)
-    assign(:go_back_path, go_back_path)
     allow(view).to receive(:params).and_return(params)
 
     render
   end
 
   it 'renders go back path' do
-    expect(rendered).to have_link(t('links.go_back'), href: go_back_path)
+    expect(rendered).to have_button(t('links.go_back'))
   end
 
   context 'with hybrid flow' do


### PR DESCRIPTION
**Why**: So that we can more easily track the user's path through IAL2.

Very open to implementation feedback, specifically around...

1. Do we really want this as a separate controller action?
2. Does "Go back" make sense to make as the `PUT` verb of the `CancellationsController` this way?
3. Are we okay to store the "go back" path in session like this?
4. Any other options to reconcile hybrid vs. no-hybrid session storage?
5. Naming of the event: "go back" is rather awkward, but felt less awkward than "cancellation cancelled" 🤷 