### PR TITLE
Enable Rubocop Layout/SpaceInsideHashLiteralBraces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -305,6 +305,9 @@ Layout/SpaceInLambdaLiteral:
 Layout/SpaceInsideBlockBraces:
   Enabled: true
 
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
 Layout/SpaceInsideParens:
   Enabled: true
 

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -55,7 +55,7 @@ module Reports
     end
 
     def track_report_data_event(event, hash = {})
-      write_hash_to_reports_log({name: event, time: Time.zone.now.iso8601}.merge(hash))
+      write_hash_to_reports_log({ name: event, time: Time.zone.now.iso8601 }.merge(hash))
     end
 
     def write_hash_to_reports_log(log_hash)

--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -41,7 +41,7 @@ module DocAuth
       'Issue Date Valid': { type: ID, msg_key: Errors::ISSUE_DATE_CHECKS },
       'Layout Valid': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
       'Near-Infrared Response': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
-      'Photo Printing': {type: FRONT, msg_key: Errors::VISIBLE_PHOTO_CHECK },
+      'Photo Printing': { type: FRONT, msg_key: Errors::VISIBLE_PHOTO_CHECK },
       'Physical Document Presence': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
       'Sex Crosscheck': { type: ID, msg_key: Errors::SEX_CHECK },
       'Visible Color Response': { type: ID, msg_key: Errors::VISIBLE_COLOR_CHECK },

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -14,7 +14,7 @@
 <div class="margin-top-4 margin-bottom-4">
   <%= validated_form_for(
         :idv_form, url: idv_address_path, method: 'POST',
-                   html: {autocomplete: 'off', class: 'margin-top-2'}
+                   html: { autocomplete: 'off', class: 'margin-top-2' }
       ) do |f| %>
     <div class="margin-bottom-4">
       <%= f.input :address1,  label: t('idv.form.address1'), wrapper: false,

--- a/app/views/shared/_dap_analytics.html.erb
+++ b/app/views/shared/_dap_analytics.html.erb
@@ -1,4 +1,4 @@
 <!-- <%= t('notices.dap_participation') %> -->
 <% dap_source = 'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS' %>
-<%= nonced_javascript_tag({src: dap_source, async: true, id: '_fed_an_ua_tag'}) do %>
+<%= nonced_javascript_tag({ src: dap_source, async: true, id: '_fed_an_ua_tag' }) do %>
 <% end %>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -3,7 +3,7 @@
 
 <%= validated_form_for(
       @edit_phone_form,
-      html: {autocomplete: 'off', method: :put},
+      html: { autocomplete: 'off', method: :put },
       url: manage_phone_path(id: @phone_configuration.id),
     ) do |f| %>
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -127,7 +127,7 @@ describe Idv::DocAuthController do
         pii_like_keypaths: [[:errors, :ssn], [:error_details, :ssn]],
       }
 
-      put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
+      put :update, params: { step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
 
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} ssn submitted".downcase, result
@@ -146,8 +146,8 @@ describe Idv::DocAuthController do
         pii_like_keypaths: [[:errors, :ssn], [:error_details, :ssn]],
       }
 
-      put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '666-66-6666' } }
-      put :update, params: {step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
+      put :update, params: { step: 'ssn', doc_auth: { step: 'ssn', ssn: '666-66-6666' } }
+      put :update, params: { step: 'ssn', doc_auth: { step: 'ssn', ssn: '111-11-1111' } }
 
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} ssn submitted".downcase,

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe Idv::GpoVerifyController do
         expect(@analytics).to receive(:track_event).with(
           Analytics::IDV_GPO_VERIFICATION_SUBMITTED,
           success: false,
-          errors: { otp: [t('errors.messages.confirmation_code_incorrect')]},
-          error_details: { otp: [:confirmation_code_incorrect]},
+          errors: { otp: [t('errors.messages.confirmation_code_incorrect')] },
+          error_details: { otp: [:confirmation_code_incorrect] },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
 
@@ -141,8 +141,8 @@ RSpec.describe Idv::GpoVerifyController do
         expect(@analytics).to receive(:track_event).with(
           Analytics::IDV_GPO_VERIFICATION_SUBMITTED,
           success: false,
-          errors: { otp: [t('errors.messages.confirmation_code_incorrect')]},
-          error_details: { otp: [:confirmation_code_incorrect]},
+          errors: { otp: [t('errors.messages.confirmation_code_incorrect')] },
+          error_details: { otp: [:confirmation_code_incorrect] },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         ).exactly(max_attempts).times
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -959,7 +959,7 @@ describe SamlIdpController do
         auth_settings = saml_settings(
           overrides: { authn_context: [
             Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-          ]},
+          ] },
         )
         IdentityLinker.new(user, auth_settings.issuer).link_identity
         user.identities.last.update!(verified_attributes: ['email'])

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -45,7 +45,7 @@ describe UserPivCacVerificationForm do
           result = instance_double(FormResponse)
 
           expect(FormResponse).to receive(:new).
