### PR TITLE
[Logging] Log an event when the user chooses to use a different number. (LG-5259)

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -8,8 +8,8 @@ module Idv
     before_action :set_idv_form
 
     def new
-      if params[:location]
-        analytics.track_event(Analytics::IDV_PHONE_USE_DIFFERENT, location: params[:location])
+      if params[:step]
+        analytics.track_event(Analytics::IDV_PHONE_USE_DIFFERENT, step: params[:step])
       end
 
       redirect_to failure_url(:fail) and return if throttle.throttled?

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -8,6 +8,10 @@ module Idv
     before_action :set_idv_form
 
     def new
+      if params[:location]
+        analytics.track_event(Analytics::IDV_PHONE_USE_DIFFERENT, location: params[:location])
+      end
+
       redirect_to failure_url(:fail) and return if throttle.throttled?
 
       async_state = step.async_state

--- a/app/presenters/idv/otp_verification_presenter.rb
+++ b/app/presenters/idv/otp_verification_presenter.rb
@@ -19,8 +19,9 @@ module Idv
     end
 
     def update_phone_link
-      current_path = Rails.application.routes.url_helpers.idv_otp_verification_path
-      phone_path = Rails.application.routes.url_helpers.idv_phone_path(location: current_path)
+      phone_path = Rails.application.routes.url_helpers.idv_phone_path(
+        step: 'phone_otp_verification',
+      )
       link = link_to(t('forms.two_factor.try_again'), phone_path)
       t('instructions.mfa.wrong_number_html', link: link)
     end

--- a/app/presenters/idv/otp_verification_presenter.rb
+++ b/app/presenters/idv/otp_verification_presenter.rb
@@ -19,7 +19,8 @@ module Idv
     end
 
     def update_phone_link
-      phone_path = Rails.application.routes.url_helpers.idv_phone_path
+      current_path = Rails.application.routes.url_helpers.idv_otp_verification_path
+      phone_path = Rails.application.routes.url_helpers.idv_phone_path(location: current_path)
       link = link_to(t('forms.two_factor.try_again'), phone_path)
       t('instructions.mfa.wrong_number_html', link: link)
     end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -173,6 +173,7 @@ class Analytics
   IDV_PHONE_CONFIRMATION_OTP_VISIT = 'IdV: phone confirmation otp visited'.freeze
   IDV_PHONE_OTP_DELIVERY_SELECTION_SUBMITTED = 'IdV: Phone OTP Delivery Selection Submitted'.freeze
   IDV_PHONE_OTP_DELIVERY_SELECTION_VISIT = 'IdV: Phone OTP delivery Selection Visited'.freeze
+  IDV_PHONE_USE_DIFFERENT = 'IdV: use different phone number'.freeze
   IDV_PHONE_RECORD_VISIT = 'IdV: phone of record visited'.freeze
   IDV_REVIEW_COMPLETE = 'IdV: review complete'.freeze
   IDV_REVIEW_VISIT = 'IdV: review info visited'.freeze

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -64,7 +64,7 @@
       heading: t('idv.troubleshooting.headings.having_trouble'),
       options: [
         {
-          url: idv_phone_path(location: idv_otp_delivery_method_path),
+          url: idv_phone_path(step: 'phone_otp_delivery_selection'),
           text: t('idv.troubleshooting.options.change_phone_number'),
         },
         gpo_letter_available && {

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -64,7 +64,7 @@
       heading: t('idv.troubleshooting.headings.having_trouble'),
       options: [
         {
-          url: idv_phone_path,
+          url: idv_phone_path(location: idv_otp_delivery_method_path),
           text: t('idv.troubleshooting.options.change_phone_number'),
         },
         gpo_letter_available && {

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -78,6 +78,23 @@ describe Idv::PhoneController do
       end
     end
 
+    context 'when the user has chosen to use a different number' do
+      let(:path_from) { 'path_where_user_asked_to_use_different_number' }
+      let(:params) { { location: path_from } }
+
+      before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
+
+      it 'logs an event showing that the user wants to choose a different number' do
+        get :new, params: params
+
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::IDV_PHONE_USE_DIFFERENT, location: path_from)
+      end
+    end
+
     it 'shows phone form if async process times out and allows successful resubmission' do
       stub_analytics
       allow(@analytics).to receive(:track_event)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -79,8 +79,8 @@ describe Idv::PhoneController do
     end
 
     context 'when the user has chosen to use a different number' do
-      let(:path_from) { 'path_where_user_asked_to_use_different_number' }
-      let(:params) { { location: path_from } }
+      let(:step) { 'path_where_user_asked_to_use_different_number' }
+      let(:params) { { step: step } }
 
       before do
         stub_analytics
@@ -91,7 +91,7 @@ describe Idv::PhoneController do
         get :new, params: params
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::IDV_PHONE_USE_DIFFERENT, location: path_from)
+          with(Analytics::IDV_PHONE_USE_DIFFERENT, step: step)
       end
     end
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -62,7 +62,7 @@ feature 'idv phone step' do
       click_link t('forms.two_factor.try_again')
 
       expect(page).to have_content(t('idv.titles.session.phone'))
-      expect(page).to have_current_path(idv_phone_path)
+      expect(page).to have_current_path(idv_phone_path(step: 'phone_otp_verification'))
 
       fill_out_phone_form_ok(second_phone_number)
       click_idv_continue


### PR DESCRIPTION
Currently "use a different phone number" links on both the IAL2 phone OTP pages aren't logged at all. This PR adds a `location` param to the link on each page with the path it is coming from, and if that location param is present, logs a new event.