### PR TITLE
Render the logout response on remote logout

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -25,11 +25,7 @@ module SamlIdpLogoutConcern
     # Remotely invalidate the user's current session, see config/initializers/session_limitable.rb
     User.find(user_id).update!(unique_session_id: nil)
 
-    render_template_for(
-      Base64.strict_encode64(logout_response),
-      saml_request.response_url,
-      'SAMLResponse',
-    )
+    render inline: logout_response, content_type: 'text/xml'
   end
 
   def find_user_from_session_index


### PR DESCRIPTION
**Why**: Previously we were rendering a template with JS to make a post request to the ACS url. This does not make sense in a back channel logout request. Since the request is server to server there is no javascript to make the post request.

In this case, the IdP should render the logout request, and then make a best effort back channel post request to the ACS url. This PR makes the change to render the logout request. The ability to post to the ACS url may be problematic because of the need to work through firewall changes. I will leave that for a follow-on if a customer requests that change.