### PR TITLE
create rake task to look up UUID by email address

### DIFF
--- a/lib/tasks/users_lookup.rake
+++ b/lib/tasks/users_lookup.rake
@@ -1,0 +1,13 @@
+namespace :users do
+  desc 'Look up a user by email address'
+  task lookup_by_email: :environment do |_task, args|
+    print 'Enter the email address to look up: '
+    email = gets.strip
+    user = User.find_with_email(email)
+    if user.present?
+      puts "uuid: #{user.uuid}"
+    else
+      puts 'No user found'
+    end
+  end
+end


### PR DESCRIPTION
Does what it says on the tin! Addresses https://github.com/18F/identity-devops/issues/4162

Tested in my sandbox `idp`:

```
root@idp-i-018374.bleachbyte:~# sudo -H -u websrv env "app=idp" sh -euxc "cd '/srv/idp/current'; bundle exec rails users:lookup_by_email"
+ cd /srv/idp/current
+ bundle exec rails users:lookup_by_email
Enter the email address to look up: jonathan.pirro@gsa.gov
uuid: <REDACTED>

root@idp-i-018374.bleachbyte:~# sudo -H -u websrv env "app=idp" sh -euxc "cd '/srv/idp/current'; bundle exec rails users:lookup_by_email"
+ cd /srv/idp/current
+ bundle exec rails users:lookup_by_email
Enter the email address to look up: john.wong@example.com
No user found
```