### PR TITLE
Simplify account page personal key logic

### DIFF
--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -1,0 +1,45 @@
+module Accounts
+  # Lets users generate a new personal key
+  class PersonalKeysController < ApplicationController
+    include PersonalKeyConcern
+
+    before_action :confirm_two_factor_authenticated
+
+    def create
+      user_session[:personal_key] = create_new_code
+      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      create_user_event(:new_personal_key)
+      result = send_new_personal_key_notifications
+      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS, result.to_h)
+      redirect_to manage_personal_key_url
+    end
+
+    # @return [FormResponse]
+    def send_new_personal_key_notifications
+      emails = current_user.confirmed_email_addresses.map do |email_address|
+        UserMailer.personal_key_regenerated(current_user, email_address.email).deliver_now_or_later
+      end
+
+      telephony_responses = MfaContext.new(current_user).
+                            phone_configurations.map do |phone_configuration|
+        phone = phone_configuration.phone
+        Telephony.send_personal_key_regeneration_notice(
+          to: phone,
+          country_code: Phonelib.parse(phone).country,
+        )
+      end
+
+      form_response(emails: emails, telephony_responses: telephony_responses)
+    end
+
+    def form_response(emails:, telephony_responses:)
+      FormResponse.new(
+        success: true,
+        extra: {
+          emails: emails.count,
+          sms_message_ids: telephony_responses.map { |resp| resp.to_h[:message_id] },
+        },
+      )
+    end
+  end
+end

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -1,5 +1,5 @@
 module Users
-  # Handles updating a user's personal key if it used for 2FA
+  # Handles updating a user's personal key if it used for 2FA (legacy behavior)
   class PersonalKeysController < ApplicationController
     include PersonalKeyConcern
     include SecureHeadersConcern

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -1,4 +1,5 @@
 module Users
+  # Handles updating a user's personal key if it used for 2FA
   class PersonalKeysController < ApplicationController
     include PersonalKeyConcern
     include SecureHeadersConcern
@@ -23,15 +24,6 @@ module Users
       redirect_to next_step
     end
 
-    def create
-      user_session[:personal_key] = create_new_code
-      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE)
-      create_user_event(:new_personal_key)
-      result = send_new_personal_key_notifications
-      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS, result.to_h)
-      redirect_to manage_personal_key_url
-    end
-
     private
 
     def next_step
@@ -46,34 +38,6 @@ module Users
 
     def user_has_not_visited_any_sp_yet?
       current_user.identities.pluck(:last_authenticated_at).compact.empty?
-    end
-
-    # @return [FormResponse]
-    def send_new_personal_key_notifications
-      emails = current_user.confirmed_email_addresses.map do |email_address|
-        UserMailer.personal_key_regenerated(current_user, email_address.email).deliver_now_or_later
-      end
-
-      telephony_responses = MfaContext.new(current_user).
-                            phone_configurations.map do |phone_configuration|
-        phone = phone_configuration.phone
-        Telephony.send_personal_key_regeneration_notice(
-          to: phone,
-          country_code: Phonelib.parse(phone).country,
-        )
-      end
-
-      form_response(emails: emails, telephony_responses: telephony_responses)
-    end
-
-    def form_response(emails:, telephony_responses:)
-      FormResponse.new(
-        success: true,
-        extra: {
-          emails: emails.count,
-          sms_message_ids: telephony_responses.map { |resp| resp.to_h[:message_id] },
-        },
-      )
     end
   end
 end

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -26,12 +26,8 @@ class AccountShow
   end
 
   def show_manage_personal_key_partial?
-    if TwoFactorAuthentication::PersonalKeyPolicy.new(decorated_user.user).visible? &&
-       decorated_user.password_reset_profile.blank?
-      true
-    else
-      false
-    end
+    TwoFactorAuthentication::PersonalKeyPolicy.new(decorated_user.user).visible? &&
+      decorated_user.password_reset_profile.blank?
   end
 
   def show_service_provider_continue_partial?
@@ -43,7 +39,7 @@ class AccountShow
   end
 
   def showing_any_partials?
-    show_service_provider_continue_partial? || show_manage_personal_key_partial? ||
+    show_service_provider_continue_partial? ||
       show_pii_partial? || show_password_reset_partial? || show_personal_key_partial? ||
       show_gpo_partial?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,9 +205,11 @@ Rails.application.routes.draw do
     get '/manage/phone/:id' => 'users/edit_phone#edit', as: :manage_phone
     match '/manage/phone/:id' => 'users/edit_phone#update', via: %i[patch put]
     delete '/manage/phone/:id' => 'users/edit_phone#destroy'
