### PR TITLE
Drop device_user_id_cookie_uuid index

### DIFF
--- a/db/primary_migrate/20220105174343_drop_index_devices_user_id_cookie_uuid.rb
+++ b/db/primary_migrate/20220105174343_drop_index_devices_user_id_cookie_uuid.rb
@@ -1,0 +1,5 @@
+class DropIndexDevicesUserIdCookieUuid < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :devices, column: [:user_id, :cookie_uuid], name: "index_device_user_id_cookie_uuid"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_143540) do
+ActiveRecord::Schema.define(version: 2022_01_05_174343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -100,7 +100,6 @@ ActiveRecord::Schema.define(version: 2022_01_05_143540) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["cookie_uuid"], name: "index_devices_on_cookie_uuid"
-    t.index ["user_id", "cookie_uuid"], name: "index_device_user_id_cookie_uuid"
     t.index ["user_id", "last_used_at"], name: "index_device_user_id_last_used_at"
   end
 


### PR DESCRIPTION
We have indexes on `cookie_uuid`, `user_id, cookie_uuid`, and `user_id, last_used_at` for the `devices` table. The `user_id, cookie_uuid` index is mostly redundant because querying by `cookie_uuid` or `user_id` should be able to fall back to one of the other two indexes without significant loss in performance (more details [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1641409752069400)).