### PR TITLE
Add new account management flow to reset personal key (LG-5664)

### DIFF
--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -15,6 +15,8 @@ module Accounts
       create_user_event(:new_personal_key)
       result = send_new_personal_key_notifications
       analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS, result.to_h)
+
+      flash[:info] = t('account.personal_key.old_key_will_not_work')
       redirect_to manage_personal_key_url
     end
 

--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -1,9 +1,13 @@
 module Accounts
   # Lets users generate a new personal key
-  class PersonalKeysController < ApplicationController
+  class PersonalKeysController < ReauthnRequiredController
     include PersonalKeyConcern
 
     before_action :confirm_two_factor_authenticated
+
+    def new
+      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_VISIT)
+    end
 
     def create
       user_session[:personal_key] = create_new_code

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -15,7 +15,7 @@ class ReauthnRequiredController < ApplicationController
     return false if user_session.blank?
     authn_at = user_session[:authn_at]
     return false if authn_at.blank?
-    authn_at > Time.zone.now - IdentityConfig.store.reauthn_window
+    authn_at > Time.zone.now - IdentityConfig.store.reauthn_window.seconds
   end
 
   def prompt_for_current_password
@@ -38,10 +38,12 @@ class ReauthnRequiredController < ApplicationController
 
   def factor_from_controller_name
     {
+      # see LG-5701, translate these
       'emails' => 'email',
       'passwords' => 'password',
       'phones' => 'phone',
       'delete' => 'delete',
+      'personal_keys' => 'personal key',
     }[controller_name]
   end
 

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -15,7 +15,7 @@ class ReauthnRequiredController < ApplicationController
     return false if user_session.blank?
     authn_at = user_session[:authn_at]
     return false if authn_at.blank?
-    authn_at > Time.zone.now - IdentityConfig.store.reauthn_window.seconds
+    authn_at > Time.zone.now - IdentityConfig.store.reauthn_window
   end
 
   def prompt_for_current_password

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -32,6 +32,7 @@ module Users
       elsif session[:sp] && user_has_not_visited_any_sp_yet?
         sign_up_completed_url
       else
+        flash[:success] = t('account.personal_key.reset_success')
         after_sign_in_path_for(current_user)
       end
     end

--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -42,6 +42,7 @@ module UserAccessKeyOverrides
       password: new_personal_key,
       user_uuid: uuid || generate_uuid,
     )
+    self.encrypted_recovery_code_digest_generated_at = Time.zone.now
   end
 
   # This is a callback initiated by Devise after successfully authenticating.

--- a/app/policies/two_factor_authentication/personal_key_policy.rb
+++ b/app/policies/two_factor_authentication/personal_key_policy.rb
@@ -14,10 +14,6 @@ module TwoFactorAuthentication
       configured? && user.profiles.none?
     end
 
-    def visible?
-      enabled?
-    end
-
     private
 
     attr_reader :user

--- a/app/policies/two_factor_authentication/personal_key_policy.rb
+++ b/app/policies/two_factor_authentication/personal_key_policy.rb
@@ -1,4 +1,6 @@
 module TwoFactorAuthentication
+  # Checks if a user has a personal key as a 2FA method
+  # (legacy 2FA, independent of having one for a profile)
   class PersonalKeyPolicy
     def initialize(user)
       @user = user

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -225,6 +225,7 @@ class Analytics
   PHONE_DELETION = 'Phone Number Deletion: Submitted'.freeze
   PIV_CAC_LOGIN = 'PIV/CAC Login'.freeze
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
+  PROFILE_PERSONAL_KEY_VISIT = 'Profile: Visited new personal key'.freeze
   PROFILE_PERSONAL_KEY_CREATE = 'Profile: Created new personal key'.freeze
   PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'.freeze
   PROOFING_ADDRESS_TIMEOUT = 'Proofing Address Timeout'.freeze

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -26,7 +26,7 @@ class AccountShow
   end
 
   def show_manage_personal_key_partial?
-    TwoFactorAuthentication::PersonalKeyPolicy.new(decorated_user.user).visible? &&
+    decorated_user.user.encrypted_recovery_code_digest.present? &&
       decorated_user.password_reset_profile.blank?
   end
 
@@ -46,6 +46,11 @@ class AccountShow
 
   def backup_codes_generated_at
     decorated_user.user.backup_code_configurations.order(created_at: :asc).first&.created_at
