### PR TITLE
LG-5221 logging for personal key page

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -10,20 +10,22 @@ module Idv
 
     def show
       @step_indicator_steps = step_indicator_steps
-      track_final_idv_event
+      analytics.track_event(Analytics::IDV_PERSONAL_KEY_VISITED)
+      add_proofing_component
 
       finish_idv_session
     end
 
     def update
       user_session[:need_personal_key_confirmation] = false
+      analytics.track_event(Analytics::IDV_PERSONAL_KEY_SUBMITTED)
       redirect_to next_step
     end
 
     def download
       personal_key = user_session[:personal_key]
 
-      analytics.track_event(Analytics::IDV_DOWNLOAD_PERSONAL_KEY, success: personal_key.present?)
+      analytics.track_event(Analytics::IDV_PERSONAL_KEY_DOWNLOADED, success: personal_key.present?)
 
       if personal_key.present?
         data = personal_key + "\r\n"
@@ -55,16 +57,6 @@ module Idv
 
     def confirm_profile_has_been_created
       redirect_to account_url if idv_session.profile.blank?
-    end
-
-    def track_final_idv_event
-      configured_phones = MfaContext.new(current_user).phone_configurations.map(&:phone)
-      result = {
-        success: true,
-        new_phone_added: !configured_phones.include?(idv_session.applicant['phone']),
-      }
-      analytics.track_event(Analytics::IDV_FINAL, result)
-      add_proofing_component
     end
 
     def add_proofing_component

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -1,5 +1,5 @@
 module Idv
-  class ConfirmationsController < ApplicationController
+  class PersonalKeyController < ApplicationController
     include IdvSession
     include SecureHeadersConcern
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -113,6 +113,11 @@ module Idv
 
     def async_state_done(async_state)
       form_result = step.async_state_done(async_state)
+
+      configured_phones = MfaContext.new(current_user).phone_configurations.map(&:phone)
+      applicant_phone = PhoneFormatter.format(idv_session.applicant['phone'])
+      new_phone_added = !configured_phones.include?(applicant_phone)
+
       analytics.track_event(
         Analytics::IDV_PHONE_CONFIRMATION_VENDOR,
         form_result.to_h.merge(
@@ -120,6 +125,7 @@ module Idv
             [:errors, :phone],
             [:context, :stages, :address],
           ],
+          new_phone_added: new_phone_added,
         ),
       )
       redirect_to_next_step and return if async_state.result[:success]

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -114,10 +114,6 @@ module Idv
     def async_state_done(async_state)
       form_result = step.async_state_done(async_state)
 
-      configured_phones = MfaContext.new(current_user).phone_configurations.map(&:phone)
-      applicant_phone = PhoneFormatter.format(idv_session.applicant['phone'])
-      new_phone_added = !configured_phones.include?(applicant_phone)
-
       analytics.track_event(
         Analytics::IDV_PHONE_CONFIRMATION_VENDOR,
         form_result.to_h.merge(
@@ -125,11 +121,20 @@ module Idv
             [:errors, :phone],
             [:context, :stages, :address],
           ],
-          new_phone_added: new_phone_added,
+          new_phone_added: new_phone_added?,
         ),
       )
       redirect_to_next_step and return if async_state.result[:success]
       handle_proofing_failure
+    end
+
+    def new_phone_added?
+      context = MfaContext.new(current_user)
+      configured_phones = context.phone_configurations.map(&:phone).map do |number|
+        PhoneFormatter.format(number)
+      end
+      applicant_phone = PhoneFormatter.format(idv_session.applicant['phone'])
+      !configured_phones.include?(applicant_phone)
     end
 
     def gpo_letter_available

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -46,6 +46,7 @@ module Idv
       user_session[:need_personal_key_confirmation] = true
       redirect_to idv_personal_key_url
       analytics.track_event(Analytics::IDV_REVIEW_COMPLETE)
