### PR TITLE
Add specs around SMS message lengths

### DIFF
--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -19,6 +19,20 @@ require 'telephony/pinpoint/sms_sender'
 require 'telephony/pinpoint/voice_sender'
 
 module Telephony
+  # GSM 03.38 character set
+  # https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-limitations-characters.html
+  GSM_NON_WHITE_SPACE_CHARACTERS = %w[
+    A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e
+    f g h i j k l m n o p q r s t u v w x y z à Å å Ä ä Ç É é è ì Ñ ñ ò Ø ø Ö ö ù Ü ü Æ æ ß 0 1 2 3
+    4 5 6 7 8 9 & * @ : , ¤ $ = ! > # - ¡ ¿ ( < % . + £ ? " ) § ; ' / _ ¥ Δ Φ Γ Λ Ω Π Ψ Σ Θ Ξ
+  ]
+  GSM_WHITESPACE_CHARACTERS = ["\n", "\r", ' ']
+  GSM_DOUBLE_CHARACTERS = ['^', '{', '}', '\\', '[', ']', '~', '|', '€']
+  GSM_CHARACTERS = GSM_NON_WHITE_SPACE_CHARACTERS + GSM_WHITESPACE_CHARACTERS +
+                   GSM_DOUBLE_CHARACTERS
+
+  UCS_2_BASIC_CHAR_MAX = 0xFFFF
+
   extend SingleForwardable
 
   def self.config
@@ -72,4 +86,67 @@ module Telephony
 
     sender.phone_info(phone_number)
   end
+
+  # A character in a GSM 03.38 message counts as one character, unless it is explicitly one of
+  # the characters that requires an escape sequence, which makes it count as two characters.
+  #
+  # Messages that contain non-GSM 03.38 characters are encoded as UCS-2 with 2-byte characters.
+  # Codepoints less than 0xFFFF can be represented as one character, but other codepoints are
+  # encoded as two.
+  #
+  # This method does not handle message length added for multi-part message headers.
+  def self.sms_character_length(text)
+    if text.chars.all? { |x| GSM_CHARACTERS.include?(x) }
+      text.chars.sum do |character|
+        if GSM_DOUBLE_CHARACTERS.include?(character)
+          2
+        else
+          1
+        end
+      end
+    else
+      text.chars.sum do |char|
+        char.codepoints.sum do |codepoint|
+          if codepoint <= UCS_2_BASIC_CHAR_MAX
+            1
+          else
+            2
+          end
+        end
+      end
+    end
+  end
+
+  # A single GSM 03.38 message can contain up to 160 characters. If the length is beyond that,
+  # the message is split into parts containing 153 characters each. The capacity is lower because
+  # messages must now also encode information about message order.
+  #
+  # UCS-2 messages behave similarly, but the size is limited to 70 and 67 characters respectively.
+  def self.sms_parts(text)
+    length = sms_character_length(text)
+
+    if text.chars.all? { |x| GSM_CHARACTERS.include?(x) }
+      gsm_parts(length)
+    else
+      non_gsm_parts(length)
+    end
+  end
+
+  def self.gsm_parts(length)
+    if length <= 160
+      1
+    else
+      (length / 153.0).ceil
+    end
+  end
+
+  def self.non_gsm_parts(length)
+    if length <= 70
+      1
+    else
+      (length / 67.0).ceil
+    end
+  end
+
+  private_class_method :gsm_parts, :non_gsm_parts
 end

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -96,7 +96,7 @@ module Telephony
   #
   # This method does not handle message length added for multi-part message headers.
   def self.sms_character_length(text)
-    if text.chars.all? { |x| GSM_CHARACTERS.include?(x) }
+    if gsm_chars_only?(text)
       text.chars.sum do |character|
         if GSM_DOUBLE_CHARACTERS.include?(character)
           2
@@ -125,11 +125,15 @@ module Telephony
   def self.sms_parts(text)
     length = sms_character_length(text)
 
-    if text.chars.all? { |x| GSM_CHARACTERS.include?(x) }
+    if gsm_chars_only?(text)
       gsm_parts(length)
     else
       non_gsm_parts(length)
     end
