### PR TITLE
Log WebAuthn Platform setups/authentications differently than roaming

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -81,10 +81,10 @@ module TwoFactorAuthentication
 
     def analytics_properties
       auth_method = if platform_authenticator?
-                 'webauthn_platform'
-               else
-                 'webauthn'
-               end
+                      'webauthn_platform'
+                    else
+                      'webauthn'
+                    end
       {
         context: context,
         multi_factor_auth_method: auth_method,

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -62,7 +62,7 @@ module TwoFactorAuthentication
         data: { credential_ids: credential_ids,
                 user_opted_remember_device_cookie: user_opted_remember_device_cookie },
         remember_device_default: remember_device_default,
-        platform_authenticator: platform_authenticator?,
+        platform_authenticator: params[:platform].to_s == 'true',
       )
     end
 
@@ -80,7 +80,7 @@ module TwoFactorAuthentication
     end
 
     def analytics_properties
-      auth_method = if platform_authenticator?
+      auth_method = if form&.webauthn_configuration&.platform_authenticator
                       'webauthn_platform'
                     else
                       'webauthn'
@@ -94,12 +94,6 @@ module TwoFactorAuthentication
 
     def form
       @form ||= WebauthnVerificationForm.new(current_user, user_session)
-    end
-
-    private
-
-    def platform_authenticator?
-      params[:platform].to_s == 'true'
     end
   end
 end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -62,7 +62,7 @@ module TwoFactorAuthentication
         data: { credential_ids: credential_ids,
                 user_opted_remember_device_cookie: user_opted_remember_device_cookie },
         remember_device_default: remember_device_default,
-        platform_authenticator: params[:platform].to_s == 'true',
+        platform_authenticator: platform_authenticator?,
       )
     end
 
@@ -80,15 +80,26 @@ module TwoFactorAuthentication
     end
 
     def analytics_properties
+      auth_method = if platform_authenticator?
+                 'webauthn_platform'
+               else
+                 'webauthn'
+               end
       {
         context: context,
-        multi_factor_auth_method: 'webauthn',
+        multi_factor_auth_method: auth_method,
         webauthn_configuration_id: form&.webauthn_configuration&.id,
       }
     end
 
     def form
       @form ||= WebauthnVerificationForm.new(current_user, user_session)
+    end
+
+    private
+
+    def platform_authenticator?
+      params[:platform].to_s == 'true'
     end
   end
 end

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -102,9 +102,14 @@ class WebauthnSetupForm
   end
 
   def extra_analytics_attributes
+    auth_method = if platform_authenticator?
+                    'webauthn_platform'
+                  else
+                    'webauthn'
+                  end
     {
       mfa_method_counts: MfaContext.new(user).enabled_two_factor_configuration_counts_hash,
-      multi_factor_auth_method: 'webauthn',
+      multi_factor_auth_method: auth_method,
       pii_like_keypaths: [[:mfa_method_counts, :phone]],
     }
   end

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -69,8 +69,14 @@ class WebauthnVerificationForm
   end
 
   def extra_analytics_attributes
+    auth_method = if @webauthn_configuration&.platform_authenticator
+                    'webauthn_platform'
+                  else
+                    'webauthn'
+                  end
+
     {
-      multi_factor_auth_method: 'webauthn',
+      multi_factor_auth_method: auth_method,
       webauthn_configuration_id: @webauthn_configuration&.id,
     }
   end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -41,7 +41,8 @@ describe WebauthnSetupForm do
           platform_authenticator: true,
         }
 
-        subject.submit(protocol, params)
+        result = subject.submit(protocol, params)
+        expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
 
         expect(user.reload.webauthn_configurations.platform_authenticators.count).to eq(1)
       end

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -6,6 +6,7 @@ describe WebauthnVerificationForm do
   let(:user) { create(:user) }
   let(:user_session) { { webauthn_challenge: webauthn_challenge } }
   let(:subject) { WebauthnVerificationForm.new(user, user_session) }
+  let(:platform_authenticator) { nil }
 
   describe '#submit' do
     before do
@@ -14,10 +15,11 @@ describe WebauthnVerificationForm do
         user: user,
         credential_id: credential_id,
         credential_public_key: credential_public_key,
+        platform_authenticator: platform_authenticator,
       )
     end
 
-    context 'when the input is valid' do
+    context 'when the input is valid for non-platform authenticator' do
       it 'returns FormResponse with success: true' do
         allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
 
@@ -31,6 +33,25 @@ describe WebauthnVerificationForm do
 
         expect(result.success?).to eq(true)
         expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
+      end
+    end
+
+    context 'when the input is valid for platform authenticator' do
+      let(:platform_authenticator) { true }
+
+      it 'returns FormResponse with success: true' do
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
+
+        result = subject.submit(
+          protocol,
+          authenticator_data: authenticator_data,
+          client_data_json: verification_client_data_json,
+          signature: signature,
+          credential_id: credential_id,
+        )
+
+        expect(result.success?).to eq(true)
+        expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn_platform')
       end
     end
 


### PR DESCRIPTION
Currently, MFA and MFA setup events for platform authenticators will have `multi_factor_auth_method: 'webauthn'`, which obscures our ability to see the usage of platform authenticators