### PR TITLE
Reduce sp_return_logs index size

### DIFF
--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -60,8 +60,7 @@ module Reports
         LEFT JOIN
           agencies ON service_providers.agency_id = agencies.id
         WHERE
-          %{start} <= sp_return_logs.requested_at
-          AND sp_return_logs.requested_at <= %{finish}
+          sp_return_logs.requested_at::date BETWEEN %{start} AND %{finish}
           AND sp_return_logs.returned_at IS NOT NULL
         GROUP BY
           sp_return_logs.ial

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -125,7 +125,7 @@ module Db
             , COUNT(sp_return_logs.id) AS auth_count
             FROM sp_return_logs
             WHERE
-                  requested_at::date BETWEEN %{range_start} AND %{range_end}
+                  sp_return_logs.requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer = %{issuer}
             GROUP BY

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -125,7 +125,7 @@ module Db
             , COUNT(sp_return_logs.id) AS auth_count
             FROM sp_return_logs
             WHERE
-                  sp_return_logs.requested_at BETWEEN %{range_start} AND %{range_end}
+                  requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer = %{issuer}
             GROUP BY

--- a/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
+++ b/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
@@ -116,7 +116,7 @@ module Db
             , sp_return_logs.ial
             FROM sp_return_logs
             WHERE
-                  sp_return_logs.requested_at BETWEEN %{range_start} AND %{range_end}
+                  requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer IN %{issuers}
             GROUP BY

--- a/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
+++ b/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
@@ -116,7 +116,7 @@ module Db
             , sp_return_logs.ial
             FROM sp_return_logs
             WHERE
-                  requested_at::date BETWEEN %{range_start} AND %{range_end}
+                  sp_return_logs.requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer IN %{issuers}
             GROUP BY

--- a/db/primary_migrate/20220105143455_create_sp_return_logs_requested_at_date_issuer_index.rb
+++ b/db/primary_migrate/20220105143455_create_sp_return_logs_requested_at_date_issuer_index.rb
@@ -1,0 +1,18 @@
+class CreateSpReturnLogsRequestedAtDateIssuerIndex < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_sp_return_logs_on_requested_at_date_issuer
+        ON public.sp_return_logs
+        USING btree ((requested_at::date), issuer)
+        WHERE (returned_at IS NOT NULL);
+      SQL
+    end
+  end
+
+  def down
+    execute "DROP INDEX index_sp_return_logs_on_requested_at_date_issuer"
+  end
+end

--- a/db/primary_migrate/20220105143540_drop_sp_return_logs_requested_at_indexes.rb
+++ b/db/primary_migrate/20220105143540_drop_sp_return_logs_requested_at_indexes.rb
@@ -1,0 +1,6 @@
+class DropSpReturnLogsRequestedAtIndexes < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :sp_return_logs, column: [:requested_at], name: "index_sp_return_logs_on_requested_at"
+    remove_index :sp_return_logs, column: [:issuer, :requested_at], name: "index_sp_return_logs_on_issuer_and_requested_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_143347) do
+ActiveRecord::Schema.define(version: 2022_01_05_143540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -554,9 +554,8 @@ ActiveRecord::Schema.define(version: 2022_01_05_143347) do
     t.integer "user_id"
     t.datetime "returned_at"
     t.boolean "billable"
-    t.index ["issuer", "requested_at"], name: "index_sp_return_logs_on_issuer_and_requested_at"
+    t.index "((requested_at)::date), issuer", name: "index_sp_return_logs_on_requested_at_date_issuer", where: "(returned_at IS NOT NULL)"
     t.index ["request_id"], name: "index_sp_return_logs_on_request_id", unique: true
-    t.index ["requested_at"], name: "index_sp_return_logs_on_requested_at"
   end
 
   create_table "throttles", force: :cascade do |t|

--- a/lib/tasks/db_sp_return_logs_index.rake
+++ b/lib/tasks/db_sp_return_logs_index.rake
@@ -1,5 +1,5 @@
 namespace :db do
-  desc 'Tear down and recreate the sp_return_logs index on devices'
+  desc 'Tear down and recreate the sp_return_logs index'
   task rebuild_sp_return_logs_index: :environment do
     ## Set statement timeout to 1 hour
     ActiveRecord::Base.connection.execute('SET statement_timeout = 3600000')
@@ -8,30 +8,32 @@ namespace :db do
     existing_index_result = ActiveRecord::Base.connection.execute <<~SQL
       SELECT indexname
       FROM pg_indexes
-      WHERE indexname = 'index_sp_return_logs_on_issuer_and_requested_at'
+      WHERE indexname = 'index_sp_return_logs_on_requested_at_date_issuer'
     SQL
     if existing_index_result.num_tuples > 0
-      puts 'Index index_sp_return_logs_on_issuer_and_requested_at exists, dropping...'
+      puts 'Index index_sp_return_logs_on_requested_at_date_issuer exists, dropping...'
       ActiveRecord::Base.connection.execute <<~SQL
-        DROP INDEX CONCURRENTLY index_sp_return_logs_on_issuer_and_requested_at
+        DROP INDEX CONCURRENTLY index_sp_return_logs_on_requested_at_date_issuer
       SQL
     end
 
     ## Run the SQL from the migration to create the new index
-    puts 'Creating new index_sp_return_logs_on_issuer_and_requested_at index'
+    puts 'Creating new index_sp_return_logs_on_requested_at_date_issuer index'
     ActiveRecord::Base.connection.execute <<~SQL
-      CREATE INDEX CONCURRENTLY "index_sp_return_logs_on_issuer_and_requested_at"
-      ON "sp_return_logs" ("issuer", "requested_at")
+      CREATE INDEX CONCURRENTLY index_sp_return_logs_on_requested_at_date_issuer
+      ON public.sp_return_logs
+      USING btree ((requested_at::date), issuer)
+      WHERE (returned_at IS NOT NULL)
     SQL
   end
 
-  desc 'Check for an invalid sp_return_logs index on devices and print the result'
+  desc 'Check for an invalid sp_return_logs index and print the result'
   task check_for_invalid_sp_return_logs_index: :environment do
     results = ActiveRecord::Base.connection.execute <<~SQL
       SELECT * FROM pg_class, pg_index
       WHERE pg_index.indisvalid = false
         AND pg_index.indexrelid = pg_class.oid
-        AND pg_class.relname = 'index_sp_return_logs_on_issuer_and_requested_at'
+        AND pg_class.relname = 'index_sp_return_logs_on_requested_at_date_issuer'
     SQL
 
     puts "Found #{results.num_tuples} invalid index(es)"


### PR DESCRIPTION
Currently, we frequently query this table by `request_id` in the application, and query by date ranges or date ranges and issuers for daily reports. This PR drops these two indexes and replaces them with a partial index on the date of `requested_at` and `issuer`, excluding rows that do not have `returned_at` set. This reduces the total index size by ~96% and should yield a very slight improvement in the queries used in the reports (more details [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1641409220067200)).