### PR TITLE
LG-4792: Update webauthn MFA screen layout

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -50,8 +50,6 @@ linters:
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent|border))?'
           - '(border|bg)-(none|black|gray|silver|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
           - 'bg-(cover|contain|center|top|right|bottom|left)'
-          - 'h([013]|00)'
-          - 'h([01]|00)-responsive'
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:
           - 'js-consent-form'

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -50,7 +50,8 @@ h2,
 .h2 {
   font-size: $h2;
 }
-h3 {
+h3,
+.h3 {
   font-size: $h3;
 }
 h4,

--- a/app/views/shared/_cancel.html.erb
+++ b/app/views/shared/_cancel.html.erb
@@ -1,4 +1,4 @@
-<div class='margin-top-2 padding-top-1 border-top border-primary-light'>
+<div class='margin-top-4 padding-top-1 border-top border-primary-light'>
   <% if user_signing_up? %>
     <%= link_to cancel_link_text, sign_up_cancel_path, method: :get, class: 'usa-button usa-button--unstyled' %>
   <% else %>

--- a/app/views/shared/_fallback_links.html.erb
+++ b/app/views/shared/_fallback_links.html.erb
@@ -2,7 +2,7 @@
   <% if @presenter.help_text.present? %>
     <p><%= @presenter.help_text %></p>
   <% end %>
-  <h2 class="margin-top-4 margin-bottom-2">
+  <h2 class="margin-top-4 margin-bottom-1">
     <%= @presenter.fallback_question %>
   </h2>
   <% if @presenter.link_path %>

--- a/app/views/shared/_fallback_links.html.erb
+++ b/app/views/shared/_fallback_links.html.erb
@@ -2,7 +2,7 @@
   <% if @presenter.help_text.present? %>
     <p><%= @presenter.help_text %></p>
   <% end %>
-  <h2 class="margin-top-4 margin-bottom-1">
+  <h2 class="h3 margin-top-4 margin-bottom-1">
     <%= @presenter.fallback_question %>
   </h2>
   <% if @presenter.link_path %>

--- a/app/views/shared/_fallback_links.html.erb
+++ b/app/views/shared/_fallback_links.html.erb
@@ -1,7 +1,7 @@
-<p class='margin-top-4' id='code-instructs'>
-  <%= @presenter.help_text %>
-</p>
-<h2 class='margin-y-0'>
+<% if @presenter.help_text.present? %>
+  <p><%= @presenter.help_text %></p>
+<% end %>
+<h2 class="margin-top-4 margin-bottom-2">
   <%= @presenter.fallback_question %>
 </h2>
 <% if @presenter.link_path %>

--- a/app/views/shared/_fallback_links.html.erb
+++ b/app/views/shared/_fallback_links.html.erb
@@ -1,10 +1,11 @@
-<% if @presenter.help_text.present? %>
-  <p><%= @presenter.help_text %></p>
-<% end %>
-<h2 class="margin-top-4 margin-bottom-2">
-  <%= @presenter.fallback_question %>
-</h2>
-<% if @presenter.link_path %>
-  <%= link_to(@presenter.link_text, @presenter.link_path) %>
-<% end %>
-<br>
+<div class="margin-top-5">
+  <% if @presenter.help_text.present? %>
+    <p><%= @presenter.help_text %></p>
+  <% end %>
+  <h2 class="margin-top-4 margin-bottom-2">
+    <%= @presenter.fallback_question %>
+  </h2>
+  <% if @presenter.link_path %>
+    <%= link_to(@presenter.link_text, @presenter.link_path) %>
+  <% end %>
+</div>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -2,9 +2,9 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
-<div class='mt-tiny margin-bottom-4'>
+<p>
   <%= @presenter.webauthn_help %>
-</div>
+</p>
 
 <%= simple_form_for(
       '',
@@ -23,21 +23,21 @@
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
 
   <%= content_tag :div, id: 'webauthn-auth-in-progress', data: { webauthn_not_enabled_url: login_two_factor_options_path } do %>
-    <div class="spinner hidden" id="spinner">
-      <div class="col-12 center margin-bottom-2">
-        <%= image_tag(
-              asset_url('spinner.gif'),
-              srcset: asset_url('spinner@2x.gif'),
-              height: 144,
-              width: 144,
-              alt: '',
-            ) %>
-      </div>
+    <div class="hidden spinner center margin-bottom-4" id="spinner">
+      <%= image_tag(
+            asset_url('spinner.gif'),
+            srcset: asset_url('spinner@2x.gif'),
+            height: 144,
+            width: 144,
+            alt: '',
+          ) %>
     </div>
-    <p class="half-center">
-      <span class="h2"><%= @presenter.login_text %></span>
-      <input type="button" id="webauthn-button" class="margin-top-2 usa-button usa-button--big usa-button--wide" value="<%= @presenter.authenticate_button_text %>">
+    <p class="text-bold">
+      <%= @presenter.login_text %>
     </p>
+    <button type="button" id="webauthn-button" class="display-block margin-y-4 usa-button usa-button--big usa-button--wide">
+      <%= @presenter.authenticate_button_text %>
+    </button>
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>
 
@@ -67,7 +67,7 @@
           },
         ) %>
     <%= submit_tag t('forms.buttons.continue'),
