### PR TITLE
Clean up Profile.proofing_components column encoding

### DIFF
--- a/app/jobs/profile_proofing_components_backfill_job.rb
+++ b/app/jobs/profile_proofing_components_backfill_job.rb
@@ -1,0 +1,16 @@
+class ProfileProofingComponentsBackfillJob < ApplicationJob
+  queue_as :long_running
+
+  def perform
+    Profile.find_in_batches do |batch|
+      batch.each do |profile|
+        update_profile(profile)
+      end
+    end
+  end
+
+  def update_profile(profile)
+    profile.proofing_components = profile.proofing_components
+    profile.save! if profile.proofing_components_changed?
+  end
+end

--- a/app/jobs/profile_proofing_components_backfill_job.rb
+++ b/app/jobs/profile_proofing_components_backfill_job.rb
@@ -2,7 +2,7 @@ class ProfileProofingComponentsBackfillJob < ApplicationJob
   queue_as :long_running
 
   def perform
-    Profile.find_in_batches do |batch|
+    Profile.where("proofing_components->'id' IS NULL").find_in_batches do |batch|
       updated_count = 0
 
       batch.each do |profile|

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -24,9 +24,9 @@ class Profile < ApplicationRecord
   def proofing_components
     value = super
     if value.present?
-      if value.kind_of?(Hash)
+      if value.is_a?(Hash)
         value
-      elsif value.kind_of?(String)
+      elsif value.is_a?(String)
         JSON.parse(value)
       end
     end
@@ -37,7 +37,7 @@ class Profile < ApplicationRecord
     now = Time.zone.now
     is_reproof = Profile.find_by(user_id: user_id, active: true)
     transaction do
-      Profile.where(user_id:  user_id).update_all(active: false)
+      Profile.where(user_id: user_id).update_all(active: false)
       update!(active: true, activated_at: now, deactivation_reason: nil, verified_at: now)
     end
     send_push_notifications if is_reproof

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,12 +18,26 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
+  # Rails natively handles JSONB columns, however we have been double-serializing our data
+  # until now (saving JSON objects as JSON atoms)
+  # We can remove this override once run the backfill job to re-encode older values
+  def proofing_components
+    value = super
+    if value.present?
+      if value.kind_of?(Hash)
+        value
+      elsif value.kind_of?(String)
+        JSON.parse(value)
+      end
+    end
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def activate
     now = Time.zone.now
     is_reproof = Profile.find_by(user_id: user_id, active: true)
     transaction do
-      Profile.where('user_id=?', user_id).update_all(active: false)
+      Profile.where(user_id:  user_id).update_all(active: false)
       update!(active: true, activated_at: now, deactivation_reason: nil, verified_at: now)
     end
     send_push_notifications if is_reproof
@@ -81,7 +95,7 @@ class Profile < ApplicationRecord
 
   def includes_liveness_check?
     return if proofing_components.blank?
-    JSON.parse(proofing_components)['liveness_check']
+    proofing_components['liveness_check']
   end
 
   private

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -26,7 +26,7 @@ module Idv
     private
 
     def current_proofing_components
-      ProofingComponent.find_by(user_id: user.id)&.as_json || {}
+      user.proofing_component&.as_json || {}
     end
 
     attr_accessor :user, :user_password, :phone_confirmed, :document_expired

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -15,7 +15,7 @@ module Idv
         user: user,
       )
       profile.encrypt_pii(pii_attributes, user_password)
-      profile.proofing_components = current_proofing_components_to_json
+      profile.proofing_components = current_proofing_components
       if document_expired
         profile.reproof_at = IdentityConfig.store.proofing_expired_license_reproof_at
       end
@@ -25,9 +25,8 @@ module Idv
 
     private
 
-    def current_proofing_components_to_json
-      proofing_component = ProofingComponent.find_by(user_id: user.id)
-      (proofing_component || {}).to_json
+    def current_proofing_components
+      ProofingComponent.find_by(user_id: user.id)&.as_json || {}
     end
 
     attr_accessor :user, :user_password, :phone_confirmed, :document_expired

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
       :backup_code_configurations,
       :webauthn_configurations,
       :email_addresses,
+      :proofing_component,
     ].each do |association|
       Bullet.add_safelist(type: :n_plus_one_query, class_name: 'User', association: association)
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,7 +115,7 @@ describe ApplicationHelper do
                 :profile,
                 :verified,
                 deactivation_reason: :password_reset,
-                proofing_components: { liveness_check: DocAuthRouter.doc_auth_vendor }.to_json,
+                proofing_components: { liveness_check: DocAuthRouter.doc_auth_vendor },
               ),
             ],
           )

