### PR TITLE
LG-4792: Update "Delete Account" confirmation page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Unreleased
 -----------
 
 ### Improvements/Changes
+- Layout: The "Delete Account" confirmation page has a new layout consistent with other content pages. (#5857)
 
 ### Accessibility
 
 ### Bug Fixes Users Might Notice
-- Layout: The "Delete Account" confirmation page has a new layout consistent with other content pages. (#5857)
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 ### Accessibility
 
 ### Bug Fixes Users Might Notice
+- Layout: The "Delete Account" confirmation page has a new layout consistent with other content pages. (#5857)
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -1,34 +1,44 @@
 <% title t('titles.confirmations.delete') %>
 
-<div class="padding-0 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
-  <h1 class="margin-y-2 fs-20p sans-serif regular center">
-    <%= t('users.delete.heading') %>
-  </h1>
-  <hr class="margin-bottom-4 border-width-05" />
-  <div class="margin-bottom-1 bold">
-    <%= t('users.delete.subheading') %>
-  </div>
-  <ul class="padding-x-2">
-    <li class="margin-bottom-1"><%= t('users.delete.bullet_1', app_name: APP_NAME) %></li>
-    <li class="margin-bottom-1"><%= current_user.decorate.delete_account_bullet_key %></li>
-    <li class="margin-bottom-1"><%= t('users.delete.bullet_3', app_name: APP_NAME) %></li>
-    <li class="margin-bottom-1"><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
-  </ul>
-  <%= validated_form_for(
-        current_user, url: account_delete_path,
-                      html: { autocomplete: 'off', method: :post }
-      ) do |f| %>
-    <div class="margin-bottom-4">
-      <%= t('users.delete.instructions') %>
-    </div>
-    <%= f.input :password, label: t('idv.form.password'), required: true,
-                           input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
-    <%= f.button :submit,
-                 t('users.delete.actions.delete'),
-                 class: 'usa-button--big usa-button--full-width margin-bottom-2' %>
-  <% end %>
+<%= render PageHeadingComponent.new.with_content(t('users.delete.heading')) %>
 
-  <%= link_to t('users.delete.actions.cancel'), account_path,
-              role: 'button',
-              class: 'usa-button usa-button--big usa-button--full-width usa-button--outline' %>
-</div>
+<p class="margin-bottom-1">
+  <%= t('users.delete.subheading') %>
+</p>
+
+<ul>
+  <li class="margin-bottom-1"><%= t('users.delete.bullet_1', app_name: APP_NAME) %></li>
+  <li class="margin-bottom-1"><%= current_user.decorate.delete_account_bullet_key %></li>
+  <li class="margin-bottom-1"><%= t('users.delete.bullet_3', app_name: APP_NAME) %></li>
+  <li class="margin-bottom-1"><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
+</ul>
+
+<%= simple_form_for(
+      current_user,
+      url: account_delete_path,
+      html: { autocomplete: 'off', method: :post },
+    ) do |f| %>
+  <p class="margin-bottom-4">
+    <%= t('users.delete.instructions') %>
+  </p>
+
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :password,
+        label: t('idv.form.password'),
+        required: true,
+        input_html: { class: 'password-toggle' },
+      ) %>
+
+  <%= f.button(
+        :submit,
+        t('users.delete.actions.delete'),
+        class: 'usa-button--big usa-button--wide usa-button--danger margin-top-1 margin-bottom-2',
+      ) %>
+<% end %>
+
+<%= link_to(
+      t('users.delete.actions.cancel'),
+      account_path,
+      class: 'usa-button usa-button--big usa-button--wide usa-button--outline',
+    ) %>

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -5,7 +5,7 @@ en:
       generated_on_html: Generated on %{date}
     delete:
       actions:
-        cancel: Cancel and return to your profile
+        cancel: Back to profile
         delete: Delete account
       bullet_1: You won’t have a %{app_name} account
       bullet_2_loa1: We’ll delete your email address, password, and phone number
@@ -17,7 +17,7 @@ en:
         longer have an account
       heading: Are you sure you want to delete your account?
       instructions: Enter your password to confirm that you want to delete your account.
-      subheading: If you delete your account
+      subheading: 'If you delete your account:'
     personal_key:
       close: Close
       confirmation_error: You’ve entered an incorrect personal key.

--- a/config/locales/users/es.yml
+++ b/config/locales/users/es.yml
@@ -5,7 +5,7 @@ es:
       generated_on_html: Generado el %{date}
     delete:
       actions:
-        cancel: Anular y regresar a su perfil
+        cancel: Volver al perfil
         delete: Eliminar cuenta
       bullet_1: Usted no tendrá una %{app_name} cuenta.
       bullet_2_loa1: Eliminaremos su dirección de correo electrónico, contraseña y
@@ -18,7 +18,7 @@ es:
         ya tengo una cuenta
       heading: '¿Está seguro que desea eliminar su cuenta?'
       instructions: Ingrese su contraseña para confirmar que desea eliminar su cuenta.
-      subheading: Si elimina su cuenta
+      subheading: 'Si elimina su cuenta:'
     personal_key:
       close: Cerrar
       confirmation_error: Ha ingresado una clave personal incorrecta.

--- a/config/locales/users/fr.yml
+++ b/config/locales/users/fr.yml
@@ -5,7 +5,7 @@ fr:
       generated_on_html: Généré le %{date}
     delete:
       actions:
-        cancel: Annuler et retourner à votre profil
+        cancel: Retour au profil
         delete: Supprimer le compte
       bullet_1: Vous n’aurez pas de compte %{app_name}.
       bullet_2_loa1: Nous effacerons votre adresse email, votre mot de passe et votre
@@ -20,7 +20,7 @@ fr:
       heading: Êtes-vous sûr de vouloir supprimer votre compte?
       instructions: Saisissez votre mot de passe pour confirmer que vous souhaitez
         supprimer votre compte.
-      subheading: Si vous supprimez votre compte
+      subheading: 'Si vous supprimez votre compte:'
     personal_key:
       close: Fermer
       confirmation_error: Vous avez entré un clé personnelle erronée.

--- a/spec/views/users/delete/show.html.erb_spec.rb
+++ b/spec/views/users/delete/show.html.erb_spec.rb
@@ -40,15 +40,13 @@ describe 'users/delete/show.html.erb' do
   it 'contains link to delete account button' do
     render
 
-    expect(rendered).to have_button t('users.delete.actions.delete', href: account_delete_path)
+    expect(rendered).to have_css("form[action='#{account_delete_path}']")
+    expect(rendered).to have_button(t('users.delete.actions.delete'))
   end
 
   it 'contains link to cancel delete account link' do
     render
-    page = Capybara.string(rendered)
-    link = page.find_link(t('users.delete.actions.cancel'), href: account_path)
 
-    expect(link).to be_present
-    expect(link['role']).to eq('button')
+    expect(rendered).to have_link(t('users.delete.actions.cancel'), href: account_path)
   end
 end


### PR DESCRIPTION
**Why**: As a user, I want all information to be displayed in a clear visual hierarchy without visual design issues, so that I am not distracted while I am signing in or verifying my identity.

Before|After
---|---
![account-delete-before](https://user-images.githubusercontent.com/1779930/151056730-0f3a4536-5140-4eb6-bcdc-250d60816bef.png)|![account-delete-after](https://user-images.githubusercontent.com/1779930/151056726-1015bcae-d537-418d-8df4-5cad41b62ca5.png)


