### PR TITLE
Fix TOTP copy button layout with longer code (LG-5436)

### DIFF
--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -15,7 +15,7 @@ module UserOtpMethods
   end
 
   def generate_totp_secret
-    ROTP::Base32.random(20)
+    ROTP::Base32.random(20) # 160-bit secret, per RFC 4226
   end
 
   def authenticate_direct_otp(code)

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -39,14 +39,14 @@
           <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
             <%= @code %>
           </code>
-          <%= render ClipboardButtonComponent.new(
-                clipboard_text: @code.upcase,
-                outline: true,
-                class: 'margin-right-0 margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2 ico ico-copy',
-              ) do %>
-            <%= t('links.copy') %>
-          <% end %>
         </div>
+        <%= render ClipboardButtonComponent.new(
+              clipboard_text: @code.upcase,
+              outline: true,
+              class: 'ico ico-copy margin-top-2',
+            ) do %>
+          <%= t('links.copy') %>
+        <% end %>
       </div>
     </li>
     <li class="padding-y-2 border-top border-primary-light">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -35,15 +35,13 @@
           <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
         </div>
         <%= t('instructions.mfa.authenticator.manual_entry') %>
-        <div class="grid-row margin-top-2 flex-align-center">
-          <code class="grid-col-fill font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
-            <%= @code %>
-          </code>
-        </div>
+        <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
+          <%= @code %>
+        </code>
         <%= render ClipboardButtonComponent.new(
               clipboard_text: @code.upcase,
               outline: true,
-              class: 'ico ico-copy margin-top-2',
+              class: 'ico ico-copy',
             ) do %>
           <%= t('links.copy') %>
         <% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe User do
   end
 
   describe '#generate_totp_secret' do
-    it 'generates a secret 16 characters long' do
+    it 'generates a secret 32 characters long' do
       user = build(:user)
       secret = user.generate_totp_secret
       expect(secret.length).to eq 32


### PR DESCRIPTION
Follow-up to #5604, which had a small visual regression

| | before | after |
| -- | --- | --- |
| mobile | <img width="242" alt="Screen Shot 2021-12-21 at 11 06 43 AM" src="https://user-images.githubusercontent.com/458784/146984819-a7554b70-45f1-42eb-9bbd-f5e2f75ff2fa.png"> | <img width="242" alt="Screen Shot 2021-12-21 at 11 06 51 AM" src="https://user-images.githubusercontent.com/458784/146984823-1924d4e4-d4be-444c-8f1f-82bfbceeaebb.png"> |
| desktop | <img width="677" alt="Screen Shot 2021-12-21 at 11 06 20 AM" src="https://user-images.githubusercontent.com/458784/146984833-89a1363e-ad5b-4f12-a25f-a1a5724dab2f.png"> | <img width="677" alt="Screen Shot 2021-12-21 at 11 06 08 AM" src="https://user-images.githubusercontent.com/458784/146984837-ff7b62bc-326d-494e-951a-1aa6704e054b.png"> |

 