+  end
+
+  def self.gsm_chars_only?(text)
+    text.chars.all? { |x| GSM_CHARACTERS.include?(x) }
   end
 
   def self.gsm_parts(length)

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -25,11 +25,11 @@ module Telephony
     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e
     f g h i j k l m n o p q r s t u v w x y z à Å å Ä ä Ç É é è ì Ñ ñ ò Ø ø Ö ö ù Ü ü Æ æ ß 0 1 2 3
     4 5 6 7 8 9 & * @ : , ¤ $ = ! > # - ¡ ¿ ( < % . + £ ? " ) § ; ' / _ ¥ Δ Φ Γ Λ Ω Π Ψ Σ Θ Ξ
-  ]
-  GSM_WHITESPACE_CHARACTERS = ["\n", "\r", ' ']
-  GSM_DOUBLE_CHARACTERS = ['^', '{', '}', '\\', '[', ']', '~', '|', '€']
-  GSM_CHARACTERS = GSM_NON_WHITE_SPACE_CHARACTERS + GSM_WHITESPACE_CHARACTERS +
-                   GSM_DOUBLE_CHARACTERS
+  ].to_set.freeze
+  GSM_WHITESPACE_CHARACTERS = ["\n", "\r", ' '].to_set.freeze
+  GSM_DOUBLE_CHARACTERS = ['^', '{', '}', '\\', '[', ']', '~', '|', '€'].to_set.freeze
+  GSM_CHARACTERS = (GSM_NON_WHITE_SPACE_CHARACTERS + GSM_WHITESPACE_CHARACTERS +
+                   GSM_DOUBLE_CHARACTERS).freeze
 
   UCS_2_BASIC_CHAR_MAX = 0xFFFF
 

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -33,6 +33,30 @@ module Telephony
       response
     end
 
+    def authentication_message
+      wrap_in_ssml_if_needed(
+        I18n.t(
+          "telephony.authentication_otp.#{channel}",
+          app_name: APP_NAME,
+          code: otp_transformed_for_channel,
+          expiration: expiration,
+          domain: domain,
+        ),
+      )
+    end
+
+    def confirmation_message
+      wrap_in_ssml_if_needed(
+        I18n.t(
+          "telephony.confirmation_otp.#{channel}",
+          app_name: APP_NAME,
+          code: otp_transformed_for_channel,
+          expiration: expiration,
+          domain: domain,
+        ),
+      )
+    end
+
     private
 
     def adapter
@@ -58,30 +82,6 @@ module Telephony
       }
       output = response.to_h.merge(extra).to_json
       Telephony.config.logger.info(output)
-    end
-
-    def authentication_message
-      wrap_in_ssml_if_needed(
-        I18n.t(
-          "telephony.authentication_otp.#{channel}",
-          app_name: APP_NAME,
-          code: otp_transformed_for_channel,
-          expiration: expiration,
-          domain: domain,
-        ),
-      )
-    end
-
-    def confirmation_message
-      wrap_in_ssml_if_needed(
-        I18n.t(
-          "telephony.confirmation_otp.#{channel}",
-          app_name: APP_NAME,
-          code: otp_transformed_for_channel,
-          expiration: expiration,
-          domain: domain,
-        ),
-      )
     end
 
     def otp_transformed_for_channel

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Telephony::OtpSender do
         it 'does not contain any non-GSM characters and is less than or equal to 160 characters' do
           message = sender.authentication_message
           expect(Telephony.sms_parts(message)).to eq 1
-          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         end
       end
 
@@ -296,7 +296,7 @@ RSpec.describe Telephony::OtpSender do
 
           message = sender.authentication_message
           expect(Telephony.sms_parts(message)).to eq 1
-          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         ensure
           I18n.locale = :en
         end
@@ -321,7 +321,7 @@ RSpec.describe Telephony::OtpSender do
         it 'does not contain any non-GSM characters and is sent in one part' do
           message = sender.confirmation_message
           expect(Telephony.sms_parts(message)).to eq 1
-          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         end
       end
 
@@ -344,7 +344,7 @@ RSpec.describe Telephony::OtpSender do
 
           message = sender.confirmation_message
           expect(Telephony.sms_parts(message)).to eq 1
-          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         ensure
           I18n.locale = :en
         end

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -255,4 +255,100 @@ RSpec.describe Telephony::OtpSender do
       end
     end
   end
