### PR TITLE
Remove unused personal-key pattern validation message

### DIFF
--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -3,10 +3,6 @@ import { loadPolyfills } from '@18f/identity-polyfill';
 /** @typedef {{t:(key:string)=>string, key:(key:string)=>string}} LoginGovI18n */
 /** @typedef {{LoginGov:{I18n:LoginGovI18n}}} LoginGovGlobal */
 
-const PATTERN_TYPES = ['personal-key'];
-
-const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').toLowerCase();
-
 /**
  * Given a submit event, disables all submit buttons within the target form.
  *
@@ -60,14 +56,6 @@ function checkInputValidity(event) {
   if (input.validity.valueMissing) {
     input.setCustomValidity(I18n.t('simple_form.required.text'));
     input.setAttribute('data-form-validation-message', '');
-  } else if (input.validity.patternMismatch) {
-    PATTERN_TYPES.forEach((type) => {
-      if (input.classList.contains(type)) {
-        // i18n-tasks-use t('idv.errors.pattern_mismatch.personal_key')
-        input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${snakeCase(type)}`));
-        input.setAttribute('data-form-validation-message', '');
-      }
-    });
   }
 }
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -30,8 +30,6 @@ en:
       incorrect_password: The password you entered is not correct.
       mail_limit_reached: You have requested too much mail in the last month.
       pattern_mismatch:
-        personal_key: 'Please enter your personal key for this account. Example:
-          ABC1-DEF2-G3HI-J456'
         ssn: 'Your Social Security Number must be entered in as ###-##-####'
         zipcode: Enter a 5 or 9 digit ZIP code
       unsupported_otp_delivery_method: Select a method to receive a code.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -32,8 +32,6 @@ es:
       incorrect_password: La contraseña que ingresó no es correcta.
       mail_limit_reached: Usted ha solicitado demasiado correo en el último mes.
       pattern_mismatch:
-        personal_key: 'Introduzca su clave personal para esta cuenta. Ejemplo:
-          ABC1-DEF2-G3HI-J456'
         ssn: 'Su número de Seguro Social debe ser ingresado como ### - ## - ####'
         zipcode: Ingresa un código postal de 5 o 9 dígitos
       unsupported_otp_delivery_method: Seleccione una manera de recibir un código.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -34,8 +34,6 @@ fr:
       incorrect_password: Le mot de passe que vous avez inscrit est incorrect.
       mail_limit_reached: Vous avez demandé trop de lettres au cours du dernier mois.
       pattern_mismatch:
-        personal_key: 'Veuillez inscrire votre clé personnelle pour ce compte, par
-          exemple : ABC1-DEF2-G3HI-J456'
         ssn: 'Votre numéro de sécurité sociale doit être inscrit de cette façon :
           ###-##-####'
         zipcode: Entrez un code postal à 5 ou 9 chiffres

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -55,9 +55,6 @@ describe('form-validation', () => {
       <form>
         <input type="text" aria-label="not required field">
         <input type="text" aria-label="required field" required class="field">
-        <input type="text" aria-label="format" pattern="\\\\A\\\\d{5}(-?\\\\d{4})?\\\\z">
-        <input type="text" aria-label="format unknown field" pattern="\\\\A\\\\d{5}(-?\\\\d{4})?\\\\z" class="field">
-        <input type="text" aria-label="format field" pattern="(?:[a-zA-Z0-9]{4}([ -])?){3}[a-zA-Z0-9]{4}" class="field personal-key">
       </form>`;
 
     initialize(document.querySelector('form'));
@@ -71,24 +68,6 @@ describe('form-validation', () => {
     expect(requiredField.validationMessage).to.equal('simple_form.required.text');
     await userEvent.type(requiredField, 'a');
     expect(notRequiredField.validationMessage).to.be.empty();
-
-    const format = screen.getByLabelText('format');
-    await userEvent.type(format, 'a');
-    expect(format.validationMessage).to.not.be.empty.and.not.match(
-      /^idv\.errors\.pattern_mismatch\./,
-    );
-
-    const formatUnknownField = screen.getByLabelText('format unknown field');
-    await userEvent.type(formatUnknownField, 'a');
-    expect(formatUnknownField.validationMessage).to.not.be.empty.and.not.match(
-      /^idv\.errors\.pattern_mismatch\./,
-    );
-
-    const formatField = screen.getByLabelText('format field');
-    await userEvent.type(formatField, 'a');
-    expect(formatField.validationMessage).to.equal('idv.errors.pattern_mismatch.personal_key');
-    await userEvent.type(formatField, 'aaa-aaaa-aaaa-aaaa');
-    expect(formatField.validationMessage).to.be.empty();
   });
 
   it('resets its own custom validity message on input', () => {


### PR DESCRIPTION
**Why**: Because it's unused.

Personal key fields are rendered in three places, none of which use this logic:

- [**IAL2 confirmation**](https://github.com/18F/identity-idp/blob/c2e26ec11670d6ee4dbbe2ff3c44235e08eb281b/app/views/shared/_personal_key_confirmation_modal.html.erb#L19) and [**post-password reset profile restore**](https://github.com/18F/identity-idp/blob/c2e26ec11670d6ee4dbbe2ff3c44235e08eb281b/app/views/users/verify_personal_key/new.html.erb#L11) are not rendered within a `validated_form_for`, and therefore `form-validation.js` is not loaded at all.
- [**Personal key MFA login**](https://github.com/18F/identity-idp/blob/c2e26ec11670d6ee4dbbe2ff3c44235e08eb281b/app/views/partials/personal_key/_entry_fields.html.erb) is rendered within a `validated_form_for`, but because it has no `pattern` attribute, it would never fail the `patternMismatch` validation.

In all of these cases, we should plan to move toward [`ValidatedFieldComponent`](https://github.com/18F/identity-idp/blob/main/app/components/validated_field_component.rb) anyways.