+      analytics.track_event(Analytics::IDV_FINAL, success: true)
 
       return unless FeatureManagement.reveal_gpo_code?
       session[:last_gpo_confirmation_code] = idv_session.gpo_otp

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -44,7 +44,7 @@ module Idv
     def create
       init_profile
       user_session[:need_personal_key_confirmation] = true
-      redirect_to idv_confirmations_url
+      redirect_to idv_personal_key_url
       analytics.track_event(Analytics::IDV_REVIEW_COMPLETE)
 
       return unless FeatureManagement.reveal_gpo_code?
@@ -105,7 +105,7 @@ module Idv
     def personal_key_confirmed
       return unless current_user
       return unless current_user.active_profile.present? && need_personal_key_confirmation?
-      redirect_to idv_confirmations_url
+      redirect_to idv_personal_key_url
     end
 
     def need_personal_key_confirmation?

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -1,5 +1,5 @@
 import { encodeInput } from '@18f/identity-personal-key-input';
-import { trackEvent } from "@18f/identity-analytics";
+import { trackEvent } from '@18f/identity-analytics';
 
 const modalSelector = '#personal-key-confirm';
 const modal = new window.LoginGov.Modal({ el: modalSelector });

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -1,4 +1,5 @@
 import { encodeInput } from '@18f/identity-personal-key-input';
+import { trackEvent } from "@18f/identity-analytics";
 
 const modalSelector = '#personal-key-confirm';
 const modal = new window.LoginGov.Modal({ el: modalSelector });
@@ -100,6 +101,7 @@ function show(event) {
     input.focus();
   });
 
+  trackEvent('IdV: show personal key modal');
   modal.show();
 }
 
@@ -108,6 +110,7 @@ function hide() {
     resetForm();
   });
 
+  trackEvent('IdV: hide personal key modal');
   modal.hide();
 }
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -163,7 +163,7 @@ class Analytics
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze
   IDV_JURISDICTION_VISIT = 'IdV: jurisdiction visited'.freeze
   IDV_JURISDICTION_FORM = 'IdV: jurisdiction form submitted'.freeze
-  IDV_PERSONAL_KEY_DOWNLOADED = 'IdV: personal key downloaded'.freeze
+  IDV_PERSONAL_KEY_DOWNLOADED = 'IdV: personal key downloaded'.freeze # previously "IdV: download personal key"
   IDV_PERSONAL_KEY_VISITED = 'IdV: personal key visited'.freeze
   IDV_PERSONAL_KEY_SUBMITTED = 'IdV: personal key submitted'.freeze
   IDV_PHONE_CONFIRMATION_FORM = 'IdV: phone confirmation form'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -157,13 +157,14 @@ class Analytics
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
-  IDV_DOWNLOAD_PERSONAL_KEY = 'IdV: download personal key'.freeze
-  IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze
   IDV_FORGOT_PASSWORD_CONFIRMED = 'IdV: forgot password confirmed'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze
   IDV_JURISDICTION_VISIT = 'IdV: jurisdiction visited'.freeze
   IDV_JURISDICTION_FORM = 'IdV: jurisdiction form submitted'.freeze
+  IDV_PERSONAL_KEY_DOWNLOADED = 'IdV: personal key downloaded'.freeze
+  IDV_PERSONAL_KEY_VISITED = 'IdV: personal key visited'.freeze
+  IDV_PERSONAL_KEY_SUBMITTED = 'IdV: personal key submitted'.freeze
   IDV_PHONE_CONFIRMATION_FORM = 'IdV: phone confirmation form'.freeze
   IDV_PHONE_CONFIRMATION_VENDOR = 'IdV: phone confirmation vendor'.freeze
   IDV_PHONE_CONFIRMATION_OTP_RATE_LIMIT_ATTEMPTS = 'Idv: Phone OTP attempts rate limited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -157,7 +157,7 @@ class Analytics
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
-  IDV_FINAL = 'IdV: final resolution'.freeze # deprecated
+  IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze
   IDV_FORGOT_PASSWORD_CONFIRMED = 'IdV: forgot password confirmed'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -157,6 +157,7 @@ class Analytics
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'.freeze
+  IDV_FINAL = 'IdV: final resolution'.freeze # deprecated
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze
   IDV_FORGOT_PASSWORD_CONFIRMED = 'IdV: forgot password confirmed'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze

