### PR TITLE
Configure and fix Rubocop redundant disabling/enabling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -480,6 +480,12 @@ Lint/RaiseException:
 Lint/RandOne:
   Enabled: true
 
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
+Lint/RedundantCopEnableDirective:
+  Enabled: true
+
 Lint/RedundantRequireStatement:
   Enabled: true
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,5 +1,4 @@
 module FormHelper
-  # rubocop:disable Style/WordArray
   # This method is single statement spread across many lines for readability
   def us_states_territories
     [
@@ -65,7 +64,6 @@ module FormHelper
       ['Wyoming', 'WY'],
     ]
   end
-  # rubocop:enable Style/WordArray
 
   private
 

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -30,7 +30,6 @@ class AttributeAsserter
     self.user_session = user_session
   end
 
-  # rubocop:disable Metrics/PerceivedComplexity
   def build
     attrs = default_attrs
     add_email(attrs) if bundle.include? :email
@@ -42,7 +41,6 @@ class AttributeAsserter
     add_x509(attrs) if bundle.include?(:x509_presented) && x509_data
     user.asserted_attributes = attrs
   end
-  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -49,7 +49,6 @@ module DocAuth
       'Visible Photo Characteristics': { type: FRONT, msg_key: Errors::VISIBLE_PHOTO_CHECK },
     }.freeze
 
-    # rubocop:disable Metrics/PerceivedComplexity
     def generate_doc_auth_errors(response_info)
       liveness_enabled = response_info[:liveness_enabled]
       alert_error_count = response_info[:alert_failure_count]
@@ -95,8 +94,6 @@ module DocAuth
 
       errors.transform_values(&:to_a)
     end
-    # rubocop:enable Metrics/PerceivedComplexity
-
     # private
 
     def get_image_metric_errors(processed_image_metrics)

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Lint/UnusedMethodArgument
 module DocAuth
   module Mock
     class DocAuthMockClient
@@ -124,4 +123,3 @@ module DocAuth
     end
   end
 end
-# rubocop:enable Lint/UnusedMethodArgument

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -98,7 +98,7 @@ module Encryption
       # checking if it looks like the JSON hash we want
       if ciphertext.start_with?('{"regions"')
         parsed_payload = JSON.parse(ciphertext)
-        if parsed_payload.is_a?(Hash) # rubocop:disable Style/GuardClause
+        if parsed_payload.is_a?(Hash)
           regions = parsed_payload['regions']
           resolve_region_decryption(regions)
         else

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -147,7 +147,6 @@ module Telephony
           },
         )
       end
-      # rubocop:enable Metrics/MethodLength
 
       def success?(message_response_result)
         message_response_result.delivery_status == 'SUCCESSFUL'

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -165,14 +165,11 @@ feature 'doc auth verify step' do
         success: true, errors: {}, context: { stages: [] },
       )
 
-      # rubocop:disable Layout/LineLength
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS +
           [DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
       )
-      # rubocop:enable Layout/LineLength
-
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
       click_idv_continue
@@ -195,14 +192,11 @@ feature 'doc auth verify step' do
         success: true, errors: {}, context: { stages: [] },
       )
 
-      # rubocop:disable Layout/LineLength
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS -
           [DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
       )
-      # rubocop:enable Layout/LineLength
-
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
       click_idv_continue

--- a/spec/services/proofing/base_spec.rb
+++ b/spec/services/proofing/base_spec.rb
@@ -273,13 +273,10 @@ describe Proofing::Base do
       subject { impl.new.proof(applicant) }
 
       it 'does not affect the other proofer' do
-        # rubocop:disable Lint/UselessAssignment
         # This is an explicit check for class-level side effects
         impl2 = Class.new(Proofing::Base) do
           required_attributes :foobarbaz
         end
-        # rubocop:enable Lint/UselessAssignment
-
         expect(subject.exception?).to eq(false)
         expect(subject.failed?).to eq(false)
         expect(subject.success?).to eq(true)

--- a/spec/support/acuant_fixtures.rb
+++ b/spec/support/acuant_fixtures.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Naming/AccessorMethodName
 module AcuantFixtures
   def self.create_document_response
     load_response_fixture('create_document_response.json')
@@ -45,4 +44,3 @@ module AcuantFixtures
     File.read(path)
   end
 end
-# rubocop:enable Naming/AccessorMethodName


### PR DESCRIPTION
**Why**: Because the inline configuration should only be used in cases where we're expecting a cop failure to otherwise occur.

Resources:

- https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantcopdisabledirective
- https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantcopenabledirective