### PR TITLE
Add additional metadata to SAML Auth event

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -101,6 +101,7 @@ class SamlIdpController < ApplicationController
       endpoint: remap_auth_post_path(request.env['PATH_INFO']),
       idv: identity_needs_verification?,
       finish_profile: profile_needs_verification?,
+      requested_ial: saml_request&.requested_ial_authn_context || 'none',
     )
     analytics.track_event(Analytics::SAML_AUTH, analytics_payload)
   end

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -22,6 +22,7 @@ class SamlRequestValidator
     {
       nameid_format: nameid_format,
       authn_context: authn_context,
+      authn_context_comparison: authn_context_comparison,
       service_provider: service_provider&.issuer,
     }
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -518,6 +518,8 @@ describe SamlIdpController do
                errors: {},
                nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
                authn_context: ['http://idmanagement.gov/ns/assurance/ial/2'],
+               authn_context_comparison: 'exact',
+               requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                service_provider: sp1_issuer,
                endpoint: '/api/saml/auth2022',
                idv: false,
@@ -588,6 +590,7 @@ describe SamlIdpController do
           error_details: { authn_context: [:unauthorized_authn_context] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
+          authn_context_comparison: 'exact',
           service_provider: 'http://localhost:3000',
         }
 
@@ -697,6 +700,7 @@ describe SamlIdpController do
           error_details: { service_provider: [:unauthorized_service_provider] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
           service_provider: nil,
         }
 
@@ -739,6 +743,7 @@ describe SamlIdpController do
           },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
+          authn_context_comparison: 'exact',
           service_provider: nil,
         }
 
@@ -942,6 +947,44 @@ describe SamlIdpController do
       end
     end
 
+    context 'no IAL explicitly requested' do
+      let(:user) { create(:user, :signed_up) }
+
+      before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
+
+      it 'notes that in the analytics event' do
+        auth_settings = saml_settings(
+          overrides: { authn_context: [
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          ]},
+        )
+        IdentityLinker.new(user, auth_settings.issuer).link_identity
+        user.identities.last.update!(verified_attributes: ['email'])
+        generate_saml_response(user, auth_settings)
+
+        expect(response.status).to eq(200)
+
+        analytics_hash = {
+          success: true,
+          errors: {},
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          authn_context: [Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF],
+          authn_context_comparison: 'exact',
+          requested_ial: 'none',
+          service_provider: 'http://localhost:3000',
+          endpoint: '/api/saml/auth2022',
+          idv: false,
+          finish_profile: false,
+        }
+
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::SAML_AUTH, analytics_hash)
+      end
+    end
+
     context 'nameid_format is missing' do
       let(:user) { create(:user, :signed_up) }
 
@@ -963,6 +1006,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -994,6 +1039,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: auth_settings.issuer,
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -1025,6 +1072,7 @@ describe SamlIdpController do
           error_details: { nameid_format: [:unauthorized_nameid_format] },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
           service_provider: 'http://localhost:3000',
         }
 
@@ -1059,6 +1107,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -1087,6 +1137,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: auth_settings.issuer,
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -1115,6 +1167,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -1593,6 +1647,8 @@ describe SamlIdpController do
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           ],
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: true,
@@ -1629,6 +1685,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: false,
@@ -1659,6 +1717,8 @@ describe SamlIdpController do
           errors: {},
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           endpoint: '/api/saml/auth2022',
           idv: false,

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -11,6 +11,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
 
         response = SamlRequestValidator.new.call(
@@ -36,6 +37,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp&.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           service_provider: [t('errors.messages.unauthorized_service_provider')],
@@ -65,6 +67,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],
@@ -95,6 +98,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
 
         response = SamlRequestValidator.new.call(
@@ -120,6 +124,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
 
         response = SamlRequestValidator.new.call(
@@ -147,6 +152,7 @@ describe SamlRequestValidator do
             authn_context: authn_context,
             service_provider: sp.issuer,
             nameid_format: name_id_format,
+            authn_context_comparison: 'minimum',
           }
 
           response = SamlRequestValidator.new.call(
@@ -174,6 +180,7 @@ describe SamlRequestValidator do
             authn_context: authn_context,
             service_provider: sp.issuer,
             nameid_format: name_id_format,
+            authn_context_comparison: 'better',
           }
 
           response = SamlRequestValidator.new.call(
@@ -202,6 +209,7 @@ describe SamlRequestValidator do
             authn_context: authn_context,
             service_provider: sp.issuer,
             nameid_format: name_id_format,
+            authn_context_comparison: 'exact',
           }
           errors = {
             authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -232,6 +240,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -260,6 +269,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -289,6 +299,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp&.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -319,6 +330,7 @@ describe SamlRequestValidator do
           authn_context: authn_context,
           service_provider: sp.issuer,
           nameid_format: name_id_format,
+          authn_context_comparison: 'exact',
         }
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],


### PR DESCRIPTION
**Why:** Because we want to ensure that partners won't run into issues
when we launch the IALMAX implementation using the Comparison attribute
of the RequestedAuthnContext element in the auth request (#5652). This will
allow us to analyze how partners are sending us their SAML requests and
can also be used for troubleshooting in the future.