### PR TITLE
Skip generating GZIP assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true
+  config.assets.gzip = false
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
+  config.assets.gzip = false
   config.i18n.raise_on_missing_translations = true
 
   config.action_mailer.delivery_method = :test


### PR DESCRIPTION
**Why**: Because we don't use them currently, it's a waste of time.

Docs: https://guides.rubyonrails.org/asset_pipeline.html#gzipping-your-assets

Related: 18F/identity-devops#3486