### PR TITLE
Smoke tests in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,6 +199,7 @@ smoketest-int:
     - bin/smoke_test --remote --no-source-env
 
 coverage:
+  extends: .on_push
   stage: after_test
   script:
     - *bundle_install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,6 +165,39 @@ js_tests:
     - *yarn_install
     - yarn test
 
+
+smoketest-dev:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $DEV_SMOKETEST == "true"
+  variables:
+    MONITOR_ENV: 'DEV'
+    HEADLESS_BROWSER: 'true'
+    MONITOR_SMS_SIGN_IN_EMAIL: ''
+    MONITOR_GOOGLE_VOICE_PHONE: ''
+  cache:
+    - <<: *ruby_cache
+    - <<: *yarn_cache
+  script:
+    - *bundle_install
+    - *yarn_install
+    - bin/smoke_test --remote --no-source-env
+
+smoketest-int:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $INT_SMOKETEST == "true"
+  variables:
+    MONITOR_ENV: 'INT'
+    HEADLESS_BROWSER: 'true'
+    MONITOR_SMS_SIGN_IN_EMAIL: ''
+    MONITOR_GOOGLE_VOICE_PHONE: ''
+  cache:
+    - <<: *ruby_cache
+    - <<: *yarn_cache
+  script:
+    - *bundle_install
+    - *yarn_install
+    - bin/smoke_test --remote --no-source-env
+
 coverage:
   stage: after_test
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ coverage:
 sync_from_github:
   image: mirror.gcr.io/alpine/git:latest
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $GITHUB_SYNC == "true"
   script:
     - cd .git
     - git config --bool core.bare true


### PR DESCRIPTION
Implements a minimal subset of the CircleCI smoke tests.

Things that are intentionally excluded:

- Checking out the deployed SHA
- Staging and Prod smoke tests


GitLab's configuration of CI schedules doesn't allow specifying the job in the schedule configuration, so it's handled by setting environment variables and checking it in the `rules` of the job.