### PR TITLE
Prevent simultaneous active Acuant instances

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-camera.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.jsx
@@ -182,7 +182,7 @@ function AcuantCamera({
   onCropStart = () => {},
   children,
 }) {
-  const { isReady } = useContext(AcuantContext);
+  const { isReady, setIsActive } = useContext(AcuantContext);
   const { t } = useI18n();
   const onCropped = useImmutableCallback(
     (response) => {
@@ -213,11 +213,13 @@ function AcuantCamera({
           },
         },
       );
+      setIsActive(true);
     }
 
     return () => {
       if (isReady) {
         /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
+        setIsActive(false);
       }
     };
   }, [isReady]);

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -263,6 +263,7 @@ function AcuantCapture(
 ) {
   const {
     isReady,
+    isActive: isAcuantInstanceActive,
     isAcuantLoaded,
     isError,
     isCameraSupported,
@@ -416,7 +417,7 @@ function AcuantCapture(
             onChangeAndResetError(dataURI);
           }),
         );
-      } else if (shouldStartAcuantCapture) {
+      } else if (shouldStartAcuantCapture && !isAcuantInstanceActive) {
         setIsCapturingEnvironment(true);
       }
 

--- a/app/javascript/packages/document-capture/context/acuant.jsx
+++ b/app/javascript/packages/document-capture/context/acuant.jsx
@@ -114,6 +114,8 @@ const AcuantContext = createContext({
   isAcuantLoaded: false,
   isError: false,
   isCameraSupported: /** @type {boolean?} */ (null),
+  isActive: false,
+  setIsActive: /** @type {(nextIsActive: boolean) => void} */ (() => {}),
   credentials: /** @type {string?} */ (null),
   glareThreshold: DEFAULT_ACCEPTABLE_GLARE_SCORE,
   sharpnessThreshold: DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
@@ -144,12 +146,15 @@ function AcuantContextProvider({
   // Acuant SDK loads, so assign a value of `null` as representing this unknown state. Other device
   // types should treat camera as unsupported, since it's not relevant for Acuant SDK usage.
   const [isCameraSupported, setIsCameraSupported] = useState(isMobile ? null : false);
+  const [isActive, setIsActive] = useState(false);
   const value = useMemo(
     () => ({
       isReady,
       isAcuantLoaded,
       isError,
       isCameraSupported,
+      isActive,
+      setIsActive,
       endpoint,
       credentials,
       glareThreshold,
@@ -160,6 +165,8 @@ function AcuantContextProvider({
       isAcuantLoaded,
       isError,
       isCameraSupported,
+      isActive,
+      setIsActive,
       endpoint,
       credentials,
       glareThreshold,

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -200,6 +200,42 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end.called).to.be.false();
     });
 
+    it('does not start capturing if an acuant instance is already active', async () => {
+      const { getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+            <AcuantCapture label="First Image" />
+            <AcuantCapture label="Second Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      let onCropped;
+
+      initialize({
+        start: sinon.stub().callsFake(async (callbacks) => {
+          await Promise.resolve();
+          callbacks.onCaptured();
+          onCropped = () => callbacks.onCropped(ACUANT_CAPTURE_SUCCESS_RESULT);
+        }),
+      });
+
+      const firstInput = getByLabelText('First Image');
+      const secondInput = getByLabelText('Second Image');
+      fireEvent.click(firstInput);
+      fireEvent.click(secondInput);
+
+      expect(window.AcuantCameraUI.start).to.have.been.calledOnce();
+
+      await waitFor(() => firstInput.getAttribute('aria-busy') === 'true');
+      onCropped();
+      await waitFor(() => firstInput.getAttribute('aria-busy') === 'false');
+
+      fireEvent.click(secondInput);
+
+      expect(window.AcuantCameraUI.start).to.have.been.calledTwice();
+    });
+
     it('starts capturing when clicking input on supported device', () => {
       const { getByLabelText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>


### PR DESCRIPTION
**Why**: Because the Acuant SDK (or at least our implementation of it) is treated as a singleton, unexpected behavior can occur when trying to start capturing a second image before the first is finished, as in the case of the new loading experience introduced in #5747.

Previously, if a user with fast fingers were to tap on the "Back Image" while the "Front Image" is still being processed, the camera would be shown, but eventually it would be removed from the dialog. The reason for this is that [the first instance will call `AcuantCameraUI.end()`](https://github.com/18F/identity-idp/blob/e8dcc5680f1a16156056d4f5c30b055d325bb81d/app/javascript/packages/document-capture/components/acuant-camera.jsx#L220) when it is finished processing and unmounted, which will in-fact end all active cameras, including for the second field being captured.

The workaround here is to prevent the dialog experience from being launched if there is still an active Acuant instance. This could likely be improved, but as a workaround is may be sufficiently clear (visually and spoken) that it cannot be started because the first image is still loading.

Future improvements could include:

- Possibly allow multiple instances by avoiding or deferring the call to `AcuantCameraUI.end()` from individual instances.
- Treat the pending state in a similar way that we do with the `isReady` handling, where the dialog is launched, but a spinner is shown until we are ready to take the image, i.e. other instances are finished.
- Add a disabled effect to the other inputs while they cannot be used. We may not currently have the styling implemented for this, and we may need to make additional considerations for the current field being loaded, since we want it to be where focus is returned after the dialog is closed, but disabled fields are not focusable.