### PR TITLE
De-duplicate Rack::Attack when rate limiting is enabled

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -138,9 +138,7 @@ module Upaya
     end
     # rubocop:enable Metrics/BlockLength
 
-    if IdentityConfig.store.enable_rate_limiting
-      config.middleware.use Rack::Attack
-    else
+    if !IdentityConfig.store.enable_rate_limiting
       # Rack::Attack auto-includes itself as a Railtie, so we need to
       # explicitly remove it when we want to disable it
       config.middleware.delete Rack::Attack


### PR DESCRIPTION
Spotted by @aduth, we were adding when after it adds itself, so there were two Rack::Attacks in the middleware. Luckily Rack::Attack early-aborts if it has already run, but this should a small amount of memory/CPU time nonetheless