### PR TITLE
Remove clipboard script where unused

### DIFF
--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -51,5 +51,3 @@
 </div>
 
 <%= render 'shared/cancel', link: @referrer %>
-
-<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -64,4 +64,4 @@
 <% end %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>
 
-<%== javascript_packs_tag_once 'clipboard', 'webauthn-authenticate' %>
+<%== javascript_packs_tag_once 'webauthn-authenticate' %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -68,4 +68,4 @@
 
 <%= render 'shared/cancel_or_back_to_options' %>
 
-<%= javascript_packs_tag_once 'clipboard', 'webauthn-setup' %>
+<%= javascript_packs_tag_once 'webauthn-setup' %>


### PR DESCRIPTION
**Why**:

- Because it's unnecessary JavaScript for a user to download and run
- As part of transition to ClipboardButton component implementation

**Notes:**

The general process for checking this was to confirm the absence of any `clipboard` class selectors on the page ([referenced by the pack](https://github.com/18F/identity-idp/blob/385f599e9a2055a82a956affb6cfe524651cca0a/app/javascript/packs/clipboard.js#L3)) and confirm no regressions in expected behavior by removal of the script.