### PR TITLE
Correctly set RAILS_ENV for Make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,11 @@ brakeman: ## Runs brakeman
 public/packs/manifest.json: yarn.lock $(shell find app/javascript -type f) ## Builds JavaScript assets
 	yarn build
 
+test: export RAILS_ENV := test
 test: $(CONFIG) public/packs/manifest.json ## Runs RSpec and yarn tests
-	RAILS_ENV=test bundle exec rake parallel:spec && yarn test
+	bundle exec rake parallel:spec && yarn test
 
+fast_test: export RAILS_ENV := test
 fast_test: public/packs/manifest.json ## Abbreviated test run, runs RSpec tests without accessibility specs
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 


### PR DESCRIPTION
**Why**: Since the Webpack configuration has special considerations† for test environment (specifically, checking absence of i18n keys), ensure that the `yarn build` would be run with the correct environment.

---

†:

https://github.com/18F/identity-idp/blob/33e3781d4306869c355048b19bc0bc97731c3677/webpack.config.js#L70-L76