### PR TITLE
Persist Webpack assets manifest between requests

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -1,7 +1,5 @@
 # rubocop:disable Rails/HelperInstanceVariable
 module ScriptHelper
-  MANIFEST_PATH = Rails.root.join('public', 'packs', 'manifest.json').freeze
-
   def javascript_include_tag_without_preload(*sources)
     original_preload_links_header = ActionView::Helpers::AssetTagHelper.preload_links_header
     ActionView::Helpers::AssetTagHelper.preload_links_header = false
@@ -24,30 +22,7 @@ module ScriptHelper
 
   def render_javascript_pack_once_tags(*names)
     javascript_packs_tag_once(*names) if names.present?
-    return if !@scripts
-
-    # RailsI18nWebpackPlugin will generate additional assets suffixed per locale, e.g. `.fr.js`.
-    # See: app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
-    regexp_locale_suffix = %r{\.(#{I18n.available_locales.join('|')})\.js$}
-
-    locale_sources, sources = @scripts.flat_map do |name|
-      manifest.dig('entrypoints', name, 'assets', 'js')
-    end.uniq.compact.partition { |source| regexp_locale_suffix.match?(source) }
-
-    javascript_include_tag(
-      *locale_sources.filter { |source| source.end_with? ".#{I18n.locale}.js" },
-      *sources,
-    )
-  end
-
-  private
-
-  def manifest
-    @manifest ||= begin
-      JSON.parse(File.read(MANIFEST_PATH))
-    rescue JSON::ParserError, Errno::ENOENT
-      {}
-    end
+    javascript_include_tag(*AssetSources.get_sources(*@scripts)) if @scripts
   end
 end
 # rubocop:enable Rails/HelperInstanceVariable

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Upaya
     IdentityConfig.build_store(configuration)
 
     AssetSources.manifest_path = Rails.root.join('public', 'packs', 'manifest.json')
-    AssetSources.cache_manifest = Rails.env.production?
+    AssetSources.cache_manifest = Rails.env.production? || Rails.env.test?
 
     console do
       if ENV['ALLOW_CONSOLE_DB_WRITE_ACCESS'] != 'true' &&

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,6 @@ module Upaya
 
     AssetSources.manifest_path = Rails.root.join('public', 'packs', 'manifest.json')
     AssetSources.cache_manifest = Rails.env.production?
-    AssetSources.load_manifest if Rails.env.production?
 
     console do
       if ENV['ALLOW_CONSOLE_DB_WRITE_ACCESS'] != 'true' &&

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
 require 'identity/logging/railtie'
 
+require_relative '../lib/asset_sources'
 require_relative '../lib/identity_config'
 require_relative '../lib/fingerprinter'
 require_relative '../lib/identity_job_log_subscriber'
@@ -22,6 +23,9 @@ module Upaya
       Rails.env, write_copy_to: Rails.root.join('tmp', 'application.yml')
     )
     IdentityConfig.build_store(configuration)
+
+    AssetSources.manifest_path = Rails.root.join('public', 'packs', 'manifest.json')
+    AssetSources.load_manifest if Rails.env.production?
 
     console do
       if ENV['ALLOW_CONSOLE_DB_WRITE_ACCESS'] != 'true' &&

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module Upaya
     IdentityConfig.build_store(configuration)
 
     AssetSources.manifest_path = Rails.root.join('public', 'packs', 'manifest.json')
+    AssetSources.cache_manifest = Rails.env.production?
     AssetSources.load_manifest if Rails.env.production?
 
     console do

--- a/lib/asset_sources.rb
+++ b/lib/asset_sources.rb
@@ -1,0 +1,32 @@
+class AssetSources
+  class << self
+    attr_accessor :manifest_path
+    attr_accessor :manifest
+
+    def get_sources(*names)
+      # RailsI18nWebpackPlugin will generate additional assets suffixed per locale, e.g. `.fr.js`.
+      # See: app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
+      regexp_locale_suffix = %r{\.(#{I18n.available_locales.join('|')})\.js$}
+
+      load_manifest unless manifest
+
+      locale_sources, sources = names.flat_map do |name|
+        manifest&.dig('entrypoints', name, 'assets', 'js')
+      end.uniq.compact.partition { |source| regexp_locale_suffix.match?(source) }
+
+      [
+        *locale_sources.filter { |source| source.end_with? ".#{I18n.locale}.js" },
+        *sources,
+      ]
+    end
+
+    def load_manifest
+      self.manifest = begin
+        JSON.parse(File.read(manifest_path))
+      rescue JSON::ParserError, Errno::ENOENT
+        raise if Rails.env.production?
+        nil
+      end
+    end
+  end
+end

--- a/lib/asset_sources.rb
+++ b/lib/asset_sources.rb
@@ -25,7 +25,6 @@ class AssetSources
       self.manifest = begin
         JSON.parse(File.read(manifest_path))
       rescue JSON::ParserError, Errno::ENOENT
-        raise if Rails.env.production?
         nil
       end
     end

--- a/lib/asset_sources.rb
+++ b/lib/asset_sources.rb
@@ -2,13 +2,14 @@ class AssetSources
   class << self
     attr_accessor :manifest_path
     attr_accessor :manifest
+    attr_accessor :cache_manifest
 
     def get_sources(*names)
       # RailsI18nWebpackPlugin will generate additional assets suffixed per locale, e.g. `.fr.js`.
       # See: app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
       regexp_locale_suffix = %r{\.(#{I18n.available_locales.join('|')})\.js$}
 
-      load_manifest unless manifest
+      load_manifest if !manifest || !cache_manifest
 
       locale_sources, sources = names.flat_map do |name|
         manifest&.dig('entrypoints', name, 'assets', 'js')

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -3,19 +3,6 @@ require 'rails_helper'
 RSpec.describe ScriptHelper do
   include ScriptHelper
 
-  before do
-    allow_any_instance_of(ScriptHelper).to receive(:manifest).and_return(
-      'entrypoints' => {
-        'application' => {
-          'assets' => { 'js' => ['/packs/application.js', '/packs/application.en.js'] },
-        },
-        'document-capture' => {
-          'assets' => { 'js' => ['/packs/document-capture.js', '/packs/document-capture.en.js'] },
-        },
-      },
-    )
-  end
-
   describe '#javascript_include_tag_without_preload' do
     it 'avoids modifying headers' do
       javascript_include_tag_without_preload 'application'
@@ -43,32 +30,31 @@ RSpec.describe ScriptHelper do
       before do
         javascript_packs_tag_once('document-capture', 'document-capture')
         javascript_packs_tag_once('application', prepend: true)
+        allow(AssetSources).to receive(:get_sources).with('application', 'document-capture').
+          and_return(['/application.js', '/document-capture.js'])
       end
 
-      it 'prints all unique packs in order, locale scripts first' do
+      it 'prints script sources' do
         output = render_javascript_pack_once_tags
 
-        selectors = [
-          "script[src^='/packs/application.en.js']",
-          "script[src^='/packs/document-capture.en.js']",
-          "script[src^='/packs/application.js']",
-          "script[src^='/packs/document-capture.js']",
-        ]
-
-        selectors.each_with_index do |selector, i|
-          next_selector = selectors[i + 1]
-          test_selector = selector
-          test_selector += " ~ #{next_selector}" if next_selector
-          expect(output).to have_css(test_selector, count: 1, visible: false)
-        end
+        expect(output).to have_css(
+          "script[src^='/application.js'] ~ script[src^='/document-capture.js']",
+          count: 1,
+          visible: :all,
+        )
       end
     end
 
     context 'with named scripts argument' do
+      before do
+        allow(AssetSources).to receive(:get_sources).with('application').
+          and_return(['/application.js'])
+      end
+
       it 'enqueues those scripts before printing them' do
         output = render_javascript_pack_once_tags('application')
 
-        expect(output).to have_css('script[src="/packs/application.js"]', visible: :all)
+        expect(output).to have_css('script[src="/application.js"]', visible: :all)
       end
     end
 

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe AssetSources do
     context 'cached manifest' do
       before do
         allow(AssetSources).to receive(:cache_manifest).and_return(true)
+        AssetSources.manifest = nil
       end
 
       it 'loads the manifest once' do

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe AssetSources do
   end
 
   before do
-    AssetSources.manifest = nil
     File.open(manifest_file.path, 'w') { |f| f.puts manifest_content }
     allow(AssetSources).to receive(:manifest_path).and_return(manifest_file.path)
     allow(I18n).to receive(:available_locales).and_return([:en, :es, :fr])
@@ -47,7 +46,6 @@ RSpec.describe AssetSources do
 
   after do
     manifest_file.unlink
-    AssetSources.manifest = nil
   end
 
   describe '.get_sources' do
@@ -66,6 +64,26 @@ RSpec.describe AssetSources do
 
       it 'returns an empty array' do
         expect(AssetSources.get_sources('missing')).to eq([])
+      end
+    end
+
+    it 'loads the manifest' do
+      expect(AssetSources).to receive(:load_manifest).twice.and_call_original
+
+      AssetSources.get_sources('application')
+      AssetSources.get_sources('input')
+    end
+
+    context 'cached manifest' do
+      before do
+        allow(AssetSources).to receive(:cache_manifest).and_return(true)
+      end
+
+      it 'loads the manifest once' do
+        expect(AssetSources).to receive(:load_manifest).once.and_call_original
+
+        AssetSources.get_sources('application')
+        AssetSources.get_sources('input')
       end
     end
   end

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe AssetSources do
   end
 
   before do
+    AssetSources.manifest = nil
     File.open(manifest_file.path, 'w') { |f| f.puts manifest_content }
     allow(AssetSources).to receive(:manifest_path).and_return(manifest_file.path)
     allow(I18n).to receive(:available_locales).and_return([:en, :es, :fr])
@@ -46,6 +47,7 @@ RSpec.describe AssetSources do
 
   after do
     manifest_file.unlink
+    AssetSources.manifest = nil
   end
 
   describe '.get_sources' do
@@ -77,7 +79,6 @@ RSpec.describe AssetSources do
     context 'cached manifest' do
       before do
         allow(AssetSources).to receive(:cache_manifest).and_return(true)
-        AssetSources.manifest = nil
       end
 
       it 'loads the manifest once' do

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -108,16 +108,6 @@ RSpec.describe AssetSources do
 
         expect(AssetSources.manifest).to be_nil
       end
-
-      context 'production environment' do
-        before do
-          allow(Rails.env).to receive(:production?).and_return(true)
-        end
-
-        it 'raises an exception' do
-          expect { AssetSources.load_manifest }.to raise_exception(Errno::ENOENT)
-        end
-      end
     end
 
     context 'invalid json' do
@@ -127,16 +117,6 @@ RSpec.describe AssetSources do
         AssetSources.load_manifest
 
         expect(AssetSources.manifest).to be_nil
-      end
-
-      context 'production environment' do
-        before do
-          allow(Rails.env).to receive(:production?).and_return(true)
-        end
-
-        it 'raises an exception' do
-          expect { AssetSources.load_manifest }.to raise_exception(JSON::ParserError)
-        end
       end
     end
   end

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -69,20 +69,20 @@ RSpec.describe AssetSources do
       end
     end
 
-    it 'loads the manifest' do
-      expect(AssetSources).to receive(:load_manifest).twice.and_call_original
+    it 'loads the manifest once' do
+      expect(AssetSources).to receive(:load_manifest).once.and_call_original
 
       AssetSources.get_sources('application')
       AssetSources.get_sources('input')
     end
 
-    context 'cached manifest' do
+    context 'uncached manifest' do
       before do
-        allow(AssetSources).to receive(:cache_manifest).and_return(true)
+        allow(AssetSources).to receive(:cache_manifest).and_return(false)
       end
 
-      it 'loads the manifest once' do
-        expect(AssetSources).to receive(:load_manifest).once.and_call_original
+      it 'loads the manifest' do
+        expect(AssetSources).to receive(:load_manifest).twice.and_call_original
 
         AssetSources.get_sources('application')
         AssetSources.get_sources('input')

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+require 'asset_sources'
+require 'tempfile'
+
+RSpec.describe AssetSources do
+  include ActionView::Helpers::TranslationHelper
+
+  let(:manifest_file) { Tempfile.new }
+  let(:manifest_content) do
+    <<~STR
+      {
+        "entrypoints": {
+          "application": {
+            "assets": {
+              "js": [
+                "vendor.js",
+                "application.en.js",
+                "application.fr.js",
+                "application.es.js",
+                "application.js"
+              ]
+            }
+          },
+          "input": {
+            "assets": {
+              "js": [
+                "vendor.js",
+                "input.en.js",
+                "input.fr.js",
+                "input.es.js",
+                "input.js"
+              ]
+            }
+          }
+        }
+      }
+    STR
+  end
+
+  before do
+    File.open(manifest_file.path, 'w') { |f| f.puts manifest_content }
+    allow(AssetSources).to receive(:manifest_path).and_return(manifest_file.path)
+    allow(I18n).to receive(:available_locales).and_return([:en, :es, :fr])
+    allow(I18n).to receive(:locale).and_return(:en)
+  end
+
+  after do
+    manifest_file.unlink
+    AssetSources.manifest = nil
+  end
+
+  describe '.get_sources' do
+    it 'returns unique localized assets for existing sources, in order, localized scripts first' do
+      expect(AssetSources.get_sources('application', 'application', 'missing', 'input')).to eq [
+        'application.en.js',
+        'input.en.js',
+        'vendor.js',
+        'application.js',
+        'input.js',
+      ]
+    end
+
+    context 'unset manifest' do
+      let(:manifest_content) { nil }
+
+      it 'returns an empty array' do
+        expect(AssetSources.get_sources('missing')).to eq([])
+      end
+    end
+  end
+
+  describe '.load_manifest' do
+    context 'missing file' do
+      let(:manifest_content) { nil }
+
+      before do
+        manifest_file.unlink
+      end
+
+      it 'gracefully sets nil manifest' do
+        AssetSources.load_manifest
+
+        expect(AssetSources.manifest).to be_nil
+      end
+
+      context 'production environment' do
+        before do
+          allow(Rails.env).to receive(:production?).and_return(true)
+        end
+
+        it 'raises an exception' do
+          expect { AssetSources.load_manifest }.to raise_exception(Errno::ENOENT)
+        end
+      end
+    end
+
+    context 'invalid json' do
+      let(:manifest_content) { '{' }
+
+      it 'gracefully sets nil manifest' do
+        AssetSources.load_manifest
+
+        expect(AssetSources.manifest).to be_nil
+      end
+
+      context 'production environment' do
+        before do
+          allow(Rails.env).to receive(:production?).and_return(true)
+        end
+
+        it 'raises an exception' do
+          expect { AssetSources.load_manifest }.to raise_exception(JSON::ParserError)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe AssetSources do
   end
 
   describe '.load_manifest' do
+    it 'sets the manifest' do
+      AssetSources.load_manifest
+
+      expect(AssetSources.manifest).to be_kind_of(Hash).and eq(JSON.parse(manifest_content))
+    end
+
     context 'missing file' do
       let(:manifest_content) { nil }
 

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe AssetSources do
   end
 
   before do
+    AssetSources.manifest = nil
     File.open(manifest_file.path, 'w') { |f| f.puts manifest_content }
     allow(AssetSources).to receive(:manifest_path).and_return(manifest_file.path)
     allow(I18n).to receive(:available_locales).and_return([:en, :es, :fr])


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5746#discussion_r781272048

**Why**: To avoid touching the filesystem for every request in production, since the manifest will never change during the lifetime of the application. Also, by loading the manifest at initialization, we can fail an instance quickly if, for some reason, the manifest file is not available.

In the discussion at https://github.com/18F/identity-idp/pull/5746#discussion_r781272048, it was considered if caching should only apply to production. However, since we aren't currently using fingerprinting in development, it may be fine to cache in development as well. The only downside is that _newly-added_ entrypoints would require an application restart, though this seems to be a reasonable compromise.