### PR TITLE
Update rules_of_use_updated_at timestamp

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -198,7 +198,7 @@ risc_notifications_rate_limit_overrides: '{"https://example.com/push":{"interval
 risc_notifications_request_timeout: '3'
 ruby_workers_idv_enabled: 'true'
 rules_of_use_horizon_years: '6'
-rules_of_use_updated_at: '2021-05-21T00:00:00Z'
+rules_of_use_updated_at: '2022-01-19T00:00:00Z'
 s3_public_reports_enabled: 'false'
 s3_reports_enabled: 'false'
 saml_secret_rotation_enabled: 'false'


### PR DESCRIPTION
This is used to trigger users to accept the new rules of use. Relates to: https://github.com/18F/identity-site/pull/792

This is for LG-5520