### PR TITLE
LG-4792: Use component for consistent headings

### DIFF
--- a/app/assets/stylesheets/components/_page-heading.scss
+++ b/app/assets/stylesheets/components/_page-heading.scss
@@ -1,18 +1,13 @@
 .page-heading {
   @include u-margin-top(0);
   @include u-margin-bottom(2);
-}
 
-// Disable reason: Technically the qualifiers are redundant, but are included to communicate
-// expectations and precautions around why the qualifiers exist:
-// 1. A page heading should always be an H1
-// 2. The focus styling is specific to non-interactive content not included in regular tab order,
-//    expected to be used only for programmatic fallback, and with exception to allow supported
-//    `:focus-visible` to restore identified indicator.
-h1[tabindex='-1'].page-heading:focus {
-  outline: none;
-
-  &:focus-visible {
-    @include focus-outline;
+  // Typically, a non-interactive element should not be focusable, nor should the focus outline be
+  // hidden. However, it may be necessary to programmatically shift focus to retain continuity of
+  // page content progression, especially in the case of single-page application navigation. This is
+  // typically considered a reasonable exception to visible focus outline, though we are careful to
+  // respect `:focus-visible` where applicable and supported.
+  &[tabindex='-1']:not(:focus-visible):focus {
+    outline: none;
   }
 }

--- a/app/components/page_heading_component.rb
+++ b/app/components/page_heading_component.rb
@@ -1,0 +1,11 @@
+class PageHeadingComponent < BaseComponent
+  attr_reader :tag_options
+
+  def initialize(**tag_options)
+    @tag_options = tag_options
+  end
+
+  def call
+    tag.h1 content, **tag_options, class: ['page-heading', *tag_options[:class]]
+  end
+end

--- a/app/views/account_reset/cancel/show.html.erb
+++ b/app/views/account_reset/cancel/show.html.erb
@@ -2,8 +2,6 @@
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.cancel_request.title')) %>
 
-<br/>
-
 <h4 class='margin-y-2'>
   <%= t('account_reset.cancel_request.are_you_sure') %>
 </h4>

--- a/app/views/account_reset/cancel/show.html.erb
+++ b/app/views/account_reset/cancel/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('account_reset.cancel_request.title') %>
 
-<h1 class='margin-y-0'>
-  <%= t('account_reset.cancel_request.title') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.cancel_request.title')) %>
 
 <br/>
 

--- a/app/views/account_reset/confirm_request/show.html.erb
+++ b/app/views/account_reset/confirm_request/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.verify_email') %>
 
-<h1 class="margin-top-0"><%= t('headings.verify_email') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 
 <p><%= t('account_reset.confirm_request.instructions_start') %>
   <strong><%= email %></strong>

--- a/app/views/account_reset/delete_account/show.html.erb
+++ b/app/views/account_reset/delete_account/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('account_reset.delete_account.title') %>
 
-<h1 class='margin-y-0'>
-  <%= t('account_reset.delete_account.title') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.delete_account.title')) %>
 <p class='mt-tiny margin-bottom-0'>
   <%= t('account_reset.delete_account.info', app_name: APP_NAME) %>
 </p>

--- a/app/views/account_reset/pending/cancel.html.erb
+++ b/app/views/account_reset/pending/cancel.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('account_reset.pending.cancelled') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.pending.cancelled')) %>
 
 <%= link_to(
       t('links.continue_sign_in'),

--- a/app/views/account_reset/pending/show.html.erb
+++ b/app/views/account_reset/pending/show.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('account_reset.pending.header') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.pending.header')) %>
 
 <p>
   <%= t(

--- a/app/views/account_reset/request/show.html.erb
+++ b/app/views/account_reset/request/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('account_reset.request.title') %>
 
-<h1 class='margin-y-0'><%= t('account_reset.request.title') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.request.title')) %>
 
 <p class='mt-tiny margin-bottom-0'>
   <%= t('account_reset.request.info').html_safe %>

--- a/app/views/accounts/connected_accounts/show.html.erb
+++ b/app/views/accounts/connected_accounts/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('account.navigation.connected_accounts') %>
 
-<h1 class="margin-top-0">
-  <%= t('headings.account.connected_accounts') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.account.connected_accounts')) %>
 
 <p>
   <%= t('account.connected_apps.description', app_name: APP_NAME) %>

--- a/app/views/accounts/history/show.html.erb
+++ b/app/views/accounts/history/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('account.navigation.history') %>
 
-<h1 class="margin-top-0">
-  <%= t('account.navigation.history') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('account.navigation.history')) %>
 
 <div class="margin-bottom-4 card profile-info-box">
   <div class="margin-top-0 border-bottom border-primary-light">

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('account.personal_key.get_new') %>
 
-<h1 class="margin-top-0"><%= t('account.personal_key.get_new') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('account.personal_key.get_new')) %>
 
 <p>
   <%= t('account.personal_key.get_new_description') %>

--- a/app/views/accounts/two_factor_authentication/show.html.erb
+++ b/app/views/accounts/two_factor_authentication/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('account.navigation.two_factor_authentication') %>
 
-<h1 class="margin-top-0">
-  <%= t('headings.account.two_factor') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.account.two_factor')) %>
 
 <div class="margin-bottom-4 card profile-info-box">
   <% if TwoFactorAuthentication::PhonePolicy.new(current_user).visible? %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.passwords.change') %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.passwords.change') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 
 <%= validated_form_for(
       @reset_password_form,

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,9 +3,7 @@
 
 <%= render 'shared/sp_alert' %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.passwords.forgot') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.passwords.forgot')) %>
 
 <p class="mt-tiny margin-bottom-0" id="email-description">
   <%= t('instructions.password.forgot') %>