--- a/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
@@ -5,6 +5,7 @@ module Funnel
         Analytics::IDV_PHONE_RECORD_VISIT => :verify_phone,
         Analytics::IDV_REVIEW_VISIT => :encrypt,
         Analytics::IDV_PERSONAL_KEY_VISITED => :verified,
+        Analytics::IDV_FINAL => :verified, # deprecated
         Analytics::IDV_GPO_ADDRESS_VISITED => :usps_address,
       }.freeze
 

--- a/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
@@ -4,8 +4,7 @@ module Funnel
       ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN = {
         Analytics::IDV_PHONE_RECORD_VISIT => :verify_phone,
         Analytics::IDV_REVIEW_VISIT => :encrypt,
-        Analytics::IDV_PERSONAL_KEY_VISITED => :verified,
-        Analytics::IDV_FINAL => :verified, # deprecated
+        Analytics::IDV_FINAL => :verified,
         Analytics::IDV_GPO_ADDRESS_VISITED => :usps_address,
       }.freeze
 

--- a/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
@@ -4,7 +4,7 @@ module Funnel
       ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN = {
         Analytics::IDV_PHONE_RECORD_VISIT => :verify_phone,
         Analytics::IDV_REVIEW_VISIT => :encrypt,
-        Analytics::IDV_FINAL => :verified,
+        Analytics::IDV_PERSONAL_KEY_VISITED => :verified,
         Analytics::IDV_GPO_ADDRESS_VISITED => :usps_address,
       }.freeze
 

--- a/app/views/idv/personal_key/show.html.erb
+++ b/app/views/idv/personal_key/show.html.erb
@@ -9,4 +9,4 @@
 
 <% title t('titles.idv.personal_key') %>
 
-<%= render 'shared/personal_key', code: @code, update_path: idv_confirmations_path %>
+<%= render 'shared/personal_key', code: @code, update_path: idv_personal_key_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -263,9 +263,9 @@ Rails.application.routes.draw do
     end
     scope '/verify', module: 'idv', as: 'idv' do
       get '/come_back_later' => 'come_back_later#show'
-      get '/confirmations' => 'confirmations#show'
-      post '/confirmations' => 'confirmations#update'
-      get '/download_personal_key' => 'confirmations#download'
+      get '/personal_key' => 'personal_key#show'
+      post '/personal_key' => 'personal_key#update'
+      get '/download_personal_key' => 'personal_key#download'
       get '/forgot_password' => 'forgot_password#new'
       post '/forgot_password' => 'forgot_password#update'
       get '/otp_delivery_method' => 'otp_delivery_method#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,10 @@ Rails.application.routes.draw do
       get '/capture_doc/return_to_sp' => 'capture_doc#return_to_sp'
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
+
+      # deprecated routes
+      get '/confirmations' => 'personal_key#show'
+      post '/confirmations' => 'personal_key#update'
     end
 
     get '/account/verify' => 'idv/gpo_verify#index', as: :idv_gpo_verify

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -125,47 +125,6 @@ describe Idv::PersonalKeyController do
       expect(flash[:success]).to eq t('idv.messages.confirm')
     end
 
-    context 'user used 2FA phone as phone of record' do
-      before do
-        subject.idv_session.applicant['phone'] =
-          MfaContext.new(user).phone_configurations.first.phone
-      end
-
-      it 'tracks final IdV event' do
-        stub_analytics
-
-        result = {
-          success: true,
-          new_phone_added: false,
-        }
-
-        expect(@analytics).to receive(:track_event).
-          with(Analytics::IDV_FINAL, result)
-
-        get :show
-      end
-    end
-
-    context 'user confirmed a new phone' do
-      before do
-        subject.idv_session.applicant['phone'] = '+1 (202) 555-9876'
-      end
-
-      it 'tracks final IdV event' do
-        stub_analytics
-
-        result = {
-          success: true,
-          new_phone_added: true,
-        }
-
-        expect(@analytics).to receive(:track_event).
-          with(Analytics::IDV_FINAL, result)
-
-        get :show
-      end
-    end
-
     context 'user selected gpo verification' do
       before do
         subject.idv_session.address_verification_mechanism = 'gpo'
