### PR TITLE
make text readable in personal key custom dialog

### DIFF
--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,7 +1,7 @@
 <div id="reactivate-account-modal" class="display-none">
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
-      <h2 class="margin-y-2 fs-20p sans-serif regular center" id='reactivate-modal-label'>
+      <h2 class="margin-y-2 fs-20p sans-serif regular center" id="<%= label_id %>">
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>
       <hr class="margin-bottom-4 border-width-05" />

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -5,7 +5,7 @@
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>
       <hr class="margin-bottom-4 border-width-05" />
-      <div class="margin-bottom-8" id="reactivate-modal-description">
+      <div class="margin-bottom-8" id="<%= description_id %>">
         <%= t('instructions.account.reactivate.modal.copy') %>
       </div>
       <div class="center">

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,8 +1,5 @@
 <div id="reactivate-account-modal" class="display-none">
-  <%= render layout: 'shared/modal_layout', 
-      locals: { description_id: 'reactivate-modal-description', 
-                label_id: 'reactivate-modal-label' }
-      do %>
+  <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
       <h2 class="margin-y-2 fs-20p sans-serif regular center" id='reactivate-modal-label'>
         <%= t('instructions.account.reactivate.modal.heading') %>

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,11 +1,14 @@
 <div id="reactivate-account-modal" class="display-none">
-  <%= render layout: 'shared/modal_layout', description_id: 'dialog_description', label_id: 'dialog_label' do %>
+  <%= render layout: 'shared/modal_layout', 
+      locals: { description_id: 'reactivate-modal-description', 
+                label_id: 'reactivate-modal-label' }
+      do %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
-      <h2 class="margin-y-2 fs-20p sans-serif regular center">
+      <h2 class="margin-y-2 fs-20p sans-serif regular center" id='reactivate-modal-label'>
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>
       <hr class="margin-bottom-4 border-width-05" />
-      <div class="margin-bottom-8">
+      <div class="margin-bottom-8" id="reactivate-modal-description">
         <%= t('instructions.account.reactivate.modal.copy') %>
       </div>
       <div class="center">

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,4 +1,4 @@
-<div id="reactivate-account-modal" class="display-none">
+<div id="reactivate-account-modal" class="display-none" tabindex="-1">
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
       <h2 class="margin-y-2 fs-20p sans-serif regular center" id="<%= label_id %>">

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="reactivate-account-modal" class="display-none">
-  <%= render layout: '/shared/modal_layout' do %>
+  <%= render layout: 'shared/modal_layout', description_id: 'dialog_description', label_id: 'dialog_label' do %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
       <h2 class="margin-y-2 fs-20p sans-serif regular center">
         <%= t('instructions.account.reactivate.modal.heading') %>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,12 +1,14 @@
 <div id='session-timeout-msg' class='display-none'>
-  <%= render layout: 'shared/modal_layout', description_id: 'dialog_description1', label_id: 'dialog_label1' do %>
+  <%= render layout: 'shared/modal_layout', 
+      locals: { description_id: 'session_timeout_description', 
+                label_id: 'session_timeout_label'} do %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
-      <h2 class='margin-y-2 fs-20p sans-serif regular center' id="dialog_label">
+      <h2 class='margin-y-2 fs-20p sans-serif regular center' id="session_timeout_label">
         <%= t('headings.session_timeout_warning') %>
       </h2>
       <hr class='margin-bottom-4 border-width-05' />
       <div class='margin-bottom-6'>
-        <p id="dialog_description">
+        <p id="session_timeout_description">
           <%= modal.message %>
         </p>
       </div>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,4 +1,4 @@
-<div id='session-timeout-msg' class='display-none'>
+<div id='session-timeout-msg' class='display-none' tabindex='-1'>
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
       <h2 class='margin-y-2 fs-20p sans-serif regular center' id='<%= label_id %>'>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,14 +1,12 @@
 <div id='session-timeout-msg' class='display-none'>