+  end
+
+  def personal_key_generated_at
+    decorated_user.user.encrypted_recovery_code_digest_generated_at ||
+      decorated_user.user.active_profile.verified_at
   end
 
   def header_personalization

--- a/app/view_models/navigation.rb
+++ b/app/view_models/navigation.rb
@@ -3,6 +3,8 @@ class Navigation
 
   NavItem = Struct.new(:title, :href, :children)
 
+  attr_reader :user
+
   def initialize(user:, url_options:)
     @user = user
     @url_options = url_options
@@ -15,7 +17,10 @@ class Navigation
           NavItem.new(I18n.t('account.navigation.add_email'), add_email_path),
           NavItem.new(I18n.t('account.navigation.edit_password'), manage_password_path),
           NavItem.new(I18n.t('account.navigation.delete_account'), account_delete_path),
-        ]
+          user.encrypted_recovery_code_digest.present? ? NavItem.new(
+            I18n.t('account.navigation.reset_personal_key'), create_new_personal_key_path
+          ) : nil,
+        ].compact
       ),
       NavItem.new(
         I18n.t('account.navigation.two_factor_authentication'),
@@ -58,7 +63,7 @@ class Navigation
   end
 
   def backup_codes_path
-    if TwoFactorAuthentication::BackupCodePolicy.new(@user).configured?
+    if TwoFactorAuthentication::BackupCodePolicy.new(user).configured?
       backup_code_regenerate_path
     else
       backup_code_create_path

--- a/app/views/accounts/_manage_personal_key.html.erb
+++ b/app/views/accounts/_manage_personal_key.html.erb
@@ -3,6 +3,9 @@
     <%= t('account.items.personal_key') %>
   </h2>
 </div>
+<p>
+  <%= t('account.personal_key.reset_instructions') %>
+</p>
 <div class="grid-row padding-1 border border-primary-light">
   <div class="grid-col-7">
     ************
@@ -11,3 +14,11 @@
     <%= render 'accounts/actions/manage_personal_key' %>
   </div>
 </div>
+<% if @view_model.personal_key_generated_at %>
+  <p class="margin-top-1 margin-bottom-0 font-body-2xs">
+    <em>
+      <%= t('account.personal_key.last_generated',
+            timestamp: I18n.l(@view_model.personal_key_generated_at, format: :event_date)) %>
+    </em>
+  </p>
+<% end %>

--- a/app/views/accounts/_manage_personal_key.html.erb
+++ b/app/views/accounts/_manage_personal_key.html.erb
@@ -17,8 +17,10 @@
 <% if @view_model.personal_key_generated_at %>
   <p class="margin-top-1 margin-bottom-0 font-body-2xs">
     <em>
-      <%= t('account.personal_key.last_generated',
-            timestamp: I18n.l(@view_model.personal_key_generated_at, format: :event_date)) %>
+      <%= t(
+            'account.personal_key.last_generated',
+            timestamp: I18n.l(@view_model.personal_key_generated_at, format: :event_date),
+          ) %>
     </em>
   </p>
 <% end %>

--- a/app/views/accounts/actions/_manage_personal_key.html.erb
+++ b/app/views/accounts/actions/_manage_personal_key.html.erb
@@ -1,9 +1,4 @@
-<%= button_to(
-      create_new_personal_key_url,
-      method: :post,
-      class: 'usa-button usa-button--unstyled',
-      form_class: 'inline-block padding-left-1',
-    ) do %>
+<%= link_to(create_new_personal_key_url) do %>
   <span class='usa-sr-only'>
     <%= t('account.items.personal_key') %>
   </span>

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -1,6 +1,6 @@
 <% title(t('account.personal_key.get_new')) %>
 
-<h1><%= t('account.personal_key.get_new') %></h1>
+<h1 class="margin-top-0"><%= t('account.personal_key.get_new') %></h1>
 
 <p class="margin-top-4">
   <%= t('account.personal_key.get_new_description') %>

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="margin-top-0"><%= t('account.personal_key.get_new') %></h1>
 
-<p class="margin-top-4">
+<p>
   <%= t('account.personal_key.get_new_description') %>
 </p>
 

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -1,0 +1,21 @@
+<% title(t('account.personal_key.get_new')) %>
+
+<h1><%= t('account.personal_key.get_new') %></h1>
+
+<p class="margin-top-4">
+  <%= t('account.personal_key.get_new_description') %>
+</p>
+
+<%= button_to(
+      create_new_personal_key_path,
+      method: 'post',
+      class: 'usa-button usa-button--wide usa-button--big margin-top-4') do %>
+  <%= t('forms.buttons.continue') %>
+<% end %>
+
+
+<div class="margin-top-4 border-top border-primary-light">
+  <div class="margin-top-1">
+    <%= link_to(t('links.cancel'), account_path) %>
+  </div>
+</div>

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -1,4 +1,4 @@
-<% title(t('account.personal_key.get_new')) %>
+<% title t('account.personal_key.get_new') %>
 
 <h1 class="margin-top-0"><%= t('account.personal_key.get_new') %></h1>
 
@@ -12,6 +12,5 @@
       class: 'usa-button usa-button--wide usa-button--big margin-top-4') do %>
   <%= t('forms.buttons.continue') %>
 <% end %>
