### PR TITLE
Add requesting user UUID to reports for the OIG reports

### DIFF
--- a/app/services/data_requests/write_user_events.rb
+++ b/app/services/data_requests/write_user_events.rb
@@ -2,28 +2,34 @@ require 'csv'
 
 module DataRequests
   class WriteUserEvents
-    attr_reader :user_report, :output_dir
+    attr_reader :user_report, :output_dir, :requesting_issuer_uuid
 
-    def initialize(user_report, output_dir)
+    def initialize(user_report, output_dir, requesting_issuer_uuid)
       @user_report = user_report
       @output_dir = output_dir
+      @requesting_issuer_uuid = requesting_issuer_uuid
     end
 
     def call
-      File.open(File.join(output_dir, 'events.csv'), 'w') do |file|
-        file.puts('event_name,date_time,ip,disavowed_at,user_agent,device_cookie')
+      CSV.open(File.join(output_dir, 'events.csv'), 'w') do |csv|
+        csv << %w[
+          uuid
+          event_name
+          date_time
+          ip
+          disavowed_at
+          user_agent
+          device_cookie
+        ]
+
         user_report[:user_events].each do |row|
-          file.puts(
-            CSV.generate_line(
-              row.values_at(
-                :event_name,
-                :date_time,
-                :ip,
-                :disavowed_at,
-                :user_agent,
-                :device_cookie,
-              ),
-            ),
+          csv << [requesting_issuer_uuid] + row.values_at(
+            :event_name,
+            :date_time,
+            :ip,
+            :disavowed_at,
+            :user_agent,
+            :device_cookie,
           )
         end
       end

--- a/lib/tasks/data_requests.rake
+++ b/lib/tasks/data_requests.rake
@@ -40,7 +40,9 @@ namespace :data_requests do
       FileUtils.mkdir_p(user_output_dir)
 
       DataRequests::WriteUserInfo.new(user_report, user_output_dir).call
-      DataRequests::WriteUserEvents.new(user_report, user_output_dir).call
+      DataRequests::WriteUserEvents.new(
+        user_report, user_output_dir, user_report[:requesting_issuer_uuid],
+      ).call
 
       cloudwatch_dates = user_report[:user_events].map { |row| row[:date_time] }.map do |date_time|
         Time.zone.parse(date_time).to_date

--- a/lib/tasks/data_requests.rake
+++ b/lib/tasks/data_requests.rake
@@ -41,7 +41,7 @@ namespace :data_requests do
 
       DataRequests::WriteUserInfo.new(user_report, user_output_dir).call
       DataRequests::WriteUserEvents.new(
-        user_report, user_output_dir, user_report[:requesting_issuer_uuid],
+        user_report, user_output_dir, user_report[:requesting_issuer_uuid]
       ).call
 
       cloudwatch_dates = user_report[:user_events].map { |row| row[:date_time] }.map do |date_time|

--- a/spec/services/data_requests/write_user_events_spec.rb
+++ b/spec/services/data_requests/write_user_events_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe DataRequests::WriteUserEvents do
+  let(:requesting_issuer_uuid) { SecureRandom.uuid }
+
   describe '#call' do
     it 'writes a file with event information' do
       user_report = JSON.parse(
@@ -8,9 +10,10 @@ describe DataRequests::WriteUserEvents do
       ).first
 
       Dir.mktmpdir do |dir|
-        described_class.new(user_report, dir).call
+        described_class.new(user_report, dir, requesting_issuer_uuid).call
         events = File.read(File.join(dir, 'events.csv'))
         csv = CSV.parse(events, headers: true)
+        expect(csv.first['uuid']).to eq(requesting_issuer_uuid)
         expect(csv.count).to eq(user_report[:user_events].length)
       end
     end


### PR DESCRIPTION
- Also use the CSV library to generate the entire file

I handled an OIG request recently, and they wanted to combine the various `events.csv` files, but since the UUID was outside the file, it was a lot of manual work to combine. Including the UUID helps combine more easily