### PR TITLE
Change useCookie hook to getter, avoid global override

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -281,7 +281,7 @@ function AcuantCapture(
   const { isMobile } = useContext(DeviceContext);
   const { t, formatHTML } = useI18n();
   const [attempt, incrementAttempt] = useCounter(1);
-  const [acuantFailureCookie, setAcuantFailureCookie] = useCookie('AcuantCameraHasFailed');
+  const [getAcuantFailureCookie, setAcuantFailureCookie] = useCookie('AcuantCameraHasFailed');
   const { onFailedCaptureAttempt, onResetFailedCaptureAttempts } = useContext(
     FailedCaptureAttemptsContext,
   );
@@ -394,7 +394,7 @@ function AcuantCapture(
    */
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
-      const isAcuantCaptureCapable = hasCapture && !acuantFailureCookie;
+      const isAcuantCaptureCapable = hasCapture && !getAcuantFailureCookie();
       const shouldStartAcuantCapture =
         isAcuantCaptureCapable && capture !== 'user' && !isForceUploading.current;
       const shouldStartSelfieCapture =

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -281,7 +281,7 @@ function AcuantCapture(
   const { isMobile } = useContext(DeviceContext);
   const { t, formatHTML } = useI18n();
   const [attempt, incrementAttempt] = useCounter(1);
-  const [getAcuantFailureCookie, setAcuantFailureCookie] = useCookie('AcuantCameraHasFailed');
+  const [acuantFailureCookie, setAcuantFailureCookie] = useCookie('AcuantCameraHasFailed');
   const { onFailedCaptureAttempt, onResetFailedCaptureAttempts } = useContext(
     FailedCaptureAttemptsContext,
   );
@@ -394,7 +394,7 @@ function AcuantCapture(
    */
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
-      const isAcuantCaptureCapable = hasCapture && !getAcuantFailureCookie();
+      const isAcuantCaptureCapable = hasCapture && !acuantFailureCookie;
       const shouldStartAcuantCapture =
         isAcuantCaptureCapable && capture !== 'user' && !isForceUploading.current;
       const shouldStartSelfieCapture =

--- a/app/javascript/packages/document-capture/hooks/use-cookie.js
+++ b/app/javascript/packages/document-capture/hooks/use-cookie.js
@@ -1,20 +1,46 @@
-import useForceRender from './use-force-render';
+import { createContext, useContext, useState, useEffect } from 'react';
+
+/** @typedef {import('react').Dispatch<A>} Dispatch @template A */
+/** @typedef {import('react').SetStateAction<S>} SetStateAction @template S */
+
+/**
+ * @typedef {Dispatch<SetStateAction<string|null>>[]} Subscribers
+ */
+
+const CookieSubscriberContext = createContext(/** @type {Map<string, Subscribers>} */ (new Map()));
 
 /**
  * React hook to access and manage a cookie value by name.
  *
  * @param {string} name Cookie name.
  *
- * @return {[getValue: () => string|null, setValue: (nextValue: string?) => void]}
+ * @return {[value: string|null, setValue: (nextValue: string?) => void]}
  */
 function useCookie(name) {
-  const forceRender = useForceRender();
-
   const getValue = () =>
     document.cookie
       .split(';')
       .map((part) => part.trim().split('='))
       .find(([key]) => key === name)?.[1] ?? null;
+
+  const subscriptions = useContext(CookieSubscriberContext);
+  const [value, setStateValue] = useState(getValue);
+
+  useEffect(() => {
+    if (!subscriptions.has(name)) {
+      subscriptions.set(name, []);
+    }
+
+    const subscribers = /** @type {Subscribers} */ (subscriptions.get(name));
+    subscribers.push(setStateValue);
+
+    return () => {
+      subscribers.splice(subscribers.indexOf(setStateValue), 1);
+      if (!subscribers.length) {
+        subscriptions.delete(name);
+      }
+    };
+  }, [name]);
 
   /**
    * @param {string?} nextValue Value to set, or null to delete the value.
@@ -22,10 +48,11 @@ function useCookie(name) {
   function setValue(nextValue) {
     const cookieValue = nextValue === null ? '; Max-Age=0' : nextValue;
     document.cookie = `${name}=${cookieValue}`;
-    forceRender();
+    const subscribers = /** @type {Subscribers} */ (subscriptions.get(name));
+    subscribers.forEach((setSubscriberValue) => setSubscriberValue(getValue));
   }
 
-  return [getValue, setValue];
+  return [value, setValue];
 }
 
 export default useCookie;

--- a/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
@@ -10,23 +10,25 @@ describe('document-capture/hooks/use-cookie', () => {
 
     const { result } = renderHook(() => useCookie('foo'));
 
-    const [getValue] = result.current;
+    const [value] = result.current;
 
-    expect(getValue()).to.equal('baz');
+    expect(value).to.equal('baz');
   });
 
   it('sets a new cookie value', () => {
     const render = sinon.stub().callsFake(() => useCookie('foo'));
     const { result } = renderHook(render);
 
-    const [getValue, setValue] = result.current;
+    const [, setValue] = result.current;
 
-    render.reset();
+    render.resetHistory();
     setValue('bar');
-    expect(render).to.have.been.called();
+    expect(render).to.have.been.calledOnce();
+
+    const [value] = result.current;
 
     expect(document.cookie).to.equal('foo=bar');
-    expect(getValue()).to.equal('bar');
+    expect(value).to.equal('bar');
   });
 
   it('unsets a cookie value by null', () => {
@@ -35,26 +37,36 @@ describe('document-capture/hooks/use-cookie', () => {
     const render = sinon.stub().callsFake(() => useCookie('foo'));
     const { result } = renderHook(render);
 
-    const [getValue, setValue] = result.current;
+    const [, setValue] = result.current;
 
-    render.reset();
+    render.resetHistory();
     setValue(null);
-    expect(render).to.have.been.called();
+    expect(render).to.have.been.calledOnce();
+
+    const [value] = result.current;
 
     expect(document.cookie).to.equal('');
-    expect(getValue()).to.be.null();
+    expect(value).to.be.null();
   });
 
   it('returns the same updated value between instances', () => {
-    const { result: result1 } = renderHook(() => useCookie('foo'));
-    const { result: result2 } = renderHook(() => useCookie('foo'));
+    const render1 = sinon.stub().callsFake(() => useCookie('foo'));
+    const render2 = sinon.stub().callsFake(() => useCookie('foo'));
+    const { result: result1 } = renderHook(render1);
+    const { result: result2 } = renderHook(render2);
 
-    const [getValue1, setValue] = result1.current;
-    const [getValue2] = result2.current;
+    const [, setValue] = result1.current;
 
+    render1.resetHistory();
+    render2.resetHistory();
     setValue('bar');
+    expect(render1).to.have.been.calledOnce();
+    expect(render2).to.have.been.calledOnce();
 
-    expect(getValue1()).to.equal('bar');
-    expect(getValue2()).to.equal('bar');
+    const [value1] = result1.current;
+    const [value2] = result2.current;
+
+    expect(value1).to.equal('bar');
+    expect(value2).to.equal('bar');
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
@@ -44,4 +44,17 @@ describe('document-capture/hooks/use-cookie', () => {
     expect(document.cookie).to.equal('');
     expect(getValue()).to.be.null();
   });
+
+  it('returns the same updated value between instances', () => {
+    const { result: result1 } = renderHook(() => useCookie('foo'));
+    const { result: result2 } = renderHook(() => useCookie('foo'));
+
+    const [getValue1, setValue] = result1.current;
+    const [getValue2] = result2.current;
+
+    setValue('bar');
+
+    expect(getValue1()).to.equal('bar');
+    expect(getValue2()).to.equal('bar');
+  });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { renderHook } from '@testing-library/react-hooks';
 import useCookie from '@18f/identity-document-capture/hooks/use-cookie';
 
@@ -9,44 +10,38 @@ describe('document-capture/hooks/use-cookie', () => {
 
     const { result } = renderHook(() => useCookie('foo'));
 
-    const [value] = result.current;
+    const [getValue] = result.current;
 
-    expect(value).to.equal('baz');
-  });
-
-  it('does not interfere with default cookie setting behavior', () => {
-    renderHook(() => useCookie('foo'));
-
-    document.cookie = 'foo=bar';
-
-    expect(document.cookie).to.equal('foo=bar');
+    expect(getValue()).to.equal('baz');
   });
 
   it('sets a new cookie value', () => {
-    const { result } = renderHook(() => useCookie('foo'));
+    const render = sinon.stub().callsFake(() => useCookie('foo'));
+    const { result } = renderHook(render);
 
-    const [, setValue] = result.current;
+    const [getValue, setValue] = result.current;
 
+    render.reset();
     setValue('bar');
-
-    const [value] = result.current;
+    expect(render).to.have.been.called();
 
     expect(document.cookie).to.equal('foo=bar');
-    expect(value).to.equal('bar');
+    expect(getValue()).to.equal('bar');
   });
 
   it('unsets a cookie value by null', () => {
     document.cookie = 'foo=bar';
 
-    const { result } = renderHook(() => useCookie('foo'));
+    const render = sinon.stub().callsFake(() => useCookie('foo'));
+    const { result } = renderHook(render);
 
-    const [, setValue] = result.current;
+    const [getValue, setValue] = result.current;
 
+    render.reset();
     setValue(null);
-
-    const [value] = result.current;
+    expect(render).to.have.been.called();
 
     expect(document.cookie).to.equal('');
-    expect(value).to.be.null();
+    expect(getValue()).to.be.null();
   });
 });

--- a/spec/javascripts/support/console.js
+++ b/spec/javascripts/support/console.js
@@ -44,15 +44,17 @@ export function chaiConsoleSpy(chai, utils) {
  * `chaiConsoleSpy` Chai plugin.
  */
 export function useConsoleLogSpy() {
+  let originalConsoleError;
   beforeEach(() => {
     console.unverifiedCalls = [];
-    sinon.stub(console, 'error').callsFake((message, ...args) => {
+    originalConsoleError = console.error;
+    console.error = sinon.stub().callsFake((message, ...args) => {
       console.unverifiedCalls = console.unverifiedCalls.concat(format(message, ...args));
     });
   });
 
   afterEach(() => {
-    console.error.restore();
+    console.error = originalConsoleError;
     expect(console.unverifiedCalls).to.be.empty(
       `Unexpected console logging: ${console.unverifiedCalls.join(', ')}`,
     );


### PR DESCRIPTION
Extracted from: #5747

**Why**: As observed in #5747, the current logic can be prone to race conditions when multiple instances of the hook exist (mostly affecting specs). The implementation overriding the global was meant to support a use-case where a component would re-render in response to an external script modifying a cookie (e.g. Acuant SDK). Since our current sole usage is to get the cookie value at the time of a user initiating a capture, this live-updating support isn't necessary and unnecessarily complicates the implementation.