### PR TITLE
LG-5477 Log total users counts w/breakdowns to analytics

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -73,10 +73,6 @@ module Reports
       @reports_log ||= ActiveSupport::Logger.new(Rails.root.join('log', 'reports.log'))
     end
 
-    def build_analytics
-      Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
-    end
-
     def upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
       latest_path, path = generate_s3_paths(report_name, extension)
       content_type = Mime::Type.lookup_by_extension(extension).to_s

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -47,7 +47,6 @@ module Reports
     end
 
     def save_report(report_name, body, extension:)
-      write_data_to_analytics_logs(report_name, body, extension)
       if !IdentityConfig.store.s3_reports_enabled
         logger.info('Not uploading report to S3, s3_reports_enabled is false')
         return body
@@ -55,14 +54,13 @@ module Reports
       upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
     end
 
-    def write_data_to_analytics_logs(report_name, body, extension)
-      return unless extension == 'json'
-      log_hash = {
+    def track_report_data_event(event, hash = {})
+      analytics_hash = {
+        name: event,
         time: Time.zone.now.iso8601,
-        report_name: report_name,
-        report_body: JSON.parse(body),
       }
-      write_hash_to_reports_log(log_hash)
+      analytics_hash.merge!(hash)
+      write_hash_to_reports_log(analytics_hash)
     end
 
     def write_hash_to_reports_log(log_hash)

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -57,8 +57,12 @@ module Reports
 
     def write_json_report_to_analytics(report_name, body, extension)
       return unless extension == 'json'
-      build_analytics.track_event(Analytics::REPORT_RESULTS,
-                                  user_id: '', report_name: report_name, report_body: JSON.parse(body))
+      build_analytics.track_event(
+        Analytics::REPORT_RESULTS,
+        user_id: '',
+        report_name: report_name,
+        report_body: JSON.parse(body),
+      )
     end
 
     def build_analytics

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -55,12 +55,7 @@ module Reports
     end
 
     def track_report_data_event(event, hash = {})
-      analytics_hash = {
-        name: event,
-        time: Time.zone.now.iso8601,
-      }
-      analytics_hash.merge!(hash)
-      write_hash_to_reports_log(analytics_hash)
+      write_hash_to_reports_log({name: event, time: Time.zone.now.iso8601}.merge(hash))
     end
 
     def write_hash_to_reports_log(log_hash)

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -47,11 +47,22 @@ module Reports
     end
 
     def save_report(report_name, body, extension:)
+      write_json_report_to_analytics(report_name, body, extension)
       if !IdentityConfig.store.s3_reports_enabled
         logger.info('Not uploading report to S3, s3_reports_enabled is false')
         return body
       end
       upload_file_to_s3_timestamped_and_latest(report_name, body, extension)
+    end
+
+    def write_json_report_to_analytics(report_name, body, extension)
+      return unless extension == 'json'
+      build_analytics.track_event(Analytics::REPORT_RESULTS,
+                                  user_id: '', report_name: report_name, report_body: JSON.parse(body))
+    end
+
+    def build_analytics
+      Analytics.new(user: nil, request: nil, session: {}, sp: nil)
     end
 
     def upload_file_to_s3_timestamped_and_latest(report_name, body, extension)

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -66,7 +66,7 @@ module Reports
     end
 
     def build_analytics
-      Analytics.new(user: nil, request: nil, session: {}, sp: nil)
+      Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
     end
 
     def upload_file_to_s3_timestamped_and_latest(report_name, body, extension)

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -23,16 +23,29 @@ module Reports
     private
 
     def track_report_data_events(user_counts)
+      total_ial1_count = 0
+      total_ial2_count = 0
       user_counts.each do |hash|
+        ial1_count = hash['ial1_total'].to_i
+        ial2_count = hash['ial2_total'].to_i
         track_report_data_event(
           Analytics::REPORT_SP_USER_COUNTS,
           issuer: hash['issuer'],
-          user_total: hash['total'],
-          ial1_user_total: hash['ial1_total'],
-          ial2_user_total: hash['ial2_total'],
+          user_total: hash['total'].to_i,
+          ial1_user_total: ial1_count,
+          ial2_user_total: ial2_count,
           app_id: hash['app_id'].to_s,
         )
+        total_ial1_count += ial1_count
+        total_ial2_count += ial1_count
       end
+
+      track_report_data_event(
+        Analytics::REPORT_TOTAL_SP_USER_COUNTS,
+        user_total: total_ial1_count + total_ial2_count,
+        ial1_user_total: total_ial1_count,
+        ial2_user_total: total_ial2_count,
+      )
     end
   end
 end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -17,7 +17,10 @@ module Reports
       end
 
       track_report_data_events(user_counts)
-      save_report(REPORT_NAME, user_counts.to_json, extension: 'json')
+      results = save_report(REPORT_NAME, user_counts.to_json, extension: 'json')
+
+      track_global_user_total_events
+      results
     end
 
     private
@@ -31,6 +34,15 @@ module Reports
           ial1_user_total: hash['ial1_total'],
           ial2_user_total: hash['ial2_total'],
           app_id: hash['app_id'].to_s,
+        )
+      end
+    end
+
+    def track_global_user_total_events
+      transaction_with_timeout do
+        track_report_data_event(
+          Analytics::REPORT_REGISTERED_USERS_COUNT,
+          count: Funnel::Registration::TotalRegisteredCount.call,
         )
       end
     end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -25,7 +25,7 @@ module Reports
     def track_report_data_events(user_counts)
       user_counts.each do |hash|
         track_report_data_event(
-          Analytics::REPORT_USER_COUNTS,
+          Analytics::REPORT_SP_USER_COUNTS,
           issuer: hash['issuer'],
           user_total: hash['total'],
           ial1_user_total: hash['ial1_total'],

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -39,10 +39,34 @@ module Reports
     end
 
     def track_global_user_total_events
+      track_global_registered_users
+      track_ial1_users_linked_to_sps
+      track_ial2_users_linked_to_sps
+    end
+
+    def track_global_registered_users
       transaction_with_timeout do
         track_report_data_event(
           Analytics::REPORT_REGISTERED_USERS_COUNT,
           count: Funnel::Registration::TotalRegisteredCount.call,
+        )
+      end
+    end
+
+    def track_ial1_users_linked_to_sps
+      transaction_with_timeout do
+        track_report_data_event(
+          Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT,
+          count: ServiceProviderIdentity.where(ial: 1).select(:user_id).distinct.count,
+        )
+      end
+    end
+
+    def track_ial2_users_linked_to_sps
+      transaction_with_timeout do
+        track_report_data_event(
+          Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT,
+          count: ServiceProviderIdentity.where(ial: 2).select(:user_id).distinct.count,
         )
       end
     end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -23,32 +23,16 @@ module Reports
     private
 
     def track_report_data_events(user_counts)
-      total_ial1_count = 0
-      total_ial2_count = 0
-      total_count = 0
       user_counts.each do |hash|
-        ial1_count = hash['ial1_total'].to_i
-        ial2_count = hash['ial2_total'].to_i
-        count = hash['total'].to_i
         track_report_data_event(
           Analytics::REPORT_SP_USER_COUNTS,
           issuer: hash['issuer'],
-          user_total: count,
-          ial1_user_total: ial1_count,
-          ial2_user_total: ial2_count,
+          user_total: hash['total'],
+          ial1_user_total: hash['ial1_total'],
+          ial2_user_total: hash['ial2_total'],
           app_id: hash['app_id'].to_s,
         )
-        total_ial1_count += ial1_count
-        total_ial2_count += ial2_count
-        total_count += count
       end
-
-      track_report_data_event(
-        Analytics::REPORT_TOTAL_SP_USER_COUNTS,
-        user_total: total_count,
-        ial1_user_total: total_ial1_count,
-        ial2_user_total: total_ial2_count,
-      )
     end
   end
 end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -15,7 +15,24 @@ module Reports
       user_counts = transaction_with_timeout do
         Db::Identity::SpUserCounts.call
       end
+
+      track_report_data_events(user_counts)
       save_report(REPORT_NAME, user_counts.to_json, extension: 'json')
+    end
+
+    private
+
+    def track_report_data_events(user_counts)
+      user_counts.each do |hash|
+        track_report_data_event(
+          Analytics::REPORT_USER_COUNTS,
+          issuer: hash['issuer'],
+          user_total: hash['total'],
+          ial1_user_total: hash['ial1_total'],
+          ial2_user_total: hash['ial2_total'],
+          app_id: hash['app_id'].to_s,
+        )
+      end
     end
   end
 end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -40,8 +40,8 @@ module Reports
 
     def track_global_user_total_events
       track_global_registered_users
-      track_ial1_users_linked_to_sps
-      track_ial2_users_linked_to_sps
+      track_users_linked_to_sps(ial: 1, event: Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT)
+      track_users_linked_to_sps(ial: 2, event: Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT)
     end
 
     def track_global_registered_users
@@ -53,20 +53,11 @@ module Reports
       end
     end
 
-    def track_ial1_users_linked_to_sps
+    def track_users_linked_to_sps(ial:, event:)
       transaction_with_timeout do
         track_report_data_event(
-          Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT,
-          count: ServiceProviderIdentity.where(ial: 1).select(:user_id).distinct.count,
-        )
-      end
-    end
-
-    def track_ial2_users_linked_to_sps
-      transaction_with_timeout do
-        track_report_data_event(
-          Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT,
-          count: ServiceProviderIdentity.where(ial: 2).select(:user_id).distinct.count,
+          event,
+          count: ServiceProviderIdentity.where(ial: ial).select(:user_id).distinct.count,
         )
       end
     end

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -37,7 +37,7 @@ module Reports
           app_id: hash['app_id'].to_s,
         )
         total_ial1_count += ial1_count
