### PR TITLE
Fix CSP for Rails mailer previews

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -47,7 +47,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   default_csp_config[:script_src] = ["'self'", "'unsafe-eval'"] if !Rails.env.production?
 
   if IdentityConfig.store.rails_mailer_previews_enabled
-    default_csp_config[:style_src] = ["'self'", "'unsafe-inline'"]
+    default_csp_config[:style_src] << "'unsafe-inline'"
   end
 
   config.csp = default_csp_config

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -46,6 +46,10 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
 
   default_csp_config[:script_src] = ["'self'", "'unsafe-eval'"] if !Rails.env.production?
 
+  if IdentityConfig.store.rails_mailer_previews_enabled
+    default_csp_config[:style_src] = ["'self'", "'unsafe-inline'"]
+  end
+
   config.csp = default_csp_config
 
   if ENV['WEBPACK_PORT']


### PR DESCRIPTION
Re: https://github.com/18F/identity-idp/pull/5844#issuecomment-1020297806

The Rails mailer previews use inline CSS style, so we need to allow them in order to have previews work. Would be nice if we could scope these changes to certain URLs, but this works for now:

| before | after |
| --- | --- |
| <img width="590" alt="Screen Shot 2022-01-24 at 12 56 04 PM" src="https://user-images.githubusercontent.com/458784/150863624-a43085c6-b6e5-46da-9fa2-9696a724d941.png"> | <img width="590" alt="Screen Shot 2022-01-24 at 12 53 45 PM" src="https://user-images.githubusercontent.com/458784/150863654-1a052c42-04fd-460f-8736-7e075f1c4821.png"> |
| <img width="590" alt="Screen Shot 2022-01-24 at 12 56 14 PM" src="https://user-images.githubusercontent.com/458784/150863676-1e42dfbd-9625-4aef-9bc4-3fa028ef817b.png"> | <img width="1220" alt="Screen Shot 2022-01-24 at 12 54 38 PM" src="https://user-images.githubusercontent.com/458784/150863721-37e5966a-98fd-4682-91d1-83ed347c6f04.png"> |



