### PR TITLE
Upgrade CI Postgres to 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/postgres:9.6-alpine
+      - image: cimg/postgres:13.4
         environment:
           POSTGRES_USER: circleci
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,7 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: postgres:9.6
+    - name: postgres:13.4
       alias: db-postgres
     - name: redis
       alias: db-redis


### PR DESCRIPTION
We'll be upgrading to 13 very soon, so we should run CI tests against 13!