-  <%= render layout: 'shared/modal_layout', 
-      locals: { description_id: 'session_timeout_description', 
-                label_id: 'session_timeout_label'} do %>
+  <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
-      <h2 class='margin-y-2 fs-20p sans-serif regular center' id="session_timeout_label">
+      <h2 class='margin-y-2 fs-20p sans-serif regular center' id='<%= label_id %>'>
         <%= t('headings.session_timeout_warning') %>
       </h2>
       <hr class='margin-bottom-4 border-width-05' />
       <div class='margin-bottom-6'>
-        <p id="session_timeout_description">
+        <p id='<%= description_id %>'>
           <%= modal.message %>
         </p>
       </div>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,12 +1,12 @@
 <div id='session-timeout-msg' class='display-none'>
-  <%= render layout: '/shared/modal_layout' do %>
+  <%= render layout: 'shared/modal_layout', description_id: 'dialog_description1', label_id: 'dialog_label1' do %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
-      <h2 class='margin-y-2 fs-20p sans-serif regular center'>
+      <h2 class='margin-y-2 fs-20p sans-serif regular center' id="dialog_label">
         <%= t('headings.session_timeout_warning') %>
       </h2>
       <hr class='margin-bottom-4 border-width-05' />
       <div class='margin-bottom-6'>
-        <p>
+        <p id="dialog_description">
           <%= modal.message %>
         </p>
       </div>

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -1,14 +1,13 @@
 <div class="modal-backdrop">
 </div>
-<div   
-  aria-describedby="dialog_description"
-  aria-labelledby="dialog_label"
-  class="padding-x-2 padding-y-6 modal"
-  role="dialog" 
->
-  <div class="modal-center">
-    <div class="modal-content">
-      <%= yield %>
+  <%= tag.div(role: 'dialog', 
+      class: 'padding-x-2 padding-y-6 modal', 
+      aria: { describedby: local_assigns[:description_id], 
+              labelledby: local_assigns[:label_id] }) do %>
+    <div class="modal-center">
+      <div class="modal-content">
+        <%= yield %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -1,6 +1,11 @@
 <div class="modal-backdrop">
 </div>
-<div class="padding-x-2 padding-y-6 modal" role="dialog">
+<div   
+  aria-describedby="dialog_description"
+  aria-labelledby="dialog_label"
+  class="padding-x-2 padding-y-6 modal"
+  role="dialog" 
+>
   <div class="modal-center">
     <div class="modal-content">
       <%= yield %>

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -2,11 +2,11 @@
 </div>
   <%= tag.div(role: 'dialog', 
       class: 'padding-x-2 padding-y-6 modal', 
-      aria: { describedby: local_assigns[:description_id], 
-              labelledby: local_assigns[:label_id] }) do %>
+      aria: { describedby: (description_id = SecureRandom.uuid), 
+              labelledby: (label_id = SecureRandom.uuid) }) do %>
     <div class="modal-center">
       <div class="modal-content">
-        <%= yield %>
+        <%= yield label_id, description_id %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -1,9 +1,11 @@
 <div class="modal-backdrop">
 </div>
-  <%= tag.div(role: 'dialog', 
-      class: 'padding-x-2 padding-y-6 modal', 
-      aria: { describedby: (description_id = SecureRandom.uuid), 
-              labelledby: (label_id = SecureRandom.uuid) }) do %>
+  <%= tag.div(
+        role: 'dialog',
+        class: 'padding-x-2 padding-y-6 modal',
+        aria: { describedby: (description_id = SecureRandom.uuid),
+                labelledby: (label_id = SecureRandom.uuid) },
+      ) do %>
     <div class="modal-center">
       <div class="modal-content">
         <%= yield label_id, description_id %>

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,10 +1,10 @@
 <div id="personal-key-confirm" class="display-none">
