### PR TITLE
Migrate ClipboardJS to ClipboardButtonComponent

### DIFF
--- a/app/javascript/packs/clipboard.js
+++ b/app/javascript/packs/clipboard.js
@@ -1,7 +1,0 @@
-import ClipboardJS from 'clipboard';
-
-const clipboard = new ClipboardJS('.clipboard');
-
-clipboard.on('success', function (e) {
-  e.clearSelection();
-});

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -40,14 +40,16 @@
     <%= link_to t('forms.backup_code.print'), '#',
                 data: { print: true },
                 class: 'usa-button usa-button--outline margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 ico ico-print' -%>
-    <%= link_to t('links.copy'), '#',
-                class: 'usa-button usa-button--outline margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 clipboard ico ico-copy',
-                data: { "clipboard-text": @codes.join(' ') } -%>
+    <%= render ClipboardButtonComponent.new(
+          clipboard_text: @codes.join(' '),
+          outline: true,
+          class: 'margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 ico ico-copy',
+        ) do %>
+      <%= t('links.copy') %>
+    <% end %>
   </div>
 </div>
 
 <%= form_tag(backup_code_continue_path, method: :patch) do %>
   <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide' %>
 <% end %>
-
-<%= javascript_packs_tag_once 'clipboard' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -39,11 +39,13 @@
           <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
             <%= @code %>
           </code>
-          <button class="clipboard margin-right-0 margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 usa-button usa-button--outline ico ico-copy"
-                  type="button"
-                  data-clipboard-text="<%= @code.upcase %>">
+          <%= render ClipboardButtonComponent.new(
+                clipboard_text: @code.upcase,
+                outline: true,
+                class: 'margin-right-0 margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 ico ico-copy',
+              ) do %>
             <%= t('links.copy') %>
-          </button>
+          <% end %>
         </div>
       </div>
     </li>
@@ -77,4 +79,3 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
-<%= javascript_packs_tag_once 'clipboard' %>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "basscss-sass": "^3.0.0",
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.6.0",
-    "clipboard": "^2.0.6",
     "fast-glob": "^3.2.7",
     "focus-trap": "^6.2.3",
     "identity-style-guide": "^6.2.0",

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -112,7 +112,7 @@ feature 'Sign Up' do
       page.driver.browser.execute_cdp(
         'Browser.grantPermissions',
         origin: page.server_url,
-        permissions: ['clipboardReadWrite'],
+        permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
       )
     end
 

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe ScriptHelper do
 
     context 'scripts enqueued' do
       before do
-        javascript_packs_tag_once('clipboard', 'clipboard')
-        javascript_packs_tag_once('document-capture')
+        javascript_packs_tag_once('document-capture', 'document-capture')
         javascript_packs_tag_once('application', prepend: true)
       end
 
@@ -44,7 +43,6 @@ RSpec.describe ScriptHelper do
           "script[src^='/#{output_path}/js/document-capture-'][src$='.chunk.en.js']",
           "script[src^='/#{output_path}/js/runtime~application-']",
           "script[src^='/#{output_path}/js/application-'][src$='.chunk.js']",
-          "script[src^='/#{output_path}/js/clipboard-'][src$='.chunk.js']",
           "script[src^='/#{output_path}/js/document-capture-'][src$='.chunk.js']",
         ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2683,15 +2683,6 @@ clipboard-polyfill@^3.0.3:
   resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-3.0.3.tgz#159ea0768e20edc7ffda404bd13c54c73de4ff40"
   integrity sha512-hts0o01ZkwjA1qHA5gFePzAj/780W7v+eyN3GdaCRyDnapzcPsKRV5aodv77gcr40NDIcyNjNmc+HvfKV+jD0g==
 
-clipboard@^2.0.6:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
-  integrity sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -3436,11 +3427,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -4645,13 +4631,6 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
-  dependencies:
-    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.8"
@@ -8354,11 +8333,6 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
-
 selfsigned@^1.10.8:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
@@ -9242,11 +9216,6 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Builds upon: #5705, #5730 (temporarily merges to #5730)

**Why**:

- Better isolation of concerns
- Fewer dependencies
- Smaller bundle size
- Polyfill-based implementation of ClipboardButtonComponent allows targeting native browser APIs with eventual removal of polyfill (see #5705 for details)
- Fixes instance of inappropriate `link` role for copy button ([related](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_link_role#notes))