--- a/app/views/devise/sessions/bounced.html.erb
+++ b/app/views/devise/sessions/bounced.html.erb
@@ -1,7 +1,5 @@
 <% title t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
-<h1 class='margin-y-0'>
-  <%= t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.sp_handoff_bounced', sp_name: @sp_name)) %>
 <p class='margin-top-2 margin-bottom-2'>
   <%= t(
         'instructions.sp_handoff_bounced',

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,9 +9,7 @@
     <%= render decorated_session.registration_heading %>
   </div>
 <% else %>
-  <h1 class='margin-y-0'>
-    <%= decorated_session.new_session_heading %>
-  </h1>
+  <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>
 <%= render 'shared/sp_alert' %>
 

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.passwords.change') %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.passwords.change') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 
 <%= validated_form_for(
       @password_reset_from_disavowal_form,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,9 +4,7 @@
 
 <% title t('titles.account') %>
 
-<h1 class="margin-top-0">
-  <%= t('headings.account.activity') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.account.activity')) %>
 
 <div class="margin-bottom-4 card profile-info-box">
   <div class="border-bottom border-primary-light">

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -5,7 +5,7 @@
   <%= render 'forgot_password/resend_alert' %>
 <% end %>
 
-<h1 class="margin-top-0"><%= t('headings.verify_email') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 
 <p><%= t('notices.forgot_password.first_paragraph_start') %>
    <strong><%= @view_model.email %></strong>

--- a/app/views/idv/activated.html.erb
+++ b/app/views/idv/activated.html.erb
@@ -1,8 +1,6 @@
 <% title t('idv.titles.activated') %>
 
-<h1 class='margin-y-0'>
-  <%= t('idv.titles.activated') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.activated')) %>
 <p class='mt-tiny margin-bottom-0'>
   <%= t(
         'idv.messages.activated_html',

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -9,9 +9,7 @@
 
 <% title t('titles.doc_auth.address') %>
 
-<h1 class="margin-y-0">
-  <%= t('doc_auth.headings.address') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.address')) %>
 
 <div class="margin-top-4 margin-bottom-4">
   <%= validated_form_for(

--- a/app/views/idv/cancel.html.erb
+++ b/app/views/idv/cancel.html.erb
@@ -1,8 +1,6 @@
 <% title t('idv.titles.cancel') %>
 
-<h1 class='margin-y-0'>
-  <%= t('idv.titles.cancel') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.cancel')) %>
 
 <p class='mt-tiny margin-bottom-0'>
   <%= t('idv.messages.cancel', app_name: APP_NAME) %>

--- a/app/views/idv/capture_doc/capture_complete.html.erb
+++ b/app/views/idv/capture_doc/capture_complete.html.erb
@@ -4,7 +4,6 @@
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 
-<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
-  <%= t('doc_auth.instructions.switch_back') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.instructions.switch_back')) %>
+
 <%= image_tag(asset_url('idv/switch.png'), width: 193) %>

--- a/app/views/idv/doc_auth/_ssn_init.html.erb
+++ b/app/views/idv/doc_auth/_ssn_init.html.erb
@@ -7,9 +7,7 @@
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 
-<h1>
-  <%= t('doc_auth.headings.ssn') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn')) %>
 
 <p>
   <%= t('doc_auth.info.ssn') %>

--- a/app/views/idv/doc_auth/_ssn_update.html.erb
+++ b/app/views/idv/doc_auth/_ssn_update.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.doc_auth.ssn') %>
 
-<h1>
-  <%= t('doc_auth.headings.ssn_update') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn_update')) %>
 
 <p>
   <%= t('doc_auth.info.ssn') %>

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -10,7 +10,7 @@
       message: flow_session[:error_message].presence || t('errors.doc_auth.consent_form'),
     ) %>
 
-<h1><%= t('doc_auth.headings.lets_go') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.lets_go')) %>
 <p><%= t('doc_auth.info.lets_go') %></p>
 <h2><%= t('doc_auth.headings.verify_identity') %></h2>
 <p><%= t('doc_auth.info.verify_identity') %></p>

--- a/app/views/idv/doc_auth/email_sent.html.erb
+++ b/app/views/idv/doc_auth/email_sent.html.erb
@@ -1,9 +1,9 @@
 <% title t('titles.doc_auth.verify') %>
 
-<%= image_tag(asset_url('state-id-confirm@3x.png'), width: 210) %>
+<%= image_tag(asset_url('state-id-confirm@3x.png'), width: 210, class: 'margin-bottom-2') %>
 
-<h1 class='margin-bottom-2 margin-top-4 margin-y-0'>
+<%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.instructions.email_sent', email: current_user.email) %>
-</h1>
+<% end %>
 
 <%= render 'idv/doc_auth/start_over_or_cancel', step: 'email_sent' %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -11,7 +11,7 @@
         message: flow_session[:error_message],
       ) %>
 <% end %>
-<h1 class='margin-y-0'><%= t('doc_auth.headings.text_message') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.text_message')) %>
 
 <br />
 

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -13,8 +13,6 @@
 <% end %>
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.text_message')) %>
 
-<br />
-
 <div class='clearfix margin-x-neg-1'>
   <div class='sm-col sm-col-3 padding-x-1'>
     <%= image_tag asset_url('idv/phone.png'), alt: t('image_description.camera_mobile_phone') %>

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -8,9 +8,7 @@
       ) %>
 <% end %>
 
