### PR TITLE
Log worker metrics to workers.log

### DIFF
--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -2,7 +2,7 @@ class HeartbeatJob < ApplicationJob
   queue_as :default
 
   def perform
-    Rails.logger.info(
+    IdentityJobLogSubscriber.new.logger.info(
       {
         name: 'queue_metric.good_job',
         # borrowed from: https://github.com/bensheldon/good_job/blob/main/engine/app/controllers/good_job/dashboards_controller.rb#L35

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -122,6 +122,18 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     error(json.to_json)
   end
 
+  def logger
+    if Rails.env.test?
+      Rails.logger
+    else
+      IdentityJobLogSubscriber.worker_logger
+    end
+  end
+
+  def self.worker_logger
+    @worker_logger ||= ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
+  end
+
   private
 
   def default_attributes(event, job)
@@ -148,14 +160,6 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
 
   def scheduled_at(event)
     Time.zone.at(event.payload[:job].scheduled_at).utc
-  end
-
-  def logger
-    if Rails.env.test?
-      Rails.logger
-    else
-      ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
-    end
   end
 
   def trace_id(job)


### PR DESCRIPTION
So our worker metrics go to `workers.log` instead of `production.log`