### PR TITLE
Grammar typo - "on to" to "to"

### DIFF
--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,8 +128,8 @@ en:
     webauthn_platform_setup:
       continue: Continue
       instructions_text: Use Touch or Face Unlock to access your account with %{app_name}
-      instructions_title: Use Touch or Face Unlock on to access your account.
-      intro: Use Touch or Face Unlock on to access your account.
+      instructions_title: Use Touch or Face Unlock to access your account.
+      intro: Use Touch or Face Unlock to access your account.
       login_text: When you are ready, press the button.
       nickname: Device nickname
     webauthn_setup:


### PR DESCRIPTION
The WebAuthn platform authenticator screen has a grammar typo - it uses "on to access your account" instead of "to access your account". I fixed this in the two places I saw it in `forms/en.yml`.