-        total_ial2_count += ial1_count
+        total_ial2_count += ial2_count
       end
 
       track_report_data_event(

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -25,24 +25,27 @@ module Reports
     def track_report_data_events(user_counts)
       total_ial1_count = 0
       total_ial2_count = 0
+      total_count = 0
       user_counts.each do |hash|
         ial1_count = hash['ial1_total'].to_i
         ial2_count = hash['ial2_total'].to_i
+        count = hash['total'].to_i
         track_report_data_event(
           Analytics::REPORT_SP_USER_COUNTS,
           issuer: hash['issuer'],
-          user_total: hash['total'].to_i,
+          user_total: count,
           ial1_user_total: ial1_count,
           ial2_user_total: ial2_count,
           app_id: hash['app_id'].to_s,
         )
         total_ial1_count += ial1_count
         total_ial2_count += ial2_count
+        total_count += count
       end
 
       track_report_data_event(
         Analytics::REPORT_TOTAL_SP_USER_COUNTS,
-        user_total: total_ial1_count + total_ial2_count,
+        user_total: total_count,
         ial1_user_total: total_ial1_count,
         ial2_user_total: total_ial2_count,
       )

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -230,6 +230,8 @@ class Analytics
   PROOFING_RESOLUTION_TIMEOUT = 'Proofing Resolution Timeout'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
   REPORT_REGISTERED_USERS_COUNT = 'Report Registered Users Count'.freeze
+  REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT = 'Report IAL1 Users Linked to SPs Count'.freeze
+  REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT= 'Report IAL2 Users Linked to SPs Count'.freeze
   REPORT_SP_USER_COUNTS = 'Report SP User Counts'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -230,6 +230,7 @@ class Analytics
   PROOFING_RESOLUTION_TIMEOUT = 'Proofing Resolution Timeout'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
   REPORT_SP_USER_COUNTS = 'Report SP User Counts'.freeze
+  REPORT_TOTAL_SP_USER_COUNTS = 'Report Total SP User Counts'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -232,6 +232,7 @@ class Analytics
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze
+  REPORT_RESULTS = "Report Results".freeze
   RETURN_TO_SP_CANCEL = 'Return to SP: Cancelled'.freeze
   RETURN_TO_SP_FAILURE_TO_PROOF = 'Return to SP: Failed to proof'.freeze
   RULES_OF_USE_VISIT = 'Rules Of Use Visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -232,7 +232,7 @@ class Analytics
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze
-  REPORT_RESULTS = "Report Results".freeze
+  REPORT_RESULTS = 'Report Results'.freeze
   RETURN_TO_SP_CANCEL = 'Return to SP: Cancelled'.freeze
   RETURN_TO_SP_FAILURE_TO_PROOF = 'Return to SP: Failed to proof'.freeze
   RULES_OF_USE_VISIT = 'Rules Of Use Visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -232,7 +232,6 @@ class Analytics
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze
-  REPORT_RESULTS = 'Report Results'.freeze
   RETURN_TO_SP_CANCEL = 'Return to SP: Cancelled'.freeze
   RETURN_TO_SP_FAILURE_TO_PROOF = 'Return to SP: Failed to proof'.freeze
   RULES_OF_USE_VISIT = 'Rules Of Use Visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -229,7 +229,7 @@ class Analytics
   PROOFING_DOCUMENT_TIMEOUT = 'Proofing Document Timeout'.freeze
   PROOFING_RESOLUTION_TIMEOUT = 'Proofing Resolution Timeout'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
-  REPORT_USER_COUNTS = 'Report User Counts'.freeze
+  REPORT_SP_USER_COUNTS = 'Report SP User Counts'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -229,8 +229,8 @@ class Analytics
   PROOFING_DOCUMENT_TIMEOUT = 'Proofing Document Timeout'.freeze
   PROOFING_RESOLUTION_TIMEOUT = 'Proofing Resolution Timeout'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
+  REPORT_REGISTERED_USERS_COUNT = 'Report Registered Users Count'.freeze
   REPORT_SP_USER_COUNTS = 'Report SP User Counts'.freeze
-  REPORT_TOTAL_SP_USER_COUNTS = 'Report Total SP User Counts'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -229,6 +229,7 @@ class Analytics
   PROOFING_DOCUMENT_TIMEOUT = 'Proofing Document Timeout'.freeze
   PROOFING_RESOLUTION_TIMEOUT = 'Proofing Resolution Timeout'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
+  REPORT_USER_COUNTS = 'Report User Counts'.freeze
   RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   REMEMBERED_DEVICE_USED_FOR_AUTH = 'Remembered device used for authentication'.freeze
   REMOTE_LOGOUT_INITIATED = 'Remote Logout initiated'.freeze

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -26,6 +26,14 @@ describe Reports::SpUserCountsReport do
         user_total: 1,
       }
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
+      log_hash = {
+        ial1_user_total: 1,
+        ial2_user_total: 1,
+        name: Analytics::REPORT_TOTAL_SP_USER_COUNTS,
+        time: timestamp,
+        user_total: 2,
+      }
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
       subject.perform(Time.zone.today)
     end
   end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -5,9 +5,18 @@ describe Reports::SpUserCountsReport do
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }
+  let(:fake_analytics) { FakeAnalytics.new }
 
   it 'is empty' do
     expect(subject.perform(Time.zone.today)).to eq('[]')
