### PR TITLE
LG-5251: Add location to logging for upload submitted event

### DIFF
--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -47,20 +47,27 @@ module Idv
         UserMailer.doc_auth_desktop_link_to_sp(
           current_user, current_user.email, application, link
         ).deliver_now_or_later
+        form_response(destination: :email_sent)
       end
 
       def send_user_to_send_link_step
         mark_step_complete(:email_sent)
+        form_response(destination: :send_link)
       end
 
       def bypass_send_link_steps
         mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
         mark_step_complete(:email_sent)
+        form_response(destination: :document_capture)
       end
 
       def mobile_device?
         BrowserCache.parse(request.user_agent).mobile?
+      end
+
+      def form_response(destination:)
+        FormResponse.new(success: true, errors: {}, extra: { destination: destination })
       end
     end
   end

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -4,9 +4,12 @@ feature 'doc auth upload step' do
   include IdvStepHelper
   include DocAuthHelper
 
+  let(:fake_analytics) { FakeAnalytics.new }
+
   before do
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_upload_step
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
   end
 
   context 'on a mobile device' do
@@ -21,11 +24,19 @@ feature 'doc auth upload step' do
     it 'proceeds to send link via email page when user chooses to upload from computer' do
       click_on t('doc_auth.info.upload_computer_link')
       expect(page).to have_current_path(idv_doc_auth_email_sent_step)
+      expect(fake_analytics).to have_logged_event(
+        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        hash_including(step: 'upload', destination: :email_sent),
+      )
     end
 
     it 'proceeds to document capture when user chooses to use phone' do
       click_on t('doc_auth.buttons.use_phone')
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+      expect(fake_analytics).to have_logged_event(
+        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        hash_including(step: 'upload', destination: :document_capture),
+      )
     end
   end
 
@@ -37,11 +48,19 @@ feature 'doc auth upload step' do
     it 'proceeds to document capture when user chooses to upload from computer' do
       click_on t('doc_auth.info.upload_computer_link')
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+      expect(fake_analytics).to have_logged_event(
+        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        hash_including(step: 'upload', destination: :document_capture),
+      )
     end
 
     it 'proceeds to send link to phone page when user chooses to use phone' do
       click_on t('doc_auth.buttons.use_phone')
       expect(page).to have_current_path(idv_doc_auth_send_link_step)
+      expect(fake_analytics).to have_logged_event(
+        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        hash_including(step: 'upload', destination: :send_link),
+      )
     end
   end
 

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -25,7 +25,7 @@ feature 'doc auth upload step' do
       click_on t('doc_auth.info.upload_computer_link')
       expect(page).to have_current_path(idv_doc_auth_email_sent_step)
       expect(fake_analytics).to have_logged_event(
-        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        "IdV: #{Analytics::DOC_AUTH.downcase} upload submitted",
         hash_including(step: 'upload', destination: :email_sent),
       )
     end
@@ -34,7 +34,7 @@ feature 'doc auth upload step' do
       click_on t('doc_auth.buttons.use_phone')
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
       expect(fake_analytics).to have_logged_event(
-        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        "IdV: #{Analytics::DOC_AUTH.downcase} upload submitted",
         hash_including(step: 'upload', destination: :document_capture),
       )
     end
@@ -49,7 +49,7 @@ feature 'doc auth upload step' do
       click_on t('doc_auth.info.upload_computer_link')
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
       expect(fake_analytics).to have_logged_event(
-        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        "IdV: #{Analytics::DOC_AUTH.downcase} upload submitted",
         hash_including(step: 'upload', destination: :document_capture),
       )
     end
@@ -58,7 +58,7 @@ feature 'doc auth upload step' do
       click_on t('doc_auth.buttons.use_phone')
       expect(page).to have_current_path(idv_doc_auth_send_link_step)
       expect(fake_analytics).to have_logged_event(
-        'IdV: ' + "#{Analytics::DOC_AUTH} upload submitted".downcase,
+        "IdV: #{Analytics::DOC_AUTH.downcase} upload submitted",
         hash_including(step: 'upload', destination: :send_link),
       )
     end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -95,7 +95,11 @@ RSpec::Matchers.define :have_logged_event do |event_name, attributes|
   match do |actual|
     expect(actual).to be_kind_of(FakeAnalytics)
 
-    expect(actual.events[event_name]).to(be_any { |event| attributes <= event })
+    if RSpec::Support.is_a_matcher?(attributes)
+      expect(actual.events[event_name]).to include(attributes)
+    else
+      expect(actual.events[event_name]).to(be_any { |event| attributes <= event })
+    end
   end
 
   failure_message do |actual|


### PR DESCRIPTION
**Why**: So we can differentiate where the user will be lead as a result of the submission event.