+
+  describe '#authentication_message' do
+    let(:sender) do
+      sender = Telephony::OtpSender.new(
+        to: '+18888675309',
+        otp: 'ABC123',
+        channel: 'sms',
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
+        domain: 'secure.login.gov',
+        country_code: 'US',
+      )
+    end
+
+    context 'sms' do
+      context 'English' do
+        it 'does not contain any non-GSM characters and is less than or equal to 160 characters' do
+          message = sender.authentication_message
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+        end
+      end
+
+      # The Spanish-language translation currently includes the 'ó', character, which is not
+      # in the GSM 03.38 character set
+      context 'Spanish' do
+        it 'is sent in three parts' do
+          I18n.locale = :es
+
+          message = sender.authentication_message
+          expect(Telephony.sms_parts(message)).to eq 3
+        ensure
+          I18n.locale = :en
+        end
+      end
+
+      context 'French' do
+        it 'does not contain any non-GSM characters and is less than or equal to 160 characters' do
+          I18n.locale = :fr
+
+          message = sender.authentication_message
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+        ensure
+          I18n.locale = :en
+        end
+      end
+    end
+  end
+
+  describe '#confirmation_message' do
+    let(:sender) do
+      sender = Telephony::OtpSender.new(
+        to: '+18888675309',
+        otp: 'ABC123',
+        channel: 'sms',
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
+        domain: 'secure.login.gov',
+        country_code: 'US',
+      )
+    end
+
+    context 'sms' do
+      context 'English' do
+        it 'does not contain any non-GSM characters and is sent in one part' do
+          message = sender.confirmation_message
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+        end
+      end
+
+      # The Spanish-language translation currently includes the 'ó', character, which is not
+      # in the GSM 03.38 character set
+      context 'Spanish' do
+        it 'is sent in three parts' do
+          I18n.locale = :es
+
+          message = sender.confirmation_message
+          expect(Telephony.sms_parts(message)).to eq 3
+        ensure
+          I18n.locale = :en
+        end
+      end
+
+      context 'French' do
+        it 'does not contain any non-GSM characters and is sent in one part' do
+          I18n.locale = :fr
+
+          message = sender.confirmation_message
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(message.chars.all? { |x| Telephony::GSM_CHARACTERS.include?(x) }).to eq true
+        ensure
+          I18n.locale = :en
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/telephony/telephony_spec.rb
+++ b/spec/lib/telephony/telephony_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Telephony do
 
       expect(Telephony.sms_character_length("Login.gov\nParty")).to eq 15
 
-      random_double_character = Telephony::GSM_DOUBLE_CHARACTERS.sample
+      random_double_character = Telephony::GSM_DOUBLE_CHARACTERS.to_a.sample
       expect(Telephony.sms_character_length("abc\n¥ΔΦΓΛΩΠΨΣΘΞ#{random_double_character}")).
              to eq 17
     end

--- a/spec/lib/telephony/telephony_spec.rb
+++ b/spec/lib/telephony/telephony_spec.rb
@@ -32,4 +32,100 @@ RSpec.describe Telephony do
       end
     end
   end