+  end
+
+  it 'logs to analytics' do
+    allow(subject).to receive(:build_analytics).and_return(fake_analytics)
+
+    subject.perform(Time.zone.today)
+    expect(fake_analytics).to have_logged_event(Analytics::REPORT_RESULTS,
+                                                user_id: '', report_name: 'sp-user-counts-report', report_body: [])
   end
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -26,14 +26,6 @@ describe Reports::SpUserCountsReport do
         user_total: 1,
       }
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
-      log_hash = {
-        ial1_user_total: 1,
-        ial2_user_total: 0,
-        name: Analytics::REPORT_TOTAL_SP_USER_COUNTS,
-        time: timestamp,
-        user_total: 1,
-      }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
       subject.perform(Time.zone.today)
     end
   end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -21,7 +21,7 @@ describe Reports::SpUserCountsReport do
         ial1_user_total: 1,
         ial2_user_total: 0,
         issuer: issuer,
-        name: Analytics::REPORT_USER_COUNTS,
+        name: Analytics::REPORT_SP_USER_COUNTS,
         time: timestamp,
         user_total: 1,
       }

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -12,15 +12,16 @@ describe Reports::SpUserCountsReport do
   end
 
   it 'logs to analytics' do
-    allow(subject).to receive(:build_analytics).and_return(fake_analytics)
-
-    subject.perform(Time.zone.today)
-    expect(fake_analytics).to have_logged_event(
-      Analytics::REPORT_RESULTS,
-      user_id: AnonymousUser.new.uuid,
-      report_name: 'sp-user-counts-report',
-      report_body: [],
-    )
+    freeze_time do
+      timestamp = Time.zone.now.iso8601
+      log_hash = {
+        time: timestamp,
+        report_name: 'sp-user-counts-report',
+        report_body: [],
+      }
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
+      subject.perform(Time.zone.today)
+    end
   end
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -5,23 +5,9 @@ describe Reports::SpUserCountsReport do
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }
-  let(:fake_analytics) { FakeAnalytics.new }
 
   it 'is empty' do
     expect(subject.perform(Time.zone.today)).to eq('[]')