-<h1>
-  <%= t('doc_auth.headings.take_picture') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.take_picture')) %>
 
 <p><%= t('doc_auth.info.take_picture') %></p>
 

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -2,13 +2,13 @@
 
 <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-<h1 class='margin-top-0 margin-bottom-1'>
+<%= render PageHeadingComponent.new do %>
   <% if liveness_checking_enabled? %>
     <%= t('doc_auth.headings.upload_liveness_enabled') %>
   <% else %>
     <%= t('doc_auth.headings.upload') %>
   <% end %>
-</h1>
+<% end %>
 
 <% if liveness_checking_enabled? %>
   <p>

--- a/app/views/idv/doc_auth/verify.html.erb
+++ b/app/views/idv/doc_auth/verify.html.erb
@@ -2,9 +2,7 @@
 
 <% title t('titles.doc_auth.verify_info') %>
 
-<h1 class='margin-y-0'>
-  <%= t('doc_auth.headings.verify') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div>
     <%= "#{t('doc_auth.forms.first_name')}: #{flow_session[:pii_from_doc][:first_name]}" %>
@@ -29,10 +27,10 @@
         <div>
           <%= "#{t('doc_auth.forms.zip_code')}: #{flow_session[:pii_from_doc][:zipcode]}" %>
         </div>
-      </div>  
+      </div>
       <div class='grid-auto'>
         <%= link_to(t('doc_auth.buttons.change_address'), idv_address_url, 'aria-label': t('doc_auth.buttons.change_address_label')) %>
-      </div>        
+      </div>
     </div>
     <div class='grid-row padding-top-1'>
       <div class='grid-col-fill'>
@@ -57,7 +55,7 @@
               'aria-label': t('doc_auth.buttons.change_ssn_label'),
             ) { t('doc_auth.buttons.change_ssn') } %>
       </div>
-    </div>  
+    </div>
   <div class="margin-top-5">
     <%= render 'shared/spinner_button',
                action_message: t('doc_auth.info.verifying'),

--- a/app/views/idv/doc_auth/verify_wait.html.erb
+++ b/app/views/idv/doc_auth/verify_wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { @meta_refresh.to_s } %>
 <% title t('titles.doc_auth.processing_images') %>
 
-<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -5,7 +5,7 @@
 <% step = 0 %>
 
 <%= render 'shared/maintenance_window_alert' do %>
-  <h1><%= t('doc_auth.headings.welcome') %></h1>
+  <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.welcome')) %>
   <p class='mt-tiny margin-bottom-0'>
     <%= t('doc_auth.info.welcome_html', sp_name: decorated_session.sp_name || t('doc_auth.info.no_sp_name')) %>
   </p>

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -1,10 +1,8 @@
 <% title t('titles.idv.reset_password') %>
 
-<%= image_tag(asset_url('alert/forgot.svg'), width: 54) %>
+<%= image_tag(asset_url('alert/forgot.svg'), width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('idv.forgot_password.modal_header') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.forgot_password.modal_header')) %>
 
 <hr>
 

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -9,7 +9,7 @@
       } %>
 <% end %>
 
-<h1 class="margin-top-0"><%= @presenter.title %></h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.title) %>
 
 <p>
   <%= @presenter.byline %>

--- a/app/views/idv/gpo/wait.html.erb
+++ b/app/views/idv/gpo/wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { '15' } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -11,9 +11,7 @@
 
 <% title t('titles.verify_profile') %>
 
-<h1 class="margin-y-0">
-  <%= t('forms.verify_profile.title') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.title')) %>
 <p class="mt-tiny margin-bottom-0">
   <%= t('forms.verify_profile.instructions') %>
 </p>

--- a/app/views/idv/gpo_verify/throttled.html.erb
+++ b/app/views/idv/gpo_verify/throttled.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.verify_profile') %>
 
-<h1 class="margin-y-0">
-  <%= t('forms.verify_profile.title') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.title')) %>
 
 <p>
   <%= t(

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -11,9 +11,7 @@
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], context: :idv)) %>
 