-  <%= render layout: '/shared/modal_layout', description_id: 'dialog_description', label_id: 'dialog_label' do %>
+  <%= render layout: '/shared/modal_layout', locals: {description_id: "personal_key_description", label_id: "personal_key_label"} do %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
-      <h2 class="margin-top-0 margin-bottom-2" id="dialog_label">
+      <h2 class="margin-top-0 margin-bottom-2" id="personal_key_label">
         <%= t('forms.personal_key.title') %>
       </h2>
-      <p class="margin-bottom-4" id="dialog_description">
+      <p class="margin-bottom-4" id="personal_key_description">
         <%= t('forms.personal_key.instructions') %>
       </p>
 

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="personal-key-confirm" class="display-none">
-  <%= render layout: 'shared/modal_layout' do %>
+  <%= render layout: '/shared/modal_layout', description_id: 'dialog_description', label_id: 'dialog_label' do %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
       <h2 class="margin-top-0 margin-bottom-2" id="dialog_label">
         <%= t('forms.personal_key.title') %>

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,5 +1,7 @@
 <div id="personal-key-confirm" class="display-none">
-  <%= render layout: '/shared/modal_layout', locals: {description_id: "personal_key_description", label_id: "personal_key_label"} do %>
+  <%= render layout: '/shared/modal_layout', 
+      locals: { description_id: "personal_key_description", 
+              label_id: "personal_key_label" } do %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
       <h2 class="margin-top-0 margin-bottom-2" id="personal_key_label">
         <%= t('forms.personal_key.title') %>

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,4 +1,4 @@
-<div id="personal-key-confirm" class="display-none">
+<div id="personal-key-confirm" class="display-none" tabindex='-1'>
   <%= render layout: '/shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
       <h2 class="margin-top-0 margin-bottom-2" id="<%= label_id %>">

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,12 +1,10 @@
 <div id="personal-key-confirm" class="display-none">
-  <%= render layout: '/shared/modal_layout', 
-      locals: { description_id: "personal_key_description", 
-              label_id: "personal_key_label" } do %>
+  <%= render layout: '/shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
-      <h2 class="margin-top-0 margin-bottom-2" id="personal_key_label">
+      <h2 class="margin-top-0 margin-bottom-2" id="<%= label_id %>">
         <%= t('forms.personal_key.title') %>
       </h2>
-      <p class="margin-bottom-4" id="personal_key_description">
+      <p class="margin-bottom-4" id="<%= description_id %>">
         <%= t('forms.personal_key.instructions') %>
       </p>
 

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,10 +1,10 @@
 <div id="personal-key-confirm" class="display-none">
   <%= render layout: 'shared/modal_layout' do %>
     <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
-      <h2 class="margin-top-0 margin-bottom-2">
+      <h2 class="margin-top-0 margin-bottom-2" id="dialog_label">
         <%= t('forms.personal_key.title') %>
       </h2>
-      <p class="margin-bottom-4">
+      <p class="margin-bottom-4" id="dialog_description">
         <%= t('forms.personal_key.instructions') %>
       </p>
 


### PR DESCRIPTION
This PR makes it so that text in the "Confirm personal key" dialog is announced by the screen reader. 

**Why**: So that a screen reader user can receive all instructions as well as have parity between experiences.
| Current state | Change after fix |
|---------------|------------------|
|![image](https://user-images.githubusercontent.com/17969963/148998142-54e15854-7d95-41b2-85f9-300a21da084e.png)| ![Screen Shot 2022-01-11 at 1 16 33 PM](https://user-images.githubusercontent.com/17969963/148998953-b0be6533-9f1b-42ea-932d-8695654f0bb1.png)|

Follow up work:
- Audit all custom dialog modals to make sure that text is read by screen readers.
- Ensure that **all** validation and error messages in modals are read by a screen reader once generated (work for the personal key dialog is captured in LG-5315, but there should be a catch all for all other modals)