### PR TITLE
Remove redundant empty div wrappers

### DIFF
--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -1,31 +1,29 @@
-<div>
-  <div class="grid-row margin-bottom-1 margin-top-0">
-    <h2 class="grid-col-fill margin-y-0 padding-right-2">
-      <%= t('headings.account.authentication_apps') %>
-    </h2>
-    <% if current_user.auth_app_configurations.count < IdentityConfig.store.max_auth_apps_per_account %>
-      <div class="grid-col-auto">
-        <%= link_to(
-              prefix_with_plus(t('account.index.auth_app_add')),
-              authenticator_setup_url,
-              class: 'account-action-button',
-            ) %>
-      </div>
-    <% end %>
-  </div>
+<div class="grid-row margin-bottom-1 margin-top-0">
+  <h2 class="grid-col-fill margin-y-0 padding-right-2">
+    <%= t('headings.account.authentication_apps') %>
+  </h2>
+  <% if current_user.auth_app_configurations.count < IdentityConfig.store.max_auth_apps_per_account %>
+    <div class="grid-col-auto">
+      <%= link_to(
+            prefix_with_plus(t('account.index.auth_app_add')),
+            authenticator_setup_url,
+            class: 'account-action-button',
+          ) %>
+    </div>
+  <% end %>
+</div>
 
-  <div class="border-bottom border-primary-light">
-    <% MfaContext.new(current_user).auth_app_configurations.each do |auth_app_configuration| %>
-      <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-        <div class="grid-col-8">
-          <div class="grid-col-12 mobile-lg:grid-col-6">
-            <%= auth_app_configuration.name %>
-          </div>
-        </div>
-        <div class="grid-col-4 right-align">
-          <%= render 'accounts/actions/disable_totp', id: auth_app_configuration.id %>
+<div class="border-bottom border-primary-light">
+  <% MfaContext.new(current_user).auth_app_configurations.each do |auth_app_configuration| %>
+    <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
+      <div class="grid-col-8">
+        <div class="grid-col-12 mobile-lg:grid-col-6">
+          <%= auth_app_configuration.name %>
         </div>
       </div>
-    <% end %>
-  </div>
+      <div class="grid-col-4 right-align">
+        <%= render 'accounts/actions/disable_totp', id: auth_app_configuration.id %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/accounts/_manage_personal_key.html.erb
+++ b/app/views/accounts/_manage_personal_key.html.erb
@@ -1,15 +1,13 @@
-<div>
-  <div class="grid-row margin-bottom-1 margin-top-0">
-    <h2 class="grid-col-6 margin-0">
-      <%= t('account.items.personal_key') %>
-    </h2>
+<div class="grid-row margin-bottom-1 margin-top-0">
+  <h2 class="grid-col-6 margin-0">
+    <%= t('account.items.personal_key') %>
+  </h2>
+</div>
+<div class="grid-row padding-1 border border-primary-light">
+  <div class="grid-col-7">
+    ************
   </div>
-  <div class="grid-row padding-1 border border-primary-light">
-    <div class="grid-col-7">
-      ************
-    </div>
-    <div class="grid-col-5 right-align">
-      <%= render 'accounts/actions/manage_personal_key' %>
-    </div>
+  <div class="grid-col-5 right-align">
+    <%= render 'accounts/actions/manage_personal_key' %>
   </div>
 </div>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -1,27 +1,25 @@
-<div>
-  <h2 class="margin-top-0">
-    <%= t('account.index.phone') %>
-  </h2>
-  <% if flash[:phone_error] %>
-    <%= render AlertComponent.new(type: :error, id: 'phones', class: 'margin-bottom-1', message: flash[:phone_error]) %>
-  <% end %>
-  <div class="border-bottom border-primary-light">
-    <% MfaContext.new(current_user).phone_configurations.each do |phone_configuration| %>
-      <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-        <div class="grid-col-5">
-          <%= PhoneFormatter.format(phone_configuration.phone) %>
-        </div>
-        <div class="grid-col-4 text-center">
-          <% if current_user.default_phone_configuration == phone_configuration %>
-            <%= I18n.t('account.index.default') %>
-          <% end %>
-        </div>
-        <div class="grid-col-3 right-align">
-          <%= render 'accounts/actions/manage_action_button',
-                     path: manage_phone_path(id: phone_configuration.id),
-                     name: t('account.index.phone') %>
-        </div>
+<h2 class="margin-top-0">
+  <%= t('account.index.phone') %>
+</h2>
+<% if flash[:phone_error] %>
+  <%= render AlertComponent.new(type: :error, id: 'phones', class: 'margin-bottom-1', message: flash[:phone_error]) %>
+<% end %>
+<div class="border-bottom border-primary-light">
+  <% MfaContext.new(current_user).phone_configurations.each do |phone_configuration| %>
+    <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
+      <div class="grid-col-5">
+        <%= PhoneFormatter.format(phone_configuration.phone) %>
       </div>