-<h1 class="margin-y-0">
-  <%= t('idv.titles.otp_delivery_method') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.otp_delivery_method')) %>
 <p class="margin-top-1">
   <%= t('idv.messages.otp_delivery_method.phone_number_html', phone: @idv_phone) %>
 </p>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -9,9 +9,7 @@
 
 <% title t('titles.idv.enter_security_code') %>
 
-<h1 class="margin-y-0">
-  <%= t('two_factor_authentication.header_text') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.header_text')) %>
 
 <p>
   <%= @presenter.phone_number_message %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -19,15 +19,15 @@
 
 <%= render PageHeadingComponent.new.with_content(t('idv.titles.session.phone')) %>
 
-<div class="padding-y-1 margin-0">
+<p>
   <%= t('idv.messages.phone.description') %>
-</div>
+</p>
 
-<div class="margin-top-2">
+<p class="margin-bottom-1">
   <%= t('idv.messages.phone.alert_html') %>
-</div>
+</p>
 
-<ul class="padding-y-1 margin-0">
+<ul>
   <% t('idv.messages.phone.rules').each do |msg| %>
     <li>
       <%= msg %>
@@ -35,11 +35,9 @@
   <% end %>
 </ul>
 
-<div class="margin-top-2">
+<p>
   <%= t('idv.messages.phone.final_note_html') %>
-  <br/>
-  <br/>
-</div>
+</p>
 
 <%= validated_form_for(
       @idv_form,
@@ -54,7 +52,6 @@
       html: {
         autocomplete: 'off',
         method: :put,
-        class: 'margin-top-2',
       },
     ) do |f| %>
   <%= render PhoneInputComponent.new(

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -17,9 +17,7 @@
 
 <% title t('titles.idv.phone') %>
 
-<h1 class="margin-y-0">
-  <%= t('idv.titles.session.phone') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.session.phone')) %>
 
 <div class="padding-y-1 margin-0">
   <%= t('idv.messages.phone.description') %>

--- a/app/views/idv/phone/wait.html.erb
+++ b/app/views/idv/phone/wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { '15' } %>
 <% title t('titles.doc_auth.verify') %>
 
-<h1 class="margin-y-0"><%= t('doc_auth.info.interstitial_eta') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -9,9 +9,7 @@
       } %>
 <% end %>
 
-<h1>
-  <%= t('idv.titles.session.review', app_name: APP_NAME) %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.session.review', app_name: APP_NAME)) %>
 
 <p>
   <%= t('idv.messages.sessions.review_message', app_name: APP_NAME) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -49,13 +49,13 @@
 <div class="no-js">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-  <h1 class="margin-y-0">
+  <%= render PageHeadingComponent.new do %>
     <% if liveness_checking_enabled? %>
       <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
     <% else %>
       <%= t('doc_auth.headings.document_capture_heading_html') %>
     <% end %>