-  end
-
-  it 'logs to analytics' do
-    freeze_time do
-      timestamp = Time.zone.now.iso8601
-      log_hash = {
-        time: timestamp,
-        report_name: 'sp-user-counts-report',
-        report_body: [],
-      }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
-      subject.perform(Time.zone.today)
-    end
   end
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -5,9 +5,29 @@ describe Reports::SpUserCountsReport do
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }
+  let(:fake_analytics) { FakeAnalytics.new }
 
   it 'is empty' do
     expect(subject.perform(Time.zone.today)).to eq('[]')
+  end
+
+  it 'logs to analytics' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    freeze_time do
+      timestamp = Time.zone.now.iso8601
+      log_hash = {
+        app_id: app_id,
+        ial1_user_total: 1,
+        ial2_user_total: 0,
+        issuer: issuer,
+        name: Analytics::REPORT_USER_COUNTS,
+        time: timestamp,
+        user_total: 1,
+      }
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
+      subject.perform(Time.zone.today)
+    end
   end
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -28,10 +28,10 @@ describe Reports::SpUserCountsReport do
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
       log_hash = {
         ial1_user_total: 1,
-        ial2_user_total: 1,
+        ial2_user_total: 0,
         name: Analytics::REPORT_TOTAL_SP_USER_COUNTS,
         time: timestamp,
-        user_total: 2,
+        user_total: 1,
       }
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
       subject.perform(Time.zone.today)

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -15,8 +15,9 @@ describe Reports::SpUserCountsReport do
     allow(subject).to receive(:build_analytics).and_return(fake_analytics)
 
     subject.perform(Time.zone.today)
