### PR TITLE
Remove redundant simple_form default class assignment

### DIFF
--- a/app/views/idv/doc_auth/_ssn_init.html.erb
+++ b/app/views/idv/doc_auth/_ssn_init.html.erb
@@ -30,7 +30,7 @@
       :doc_auth,
       url: url_for,
       method: :put,
-      html: { autocomplete: 'off', class: 'margin-top-4' },
+      html: { autocomplete: 'off' },
     ) do |f| %>
   <div class="tablet:grid-col-8">
     <%= render 'shared/ssn_field', f: f %>

--- a/app/views/idv/doc_auth/_ssn_update.html.erb
+++ b/app/views/idv/doc_auth/_ssn_update.html.erb
@@ -23,7 +23,7 @@
       :doc_auth,
       url: url_for,
       method: :put,
-      html: { autocomplete: 'off', class: 'margin-top-4' },
+      html: { autocomplete: 'off' },
     ) do |f| %>
   <div class="tablet:grid-col-8">
     <%= render 'shared/ssn_field', f: f %>

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -21,7 +21,7 @@
       :doc_auth,
       url: url_for,
       method: 'PUT',
-      html: { autocomplete: 'off', class: 'margin-top-4' },
+      html: { autocomplete: 'off' },
     ) do |f| %>
   <%= render PhoneInputComponent.new(
         form: f,

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -17,7 +17,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= validated_form_for(:idv_otp_verification, method: :put, class: 'margin-top-4') do %>
+<%= validated_form_for(:idv_otp_verification, method: :put) do %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
       <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -8,7 +8,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= validated_form_for(:login_otp, method: :post, class: 'margin-top-4') do %>
+<%= validated_form_for(:login_otp, method: :post) do %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>


### PR DESCRIPTION
**Why**: Because the class would already be applied, and in some cases we aren't applying the option correctly, since it must be passed as part of the `html` keyword option of `simple_form_for`.

See: https://github.com/18F/identity-idp/blob/3945fb03030d5c3569d824e6bd7498e5c796fc7a/config/initializers/simple_form.rb#L8