### PR TITLE
Fix Acuant sequence-break error cookie sync issue

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -283,7 +283,9 @@ function AcuantCapture(
   const { isMobile } = useContext(DeviceContext);
   const { t, formatHTML } = useI18n();
   const [attempt, incrementAttempt] = useCounter(1);
-  const [acuantFailureCookie, setAcuantFailureCookie] = useCookie('AcuantCameraHasFailed');
+  const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] = useCookie(
+    'AcuantCameraHasFailed',
+  );
   const { onFailedCaptureAttempt, onResetFailedCaptureAttempts } = useContext(
     FailedCaptureAttemptsContext,
   );
@@ -533,6 +535,8 @@ function AcuantCapture(
                   .split(' ')
                   .join(NBSP_UNICODE)}`,
               );
+
+              refreshAcuantFailureCookie();
             } else {
               setOwnErrorMessage(t('doc_auth.errors.camera.failed'));
             }

--- a/app/javascript/packages/document-capture/hooks/use-cookie.js
+++ b/app/javascript/packages/document-capture/hooks/use-cookie.js
@@ -14,7 +14,7 @@ const CookieSubscriberContext = createContext(/** @type {Map<string, Subscribers
  *
  * @param {string} name Cookie name.
  *
- * @return {[value: string|null, setValue: (nextValue: string?) => void]}
+ * @return {[value: string|null, setValue: (nextValue: string?) => void, refreshValue: () => void]}
  */
 function useCookie(name) {
   const getValue = () =>
@@ -43,16 +43,23 @@ function useCookie(name) {
   }, [name]);
 
   /**
+   * Refresh cookie value for all current subscribers.
+   */
+  function refreshValue() {
+    const subscribers = /** @type {Subscribers} */ (subscriptions.get(name));
+    subscribers.forEach((setSubscriberValue) => setSubscriberValue(getValue));
+  }
+
+  /**
    * @param {string?} nextValue Value to set, or null to delete the value.
    */
   function setValue(nextValue) {
     const cookieValue = nextValue === null ? '; Max-Age=0' : nextValue;
     document.cookie = `${name}=${cookieValue}`;
-    const subscribers = /** @type {Subscribers} */ (subscriptions.get(name));
-    subscribers.forEach((setSubscriberValue) => setSubscriberValue(getValue));
+    refreshValue();
   }
 
-  return [value, setValue];
+  return [value, setValue, refreshValue];
 }
 
 export default useCookie;

--- a/app/javascript/packages/document-capture/hooks/use-cookie.js
+++ b/app/javascript/packages/document-capture/hooks/use-cookie.js
@@ -46,8 +46,9 @@ function useCookie(name) {
    * Refresh cookie value for all current subscribers.
    */
   function refreshValue() {
+    const nextValue = getValue();
     const subscribers = /** @type {Subscribers} */ (subscriptions.get(name));
-    subscribers.forEach((setSubscriberValue) => setSubscriberValue(getValue));
+    subscribers.forEach((setSubscriberValue) => setSubscriberValue(nextValue));
   }
 
   /**

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -260,7 +260,13 @@ describe('document-capture/components/acuant-capture', () => {
       );
 
       initialize({
-        start: sinon.stub().callsArgWithAsync(1, 'iOS 15 sequence break', 'sequence-break-code'),
+        start: sinon.stub().callsFake((_callbacks, onError) => {
+          setTimeout(() => {
+            const code = 'sequence-break-code';
+            document.cookie = `AcuantCameraHasFailed=${code}`;
+            onError('iOS 15 sequence break', code);
+          }, 0);
+        }),
       });
 
       const button = getByLabelText('Image');
@@ -274,6 +280,12 @@ describe('document-capture/components/acuant-capture', () => {
         payload: { field: 'test', error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)' },
       });
       expect(document.activeElement).to.equal(button);
+
+      const defaultPrevented = !fireEvent.click(button);
+
+      window.AcuantCameraUI.start.resetHistory();
+      expect(defaultPrevented).to.be.false();
+      expect(window.AcuantCameraUI.start.called).to.be.false();
     });
 
     it('calls onCameraAccessDeclined if camera access is declined', async () => {

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -279,7 +279,7 @@ describe('document-capture/components/acuant-capture', () => {
         label: 'IdV: Image capture failed',
         payload: { field: 'test', error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)' },
       });
-      expect(document.activeElement).to.equal(button);
+      await waitFor(() => document.activeElement === button);
 
       const defaultPrevented = !fireEvent.click(button);
 

--- a/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-cookie-spec.jsx
@@ -69,4 +69,21 @@ describe('document-capture/hooks/use-cookie', () => {
     expect(value1).to.equal('bar');
     expect(value2).to.equal('bar');
   });
+
+  it('refreshes a cookie value', () => {
+    const render = sinon.stub().callsFake(() => useCookie('foo'));
+    const { result } = renderHook(render);
+
+    document.cookie = 'foo=bar';
+
+    const [, , refreshValue] = result.current;
+
+    render.resetHistory();
+    refreshValue();
+    expect(render).to.have.been.calledOnce();
+
+    const [value] = result.current;
+
+    expect(value).to.equal('bar');
+  });
 });


### PR DESCRIPTION
**Why**: To fix a bug where if the Acuant camera fails to start due to iOS 15 "sequence-break" error, subsequent attempts to capture would result in the captured image not being set correctly.

This fixes a regression introduced in #5778 where the cookie value tracked by AcuantCapture falls out of date after Acuant handles the error, since we never refresh the value after it is [set internally by Acuant's error handling](https://github.com/Acuant/JavascriptWebSDKV11/blob/9a5387576a33710188501ad6233f986b1b6bb1cb/SimpleHTMLApp/webSdk/dist/AcuantCamera.js#L616). Thus, the next time the user clicks  "Take Photo", the [cookie value logic](https://github.com/18F/identity-idp/blob/eceea0f4df59cf3bb934b561e1d141edf1276174/app/javascript/packages/document-capture/components/acuant-capture.jsx#L400) is out-of-date, and Acuant capture is started instead of the default manual capture handling.

To resolve this, we anticipate that Acuant would set the cookie in their error handling of sequence-break, and refresh the cookie value when we get a chance to handle the error in our own code.

**Steps to reproduce:**

1. Visit document capture step on iOS 15
2. Attempt to "Take Photo" until a sequence break error occurs (dialog closes and "an error on our end" message is displayed)
3. Click "Take Photo"
4. Take a photo using the native camera UI

Before: The photo value is never assigned to the field
After: The photo value is assigned to the field