### PR TITLE
Fix bug with IDV hybrid flow handoff after cancellation (LG-5367)

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -46,6 +46,9 @@ module Idv
     end
 
     def cancel_document_capture_session
+      # Goal: reset the Idv::Steps::LinkSentStep but we don't have access to the
+      # flow_session from here (because this is the mobile session and that is only
+      # on the desktop session)
       document_capture_session&.update(cancelled_at: Time.zone.now)
     end
 

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -54,6 +54,10 @@ module Idv
 
       def update_document_capture_session_requested_at(session_uuid)
         document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
+        if document_capture_session.cancelled_at
+          # See note at CancellationsController#cancel_document_capture_session
+          flow_session.delete(Idv::Steps::LinkSentStep.name)
+        end
         return unless document_capture_session
         document_capture_session.update!(
           requested_at: Time.zone.now,

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -12,7 +12,7 @@ describe 'Hybrid Flow' do
   end
 
   before do
-    expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
+    allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
       @sms_link = config[:link]
       impl.call(**config)
     end.at_least(1).times

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -11,14 +11,15 @@ describe 'Hybrid Flow' do
       and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
   end
 
+  before do
+    expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
+      @sms_link = config[:link]
+      impl.call(**config)
+    end.at_least(1).times
+  end
+
   it 'proofs and hands off to mobile', js: true do
     user = nil
-    sms_link = nil
-
-    expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
-      sms_link = config[:link]
-      impl.call(**config)
-    end
 
     perform_in_browser(:desktop) do
       user = sign_in_and_2fa_user
@@ -29,10 +30,10 @@ describe 'Hybrid Flow' do
       expect(page).to have_content(t('doc_auth.headings.text_message'))
     end
 
-    expect(sms_link).to be_present
+    expect(@sms_link).to be_present
 
     perform_in_browser(:mobile) do
-      visit sms_link
+      visit @sms_link
       attach_and_submit_images
       expect(page).to have_text(t('doc_auth.instructions.switch_back'))
     end
@@ -56,6 +57,36 @@ describe 'Hybrid Flow' do
 
       expect(page).to have_current_path(account_path)
       expect(page).to have_content(t('headings.account.verified_account'))
+    end
+  end
+
+  it 'shows the waiting screen correctly after cancelling from mobile and restarting', js: true do
+    user = nil
+
+    perform_in_browser(:desktop) do
+      user = sign_in_and_2fa_user
+      complete_doc_auth_steps_before_send_link_step
+      fill_in :doc_auth_phone, with: '415-555-0199'
+      click_idv_continue
+
+      expect(page).to have_content(t('doc_auth.headings.text_message'))
+    end
+
+    expect(@sms_link).to be_present
+
+    perform_in_browser(:mobile) do
+      visit @sms_link
+      click_on t('links.cancel')
+      click_on t('forms.buttons.cancel') # Yes, cancel
+    end
+
+    perform_in_browser(:desktop) do
+      expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
+      click_on t('doc_auth.buttons.use_phone')
+      fill_in :doc_auth_phone, with: '415-555-0199'
+      click_idv_continue
+
+      expect(page).to have_content(t('doc_auth.headings.text_message'))
     end
   end
 end


### PR DESCRIPTION
This fixes a really weird bug, when trying to re-enter the hybrid flow after cancelling on mobile

To reproduce:
1. Start IDV on desktop
2. Go through the Use Phone/Hybrid flow
3. From mobile, hit cancel
4. Back on desktop, go through Use Phone/Hybrid again
5. Then:
    - **Before**: the desktop would show the desktop upload form (but would still send an SMS)
    - **After**: desktop correctly shows the "waiting for mobile" screen

The core issue was that the code that detects which step to go to next was relying on a key being missing in the `flow_session`, which was not being reset correctly (see except below). It's tricky because the mobile flow gets a separate rails session from the desktop session, so we can't just delete that key from mobile

https://github.com/18F/identity-idp/blob/d02eb7a81201de83fc25c0cb44f93bbdd9aa0c4a/app/services/flow/base_flow.rb#L16-L22

My workaround was to look for the `cancelled_at` timestamp on the DB record (which is correctly cleared each attempt, so we should be able to trust it) and delete the specific key needed to make this work correctly. It's definitely delicate 😬 