### PR TITLE
LG-5450 update RiscDeliveryJob retry handling

### DIFF
--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -11,7 +11,7 @@ class RiscDeliveryJob < ApplicationJob
   retry_on(
     *NETWORK_ERRORS,
     wait: :exponentially_longer,
-    attempts: 5,
+    attempts: 2,
   )
   retry_on RedisRateLimiter::LimitError,
            wait: :exponentially_longer,


### PR DESCRIPTION
**Why**: Retry less on network errors: 2 instead of 5.  Discard exception after retries. ( GoodJob.retry_on_unhandled_error = false) already set