-
 
 <%= render 'shared/cancel', link: account_path %>

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -9,7 +9,8 @@
 <%= button_to(
       create_new_personal_key_path,
       method: 'post',
-      class: 'usa-button usa-button--wide usa-button--big margin-top-4') do %>
+      class: 'usa-button usa-button--wide usa-button--big margin-top-4',
+    ) do %>
   <%= t('forms.buttons.continue') %>
 <% end %>
 

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -14,8 +14,4 @@
 <% end %>
 
 
-<div class="margin-top-4 border-top border-primary-light">
-  <div class="margin-top-1">
-    <%= link_to(t('links.cancel'), account_path) %>
-  </div>
-</div>
+<%= render 'shared/cancel', link: account_path %>

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -9,7 +9,8 @@
 <%= button_to(
       create_new_personal_key_path,
       method: 'post',
-      class: 'usa-button usa-button--wide usa-button--big margin-top-4',
+      class: 'usa-button usa-button--wide usa-button--big',
+      form_class: 'margin-y-5',
     ) do %>
   <%= t('forms.buttons.continue') %>
 <% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -56,6 +56,12 @@
   </div>
 </div>
 
+<% if @view_model.show_manage_personal_key_partial? %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/manage_personal_key' %>
+  </div>
+<% end %>
+
 <div class="margin-bottom-4 card profile-info-box">
   <% if TwoFactorAuthentication::PhonePolicy.new(current_user).visible? %>
     <%= render 'phone' %>

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -4,6 +4,7 @@
   <%= t('headings.passwords.confirm') %>
 </h1>
 <p class='mt-tiny margin-bottom-0'>
+  <%# for follow up: translate factor_to_change (LG-5701) %>
   <%= user_session[:no_factor_message] ||
         t('help_text.change_factor', factor: user_session[:factor_to_change]) %>
 </p>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -97,16 +97,19 @@ en:
       history: History
       learn_more: Learn more about %{app_name}
       menu: Menu
-      two_factor_authentication: Your authentication methods
       reset_personal_key: Reset personal key
+      two_factor_authentication: Your authentication methods
       your_account: Your Account
     personal_key:
       get_new: Reset personal key
       get_new_description: When you receive a new personal key, your old personal key
         will not work anymore.
       last_generated: 'Last generated on %{timestamp}'
+      old_key_will_not_work: Please print, copy, or download the new personal key
+        below. Your old personal key will not work if you forget your password.
       reset_instructions: Reset your personal key if you don’t have it. You’ll need
         this personal key if you forget your password.
+      reset_success: Your personal key has been reset
     re_verify:
       banner: We’ve hidden your profile information to protect your privacy.
       footer: Authenticate to view your information.

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -70,7 +70,7 @@ en:
       personal_key: Personal key
     links:
       delete_account: Delete
-      regenerate_personal_key: Get a new key
+      regenerate_personal_key: Reset
     login:
       piv_cac: Sign in with your government employee ID
       piv_cac_info:
@@ -98,7 +98,15 @@ en:
       learn_more: Learn more about %{app_name}
       menu: Menu
       two_factor_authentication: Your authentication methods
+      reset_personal_key: Reset personal key
       your_account: Your Account
+    personal_key:
+      get_new: Reset personal key
+      get_new_description: When you receive a new personal key, your old personal key
+        will not work anymore.
+      last_generated: 'Last generated on %{timestamp}'
+      reset_instructions: Reset your personal key if you don’t have it. You’ll need
+        this personal key if you forget your password.
     re_verify:
       banner: We’ve hidden your profile information to protect your privacy.
       footer: Authenticate to view your information.

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -101,7 +101,7 @@ en:
       two_factor_authentication: Your authentication methods
       your_account: Your Account
     personal_key:
