### PR TITLE
Remove smart quotes from SMS message templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt
 
 normalize_yaml:
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation
-	find ./config/locales -type f | xargs yarn normalize-yaml \
+	find ./config/locales/telephony "./config/locales/telephony*" -type f | xargs yarn normalize-yaml --disable-smart-punctuation
+	find ./config/locales -not -path "./config/locales/telephony*" -type f | xargs yarn normalize-yaml \
 		config/pinpoint_supported_countries.yml \
 		config/pinpoint_overrides.yml \
 		config/country_dialing_codes.yml

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -3,24 +3,24 @@ en:
   telephony:
     account_reset_cancellation_notice: Your request to delete your %{app_name} account has been cancelled.
     account_reset_notice: As requested, your %{app_name} account will be deleted in
-      24 hours. Don’t want to delete your account? Sign in to your %{app_name}
+      24 hours. Don't want to delete your account? Sign in to your %{app_name}
       account to cancel.
     authentication_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don’t share this code with anyone.
+        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
         passcode is, %{code}, This code expires in %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don’t share this code with anyone.
+        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
         passcode is, %{code}, This code expires in %{expiration} minutes.
-    doc_auth_link: '%{link} You’ve requested to verify your identity on a mobile
-      phone.  Please take a photo of your state issued ID.'
+    doc_auth_link: "%{link} You've requested to verify your identity on a mobile
+      phone.  Please take a photo of your state issued ID."
     error:
       friendly_message:
         duplicate_endpoint: The phone number entered is not valid.
@@ -40,6 +40,6 @@ en:
         voice_unsupported: Invalid phone number. Check that you’ve entered the correct
           country code or area code.
     personal_key_regeneration_notice: A new personal key has been issued for your
-      %{app_name} account. If this wasn’t you, reset your password.
+      %{app_name} account. If this wasn't you, reset your password.
     personal_key_sign_in_notice: Your personal key was just used to sign into your
-      %{app_name} account. If this wasn’t you, reset your password.
+      %{app_name} account. If this wasn't you, reset your password.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -21,9 +21,9 @@ fr:
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
         %{code}, de nouveau, votre code de sécurité est, %{code}, Ce code
         expirera dans %{expiration} minutes.
-    doc_auth_link: '%{link} Vous avez demandé à vérifier votre identité sur un
-      téléphone mobile. S’il vous plaît prendre une photo de votre identité
-      émise par l’état'
+    doc_auth_link: "%{link} Vous avez demandé à vérifier votre identité sur un
+      téléphone mobile. S'il vous plaît prendre une photo de votre identité
+      émise par l'état"
     error:
       friendly_message:
         duplicate_endpoint: Le numéro de téléphone entré n’est pas valide.
@@ -46,8 +46,8 @@ fr:
         voice_unsupported: Numéro de téléphone invalide. Vérifiez que vous avez entré le
           bon indicatif international ou régional.
     personal_key_regeneration_notice: Une nouvelle clé personnelle a été émise pour
-      votre compte %{app_name}. Si vous ne l’avez pas demandée, réinitialisez
+      votre compte %{app_name}. Si vous ne l'avez pas demandée, réinitialisez
       votre mot de passe.
     personal_key_sign_in_notice: Votre clé personnelle a été utilisée pour vous
-      connecter à votre compte %{app_name}. Si ce n’était pas vous, changez
+      connecter à votre compte %{app_name}. Si ce n'était pas vous, changez
       votre mot de passe.


### PR DESCRIPTION
Reverts some of the changes in https://github.com/18F/identity-idp/pull/5621 because Pinpoint treats smart quotes differently than simple quotes.