### PR TITLE
Upgrade identity-style-guide to 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
+- Dependencies: Upgrade the Login.gov Design System to the latest version (#5860)
 
 RC 175 - 2022-01-27
 ----------------------

--- a/app/assets/stylesheets/_required.scss
+++ b/app/assets/stylesheets/_required.scss
@@ -1,2 +1,1 @@
-$font-path: 'identity-style-guide/dist/assets/fonts';
-$image-path: 'identity-style-guide/dist/assets/img';
+@import 'variables/vendor';

--- a/app/assets/stylesheets/components/_external-link.scss
+++ b/app/assets/stylesheets/components/_external-link.scss
@@ -1,14 +1,4 @@
-// We're not (yet) using USWDS links consistently, where we'd expect color changes on hover, so in order to prevent the icon from flipping color independently from the rest of the link text on hover, we have to override it.
-
-// In the future, we'll want to either apply usa-link to all links, or to configure $theme-global-link-styles to apply link styling globally. This will bring hover color styles, at which point we can remove these overrides.
-
 .usa-link--external {
-  @include external-link(external-link, external-link);
-
-  &.usa-link--alt {
-    @include external-link(external-link-alt, external-link-alt);
-  }
-
   &::after,
   &.usa-link--alt::after {
     margin-left: units(0.5);

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -41,6 +41,11 @@ textarea {
   &.is-error {
     border-color: $border-color;
   }
+
+  // Temporary: Remove after LG-3877 (with BassCSS "color-forms")
+  &.usa-input--error:invalid {
+    border-color: color('error');
+  }
 }
 
 input::-webkit-outer-spin-button,
@@ -70,11 +75,6 @@ input::-webkit-inner-spin-button {
 // Pending upstream Login Design System revisions:
 // ===============================================
 
-// Upstream: https://github.com/18F/identity-style-guide/pull/262
-.usa-hint {
-  font-style: italic;
-}
-
 .usa-form-group--error {
   border-left-style: none;
   margin-top: units(3); // Remove after: https://github.com/uswds/uswds/issues/4189
@@ -83,31 +83,4 @@ input::-webkit-inner-spin-button {
   @include at-media('desktop') {
     margin-left: 0;
   }
-}
-
-// Upstream: https://github.com/18F/identity-style-guide/pull/275
-.usa-input--error {
-  &,
-  // Temporary: Remove after LG-3877 (with BassCSS "color-forms")
-  &.field:invalid {
-    border-color: color('error');
-  }
-}
-
-// Upstream: https://github.com/18F/identity-style-guide/pull/265
-.usa-error-message,
-.usa-success-message {
-  @include u-padding-y(0.5);
-  background-position: 0 0.5em;
-  background-repeat: no-repeat;
-  background-size: units($icon-size);
-  font-weight: font-weight('bold');
-  padding-left: 1.5rem;
-}
-
-// Upstream: https://github.com/18F/identity-style-guide/pull/265
-.usa-success-message {
-  background-image: url(image-path('alert/success.svg'));
-  color: color('success');
-  display: block;
 }

--- a/app/assets/stylesheets/variables/_vendor.scss
+++ b/app/assets/stylesheets/variables/_vendor.scss
@@ -1,0 +1,4 @@
+$theme-font-path: 'identity-style-guide/dist/assets/fonts';
+$theme-font-type-sans: 'source-sans-pro';
+$theme-font-type-serif: 'merriweather';
+$theme-image-path: 'identity-style-guide/dist/assets/img';

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -26,19 +26,19 @@
   <div class='container padding-y-1 padding-x-2 desktop:padding-x-0 <%= 'tablet:padding-y-0' if show_language_dropdown %>'>
     <div class="display-flex flex-align-center flex-justify-center">
       <div class="display-flex flex-auto">
-        <div class="tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 tablet:display-none',
+        <div class="display-flex tablet:display-none">
+          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none h6 margin-right-1 usa-link--alt tablet:display-none',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
                           width: 20, alt: '' %>
           <% end %>
         </div>
 
-        <div class="display-none tablet:display-block">
+        <div class="display-none tablet:display-flex">
           <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-1 usa-link--alt',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
-                          width: 20, class: 'margin-right-1', alt: '' %>
+                          width: 20, class: 'float-left margin-right-1', alt: '' %>
             <span>
               <%= t('shared.footer_lite.gsa') %>
             </span>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "core-js": "^3.20.2",
     "fast-glob": "^3.2.7",
     "focus-trap": "^6.7.1",
-    "identity-style-guide": "^6.2.0",
+    "identity-style-guide": "^6.3.0",
     "intl-tel-input": "^17.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,13 +4010,13 @@ iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-identity-style-guide@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-6.2.0.tgz#ff6e4014e85a73358d284a50c0902c9e40bc376f"
-  integrity sha512-9LocCBwM7fsilYk7zy7HxTmHyDRiw5bArOpK384Kyv/AhrUQRpBaCoZPdcMY45kZO81p3yCtv3Re16TOHq0kdw==
+identity-style-guide@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-6.3.0.tgz#eb9d776f3e9cbed9640c09fcce07e89881004279"
+  integrity sha512-dmQNHo84HQmNitAt8mt0Rb/kxADJ3ZE7jmwrrSRPSrTh8t6N37ORh1gBjk/qeCGWnZHYnIcGA2bYmUmr6WuEHQ==
   dependencies:
     domready "^1.0.8"
-    uswds "^2.12.1"
+    uswds "^2.13.1"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -6680,13 +6680,12 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uswds@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.12.1.tgz#5c4d3ad41ba408b2468d0e094e3ff800c07b84da"
-  integrity sha512-/GxcYeDGeRYwdTg03MokGXczMJ+0gbJ3uLXPHSkSPktzjO+6tuWu7EtXCSxa3yBzNGXTUTeYRRIhTF+WzzbA4w==
+uswds@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.13.1.tgz#4a1d1cb88debacfb854edef4d946be87ee306e7b"
+  integrity sha512-tl4bSB+0ejZw90gwqsbO5XA+1b9nnGdbvVhY4ARGKoTIJ7M8/vpUBoz+Tm327ATZI2LUWmoced5V986muq1Iew==
   dependencies:
     classlist-polyfill "^1.0.3"
-    del "^6.0.0"
     domready "^1.0.8"
     object-assign "^4.1.1"
     receptor "^1.0.0"


### PR DESCRIPTION
**Why**: To take advantage of the latest features and bug fixes, to eliminate backported styles, and as a prerequisite for implementing the new Process List component (LG-4791).

Release notes: https://github.com/18F/identity-style-guide/releases/tag/v6.3.0