### PR TITLE
Fix HTTP host binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt: ## Self-signed cert for local H
 		-out tmp/$(HOST)-$(PORT).crt
 
 run: ## Runs the development server
-	foreman start -p $(PORT)
+	FOREMAN_HOST=$(HOST) foreman start -p $(PORT)
 
 run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the development server with HTTPS
 	HTTPS=on FOREMAN_HOST="ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt" foreman start -p $(PORT)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt: ## Self-signed cert for local H
 		-out tmp/$(HOST)-$(PORT).crt
 
 run: ## Runs the development server
-	FOREMAN_HOST=$(HOST) foreman start -p $(PORT)
+	foreman start -p $(PORT)
 
 run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the development server with HTTPS
 	HTTPS=on FOREMAN_HOST="ssl://$(HOST):$(PORT)?key=tmp/$(HOST)-$(PORT).key&cert=tmp/$(HOST)-$(PORT).crt" foreman start -p $(PORT)

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-localhost}
+web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-${HOST:-localhost}}
 worker: bundle exec good_job start
 mailcatcher: mailcatcher -f
 js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack $([ -n "$HTTPS" ] && echo "--watch" || echo "serve") 


### PR DESCRIPTION
Regression of #5835

**Why**: So that a developer can follow the instructions for accessing the IdP across a network as documented.

Documentation: https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine

Observed by @peggles2 in Slack conversation: https://gsa-tts.slack.com/archives/C01710KMYUB/p1643133502021400?thread_ts=1643129805.019900&cid=C01710KMYUB

Issue is that #5835 uses a different environment variable for Foreman host binding, so that `run-https` target can specify a `ssl:` scheme host. This wasn't accounted for in the normal `make run` workflow, which was still expecting to be able to pass the `HOST` environment variable.