-      get_new: Reset personal key
+      get_new: Get a new personal key
       get_new_description: When you receive a new personal key, your old personal key
         will not work anymore.
       last_generated: 'Last generated on %{timestamp}'

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -102,7 +102,7 @@ es:
       two_factor_authentication: Tus métodos de autenticación
       your_account: Su cuenta
     personal_key:
-      get_new: Restablecer la clave personal
+      get_new: TODO
       get_new_description: TODO
       last_generated: 'Generada por última vez en %{timestamp}'
       old_key_will_not_work: Por favor, imprima, copie o descargue la nueva clave

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -71,7 +71,7 @@ es:
       personal_key: Clave personal
     links:
       delete_account: Eliminar
-      regenerate_personal_key: Obtenga una clave nueva.
+      regenerate_personal_key: Restablecer
     login:
       piv_cac: Inicie sesión con su identificación de empleado del gobierno
       piv_cac_info:
@@ -99,7 +99,14 @@ es:
       learn_more: Obtenga más información sobre %{app_name}
       menu: Menú
       two_factor_authentication: Tus métodos de autenticación
+      reset_personal_key: Restablecer la clave personal
       your_account: Su cuenta
+    personal_key:
+      get_new: Restablecer la clave personal
+      get_new_description: TODO
+      last_generated: 'Generada por última vez en %{timestamp}'
+      reset_instructions: Restablezca su clave personal si no la tiene. Necesitará
+        esta clave personal si olvida su contraseña.
     re_verify:
       banner: Hemos ocultado la información de su perfil para proteger su privacidad.
       footer: Autentíquese nuevamente para ver la información de su perfil

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -98,15 +98,19 @@ es:
       history: Historia
       learn_more: Obtenga más información sobre %{app_name}
       menu: Menú
-      two_factor_authentication: Tus métodos de autenticación
       reset_personal_key: Restablecer la clave personal
+      two_factor_authentication: Tus métodos de autenticación
       your_account: Su cuenta
     personal_key:
       get_new: Restablecer la clave personal
       get_new_description: TODO
       last_generated: 'Generada por última vez en %{timestamp}'
+      old_key_will_not_work: Por favor, imprima, copie o descargue la nueva clave
+        personal que aparece a continuación. Su antigua clave personal no
+        funcionará si olvida su contraseña.
       reset_instructions: Restablezca su clave personal si no la tiene. Necesitará
         esta clave personal si olvida su contraseña.
+      reset_success: Su clave personal ha sido restablecida
     re_verify:
       banner: Hemos ocultado la información de su perfil para proteger su privacidad.
       footer: Autentíquese nuevamente para ver la información de su perfil

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -102,8 +102,8 @@ es:
       two_factor_authentication: Tus métodos de autenticación
       your_account: Su cuenta
     personal_key:
-      get_new: TODO
-      get_new_description: TODO
+      get_new: Obtenga una nueva clave personal
+      get_new_description: Su antigua clave personal dejará de funcionar en cuanto reciba una nueva.
       last_generated: 'Generada por última vez en %{timestamp}'
       old_key_will_not_work: Por favor, imprima, copie o descargue la nueva clave
         personal que aparece a continuación. Su antigua clave personal no

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -104,16 +104,20 @@ fr:
       history: L’histoire
       learn_more: En savoir plus sur %{app_name}
       menu: Menu
-      two_factor_authentication: Vos méthodes d’authentification
       reset_personal_key: Réinitialisation de la clé personnelle
+      two_factor_authentication: Vos méthodes d’authentification
       your_account: Votre compte
     personal_key:
       get_new: Réinitialisation de la clé personnelle
       get_new_description: TODO
       last_generated: 'Dernière génération le %{timestamp}'
+      old_key_will_not_work: Veuillez imprimer, copier ou télécharger la nouvelle clé
+        personnelle ci-dessous. Votre ancienne clé personnelle ne fonctionnera
+        pas si vous oubliez votre mot de passe.
       reset_instructions: Réinitialisez votre clé personnelle si vous ne l’avez pas.
         Vous aurez besoin de cette clé personnelle si vous oubliez votre mot de
         passe.
+      reset_success: Votre code personnel a été réinitialisé
     re_verify:
       banner: Nous avons masqué les informations de votre profil pour protéger votre
         vie privée.

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -76,7 +76,7 @@ fr:
       personal_key: Clé personnelle
     links:
       delete_account: Effacer
