### PR TITLE
LG-4792: Split "Use another phone number" to newline

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -252,7 +252,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
       otp_delivery_preference: two_factor_authentication_method,
       otp_make_default_number: selected_otp_make_default_number,
       voice_otp_delivery_unsupported: voice_otp_delivery_unsupported?,
-      reenter_phone_number_path: reenter_phone_number_path,
       unconfirmed_phone: unconfirmed_phone?,
       account_reset_token: account_reset_token }.merge(generic_data)
   end
@@ -299,11 +298,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
   def decorated_user
     current_user.decorate
-  end
-
-  def reenter_phone_number_path
-    locale = LinkLocaleResolver.locale
-    phone_setup_path(locale: locale)
   end
 
   def confirmation_for_add_phone?

--- a/app/presenters/idv/otp_verification_presenter.rb
+++ b/app/presenters/idv/otp_verification_presenter.rb
@@ -18,14 +18,6 @@ module Idv
       )
     end
 
-    def update_phone_link
-      phone_path = Rails.application.routes.url_helpers.idv_phone_path(
-        step: 'phone_otp_verification',
-      )
-      link = link_to(t('forms.two_factor.try_again'), phone_path)
-      t('instructions.mfa.wrong_number_html', link: link)
-    end
-
     private
 
     def phone_number

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -1,8 +1,8 @@
 module TwoFactorAuthCode
   class PhoneDeliveryPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
-    attr_reader(
-      :otp_delivery_preference, :otp_make_default_number
-    )
+    attr_reader :otp_delivery_preference, :otp_make_default_number, :unconfirmed_phone
+
+    alias_method :unconfirmed_phone?, :unconfirmed_phone
 
     def header
       t('two_factor_authentication.header_text')
@@ -24,12 +24,6 @@ module TwoFactorAuthCode
       ''
     end
 
-    def update_phone_link
-      return unless unconfirmed_phone
-      link = view.link_to(t('forms.two_factor.try_again'), reenter_phone_number_path)
-      t('instructions.mfa.wrong_number_html', link: link)
-    end
-
     def cancel_link
       locale = LinkLocaleResolver.locale
       if confirmation_for_add_phone || reauthn
@@ -42,9 +36,7 @@ module TwoFactorAuthCode
     private
 
     attr_reader(
-      :reenter_phone_number_path,
       :phone_number,
-      :unconfirmed_phone,
       :account_reset_token,
       :confirmation_for_add_phone,
       :voice_otp_delivery_unsupported,

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -38,12 +38,13 @@
 
 <%= button_to idv_resend_otp_path,
               method: :post,
-              class: 'usa-button usa-button--outline ico ico-refresh' do %>
+              class: 'usa-button usa-button--outline ico ico-refresh margin-bottom-4' do %>
   <%= t('links.two_factor_authentication.get_another_code') %>
 <% end %>
 
-<p class="margin-top-6">
-  <%= @presenter.update_phone_link %>
+<p>
+  <%= t('instructions.mfa.wrong_number') %><br>
+  <%= link_to(t('forms.two_factor.try_again'), idv_phone_path(step: 'phone_otp_verification')) %>
 </p>
 
 <%= render 'idv/doc_auth/start_over_or_cancel', step: 'phone_otp_verification' %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -44,13 +44,13 @@
             resend: true,
           },
         ),
-        class: 'usa-button usa-button--outline ico ico-refresh',
+        class: 'usa-button usa-button--outline ico ico-refresh margin-bottom-4',
       ) %>
 <% end %>
 
-<% if @presenter.update_phone_link.present? %>
-  <br />
-  <%= @presenter.update_phone_link %>
+<% if @presenter.unconfirmed_phone? %>
+  <%= t('instructions.mfa.wrong_number') %><br>
+  <%= link_to(t('forms.two_factor.try_again'), phone_setup_path) %>
 <% else %>
   <%= render 'shared/fallback_links', presenter: @presenter %>
 <% end %>

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -82,7 +82,7 @@ en:
           security key or government employee ID (PIV or CAC) to access your
           information.
         confirm_webauthn_platform_html: You have Face or Touch Unlock enabled for your %{app_name} account.
-      wrong_number_html: Entered the wrong phone number? %{link}
+      wrong_number: Entered the wrong phone number?
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.
       help_text: The longer and more unusual the password, the harder it is to guess.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -87,7 +87,7 @@ es:
           (PIV o CAC) para acceder a su información.
         confirm_webauthn_platform_html: Tiene activado el desbloqueo facial o táctil
           para su cuenta de %{app_name}.
-      wrong_number_html: '¿Ingresó el número de teléfono equivocado? %{link}'
+      wrong_number: ¿Ingresó el número de teléfono equivocado?
     password:
       forgot: '¿No sabe su contraseña? Restablézcala después de confirmar su email.'
       help_text: Cuanto más larga y más inusual sea la contraseña, más difícil es de

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -96,7 +96,7 @@ fr:
           du gouvernement (PIV ou CAC) pour accéder à vos informations.
         confirm_webauthn_platform_html: Vous avez activé le déverrouillage facial ou
           tactile pour votre compte %{app_name}.
-      wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
+      wrong_number: Vous avez entré un mauvais numéro de téléphone?
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir
         confirmé votre adresse courriel.

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -10,7 +10,6 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       phone_number: '5555559876',
       code_value: '999999',
       otp_delivery_preference: 'sms',
-      reenter_phone_number_path: '/manage/phone',
       unconfirmed_phone: true,
       totp_enabled: false,
       personal_key_unavailable: true,

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -7,7 +7,6 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
       phone_number: '***-***-1212',
       code_value: '12777',
       unconfirmed_user: false,
-      reenter_phone_number_path: phone_setup_path,
     }
   end
 


### PR DESCRIPTION
**Why**: Typographical and margin improvements ahead of switch to Public Sans font. Also serves as a general simplification and avoids unnecessary HTML interpolation to locale strings.

**Screenshots:**

Screen|Before|After
---|---|---
Add Phone|![localhost_3000_login_two_factor_sms_otp_make_default_number=false reauthn=false (1)](https://user-images.githubusercontent.com/1779930/150863468-35616dd6-821d-4051-811c-65f410a832cd.png)|![localhost_3000_login_two_factor_sms_otp_make_default_number=false reauthn=false](https://user-images.githubusercontent.com/1779930/150863469-e88e7bc3-a1eb-437a-83cc-98d726cd0207.png)
IAL2 Phone|![localhost_3000_verify_phone_confirmation (1)](https://user-images.githubusercontent.com/1779930/150863470-08573f6b-8252-46ac-a843-7db90612f60b.png)|![localhost_3000_verify_phone_confirmation](https://user-images.githubusercontent.com/1779930/150863472-9aa42a5b-4c2e-4bd8-9cf5-c12ec1f7b6c9.png)
