### PR TITLE
Use consistent ivar memoization naming style (LG-4866)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -641,6 +641,10 @@ Naming/HeredocDelimiterCase:
   Enabled: true
   EnforcedStyle: uppercase
 
+Naming/MemoizedInstanceVariableName:
+  Enabled: true
+  EnforcedStyleForLeadingUnderscores: disallowed
+
 Naming/MethodParameterName:
   MinNameLength: 2
 

--- a/app/controllers/account_reset/pending_controller.rb
+++ b/app/controllers/account_reset/pending_controller.rb
@@ -24,7 +24,7 @@ module AccountReset
     end
 
     def pending_account_reset_request
-      @account_reset_request ||= AccountReset::FindPendingRequestForUser.new(
+      @pending_account_reset_request ||= AccountReset::FindPendingRequestForUser.new(
         current_user,
       ).call
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   delegate :remember_device_default, to: :decorated_session
 
   def decorated_session
-    @_decorated_session ||= DecoratedSession.new(
+    @decorated_session ||= DecoratedSession.new(
       sp: current_sp,
       view_context: view_context,
       sp_session: sp_session,

--- a/app/controllers/concerns/account_reactivation_concern.rb
+++ b/app/controllers/concerns/account_reactivation_concern.rb
@@ -7,7 +7,7 @@ module AccountReactivationConcern
   end
 
   def reactivate_account_session
-    @_reactivate_account_session ||= ReactivateAccountSession.new(
+    @reactivate_account_session ||= ReactivateAccountSession.new(
       user: current_user,
       user_session: user_session,
     )

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -33,7 +33,7 @@ module IdvSession
   end
 
   def idv_session
-    @_idv_session ||= Idv::Session.new(
+    @idv_session ||= Idv::Session.new(
       user_session: user_session,
       current_user: effective_user,
       issuer: sp_session[:issuer],

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -187,12 +187,12 @@ module SamlIdpAuthConcern
   end
 
   def current_service_provider
-    return @_sp if defined?(@_sp)
-    @_sp = ServiceProvider.find_by(issuer: current_issuer)
+    return @current_service_provider if defined?(@current_service_provider)
+    @current_service_provider = ServiceProvider.find_by(issuer: current_issuer)
   end
 
   def current_issuer
-    @_issuer ||= saml_request.service_provider&.identifier
+    @current_issuer ||= saml_request.service_provider&.identifier
   end
 
   def request_url

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,7 +34,7 @@ class EventsController < ApplicationController
   end
 
   def device_id
-    @device_id_param ||= begin
+    @device_id ||= begin
       id = params[:id].try(:to_i)
       id || 0
     end

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -47,7 +47,7 @@ module Idv
     end
 
     def gpo_mail_service
-      @_gpo_mail_service ||= Idv::GpoMail.new(current_user)
+      @gpo_mail_service ||= Idv::GpoMail.new(current_user)
     end
 
     private

--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -79,8 +79,8 @@ module Idv
     end
 
     def gpo_letter_available
-      @_gpo_letter_available ||= FeatureManagement.enable_gpo_verification? &&
-                                 !Idv::GpoMail.new(current_user).mail_spammed?
+      @gpo_letter_available ||= FeatureManagement.enable_gpo_verification? &&
+                                !Idv::GpoMail.new(current_user).mail_spammed?
     end
   end
 end

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -81,7 +81,7 @@ module Idv
     end
 
     def step
-      @_step ||= Idv::PhoneStep.new(idv_session: idv_session, trace_id: amzn_trace_id)
+      @step ||= Idv::PhoneStep.new(idv_session: idv_session, trace_id: amzn_trace_id)
     end
 
     def step_params
@@ -93,7 +93,7 @@ module Idv
     end
 
     def set_idv_form
-      @idv_form ||= Idv::PhoneForm.new(
+      @idv_form = Idv::PhoneForm.new(
         user: current_user,
         previous_params: idv_session.previous_phone_step_params,
         allowed_countries: ['US'],
@@ -127,8 +127,8 @@ module Idv
     end
 
     def gpo_letter_available
-      @_gpo_letter_available ||= FeatureManagement.enable_gpo_verification? &&
-                                 !Idv::GpoMail.new(current_user).mail_spammed?
+      @gpo_letter_available ||= FeatureManagement.enable_gpo_verification? &&
+                                !Idv::GpoMail.new(current_user).mail_spammed?
     end
   end
 end

--- a/app/controllers/redirect/return_to_sp_controller.rb
+++ b/app/controllers/redirect/return_to_sp_controller.rb
@@ -23,7 +23,7 @@ module Redirect
     end
 
     def sp_request_params
-      @request_params ||= begin
+      @sp_request_params ||= begin
         if sp_request_url.present?
           UriService.params(sp_request_url)
         else

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -87,9 +87,11 @@ module SignUp
       analytics.track_event(Analytics::USER_REGISTRATION_COMPLETE, analytics_attributes(last_page))
     end
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def pii
       @parsed_pii ||= JSON.parse(user_session['decrypted_pii']).symbolize_keys
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def address
       addr = pii[:address2]

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -77,11 +77,11 @@ module TwoFactorAuthentication
     end
 
     def password_reset_profile
-      @_password_reset_profile ||= current_user.decorate.password_reset_profile
+      @password_reset_profile ||= current_user.decorate.password_reset_profile
     end
 
     def pii
-      @_pii ||= password_reset_profile.recover_pii(normalized_personal_key)
+      @pii ||= password_reset_profile.recover_pii(normalized_personal_key)
     end
 
     def personal_key_param

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -26,7 +26,7 @@ module TwoFactorAuthentication
     private
 
     def process_token
-      result = piv_cac_verfication_form.submit
+      result = piv_cac_verification_form.submit
       analytics.track_mfa_submit_event(
         result.to_h.merge(analytics_properties),
       )
@@ -40,8 +40,8 @@ module TwoFactorAuthentication
     def handle_valid_piv_cac
       clear_piv_cac_nonce
       save_piv_cac_information(
-        subject: piv_cac_verfication_form.x509_dn,
-        issuer: piv_cac_verfication_form.x509_issuer,
+        subject: piv_cac_verification_form.x509_dn,
+        issuer: piv_cac_verification_form.x509_issuer,
         presented: true,
       )
 
@@ -72,7 +72,7 @@ module TwoFactorAuthentication
       }.merge(generic_data)
     end
 
-    def piv_cac_verfication_form
+    def piv_cac_verification_form
       @piv_cac_verification_form ||= UserPivCacVerificationForm.new(
         user: current_user,
         token: params[:token],
@@ -99,7 +99,7 @@ module TwoFactorAuthentication
       {
         context: context,
         multi_factor_auth_method: 'piv_cac',
-        piv_cac_configuration_id: piv_cac_verfication_form&.piv_cac_configuration&.id,
+        piv_cac_configuration_id: piv_cac_verification_form&.piv_cac_configuration&.id,
       }
     end
   end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -103,7 +103,7 @@ module Users
     end
 
     def token_user
-      @_token_user ||= User.with_reset_password_token(params[:reset_password_token])
+      @token_user ||= User.with_reset_password_token(params[:reset_password_token])
     end
 
     def build_user

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -138,7 +138,7 @@ module Users
     end
 
     def now
-      @_now ||= Time.zone.now
+      @now ||= Time.zone.now
     end
 
     def update_sp_return_logs_with_user(user_id)

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -232,7 +232,7 @@ module Users
     end
 
     def otp_rate_limiter
-      @_otp_rate_limited ||= OtpRateLimiter.new(
+      @otp_rate_limiter ||= OtpRateLimiter.new(
         phone: phone_to_deliver_to,
         user: current_user,
         phone_confirmed: UserSessionContext.authentication_context?(context),

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -29,10 +29,12 @@ module Users
       redirect_to root_url
     end
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     # @return [Pii::Attributes, nil]
     def decrypted_pii
       @_decrypted_pii ||= reactivate_account_session.decrypted_pii
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def handle_success(result)
       flash[:personal_key] = result.extra[:personal_key]

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -170,7 +170,7 @@ class UserDecorator
   end
 
   def lockout_period_config
-    @config ||= IdentityConfig.store.lockout_period_in_minutes
+    @lockout_period_config ||= IdentityConfig.store.lockout_period_in_minutes
   end
 
   def lockout_period_expired?

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -55,6 +55,6 @@ class AddUserEmailForm
   end
 
   def existing_user
-    @_user ||= User.find_with_email(email) || AnonymousUser.new
+    @existing_user ||= User.find_with_email(email) || AnonymousUser.new
   end
 end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -33,7 +33,7 @@ class GpoVerifyForm
   protected
 
   def pending_profile
-    @_pending_profile ||= user.pending_profile
+    @pending_profile ||= user.pending_profile
   end
 
   def gpo_confirmation_code

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -49,7 +49,7 @@ class OtpDeliverySelectionForm
   end
 
   def parsed_phone
-    @_parsed_phone ||= Phonelib.parse(phone)
+    @parsed_phone ||= Phonelib.parse(phone)
   end
 
   def confirmed_phone?

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -32,6 +32,6 @@ class PasswordResetEmailForm
   end
 
   def user
-    @_user ||= User.find_with_email(email)
+    @user ||= User.find_with_email(email)
   end
 end

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -158,7 +158,7 @@ class RegisterUserEmailForm
   end
 
   def existing_user
-    @_user ||= User.find_with_email(email) || AnonymousUser.new
+    @existing_user ||= User.find_with_email(email) || AnonymousUser.new
   end
 
   def email_request_id(request_id)

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -38,6 +38,6 @@ class UpdateUserPasswordForm
   end
 
   def encryptor
-    @_encryptor ||= ActiveProfileEncryptor.new(user, user_session, password)
+    @encryptor ||= ActiveProfileEncryptor.new(user, user_session, password)
   end
 end

--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -40,6 +40,6 @@ class VerifyPasswordForm
   end
 
   def profile
-    @_profile ||= user.decorate.password_reset_profile
+    @profile ||= user.decorate.password_reset_profile
   end
 end

--- a/app/forms/verify_personal_key_form.rb
+++ b/app/forms/verify_personal_key_form.rb
@@ -24,7 +24,7 @@ class VerifyPersonalKeyForm
 
   # @return [Pii::Attributes,nil]
   def decrypted_pii
-    @_pii ||= password_reset_profile.recover_pii(personal_key)
+    @decrypted_pii ||= password_reset_profile.recover_pii(personal_key)
   end
 
   private

--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -54,7 +54,7 @@ module EncryptableAttribute
   private
 
   def encrypted_attributes
-    @_encrypted_attributes ||= {}
+    @encrypted_attributes ||= {}
   end
 
   def get_encrypted_attribute(name:)

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -17,7 +17,7 @@ module FederatedProtocols
     end
 
     def requested_attributes
-      @_attributes ||= SamlRequestPresenter.new(
+      @requested_attributes ||= SamlRequestPresenter.new(
         request: request, service_provider: current_service_provider,
       ).requested_attributes
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -101,7 +101,7 @@ class Profile < ApplicationRecord
   private
 
   def personal_key_generator
-    @_personal_key_generator ||= PersonalKeyGenerator.new(user)
+    @personal_key_generator ||= PersonalKeyGenerator.new(user)
   end
 
   def encrypt_ssn_fingerprint(pii)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   end
 
   def active_profile
-    @_active_profile ||= profiles.verified.find(&:active?)
+    @active_profile ||= profiles.verified.find(&:active?)
   end
 
   def pending_profile?

--- a/app/presenters/saml_request_presenter.rb
+++ b/app/presenters/saml_request_presenter.rb
@@ -49,7 +49,7 @@ class SamlRequestPresenter
   end
 
   def bundle
-    @_bundle ||= (
+    @bundle ||= (
       authn_request_bundle || service_provider&.attribute_bundle || []
     ).map(&:to_sym)
   end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -175,7 +175,7 @@ class AttributeAsserter
   end
 
   def bundle
-    @_bundle ||= (
+    @bundle ||= (
       authn_request_bundle || service_provider.metadata[:attribute_bundle] || []
     ).map(&:to_sym)
   end

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -50,7 +50,7 @@ module DataRequests
     end
 
     def looked_up_user_uuids
-      @looked_up_users ||= Set.new
+      @looked_up_user_uuids ||= Set.new
     end
 
     def users_to_lookup

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -83,7 +83,7 @@ module DocAuth
         end
 
         def processed_image_metrics
-          @image_metrics ||= raw_images_data.index_by do |image|
+          @processed_image_metrics ||= raw_images_data.index_by do |image|
             image.delete('Uri')
             get_image_side_name(image['Side'])
           end

--- a/app/services/event_disavowal/find_disavowed_event.rb
+++ b/app/services/event_disavowal/find_disavowed_event.rb
@@ -7,14 +7,18 @@ module EventDisavowal
     end
 
     def call
+      event
+    end
+
+    private
+
+    def event
       # Use `#all` here instead of `#first` to avoid setting a 'LIMIT 1' to the
       # postgres query which causes it to run slowly.
       @event ||= Event.where(
         disavowal_token_fingerprint: disavowal_token_fingerprints,
       ).all[0]
     end
-
-    private
 
     def disavowal_token_fingerprints
       old_keys = IdentityConfig.store.hmac_fingerprinter_key_queue

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -21,10 +21,10 @@ module Idv
     attr_reader :current_user
 
     def user_mail_events
-      @_user_mail_events ||= current_user.events.
-                             gpo_mail_sent.
-                             order('updated_at DESC').
-                             limit(MAX_MAIL_EVENTS)
+      @user_mail_events ||= current_user.events.
+                            gpo_mail_sent.
+                            order('updated_at DESC').
+                            limit(MAX_MAIL_EVENTS)
     end
 
     def max_events?

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -65,7 +65,7 @@ module Idv
     end
 
     def profile
-      @_profile ||= Profile.find_by(id: profile_id)
+      @profile ||= Profile.find_by(id: profile_id)
     end
 
     def clear

--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -41,9 +41,11 @@ class OtpRateLimiter
 
   attr_reader :phone, :user, :phone_confirmed
 
+  # rubocop:disable Naming/MemoizedInstanceVariableName
   def entry_for_current_phone
     @entry ||= OtpRequestsTracker.find_or_create_with_phone_and_confirmed(phone, phone_confirmed)
   end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
 
   def otp_last_sent_at
     entry_for_current_phone.otp_last_sent_at

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -3,7 +3,7 @@ module Pii
     def initialize(user: nil, user_session: nil, pii: nil, profile: nil)
       @user = user
       @user_session = user_session
-      @pii = pii
+      @pii_attributes = pii
       @profile = profile
     end
 
@@ -17,11 +17,11 @@ module Pii
     attr_reader :user, :user_session
 
     def pii_attributes
-      @pii ||= cacher.fetch
+      @pii_attributes ||= cacher.fetch
     end
 
     def cacher
-      @_cacher ||= Pii::Cacher.new(user, user_session)
+      @cacher ||= Pii::Cacher.new(user, user_session)
     end
 
     def profile

--- a/app/services/proofing/aamva/soap_error_handler.rb
+++ b/app/services/proofing/aamva/soap_error_handler.rb
@@ -41,7 +41,8 @@ module Proofing
       end
 
       def program_exception_nodes
-        @nodes ||= REXML::XPath.match(document, '//ProgramExceptions/ProgramException')
+        @program_exception_nodes ||=
+          REXML::XPath.match(document, '//ProgramExceptions/ProgramException')
       end
 
       def soap_error_reason_text_node

--- a/app/services/saml_request_parser.rb
+++ b/app/services/saml_request_parser.rb
@@ -15,7 +15,7 @@ class SamlRequestParser
   attr_reader :request
 
   def authn_context_attr_nodes
-    @_attr_nodes ||= begin
+    @authn_context_attr_nodes ||= begin
       doc = Saml::XML::Document.parse(request.raw_xml)
       doc.xpath(
         '//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef',

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -22,7 +22,7 @@ class SendSignUpEmailConfirmation
 
   def confirmation_token
     return email_address.confirmation_token if valid_confirmation_token_exists?
-    @token ||= Devise.friendly_token
+    @confirmation_token ||= Devise.friendly_token
   end
 
   def confirmation_sent_at

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -69,7 +69,7 @@ class ServiceProviderUpdater
   end
 
   def dashboard_response
-    @_dashboard_response ||= Faraday.get(url)
+    @dashboard_response ||= Faraday.get(url)
   end
 
   def log_error(msg)

--- a/app/validators/personal_key_validator.rb
+++ b/app/validators/personal_key_validator.rb
@@ -18,6 +18,6 @@ module PersonalKeyValidator
   end
 
   def personal_key_generator
-    @_personal_key_generator ||= PersonalKeyGenerator.new(user)
+    @personal_key_generator ||= PersonalKeyGenerator.new(user)
   end
 end

--- a/app/view_models/forgot_password_show.rb
+++ b/app/view_models/forgot_password_show.rb
@@ -11,6 +11,6 @@ class ForgotPasswordShow
   end
 
   def email
-    @_email ||= session.delete(:email)
+    @email ||= session.delete(:email)
   end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -101,7 +101,7 @@ module SamlAuthHelper
   end
 
   def saml_test_sp_key
-    @private_key ||= OpenSSL::PKey::RSA.new(
+    @saml_test_sp_key ||= OpenSSL::PKey::RSA.new(
       File.read(Rails.root + 'keys/saml_test_sp.key'),
     ).to_pem
   end

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -45,14 +45,14 @@ class SamlResponseDoc
   end
 
   def saml_response(settings)
-    @_saml_response ||= OneLogin::RubySaml::Response.new(
+    @saml_response ||= OneLogin::RubySaml::Response.new(
       raw_xml_response,
       settings: settings,
     )
   end
 
   def saml_document
-    @_saml_document ||= Saml::XML::Document.parse(raw_xml_response)
+    @saml_document ||= Saml::XML::Document.parse(raw_xml_response)
   end
 
   def response_doc
@@ -73,11 +73,11 @@ class SamlResponseDoc
   end
 
   def status_code
-    @_status_code ||= status.xpath('//samlp:StatusCode', samlp: Saml::XML::Namespaces::PROTOCOL)
+    @status_code ||= status.xpath('//samlp:StatusCode', samlp: Saml::XML::Namespaces::PROTOCOL)
   end
 
   def status
-    @_status ||= response_doc.xpath('//samlp:Status', samlp: Saml::XML::Namespaces::PROTOCOL)
+    @status ||= response_doc.xpath('//samlp:Status', samlp: Saml::XML::Namespaces::PROTOCOL)
   end
 
   def response_assertion_nodeset
@@ -185,14 +185,14 @@ class SamlResponseDoc
   end
 
   def transforms_nodeset
-    @_transforms ||= response_doc.xpath(
+    @transforms_nodeset ||= response_doc.xpath(
       '//ds:Reference/ds:Transforms',
       ds: Saml::XML::Namespaces::SIGNATURE,
     )
   end
 
   def transform(algorithm)
-    @_transform ||= transforms_nodeset[0].xpath(
+    transforms_nodeset[0].xpath(
       "//ds:Transform[@Algorithm='#{algorithm}']",
       ds: Saml::XML::Namespaces::SIGNATURE,
     )[0]


### PR DESCRIPTION
- Enforce it with rubocop

The ticket was just about the ivar names themselves, but the rubocop cop helps check that they match the method name too, which seemed worthwhile including

To pick between `@variable` and `@_variable`, I counted usages of each:
```
identity-idp:main> git grep "@[^_].*||=" -- 'app/*.rb' | wc -l
     190
identity-idp:main> git grep "@_.*||=" -- 'app/*.rb' | wc -l 
      35
```
so `@variable` was more prevalent, so I kept it