### PR TITLE
Improve "make run-https" asset workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ run: ## Runs the development server
 	foreman start -p $(PORT)
 
 run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the development server with HTTPS
-	HTTPS=on rails s -b "ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt"
+	HTTPS=on FOREMAN_HOST="ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt" foreman start -p $(PORT)
 
 normalize_yaml: ## Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${HOST:-localhost}
+web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-localhost}
 worker: bundle exec good_job start
 mailcatcher: mailcatcher -f
 js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack serve

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-localhost}
 worker: bundle exec good_job start
 mailcatcher: mailcatcher -f
-js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack serve
+js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack $([ -n "$HTTPS" ] && echo "--watch" || echo "serve") 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
     config.action_controller.perform_caching = false
 
     config.cache_store = :null_store
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, no-cache, must-revalidate',
+      'Vary' => '*',
+    }
   end
 
   # Bullet gem config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const RailsI18nWebpackPlugin = require('@18f/identity-rails-i18n-webpack-plugin');
 
 const env = process.env.NODE_ENV || process.env.RAILS_ENV || 'development';
+const host = process.env.HOST || 'localhost';
+const isLocalhost = host === 'localhost';
 const isProductionEnv = env === 'production';
 const isTestEnv = env === 'test';
 const mode = isProductionEnv ? 'production' : 'development';
@@ -16,7 +18,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   mode,
   devtool: isProductionEnv ? false : 'eval-source-map',
   target: ['web', 'es5'],
-  devServer: devServerPort && {
+  devServer: {
     static: {
       directory: './public',
       watch: false,
@@ -34,7 +36,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     chunkFilename: `js/[name].chunk${hashSuffix}.js`,
     sourceMapFilename: `js/[name]${hashSuffix}.js.map`,
     path: resolve(__dirname, 'public/packs'),
-    publicPath: devServerPort ? `http://localhost:${devServerPort}/packs/` : '/packs/',
+    publicPath: isLocalhost ? `http://localhost:${devServerPort}/packs/` : '/packs/',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,8 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     chunkFilename: `js/[name].chunk${hashSuffix}.js`,
     sourceMapFilename: `js/[name]${hashSuffix}.js.map`,
     path: resolve(__dirname, 'public/packs'),
-    publicPath: isLocalhost ? `http://localhost:${devServerPort}/packs/` : '/packs/',
+    publicPath:
+      devServerPort && isLocalhost ? `http://localhost:${devServerPort}/packs/` : '/packs/',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],


### PR DESCRIPTION
**Why**:

- To prevent caching in development with the Rails public file server
- To avoid writing webpack-dev-server URLs into the asset manifest when the app is requested across the network
- To automatically recompile JavaScript while running "make run-https"

Specifically, I've experienced some challenges following our [mobile device testing documentation](https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine) since the changes introduced in #5746. While it would be possible to run `yarn webpack --watch` in a separate terminal process, it would be nice to streamline this. Additionally, without adjusted public file server headers, Safari caching is particularly aggressive, even when trying to reload without cache.

I had also experimented with letting the client request from the webpack-dev-server over the network, and it was quite close to working, but since the dev-server will run its own self-signed (invalid) certificate, the requests are blocked by the browser, and there's no equivalent bypass to the one discussed in the last paragraph of ["Testing the application over HTTPS"](https://github.com/18F/identity-idp#testing-the-application-over-https).

For posterity, fragments of that code:

```diff
diff --git a/config/initializers/secure_headers.rb b/config/initializers/secure_headers.rb
index 43bdd9cf5..555c405cf 100644
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -52,8 +52,9 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
                end
 
   if ENV['WEBPACK_PORT']
-    config.csp[:connect_src] << "ws://localhost:#{ENV['WEBPACK_PORT']}"
-    config.csp[:script_src] << "localhost:#{ENV['WEBPACK_PORT']}"
+    host, _port = IdentityConfig.store.domain_name.split(':')
+    config.csp[:connect_src] << "ws://#{host}:#{ENV['WEBPACK_PORT']}"
+    config.csp[:script_src] << "#{host}:#{ENV['WEBPACK_PORT']}"
   end
 
   config.cookies = {
diff --git a/webpack.config.js b/webpack.config.js
index 6184e26e9..e4c3ca2dc 100644
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,24 @@
 const { parse, resolve } = require('path');
+const { networkInterfaces } = require('os');
 const { sync: glob } = require('fast-glob');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const RailsI18nWebpackPlugin = require('@18f/identity-rails-i18n-webpack-plugin');
 
 const env = process.env.NODE_ENV || process.env.RAILS_ENV || 'development';
-const host = process.env.HOST || 'localhost';
-const isLocalhost = host === 'localhost';
 const isProductionEnv = env === 'production';
 const isTestEnv = env === 'test';
 const mode = isProductionEnv ? 'production' : 'development';
 const hashSuffix = isProductionEnv ? '-[contenthash:8]' : '';
+const isHTTPS = 'HTTPS' in process.env;
+
 const devServerPort = process.env.WEBPACK_PORT;
+const devServerProtocol = isHTTPS ? 'https' : 'http';
+let devServerHost = process.env.HOST || 'localhost';
+if (devServerHost === '0.0.0.0') {
+  devServerHost = Object.values(networkInterfaces())
+    .flat()
+    .find((i) => !i.internal && i.family === 'IPv4').address;
+}
 
 const entries = glob('app/{components,javascript/packs}/*.{js,jsx}');
 
@@ -19,6 +27,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   devtool: isProductionEnv ? false : 'eval-source-map',
   target: ['web', 'es5'],
   devServer: {
+    server: devServerProtocol,
     static: {
       directory: './public',
       watch: false,
@@ -36,7 +45,9 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     chunkFilename: `js/[name].chunk${hashSuffix}.js`,
     sourceMapFilename: `js/[name]${hashSuffix}.js.map`,
     path: resolve(__dirname, 'public/packs'),
-    publicPath: isLocalhost ? `http://localhost:${devServerPort}/packs/` : '/packs/',
+    publicPath: devServerPort
+      ? `${devServerProtocol}://${devServerHost}:${devServerPort}/packs/`
+      : '/packs/',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
```