+
     get '/manage/personal_key' => 'users/personal_keys#show', as: :manage_personal_key
-    post '/account/personal_key' => 'users/personal_keys#create', as: :create_new_personal_key
     post '/manage/personal_key' => 'users/personal_keys#update'
+
+    post '/account/personal_key' => 'accounts/personal_keys#create', as: :create_new_personal_key
 
     get '/otp/send' => 'users/two_factor_authentication#send_code'
     get '/two_factor_options' => 'users/two_factor_authentication_setup#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,7 +205,6 @@ Rails.application.routes.draw do
     get '/manage/phone/:id' => 'users/edit_phone#edit', as: :manage_phone
     match '/manage/phone/:id' => 'users/edit_phone#update', via: %i[patch put]
     delete '/manage/phone/:id' => 'users/edit_phone#destroy'
-
     get '/manage/personal_key' => 'users/personal_keys#show', as: :manage_personal_key
     post '/manage/personal_key' => 'users/personal_keys#update'
 

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Accounts::PersonalKeysController do
+  describe '#create' do
+    it 'generates a new personal key, tracks an analytics event, and redirects' do
+      stub_sign_in(create(:user, :with_phone))
+      stub_analytics
+
+      generator = instance_double(PersonalKeyGenerator)
+      allow(PersonalKeyGenerator).to receive(:new).
+        with(subject.current_user).and_return(generator)
+
+      expect(generator).to receive(:create)
+      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      expect(@analytics).to receive(:track_event).with(
+        Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS,
+        hash_including(emails: 1, sms_message_ids: ['fake-message-id']),
+      )
+
+      post :create
+
+      expect(response).to redirect_to manage_personal_key_path
+    end
+
+    it 'tracks CSRF errors' do
+      stub_sign_in
+      stub_analytics
+      analytics_hash = {
+        controller: 'accounts/personal_keys#create',
+        user_signed_in: true,
+      }
+      allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::INVALID_AUTHENTICITY_TOKEN, analytics_hash)
+
+      post :create
+
+      expect(response).to redirect_to new_user_session_url
+      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
+    end
+  end
+end

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Users::PersonalKeysController do
+RSpec.describe Users::PersonalKeysController do
   describe '#show' do
     context 'when user signed in but user_session[:personal_key] is not present' do
       it 'redirects to account_url' do
@@ -119,46 +119,6 @@ describe Users::PersonalKeysController do
         with(Analytics::INVALID_AUTHENTICITY_TOKEN, analytics_hash)
 
       post :update
-
-      expect(response).to redirect_to new_user_session_url
-      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
-    end
-  end
-
-  describe '#create' do
-    it 'generates a new personal key, tracks an analytics event, and redirects' do
-      stub_sign_in(create(:user, :with_phone))
-      stub_analytics
-
-      generator = instance_double(PersonalKeyGenerator)
-      allow(PersonalKeyGenerator).to receive(:new).
-        with(subject.current_user).and_return(generator)
-
-      expect(generator).to receive(:create)
-      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_CREATE)
-      expect(@analytics).to receive(:track_event).with(
-        Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS,
-        hash_including(emails: 1, sms_message_ids: ['fake-message-id']),
-      )
-
-      post :create
-
-      expect(response).to redirect_to manage_personal_key_path
-    end
-
-    it 'tracks CSRF errors' do
-      stub_sign_in
-      stub_analytics
-      analytics_hash = {
-        controller: 'users/personal_keys#create',
-        user_signed_in: true,
-      }
-      allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
-
-      expect(@analytics).to receive(:track_event).
-        with(Analytics::INVALID_AUTHENTICITY_TOKEN, analytics_hash)
-
-      post :create
 
       expect(response).to redirect_to new_user_session_url
       expect(flash[:error]).to eq t('errors.invalid_authenticity_token')


### PR DESCRIPTION
I'm about to do some bigger cleanup to the personal key sections of the account page, and I noticed some things I could clean up and break into a smaller PR

- Simplifying the `AccountShow` object
- Splitting `Users::PersonalKeysController` into two separate controllers
   - One is used inline with the authentication flow to generate a new personal key when the old one is used (legacy flow)
   - The other is more in the direction of the feature work we're doing, to let users regenerate their personal keys when they choose to (LG-5664 work)