+
+  # Assertions validated against https://twiliodeved.github.io/message-segment-calculator/
+  describe '.sms_character_length' do
+    it 'calculates correct length of simple GSM messages' do
+      expect(Telephony.sms_character_length('')).to eq 0
+      expect(Telephony.sms_character_length('login')).to eq 5
+      expect(Telephony.sms_character_length('b' * 170)).to eq 170
+    end
+
+    it 'calculates correct length of more complicated GSM messages' do
+      # Each of these characters is in GSM 03.38 and counts as 1 character
+      # and there are 124 of them
+      expect(
+        Telephony.sms_character_length(
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzàÅåÄäÇÉéèìÑñòØøÖöùÜ'\
+          'üÆæß0123456789&*@:,¤$=!>#-¡¿(<%.+£?")§;\'/_¥ΔΦΓΛΩΠΨΣΘΞ',
+        ),
+      ).to eq 124
+
+      # The double-length characters should count as twice their length
+      expect(Telephony.sms_character_length(Telephony::GSM_DOUBLE_CHARACTERS.join(''))).
+        to eq(Telephony::GSM_DOUBLE_CHARACTERS.length * 2)
+
+      # Space, new line, and carriage return all count as 1 character
+      expect(Telephony.sms_character_length("\n\r ")).to eq 3
+
+      expect(Telephony.sms_character_length("Login.gov\nParty")).to eq 15
+
+      random_double_character = Telephony::GSM_DOUBLE_CHARACTERS.sample
+      expect(Telephony.sms_character_length("abc\n¥ΔΦΓΛΩΠΨΣΘΞ#{random_double_character}")).
+             to eq 17
+    end
+
+    it 'calculates correct length of messages containing non-GSM characters' do
+      expect(Telephony.sms_character_length('âabcó')).to eq 5
+
+      # Messages containing non-GSM characters count double-length GSM as 1 character
+      # because of the different encoding
+      expect(Telephony.sms_character_length('|ó')).to eq 2
+    end
+
+    it 'calculates correct length of messages containing emoji' do
+      expect(Telephony.sms_character_length('😴')).to eq 2
+      expect(Telephony.sms_character_length('🛌')).to eq 2
+
+      # [0x1f6b6, 0x1f3fd, 0x200d, 0x2640, 0xfe0f]
+      # 0x1f6b6 and 0x1f3fd count as two since they are greater than 0xffff
+      expect(Telephony.sms_character_length('🚶🏽‍♀️')).to eq 7
+
+      # [0x1f93e, 0x1f3fd, 0x200d, 0x2640, 0xfe0f]
+      # 0x1f93e and 0x1f3fd count as two since they are greater than 0xffff
+      expect(Telephony.sms_character_length('🤾🏽‍♀️')).to eq 7
+
+      # [0x1f469, 0x200d, 0x2764, 0xfe0f, 0x200d, 0x1f469]
+      # 0x1f469 and 0x1f469 count as two since they are greater than 0xffff
+      expect(Telephony.sms_character_length('👩‍❤️‍👩')).to eq 8
+
+      # [0x1f1fa, 0x1f1f8]
+      # 0x1f1fa and 0x1f1f8 count as two since they are greater than 0xffff
+      expect(Telephony.sms_character_length('🇺🇸')).to eq 4
+    end
+  end
+
+  describe '.sms_parts' do
+    it 'correctly calculates number of parts in simple GSM messages' do
+      # Maximum characters in a single message that doesn't need to be split is 160
+      expect(Telephony.sms_parts('a')).to eq 1
+      expect(Telephony.sms_parts('a' * 160)).to eq 1
+
+      # Maximum characters in a multi-part message is 153
+      expect(Telephony.sms_parts('a' * 306)).to eq 2
+      expect(Telephony.sms_parts('a' * 307)).to eq 3
+    end
+
+    it 'correctly calculates number of parts in more complicated GSM messages' do
+      # Double-length characters can fit half as many characters in a given message or part
+      expect(Telephony.sms_parts('|')).to eq 1
+      expect(Telephony.sms_parts('|' * 80)).to eq 1
+      expect(Telephony.sms_parts('|' * 81)).to eq 2
+      expect(Telephony.sms_parts('|' * 153)).to eq 2
+      expect(Telephony.sms_parts('|' * 154)).to eq 3
+
+      expect(Telephony.sms_parts('a' * 159 + '|')).to eq 2
+    end
+
+    it 'correctly calculates number of parts in non-GSM messages' do
+      # Maximum characters in a single non-GSM message that doesn't need to be split is 70
+      expect(Telephony.sms_parts('🤠' * 35)).to eq 1
+      expect(Telephony.sms_parts('a' * 68 + '😑')).to eq 1
+      expect(Telephony.sms_parts('a' * 69 + '😑')).to eq 2
+      expect(Telephony.sms_parts('|' * 68 + '😑')).to eq 1
+      expect(Telephony.sms_parts('|' * 69 + '😑')).to eq 2
+      expect(Telephony.sms_parts('🇺🇸' * 17)).to eq 1
+      expect(Telephony.sms_parts('🇺🇸' * 18)).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
Following #5732, we identified some missing guardrails around SMS message lengths and splitting. Using the documentation from AWS[^1], this PR implements tests and functionality to count and automate testing of how long our messages are so we get notified if they've changed.

Twilio is not our telephony provider, but they have helpful documentation as well[^2][^3][^4]. Their [Message Segment Calculator](https://twiliodeved.github.io/message-segment-calculator/) is also very good.

I tried to include more documentation around the tests and implementation, but it still feels kind of lacking.

[^1]: https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-limitations-characters.html#channels-sms-limitations-characters-gsm-alphabet
[^2]: https://www.twilio.com/docs/glossary/what-is-ucs-2-character-encoding
[^3]: https://support.twilio.com/hc/en-us/articles/223134307-Unicode-messages-are-being-split
[^4]: https://www.twilio.com/blog/2017/03/what-the-heck-is-a-segment.html