-  </h1>
+  <% end %>
 
   <%= validated_form_for(
         :doc_auth,

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -17,9 +17,9 @@ else
 end
 %>
 <% title local_assigns.fetch(:title, heading) %>
-<%= image_tag(image_src, width: 54, alt: '', class: 'display-block') %>
+<%= image_tag(image_src, width: 54, alt: '', class: 'display-block margin-bottom-4') %>
 
-<h1 class="margin-top-4 margin-bottom-2"><%= heading %></h1>
+<%= render PageHeadingComponent.new.with_content(heading) %>
 
 <%= yield %>
 

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.passwords.confirm') %>
 
-<h1 class='margin-y-0'>
-  <%= t('headings.passwords.confirm') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.passwords.confirm')) %>
 <p class='mt-tiny margin-bottom-0'>
   <%# for follow up: translate factor_to_change (LG-5701) %>
   <%= user_session[:no_factor_message] ||

--- a/app/views/pages/page_took_too_long.html.erb
+++ b/app/views/pages/page_took_too_long.html.erb
@@ -20,9 +20,7 @@
             </div>
           </div>
           <div class="inner cover">
-            <h1>
-              <%= t('pages.page_took_too_long.header') %>
-            </h1>
+            <%= render PageHeadingComponent.new.with_content(t('pages.page_took_too_long.header')) %>
             <p>
               <%= t('pages.page_took_too_long.body') %>
             </p>

--- a/app/views/pages/page_took_too_long.html.erb
+++ b/app/views/pages/page_took_too_long.html.erb
@@ -20,7 +20,9 @@
             </div>
           </div>
           <div class="inner cover">
-            <%= render PageHeadingComponent.new.with_content(t('pages.page_took_too_long.header')) %>
+            <h1>
+              <%= t('pages.page_took_too_long.header') %>
+            </h1>
             <p>
               <%= t('pages.page_took_too_long.body') %>
             </p>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.visitors.index') %>
 
-<h1 class='margin-y-0'>
-  <%= t('headings.passwords.confirm') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.passwords.confirm')) %>
 
 <%= validated_form_for(
       current_user,

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -11,9 +11,7 @@
   <% end %>
 </div>
 
-<h1 class="margin-top-0 margin-bottom-2">
-  <%= t('headings.account.reactivate') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.account.reactivate')) %>
 
 <p class="margin-bottom-6">
   <%= t('instructions.account.reactivate.intro') %>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -10,9 +10,7 @@
   <body>
     <div class="container tablet:padding-y-6">
       <div class="card margin-x-auto sm-col-6">
-        <h1 class="margin-y-0">
-          <%= t('.heading') %>
-        </h1>
+        <%= render PageHeadingComponent.new.with_content(t('.heading')) %>
 
         <p>
           <%= t('.no_js') %>

--- a/app/views/saml_post/auth.html.erb
+++ b/app/views/saml_post/auth.html.erb
@@ -10,9 +10,7 @@
   <body>
     <div class="container tablet:padding-y-6">
       <div class="card margin-x-auto sm-col-6">
-        <h1 class="margin-y-0">
-          <%= t('saml_idp.shared.saml_post_binding.heading') %>
-        </h1>
+        <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
 
         <p>
           <%= t('saml_idp.shared.saml_post_binding.no_js') %>

--- a/app/views/shared/_failure.html.erb
+++ b/app/views/shared/_failure.html.erb
@@ -1,10 +1,8 @@
 <% title presenter.title %>
 
-<%= image_tag(asset_url(presenter.state_icon), alt: '', width: 54) %>
+<%= image_tag(asset_url(presenter.state_icon), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= presenter.header %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(presenter.header) %>
 
 <p>
   <%= presenter.description %>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -1,4 +1,4 @@
-<h1 class="margin-y-0"><%= t('headings.personal_key') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.personal_key')) %>
 <p class="mt-tiny margin-bottom-6">
   <%= t(
         'instructions.personal_key.info_html',

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -4,9 +4,9 @@
     <%= image_tag asset_url(@presenter.image_name), width: 140, alt: '', class: 'margin-bottom-2' %>
   </div>
 
-  <h1 class="margin-bottom-2 margin-y-0 tablet:margin-right-1 tablet:margin-left-1 center">
+  <%= render PageHeadingComponent.new(class: 'tablet:margin-right-1 tablet:margin-left-1 text-center') do %>
     <%= @presenter.heading %>
-  </h1>
+  <% end %>
 
   <p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
     <%= t(

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.confirmations.new') %>
 
-<h1 class='margin-y-0'>
-  <%= t('headings.confirmations.new') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.confirmations.new')) %>
 <%= validated_form_for(
       @resend_email_confirmation_form,
       url: sign_up_register_path,

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -8,7 +8,7 @@
       ) %>
 <% end %>
 
-<h1 class="margin-top-0"><%= t('headings.verify_email') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 
 <p><%= t('notices.signed_up_but_unconfirmed.first_paragraph_start') %>
    <strong><%= email %></strong>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.confirmations.show') %>
 
-<h1 class="margin-y-0">
-  <%= t('forms.confirmation.show_hdr') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.confirmation.show_hdr')) %>
 
 <p class="margin-top-2 margin-bottom-0" id="password-description">
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'shared/sp_alert' %>
 
-<h1 class='margin-y-0'><%= t('titles.registrations.new') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.registrations.new')) %>
 
 <%= simple_form_for(
       @register_user_email_form,

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -1,8 +1,6 @@
 <% title 'Enter PIV/CAC Test Information' %>
 
-<h1 class="margin-y-0">
-  Enter PIV/CAC Test Information
-</h1>
+<%= render PageHeadingComponent.new.with_content('Enter PIV/CAC Test Information') %>
 
 <p class="mt-tiny margin-bottom-4">
   Either enter a subject for a certificate or select an error to simulate a piv/cac response.

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class='margin-y-0'>
-  <%= t('two_factor_authentication.backup_code_header_text') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.backup_code_header_text')) %>
 
 <p class='mt-tiny margin-bottom-0'>
   <%= t('two_factor_authentication.backup_code_prompt') %>

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -2,9 +2,7 @@
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 
-<h1 class="margin-y-0">
-  <%= @presenter.heading %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p class="mt-tiny margin-bottom-4">
   <%= @presenter.info %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class="margin-y-0">
-  <%= @presenter.header %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
 <p>
   <%= @presenter.phone_number_message %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class='margin-y-0'>
-  <%= t('two_factor_authentication.personal_key_header_text') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.personal_key_header_text')) %>
 
 <p class='mt-tiny margin-bottom-0'>
   <%= t('two_factor_authentication.personal_key_prompt') %>

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.present_piv_cac') %>
 
-<h1 class='margin-y-0'>
-  <%= @presenter.header %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
 <p class='mt-tiny margin-bottom-4'>
   <%= @presenter.piv_cac_help %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.enter_2fa_code') %>
 
-<h1 class="margin-top-0">
-  <%= @presenter.header %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
 <%= validated_form_for('', method: :post, html: { class: 'margin-bottom-5' }) do |f| %>
   <% if @presenter.reauthn %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.present_webauthn') %>
 
-<h1 class='margin-y-0'>
-  <%= @presenter.header %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
 <div class='mt-tiny margin-bottom-4'>
   <%= @presenter.webauthn_help %>

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -7,9 +7,7 @@
     <%= render decorated_session.registration_heading %>
   </div>
 <% else %>
-  <h1 class='margin-y-0'>
-    <%= decorated_session.new_session_heading %>
-  </h1>
+  <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>
 
 <div class='sm-left-align'>

--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -1,10 +1,8 @@
 <% title t('forms.backup_code.confirm_delete') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('forms.backup_code.confirm_delete') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.backup_code.confirm_delete')) %>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -1,8 +1,6 @@
 <% title t('forms.backup_code.title') %>
 
-<h1 class="margin-y-0 margin-top-0">
-  <%= t('forms.backup_code.subtitle') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.backup_code.subtitle')) %>
 
 <%= t(
       'users.backup_code.generated_on_html',

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -1,10 +1,8 @@
 <% title t('forms.backup_code_regenerate.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('forms.backup_code_regenerate.confirm') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.backup_code_regenerate.confirm')) %>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="margin-y-0 margin-top-0"><%= @presenter.title %></h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.title) %>
 <p class="mt-tiny margin-bottom-4"><%== @presenter.description %></p>
 
 <% if @presenter.other_option_display %>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -1,7 +1,5 @@
 <% title t('titles.edit_info.phone') %>
-<h1 class="margin-y-0">
-  <%= t('headings.edit_info.phone') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.edit_info.phone')) %>
 
 <%= validated_form_for(
       @edit_phone_form,

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.edit_info.email_language') %>
 
-<h1><%= t('account.email_language.edit_title') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('account.email_language.edit_title')) %>
 
 <p class="margin-bottom-4">
   <%= t(

--- a/app/views/users/emails/confirm_delete.html.erb
+++ b/app/views/users/emails/confirm_delete.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.confirmations.delete') %>
 
-<h1 class='margin-y-0'>
-  <%= @presenter.confirm_delete_message %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.confirm_delete_message) %>
 
 <br/>
 

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -2,9 +2,7 @@
 
 <%= render 'shared/sp_alert' %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.add_email') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.add_email')) %>
 
 <div class="margin-bottom-6">
   <%= validated_form_for(

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -8,7 +8,7 @@
       ) %>
 <% end %>
 
-<h1 class="margin-top-0"><%= t('headings.verify_email') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 
 <p><%= t('notices.signed_up_and_confirmed.first_paragraph_start') %>
    <strong><%= email %></strong>

--- a/app/views/users/forget_all_browsers/show.html.erb
+++ b/app/views/users/forget_all_browsers/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('titles.forget_all_browsers')) %>
 
-<p class="margin-top-4">
+<p>
   <%= t('account.forget_all_browsers.longer_description') %>
 </p>
 

--- a/app/views/users/forget_all_browsers/show.html.erb
+++ b/app/views/users/forget_all_browsers/show.html.erb
@@ -1,8 +1,6 @@
 <%= title t('titles.forget_all_browsers') %>
 
-<h1 class="margin-y-0">
-  <%= t('titles.forget_all_browsers') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.forget_all_browsers')) %>
 
 <p class="margin-top-4">
   <%= t('account.forget_all_browsers.longer_description') %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.edit_info.password') %>
 
-<h1 class="margin-y-0">
-  <%= t('headings.edit_info.password') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.edit_info.password')) %>
 
 <p class="mt-tiny margin-bottom-0" id="password-description">
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -4,7 +4,7 @@
 
 <%= image_tag asset_url('2FA-voice.svg'), alt: '', width: 200, class: 'margin-bottom-2' %>
 
-<h1><%= t('titles.phone_setup') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.phone_setup')) %>
 
 <p>
   <%= t('two_factor_authentication.phone_info_html') %>

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -2,7 +2,7 @@
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 
-<h1><%= t('headings.add_info.phone') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.add_info.phone')) %>
 
 <p>
   <%= t('two_factor_authentication.phone_info_html') %>

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -1,8 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class="margin-y-0">
-  <%= @presenter.heading %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p class="margin-top-2 margin-bottom-2">
   <%= @presenter.description %>

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -1,6 +1,8 @@
 <% title @presenter.title %>
 
-<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
+<%= render PageHeadingComponent.new do %>
+  <%= @presenter.heading %>
+<% end %>
 
 <p class="margin-top-2 margin-bottom-2">
   <%= @presenter.description %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class='margin-y-0'><%= t('titles.piv_cac_login.add') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
 <p class='mt-tiny margin-bottom-4'><%= t('headings.piv_cac_login.add') %></p>
 
 <%= form_tag(submit_new_piv_cac_url) do %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,8 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class="margin-y-0">
-  <%= @presenter.heading %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p class="margin-top-2 margin-bottom-2">
   <%= @presenter.description %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,6 +1,8 @@
 <% title @presenter.title %>
 
-<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
+<%= render PageHeadingComponent.new do %>
+  <%= @presenter.heading %>
+<% end %>
 
 <p class="margin-top-2 margin-bottom-2">
   <%= @presenter.description %>

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -1,8 +1,6 @@
 <% title @presenter.title %>
 
-<h1 class='margin-y-0'>
-  <%= @presenter.heading %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p class='margin-top-2 margin-bottom-2'>
   <%= raw @presenter.info %>

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -1,10 +1,8 @@
 <%= title t('forms.piv_cac_delete.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('forms.piv_cac_delete.confirm') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.piv_cac_delete.confirm')) %>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -1,8 +1,6 @@
 <% title t('titles.piv_cac_login.add') %>
 
-<h1 class="margin-y-0">
-  <%= t('titles.piv_cac_login.add') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
 
 <p class="margin-top-2 margin-bottom-2">
   <%= t('headings.piv_cac_login.add') %>

--- a/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
@@ -1,9 +1,8 @@
 <% title t('headings.piv_cac_login.success') %>
 
-<%= image_tag asset_url('alert/success.svg'), width: 90 %>
+<%= image_tag asset_url('alert/success.svg'), width: 90, class: 'margin-bottom-2' %>
 
-<h1 class="margin-bottom-2 margin-top-4 margin-y-0"><%= t('headings.piv_cac_login.success') %></h1>
-<br>
+<%= render PageHeadingComponent.new.with_content(t('headings.piv_cac_login.success')) %>
 
 <%= button_to t('forms.buttons.continue'), login_add_piv_cac_success_path,
               class: 'usa-button usa-button--big usa-button--wide', method: :post %>

--- a/app/views/users/rules_of_use/new.html.erb
+++ b/app/views/users/rules_of_use/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.registrations.new') %>
 
-<h1><%= t('titles.rules_of_use') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.rules_of_use')) %>
 
 <p>
 <%= t(

--- a/app/views/users/service_provider_revoke/show.html.erb
+++ b/app/views/users/service_provider_revoke/show.html.erb
@@ -1,8 +1,6 @@
 <%= title t('titles.revoke_consent') %>
 
-<h1 class="margin-y-0">
-  <%= t('titles.revoke_consent') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('titles.revoke_consent')) %>
 
 <p class="margin-top-4">
   <%= t(

--- a/app/views/users/service_provider_revoke/show.html.erb
+++ b/app/views/users/service_provider_revoke/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('titles.revoke_consent')) %>
 
-<p class="margin-top-4">
+<p>
   <%= t(
         'account.revoke_consent.longer_description_html',
         service_provider: content_tag(:b, @service_provider.friendly_name),

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -1,10 +1,8 @@
 <%= title t('forms.totp_delete.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<h1 class="margin-bottom-1 margin-top-4 margin-y-0">
-  <%= t('forms.totp_delete.confirm') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('forms.totp_delete.confirm')) %>
 
 <div class="col-2 margin-bottom-2">
   <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -2,7 +2,7 @@
 
 <% help_link = new_window_link_to t('links.what_is_totp'),
                                   MarketingSite.help_authentication_app_url %>
-<h1 class="margin-y-0"><%= t('headings.totp_setup.new') %></h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
 <p class="mt-tiny margin-bottom-4"><%= t('forms.totp_setup.totp_intro_html', link: help_link) %></p>
 <%= validated_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <ul class="list-reset margin-bottom-0">

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -10,7 +10,7 @@
       ) %>
 <% end %>
 
-<h1 class="margin-y-0"><%= @presenter.heading %></h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p class="mt-tiny"><%== @presenter.intro %></p>
 

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -1,8 +1,6 @@
 <% title t('idv.titles.review') %>
 
-<h1>
-  <%= t('idv.titles.session.review', app_name: APP_NAME) %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.session.review', app_name: APP_NAME)) %>
 
 <p>
   <%= t('idv.messages.sessions.review_message', app_name: APP_NAME) %>

--- a/app/views/users/verify_personal_key/throttled.html.erb
+++ b/app/views/users/verify_personal_key/throttled.html.erb
@@ -1,8 +1,6 @@
 <% title t('headings.verify_personal_key') %>
 
-<h1>
-  <%= t('headings.verify_personal_key') %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify_personal_key')) %>
 
 <p>
   <%= t(

--- a/app/views/users/webauthn_setup/delete.html.erb
+++ b/app/views/users/webauthn_setup/delete.html.erb
@@ -3,12 +3,14 @@
 <% else %>
   <% title t('forms.webauthn_delete.confirm') %>
 <% end %>
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54) %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: '', width: 54, class: 'margin-bottom-2') %>
 
