### PR TITLE
Require Changelog on Pull Requests (LG-5631)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,7 @@ jobs:
       - run:
           name: Check Changelog
           command: |-
-            if [ -z "${CIRCLE_PULL_REQUEST}" ]
+            if [ -z "${CIRCLE_PULL_REQUEST}" ] || echo ${CIRCLE_BRANCH} | grep -q '^stages/'
             then
               exit 0
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,6 +398,7 @@ jobs:
           command: |-
             if [ -z "${CIRCLE_PULL_REQUEST}" ] || echo ${CIRCLE_BRANCH} | grep -q '^stages/'
             then
+              echo "Skipping changelock check because this is not a PR or is a release branch"
               exit 0
             else
               ./scripts/changelog-check -b main -s "${CIRCLE_BRANCH}" || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
             then
               exit 0
             else
-              ./scripts/changelog-check -b "${CIRCLE_BRANCH}" -s main
+              ./scripts/changelog-check -b main -s "${CIRCLE_BRANCH}"
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,8 @@ jobs:
           fail_only: true
           failure_message: ':aws-emoji: :red_circle: AWS Pinpoint country configuration is out of date'
   check_changelog:
-    executor: ruby_browsers
+    docker:
+      - image: cimg/ruby:3.0
     steps:
       - checkout
       - run:
@@ -399,7 +400,7 @@ jobs:
             then
               exit 0
             else
-              ./scripts/changelog-check -b main -s "${CIRCLE_BRANCH}"
+              ./scripts/changelog-check -b main -s "${CIRCLE_BRANCH}" || true
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,11 +388,26 @@ jobs:
       - slack/status:
           fail_only: true
           failure_message: ':aws-emoji: :red_circle: AWS Pinpoint country configuration is out of date'
+  check_changelog:
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - run:
+          name: Check Changelog
+          command: |-
+            if [ -z "${CIRCLE_PULL_REQUEST}" ]
+            then
+              exit 0
+            else
+              ./scripts/changelog-check -b "${CIRCLE_BRANCH}" -s main
+            fi
+
 workflows:
   version: 2
   release:
     jobs:
       - setup
+      - check_changelog
       - ruby_test:
           requires:
             - setup

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,19 @@ stages:
       when: never
     - if: $CI_COMMIT_BRANCH
 
+check_changelog:
+  extends: .on_push
+  stage: build
+  script:
+    - |
+      if [ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]
+      then
+        echo "Skipping because this is not a PR or is not targeting main"
+        exit 0
+      else
+        git fetch origin --quiet
+        ./scripts/changelog-check -b origin/"${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" -s origin/"${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
+      fi
 install:
   extends: .on_push
   stage: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Unreleased
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
 
