### PR TITLE
Increase rack timeout in development to fix assets locally

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -277,6 +277,7 @@ development:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   rails_mailer_previews_enabled: 'true'
+  rack_timeout_service_timeout_seconds: 9_999_999_999
   recurring_jobs_disabled_names: "[]"
   s3_report_bucket_prefix: ''
   s3_report_public_bucket_prefix: ''


### PR DESCRIPTION
**Why**: Low timeouts consistently trigger a segfault in
sassc, it happens even more often in Ruby 3 than it did
before