-<% if @webauthn.platform_authenticator %>
-  <h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t('forms.webauthn_platform_delete.confirm') %></h1>
-<% else %>
-  <h1 class="margin-bottom-1 margin-top-4 margin-y-0"><%= t('forms.webauthn_delete.confirm') %></h1>
+<%= render PageHeadingComponent.new do %>
+  <% if @webauthn.platform_authenticator %>
+    <%= t('forms.webauthn_platform_delete.confirm') %>
+  <% else %>
+    <%= t('forms.webauthn_delete.confirm') %>
+  <% end %>
 <% end %>
 
 <div class="col-2">

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,10 +1,9 @@
 <% title t('titles.totp_setup.new') %>
 
-<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1' %>
+<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2' %>
 
-<h1 class="margin-bottom-0">
-  <%= @presenter.heading %>
-</h1>
+<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
+
 <p class='mt-tiny margin-bottom-4'>
   <%= @presenter.intro %>
 </p>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -3,7 +3,7 @@ en:
   forms:
     backup_code:
       are_you_sure_continue_prologue: If you don’t have access to any other authentication method,
-      are_you_sure_desc: '<br><b>Backup codes are not very safe</b> because they can
+      are_you_sure_desc: '<b>Backup codes are not very safe</b> because they can
         easily be lost or stolen. <b>If you can, choose a different method</b>
         (use a phone, download an authentication application, or use a security
         key). <br><br><b>If you continue with backup codes, keep them

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -3,13 +3,13 @@ es:
   forms:
     backup_code:
       are_you_sure_continue_prologue: Si no tienes acceso a ningún otro método de autenticación,
