### PR TITLE
Refactor remote SAML logout user lookup

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -36,15 +36,9 @@ module SamlIdpLogoutConcern
     uuid = saml_request.session_index
     issuer = saml_request.issuer
     agency_id = ServiceProvider.find_by(issuer: issuer).agency_id
-    AgencyIdentity.find_by(agency_id: agency_id, uuid: uuid)&.user_id
-  end
-
-  def valid_remote_logout_user_id?(user_id)
-    return false unless user_id.present?
-    ServiceProviderIdentity.where(
-      user_id: user_id,
-      service_provider: saml_request.issuer,
-    ).count.positive?
+    user_id = AgencyIdentity.find_by(agency_id: agency_id, uuid: uuid)&.user_id
+    # ensure that the user has authenticated to that SP
+    ServiceProviderIdentity.find_by(user_id: user_id, service_provider: issuer)&.user_id
   end
 
   def logout_response

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -60,7 +60,7 @@ class SamlIdpController < ApplicationController
 
     user_id = find_user_from_session_index
 
-    return head(:bad_request) unless valid_remote_logout_user_id?(user_id)
+    return head(:bad_request) unless user_id.present?
 
     handle_valid_sp_remote_logout_request(user_id)
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -121,27 +121,46 @@ describe SamlIdpController do
       delete :remotelogout, params: { SAMLRequest: 'foo' }
     end
 
+    let(:agency) { create(:agency) }
     let(:service_provider) do
       create(
         :service_provider,
         certs: ['sp_sinatra_demo', 'saml_test_sp'],
         active: true,
         assertion_consumer_logout_service_url: 'https://example.com',
+        agency_id: agency.id,
       )
     end
+    let(:other_sp) { create(:service_provider, active: true, agency_id: agency.id) }
 
     let(:user) { create(:user, :signed_up, unique_session_id: 'abc123') }
+    let(:other_user) { create(:user, :signed_up) }
+
     let!(:identity) do
       ServiceProviderIdentity.create(
         service_provider: service_provider.issuer,
         user: user,
       )
     end
+    let!(:other_identity) do
+      ServiceProviderIdentity.create(
+        service_provider: other_sp.issuer,
+        user: other_user,
+      )
+    end
+
     let!(:agency_identity) do
       AgencyIdentity.create!(
-        agency: service_provider.agency,
+        agency: agency,
         user: user,
         uuid: identity.uuid,
+      )
+    end
+    let!(:other_agency_identity) do
+      AgencyIdentity.create!(
+        agency: agency,
+        user: other_user,
+        uuid: other_identity.uuid,
       )
     end
 
@@ -170,6 +189,16 @@ describe SamlIdpController do
           issuer: service_provider.issuer,
           assertion_consumer_logout_service_url: 'https://example.com',
           sessionindex: 'abc123',
+        },
+      )
+    end
+
+    let(:right_cert_bad_user_settings) do
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          assertion_consumer_logout_service_url: 'https://example.com',
+          sessionindex: other_agency_identity.uuid,
         },
       )
     end
@@ -252,6 +281,37 @@ describe SamlIdpController do
     it 'rejects requests from a correct cert but bad session index' do
       saml_request = UriService.params(
         OneLogin::RubySaml::Logoutrequest.new.create(right_cert_bad_session_settings),
+      )[:SAMLRequest]
+
+      payload = [
+        ['SAMLRequest', saml_request],
+        ['RelayState', 'aaa'],
+        ['SigAlg', 'SHA256'],
+      ]
+      canon_string = payload.map { |k, v| "#{k}=#{CGI.escape(v)}" }.join('&')
+
+      private_sp_key = OpenSSL::PKey::RSA.new(right_cert_settings.private_key)
+      signature = private_sp_key.sign(OpenSSL::Digest.new('SHA256'), canon_string)
+
+      certificate = OpenSSL::X509::Certificate.new(right_cert_settings.certificate)
+
+      # This is the same verification process we expect the SAML gem will run
+      expect(
+        certificate.public_key.verify(
+          OpenSSL::Digest.new('SHA256'),
+          signature,
+          canon_string,
+        ),
+      ).to eq(true)
+
+      delete :remotelogout, params: payload.to_h.merge(Signature: Base64.encode64(signature))
+
+      expect(response).to be_bad_request
+    end
+
+    it 'rejects requests from a correct cert but a non-associated user' do
+      saml_request = UriService.params(
+        OneLogin::RubySaml::Logoutrequest.new.create(right_cert_bad_user_settings),
       )[:SAMLRequest]
 
       payload = [


### PR DESCRIPTION
**Why:** We weren't testing this case explicitly and in the course of
writing said test this refactor in the concern seemed cleaner than the
original.