-      regenerate_personal_key: Obtenez une nouvelle clé
+      regenerate_personal_key: Réinitialiser
     login:
       piv_cac: Connectez-vous avec votre ID d’employé du gouvernement
       piv_cac_info:
@@ -105,7 +105,15 @@ fr:
       learn_more: En savoir plus sur %{app_name}
       menu: Menu
       two_factor_authentication: Vos méthodes d’authentification
+      reset_personal_key: Réinitialisation de la clé personnelle
       your_account: Votre compte
+    personal_key:
+      get_new: Réinitialisation de la clé personnelle
+      get_new_description: TODO
+      last_generated: 'Dernière génération le %{timestamp}'
+      reset_instructions: Réinitialisez votre clé personnelle si vous ne l’avez pas.
+        Vous aurez besoin de cette clé personnelle si vous oubliez votre mot de
+        passe.
     re_verify:
       banner: Nous avons masqué les informations de votre profil pour protéger votre
         vie privée.

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -108,8 +108,9 @@ fr:
       two_factor_authentication: Vos méthodes d’authentification
       your_account: Votre compte
     personal_key:
-      get_new: TODO
-      get_new_description: TODO
+      get_new: Obtenir une nouvelle clé personnelle
+      get_new_description: Lorsque vous recevez une nouvelle clé personnelle, votre
+        ancienne clé personnelle ne fonctionnera plus.
       last_generated: 'Dernière génération le %{timestamp}'
       old_key_will_not_work: Veuillez imprimer, copier ou télécharger la nouvelle clé
         personnelle ci-dessous. Votre ancienne clé personnelle ne fonctionnera

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -108,7 +108,7 @@ fr:
       two_factor_authentication: Vos méthodes d’authentification
       your_account: Votre compte
     personal_key:
-      get_new: Réinitialisation de la clé personnelle
+      get_new: TODO
       get_new_description: TODO
       last_generated: 'Dernière génération le %{timestamp}'
       old_key_will_not_work: Veuillez imprimer, copier ou télécharger la nouvelle clé

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -149,7 +149,7 @@ es:
       address: Actualice su dirección postal
       back: Parte Trasera
       capture_complete: Hemos verificado su identificación expedida por el estado
-      capture_troubleshooting_tips: ¿Tiene problemas para agregar su identificación emitida por el estado?
+      capture_troubleshooting_tips: '¿Tiene problemas para agregar su identificación emitida por el estado?'
       document_capture: Añada su documento de identidad expedido por el estado
       document_capture_back: Parte trasera de su documento de identidad
       document_capture_front: Parte delantera de su documento de identidad

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -2,7 +2,7 @@
 en:
   help_text:
     change_factor: Before you’re able to edit your %{factor}, you will need to
-      confirm your password and receive a security code on your phone.
+      confirm your password and use your second factor.
     no_factor:
       delete_account: To delete your account, please confirm your password and security code.
     requested_attributes:

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -1,8 +1,8 @@
 ---
 en:
   help_text:
-    change_factor: Before you’re able to edit your %{factor}, you will need to
-      confirm your password and use your second factor.
+    change_factor: Before you’re able to reset your %{factor}, you will need to
+      confirm your password and use your authentication method.
     no_factor:
       delete_account: To delete your account, please confirm your password and security code.
     requested_attributes:

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -1,8 +1,7 @@
 ---
 es:
   help_text:
-    change_factor: Antes de poder editar su %{factor}, deberá confirmar su
-      contraseña y recibir un código de seguridad en su teléfono.
+    change_factor: TODO
     no_factor:
       delete_account: Para eliminar su cuenta, confirme su contraseña y código de seguridad.
     requested_attributes:

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -1,7 +1,8 @@
 ---
 es:
   help_text:
-    change_factor: TODO
+    change_factor: Antes de que pueda restablecer su %{factor}, tendrá que confirmar
+      su contraseña y utilizar su método de autenticación.
     no_factor:
       delete_account: Para eliminar su cuenta, confirme su contraseña y código de seguridad.
     requested_attributes:

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -1,8 +1,7 @@
 ---
 fr:
   help_text:
-    change_factor: Avant de pouvoir modifier votre %{factor}, vous devrez confirmer
-      votre mot de passe et recevoir un code de sécurité sur votre téléphone.
+    change_factor: TODO
     no_factor:
       delete_account: Pour supprimer votre compte, veuillez confirmer votre mot de
         passe et votre code de sécurité.

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -1,7 +1,8 @@
 ---
 fr:
   help_text:
-    change_factor: TODO
+    change_factor: Avant de pouvoir réinitialiser votre %{factor}, vous devrez
+      confirmer votre mot de passe et utiliser votre méthode d’authentification.
     no_factor:
       delete_account: Pour supprimer votre compte, veuillez confirmer votre mot de
         passe et votre code de sécurité.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -165,7 +165,7 @@ es:
       headings:
         missing_required_items: '¿Le falta alguno de estos puntos?'
         need_assistance: '¿Necesita ayuda inmediata? Así es como puede obtener ayuda:'
-        still_having_trouble: ¿Sigue teniendo dificultades?
+        still_having_trouble: '¿Sigue teniendo dificultades?'
       options:
         change_phone_number: Utiliza un número de teléfono diferente
         contact_support: Póngase en contacto con el servicio de asistencia de %{app_name}

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -123,10 +123,10 @@ en:
     personal_key_regenerated:
       help_html: <p>Your %{app_name} account was just issued a new 16-character
         personal key. You’re getting this email to make sure it was
-        you.</p><p>If you just signed in and regenerated your personal key,
-        great! There’s nothing you need to do.</p><p>If you did not just
-        regenerate your personal key, or if you’re not sure, please immediately
-        take these steps to secure your account:<ol><li><strong><a
+        you.</p><p>If you just signed in and reset your personal key, great!
+        There’s nothing you need to do.</p><p>If you did not just reset your
+        personal key, or if you’re not sure, please immediately take these steps
+        to secure your account:<ol><li><strong><a
         href="%{reset_password_url}">Change your password</a>.</strong> Choose a
         password that you haven’t already used with this
         account.</li><li><strong><a href="%{account_url}">Sign in to your

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -130,10 +130,10 @@ es:
     personal_key_regenerated:
       help_html: <p>Tu cuenta de %{app_name} acaba de emitir una nueva clave personal
         de 16 caracteres. Estás recibiendo este correo electrónico para
-        verificar que eras tú. </p><p>Si acabas de iniciar sesión y has
-        regenerado tu clave personal, ¡fantástico! No es necesario que hagas
-        nada.</p><p>Si no acabas de regenerar tu clave personal, o si no estás
-        seguro, sigue estos pasos para proteger tu cuenta:<ol><li><strong><a
+        verificar que eras tú. </p><p>Si acaba de iniciar sesión y restablecer
+        su clave personal, ¡estupendo! No tiene que hacer nada.</p><p>Si no
+        acaba de restablecer su clave personal o no está seguro, siga de
+        inmediato estos pasos para proteger su cuenta:<ol><li><strong><a
         href="%{reset_password_url}">Cambia tu contraseña</a>.</strong> Elige
         una contraseña que aún no hayas utilizado con esta cuenta.
         </li><li><strong><a href="%{account_url}">Inicia sesión en tu cuenta de

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -132,23 +132,24 @@ fr:
     personal_key_regenerated:
       help_html: <p>Votre compte %{app_name} vient de recevoir une nouvelle clé
         personnelle de 16 caractères. Le but de cet e-mail est de s’assurer que