--- a/spec/jobs/profile_proofing_components_backfill_job_spec.rb
+++ b/spec/jobs/profile_proofing_components_backfill_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ProfileProofingComponentsBackfillJob do
+  describe '#perform' do
+    let(:old_updated_at) { 3.days.ago }
+    let(:now) { Time.zone.now }
+
+    it 'backfills data that was double-encoded as JSON' do
+      json_str = create(
+        :profile,
+        proofing_components: { 'foo' => true }.to_json,
+        updated_at: old_updated_at,
+      )
+      json_obj = create(
+        :profile,
+        proofing_components: { 'foo' => true },
+        updated_at: old_updated_at
+      )
+      blank_val = create(:profile, proofing_components: '', updated_at: old_updated_at)
+      nil_val = create(:profile, proofing_components: nil, updated_at: old_updated_at)
+
+      ProfileProofingComponentsBackfillJob.new.perform
+
+      json_str.reload
+      expect(json_str.read_attribute(:proofing_components)).to eq('foo' => true)
+      expect(json_str.updated_at.to_i).to be_within(1).of(now.to_i)
+
+      json_obj.reload
+      expect(json_obj.read_attribute(:proofing_components)).to eq('foo' => true)
+      expect(json_obj.updated_at.to_i).
+        to eq(old_updated_at.to_i), 'does not update correctly-encoded rows'
+
+      blank_val.reload
+      expect(blank_val.read_attribute(:proofing_components)).to eq(nil)
+      expect(json_str.updated_at.to_i).to be_within(1).of(now.to_i)
+
+      nil_val.reload
+      expect(nil_val.read_attribute(:proofing_components)).to eq(nil)
+      expect(json_str.updated_at.to_i).to be_within(1).of(now.to_i)
+    end
+  end
+end

--- a/spec/jobs/profile_proofing_components_backfill_job_spec.rb
+++ b/spec/jobs/profile_proofing_components_backfill_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProfileProofingComponentsBackfillJob do
       json_obj = create(
         :profile,
         proofing_components: { 'foo' => true },
-        updated_at: old_updated_at
+        updated_at: old_updated_at,
       )
       blank_val = create(:profile, proofing_components: '', updated_at: old_updated_at)
       nil_val = create(:profile, proofing_components: nil, updated_at: old_updated_at)

--- a/spec/jobs/profile_proofing_components_backfill_job_spec.rb
+++ b/spec/jobs/profile_proofing_components_backfill_job_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe ProfileProofingComponentsBackfillJob do
       blank_val = create(:profile, proofing_components: '', updated_at: old_updated_at)
       nil_val = create(:profile, proofing_components: nil, updated_at: old_updated_at)
 
+      expect(Rails.logger).to receive(:info).with(
+        {
+          name: 'profile_proofing_components_update_batch',
+          batch_size: 4,
+          batch_updated: 2,
+          batch_start: json_str.id,
+          batch_end: nil_val.id,
+        }.to_json,
+      )
+
       ProfileProofingComponentsBackfillJob.new.perform
 
       json_str.reload
@@ -32,11 +42,12 @@ RSpec.describe ProfileProofingComponentsBackfillJob do
 
       blank_val.reload
       expect(blank_val.read_attribute(:proofing_components)).to eq(nil)
-      expect(json_str.updated_at.to_i).to be_within(1).of(now.to_i)
+      expect(blank_val.updated_at.to_i).to be_within(1).of(now.to_i)
 
       nil_val.reload
       expect(nil_val.read_attribute(:proofing_components)).to eq(nil)
-      expect(json_str.updated_at.to_i).to be_within(1).of(now.to_i)
+      expect(nil_val.updated_at.to_i).
+        to eq(old_updated_at.to_i), 'does not update rows with nil values'
     end
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -20,6 +20,38 @@ describe Profile do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:gpo_confirmation_codes).dependent(:destroy) }
 
+  describe '#proofing_components' do
+    let(:profile) { create(:profile, proofing_components: proofing_components) }
+
+    context 'when the value is nil' do
+      let(:proofing_components) { nil }
+      it 'is nil' do
+        expect(profile.proofing_components).to eq(nil)
+      end
+    end
+
+    context 'when the value is the empty string' do
+      let(:proofing_components) { '' }
+      it 'is nil' do
+        expect(profile.proofing_components).to eq(nil)
+      end
+    end
+
+    context 'when the value is legacy encoding (JSON object as a JSON string atom)' do
+      let(:proofing_components) { { 'foo' => true }.to_json }
+      it 'is the object' do
+        expect(profile.proofing_components).to eq('foo' => true)
+      end
+    end
+
+    context 'when the value is a JSON object' do
+      let(:proofing_components) { { 'foo' => true } }
+      it 'is the object' do
+        expect(profile.proofing_components).to eq('foo' => true)
+      end
+    end
+  end
+
   describe '#encrypt_pii' do
     subject(:encrypt_pii) { profile.encrypt_pii(pii, user.password) }
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -25,7 +25,7 @@ describe Idv::ProfileMaker do
       expect(profile.id).to_not be_nil
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match 'Some'
-      expect(profile.proofing_components).to match proofing_component.to_json
+      expect(profile.proofing_components).to match proofing_component.as_json
       expect(profile.reproof_at).to be_nil
 
       expect(pii).to be_a Pii::Attributes


### PR DESCRIPTION
- The column is jsonb column, which ActiveRecord serializes already
- We were basically double-encoding JSON objects
- Adds a backfill job so we can clean up existing data and simplifying