+RC 174 - 2022-01-20
+----------------------
+
+### Improvements/Changes
+- Identity Verification: Update responsiveness of image capture (#5747, #5830, #5834)
+- Rules of Use: Updated Rules of Use timestamp (#5837)
+- Multi-factor authentication: Platform authenticators (such as FaceID, Touch ID) are now supported (#5632)
+
+### Bug Fixes Users Might Notice
+- Errors: Fixed a few unhandled errors from blank fields (#5823)
+
+### Behind the Scenes Changes Users Probably Won't Notice
+- Source code: Update asset compilation pipeline (#5746, #5821)
+- Logging: Send worker metrics to workers.log (#5809)
+- Logging: Add which screen to image upload events (#5810)
+- Source code: Skip generating GZIP assets locally (#5812)
+- Source code: Remove redundant CSS class in forms (#5814)
+- Source code: Update dependencies (#5818)
+- Source code: Add support for TypeScript (#5815)
+- Source code: Simplify logic around regenerating personal keys (#5817)
+- Source code: Persist Webpack assets manifest between requests (#5805)
+- Operations: Add rake task to look up user UUIDs by email address (#5829)
+
 RC 173 - 2022-01-13
 ----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Unreleased
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
 
+RC 175 - 2022-01-27
+----------------------
+
+### Improvements/Changes
+- Account management: A new flow was added to reset the personal key from the account screen (#5825)
+- Account management: An error message is displayed if a user attempts to add more than 12 emails. (#58320)
+
+### Accessibility
+- Dialogs: The text in the "Confirm personal key dialog" is now read by screen readers. (#5806)
+
+### Bug Fixes Users Might Notice
+- Content changes: Content was updated to provide clarity to the user. (#5826, #5831, #5833)
+- Layout: The "Check Your Email" icon was removed. (#5827)
+- Layout: Accordions now use consistent vertical margins. (#5828)
+- Layout: Headings are now componentized and consistent across the app. (#5840)
+- Design system: "Remember this device" checkboxes now use the Login.gov design system. (#5820)
+
+### Behind the Scenes Changes Users Probably Won't Notice
+- Development: Assets are no longer gzipped in the development environment. (#5824)
+- Logging: An event is logged when a user sees a warning page during proofing. (#5838)
+- Content security policy: 'unsafe-inline' directives were removed from the content security policy. (#5844, #5852)
+- Content security policy: URL schemes are now preserved in the content security policy origins. (#5842, #5846)
+
 RC 174 - 2022-01-20
 ----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## Unreleased
+
+### Improvements/Changes
+
+### Accessibility
+
+## Bug Fixes Users Might Notice
+
+## Behind the Scenes Changes Users Probably Won't Notice
+- Add CI check to include changelog message in change requests (#5836)
+
+## RC 173 - 2022-01-13
+
+### Improvements/Changes
+- Authentication: Limit maximum number of phone numbers (LG-5493) (#5779)
+
+### Behind the scenes bug fixes users probably won't notice
+- Maintenance: Build IDP Artifacts in GitLab CI (LG-5360) (#5767, #5795)
+- Maintenance: Reduce database index size (#5783, #5784)
+- Maintenance: Improve Makefile documentation (LG-4635) (#5791, #5792)
+- Maintenance: Update Node.js to v14 (#5786)
+- Maintenance: Standardize stylesheeting processing pipeline (#5793, #5799)
+- Maintenance: Update Ruby code linting (#5794, #5808)
+- Maintenance: Improve CSRF handling in test environment (#5796)
+- Logging: Log document state/territory in proofing (#5798)
+- Authentication: Generate SAML cert for 2022 (#5797, #5800)
+- Logging: Improve logging for personal key page (LG-5221) (#5785)
+- Maintenance: Remove network request retries to vendors (#5801)
+- Maintenance: De-duplicate Rack::Attack rate limiting middleware when rate limiting is enabled (#5803)
+- Maintenance: Use shared GitHub sync script in GitLab (#5700)
+- Maintenance: Fix Selenium deprecation (#5802)
+- Logging: Return false instead of nil when logging invalid backup code (#5804)
+- Logging: Log worker metrics to workers.log file (#5809)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
-# Changelog
+Changelog
+========
 
-## Unreleased
+Unreleased
+-----------
 
 ### Improvements/Changes
 
 ### Accessibility
 
-## Bug Fixes Users Might Notice
+### Bug Fixes Users Might Notice
 
-## Behind the Scenes Changes Users Probably Won't Notice
+### Behind the Scenes Changes Users Probably Won't Notice
 - Add CI check to include changelog message in change requests (#5836)
 
-## RC 173 - 2022-01-13
+RC 173 - 2022-01-13
+----------------------
 
 ### Improvements/Changes
 - Authentication: Limit maximum number of phone numbers (LG-5493) (#5779)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased
 ### Bug Fixes Users Might Notice
 
 ### Behind the Scenes Changes Users Probably Won't Notice
-- Add CI check to include changelog message in change requests (#5836)
+- Maintenance: Add CI check to include changelog message in change requests (#5836)
 
 RC 173 - 2022-01-13
 ----------------------

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -23,6 +23,16 @@ def get_changelog_diff_lines(base_branch, source_branch)
   diff_lines[(index+1)..].filter { |line| !line.start_with?('@@') && line != ' ' }
 end
 
+def commit_messages_contain_skip_changelog?(base_branch, source_branch)
+  log, status = Open3.capture2(
+    'git', 'log', '--pretty=\'%B\'', "#{base_branch}...#{source_branch}"
+  )
+  raise 'git log failed' unless status.success?
+
+  return true if log.include?('[skip changelog]')
+  return false
+end
+
 def main(args)
   options = { base_branch: 'main' }
   basename = File.basename($0)
@@ -49,6 +59,12 @@ def main(args)
   optparse.parse!
 
   abort(optparse.help) if options[:source_branch].nil?
+
+  skip_check = commit_messages_contain_skip_changelog?(
+    options[:base_branch],
+    options[:source_branch],
+  )
+  return 0 if skip_check
 
   diff_lines = get_changelog_diff_lines(options[:base_branch], options[:source_branch])
 

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -2,12 +2,13 @@
 require 'open3'
 require 'optparse'
 
-CHANGELOG_REGEX = %r{^\+- (?<category>[\w ]+{2,}): (?<change>[\w\s]+{2,})}
+CHANGELOG_REGEX = %r{^\+- (?<category>[\w ]{2,}): (?<change>[\w ]{2,})}
+PR_REGEX = %r{ \([#\d+, ]*\d+\)$}
 # A valid diff line is in the form of:
-# +- CATEGORY: CHANGE DESCRIPTION
+# +- CATEGORY: CHANGE_DESCRIPTION (#PULL_REQUEST_NUMBER)
 def is_valid_changelog_diff_addition?(line)
-  matches = CHANGELOG_REGEX.match?(line)
-  !matches.nil?
+  matches = CHANGELOG_REGEX.match(line)
+  !matches.nil? && line.match?(PR_REGEX)
 end
 
 def get_changelog_diff_lines(base_branch, source_branch)
@@ -71,6 +72,13 @@ def main(args)
   if diff_lines.any? { |x| is_valid_changelog_diff_addition?(x) }
     exit 0
   else
+    warn(
+      <<~ERROR,
+        A valid changelog line was not found.
+        Changelog entries should be formatted as: - CATEGORY: CHANGE_DESCRIPTION (#PULL_REQUEST_NUMBER)
+      ERROR
+    )
+
     exit 1
   end
 end

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+require 'open3'
+require 'optparse'
+
+CHANGELOG_REGEX = %r{^\+- (?<category>[\w ]+{2,}): (?<change>[\w\s]+{2,})}
+# A valid diff line is in the form of:
+# +- CATEGORY: CHANGE DESCRIPTION
+def is_valid_changelog_diff_addition?(line)
+  matches = CHANGELOG_REGEX.match?(line)
+  !matches.nil?
+end
+
+def get_changelog_diff_lines(base_branch, source_branch)
+  diff, status = Open3.capture2(
+    'git', 'diff', '--merge-base', base_branch, source_branch,
+    'CHANGELOG.md'
+  )
+  raise 'git diff failed' unless status.success?
+
+  diff_lines = diff.chomp.split("\n")
+  index = diff_lines.find_index { |line| line.start_with?('@@') }
+  return [] if index.nil?
+  diff_lines[(index+1)..].filter { |line| !line.start_with?('@@') && line != ' ' }
+end
+
+def main(args)
+  options = { base_branch: 'main' }
+  basename = File.basename($0)
+
+  optparse = OptionParser.new do |opts|
+    opts.banner = <<-EOM
+      usage: #{basename} -s my-feature-branch [OPTIONS]
+
+    EOM
+    opts.on('-h', '--help', 'Display this message') do
+      warn opts
+      exit
+    end
+
+    opts.on('-b', '--base_branch BASE_BRANCH', 'Name of base branch, defaults to main') do |val|
+      options[:base_branch] = val
+    end
+
+    opts.on('-s', '--source_branch SOURCE_BRANCH', 'Name of source branch (required)') do |val|
+      options[:source_branch] = val
+    end
+  end
+
+  optparse.parse!
+
+  abort(optparse.help) if options[:source_branch].nil?
+
+  diff_lines = get_changelog_diff_lines(options[:base_branch], options[:source_branch])
+
+  if diff_lines.any? { |x| is_valid_changelog_diff_addition?(x) }
+    exit 0
+  else
+    exit 1
+  end
+end
+
+main(ARGV) if __FILE__ == $0

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -2,13 +2,12 @@
 require 'open3'
 require 'optparse'
 
-CHANGELOG_REGEX = %r{^\+- (?<category>[\w ]{2,}): (?<change>[\w ]{2,})}
-PR_REGEX = %r{ \([#\d+, ]*\d+\)$}
+CHANGELOG_REGEX = %r{^\+- (?<category>[\w -]{2,}): (?<change>.+) \((?<pr>(?:#\d+, ?)*(?:#\d+))\)$}
 # A valid diff line is in the form of:
 # +- CATEGORY: CHANGE_DESCRIPTION (#PULL_REQUEST_NUMBER)
 def is_valid_changelog_diff_addition?(line)
   matches = CHANGELOG_REGEX.match(line)
-  !matches.nil? && line.match?(PR_REGEX)
+  !matches.nil?
 end
 
 def get_changelog_diff_lines(base_branch, source_branch)

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -30,8 +30,7 @@ def commit_messages_contain_skip_changelog?(base_branch, source_branch)
   )
   raise 'git log failed' unless status.success?
 
-  return true if log.include?('[skip changelog]')
-  return false
+  log.include?('[skip changelog]')
 end
 
 def main(args)


### PR DESCRIPTION
This PR implements a check for pull requests against this repo that requires a line be added to CHANGELOG.md in the form of:


`+- CATEGORY: CHANGE_DESCRIPTION (#PULL_REQUEST_NUMBER)`

```diff
+-  Maintenance: Update Node.js to v14 (#5786)
```

It can be skipped with a commit message in the PR that contains `[skip changelog]`.