### PR TITLE
return false instead of nil for invalid backup code in analytics

### DIFF
--- a/app/services/backup_code_generator.rb
+++ b/app/services/backup_code_generator.rb
@@ -26,7 +26,7 @@ class BackupCodeGenerator
   def verify(plaintext_code)
     backup_code = RandomPhrase.normalize(plaintext_code)
     code = BackupCodeConfiguration.find_with_code(code: backup_code, user_id: @user.id)
-    return unless code_usable?(code)
+    return false unless code_usable?(code)
     code.update!(used_at: Time.zone.now)
     true
   end

--- a/spec/services/backup_code_generator_spec.rb
+++ b/spec/services/backup_code_generator_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BackupCodeGenerator do
     generator.generate
 
     success = generator.verify 'This is a string which will never result from code generation'
-    expect(success).to be_falsy
+    expect(success).to eq false
   end
 
   it 'creates codes with the same salt for that batch' do


### PR DESCRIPTION
I was looking at backup code success rate and it was at 100% because we log success as null instead of false, so this PR changes it to return a boolean in all cases