### PR TITLE
Ignore coverage directory when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ fixtures
 node_modules
 public
 vendor
+coverage


### PR DESCRIPTION
- When present, the coverage directory contains a 203kb minified JS file that
  eslint gets sidetracked by

[skip changelog]