### PR TITLE
Standardize SASS processing to Sprockets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,6 +1,7 @@
 //= link_tree ../images
 //= link application.js
 //= link application.css
+//= link document-capture.css
 
 //= link email.css
 //= link es5-shim.min.js

--- a/app/assets/stylesheets/_required.scss
+++ b/app/assets/stylesheets/_required.scss
@@ -1,0 +1,2 @@
+$font-path: 'identity-style-guide/dist/assets/fonts';
+$image-path: 'identity-style-guide/dist/assets/img';

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,5 +1,6 @@
 @import 'variables/colors';
 @import 'variables/app';
+@import 'required';
 @import 'vendor';
 @import 'identity-style-guide/dist/assets/scss/packages/required';
 @import 'identity-style-guide/dist/assets/scss/packages/global';

--- a/app/assets/stylesheets/document-capture.scss
+++ b/app/assets/stylesheets/document-capture.scss
@@ -1,0 +1,2 @@
+@import 'required';
+@import '../../javascript/packages/document-capture/styles';

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -102,7 +102,3 @@ $container-xskinny-width: 416px !default;
 $container-xxskinny-width: 296px !default;
 
 $mobile: '(max-width: 1023px)' !default;
-
-// Asset configuration for identity-style-guide
-$font-path: 'identity-style-guide/dist/assets/fonts';
-$image-path: 'identity-style-guide/dist/assets/img';

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -3,7 +3,6 @@ import { useI18n } from '@18f/identity-react-i18n';
 import AcuantContext from '../context/acuant';
 import useAsset from '../hooks/use-asset';
 import useImmutableCallback from '../hooks/use-immutable-callback';
-import './acuant-capture-canvas.scss';
 
 /** @typedef {import('../context/acuant').AcuantJavaScriptWebSDK} AcuantJavaScriptWebSDK */
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -20,7 +20,6 @@ import UploadContext from '../context/upload';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useCounter from '../hooks/use-counter';
 import useCookie from '../hooks/use-cookie';
-import './acuant-capture.scss';
 
 /** @typedef {import('react').ReactNode} ReactNode */
 /** @typedef {import('./acuant-capture-canvas').AcuantSuccessResponse} AcuantSuccessResponse */

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -7,7 +7,6 @@ import useHistoryParam from '../hooks/use-history-param';
 import useForceRender from '../hooks/use-force-render';
 import useDidUpdateEffect from '../hooks/use-did-update-effect';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
-import './form-steps.scss';
 
 /**
  * @typedef FormStepError

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -15,7 +15,6 @@ import StartOverOrCancel from './start-over-or-cancel';
 import Warning from './warning';
 import AnalyticsContext from '../context/analytics';
 import useDidUpdateEffect from '../hooks/use-did-update-effect';
-import './review-issues-step.scss';
 
 /**
  * @typedef {'front'|'back'} DocumentSide

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -14,7 +14,6 @@ import FileImage from './file-image';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useInstanceId from '../hooks/use-instance-id';
 import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
-import './selfie-capture.scss';
 import AppContext from '../context/app';
 
 /** @typedef {import('react').ReactNode} ReactNode */

--- a/app/javascript/packages/document-capture/styles.scss
+++ b/app/javascript/packages/document-capture/styles.scss
@@ -1,6 +1,6 @@
 @import 'identity-style-guide/dist/assets/scss/packages/required';
-@import './components/acuant-capture-canvas';
 @import './components/acuant-capture';
+@import './components/acuant-capture-canvas';
 @import './components/form-steps';
 @import './components/review-issues-step';
 @import './components/selfie-capture';

--- a/app/javascript/packages/document-capture/styles.scss
+++ b/app/javascript/packages/document-capture/styles.scss
@@ -1,0 +1,6 @@
+@import 'identity-style-guide/dist/assets/scss/packages/required';
+@import './components/acuant-capture-canvas';
+@import './components/acuant-capture';
+@import './components/form-steps';
+@import './components/review-issues-step';
+@import './components/selfie-capture';

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -1,7 +1,8 @@
 <% title t('titles.doc_auth.doc_capture') %>
