### PR TITLE
LG-4792: Use consistent Accordion spacing

### DIFF
--- a/app/components/accordion_component.html.erb
+++ b/app/components/accordion_component.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-accordion usa-accordion--bordered">
+<%= tag.div(**tag_options, class: css_class) do %>
   <div class="usa-accordion__heading">
     <button
       type="button"
@@ -14,4 +14,4 @@
       <%= content %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/components/accordion_component.rb
+++ b/app/components/accordion_component.rb
@@ -1,3 +1,16 @@
 class AccordionComponent < BaseComponent
   renders_one :header
+
+  attr_reader :bordered, :tag_options
+
+  def initialize(bordered: true, **tag_options)
+    @bordered = bordered
+    @tag_options = tag_options
+  end
+
+  def css_class
+    classes = ['usa-accordion', *tag_options[:class]]
+    classes << 'usa-accordion--bordered' if bordered
+    classes
+  end
 end

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -26,20 +26,16 @@
       current_user, url: idv_review_path,
                     html: { autocomplete: 'off', method: :put }
     ) do |f| %>
- 
-  <div class="margin-bottom-4">
-    <%= f.input :password, label: t('idv.form.password'), required: true,
-                           input_html: { aria: { invalid: false }, class: 'password-toggle' }, wrapper: false %>
-    <span class='usa-error-message margin-top-2 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-      <%= t('simple_form.required.text') %>
-    </span>
-  </div>
-  <div class="right-align margin-top-neg-2 margin-bottom-6">
+  <%= f.input :password, label: t('idv.form.password'), required: true,
+                         input_html: { aria: { invalid: false }, class: 'password-toggle' }, wrapper: false %>
+  <span class='usa-error-message margin-top-2 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
+    <%= t('simple_form.required.text') %>
+  </span>
+  <div class="right-align margin-top-2 margin-bottom-4">
     <%= t(
           'idv.forgot_password.link_html',
           link: link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1'),
         ) %>
-
   </div>
   <%= render AccordionComponent.new do |c| %>
     <% c.header { t('idv.messages.review.intro') } %>
@@ -50,7 +46,7 @@
   <%= f.button(
         :submit,
         t('forms.buttons.continue'),
-        class: 'usa-button--big usa-button--wide margin-top-4',
+        class: 'usa-button--big usa-button--wide margin-top-5',
       ) %>
 <% end %>
 

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,4 @@
-<%= render AccordionComponent.new do |c| %>
+<%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
   <%= simple_format(t('instructions.password.help_text')) %>
 <% end %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -20,7 +20,7 @@
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
-  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
+  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-bottom-5' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>

--- a/spec/components/accordion_component_spec.rb
+++ b/spec/components/accordion_component_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe AccordionComponent, type: :component do
+  let(:bordered) { nil }
+  let(:tag_options) { {} }
+  let(:options) { { bordered: bordered, **tag_options }.compact }
+
   subject(:rendered) do
-    render_inline(described_class.new) do |c|
+    render_inline(described_class.new(**options)) do |c|
       c.header { 'heading' }
       'content'
     end
   end
 
   it 'renders an accordion' do
+    expect(rendered).to have_css('.usa-accordion.usa-accordion--bordered')
     expect(rendered).to have_css('.usa-accordion__heading', text: 'heading')
     expect(rendered).to have_css('.usa-accordion__content', text: 'content')
   end
@@ -22,5 +27,29 @@ RSpec.describe AccordionComponent, type: :component do
     expect(rendered_id).to be_present
     expect(second_rendered_id).to be_present
     expect(rendered_id).to_not eq(second_rendered_id)
+  end
+
+  context 'borderless' do
+    let(:bordered) { false }
+
+    it 'renders without bordered modifier' do
+      expect(rendered).to have_css('.usa-accordion:not(.usa-accordion--bordered)')
+    end
+  end
+
+  context 'custom class' do
+    let(:tag_options) { { class: 'example-class' } }
+
+    it 'merges with base classes' do
+      expect(rendered).to have_css('.usa-accordion.usa-accordion--bordered.example-class')
+    end
+  end
+
+  context 'tag options' do
+    let(:tag_options) { { data: { foo: 'bar' } } }
+
+    it 'renders with tag options' do
+      expect(rendered).to have_css('.usa-accordion[data-foo="bar"]')
+    end
   end
 end


### PR DESCRIPTION
**Why**: As part of typographical refinement in LG-4792, accordions throughout the application should use a consistent vertical margin.

**Implementation Notes:**

- This has been split as its own pull request, since it includes improvements to the `Accordion` component to improve support for custom classes, along with support for the borderless variant.

**Screenshots:**

Screen|Before|After
---|---|---
Update Password|![password-before](https://user-images.githubusercontent.com/1779930/149972830-0d6840ef-66a1-44ea-b99c-5748f642bb5f.png)|![password-after](https://user-images.githubusercontent.com/1779930/149972889-53ecb33c-c1f8-429b-a6d0-7795e61fa0a5.png)
IAL2 Review|![review-before](https://user-images.githubusercontent.com/1779930/149971386-6fa951a7-e0ec-41f2-84bb-6e82b475bc5f.png)|![review-after](https://user-images.githubusercontent.com/1779930/149971509-947c7b9b-d6d5-424e-b08e-2fda7466c545.png)