-      are_you_sure_desc: '<br> <b> Los códigos de respaldo no son muy seguros </b>
-        porque se pueden perder o robar fácilmente. <b> Si peude, elija otra
-        opción </b>, (usar un teléfono, descargar una aplicación de
-        autenticación o usar una clave de seguridad). <br><br> <b> Si continúa
-        con los códigos de copia de seguridad, manténgalos seguros </b>. Le
-        daremos 10 códigos que puede descargar, imprimir, copiar o escribir. Más
-        tarde, deberás ingresar un codigo cada vez que inicies sesión.'
+      are_you_sure_desc: '<b> Los códigos de respaldo no son muy seguros </b> porque
+        se pueden perder o robar fácilmente. <b> Si peude, elija otra opción
+        </b>, (usar un teléfono, descargar una aplicación de autenticación o
+        usar una clave de seguridad). <br><br> <b> Si continúa con los códigos
+        de copia de seguridad, manténgalos seguros </b>. Le daremos 10 códigos
+        que puede descargar, imprimir, copiar o escribir. Más tarde, deberás
+        ingresar un codigo cada vez que inicies sesión.'
       are_you_sure_title: '¿Estás seguro? Le daremos códigos de respaldo para guardar y usar.'
       caution_delete: Si elimina sus códigos de respaldo, ya no podrá usarlos para
         iniciar sesión.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -3,8 +3,8 @@ fr:
   forms:
     backup_code:
       are_you_sure_continue_prologue: Si vous n’avez accès à aucune autre méthode d’authentification,