-    <% end %>
-  </div>
+      <div class="grid-col-4 text-center">
+        <% if current_user.default_phone_configuration == phone_configuration %>
+          <%= I18n.t('account.index.default') %>
+        <% end %>
+      </div>
+      <div class="grid-col-3 right-align">
+        <%= render 'accounts/actions/manage_action_button',
+                   path: manage_phone_path(id: phone_configuration.id),
+                   name: t('account.index.phone') %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -1,31 +1,29 @@
-<div>
-  <div class="grid-row margin-bottom-1 margin-top-0">
-    <h2 class="grid-col-fill margin-y-0 padding-right-2">
-      <%= t('headings.account.federal_employee_id') %>
-    </h2>
-    <% if current_user.piv_cac_configurations.count < IdentityConfig.store.max_piv_cac_per_account %>
-      <div class="grid-col-auto">
-        <%= link_to(
-              prefix_with_plus(t('account.index.piv_cac_add')),
-              setup_piv_cac_url,
-              class: 'account-action-button',
-            ) %>
-      </div>
-    <% end %>
-  </div>
+<div class="grid-row margin-bottom-1 margin-top-0">
+  <h2 class="grid-col-fill margin-y-0 padding-right-2">
+    <%= t('headings.account.federal_employee_id') %>
+  </h2>
+  <% if current_user.piv_cac_configurations.count < IdentityConfig.store.max_piv_cac_per_account %>
+    <div class="grid-col-auto">
+      <%= link_to(
+            prefix_with_plus(t('account.index.piv_cac_add')),
+            setup_piv_cac_url,
+            class: 'account-action-button',
+          ) %>
+    </div>
+  <% end %>
+</div>
 
-  <div class="border-bottom border-primary-light">
-    <% MfaContext.new(current_user).piv_cac_configurations.each do |piv_cac_configuration| %>
-      <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-        <div class="grid-col-8">
-          <div class="grid-col-12 mobile-lg:grid-col-6">
-            <%= piv_cac_configuration.name %>
-          </div>
-        </div>
-        <div class="grid-col-4 right-align">
-          <%= render 'accounts/actions/disable_piv_cac', id: piv_cac_configuration.id %>
+<div class="border-bottom border-primary-light">
+  <% MfaContext.new(current_user).piv_cac_configurations.each do |piv_cac_configuration| %>
+    <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
+      <div class="grid-col-8">
+        <div class="grid-col-12 mobile-lg:grid-col-6">
+          <%= piv_cac_configuration.name %>
         </div>
       </div>
-    <% end %>
-  </div>
+      <div class="grid-col-4 right-align">
+        <%= render 'accounts/actions/disable_piv_cac', id: piv_cac_configuration.id %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -1,33 +1,31 @@
-<div>
-  <div class="grid-row margin-bottom-1 margin-top-0">
-    <h2 class="grid-col-fill margin-y-0 padding-right-1">
-      <%= t('account.index.webauthn_platform') %>
-    </h2>
-    <div class="grid-col-auto">
-      <%= link_to(
-            prefix_with_plus(t('account.index.webauthn_platform_add')),
-            webauthn_setup_path(platform: true),
-            class: 'account-action-button',
-          ) %>
-    </div>
+<div class="grid-row margin-bottom-1 margin-top-0">
+  <h2 class="grid-col-fill margin-y-0 padding-right-1">
+    <%= t('account.index.webauthn_platform') %>
+  </h2>
+  <div class="grid-col-auto">
+    <%= link_to(
+          prefix_with_plus(t('account.index.webauthn_platform_add')),
+          webauthn_setup_path(platform: true),
+          class: 'account-action-button',
+        ) %>
   </div>
+</div>
 
-  <div class="border-bottom border-primary-light">
-    <% MfaContext.new(current_user).webauthn_platform_configurations.each do |cfg| %>
-      <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-        <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
-          <%= cfg.name %>
-        </div>
-        <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-          <div class="grid-col-4 mobile-lg:grid-col-6 right-align">
-            <%= link_to(
-                  t('account.index.webauthn_platform_delete'),
-                  webauthn_setup_delete_path(id: cfg.id),
-                ) %>
-          </div>
-        <% end %>
+<div class="border-bottom border-primary-light">
+  <% MfaContext.new(current_user).webauthn_platform_configurations.each do |cfg| %>
+    <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
+      <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
+        <%= cfg.name %>
       </div>
