### PR TITLE
LG-5325 Doc Auth: Error dependent hints and enhanced field level errors

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -105,6 +105,8 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
               submissionError instanceof UploadFormEntriesError
                 ? submissionError.remainingAttempts
                 : Infinity,
+            captureHints:
+              submissionError instanceof UploadFormEntriesError ? submissionError.hints : null,
           })(ReviewIssuesStep),
           validator: reviewIssuesStepValidator,
         },

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -61,6 +61,7 @@ function reviewIssuesStepValidator(value = {}) {
 /**
  * @param {import('./form-steps').FormStepComponentProps<ReviewIssuesStepValue> & {
  *  remainingAttempts: number,
+ *  captureHints: boolean,
  * }} props Props object.
  */
 function ReviewIssuesStep({
@@ -71,6 +72,7 @@ function ReviewIssuesStep({
   onError = () => {},
   registerField = () => undefined,
   remainingAttempts,
+  captureHints,
 }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
@@ -94,13 +96,17 @@ function ReviewIssuesStep({
       <PageHeading>{t('doc_auth.headings.review_issues')}</PageHeading>
       {!!unknownFieldErrors &&
         unknownFieldErrors.map(({ error }) => <p key={error.message}>{error.message}</p>)}
-      <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_id_header_text')}</p>
-      <ul>
-        <li>{t('doc_auth.tips.review_issues_id_text1')}</li>
-        <li>{t('doc_auth.tips.review_issues_id_text2')}</li>
-        <li>{t('doc_auth.tips.review_issues_id_text3')}</li>
-        <li>{t('doc_auth.tips.review_issues_id_text4')}</li>
-      </ul>
+      {captureHints && (
+        <>
+          <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_id_header_text')}</p>
+          <ul>
+            <li>{t('doc_auth.tips.review_issues_id_text1')}</li>
+            <li>{t('doc_auth.tips.review_issues_id_text2')}</li>
+            <li>{t('doc_auth.tips.review_issues_id_text3')}</li>
+            <li>{t('doc_auth.tips.review_issues_id_text4')}</li>
+          </ul>
+        </>
+      )}
       {DOCUMENT_SIDES.map((side) => (
         <DocumentSideAcuantCapture
           key={side}
@@ -181,7 +187,9 @@ function ReviewIssuesStep({
       }
     >
       {!!unknownFieldErrors &&
-        unknownFieldErrors.map(({ error }) => <p key={error.message}>{error.message}</p>)}
+        unknownFieldErrors
+          .filter((error) => !['front', 'back', 'selfie'].includes(error.field))
+          .map(({ error }) => <p key={error.message}>{error.message}</p>)}
 
       {remainingAttempts <= DISPLAY_ATTEMPTS && (
         <p>

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -51,6 +51,7 @@ UploadContext.displayName = 'UploadContext';
  * @prop {UploadFieldError[]=} errors Error messages.
  * @prop {string=} redirect URL to which user should be redirected.
  * @prop {number=} remaining_attempts Number of remaining doc capture attempts for user.
+ * @prop {boolean=} hints Boolean to decide if capture hints should be shown with error.
  */
 
 /**

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -13,6 +13,9 @@ export class UploadFormEntriesError extends Error {
 
   /** @type {number} */
   remainingAttempts = Infinity;
+
+  /** @type {boolean} */
+  hints = false;
 }
 
 /**
@@ -85,6 +88,10 @@ async function upload(payload, { method = 'POST', endpoint, csrf }) {
 
     if (errorResult.remaining_attempts) {
       error.remainingAttempts = errorResult.remaining_attempts;
+    }
+
+    if (errorResult.hints) {
+      error.hints = errorResult.hints;
     }
 
     throw error;

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -37,7 +37,9 @@ class ImageUploadResponsePresenter
       { success: false, redirect: idv_session_errors_throttled_url }
     else
       hints = @form_response.errors[:hints]
-      { success: false, errors: errors, hints: hints, remaining_attempts: remaining_attempts }
+      json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
+      json[:hints] = hints unless hints&.blank?
+      json
     end
   end
 

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -11,7 +11,7 @@ class ImageUploadResponsePresenter
   end
 
   def errors
-    @form_response.errors.flat_map do |key, errs|
+    @form_response.errors.except(:hints).flat_map do |key, errs|
       Array(errs).map { |err| { field: key, message: err } }
     end
   end
@@ -36,7 +36,8 @@ class ImageUploadResponsePresenter
     elsif @form_response.errors.key?(:limit)
       { success: false, redirect: idv_session_errors_throttled_url }
     else
-      { success: false, errors: errors, remaining_attempts: remaining_attempts }
+      hints = @form_response.errors[:hints]
+      { success: false, errors: errors, hints: hints, remaining_attempts: remaining_attempts }
     end
   end
 

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -38,7 +38,7 @@ class ImageUploadResponsePresenter
     else
       hints = @form_response.errors[:hints]
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
-      json[:hints] = hints unless hints&.blank?
+      json[:hints] = hints unless hints.blank?
       json
     end
   end

--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -51,7 +51,8 @@ module DocAuth
 
     def generate_doc_auth_errors(response_info)
       liveness_enabled = response_info[:liveness_enabled]
-      alert_error_count = response_info[:alert_failure_count]
+      alert_error_count = response_info[:doc_auth_result] == 'Passed' ?
+        0 : response_info[:alert_failure_count]
 
       unknown_fail_count = scan_for_unknown_alerts(response_info)
       alert_error_count -= unknown_fail_count
@@ -62,7 +63,7 @@ module DocAuth
       alert_errors = get_error_messages(liveness_enabled, response_info)
       alert_error_count += 1 if alert_errors.include?(SELFIE)
 
-      error = ""
+      error = ''
       side = nil
 
       if alert_error_count < 1
@@ -102,6 +103,7 @@ module DocAuth
 
       ErrorResult.new(error, side).to_h
     end
+
     # private
 
     def get_image_metric_errors(processed_image_metrics)

--- a/app/services/doc_auth/error_result.rb
+++ b/app/services/doc_auth/error_result.rb
@@ -1,0 +1,45 @@
+module DocAuth
+    class ErrorResult
+      def initialize(error = nil, side = nil)
+        @error = ""
+        @error_display = nil
+        @sides = []
+        set_error(error) unless error.nil?
+        add_side(side) unless side.nil?
+      end
+
+      def set_error(error)
+        @error = error
+        @error_display = Errors::USER_DISPLAY[@error]
+      end
+
+      def error
+        @error
+      end
+
+      def add_side(side)
+        if side == :id
+          @sides.push(:front, :back)
+        else
+          @sides << side
+        end
+      end
+
+      def empty?
+        @error.empty?
+      end
+
+      def to_h
+        error_output = {}
+
+        plural_banner = @error_display[:long_msg_plural] || @error_display[:long_msg]
+
+        error_output[:general] = [@sides.length < 2 ? @error_display[:long_msg] : plural_banner]
+        @sides.each { |side| error_output[side] = [@error_display[:field_msg]] }
+
+        error_output[:hints] = @error_display[:hints] || false
+
+        error_output
+      end
+    end
+end

--- a/app/services/doc_auth/error_result.rb
+++ b/app/services/doc_auth/error_result.rb
@@ -30,6 +30,7 @@ module DocAuth
       end
 
       def to_h
+        return {} if @error.empty? || @error_display.empty?
         error_output = {}
 
         plural_banner = @error_display[:long_msg_plural] || @error_display[:long_msg]

--- a/app/services/doc_auth/error_result.rb
+++ b/app/services/doc_auth/error_result.rb
@@ -1,7 +1,7 @@
 module DocAuth
     class ErrorResult
       def initialize(error = nil, side = nil)
-        @error = ""
+        @error = ''
         @error_display = nil
         @sides = []
         set_error(error) unless error.nil?

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -72,9 +72,10 @@ module DocAuth
       GLARE_LOW_BOTH_SIDES,
     ].freeze
 
+    # rubocop:disable Layout/LineLength
     USER_DISPLAY = {
       # Image metrics
-      DPI_LOW => { long_msg: DPI_LOW_ONE_SIDE, long_msg_plural: DPI_LOW_BOTH_SIDES,  field_msg: DPI_LOW_FIELD },
+      DPI_LOW => { long_msg: DPI_LOW_ONE_SIDE, long_msg_plural: DPI_LOW_BOTH_SIDES, field_msg: DPI_LOW_FIELD },
       SHARP_LOW => { long_msg: SHARP_LOW_ONE_SIDE, long_msg_plural: SHARP_LOW_BOTH_SIDES, field_msg: SHARP_LOW_FIELD },
       GLARE_LOW => { long_msg: GLARE_LOW_ONE_SIDE, long_msg_plural: GLARE_LOW_BOTH_SIDES, field_msg: GLARE_LOW_FIELD },
       # Alerts
@@ -107,7 +108,8 @@ module DocAuth
       GENERAL_ERROR_LIVENESS => { long_msg: GENERAL_ERROR_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       GENERAL_ERROR_NO_LIVENESS => { long_msg: GENERAL_ERROR_NO_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       # Liveness
-      SELFIE_FAILURE => { long_msg: SELFIE_FAILURE, field_msg: FALLBACK_FIELD_LEVEL, hints: false }
+      SELFIE_FAILURE => { long_msg: SELFIE_FAILURE, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
     }
+    # rubocop:enable Layout/LineLength
   end
 end

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -64,12 +64,16 @@ module DocAuth
       SEX_CHECK,
       VISIBLE_COLOR_CHECK,
       VISIBLE_PHOTO_CHECK,
+      DPI_LOW,
       DPI_LOW_ONE_SIDE,
       DPI_LOW_BOTH_SIDES,
+      SHARP_LOW,
       SHARP_LOW_ONE_SIDE,
       SHARP_LOW_BOTH_SIDES,
+      GLARE_LOW,
       GLARE_LOW_ONE_SIDE,
       GLARE_LOW_BOTH_SIDES,
+      FALLBACK_FIELD_LEVEL,
     ].freeze
 
     # rubocop:disable Layout/LineLength

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -27,12 +27,20 @@ module DocAuth
     VISIBLE_COLOR_CHECK = 'visible_color_check'
     VISIBLE_PHOTO_CHECK = 'visible_photo_check'
     # Image metrics
+    DPI_LOW = 'dpi_low'
+    DPI_LOW_FIELD = 'dpi_low_field'
     DPI_LOW_ONE_SIDE = 'dpi_low_one_side'
     DPI_LOW_BOTH_SIDES = 'dpi_low_both_sides'
+    SHARP_LOW = 'sharp_low'
+    SHARP_LOW_FIELD = 'sharp_low_field'
     SHARP_LOW_ONE_SIDE = 'sharp_low_one_side'
     SHARP_LOW_BOTH_SIDES = 'sharp_low_both_sides'
+    GLARE_LOW = 'glare_low'
+    GLARE_LOW_FIELD = 'glare_low_field'
     GLARE_LOW_ONE_SIDE = 'glare_low_one_side'
     GLARE_LOW_BOTH_SIDES = 'glare_low_both_sides'
+    # Other
+    FALLBACK_FIELD_LEVEL= 'fallback_field_level'
 
     ALL = [
       BARCODE_CONTENT_CHECK,
@@ -63,5 +71,43 @@ module DocAuth
       GLARE_LOW_ONE_SIDE,
       GLARE_LOW_BOTH_SIDES,
     ].freeze
+
+    USER_DISPLAY = {
+      # Image metrics
+      DPI_LOW => { long_msg: DPI_LOW_ONE_SIDE, long_msg_plural: DPI_LOW_BOTH_SIDES,  field_msg: DPI_LOW_FIELD },
+      SHARP_LOW => { long_msg: SHARP_LOW_ONE_SIDE, long_msg_plural: SHARP_LOW_BOTH_SIDES, field_msg: SHARP_LOW_FIELD },
+      GLARE_LOW => { long_msg: GLARE_LOW_ONE_SIDE, long_msg_plural: GLARE_LOW_BOTH_SIDES, field_msg: GLARE_LOW_FIELD },
+      # Alerts
+      REF_CONTROL_NUMBER_CHECK => { long_msg: REF_CONTROL_NUMBER_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      BARCODE_CONTENT_CHECK => { long_msg: BARCODE_CONTENT_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      BARCODE_READ_CHECK => { long_msg: BARCODE_READ_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      BIRTH_DATE_CHECKS => { long_msg: BIRTH_DATE_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      BIRTH_DATE_CHECKS => { long_msg: BIRTH_DATE_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      CONTROL_NUMBER_CHECK => { long_msg: CONTROL_NUMBER_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ID_NOT_RECOGNIZED => { long_msg: ID_NOT_RECOGNIZED, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      DOC_CROSSCHECK => { long_msg: DOC_CROSSCHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      DOCUMENT_EXPIRED_CHECK => { long_msg: DOCUMENT_EXPIRED_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      DOC_NUMBER_CHECKS => { long_msg: DOC_NUMBER_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      EXPIRATION_CHECKS => { long_msg: EXPIRATION_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      EXPIRATION_CHECKS => { long_msg: EXPIRATION_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      FULL_NAME_CHECK => { long_msg: FULL_NAME_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ISSUE_DATE_CHECKS => { long_msg: ISSUE_DATE_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ISSUE_DATE_CHECKS => { long_msg: ISSUE_DATE_CHECKS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ID_NOT_VERIFIED => { long_msg: ID_NOT_VERIFIED, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ID_NOT_VERIFIED => { long_msg: ID_NOT_VERIFIED, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      VISIBLE_PHOTO_CHECK => { long_msg: VISIBLE_PHOTO_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ID_NOT_VERIFIED => { long_msg: ID_NOT_VERIFIED, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      SEX_CHECK => { long_msg: SEX_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      VISIBLE_COLOR_CHECK => { long_msg: VISIBLE_COLOR_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      ID_NOT_VERIFIED => { long_msg: ID_NOT_VERIFIED, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      VISIBLE_PHOTO_CHECK => { long_msg: VISIBLE_PHOTO_CHECK, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      # Multiple Errors
+      MULTIPLE_FRONT_ID_FAILURES => { long_msg: MULTIPLE_FRONT_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      MULTIPLE_BACK_ID_FAILURES => { long_msg: MULTIPLE_BACK_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      GENERAL_ERROR_LIVENESS => { long_msg: GENERAL_ERROR_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      GENERAL_ERROR_NO_LIVENESS => { long_msg: GENERAL_ERROR_NO_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      # Liveness
+      SELFIE_FAILURE => { long_msg: SELFIE_FAILURE, field_msg: FALLBACK_FIELD_LEVEL, hints: false }
+    }
   end
 end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -84,8 +84,8 @@ module DocAuthRouter
     DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth',
     # i18n-tasks-use t('doc_auth.errors.http.image_size')
     DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size',
-    # i18n-tasks-use t('errors.messages.try_again')
-    DocAuth::Errors::FALLBACK_FIELD_LEVEL => 'doc_auth.errors.general.fallback_field_level'
+    # i18n-tasks-use t('doc_auth.errors.general.fallback_field_level')
+    DocAuth::Errors::FALLBACK_FIELD_LEVEL => 'doc_auth.errors.general.fallback_field_level',
   }.freeze
 
   class DocAuthErrorTranslatorProxy

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -64,20 +64,28 @@ module DocAuthRouter
     DocAuth::Errors::DPI_LOW_ONE_SIDE => 'doc_auth.errors.dpi.top_msg',
     # i18n-tasks-use t('doc_auth.errors.dpi.top_msg_plural')
     DocAuth::Errors::DPI_LOW_BOTH_SIDES => 'doc_auth.errors.dpi.top_msg_plural',
+    # i18n-tasks-use t('doc_auth.errors.dpi.failed_short')
+    DocAuth::Errors::DPI_LOW_FIELD => 'doc_auth.errors.dpi.failed_short',
     # i18n-tasks-use t('doc_auth.errors.sharpness.top_msg')
     DocAuth::Errors::SHARP_LOW_ONE_SIDE => 'doc_auth.errors.sharpness.top_msg',
     # i18n-tasks-use t('doc_auth.errors.sharpness.top_msg_plural')
     DocAuth::Errors::SHARP_LOW_BOTH_SIDES => 'doc_auth.errors.sharpness.top_msg_plural',
+    # i18n-tasks-use t('doc_auth.errors.sharpness.failed_short')
+    DocAuth::Errors::SHARP_LOW_FIELD => 'doc_auth.errors.sharpness.failed_short',
     # i18n-tasks-use t('doc_auth.errors.glare.top_msg')
     DocAuth::Errors::GLARE_LOW_ONE_SIDE => 'doc_auth.errors.glare.top_msg',
     # i18n-tasks-use t('doc_auth.errors.glare.top_msg_plural')
     DocAuth::Errors::GLARE_LOW_BOTH_SIDES => 'doc_auth.errors.glare.top_msg_plural',
+    # i18n-tasks-use t('doc_auth.errors.glare.failed_short')
+    DocAuth::Errors::GLARE_LOW_FIELD => 'doc_auth.errors.glare.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.image_load')
     DocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load',
     # i18n-tasks-use t('doc_auth.errors.http.pixel_depth')
     DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth',
     # i18n-tasks-use t('doc_auth.errors.http.image_size')
     DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size',
+    # i18n-tasks-use t('errors.messages.try_again')
+    DocAuth::Errors::FALLBACK_FIELD_LEVEL => 'doc_auth.errors.general.fallback_field_level'
   }.freeze
 
   class DocAuthErrorTranslatorProxy

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -57,6 +57,7 @@ en:
           instead.
         failed: Camera failed to start, please try again.
       dpi:
+        failed_short: Image is too small or blurry, please try again.
         top_msg: We couldn’t read your ID. Your image size may be too small, or your ID
           is too small or blurry in the photo. Make sure your ID is large within
           the image frame and try taking a new picture.
@@ -66,6 +67,7 @@ en:
       file_type:
         invalid: This file type is not accepted, please choose a JPG or PNG file.
       general:
+        fallback_field_level: Please add a new image
         liveness: We couldn’t verify your ID and photo of yourself. Try taking new
           pictures.
         multiple_back_id_failures: We couldn’t verify the back of your ID. Try taking a new picture.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -68,7 +68,8 @@ es:
           página o suba una foto en su lugar.
         failed: No se ha podido encender la cámara, por favor, inténtelo de nuevo.
       dpi:
-        failed_short: La imagen es demasiado pequeña o está borrosa, por favor inténtelo de nuevo.
+        failed_short: La imagen es demasiado pequeña o está borrosa, por favor inténtelo
+          de nuevo.
         top_msg: No pudimos leer su identificación. Es posible que el tamaño de su
           imagen sea demasiado chico, que su identificación sea demasiado
           pequeña o que la foto esté borrosa. Asegúrese de que su identificación

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -68,6 +68,7 @@ es:
           página o suba una foto en su lugar.
         failed: No se ha podido encender la cámara, por favor, inténtelo de nuevo.
       dpi:
+        failed_short: La imagen es demasiado pequeña o está borrosa, por favor inténtelo de nuevo.
         top_msg: No pudimos leer su identificación. Es posible que el tamaño de su
           imagen sea demasiado chico, que su identificación sea demasiado
           pequeña o que la foto esté borrosa. Asegúrese de que su identificación
@@ -81,6 +82,7 @@ es:
       file_type:
         invalid: Ese formato no es admitido, por favor elija un archivo JPG o PNG.
       general:
+        fallback_field_level: Agregue una imagen nueva
         liveness: No pudimos verificar su documento de identidad y su foto. Intente
           tomar nuevas fotografías.
         multiple_back_id_failures: No pudimos verificar la parte trasera de su documento

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -72,6 +72,7 @@ fr:
           système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
       dpi:
+        failed_short: L'image est trop petite ou floue, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre
           image est peut-être trop petite ou il se peut que votre pièce
           d’identité soit trop petite ou floue sur la photo. Assurez-vous que la
@@ -86,6 +87,7 @@ fr:
         invalid: Ce type de fichier n’est pas accepté, veuillez choisir un fichier JPG
           ou PNG.
       general:
+        fallback_field_level: Veuillez ajouter une nouvelle image
         liveness: Nous n’avons pas pu vérifier votre pièce d’identité et votre photo.
           Essayez de prendre de nouvelles photos.
         multiple_back_id_failures: Nous n’avons pas pu vérifier le verso de votre pièce

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -72,7 +72,7 @@ fr:
           système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
       dpi:
-        failed_short: L'image est trop petite ou floue, veuillez réessayer.
+        failed_short: L’image est trop petite ou floue, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre
           image est peut-être trop petite ou il se peut que votre pièce
           d’identité soit trop petite ou floue sur la photo. Assurez-vous que la

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -317,7 +317,7 @@ describe Idv::DocAuthController do
       {
         pii_from_doc: {},
         success: false,
-        errors: { front: 'Wrong document', hints: true },
+        errors: { front: 'Wrong document' },
         messages: ['message'],
       }
     end
@@ -356,7 +356,6 @@ describe Idv::DocAuthController do
         {
           success: false,
           errors: [{ field: 'front', message: 'Wrong document' }],
-          hints: true,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
         }.to_json,
       )
@@ -375,7 +374,6 @@ describe Idv::DocAuthController do
           success: false,
           errors: [{ field: 'pii',
                      message: I18n.t('doc_auth.errors.general.no_liveness') }],
-          hints: false,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
         }.to_json,
       )

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -317,7 +317,7 @@ describe Idv::DocAuthController do
       {
         pii_from_doc: {},
         success: false,
-        errors: { front: 'Wrong document' },
+        errors: { front: 'Wrong document', hints: true },
         messages: ['message'],
       }
     end
@@ -356,6 +356,7 @@ describe Idv::DocAuthController do
         {
           success: false,
           errors: [{ field: 'front', message: 'Wrong document' }],
+          hints: true,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
         }.to_json,
       )
@@ -374,6 +375,7 @@ describe Idv::DocAuthController do
           success: false,
           errors: [{ field: 'pii',
                      message: I18n.t('doc_auth.errors.general.no_liveness') }],
+          hints: false,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
         }.to_json,
       )

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -556,8 +556,11 @@ describe Idv::ImageUploadsController do
         expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
         expect(json[:errors]).to eq [
           {
-            field: 'back',
+            field: 'general',
             message: I18n.t('doc_auth.errors.alerts.barcode_content_check'),
+          },{
+            field: 'back',
+            message: I18n.t('doc_auth.errors.general.fallback_field_level'),
           },
         ]
       end
@@ -580,7 +583,9 @@ describe Idv::ImageUploadsController do
           Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
           success: false,
           errors: {
-            back: [I18n.t('doc_auth.errors.alerts.barcode_content_check')],
+            general: [I18n.t('doc_auth.errors.alerts.barcode_content_check')],
+            back: [I18n.t('doc_auth.errors.general.fallback_field_level')],
+            hints: true,
           },
           async: false,
           billed: true,

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -558,10 +558,10 @@ describe Idv::ImageUploadsController do
           {
             field: 'general',
             message: I18n.t('doc_auth.errors.alerts.barcode_content_check'),
-          },{
+          }, {
             field: 'back',
             message: I18n.t('doc_auth.errors.general.fallback_field_level'),
-          },
+          }
         ]
       end
 

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -128,6 +128,7 @@ describe ImageUploadResponsePresenter do
           success: false,
           errors: {
             front: t('doc_auth.errors.not_a_file'),
+            hints: true
           },
           extra: { remaining_attempts: 3 },
         )
@@ -137,6 +138,7 @@ describe ImageUploadResponsePresenter do
         expected = {
           success: false,
           errors: [{ field: :front, message: t('doc_auth.errors.not_a_file') }],
+          hints: true,
           remaining_attempts: 3,
         }
 

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -128,7 +128,7 @@ describe ImageUploadResponsePresenter do
           success: false,
           errors: {
             front: t('doc_auth.errors.not_a_file'),
-            hints: true
+            hints: true,
           },
           extra: { remaining_attempts: 3 },
         )

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -119,7 +119,12 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       aggregate_failures do
         expect(response.success?).to eq(false)
 
-        expect(response.errors).to eq(id: [DocAuth::Errors::DOCUMENT_EXPIRED_CHECK])
+        expect(response.errors).to eq(
+          general: [DocAuth::Errors::DOCUMENT_EXPIRED_CHECK],
+          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
+        )
 
         expect(response.pii_from_doc).to include(
           first_name: 'FAKEY',
@@ -143,7 +148,10 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
     it 'returns an unsuccessful response with errors' do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(
-        id: ['id_not_recognized'],
+        general: [DocAuth::Errors::ID_NOT_RECOGNIZED],
+        front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+        back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+        hints: true,
       )
       expect(response.exception).to be_nil
       expect(response.result_code).to eq(DocAuth::Acuant::ResultCodes::UNKNOWN)
@@ -162,7 +170,10 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       it 'returns the untranslated error' do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
-          id: ['id_not_recognized'],
+          general: [DocAuth::Errors::ID_NOT_RECOGNIZED],
+          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
         )
         expect(response.exception).to be_nil
       end
@@ -181,7 +192,10 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       it 'only returns one copy of the each error' do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
-          id: ['general_error_no_liveness'],
+          general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
         )
         expect(response.exception).to be_nil
       end
@@ -204,7 +218,10 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       it 'does not return errors for alerts with success result codes' do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
-          id: ['id_not_recognized'],
+          general: [DocAuth::Errors::ID_NOT_RECOGNIZED],
+          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
         )
         expect(response.exception).to be_nil
       end
@@ -224,6 +241,8 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
           general: [DocAuth::Errors::DPI_LOW_ONE_SIDE],
+          front: [DocAuth::Errors::DPI_LOW_FIELD],
+          hints: false,
         )
         expect(response.exception).to be_nil
         expect(response.result_code).to eq(DocAuth::Acuant::ResultCodes::UNKNOWN)

--- a/spec/services/doc_auth/error_generator_spec.rb
+++ b/spec/services/doc_auth/error_generator_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:back)
-      expect(output[:back]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed' do
@@ -54,8 +56,25 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::ID_NOT_VERIFIED)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::ID_NOT_VERIFIED)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
+    end
+
+    it 'DocAuthResult is Failed with single alert with a side' do
+      error_info = build_error_info(
+        doc_result: 'Failed',
+        failed: [{ name: 'Visible Pattern', result: 'Failed', side: 'front' }],
+      )
+
+      output = described_class.new(config).generate_doc_auth_errors(error_info)
+
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::ID_NOT_VERIFIED)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with multiple different alerts' do
@@ -69,8 +88,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with multiple id alerts' do
@@ -84,8 +106,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with multiple front alerts' do
@@ -99,8 +124,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::MULTIPLE_FRONT_ID_FAILURES)
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::MULTIPLE_FRONT_ID_FAILURES)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with multiple back alerts' do
@@ -114,8 +141,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::MULTIPLE_BACK_ID_FAILURES)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::MULTIPLE_BACK_ID_FAILURES)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with an unknown alert' do
@@ -129,8 +158,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with multiple alerts including an unknown' do
@@ -147,8 +179,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::BIRTH_DATE_CHECKS)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::BIRTH_DATE_CHECKS)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Failed with an unknown passed alert' do
@@ -163,8 +198,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:id)
-      expect(output[:id]).to contain_exactly(DocAuth::Errors::BIRTH_DATE_CHECKS)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::BIRTH_DATE_CHECKS)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
   end
 
@@ -178,8 +216,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:back)
-      expect(output[:back]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Attention and selfie has failed' do
@@ -191,8 +231,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_LIVENESS)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult is Attention and selfie has succeeded' do
@@ -204,8 +246,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:back)
-      expect(output[:back]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::BARCODE_READ_CHECK)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(true)
     end
 
     it 'DocAuthResult has passed but liveness failed' do
@@ -213,8 +257,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:selfie)
-      expect(output[:selfie]).to contain_exactly(DocAuth::Errors::SELFIE_FAILURE)
+      expect(output.keys).to contain_exactly(:general, :selfie, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::SELFIE_FAILURE)
+      expect(output[:selfie]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(output[:hints]).to eq(false)
     end
   end
 
@@ -242,8 +288,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::DPI_LOW_ONE_SIDE)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::DPI_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'front image VDPI is too low' do
@@ -252,8 +300,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::DPI_LOW_ONE_SIDE)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::DPI_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'back image HDPI is too low' do
@@ -262,8 +312,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::DPI_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::DPI_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'front and back image DPI is too low' do
@@ -273,8 +325,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::DPI_LOW_BOTH_SIDES)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::DPI_LOW_FIELD)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::DPI_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'front image sharpness is too low' do
@@ -283,8 +338,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::SHARP_LOW_ONE_SIDE)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'back image sharpness is too low' do
@@ -293,8 +350,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::SHARP_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'both images sharpness is too low' do
@@ -304,8 +363,11 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::SHARP_LOW_BOTH_SIDES)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'both images sharpness is too low' do
@@ -315,8 +377,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::SHARP_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'front image glare is too low' do
@@ -325,8 +389,10 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GLARE_LOW_ONE_SIDE)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
     it 'back image glare is too low' do
@@ -335,40 +401,37 @@ RSpec.describe DocAuth::ErrorGenerator do
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GLARE_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
-    it 'front image glare is too low' do
-      metrics[:back]['GlareMetric'] = 25
-      error_info = build_error_info(image_metrics: metrics)
-
-      output = described_class.new(config).generate_doc_auth_errors(error_info)
-
-      expect(output.keys).to contain_exactly(:general)
-      expect(output[:general]).to contain_exactly(DocAuth::Errors::GLARE_LOW_ONE_SIDE)
-    end
-
-    it 'both images sharpness is too low' do
+    it 'both images glare is too low' do
       metrics[:front]['GlareMetric'] = 25
       metrics[:back]['GlareMetric'] = 25
       error_info = build_error_info(image_metrics: metrics)
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GLARE_LOW_BOTH_SIDES)
+      expect(output[:front]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
 
-    it 'both images sharpness is too low' do
+    it 'both images glare is too low' do
       metrics[:front].delete('GlareMetric')
       metrics[:back]['GlareMetric'] = 25
       error_info = build_error_info(image_metrics: metrics)
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
-      expect(output.keys).to contain_exactly(:general)
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
       expect(output[:general]).to contain_exactly(DocAuth::Errors::GLARE_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
     end
   end
 end

--- a/spec/services/doc_auth/error_generator_spec.rb
+++ b/spec/services/doc_auth/error_generator_spec.rb
@@ -433,5 +433,18 @@ RSpec.describe DocAuth::ErrorGenerator do
       expect(output[:back]).to contain_exactly(DocAuth::Errors::GLARE_LOW_FIELD)
       expect(output[:hints]).to eq(false)
     end
+
+    it 'both images have different problems' do
+      metrics[:front]['GlareMetric'] = 20
+      metrics[:back]['SharpnessMetric'] = 25
+      error_info = build_error_info(image_metrics: metrics)
+
+      output = described_class.new(config).generate_doc_auth_errors(error_info)
+
+      expect(output.keys).to contain_exactly(:general, :back, :hints)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::SHARP_LOW_ONE_SIDE)
+      expect(output[:back]).to contain_exactly(DocAuth::Errors::SHARP_LOW_FIELD)
+      expect(output[:hints]).to eq(false)
+    end
   end
 end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -250,10 +250,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       output = described_class.new(failure_response_empty, false, config).to_h
 
       expect(output[:success]).to eq(false)
-      expect(output[:errors]).to eq({
+      expect(output[:errors]).to eq(
         general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
         hints: true,
-      })
+      )
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info, :exception)
       expect(output[:vendor]).to eq('TrueID')
     end
@@ -278,11 +278,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       output = described_class.new(failure_response_no_liveness_low_dpi, false, config).to_h
 
       expect(output[:success]).to eq(false)
-      expect(output[:errors]).to eq({
+      expect(output[:errors]).to eq(
         general: [DocAuth::Errors::DPI_LOW_ONE_SIDE],
         front: [DocAuth::Errors::DPI_LOW_FIELD],
         hints: false,
-      })
+      )
       expect(output[:exception]).to be_nil
       expect(output[:doc_auth_result]).to eq('Failed')
     end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -155,10 +155,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       errors = output[:errors]
 
       expect(output[:success]).to eq(false)
-      expect(errors.keys).to contain_exactly(:general)
-      expect(errors[:general]).to contain_exactly(
-        DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS,
-      )
+      expect(errors.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(errors[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(errors[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:hints]).to eq(true)
     end
 
     it 'it produces appropriate errors with liveness' do
@@ -166,11 +167,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       errors = output[:errors]
 
       expect(output[:success]).to eq(false)
-      expect(errors.keys).to contain_exactly(:general)
-      expect(errors[:general]).to contain_exactly(
-        DocAuth::Errors::GENERAL_ERROR_LIVENESS,
-      )
-      expect(output[:vendor]).to eq('TrueID')
+      expect(errors.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(errors[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_LIVENESS)
+      expect(errors[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:hints]).to eq(true)
     end
 
     it 'it produces appropriate errors with liveness and everything failing' do
@@ -178,10 +179,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       errors = output[:errors]
 
       expect(output[:success]).to eq(false)
-      expect(errors.keys).to contain_exactly(:general)
-      expect(errors[:general]).to contain_exactly(
-        DocAuth::Errors::GENERAL_ERROR_LIVENESS,
-      )
+      expect(errors.keys).to contain_exactly(:general, :front, :back, :hints)
+      expect(errors[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_LIVENESS)
+      expect(errors[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+      expect(errors[:hints]).to eq(true)
     end
 
     it 'produces expected hash output' do
@@ -190,7 +192,12 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(output).to match(
         success: false,
         exception: nil,
-        errors: { general: [DocAuth::Errors::GENERAL_ERROR_LIVENESS] },
+        errors: {
+          general: [DocAuth::Errors::GENERAL_ERROR_LIVENESS],
+          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
+        },
         conversation_id: a_kind_of(String),
         reference: a_kind_of(String),
         vendor: 'TrueID',
@@ -243,7 +250,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       output = described_class.new(failure_response_empty, false, config).to_h
 
       expect(output[:success]).to eq(false)
-      expect(output[:errors]).to eq(general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS])
+      expect(output[:errors]).to eq({
+        general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+        hints: true,
+      })
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info, :exception)
       expect(output[:vendor]).to eq('TrueID')
     end
@@ -268,9 +278,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       output = described_class.new(failure_response_no_liveness_low_dpi, false, config).to_h
 
       expect(output[:success]).to eq(false)
-      expect(output[:errors]).to eq(
+      expect(output[:errors]).to eq({
         general: [DocAuth::Errors::DPI_LOW_ONE_SIDE],
-      )
+        front: [DocAuth::Errors::DPI_LOW_FIELD],
+        hints: false,
+      })
       expect(output[:exception]).to be_nil
       expect(output[:doc_auth_result]).to eq('Failed')
     end

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -114,7 +114,11 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(id: [DocAuth::Errors::MULTIPLE_BACK_ID_FAILURES])
+        expect(response.errors).to eq(
+          general: [DocAuth::Errors::MULTIPLE_BACK_ID_FAILURES],
+          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: true,
+        )
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq({})
       end
@@ -150,7 +154,11 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(general: [DocAuth::Errors::DPI_LOW_ONE_SIDE])
+        expect(response.errors).to eq(
+          general: [DocAuth::Errors::DPI_LOW_ONE_SIDE],
+          back: [DocAuth::Errors::DPI_LOW_FIELD],
+          hints: false,
+        )
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq({})
       end
@@ -251,7 +259,11 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq({ selfie: [DocAuth::Errors::SELFIE_FAILURE]})
+        expect(response.errors).to eq({
+          general: [DocAuth::Errors::SELFIE_FAILURE],
+          selfie: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+          hints: false,
+        })
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq({})
       end

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -259,11 +259,11 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq({
+        expect(response.errors).to eq(
           general: [DocAuth::Errors::SELFIE_FAILURE],
           selfie: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
           hints: false,
-        })
+        )
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq({})
       end


### PR DESCRIPTION
Doc Auth: Added the ability to hide and show capture hints for the user depending on error returned from the backend. Also added field level errors where applicable for the user.