@@ -245,7 +204,7 @@ describe Idv::PersonalKeyController do
 
       expect(response.body).to eq(code + "\r\n")
       expect(response.header['Content-Type']).to eq('text/plain')
-      expect(@analytics).to have_logged_event(Analytics::IDV_DOWNLOAD_PERSONAL_KEY, success: true)
+      expect(@analytics).to have_logged_event(Analytics::IDV_PERSONAL_KEY_DOWNLOADED, success: true)
     end
 
     it 'recovers pii and verifies personal key digest with the code' do
@@ -264,7 +223,10 @@ describe Idv::PersonalKeyController do
       get :download
 
       expect(response).to be_bad_request
-      expect(@analytics).to have_logged_event(Analytics::IDV_DOWNLOAD_PERSONAL_KEY, success: false)
+      expect(@analytics).to have_logged_event(
+        Analytics::IDV_PERSONAL_KEY_DOWNLOADED,
+        success: false,
+      )
     end
   end
 end

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Idv::ConfirmationsController do
+describe Idv::PersonalKeyController do
   include SamlAuthHelper
   include PersonalKeyValidator
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -294,6 +294,7 @@ describe Idv::PhoneController do
         context = { stages: [{ address: 'AddressMock' }] }
         result = {
           success: true,
+          new_phone_added: true,
           errors: {},
           pii_like_keypaths: [[:errors, :phone], [:context, :stages, :address]],
           vendor: {
@@ -343,6 +344,7 @@ describe Idv::PhoneController do
         context = { stages: [{ address: 'AddressMock' }] }
         result = {
           success: false,
+          new_phone_added: true,
           errors: {
             phone: ['The phone number could not be verified.'],
           },

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -297,7 +297,7 @@ describe Idv::ReviewController do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_received(:track_event).with(Analytics::IDV_REVIEW_COMPLETE)
-        expect(response).to redirect_to idv_confirmations_path
+        expect(response).to redirect_to idv_personal_key_path
       end
 
       it 'redirects to confirmation path after user presses the back button' do
@@ -307,7 +307,7 @@ describe Idv::ReviewController do
 
         allow_any_instance_of(User).to receive(:active_profile).and_return(true)
         get :new
-        expect(response).to redirect_to idv_confirmations_path
+        expect(response).to redirect_to idv_personal_key_path
       end
 
       it 'creates Profile with applicant attributes' do

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -297,6 +297,7 @@ describe Idv::ReviewController do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_received(:track_event).with(Analytics::IDV_REVIEW_COMPLETE)
+        expect(@analytics).to have_received(:track_event).with(Analytics::IDV_FINAL, success: true)
         expect(response).to redirect_to idv_personal_key_path
       end
 

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -57,7 +57,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_confirmations_path
+      expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -71,7 +71,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_confirmations_path
+      expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -85,7 +85,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_confirmations_path
+      expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -31,7 +31,7 @@ feature 'idv review step' do
     click_idv_continue
 
     expect(page).to have_content(t('headings.personal_key'))
-    expect(page).to have_current_path(idv_confirmations_path)
+    expect(page).to have_current_path(idv_personal_key_path)
   end
 
   context 'choosing to confirm address with phone' do


### PR DESCRIPTION
An overhaul of the event logging on the personal key page.
Started with renaming the associated controller to fit the actual role the controller plays, then moves the existing event `IdV: final resolution` to the ReviewController where it better indicates the end of the IdV process.
Added new events for the entry/exit of this page (`IdV: personal key visited/submitted`) and also log the showing/hiding of the modal requiring the user to enter their personal key.

By keeping the final resolution event, no updates to any dashboards are necessary.