-      <div class="clearfix"></div>
-    <% end %>
-  </div>
+      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+        <div class="grid-col-4 mobile-lg:grid-col-6 right-align">
+          <%= link_to(
+                t('account.index.webauthn_platform_delete'),
+                webauthn_setup_delete_path(id: cfg.id),
+              ) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="clearfix"></div>
+  <% end %>
 </div>

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -1,33 +1,31 @@
-<div>
-  <div class="grid-row margin-bottom-1 margin-top-0">
-    <h2 class="grid-col-fill margin-y-0 padding-right-1">
-      <%= t('account.index.webauthn') %>
-    </h2>
-    <div class="grid-col-auto">
-      <%= link_to(
-            prefix_with_plus(t('account.index.webauthn_add')),
-            webauthn_setup_path,
-            class: 'account-action-button',
-          ) %>
-    </div>
+<div class="grid-row margin-bottom-1 margin-top-0">
+  <h2 class="grid-col-fill margin-y-0 padding-right-1">
+    <%= t('account.index.webauthn') %>
+  </h2>
+  <div class="grid-col-auto">
+    <%= link_to(
+          prefix_with_plus(t('account.index.webauthn_add')),
+          webauthn_setup_path,
+          class: 'account-action-button',
+        ) %>
   </div>
+</div>
 
-  <div class="border-bottom border-primary-light">
-    <% MfaContext.new(current_user).webauthn_roaming_configurations.each do |cfg| %>
-      <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-        <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
-          <%= cfg.name %>
-        </div>
-        <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-          <div class="grid-col-4 mobile-lg:grid-col-6 right-align">
-            <%= link_to(
-                  t('account.index.webauthn_delete'),
-                  webauthn_setup_delete_path(id: cfg.id),
-                ) %>
-          </div>
-        <% end %>
+<div class="border-bottom border-primary-light">
+  <% MfaContext.new(current_user).webauthn_roaming_configurations.each do |cfg| %>
+    <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
+      <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
+        <%= cfg.name %>
       </div>
-      <div class="clearfix"></div>
-    <% end %>
-  </div>
+      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+        <div class="grid-col-4 mobile-lg:grid-col-6 right-align">
+          <%= link_to(
+                t('account.index.webauthn_delete'),
+                webauthn_setup_delete_path(id: cfg.id),
+              ) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="clearfix"></div>
+  <% end %>
 </div>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -13,9 +13,7 @@
     ) do |f| %>
   <%= f.input :password, label: t('account.index.password'), required: true,
                          input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
-  <div>
-    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
-  </div>
+  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
 <% end %>
 
 <div class='clearfix padding-top-1 border-top border-primary-light'>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -20,9 +20,7 @@
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
-  <div>
-    <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
-  </div>
+  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -14,23 +14,21 @@
     <li class="margin-bottom-1"><%= t('users.delete.bullet_3', app_name: APP_NAME) %></li>
     <li class="margin-bottom-1"><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
   </ul>
-  <div>
-    <%= validated_form_for(
-          current_user, url: account_delete_path,
-                        html: { autocomplete: 'off', method: :post }
-        ) do |f| %>
-      <div class="margin-bottom-4">
-        <%= t('users.delete.instructions') %>
-      </div>
-      <%= f.input :password, label: t('idv.form.password'), required: true,
-                             input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
-      <%= f.button :submit,
-                   t('users.delete.actions.delete'),
-                   class: 'usa-button--big usa-button--full-width margin-bottom-2' %>
-    <% end %>
+  <%= validated_form_for(
+        current_user, url: account_delete_path,
+                      html: { autocomplete: 'off', method: :post }
+      ) do |f| %>
+    <div class="margin-bottom-4">
+      <%= t('users.delete.instructions') %>
+    </div>
+    <%= f.input :password, label: t('idv.form.password'), required: true,
+                           input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
+    <%= f.button :submit,
+                 t('users.delete.actions.delete'),
+                 class: 'usa-button--big usa-button--full-width margin-bottom-2' %>
+  <% end %>
 