-            with(success: false, errors: { type: 'user.piv_cac_mismatch'},
+            with(success: false, errors: { type: 'user.piv_cac_mismatch' },
                  extra: { multi_factor_auth_method: 'piv_cac',
                           piv_cac_configuration_id: nil,
                           key_id: nil }).and_return(result)
@@ -63,7 +63,7 @@ describe UserPivCacVerificationForm do
 
           expect(FormResponse).to receive(:new).
             with(success: true, errors: {}, extra: { multi_factor_auth_method: 'piv_cac',
-                                                     piv_cac_configuration_id: nil}).
+                                                     piv_cac_configuration_id: nil }).
             and_return(result)
           expect(form.submit).to eq result
         end
@@ -117,7 +117,7 @@ describe UserPivCacVerificationForm do
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: { multi_factor_auth_method: 'piv_cac',
-                                                    piv_cac_configuration_id: nil}).
+                                                    piv_cac_configuration_id: nil }).
           and_return(result)
         expect(Event).to_not receive(:create)
         expect(form.submit).to eq result

--- a/spec/services/doc_auth/error_generator_spec.rb
+++ b/spec/services/doc_auth/error_generator_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe DocAuth::ErrorGenerator do
       error_info = build_error_info(
         doc_result: 'Failed',
         failed: [
-          {name: '2D Barcode Read', result: 'Attention'},
-          {name: 'Visible Pattern', result: 'Failed'},
+          { name: '2D Barcode Read', result: 'Attention' },
+          { name: 'Visible Pattern', result: 'Failed' },
         ],
       )
 
@@ -99,8 +99,8 @@ RSpec.describe DocAuth::ErrorGenerator do
       error_info = build_error_info(
         doc_result: 'Failed',
         failed: [
-          {name: 'Expiration Date Valid', result: 'Attention'},
-          {name: 'Full Name Crosscheck', result: 'Failed'},
+          { name: 'Expiration Date Valid', result: 'Attention' },
+          { name: 'Full Name Crosscheck', result: 'Failed' },
         ],
       )
 
@@ -117,8 +117,8 @@ RSpec.describe DocAuth::ErrorGenerator do
       error_info = build_error_info(
         doc_result: 'Failed',
         failed: [
-          {name: 'Photo Printing', result: 'Attention'},
-          {name: 'Visible Photo Characteristics', result: 'Failed'},
+          { name: 'Photo Printing', result: 'Attention' },
+          { name: 'Visible Photo Characteristics', result: 'Failed' },
         ],
       )
 
@@ -134,8 +134,8 @@ RSpec.describe DocAuth::ErrorGenerator do
       error_info = build_error_info(
         doc_result: 'Failed',
         failed: [
-          {name: '2D Barcode Read', result: 'Attention'},
-          {name: '2D Barcode Content', result: 'Failed'},
+          { name: '2D Barcode Read', result: 'Attention' },
+          { name: '2D Barcode Content', result: 'Failed' },
         ],
       )
 

--- a/spec/services/encrypted_redis_struct_storage_spec.rb
+++ b/spec/services/encrypted_redis_struct_storage_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe EncryptedRedisStructStorage do
 
         it 'converts the data and stores it' do
           EncryptedRedisStructStorage.store(
-            struct_class.new(id: id, a: { some: { nested: [data] }}),
+            struct_class.new(id: id, a: { some: { nested: [data] } }),
           )
 
           loaded = EncryptedRedisStructStorage.load(id, type: struct_class)

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -119,7 +119,7 @@ describe 'idv/shared/_error.html.erb' do
     end
 
     context 'with options' do
-      let(:options) { [{text: 'Example', url: '#example'}] }
+      let(:options) { [{ text: 'Example', url: '#example' }] }
 
       it 'renders a list of troubleshooting options' do
         expect(rendered).to have_link('Example', href: '#example')


### PR DESCRIPTION
**Why:** Because it's conventional already, it keeps our code consistent and readable, and it matches other similar rule configurations (`Layout/SpaceInsideBlockBraces`, `Layout/SpaceInsideParens`).

Docs: https://docs.rubocop.org/rubocop/cops_layout.html#layoutspaceinsidehashliteralbraces