### PR TITLE
Enable Rubocop Layout/SpaceInsideParens cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -305,6 +305,9 @@ Layout/SpaceInLambdaLiteral:
 Layout/SpaceInsideBlockBraces:
   Enabled: true
 
+Layout/SpaceInsideParens:
+  Enabled: true
+
 Layout/TrailingEmptyLines:
   Enabled: true
   EnforcedStyle: final_newline

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -1,7 +1,7 @@
 class ImageUploadResponsePresenter
   include Rails.application.routes.url_helpers
 
-  def initialize(form_response:, url_options: )
+  def initialize(form_response:, url_options:)
     @form_response = form_response
     @url_options = url_options
   end

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -3,7 +3,7 @@
     <%= t('account.index.phone') %>
   </h2>
   <% if flash[:phone_error] %>
-    <%= render AlertComponent.new( type: :error, id: 'phones', class: 'margin-bottom-1', message: flash[:phone_error]) %>
+    <%= render AlertComponent.new(type: :error, id: 'phones', class: 'margin-bottom-1', message: flash[:phone_error]) %>
   <% end %>
   <div class="border-bottom border-primary-light">
     <% MfaContext.new(current_user).phone_configurations.each do |phone_configuration| %>

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -72,7 +72,7 @@ describe Deploy::Activate do
     end
 
     let(:geolite_content) { 'geolite test' }
-    let(:pwned_passwords_content ) { 'pwned passwords test' }
+    let(:pwned_passwords_content) { 'pwned passwords test' }
 
     it 'downloads the pwned passwords and geolite files from s3' do
       subject.run

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe MarketingSite do
   describe '.help_center_article_url' do
     let(:category) {}
     let(:article) {}
-    let(:result) { MarketingSite.help_center_article_url(category: category, article: article ) }
+    let(:result) { MarketingSite.help_center_article_url(category: category, article: article) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }
@@ -138,7 +138,7 @@ RSpec.describe MarketingSite do
   describe '.valid_help_center_article?' do
     let(:category) {}
     let(:article) {}
-    let(:result) { MarketingSite.valid_help_center_article?(category: category, article: article ) }
+    let(:result) { MarketingSite.valid_help_center_article?(category: category, article: article) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }

--- a/spec/services/phone_confirmation/confirmaton_session_spec.rb
+++ b/spec/services/phone_confirmation/confirmaton_session_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe PhoneConfirmation::ConfirmationSession do
       lowercase_code = code.downcase
       uppercase_code = code.upcase
 
-      expect(subject.matches_code?(random_case_code )).to eq(true)
+      expect(subject.matches_code?(random_case_code)).to eq(true)
       expect(subject.matches_code?(lowercase_code)).to eq(true)
       expect(subject.matches_code?(uppercase_code)).to eq(true)
     end


### PR DESCRIPTION
**Why**: So that we use consistent spacing for parentheses.