### PR TITLE
Fix deprecations

### DIFF
--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -92,10 +92,7 @@ module DocAuth
         }
 
         Faraday.new(url: url.to_s, headers: headers) do |conn|
-          conn.basic_auth(
-            config.assure_id_username,
-            config.assure_id_password,
-          )
+          conn.request :basic_auth, config.assure_id_username, config.assure_id_password
           conn.request :instrumentation, name: 'request_metric.faraday'
           conn.request :retry, retry_options
           conn.adapter :net_http

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -86,7 +86,7 @@ module DocAuth
         Faraday.new(url: url.to_s, headers: headers) do |conn|
           conn.request :retry, retry_options
           conn.request :instrumentation, name: 'request_metric.faraday'
-          conn.basic_auth username, password
+          conn.request :basic_auth, username, password
           conn.adapter :net_http
           conn.options.timeout = timeout
           conn.options.read_timeout = timeout

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -19,12 +19,11 @@ module Proofing
       def send(response_options: {})
         conn = Faraday.new do |f|
           f.request :instrumentation, name: 'request_metric.faraday'
+          f.request :basic_auth, config.username, config.password
           f.options.timeout = timeout
           f.options.read_timeout = timeout
           f.options.open_timeout = timeout
           f.options.write_timeout = timeout
-
-          f.basic_auth config.username, config.password
         end
 
         Response.new(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -111,7 +111,7 @@ RSpec.configure do |config|
 
     # Always get the logs, even if logs are allowed for the spec, since otherwise unexpected
     # messages bleed over between specs.
-    javascript_errors = page.driver.browser.manage.logs.get(:browser).map(&:message)
+    javascript_errors = page.driver.browser.logs.get(:browser).map(&:message)
     next if spec.metadata[:allow_browser_log]
 
     # Temporarily allow for document-capture bundle, since it uses React error boundaries to poll.


### PR DESCRIPTION
Fixes some deprecations from #5694 

Ex:

```
2021-12-17 14:59:55 WARN Selenium [DEPRECATION] Manager#logs is deprecated. Use Chrome::Driver#logs instead.

WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```