### PR TITLE
Preserve locale change in identity verification (LG-5329)

### DIFF
--- a/app/controllers/accounts/connected_accounts_controller.rb
+++ b/app/controllers/accounts/connected_accounts_controller.rb
@@ -9,7 +9,7 @@ module Accounts
       @view_model = AccountShow.new(
         decrypted_pii: nil,
         personal_key: flash[:personal_key],
-        sp_session_request_url: sp_session_request_url_without_prompt_login,
+        sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_session.sp_name,
         decorated_user: current_user.decorate,
         locked_for_session: pii_locked_for_session?(current_user),

--- a/app/controllers/accounts/history_controller.rb
+++ b/app/controllers/accounts/history_controller.rb
@@ -9,7 +9,7 @@ module Accounts
       @view_model = AccountShow.new(
         decrypted_pii: nil,
         personal_key: flash[:personal_key],
-        sp_session_request_url: sp_session_request_url_without_prompt_login,
+        sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_session.sp_name,
         decorated_user: current_user.decorate,
         locked_for_session: pii_locked_for_session?(current_user),

--- a/app/controllers/accounts/two_factor_authentication_controller.rb
+++ b/app/controllers/accounts/two_factor_authentication_controller.rb
@@ -10,7 +10,7 @@ module Accounts
       @view_model = AccountShow.new(
         decrypted_pii: nil,
         personal_key: flash[:personal_key],
-        sp_session_request_url: sp_session_request_url_without_prompt_login,
+        sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_session.sp_name,
         decorated_user: current_user.decorate,
         locked_for_session: pii_locked_for_session?(current_user),

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,7 @@ class AccountsController < ApplicationController
     @view_model = AccountShow.new(
       decrypted_pii: cacher.fetch,
       personal_key: flash[:personal_key],
-      sp_session_request_url: sp_session_request_url_without_prompt_login,
+      sp_session_request_url: sp_session_request_url_with_updated_params,
       sp_name: decorated_session.sp_name,
       decorated_user: current_user.decorate,
       locked_for_session: pii_locked_for_session?(current_user),

--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -34,6 +34,6 @@ module SecureHeadersConcern
   private
 
   def stored_url_for_user
-    sp_session_request_url_without_prompt_login
+    sp_session_request_url_with_updated_params
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,7 @@ class EventsController < ApplicationController
     @view_model = AccountShow.new(
       decrypted_pii: nil,
       personal_key: nil,
-      sp_session_request_url: sp_session_request_url_without_prompt_login,
+      sp_session_request_url: sp_session_request_url_with_updated_params,
       sp_name: decorated_session.sp_name,
       decorated_user: current_user.decorate,
       locked_for_session: pii_locked_for_session?(current_user),

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else
-        redirect_to(sp_session_request_url_without_prompt_login || account_url)
+        redirect_to(sp_session_request_url_with_updated_params || account_url)
       end
     end
 

--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -16,7 +16,7 @@ module Users
 
     def create
       analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION_CONTINUE)
-      redirect_to sp_session_request_url_without_prompt_login
+      redirect_to sp_session_request_url_with_updated_params
     end
 
     def destroy

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -351,6 +351,44 @@ describe ApplicationController do
     end
   end
 
+  describe '#sp_session_request_url_with_updated_params' do
+    controller do
+      def index
+        render plain: 'Hello'
+      end
+    end
+
+    before do
+      allow(controller).to receive(:session).
+        and_return(sp: { request_url: sp_session_request_url })
+    end
+
+    subject(:url_with_updated_params) do
+      controller.send(:sp_session_request_url_with_updated_params)
+    end
+
+    let(:sp_session_request_url) { nil }
+
+    it 'leaves a nil url alone' do
+      expect(url_with_updated_params).to eq(nil)
+    end
+
+    context 'with a url that has prompt=login' do
+      let(:sp_session_request_url) { '/authorize?prompt=login' }
+      it 'changes it to prompt=select_account' do
+        expect(url_with_updated_params).to eq('/authorize?prompt=select_account')
+      end
+    end
+
+    context 'when the locale has been changed' do
+      before { I18n.locale = :es }
+      let(:sp_session_request_url) { '/authorize' }
+      it 'adds the locale to the url' do
+        expect(url_with_updated_params).to eq('/authorize?locale=es')
+      end
+    end
+  end
+
   def expect_user_event_to_have_been_created(user, event_type)
     device = Device.first
     expect(device.user_id).to eq(user.id)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -261,7 +261,7 @@ module Features
 
     def fill_in_code_with_last_phone_otp
       accept_rules_of_use_and_continue_if_displayed
-      fill_in :code, with: last_phone_otp
+      fill_in I18n.t('forms.two_factor.code'), with: last_phone_otp
     end
 
     def accept_rules_of_use_and_continue_if_displayed

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -10,7 +10,7 @@ shared_examples 'creating an account with the site in Spanish' do |sp|
     end
 
     click_agree_and_continue
-    expect(current_url).to eq @saml_authn_request if sp == :saml
+    expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: :es) if sp == :saml
 
     if sp == :oidc
       redirect_uri = URI(current_url)

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -10,9 +10,9 @@ shared_examples 'creating an account with the site in Spanish' do |sp|
     end
 
     click_agree_and_continue
-    expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: :es) if sp == :saml
-
-    if sp == :oidc
+    if :sp == :saml
+      expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: :es)
+    elsif sp == :oidc
       redirect_uri = URI(current_url)
 
       expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -19,9 +19,9 @@ shared_examples 'signing in with the site in Spanish' do |sp|
 
     click_agree_and_continue
 
-    expect(current_url).to eq @saml_authn_request if sp == :saml
-
-    if sp == :oidc
+    if sp == :saml
+      expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: 'es')
+    elsif sp == :oidc
       redirect_uri = URI(current_url)
 
       expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')


### PR DESCRIPTION
Steps to reproduce the bug:
- Start from an SP that requires IAL2, get passed over to the IDP signin screen
- Before signing in, **change the locale**
- After signing in in that new locale, the locale will revert to the default locale (wrong)

The problem appears to be how we save the authorization URL `/openid_connect/authorize?param=...` and we redirect back there. However if the locale was changed after the URL is saved, the locale will be missing when we redirect to it, so this change adds in the locale before we redirect and preserve locale the rest of the flow

Since I was updating the behavior of the existing helper method, I decided to rename it too, which added some diff noise