### PR TITLE
Handle pivcac token timeout

### DIFF
--- a/app/presenters/piv_cac_error_presenter.rb
+++ b/app/presenters/piv_cac_error_presenter.rb
@@ -38,7 +38,7 @@ class PivCacErrorPresenter
       t('headings.piv_cac.token.bad')
     when 'token.invalid'
       t('headings.piv_cac.token.invalid')
-    when 'token.missing'
+    when 'token.missing', 'token.http_failure'
       t('headings.piv_cac.token.missing')
     else
       t('headings.piv_cac.did_not_work')
@@ -60,6 +60,8 @@ class PivCacErrorPresenter
       t('instructions.mfa.piv_cac.no_certificate_html', try_again: try_again_link)
     when 'certificate.not_auth_cert'
       t('instructions.mfa.piv_cac.not_auth_cert_html', please_try_again: please_try_again_link)
+    when 'token.http_failure'
+      t('instructions.mfa.piv_cac.http_failure')
     else
       t('instructions.mfa.piv_cac.did_not_work_html', please_try_again: please_try_again_link)
     end

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -71,6 +71,8 @@ module PivCacService
       ) do |req|
         req.options.context = { service_name: 'piv_cac_token' }
       end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+      nil
     end
 
     def verify_token_uri
@@ -88,6 +90,7 @@ module PivCacService
     end
 
     def decode_token_response(res)
+      return { 'error' => 'token.http_failure' } unless res
       return { 'error' => 'token.bad' } unless res.status.to_i == 200
       JSON.parse(res.body)
     rescue JSON::JSONError

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -46,6 +46,7 @@ en:
           information.
         did_not_work_html: Please %{please_try_again}. If this problem continues,
           contact your agency administrator.
+        http_failure: The server took too long to respond. Please try again.
         no_certificate_html: Please make sure your PIV/CAC is connected and
           %{try_again}. If this problem continues, contact your agency
           administrator.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -49,6 +49,7 @@ es:
           (PIV o CAC) para acceder a su información.
         did_not_work_html: '%{please_try_again}. Comuníquese con el encargado de su
           organismo si persiste este problema.'
+        http_failure: El servidor tardó demasiado en responder. Inténtalo de nuevo.
         no_certificate_html: Asegúrese de su PIV/CAC esté conectada e %{try_again}.
           Comuníquese con el encargado de su organismo si persiste este
           problema.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -56,6 +56,7 @@ fr:
           du gouvernement (PIV ou CAC) pour accéder à vos informations.
         did_not_work_html: Veuillez %{please_try_again}. Si ce problème persiste,
           contactez l’administrateur de votre agence.
+        http_failure: Le serveur a mis trop de temps à répondre. Veuillez réessayer.
         no_certificate_html: Veuillez vous assurer que votre PIV/CAC est connecté et
           %{try_again}. Si ce problème persiste, contactez l’administrateur de
           votre agence.

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -224,6 +224,26 @@ describe PivCacService do
           )
         end
       end
+
+      describe 'with HTTP failure' do
+        before(:each) do
+          allow(IdentityConfig.store).to receive(:identity_pki_disabled) { false }
+          allow(IdentityConfig.store).to receive(:piv_cac_verify_token_url) do
+            'http://localhost:8443/'
+          end
+        end
+
+        let!(:request) do
+          stub_request(:post, 'localhost:8443').
+            to_raise(Faraday::ConnectionFailed)
+        end
+
+        it 'returns an error' do
+          expect(PivCacService.decode_token('foo')).to eq(
+            'error' => 'token.http_failure',
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up to #5782 

Error messages borrowed from https://github.com/18F/identity-idp/blob/e189165d07757e1f8dffd641024b075d8fd5837e/config/locales/errors/en.yml#L26