-        c’est bien vous qui en êtes à l’origine.</p><p> Si vous venez de vous
-        connecter et de régénérer votre clé personnelle, c’est parfait ! Vous
-        n’avez rien à faire.</p><p> Si vous ne venez pas de régénérer votre clé
-        personnelle, ou en cas de doute, effectuez immédiatement les actions
-        suivantes pour sécuriser votre compte :<ol><li><strong><a
-        href="%{reset_password_url}"> Modifiez votre mot de passe</a>.</strong>
-        Choisissez un mot de passe que vous n’avez pas encore utilisé avec ce
-        compte.</li><li><strong><a href="%{account_url}"> Connectez-vous à votre
-        compte %{app_name}</a></strong> et vérifiez bien que toutes les
-        informations sur la page de votre compte sont correctes, y compris les
-        méthodes que vous utilisez pour l’authentification à deux facteurs, dont
-        le numéro de téléphone, l’application d’authentification ou la clé de
-        sécurité.</li><li><strong>Sur votre <a href="%{account_url}">page de
-        compte %{app_name}</a>, demandez une nouvelle clé personnelle.</strong>
-        N’oubliez pas de ne jamais la partager, sauf si vous l’utilisez pour
-        vous connecter à un site de confiance qui utilise
-        %{app_name}.</li></ol></p><br>Merci,<br>L’équipe %{app_name}
+        c’est bien vous qui en êtes à l’origine.</p><p>Si vous venez de vous
+        connecter et de réinitialiser votre clé personnelle, c’est parfait! Vous
+        n’avez rien à faire.</p><p>Si vous ne venez pas de réinitialiser votre
+        clé personnelle, ou si vous n’êtes pas sûr, veuillez prendre
+        immédiatement les mesures suivantes pour sécuriser votre compte
+        :<ol><li><strong><a href="%{reset_password_url}"> Modifiez votre mot de
+        passe</a>.</strong> Choisissez un mot de passe que vous n’avez pas
+        encore utilisé avec ce compte.</li><li><strong><a href="%{account_url}">
+        Connectez-vous à votre compte %{app_name}</a></strong> et vérifiez bien
+        que toutes les informations sur la page de votre compte sont correctes,
+        y compris les méthodes que vous utilisez pour l’authentification à deux
+        facteurs, dont le numéro de téléphone, l’application d’authentification
+        ou la clé de sécurité.</li><li><strong>Sur votre <a
+        href="%{account_url}">page de compte %{app_name}</a>, demandez une
+        nouvelle clé personnelle.</strong> N’oubliez pas de ne jamais la
+        partager, sauf si vous l’utilisez pour vous connecter à un site de
+        confiance qui utilise %{app_name}.</li></ol></p><br>Merci,<br>L’équipe
+        %{app_name}
       intro: Nouvelle clé personnelle émise
       subject: Alerte de sécurité du compte
     personal_key_sign_in:

--- a/config/locales/vendor_outage/fr.yml
+++ b/config/locales/vendor_outage/fr.yml
@@ -42,4 +42,4 @@ fr:
           réessayer plus tard ou vérifier votre adresse par la poste.
     get_updates: Obtenir des mises à jour
     get_updates_on_status_page: Obtenez des mises à jour sur notre page de statut
-    working: 'Nous travaillons à la résolution d’une erreur'
+    working: Nous travaillons à la résolution d’une erreur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,8 @@ Rails.application.routes.draw do
     get '/manage/personal_key' => 'users/personal_keys#show', as: :manage_personal_key
     post '/manage/personal_key' => 'users/personal_keys#update'
 
-    post '/account/personal_key' => 'accounts/personal_keys#create', as: :create_new_personal_key
+    get '/account/personal_key' => 'accounts/personal_keys#new', as: :create_new_personal_key
+    post '/account/personal_key' => 'accounts/personal_keys#create'
 
     get '/otp/send' => 'users/two_factor_authentication#send_code'
     get '/two_factor_options' => 'users/two_factor_authentication_setup#index'

--- a/db/primary_migrate/20220114183203_add_encrypted_recovery_code_digest_generated_at_to_users.rb
+++ b/db/primary_migrate/20220114183203_add_encrypted_recovery_code_digest_generated_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddEncryptedRecoveryCodeDigestGeneratedAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :encrypted_recovery_code_digest_generated_at, :timestamp, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_174343) do
+ActiveRecord::Schema.define(version: 2022_01_14_183203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -607,6 +607,7 @@ ActiveRecord::Schema.define(version: 2022_01_05_174343) do
     t.datetime "remember_device_revoked_at"
     t.string "email_language", limit: 10
     t.datetime "accepted_terms_at"
+    t.datetime "encrypted_recovery_code_digest_generated_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uuid"], name: "index_users_on_uuid", unique: true

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -1,6 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Accounts::PersonalKeysController do
+  describe 'before_actions' do
+    it 'require recent reauthn' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_recently_authenticated,
+      )
+    end
+  end
+
+  describe '#new' do
+    it 'tracks an event for viewing profile personal key' do
+      stub_sign_in(create(:user, :with_phone))
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_VISIT)
+
+      get :new
+    end
+  end
+
   describe '#create' do
     it 'generates a new personal key, tracks an analytics event, and redirects' do
       stub_sign_in(create(:user, :with_phone))

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Accounts::PersonalKeysController do
       post :create
 
       expect(response).to redirect_to manage_personal_key_path