-    <%= link_to t('users.delete.actions.cancel'), account_path,
-                role: 'button',
-                class: 'usa-button usa-button--big usa-button--full-width usa-button--outline' %>
-  </div>
+  <%= link_to t('users.delete.actions.cancel'), account_path,
+              role: 'button',
+              class: 'usa-button usa-button--big usa-button--full-width usa-button--outline' %>
 </div>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -51,9 +51,7 @@
     </fieldset>
   </div>
 
-  <div>
-    <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-1' %>
-  </div>
+  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-1' %>
 <% end %>
 
 <%= render 'shared/cancel', link: destroy_user_session_path %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -9,46 +9,45 @@
   <%= @presenter.intro %>
 </p>
 
-<div>
-   <%= form_tag(webauthn_setup_path, method: :patch, class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
-      <%= hidden_field_tag :user_id, current_user.id, id: 'user_id' %>
-      <%= hidden_field_tag :user_email, current_user.email, id: 'user_email' %>
-      <%= hidden_field_tag :user_challenge, '[' + user_session[:webauthn_challenge].split.join(',') + ']', id: 'user_challenge' %>
-      <%= hidden_field_tag :exclude_credentials, @exclude_credentials&.join(','), id: 'exclude_credentials' %>
-      <%= hidden_field_tag :webauthn_id, '', id: 'webauthn_id' %>
-      <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
-      <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
-      <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
-      <%= hidden_field_tag :platform_authenticator, @platform_authenticator, id: 'platform_authenticator' %>
-      <%= label_tag 'code', @presenter.nickname_label, class: 'block bold', for: 'nickname' %>
-      <%= text_field_tag(
-            :name,
-            '',
-            required: true,
-            aria: { invalid: false },
-            id: 'nickname',
-            class: 'block col-12 field monospace',
-            size: 16,
-            maxlength: 20,
-          ) %>
-     <div class='border border-primary-light radius-lg padding-x-2 padding-y-1 margin-top-4'>
-       <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
-       <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'margin-y-2 margin-left-2 margin-right-1' %>
-       <%= label_tag(
-             'remember_device',
-             t('forms.messages.remember_device'),
-             class: 'text-primary mt-1p',
-           ) %>
-     </div>
-     <%= submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'hidden' %>
-   <% end %>
-   <br>
-   <%= button_tag(
-         @presenter.button_text,
-         class: 'usa-button usa-button--big usa-button--wide',
-         id: 'continue-button',
-       ) %>
-</div>
+<%= form_tag(webauthn_setup_path, method: :patch, class: 'margin-bottom-1 read-after-submit', id: 'webauthn_form') do %>
+  <%= hidden_field_tag :user_id, current_user.id, id: 'user_id' %>
+  <%= hidden_field_tag :user_email, current_user.email, id: 'user_email' %>
+  <%= hidden_field_tag :user_challenge, '[' + user_session[:webauthn_challenge].split.join(',') + ']', id: 'user_challenge' %>
+  <%= hidden_field_tag :exclude_credentials, @exclude_credentials&.join(','), id: 'exclude_credentials' %>
+  <%= hidden_field_tag :webauthn_id, '', id: 'webauthn_id' %>
+  <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
+  <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
+  <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
+  <%= hidden_field_tag :platform_authenticator, @platform_authenticator, id: 'platform_authenticator' %>
+  <%= label_tag 'code', @presenter.nickname_label, class: 'block bold', for: 'nickname' %>
+  <%= text_field_tag(
+        :name,
+        '',
+        required: true,
+        aria: { invalid: false },
+        id: 'nickname',
+        class: 'block col-12 field monospace',
+        size: 16,
+        maxlength: 20,
+      ) %>
+  <div class='border border-primary-light radius-lg padding-x-2 padding-y-1 margin-top-4'>
+    <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
+    <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'margin-y-2 margin-left-2 margin-right-1' %>
+    <%= label_tag(
+          'remember_device',
+          t('forms.messages.remember_device'),
+          class: 'text-primary mt-1p',
+        ) %>
+  </div>
+  <%= submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'hidden' %>
+<% end %>
+<br>
+<%= button_tag(
+      @presenter.button_text,
+      class: 'usa-button usa-button--big usa-button--wide',
+      id: 'continue-button',
+    ) %>
+
 
 <div class='spinner hidden' id='spinner'>
   <br>


### PR DESCRIPTION
**Why**: Since `div` carries no semantics, and these elements have no other attributes or classes, the only purpose would have been to create a [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context), but this is not necessary for the changed files due their existing placement and/or surrounding content.

Going to be easiest to review with ignoring whitespace: [`?w=1`](https://github.com/18F/identity-idp/pull/5813/files?w=1)