### PR TITLE
Remove BassCSS flex-object styling

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -38,7 +38,7 @@ linters:
           - 'range-light'
           - 'field-dark'
           - 'progress'
-          - 'flex-(column|none)'
+          - 'flex(-(center|baseline|stretch|start|end|grow|none|first|last))?'
           - '((sm|md|lg)-)?table(-(cell|fixed))?'
           - '[xy]-group-item'
           - '(items|self|justify|content)-(start|end|center|baseline|stretch)'

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -12,4 +12,3 @@
 @import 'basscss-sass/white-space';
 @import 'basscss-sass/positions';
 @import 'basscss-sass/grid';
-@import 'basscss-sass/flex-object';

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -5,7 +5,7 @@
   <% if show_language_dropdown %>
     <div class='tablet:display-none border-bottom border-primary-light'>
       <div class='container cntnr-wide padding-y-1 padding-x-2 desktop:padding-x-0 h5'>
-        <div class='i18n-mobile-toggle flex flex-align-center flex-justify-center'>
+        <div class="i18n-mobile-toggle display-flex flex-align-center flex-justify-center">
             <button class='block text-decoration-none text-primary fs-13p language-mobile-button' aria-expanded='false'>
               <%= image_tag asset_url('globe-blue.svg'), width: 12,
                                                          class: 'margin-right-1', alt: '', 'aria-hidden': 'true' %><%= t('i18n.language') %><span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
@@ -24,10 +24,10 @@
     </div>
   <% end %>
   <div class='container padding-y-1 padding-x-2 desktop:padding-x-0 <%= 'tablet:padding-y-0' if show_language_dropdown %>'>
-    <div class='flex flex-align-center flex-justify-center'>
-      <div class='flex flex-auto flex-first'>
+    <div class="display-flex flex-align-center flex-justify-center">
+      <div class="display-flex flex-auto">
         <div class="tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 tablet:display-none',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 tablet:display-none',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
                           width: 20, alt: '' %>
@@ -35,7 +35,7 @@
         </div>
 
         <div class="display-none tablet:display-block">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 usa-link--alt',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 usa-link--alt',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
                           width: 20, class: 'margin-right-1', alt: '' %>
@@ -45,10 +45,10 @@
           <% end %>
         </div>
       </div>
-      <div class='flex flex-align-center flex-justify-center'>
+      <div class="display-flex flex-align-center flex-justify-center">
         <% if show_language_dropdown %>
           <ul class='list-reset display-none tablet:display-block margin-bottom-0'>
-            <li class="i18n-desktop-toggle flex margin-y-1 margin-x-2 relative">
+            <li class="i18n-desktop-toggle display-flex margin-y-1 margin-x-2 relative">
               <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
                 <%= image_tag asset_url('globe-white.svg'), width: 12,
                                                             class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -31,7 +31,7 @@
   </div>
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
-  <div class="flex flex-row flex-align-center flex-wrap">
+  <div class="display-flex flex-row flex-align-center flex-wrap">
     <%= link_to(
           t('links.two_factor_authentication.get_another_code'),
           otp_send_path(
@@ -44,7 +44,7 @@
           form_class: 'inline-block',
         ) %>
 
-    <span class="text-no-wrap flex-no-shrink flex flex-row flex-align-center">
+    <span class="text-no-wrap flex-no-shrink display-flex flex-row flex-align-center">
       <%= hidden_field_tag 'remember_device', false,
                            id: 'remember_device_preference' %>
       <%= check_box_tag 'remember_device', true,


### PR DESCRIPTION
**Why**:

- Standardize on design system
- Smaller bundled output, and faster generation
- Avoid ambiguity for developers choosing flex styling

References:

- BassCSS classes: https://github.com/basscss/basscss-sass/blob/v3.0.0/_flex-object.scss
- Design system classes: https://designsystem.digital.gov/utilities/flex/