### PR TITLE
Drop delayed_jobs table and otp requests tracker index

### DIFF
--- a/db/primary_migrate/20211230164415_drop_delayed_jobs.rb
+++ b/db/primary_migrate/20211230164415_drop_delayed_jobs.rb
@@ -1,0 +1,23 @@
+class DropDelayedJobs < ActiveRecord::Migration[6.1]
+  def self.up
+    drop_table :delayed_jobs
+  end
+
+  def self.down
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+end

--- a/db/primary_migrate/20211230165320_drop_otp_requests_trackers_on_updated_at_index.rb
+++ b/db/primary_migrate/20211230165320_drop_otp_requests_trackers_on_updated_at_index.rb
@@ -1,0 +1,9 @@
+class DropOtpRequestsTrackersOnUpdatedAtIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :otp_requests_tracker, name: :index_otp_requests_trackers_on_updated_at
+  end
+
+  def down
+    add_index :otp_requests_tracker, [:updated_at], name: :index_otp_requests_trackers_on_updated_at
+  end
+end


### PR DESCRIPTION
We don't use delayed_job and the index on otp requests isn't used anywhere 🙂 