### PR TITLE
Fix regression in displaying connected account times (LG-5472)

### DIFF
--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -12,7 +12,7 @@
       <%= t(
             'account.connected_apps.associated',
             timestamp: local_time(identity.created_at.in_time_zone('UTC'), t('time.formats.event_timestamp')),
-          ) %>
+          ).html_safe %>
     </div>
     <% if identity.service_provider_id %>
       <div class="sm-col sm-col-6 padding-x-1 sm-right-align line-height-4">

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -29,6 +29,7 @@ describe 'accounts/connected_accounts/show.html.erb' do
 
     it 'renders' do
       expect { render }.to_not raise_error
+      expect(rendered).to match '</time>'
     end
   end
 end

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -30,6 +30,7 @@ describe 'accounts/connected_accounts/show.html.erb' do
     it 'renders' do
       expect { render }.to_not raise_error
       expect(rendered).to match '</time>'
+      expect(rendered).to_not include('&lt;')
     end
   end
 end


### PR DESCRIPTION
https://github.com/18F/identity-idp/pull/5683 introduced a regression that broke displaying times, this PR reverts that change