### PR TITLE
LG-4670: Redirect document capture to throttled when no remaining attempts

### DIFF
--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -33,11 +33,10 @@ class ImageUploadResponsePresenter
   def as_json(*)
     if success?
       { success: true }
-    elsif @form_response.errors.key?(:limit)
-      { success: false, redirect: idv_session_errors_throttled_url }
     else
       hints = @form_response.errors[:hints]
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
+      json[:redirect] = idv_session_errors_throttled_url if remaining_attempts.zero?
       json[:hints] = hints unless hints.blank?
       json
     end

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -36,7 +36,7 @@ class ImageUploadResponsePresenter
     else
       hints = @form_response.errors[:hints]
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
-      json[:redirect] = idv_session_errors_throttled_url if remaining_attempts.zero?
+      json[:redirect] = idv_session_errors_throttled_url if remaining_attempts&.zero?
       json[:hints] = hints unless hints.blank?
       json
     end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -177,7 +177,9 @@ describe Idv::ImageUploadsController do
         expect(json).to eq(
           {
             success: false,
+            errors: [{ field: 'limit', message: 'We could not verify your ID' }],
             redirect: idv_session_errors_throttled_url,
+            remaining_attempts: 0,
           },
         )
       end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -108,14 +108,16 @@ describe ImageUploadResponsePresenter do
           errors: {
             limit: t('errors.doc_auth.throttled_heading'),
           },
-          extra: {},
+          extra: { remaining_attempts: 0 },
         )
       end
 
       it 'returns hash of properties' do
         expected = {
           success: false,
+          errors: [{ field: :limit, message: t('errors.doc_auth.throttled_heading') }],
           redirect: idv_session_errors_throttled_url,
+          remaining_attempts: 0,
         }
 
         expect(presenter.as_json).to eq expected
@@ -143,6 +145,31 @@ describe ImageUploadResponsePresenter do
         }
 
         expect(presenter.as_json).to eq expected
+      end
+
+      context 'no remaining attempts' do
+        let(:form_response) do
+          FormResponse.new(
+            success: false,
+            errors: {
+              front: t('doc_auth.errors.not_a_file'),
+              hints: true,
+            },
+            extra: { remaining_attempts: 0 },
+          )
+        end
+
+        it 'returns hash of properties' do
+          expected = {
+            success: false,
+            errors: [{ field: :front, message: t('doc_auth.errors.not_a_file') }],
+            hints: true,
+            redirect: idv_session_errors_throttled_url,
+            remaining_attempts: 0,
+          }
+
+          expect(presenter.as_json).to eq expected
+        end
       end
     end
   end


### PR DESCRIPTION
**Why**: As a user, I expect that I am redirected as soon as I've exhausted all attempts at document capture, so that I don't waste my time with a final attempt to capture that will be guaranteed to fail (even if the document was perfect).

This leverages the fact that the document capture upload handler will short circuit by the presence of a `redirect` property on the response:

https://github.com/18F/identity-idp/blob/9f863e54e2fc8b433e674c3f1d34d9f726aa0b0a/app/javascript/packages/document-capture/services/upload.js#L76-L82