-                   class: 'usa-button usa-button--big usa-button--wide margin-y-4' %>
+                   class: 'display-block usa-button usa-button--big usa-button--wide margin-y-4' %>
   </div>
 <% end %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -35,7 +35,7 @@
     <p class="text-bold">
       <%= @presenter.login_text %>
     </p>
-    <button type="button" id="webauthn-button" class="display-block margin-y-4 usa-button usa-button--big usa-button--wide">
+    <button type="button" id="webauthn-button" class="display-block margin-y-3 usa-button usa-button--big usa-button--wide">
       <%= @presenter.authenticate_button_text %>
     </button>
     <%= render 'shared/fallback_links', presenter: @presenter %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -128,7 +128,7 @@ en:
       instructions_text: Use Touch or Face Unlock to access your account with %{app_name}
       instructions_title: Use Touch or Face Unlock to access your account.
       intro: Use Touch or Face Unlock to access your account.
-      login_text: When you are ready, press the button.
+      login_text: 'When you are ready, press the button:'
       nickname: Device nickname
     webauthn_setup:
       continue: Continue
@@ -137,5 +137,5 @@ en:
       intro: Add a security key that meets the FIDO standard as your authentication
         method. You can add as many security keys as you want. To get started,
         first give your security key a nickname.
-      login_text: When you are ready to authenticate, press the button
+      login_text: 'When you are ready to authenticate, press the button:'
       nickname: Security key nickname

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -137,7 +137,7 @@ es:
         con %{app_name}.
       instructions_title: Use el desbloqueo facial o táctil para acceder a su cuenta.
       intro: Use el desbloqueo facial o táctil para acceder a su cuenta.
-      login_text: Cuando esté listo, presione el botón.
+      login_text: 'Cuando esté listo, presione el botón:'
       nickname: Apodo de dispositivo.
     webauthn_setup:
       continue: Continuar
@@ -147,5 +147,5 @@ es:
       intro: Añada una clave de seguridad que cumpla el estándar FIDO como método de
         autenticación. Puede añadir tantas claves de seguridad como desee. Para
         empezar, primero asigne un apodo a su clave de seguridad.
-      login_text: Cuando esté listo para autenticarse, presione el botón
+      login_text: 'Cuando esté listo para autenticarse, presione el botón:'
       nickname: Apodo clave de seguridad

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -142,7 +142,7 @@ fr:
         déverouillage facial pour accéder à votre compte.
       intro: Utilisez le déverrouillage par empreinte digitale ou le déverouillage
         facial pour accéder à votre compte.
-      login_text: Lorsque vous êtes prêt, appuyez sur le bouton.
+      login_text: 'Lorsque vous êtes prêt, appuyez sur le bouton:'
       nickname: Pseudo dispositivo
     webauthn_setup:
       continue: Continuer
@@ -153,5 +153,5 @@ fr:
         d’authentification. Vous pouvez ajouter autant de clés de sécurité que
         vous le souhaitez. Pour commencer, donnez d’abord un surnom à votre clé
         de sécurité.
-      login_text: Lorsque vous êtes prêt à vous authentifier, appuyez sur le bouton
+      login_text: 'Lorsque vous êtes prêt à vous authentifier, appuyez sur le bouton:'
       nickname: Pseudo clé de sécurité


### PR DESCRIPTION
**Why**: In anticipation of upcoming font change to Public Sans, this pull request updates typography and layout of the webauthn MFA screen based on Figma guidance included in the associated ticket.

~_Draft while I confirm revisions to shared partials like "Fallback Links" and "Cancel" on other screens._~

State|Before|After
---|---|---
Initial|![Screen Shot 2022-01-21 at 4 08 59 PM](https://user-images.githubusercontent.com/1779930/150600560-41b02990-a815-42ac-a335-063347dc258b.png)|![image](https://user-images.githubusercontent.com/1779930/150601033-25abdc58-4bc1-4848-937d-f81e71f39536.png)
Authenticating|![Screen Shot 2022-01-21 at 4 09 05 PM](https://user-images.githubusercontent.com/1779930/150600567-f6408451-4e39-4527-8030-33a591150175.png)|![image](https://user-images.githubusercontent.com/1779930/150601045-de8342c8-5bac-4b83-8aac-3882f97f47f2.png)

(Note: For clarity, the "After" screenshots artificially include revisions that would be applied as part of #5840)