-<% content_for :meta_tags do %>
+<% content_for :head do %>
   <%= tag.meta name: 'acuant-sdk-initialization-endpoint', content: IdentityConfig.store.acuant_sdk_initialization_endpoint %>
   <%= tag.meta name: 'acuant-sdk-initialization-creds', content: IdentityConfig.store.acuant_sdk_initialization_creds %>
+  <%= stylesheet_link_tag 'document-capture' %>
 <% end %>
 <% SecureHeaders.append_content_security_policy_directives(
      request,
@@ -161,4 +162,3 @@
   window.LoginGov.assets = <%= raw asset_keys.index_with { |key| asset_path(key) }.to_json %>;
 <% end %>
 <%= javascript_packs_tag_once 'document-capture' %>
-<%= stylesheet_packs_with_chunks_tag 'document-capture' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -17,9 +17,6 @@
   <meta content="noindex,nofollow" name="robots" />
   <% end %>
 
-  <%= yield(:meta_tags) if content_for?(:meta_tags) %>
-
-
   <%= content_tag(
         'title',
         content_for?(:title) ? raw("#{yield(:title)} - #{APP_NAME}") : APP_NAME,
@@ -54,6 +51,8 @@
   <% if IdentityConfig.store.newrelic_browser_key.present? && IdentityConfig.store.newrelic_browser_app_id.present? %>
   <%= render 'shared/newrelic/browser_instrumentation' %>
   <% end %>
+
+  <%= yield(:head) if content_for?(:head) %>
 </head>
 
 <body class="site <%= yield(:background_cls) %>">

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -12,6 +12,7 @@ environment.loaders.delete('nodeModules');
 environment.loaders.delete('moduleSass');
 environment.loaders.delete('moduleCss');
 environment.loaders.delete('css');
+environment.loaders.delete('sass');
 
 // Note: Because chunk splitting is enabled by default as of Webpacker 6+, this line can be removed
 // when upgrading.
@@ -25,16 +26,6 @@ babelLoader.include.push(
   /node_modules\/(@18f\/identity-|identity-style-guide|uswds|receptor|elem-dataset)/,
 );
 babelLoader.exclude = /node_modules\/(?!@18f\/identity-|identity-style-guide|uswds|receptor|elem-dataset)/;
-
-const sassLoader = environment.loaders.get('sass');
-// Prepend minimum required design system variables, mixins, and functions to make available to all
-// Webpack-imported SCSS files. Notably, this should _not_ include any actual CSS output on its own.
-sassLoader.use.find(({ loader }) => loader === 'sass-loader').options.additionalData = `
-$font-path: '~identity-style-guide/dist/assets/fonts';
-$image-path: '~identity-style-guide/dist/assets/img';
-@import '~identity-style-guide/dist/assets/scss/packages/required';`;
-
-sassLoader.use.find(({ loader }) => loader === 'css-loader').options.sourceMap = false;
 
 const sourceMapLoader = {
   test: /\.js$/,

--- a/spec/javascripts/support/mocha.js
+++ b/spec/javascripts/support/mocha.js
@@ -1,7 +1,3 @@
 const babelRegister = require('@babel/register');
 
 babelRegister({ ignore: [/node_modules\/(?!@18f\/identity-)/] });
-
-// Ignore SCSS imports. These are handled by Webpack in the browser build, but will cause parse
-// errors if loaded in Node.
-require.extensions['.scss'] = () => {};


### PR DESCRIPTION
**Why**: To simplify ongoing work in #5746, to avoid double-processing of SASS files, and to consolidate in preparation for future CSS bundling refactoring ([cssbundling-rails](https://github.com/rails/cssbundling-rails)).