### PR TITLE
Also allow 666 prefix in mock proofer

### DIFF
--- a/app/services/proofing/mock/resolution_mock_client.rb
+++ b/app/services/proofing/mock/resolution_mock_client.rb
@@ -39,9 +39,9 @@ module Proofing
       end
 
       # To reduce the chances of allowing real PII in the mock proofer, we only allow SSNs that
-      # start with 900 or appear in the configurable allow list
+      # start with 900 or 666 or appear in the configurable allow list
       def verified_ssn?(ssn)
-        ssn.start_with?('900') ||
+        ssn.start_with?('900', '666') ||
           IdentityConfig.store.test_ssn_allowed_list.include?(ssn.delete('-'))
       end
     end

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -222,7 +222,7 @@ en:
       send_sms: We’ll send a text message to your device with a link.  Follow that
         link to your browser to take photos of the front and back of your ID.
       switch_back: Switch back to your computer to finish verifying your identity.
-      test_ssn: In the test environment only SSNs that begin with “900-” are
+      test_ssn: In the test environment only SSNs that begin with “900-” or “666-” are
         considered valid. Do not enter real PII in this field.
       text1: ''
       text1a: such as a phone or computer.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -257,8 +257,8 @@ es:
         trasera de su identificación.
       switch_back: Regrese a su computadora para continuar con la verificación de su
         identidad.
-      test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” se
-        consideran válidos. No ingrese PII real en este campo.
+      test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” o
+        “666-”se consideran válidos. No ingrese PII real en este campo.
       text1: ''
       text1a: como un teléfono o una computadora.
       text2: No es necesario disponer de la credencial.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -257,8 +257,8 @@ es:
         trasera de su identificación.
       switch_back: Regrese a su computadora para continuar con la verificación de su
         identidad.
-      test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” o
-        “666-”se consideran válidos. No ingrese PII real en este campo.
+      test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” o “666-”
+        se consideran válidos. No ingrese PII real en este campo.
       text1: ''
       text1a: como un teléfono o una computadora.
       text2: No es necesario disponer de la credencial.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -270,8 +270,9 @@ fr:
         ce lien vers votre navigateur pour prendre des photos du recto et du
         verso de votre identifiant.
       switch_back: Retournez sur votre ordinateur pour continuer à vérifier votre identité.
-      test_ssn: Dans l’environnement de test seuls les SSN commençant par “900-” sont
-        considérés comme valides. N’entrez pas de vrais PII dans ce champ.
+      test_ssn: Dans l’environnement de test seuls les SSN commençant par “900-” ou
+        “900-” sont considérés comme valides. N’entrez pas de vrais PII dans ce
+        champ.
       text1: ''
       text1a: tel qu’un téléphone ou un ordinateur
       text2: Vous n’aurez pas besoin de la carte avec vous.


### PR DESCRIPTION
This is the implementation for the notice going out to sandbox partners today. The dev docs notice is in https://github.com/18F/identity-dev-docs/pull/208 and this is a follow up to https://github.com/18F/identity-idp/pull/5576

It should not be merged prior to Dec 20th