-    expect(fake_analytics).to have_logged_event(Analytics::REPORT_RESULTS,
-                                                user_id: '', report_name: 'sp-user-counts-report', report_body: [])
+    expect(fake_analytics).to have_logged_event(
+      Analytics::REPORT_RESULTS, user_id: '', report_name: 'sp-user-counts-report', report_body: []
+    )
   end
 
   it 'returns the total user counts per sp broken down by ial1 and ial2' do

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -25,12 +25,27 @@ describe Reports::SpUserCountsReport do
         user_total: 1,
       }
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
-      log_hash = {
+      log_hash1 = {
         name: Analytics::REPORT_REGISTERED_USERS_COUNT,
         time: timestamp,
         count: 0,
       }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash1)
+      ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2', ial: 1)
+      ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', ial: 1)
+      log_hash2 = {
+        name: Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT,
+        time: timestamp,
+        count: 1,
+      }
+      ServiceProviderIdentity.create(user_id: 4, service_provider: issuer, uuid: 'foo4', ial: 2)
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash2)
+      log_hash3 = {
+        name: Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT,
+        time: timestamp,
+        count: 2,
+      }
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash3)
       subject.perform(Time.zone.today)
     end
   end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -5,7 +5,6 @@ describe Reports::SpUserCountsReport do
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }
-  let(:fake_analytics) { FakeAnalytics.new }
 
   it 'is empty' do
     expect(subject.perform(Time.zone.today)).to eq('[]')

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -16,7 +16,10 @@ describe Reports::SpUserCountsReport do
 
     subject.perform(Time.zone.today)
     expect(fake_analytics).to have_logged_event(
-      Analytics::REPORT_RESULTS, user_id: '', report_name: 'sp-user-counts-report', report_body: []
+      Analytics::REPORT_RESULTS,
+      user_id: AnonymousUser.uuid,
+      report_name: 'sp-user-counts-report',
+      report_body: [],
     )
   end
 

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -26,6 +26,12 @@ describe Reports::SpUserCountsReport do
         user_total: 1,
       }
       allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