-      are_you_sure_desc: '<br><b>Les codes de sauvegarde ne sont pas très sûrs</b> car
-        ils peuvent facilement être perdus ou volés. <b> Si vous le pouvez,
+      are_you_sure_desc: '<b>Les codes de sauvegarde ne sont pas très sûrs</b> car ils
+        peuvent facilement être perdus ou volés. <b> Si vous le pouvez,
         choisissez une autre option</b> (utiliser un téléphone, télécharger une
         application d’authentification ou utiliser une clé de sécurité).
         <br><br><b>Si vous continuez à utiliser des codes de sauvegarde,

--- a/spec/components/page_heading_component_spec.rb
+++ b/spec/components/page_heading_component_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe PageHeadingComponent, type: :component do
+  let(:tag_options) { {} }
+  let(:content) { 'Heading' }
+
+  subject(:rendered) { render_inline PageHeadingComponent.new(**tag_options).with_content(content) }
+
+  it 'renders heading content' do
+    expect(rendered).to have_content(content)
+  end
+
+  it 'renders class' do
+    expect(rendered).to have_css('.page-heading')
+  end
+
+  context 'tag options' do
+    let(:tag_options) { { data: { foo: 'bar' } } }
+
+    it 'appends attributes' do
+      expect(rendered).to have_css('.page-heading[data-foo="bar"]')
+    end
+  end
+
+  context 'custom class' do
+    let(:tag_options) { { class: 'custom-class' } }
+
+    it 'appends custom class' do
+      expect(rendered).to have_css('.page-heading.custom-class')
+    end
+  end
+end


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5825#discussion_r786784694

**Why**: To avoid visual inconsistencies, to simplify and streamline developer experience, to create a single source of truth for common heading styles, and to create alignment between Rails and [React heading](https://github.com/18F/identity-idp/blob/main/app/javascript/packages/document-capture/components/page-heading.jsx) implementations.

Previously, we had a number of different heading conventions:

- `<h1>`
- `<h1 class="margin-y-0">`
- `<h1 class="margin-top-0">`
- `<h1 class="margin-bottom-2 margin-top-4 margin-y-0">` (🤯)
 
The last of these was closest to the desired, though even that only incidentally so, since it relied on browser-native `h1` `margin-bottom: 0.67em` rather than explicit `margin-bottom: 1rem`.

Replacements were largely automated using regular expression replacement:

- Pattern: `<h1(?: class=['"]margin-(?:y|top)-0['"])?>[\s\n]*<%= (.+?) %>[\s\n]*</h1>`
   - Replacement: `<%= render PageHeadingComponent.new.with_content($1) %>`
- Pattern: `<h1(?: class=['"]margin-(?:y|top)-0['"])?>[\s\n]*(\w+)[\s\n]*<\/h1>`
   - Replacement: `<%= render PageHeadingComponent.new.with_content('$1') %>`