+      expect(flash[:info]).to eq(t('account.personal_key.old_key_will_not_work'))
     end
 
     it 'tracks CSRF errors' do

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Users::PersonalKeysController do
         patch :update
 
         expect(response).to redirect_to account_url
+        expect(flash[:success]).to eq(t('account.personal_key.reset_success'))
       end
     end
 
@@ -81,6 +82,7 @@ RSpec.describe Users::PersonalKeysController do
         patch :update
 
         expect(response).to redirect_to sign_up_completed_url
+        expect(flash[:success]).to be_nil
       end
 
       it 'redirects to the reactivate account url for ial 2' do
@@ -94,6 +96,7 @@ RSpec.describe Users::PersonalKeysController do
         patch :update
 
         expect(response).to redirect_to reactivate_account_url
+        expect(flash[:success]).to be_nil
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -74,7 +74,7 @@ describe Profile do
       expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
     end
 
-    it 'updates the personal get digest generation time' do
+    it 'updates the personal key digest generation time' do
       user.encrypted_recovery_code_digest_generated_at = nil
 
       encrypt_pii

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -74,6 +74,15 @@ describe Profile do
       expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
     end
 
+    it 'updates the personal get digest generation time' do
+      user.encrypted_recovery_code_digest_generated_at = nil
+
+      encrypt_pii
+
+      expect(user.reload.encrypted_recovery_code_digest_generated_at.to_i).
+        to be_within(1).of(Time.zone.now.to_i)
+    end
+
     context 'ssn fingerprinting' do
       it 'fingerprints the ssn' do
         expect { encrypt_pii }.

--- a/spec/view_models/navigation_spec.rb
+++ b/spec/view_models/navigation_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Navigation do
+  let(:user) { build(:user) }
+
+  subject(:navigation) { Navigation.new(user: user, url_options: {}) }
+
+  describe '#navigation_items' do
+    describe 'personal key' do
+      context 'for a user with a personal key' do
+        let(:user) { build(:user, personal_key: 'abcdef') }
+
+        it 'has a link to reset personal key' do
+          nav_item = navigation.navigation_items.first.children.last
+          expect(nav_item.title).to eq(I18n.t('account.navigation.reset_personal_key'))
+        end
+      end
+
+      context 'for a user that does not have a personal key' do
+        it 'does not link to reset personal key' do
+          has_reset_personal_key = navigation.navigation_items.first.children.any? do |item|
+            item.title == I18n.t('account.navigation.reset_personal_key')
+          end
+
+          expect(has_reset_personal_key).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -56,9 +56,10 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
       render
 
       expect(rendered).to have_content t('account.items.personal_key')
-      expect(rendered).
-        to have_button t('account.links.regenerate_personal_key')
-      expect(rendered).to have_xpath("//form[@action='#{create_new_personal_key_url}']")
+      expect(rendered).to have_link(
+        t('account.links.regenerate_personal_key'),
+        href: create_new_personal_key_url,
+      )
     end
   end
 


### PR DESCRIPTION
**Why**: Previously we only let users reset their personal keys
if they *did not* have a profile (because a previous iteration
of Login had personal keys as a backup 2FA method)

Also! the old flow didn't confirm that you want to replace your personal key, if you click the "reset" link it would just go for it, so we're adding a new page to hit confirm on.

~(this is in draft because some of the copy needs to be finalized)~ _this is ready to go!_

Screenshot tour

| notes | screenshot |
| --- | --- |
| new nav item | <img width="968" alt="Screen Shot 2022-01-14 at 4 31 12 PM" src="https://user-images.githubusercontent.com/458784/149601555-9bb313d4-3917-42a5-8ed3-c53a3ecaa511.png"> |
| new to account page, also updated on 2fa page | <img width="968" alt="Screen Shot 2022-01-14 at 4 31 33 PM" src="https://user-images.githubusercontent.com/458784/149601571-480693ef-5794-44f5-aa7f-053410d5c03a.png"> |
| new confirm screen (previously it used to just replace, no confirmation) | <img width="968" alt="Screen Shot 2022-01-14 at 4 32 12 PM" src="https://user-images.githubusercontent.com/458784/149601602-eb003e30-0030-4362-be25-349d69bbfe1e.png"> |
| screen that shows personal key | <img width="968" alt="Screen Shot 2022-01-14 at 4 32 41 PM" src="https://user-images.githubusercontent.com/458784/149601660-a15911d6-6a9c-43cb-ab0b-95bfea6ee9a0.png"> |


 