### PR TITLE
Refactor banner

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -61,17 +61,6 @@
   <div class="usa-overlay"></div>
   <%= yield(:mobile_nav) if content_for?(:mobile_nav) %>
   <%= render 'shared/banner' %>
-  <div aria-label="main-navigation" role="navigation">
-    <% if content_for?(:nav) %>
-      <%= yield(:nav) %>
-    <% else %>
-      <% if decorated_session.sp_name %>
-        <%= render 'shared/nav_branded' %>
-      <% else %>
-        <%= render 'shared/nav_lite' %>
-      <% end %>
-    <% end %>
-  </div>
   <main class="site-wrap bg-light-blue" id="main-content">
     <div class="container">
       <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -60,7 +60,7 @@
   <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
   <div class="usa-overlay"></div>
   <%= yield(:mobile_nav) if content_for?(:mobile_nav) %>
-  <%= render 'shared/banner', sp_name: decorated_session.sp_name %>
+  <%= render 'shared/banner' %>
   <main class="site-wrap bg-light-blue" id="main-content">
     <div class="container">
       <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -60,7 +60,7 @@
   <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
   <div class="usa-overlay"></div>
   <%= yield(:mobile_nav) if content_for?(:mobile_nav) %>
-  <%= render 'shared/banner' %>
+  <%= render 'shared/banner', sp_name: decorated_session.sp_name %>
   <main class="site-wrap bg-light-blue" id="main-content">
     <div class="container">
       <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>">

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,8 +1,8 @@
-<div aria-label="banner" role="banner">
+<header aria-label="banner">
   <%= render 'shared/no_pii_banner' if FeatureManagement.show_no_pii_banner? %>
   <section class="usa-banner" aria-label="Official government website">
     <div class="usa-accordion">
-      <header class="usa-banner__header">
+      <div class="usa-banner__header">
         <div class="usa-banner__inner">
           <%= image_tag(
                 asset_url('us-flag.png'),
@@ -20,7 +20,7 @@
             <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
           </button>
         </div>
-      </header>
+      </div>
       <div class="usa-banner__content usa-accordion__content" id="gov-banner">
         <%= nonced_javascript_tag do %>
           document.getElementById('gov-banner').setAttribute('hidden', '');
@@ -56,4 +56,16 @@
       </div>
     </div>
   </section>
-</div>
+  <nav aria-label="main-navigation">
+    <% if content_for?(:nav) %>
+      <%= yield(:nav) %>
+
+    <% else %>
+      <% if decorated_session.sp_name %>
+        <%= render 'shared/nav_branded' %>
+      <% else %>
+        <%= render 'shared/nav_lite' %>
+      <% end %>
+    <% end %>
+  </nav>
+</header>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -58,8 +58,6 @@
   </section>
   <nav aria-label="main-navigation">
     <% if content_for?(:nav) %>
-      <%= yield(:nav) %>
-
     <% else %>
       <% if decorated_session.sp_name %>
         <%= render 'shared/nav_branded' %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -58,6 +58,7 @@
   </section>
   <nav aria-label="main-navigation">
     <% if content_for?(:nav) %>
+      <%= yield(:nav) %>
     <% else %>
       <% if decorated_session.sp_name %>
         <%= render 'shared/nav_branded' %>

--- a/spec/views/shared/_banner.html.erb_spec.rb
+++ b/spec/views/shared/_banner.html.erb_spec.rb
@@ -13,7 +13,6 @@ describe 'shared/_banner.html.erb' do
       service_provider_request: nil,
     )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
-    render
   end
 
   it 'properly HTML escapes the secure notification' do

--- a/spec/views/shared/_banner.html.erb_spec.rb
+++ b/spec/views/shared/_banner.html.erb_spec.rb
@@ -7,6 +7,7 @@ describe 'shared/_banner.html.erb' do
     )
     decorated_session = ServiceProviderSessionDecorator.new(
       sp: sp_with_logo,
+      sp_name: 'Example App',
       view_context: '',
       sp_session: {},
       service_provider_request: nil,

--- a/spec/views/shared/_banner.html.erb_spec.rb
+++ b/spec/views/shared/_banner.html.erb_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 describe 'shared/_banner.html.erb' do
+  before do
+    sp_with_logo = build_stubbed(
+      :service_provider, logo: 'generic.svg', friendly_name: 'Best SP ever'
+    )
+    decorated_session = ServiceProviderSessionDecorator.new(
+      sp: sp_with_logo,
+      view_context: '',
+      sp_session: {},
+      service_provider_request: nil,
+    )
+    allow(view).to receive(:decorated_session).and_return(decorated_session)
+    render
+  end
+
   it 'properly HTML escapes the secure notification' do
     render
 

--- a/spec/views/shared/_banner.html.erb_spec.rb
+++ b/spec/views/shared/_banner.html.erb_spec.rb
@@ -5,9 +5,9 @@ describe 'shared/_banner.html.erb' do
     sp_with_logo = build_stubbed(
       :service_provider, logo: 'generic.svg', friendly_name: 'Best SP ever'
     )
+
     decorated_session = ServiceProviderSessionDecorator.new(
       sp: sp_with_logo,
-      sp_name: 'Example App',
       view_context: '',
       sp_session: {},
       service_provider_request: nil,


### PR DESCRIPTION
This PR is a refactor of the banner in that:

- The navigation has been moved inside the banner;
- The `<div>` for the banner has been replaced with a `<header>` element. The header element has an implicit role of `banner`, so the `role=banner` has been removed;
- The navigation now uses the `<nav>` element. The nav element has an implicit role of `navigation`, therefore `role=navigation` has been removed

With these changes, the navigation will no longer be read twice. Also, the top banner and the navigation will be grouped semantically.