### PR TITLE
LG-5468: Update IAL2 full-page ID error to show three troubleshooting options

### DIFF
--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -1,4 +1,5 @@
 import { BlockLink } from '@18f/identity-components';
+import { useI18n } from '@18f/identity-react-i18n';
 
 /**
  * @typedef TroubleshootingOption
@@ -12,7 +13,7 @@ import { BlockLink } from '@18f/identity-components';
  * @typedef TroubleshootingOptionsProps
  *
  * @prop {'h1'|'h2'|'h3'|'h4'|'h5'|'h6'=} headingTag
- * @prop {string} heading
+ * @prop {string=} heading
  * @prop {TroubleshootingOption[]} options
  */
 
@@ -20,11 +21,15 @@ import { BlockLink } from '@18f/identity-components';
  * @param {TroubleshootingOptionsProps} props
  */
 function TroubleshootingOptions({ headingTag = 'h2', heading, options }) {
+  const { t } = useI18n();
+
   const HeadingTag = headingTag;
 
   return (
     <section className="troubleshooting-options">
-      <HeadingTag className="troubleshooting-options__heading">{heading}</HeadingTag>
+      <HeadingTag className="troubleshooting-options__heading">
+        {heading ?? t('components.troubleshooting_options.default_heading')}
+      </HeadingTag>
       <ul className="troubleshooting-options__options">
         {options.map(({ url, text, isExternal }) => (
           <li key={url}>

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -2,6 +2,15 @@ import { render } from '@testing-library/react';
 import TroubleshootingOptions from './troubleshooting-options';
 
 describe('TroubleshootingOptions', () => {
+  it('renders the default heading', () => {
+    const { getByRole } = render(<TroubleshootingOptions options={[]} />);
+
+    const heading = getByRole('heading');
+
+    expect(heading.tagName).to.be.equal('H2');
+    expect(heading.textContent).to.equal('components.troubleshooting_options.default_heading');
+  });
+
   it('renders a given heading', () => {
     const { getByRole } = render(<TroubleshootingOptions heading="Need help?" options={[]} />);
 

--- a/app/javascript/packages/document-capture/components/capture-advice.jsx
+++ b/app/javascript/packages/document-capture/components/capture-advice.jsx
@@ -25,7 +25,12 @@ function CaptureAdvice({ onTryAgain, isAssessedAsGlare, isAssessedAsBlurry }) {
       heading={t('doc_auth.headings.capture_troubleshooting_tips')}
       actionText={t('idv.failure.button.warning')}
       actionOnClick={onTryAgain}
-      troubleshootingOptions={<DocumentCaptureTroubleshootingOptions location="capture_tips" />}
+      troubleshootingOptions={
+        <DocumentCaptureTroubleshootingOptions
+          heading={t('idv.troubleshooting.headings.still_having_trouble')}
+          location="capture_tips"
+        />
+      }
     >
       <p>
         {isAssessedAsGlare && t('doc_auth.tips.capture_troubleshooting_glare')}

--- a/app/javascript/packages/document-capture/components/capture-advice.jsx
+++ b/app/javascript/packages/document-capture/components/capture-advice.jsx
@@ -1,9 +1,7 @@
-import { useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import ServiceProviderContext from '../context/service-provider';
-import HelpCenterContext from '../context/help-center';
 import useAsset from '../hooks/use-asset';
 import Warning from './warning';
+import DocumentCaptureTroubleshootingOptions from './document-capture-troubleshooting-options';
 
 /** @typedef {import('@18f/identity-components/troubleshooting-options').TroubleshootingOption} TroubleshootingOption */
 
@@ -19,8 +17,6 @@ import Warning from './warning';
  * @param {CaptureAdviceProps} props
  */
 function CaptureAdvice({ onTryAgain, isAssessedAsGlare, isAssessedAsBlurry }) {
-  const { name: spName, getFailureToProofURL } = useContext(ServiceProviderContext);
-  const { getHelpCenterURL } = useContext(HelpCenterContext);
   const { getAssetPath } = useAsset();
   const { t } = useI18n();
 
@@ -29,25 +25,7 @@ function CaptureAdvice({ onTryAgain, isAssessedAsGlare, isAssessedAsBlurry }) {
       heading={t('doc_auth.headings.capture_troubleshooting_tips')}
       actionText={t('idv.failure.button.warning')}
       actionOnClick={onTryAgain}
-      troubleshootingHeading={t('idv.troubleshooting.headings.still_having_trouble')}
-      troubleshootingOptions={
-        /** @type {TroubleshootingOption[]} */ ([
-          {
-            url: getHelpCenterURL({
-              category: 'verify-your-identity',
-              article: 'how-to-add-images-of-your-state-issued-id',
-              location: 'capture_tips',
-            }),
-            text: t('idv.troubleshooting.options.doc_capture_tips'),
-            isExternal: true,
-          },
-          spName && {
-            url: getFailureToProofURL('capture_tips'),
-            text: t('idv.troubleshooting.options.get_help_at_sp', { sp_name: spName }),
-            isExternal: true,
-          },
-        ].filter(Boolean))
-      }
+      troubleshootingOptions={<DocumentCaptureTroubleshootingOptions location="capture_tips" />}
     >
       <p>
         {isAssessedAsGlare && t('doc_auth.tips.capture_troubleshooting_glare')}

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
@@ -9,6 +9,7 @@ import HelpCenterContext from '../context/help-center';
 /**
  * @typedef DocumentCaptureTroubleshootingOptionsProps
  *
+ * @prop {string=} heading Custom heading to show in place of default.
  * @prop {string=} location Location parameter to append to links.
  */
 
@@ -16,6 +17,7 @@ import HelpCenterContext from '../context/help-center';
  * @param {DocumentCaptureTroubleshootingOptionsProps} props
  */
 function DocumentCaptureTroubleshootingOptions({
+  heading,
   location = 'document_capture_troubleshooting_options',
 }) {
   const { t } = useI18n();
@@ -24,6 +26,7 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <TroubleshootingOptions
+      heading={heading}
       options={
         /** @type {TroubleshootingOption[]} */ ([
           {

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
@@ -6,7 +6,18 @@ import HelpCenterContext from '../context/help-center';
 
 /** @typedef {import('@18f/identity-components/troubleshooting-options').TroubleshootingOption} TroubleshootingOption */
 
-function DocumentCaptureTroubleshootingOptions() {
+/**
+ * @typedef DocumentCaptureTroubleshootingOptionsProps
+ *
+ * @prop {string=} location Location parameter to append to links.
+ */
+
+/**
+ * @param {DocumentCaptureTroubleshootingOptionsProps} props
+ */
+function DocumentCaptureTroubleshootingOptions({
+  location = 'document_capture_troubleshooting_options',
+}) {
   const { t } = useI18n();
   const { getHelpCenterURL } = useContext(HelpCenterContext);
   const { name: spName, getFailureToProofURL } = useContext(ServiceProviderContext);
@@ -20,7 +31,7 @@ function DocumentCaptureTroubleshootingOptions() {
             url: getHelpCenterURL({
               category: 'verify-your-identity',
               article: 'how-to-add-images-of-your-state-issued-id',
-              location: 'document_capture_troubleshooting_options',
+              location,
             }),
             text: t('idv.troubleshooting.options.doc_capture_tips'),
             isExternal: true,
@@ -29,13 +40,13 @@ function DocumentCaptureTroubleshootingOptions() {
             url: getHelpCenterURL({
               category: 'verify-your-identity',
               article: 'accepted-state-issued-identification',
-              location: 'document_capture_troubleshooting_options',
+              location,
             }),
             text: t('idv.troubleshooting.options.supported_documents'),
             isExternal: true,
           },
           spName && {
-            url: getFailureToProofURL('document_capture_troubleshooting_options'),
+            url: getFailureToProofURL(location),
             text: t('idv.troubleshooting.options.get_help_at_sp', { sp_name: spName }),
             isExternal: true,
           },

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.jsx
@@ -24,7 +24,6 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <TroubleshootingOptions
-      heading={t('idv.troubleshooting.headings.having_trouble')}
       options={
         /** @type {TroubleshootingOption[]} */ ([
           {

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -13,12 +13,9 @@ import DocumentCaptureTroubleshootingOptions from './document-capture-troublesho
 import PageHeading from './page-heading';
 import StartOverOrCancel from './start-over-or-cancel';
 import Warning from './warning';
-import HelpCenterContext from '../context/help-center';
 import AnalyticsContext from '../context/analytics';
 import useDidUpdateEffect from '../hooks/use-did-update-effect';
 import './review-issues-step.scss';
-
-/** @typedef {import('@18f/identity-components/troubleshooting-options').TroubleshootingOption} TroubleshootingOption */
 
 /**
  * @typedef {'front'|'back'} DocumentSide
@@ -77,11 +74,9 @@ function ReviewIssuesStep({
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
   const serviceProvider = useContext(ServiceProviderContext);
-  const { getHelpCenterURL } = useContext(HelpCenterContext);
   const { addPageAction } = useContext(AnalyticsContext);
   const selfieError = errors.find(({ field }) => field === 'selfie')?.error;
   const [hasDismissed, setHasDismissed] = useState(remainingAttempts === Infinity);
-  const { name: spName, getFailureToProofURL } = useContext(ServiceProviderContext);
   const { onPageTransition } = useContext(FormStepsContext);
   useDidUpdateEffect(onPageTransition, [hasDismissed]);
 
@@ -168,22 +163,7 @@ function ReviewIssuesStep({
       actionText={t('idv.failure.button.warning')}
       actionOnClick={onWarningPageDismissed}
       troubleshootingOptions={
-        /** @type {TroubleshootingOption[]} */ ([
-          {
-            url: getHelpCenterURL({
-              category: 'verify-your-identity',
-              article: 'how-to-add-images-of-your-state-issued-id',
-              location: 'post_submission_warning',
-            }),
-            text: t('idv.troubleshooting.options.doc_capture_tips'),
-            isExternal: true,
-          },
-          spName && {
-            url: getFailureToProofURL('post_submission_warning'),
-            text: t('idv.troubleshooting.options.get_help_at_sp', { sp_name: spName }),
-            isExternal: true,
-          },
-        ].filter(Boolean))
+        <DocumentCaptureTroubleshootingOptions location="post_submission_warning" />
       }
     >
       {!!unknownFieldErrors &&

--- a/app/javascript/packages/document-capture/components/warning.jsx
+++ b/app/javascript/packages/document-capture/components/warning.jsx
@@ -1,10 +1,6 @@
-import { isValidElement } from 'react';
-import { useI18n } from '@18f/identity-react-i18n';
-import { TroubleshootingOptions } from '@18f/identity-components';
 import useAsset from '../hooks/use-asset';
 import PageHeading from './page-heading';
 
-/** @typedef {import('@18f/identity-components/troubleshooting-options').TroubleshootingOption} TroubleshootingOption */
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
@@ -14,22 +10,13 @@ import PageHeading from './page-heading';
  * @prop {string=} actionText Primary action button text.
  * @prop {(() => void)=} actionOnClick Primary action button text.
  * @prop {import('react').ReactNode} children Component children.
- * @prop {string=} troubleshootingHeading Heading text preceding troubleshooting options.
- * @prop {TroubleshootingOption[]|ReactNode=} troubleshootingOptions Troubleshooting options.
+ * @prop {ReactNode=} troubleshootingOptions Troubleshooting options.
  */
 
 /**
  * @param {WarningProps} props
  */
-function Warning({
-  heading,
-  actionText,
-  actionOnClick,
-  children,
-  troubleshootingHeading,
-  troubleshootingOptions,
-}) {
-  const { t } = useI18n();
+function Warning({ heading, actionText, actionOnClick, children, troubleshootingOptions }) {
   const { getAssetPath } = useAsset();
 
   return (
@@ -54,13 +41,7 @@ function Warning({
           </button>
         </div>
       )}
-      {troubleshootingOptions && isValidElement(troubleshootingOptions) && troubleshootingOptions}
-      {troubleshootingOptions && !isValidElement(troubleshootingOptions) && (
-        <TroubleshootingOptions
-          heading={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
-          options={/** @type {TroubleshootingOption[]} */ (troubleshootingOptions)}
-        />
-      )}
+      {troubleshootingOptions}
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/warning.jsx
+++ b/app/javascript/packages/document-capture/components/warning.jsx
@@ -1,9 +1,11 @@
+import { isValidElement } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
 import { TroubleshootingOptions } from '@18f/identity-components';
 import useAsset from '../hooks/use-asset';
 import PageHeading from './page-heading';
 
 /** @typedef {import('@18f/identity-components/troubleshooting-options').TroubleshootingOption} TroubleshootingOption */
+/** @typedef {import('react').ReactNode} ReactNode */
 
 /**
  * @typedef WarningProps
@@ -13,7 +15,7 @@ import PageHeading from './page-heading';
  * @prop {(() => void)=} actionOnClick Primary action button text.
  * @prop {import('react').ReactNode} children Component children.
  * @prop {string=} troubleshootingHeading Heading text preceding troubleshooting options.
- * @prop {(TroubleshootingOption[])=} troubleshootingOptions Array of troubleshooting options.
+ * @prop {TroubleshootingOption[]|ReactNode=} troubleshootingOptions Troubleshooting options.
  */
 
 /**
@@ -52,10 +54,11 @@ function Warning({
           </button>
         </div>
       )}
-      {troubleshootingOptions && (
+      {troubleshootingOptions && isValidElement(troubleshootingOptions) && troubleshootingOptions}
+      {troubleshootingOptions && !isValidElement(troubleshootingOptions) && (
         <TroubleshootingOptions
           heading={troubleshootingHeading || t('idv.troubleshooting.headings.having_trouble')}
-          options={troubleshootingOptions}
+          options={/** @type {TroubleshootingOption[]} */ (troubleshootingOptions)}
         />
       )}
     </>

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -29,7 +29,7 @@
 
 <%= render(
       'shared/troubleshooting_options',
-      heading: t('idv.troubleshooting.headings.having_trouble'),
+      heading: t('components.troubleshooting_options.default_heading'),
       options: [
         {
           url: help_center_redirect_url(

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -61,7 +61,7 @@
 
 <%= render(
       'shared/troubleshooting_options',
-      heading: t('idv.troubleshooting.headings.having_trouble'),
+      heading: t('components.troubleshooting_options.default_heading'),
       options: [
         {
           url: idv_phone_path(step: 'phone_otp_delivery_selection'),

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -74,7 +74,7 @@
 
 <%= render(
       'shared/troubleshooting_options',
-      heading: t('idv.troubleshooting.headings.having_trouble'),
+      heading: t('components.troubleshooting_options.default_heading'),
       options: [
         {
           url: help_center_redirect_url(

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -13,7 +13,7 @@ locals:
   troubleshooting_heading = t('idv.troubleshooting.headings.need_assistance')
 else
   image_src = 'alert/warning-lg.svg'
-  troubleshooting_heading = t('idv.troubleshooting.headings.having_trouble')
+  troubleshooting_heading = t('components.troubleshooting_options.default_heading')
 end
 %>
 <% title local_assigns.fetch(:title, heading) %>

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -3,3 +3,5 @@ en:
   components:
     phone_input:
       country_code_label: Country code
+    troubleshooting_options:
+      default_heading: 'Having trouble? Here’s what you can do:'

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -3,3 +3,5 @@ es:
   components:
     phone_input:
       country_code_label: Código del país
+    troubleshooting_options:
+      default_heading: '¿Tiene alguna dificultad? Esto es lo que puede hacer:'

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -3,3 +3,5 @@ fr:
   components:
     phone_input:
       country_code_label: Code pays
+    troubleshooting_options:
+      default_heading: 'Des difficultés? Voici ce que vous pouvez faire:'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -157,7 +157,6 @@ en:
         review: Re-enter your %{app_name} password to protect your data
     troubleshooting:
       headings:
-        having_trouble: 'Having trouble? Here’s what you can do:'
         missing_required_items: Are you missing one of these items?
         need_assistance: 'Need immediate assistance? Here’s how to get help:'
         still_having_trouble: Still having trouble?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -163,7 +163,6 @@ es:
         review: Vuelve a ingresar tu contraseña de %{app_name} para encriptar tus datos
     troubleshooting:
       headings:
-        having_trouble: '¿Tiene alguna dificultad? Esto es lo que puede hacer:'
         missing_required_items: '¿Le falta alguno de estos puntos?'
         need_assistance: '¿Necesita ayuda inmediata? Así es como puede obtener ayuda:'
         still_having_trouble: ¿Sigue teniendo dificultades?

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -176,7 +176,6 @@ fr:
         review: Entrez à nouveau votre mot de passe %{app_name} pour crypter vos données
     troubleshooting:
       headings:
-        having_trouble: 'Des difficultés? Voici ce que vous pouvez faire:'
         missing_required_items: Est-ce qu’il vous manque un de ces éléments?
         need_assistance: 'Avez-vous besoin d’une assistance immédiate? Voici comment
           obtenir de l’aide:'

--- a/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
@@ -105,4 +105,14 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
       });
     });
   });
+
+  context('with heading prop', () => {
+    it('shows heading text', () => {
+      const { getByRole } = render(
+        <DocumentCaptureTroubleshootingOptions heading="custom heading" />,
+      );
+
+      expect(getByRole('heading', { name: 'custom heading' })).to.exist();
+    });
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { composeComponents } from '@18f/identity-compose-components';
 import {
   HelpCenterContextProvider,
   ServiceProviderContextProvider,
@@ -7,26 +6,30 @@ import {
 import DocumentCaptureTroubleshootingOptions from '@18f/identity-document-capture/components/document-capture-troubleshooting-options';
 
 describe('DocumentCaptureTroubleshootingOptions', () => {
-  function renderWithContext({ serviceProviderContext } = {}) {
-    const Component = composeComponents(
-      ...[
-        [
-          HelpCenterContextProvider,
-          { value: { helpCenterRedirectURL: 'https://example.com/redirect/' } },
-        ],
-        serviceProviderContext && [
-          ServiceProviderContextProvider,
-          { value: serviceProviderContext },
-        ],
-        [DocumentCaptureTroubleshootingOptions],
-      ].filter(Boolean),
-    );
-
-    return render(<Component />);
-  }
+  const helpCenterRedirectURL = 'https://example.com/redirect/';
+  const serviceProviderContext = {
+    name: 'Example SP',
+    failureToProofURL: 'http://example.test/url/to/failure-to-proof',
+  };
+  const wrappers = {
+    helpCenterContext: ({ children }) => (
+      <HelpCenterContextProvider value={{ helpCenterRedirectURL }}>
+        {children}
+      </HelpCenterContextProvider>
+    ),
+    helpCenterAndServiceProviderContext: ({ children }) => (
+      <HelpCenterContextProvider value={{ helpCenterRedirectURL }}>
+        <ServiceProviderContextProvider value={serviceProviderContext}>
+          {children}
+        </ServiceProviderContextProvider>
+      </HelpCenterContextProvider>
+    ),
+  };
 
   it('renders troubleshooting options', () => {
-    const { getAllByRole } = renderWithContext();
+    const { getAllByRole } = render(<DocumentCaptureTroubleshootingOptions />, {
+      wrapper: wrappers.helpCenterContext,
+    });
 
     const links = /** @type {HTMLAnchorElement[]} */ (getAllByRole('link'));
 
@@ -49,11 +52,8 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
 
   context('with associated service provider', () => {
     it('renders troubleshooting options', () => {
-      const { getAllByRole } = renderWithContext({
-        serviceProviderContext: {
-          name: 'Example SP',
-          failureToProofURL: 'http://example.test/url/to/failure-to-proof',
-        },
+      const { getAllByRole } = render(<DocumentCaptureTroubleshootingOptions />, {
+        wrapper: wrappers.helpCenterAndServiceProviderContext,
       });
 
       const links = /** @type {HTMLAnchorElement[]} */ (getAllByRole('link'));
@@ -80,6 +80,29 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
         'http://example.test/url/to/failure-to-proof?location=document_capture_troubleshooting_options',
       );
       expect(links[2].target).to.equal('_blank');
+    });
+
+    context('with location prop', () => {
+      it('appends location to links', () => {
+        const { getAllByRole } = render(
+          <DocumentCaptureTroubleshootingOptions location="custom" />,
+          {
+            wrapper: wrappers.helpCenterAndServiceProviderContext,
+          },
+        );
+
+        const links = /** @type {HTMLAnchorElement[]} */ (getAllByRole('link'));
+
+        expect(links[0].href).to.equal(
+          'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=custom',
+        );
+        expect(links[1].href).to.equal(
+          'https://example.com/redirect/?category=verify-your-identity&article=accepted-state-issued-identification&location=custom',
+        );
+        expect(links[2].href).to.equal(
+          'http://example.test/url/to/failure-to-proof?location=custom',
+        );
+      });
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -106,7 +106,7 @@ describe('document-capture/components/documents-step', () => {
     );
 
     expect(
-      getByRole('heading', { name: 'idv.troubleshooting.headings.having_trouble' }),
+      getByRole('heading', { name: 'components.troubleshooting_options.default_heading' }),
     ).to.be.ok();
     expect(
       getByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_window' })

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -66,6 +66,15 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
     expect(getByText('idv.failure.attempts.other')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
+
+    expect(
+      getByRole('link', { name: 'idv.troubleshooting.options.doc_capture_tips links.new_window' }),
+    ).to.exist();
+    expect(
+      getByRole('link', {
+        name: 'idv.troubleshooting.options.supported_documents links.new_window',
+      }),
+    ).to.exist();
   });
 
   it('renders warning page with error and displays one attempt remaining then continues on', () => {

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -177,7 +177,7 @@ describe('document-capture/components/review-issues-step', () => {
     userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(
-      getByRole('heading', { name: 'idv.troubleshooting.headings.having_trouble' }),
+      getByRole('heading', { name: 'components.troubleshooting_options.default_heading' }),
     ).to.be.ok();
     expect(
       getByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_window' })

--- a/spec/javascripts/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/warning-spec.jsx
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import Warning from '@18f/identity-document-capture/components/warning';
+import { TroubleshootingOptions } from '@18f/identity-components';
+import { render } from '../../../support/document-capture';
+
+describe('document-capture/components/warning', () => {
+  it('renders a warning', () => {
+    const actionOnClick = sinon.spy();
+
+    const { getByRole, getByText } = render(
+      <Warning
+        heading="Oops!"
+        actionText="Try again"
+        actionOnClick={actionOnClick}
+        troubleshootingHeading="Having trouble?"
+        troubleshootingOptions={[{ text: 'Get help', url: 'https://example.com/' }]}
+      >
+        Something went wrong
+      </Warning>,
+    );
+
+    const tryAgainButton = getByRole('button', { name: 'Try again' });
+    userEvent.click(tryAgainButton);
+
+    expect(getByRole('heading', { name: 'Oops!' })).to.exist();
+    expect(tryAgainButton).to.exist();
+    expect(actionOnClick).to.have.been.calledOnce();
+    expect(getByText('Something went wrong')).to.exist();
+    expect(getByRole('heading', { name: 'Having trouble?' })).to.exist();
+    expect(getByRole('link', { name: 'Get help' }).href).to.equal('https://example.com/');
+  });
+
+  context('with troubleshooting options element', () => {
+    it('renders a warning', () => {
+      const { getByRole } = render(
+        <Warning
+          heading="Oops!"
+          actionText="Try again"
+          actionOnClick={() => {}}
+          troubleshootingOptions={
+            <TroubleshootingOptions
+              heading="Having trouble?"
+              options={[{ text: 'Get help', url: 'https://example.com/' }]}
+            />
+          }
+        >
+          Something went wrong
+        </Warning>,
+      );
+
+      expect(getByRole('heading', { name: 'Having trouble?' })).to.exist();
+      expect(getByRole('link', { name: 'Get help' }).href).to.equal('https://example.com/');
+    });
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/warning-spec.jsx
@@ -14,7 +14,12 @@ describe('document-capture/components/warning', () => {
         actionText="Try again"
         actionOnClick={actionOnClick}
         troubleshootingHeading="Having trouble?"
-        troubleshootingOptions={[{ text: 'Get help', url: 'https://example.com/' }]}
+        troubleshootingOptions={
+          <TroubleshootingOptions
+            heading="Having trouble?"
+            options={[{ text: 'Get help', url: 'https://example.com/' }]}
+          />
+        }
       >
         Something went wrong
       </Warning>,
@@ -29,28 +34,5 @@ describe('document-capture/components/warning', () => {
     expect(getByText('Something went wrong')).to.exist();
     expect(getByRole('heading', { name: 'Having trouble?' })).to.exist();
     expect(getByRole('link', { name: 'Get help' }).href).to.equal('https://example.com/');
-  });
-
-  context('with troubleshooting options element', () => {
-    it('renders a warning', () => {
-      const { getByRole } = render(
-        <Warning
-          heading="Oops!"
-          actionText="Try again"
-          actionOnClick={() => {}}
-          troubleshootingOptions={
-            <TroubleshootingOptions
-              heading="Having trouble?"
-              options={[{ text: 'Get help', url: 'https://example.com/' }]}
-            />
-          }
-        >
-          Something went wrong
-        </Warning>,
-      );
-
-      expect(getByRole('heading', { name: 'Having trouble?' })).to.exist();
-      expect(getByRole('link', { name: 'Get help' }).href).to.equal('https://example.com/');
-    });
   });
 });

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -144,7 +144,10 @@ describe 'idv/shared/_error.html.erb' do
       end
 
       it 'shows an appropriate troubleshooting heading' do
-        expect(rendered).to have_css('h2', text: t('idv.troubleshooting.headings.having_trouble'))
+        expect(rendered).to have_css(
+          'h2',
+          text: t('components.troubleshooting_options.default_heading'),
+        )
       end
     end
 


### PR DESCRIPTION
**Why**: So that we are consistent in the options that we show users during document capture.

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/146781893-38b58a66-0f41-46db-9d66-8d1a13e44b55.png)|![Screen Shot 2021-12-20 at 8 28 10 AM](https://user-images.githubusercontent.com/1779930/146781910-ab7ec841-2be6-406a-956f-2244b835ed1a.png)