+      log_hash = {
+        name: Analytics::REPORT_REGISTERED_USERS_COUNT,
+        time: timestamp,
+        count: 0,
+      }
+      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
       subject.perform(Time.zone.today)
     end
   end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -12,40 +12,35 @@ describe Reports::SpUserCountsReport do
 
   it 'logs to analytics' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    ServiceProviderIdentity.create(user_id: 1, service_provider: issuer, uuid: 'foo2', ial: 1)
+    ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo3', ial: 1)
+    ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo4', ial: 2)
     freeze_time do
       timestamp = Time.zone.now.iso8601
-      log_hash = {
+      expect(subject).to receive(:write_hash_to_reports_log).with(
         app_id: app_id,
-        ial1_user_total: 1,
+        ial1_user_total: 3,
         ial2_user_total: 0,
         issuer: issuer,
         name: Analytics::REPORT_SP_USER_COUNTS,
         time: timestamp,
-        user_total: 1,
-      }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash)
-      log_hash1 = {
+        user_total: 3,
+      )
+      expect(subject).to receive(:write_hash_to_reports_log).with(
         name: Analytics::REPORT_REGISTERED_USERS_COUNT,
         time: timestamp,
         count: 0,
-      }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash1)
-      ServiceProviderIdentity.create(user_id: 2, service_provider: issuer, uuid: 'foo2', ial: 1)
-      ServiceProviderIdentity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', ial: 1)
-      log_hash2 = {
+      )
+      expect(subject).to receive(:write_hash_to_reports_log).with(
         name: Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT,
         time: timestamp,
-        count: 1,
-      }
-      ServiceProviderIdentity.create(user_id: 4, service_provider: issuer, uuid: 'foo4', ial: 2)
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash2)
-      log_hash3 = {
+        count: 2,
+      )
+      expect(subject).to receive(:write_hash_to_reports_log).with(
         name: Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT,
         time: timestamp,
-        count: 2,
-      }
-      allow(subject).to receive(:write_hash_to_reports_log).with(log_hash3)
+        count: 1,
+      )
       subject.perform(Time.zone.today)
     end
   end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -17,7 +17,7 @@ describe Reports::SpUserCountsReport do
     subject.perform(Time.zone.today)
     expect(fake_analytics).to have_logged_event(
       Analytics::REPORT_RESULTS,
-      user_id: AnonymousUser.uuid,
+      user_id: AnonymousUser.new.uuid,
       report_name: 'sp-user-counts-report',
       report_body: [],
     )


### PR DESCRIPTION
**Why**: Log all JSON reports to analytics for time based reporting and visualization