### PR TITLE
Properly specify schemes in the CSP

### DIFF
--- a/app/services/secure_headers_allow_list.rb
+++ b/app/services/secure_headers_allow_list.rb
@@ -48,6 +48,6 @@ class SecureHeadersAllowList
   end
 
   def self.reduce_native_app_sp_uri(uri)
-    "#{uri.scheme}://"
+    "#{uri.scheme}:"
   end
 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1214,7 +1214,7 @@ describe SamlIdpController do
 
       it 'sets correct CSP config that includes any custom app scheme uri from SP redirect_uris' do
         form_action = response.request.headers.env['secure_headers_request_config'].csp.form_action
-        csp_array = ["'self'", 'http://localhost:3000', 'x-example-app://']
+        csp_array = ["'self'", 'http://localhost:3000', 'x-example-app:']
         expect(form_action).to match_array(csp_array)
       end
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -151,7 +151,7 @@ describe 'OpenID Connect' do
     )
 
     expect(page.response_headers['Content-Security-Policy']).to include(
-      'form-action \'self\' gov.gsa.openidconnect.test://',
+      'form-action \'self\' gov.gsa.openidconnect.test:',
     )
 
     visit account_path

--- a/spec/services/secure_headers_allow_list_spec.rb
+++ b/spec/services/secure_headers_allow_list_spec.rb
@@ -6,21 +6,6 @@ RSpec.describe SecureHeadersAllowList do
       SecureHeadersAllowList.csp_with_sp_redirect_uris(domain, sp_redirect_uris)
     end
 
-    it 'generates the proper CSP array from action_url domain and ServiceProvider#redirect_uris' do
-      aggregate_failures do
-        domain = 'https://example1.com'
-        test_sp_uris = ['x-example-app://test', 'https://example2.com']
-        full_return = ["'self'", 'https://example1.com', 'x-example-app://', 'https://example2.com']
-
-        expect(csp_with_sp_redirect_uris(domain, test_sp_uris)).to eq(full_return)
-
-        expect(csp_with_sp_redirect_uris(domain, test_sp_uris[0..0])).to eq(full_return[0..2])
-
-        expect(csp_with_sp_redirect_uris(domain, [])).to eq(full_return[0..1])
-        expect(csp_with_sp_redirect_uris(domain, nil)).to eq(full_return[0..1])
-      end
-    end
-
     it 'properly reduces web uris' do
       redirect_uri = 'https://example1.com/auth/result'
       allowed_redirect_uris = [
@@ -49,7 +34,7 @@ RSpec.describe SecureHeadersAllowList do
       result = csp_with_sp_redirect_uris(redirect_uri, allowed_redirect_uris)
 
       expect(result).to match_array(
-        ["'self'", 'mymobileapp://', 'myothermobileapp://', 'https://example.com'],
+        ["'self'", 'mymobileapp:', 'myothermobileapp:', 'https://example.com'],
       )
     end
 


### PR DESCRIPTION
**Why**: Schemes are meant to be rendered with a colon and no slashes, e.g. `http:` instead of `http://`