### PR TITLE
LG-5222: follow on to fix error

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -20,20 +20,20 @@ module Idv
           @flow.analytics.track_event(
             Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
             throttle_type: :idv_resolution,
-            step_name: self.class.class_name,
+            step_name: self.class,
           )
           redirect_to idv_session_errors_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           @flow.analytics.track_event(
             Analytics::IDV_DOC_AUTH_EXCEPTION_VISITED,
-            step_name: self.class.class_name,
+            step_name: self.class,
             remaining_attempts: throttle.remaining_count,
           )
           redirect_to idv_session_errors_exception_url
         else
           @flow.analytics.track_event(
             Analytics::IDV_DOC_AUTH_WARNING_VISITED,
-            step_name: self.class.class_name,
+            step_name: self.class,
             remaining_attempts: throttle.remaining_count,
           )
           redirect_to idv_session_errors_warning_url

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -20,20 +20,20 @@ module Idv
           @flow.analytics.track_event(
             Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
             throttle_type: :idv_resolution,
-            step_name: self.class,
+            step_name: self.class.name,
           )
           redirect_to idv_session_errors_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
           @flow.analytics.track_event(
             Analytics::IDV_DOC_AUTH_EXCEPTION_VISITED,
-            step_name: self.class,
+            step_name: self.class.name,
             remaining_attempts: throttle.remaining_count,
           )
           redirect_to idv_session_errors_exception_url
         else
           @flow.analytics.track_event(
             Analytics::IDV_DOC_AUTH_WARNING_VISITED,
-            step_name: self.class,
+            step_name: self.class.name,
             remaining_attempts: throttle.remaining_count,
           )
           redirect_to idv_session_errors_warning_url

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -88,7 +88,7 @@ feature 'doc auth verify step' do
 
     expect(fake_analytics).to have_logged_event(
       'IdV: doc auth warning visited',
-      step_name: 'VerifyWaitStepShow',
+      step_name: 'Idv::Steps::VerifyWaitStepShow',
       remaining_attempts: 4,
     )
     expect(page).to have_current_path(idv_session_errors_warning_path)
@@ -109,7 +109,7 @@ feature 'doc auth verify step' do
 
     expect(fake_analytics).to have_logged_event(
       'IdV: doc auth exception visited',
-      step_name: 'VerifyWaitStepShow',
+      step_name: 'Idv::Steps::VerifyWaitStepShow',
       remaining_attempts: 5,
     )
     expect(page).to have_current_path(idv_session_errors_exception_path)
@@ -152,7 +152,7 @@ feature 'doc auth verify step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
       throttle_type: :idv_resolution,
-      step_name: Idv::Steps::VerifyWaitStepShow,
+      step_name: 'Idv::Steps::VerifyWaitStepShow',
     )
 
     travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -152,7 +152,7 @@ feature 'doc auth verify step' do
     expect(fake_analytics).to have_logged_event(
       Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,
       throttle_type: :idv_resolution,
-      step_name: Idv::Steps::VerifyWaitStepShow.class_name,
+      step_name: Idv::Steps::VerifyWaitStepShow,
     )
 
     travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do


### PR DESCRIPTION
I had used `self.class.class_name` which gives just the name of the class, without the prepended modules. Unfortunately, `class_name` is not defined on `Class` but is added in the `yard` gem which is only available in `development` and `test`. Thus it works locally, and passes CI, but does not actually work when deployed. 🤦‍♂️