### PR TITLE
Log all vendor status in VendorStatus#track_event

### DIFF
--- a/app/services/vendor_status.rb
+++ b/app/services/vendor_status.rb
@@ -85,6 +85,8 @@ class VendorStatus
         acuant: IdentityConfig.store.vendor_status_acuant,
         lexisnexis_instant_verify: IdentityConfig.store.vendor_status_lexisnexis_instant_verify,
         lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
+        sms: IdentityConfig.store.vendor_status_sms,
+        voice: IdentityConfig.store.vendor_status_voice,
       },
       redirect_from: from,
     }

--- a/spec/controllers/vendor_outage_controller_spec.rb
+++ b/spec/controllers/vendor_outage_controller_spec.rb
@@ -3,28 +3,12 @@ require 'rails_helper'
 describe VendorOutageController do
   before do
     stub_analytics
-    allow(@analytics).to receive(:track_event)
-  end
-
-  let(:redirect_from) { nil }
-  let(:tracking_data) do
-    {
-      vendor_status: {
-        acuant: IdentityConfig.store.vendor_status_acuant,
-        lexisnexis_instant_verify: IdentityConfig.store.vendor_status_lexisnexis_instant_verify,
-        lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
-      },
-      redirect_from: redirect_from,
-    }
   end
 
   it 'tracks an analytics event' do
-    get :show
+    expect_any_instance_of(VendorStatus).to receive(:track_event).with(@analytics)
 
-    expect(@analytics).to have_received(:track_event).with(
-      Analytics::VENDOR_OUTAGE,
-      tracking_data,
-    )
+    get :show
   end
 
   it 'sets show_gpo_option view variable' do

--- a/spec/services/vendor_status_spec.rb
+++ b/spec/services/vendor_status_spec.rb
@@ -181,4 +181,19 @@ describe VendorStatus do
       end
     end
   end
+
+  describe '#track_event' do
+    it 'logs status of all vendors' do
+      analytics = FakeAnalytics.new
+      expect(analytics).to receive(:track_event).with(
+        Analytics::VENDOR_OUTAGE,
+        redirect_from: from,
+        vendor_status: VendorStatus::ALL_VENDORS.index_with do |_vendor|
+          satisfy { |status| IdentityConfig::VENDOR_STATUS_OPTIONS.include?(status) }
+        end,
+      )
+
+      vendor_status.track_event(analytics)
+    end
+  end
 end


### PR DESCRIPTION
**Why**: So that we're consistently logging status for all vendors, not just for a subset of them.

These should have been included in #5550.