### PR TITLE
LG-4791: Add and use Process List component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Unreleased
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5880, #5884, #5887, #5888, #5908)
 - Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#5891)
 - Icons: Replaced custom button icons using U.S. Web Design system icons. (#5904)
-- Layout: The "Delete Account" confirmation page has a new layout consistent with other content pages. (#5857)
 - User Interface: Updated styling for process lists following U.S. Web Design System best practices. (#5863)
 
 ### Accessibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5880, #5884, #5887, #5888, #5908)
 - Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#5891)
 - Icons: Replaced custom button icons using U.S. Web Design system icons. (#5904)
+- Layout: The "Delete Account" confirmation page has a new layout consistent with other content pages. (#5857)
+- User Interface: Updated styling for process lists following U.S. Web Design System best practices. (#5863)
 
 ### Accessibility
 

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -17,15 +17,6 @@
   }
 }
 
-.circle-number {
-  border-radius: 50%;
-  font-size: 1rem;
-  font-weight: bold;
-  height: 1.6rem;
-  text-align: center;
-  width: 1.6rem;
-}
-
 .success-bullets {
   .success-bullet {
     padding: 1rem 1rem 1rem 0;

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -24,3 +24,22 @@
 @import 'step-indicator';
 @import 'troubleshooting-options';
 @import 'i18n-dropdown';
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/288
+.usa-process-list__item {
+  &::before {
+    margin-top: #{(
+        units($theme-process-list-counter-size) -
+          (1.125rem * lh('heading', $theme-heading-line-height))
+      ) * -0.5};
+  }
+
+  &.usa-process-list--big::before {
+    margin-top: #{(3.125rem - (1.125rem * lh('heading', $theme-heading-line-height))) * -0.5};
+  }
+}
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/288
+.usa-process-list__heading {
+  @include u-line-height('heading', $theme-heading-line-height);
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -24,3 +24,13 @@
 @import 'step-indicator';
 @import 'troubleshooting-options';
 @import 'i18n-dropdown';
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/290
+.usa-process-list {
+  padding-top: 0;
+}
+
+// Upsteram: https://github.com/18F/identity-style-guide/pull/290
+.usa-process-list__item:last-child {
+  padding-bottom: 0;
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -24,22 +24,3 @@
 @import 'step-indicator';
 @import 'troubleshooting-options';
 @import 'i18n-dropdown';
-
-// Upstream: https://github.com/18F/identity-style-guide/pull/288
-.usa-process-list__item {
-  &::before {
-    margin-top: #{(
-        units($theme-process-list-counter-size) -
-          (1.125rem * lh('heading', $theme-heading-line-height))
-      ) * -0.5};
-  }
-
-  &.usa-process-list--big::before {
-    margin-top: #{(3.125rem - (1.125rem * lh('heading', $theme-heading-line-height))) * -0.5};
-  }
-}
-
-// Upstream: https://github.com/18F/identity-style-guide/pull/288
-.usa-process-list__heading {
-  @include u-line-height('heading', $theme-heading-line-height);
-}

--- a/app/assets/stylesheets/utilities/_space-misc.scss
+++ b/app/assets/stylesheets/utilities/_space-misc.scss
@@ -35,7 +35,4 @@
   .sm-mr-20p {
     margin-right: 20px;
   }
-  .sm-ml-28p {
-    margin-left: 28px;
-  }
 }

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -9,6 +9,10 @@ body {
   text-decoration: none;
 }
 
+.text-wrap-anywhere {
+  overflow-wrap: anywhere;
+}
+
 .fs-12p {
   font-size: 12px;
 }

--- a/app/components/process_list_component.html.erb
+++ b/app/components/process_list_component.html.erb
@@ -1,0 +1,5 @@
+<%= content_tag(:ol, class: css_class) do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/process_list_component.html.erb
+++ b/app/components/process_list_component.html.erb
@@ -1,5 +1,1 @@
-<%= content_tag(:ol, class: css_class) do %>
-  <% items.each do |item| %>
-    <%= item %>
-  <% end %>
-<% end %>
+<%= content_tag(:ol, safe_join(items.map(&:call)), class: css_class) %>

--- a/app/components/process_list_component.html.erb
+++ b/app/components/process_list_component.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:ol, class: css_class) do %>
+<%= content_tag(:ol, **tag_options, class: css_class) do %>
   <% items.each do |item| %>
     <%= item %>
   <% end %>

--- a/app/components/process_list_component.html.erb
+++ b/app/components/process_list_component.html.erb
@@ -1,1 +1,5 @@
-<%= content_tag(:ol, safe_join(items.map(&:call)), class: css_class) %>
+<%= content_tag(:ol, class: css_class) do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -1,5 +1,7 @@
 class ProcessListComponent < BaseComponent
-  renders_many :items, 'ProcessListItemComponent'
+  renders_many :items, ->(**kwargs, &block) {
+    ProcessListItemComponent.new(heading_level: heading_level, **kwargs, &block)
+  }
 
   attr_reader :heading_level, :big, :connected, :tag_options
 

--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -1,0 +1,28 @@
+class ProcessListComponent < BaseComponent
+  renders_many :items, 'ProcessListItemComponent'
+
+  attr_reader :heading_level, :big, :connected, :tag_options
+
+  def initialize(heading_level: :h2, big: false, connected: false, **tag_options)
+    @heading_level = heading_level
+    @big = big
+    @connected = connected
+    @tag_options = tag_options
+  end
+
+  def css_class
+    classes = ['usa-process-list', *tag_options[:class]]
+    classes << 'usa-process-list--big' if big
+    classes << 'usa-process-list--connected' if connected
+    classes
+  end
+
+  class ProcessListItemComponent < BaseComponent
+    attr_reader :heading, :heading_level
+
+    def initialize(heading:, heading_level: :h2)
+      @heading_level = heading_level
+      @heading = heading
+    end
+  end
+end

--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -20,9 +20,9 @@ class ProcessListComponent < BaseComponent
   end
 
   class ProcessListItemComponent < BaseComponent
-    attr_reader :heading, :heading_level
+    attr_reader :heading_level, :heading
 
-    def initialize(heading:, heading_level: :h2)
+    def initialize(heading_level:, heading:)
       @heading_level = heading_level
       @heading = heading
     end

--- a/app/components/process_list_item_component.html.erb
+++ b/app/components/process_list_item_component.html.erb
@@ -1,0 +1,4 @@
+<li class="usa-process-list__item">
+  <%= content_tag(heading_level, heading, class: 'usa-process-list__heading') %>
+  <%= content %>
+</li>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -29,12 +29,12 @@
   <%= validated_form_for :doc_auth,
                          url: url_for,
                          method: 'put',
-                         html: { autocomplete: 'off', class: 'margin-top-1 margin-bottom-5 js-consent-continue-form' } do |f| %>
-  <%= f.button :button,
-               t('doc_auth.buttons.continue'),
-               type: :submit,
-               class: 'display-block margin-y-5 usa-button--big usa-button--wide' %>
-<% end %>
+                         html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+    <%= f.button :button,
+                 t('doc_auth.buttons.continue'),
+                 type: :submit,
+                 class: 'usa-button--big usa-button--wide' %>
+  <% end %>
 
   <%= render(
         'shared/troubleshooting_options',

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -11,19 +11,19 @@
   </p>
   <h2 class='margin-bottom-0'><%= t('doc_auth.instructions.welcome') %></h2>
 
-  <%= render ProcessListComponent.new do |c| %>
-    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet1')) do %>
+  <%= render ProcessListComponent.new(heading_level: :h3) do |c| %>
+    <%= c.item(heading: t('doc_auth.instructions.bullet1')) do %>
       <p><%= t('doc_auth.instructions.text1') %></p>
     <% end %>
     <% if liveness_checking_enabled? %>
-      <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet1a')) do %>
+      <%= c.item(heading: t('doc_auth.instructions.bullet1a')) do %>
         <p><%= t('doc_auth.instructions.text1a') %></p>
       <% end %>
     <% end %>
-    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet2')) do %>
+    <%= c.item(heading: t('doc_auth.instructions.bullet2')) do %>
       <p><%= t('doc_auth.instructions.text2') %></p>
     <% end %>
-    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet3')) do %>
+    <%= c.item(heading: t('doc_auth.instructions.bullet3')) do %>
       <p><%= t('doc_auth.instructions.text3') %></p>
     <% end %>
   <% end %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -6,12 +6,12 @@
 
 <%= render 'shared/maintenance_window_alert' do %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.welcome')) %>
-  <p class='mt-tiny margin-bottom-0'>
+  <p>
     <%= t('doc_auth.info.welcome_html', sp_name: decorated_session.sp_name || t('doc_auth.info.no_sp_name')) %>
   </p>
-  <h2 class='margin-bottom-0'><%= t('doc_auth.instructions.welcome') %></h2>
+  <h2><%= t('doc_auth.instructions.welcome') %></h2>
 
-  <%= render ProcessListComponent.new(heading_level: :h3) do |c| %>
+  <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
     <%= c.item(heading: t('doc_auth.instructions.bullet1')) %>
     <% if liveness_checking_enabled? %>
       <%= c.item(heading: t('doc_auth.instructions.bullet1a')) do %>
@@ -30,11 +30,11 @@
                          url: url_for,
                          method: 'put',
                          html: { autocomplete: 'off', class: 'margin-top-1 margin-bottom-5 js-consent-continue-form' } do |f| %>
-    <%= f.button :button,
-                 t('doc_auth.buttons.continue'),
-                 type: :submit,
-                 class: 'usa-button--big usa-button--wide' %>
-  <% end %>
+  <%= f.button :button,
+               t('doc_auth.buttons.continue'),
+               type: :submit,
+               class: 'display-block margin-y-5 usa-button--big usa-button--wide' %>
+<% end %>
 
   <%= render(
         'shared/troubleshooting_options',

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -11,75 +11,27 @@
   </p>
   <h2 class='margin-bottom-0'><%= t('doc_auth.instructions.welcome') %></h2>
 
-  <ul class='list-reset'>
-    <li class='padding-top-2 padding-bottom-1'>
-      <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
-        <%= step += 1 %>
-      </div>
-      <div class='margin-right-1 inline-block'>
-        <div class='h2 inline-block bold'>
-          <%= t('doc_auth.instructions.bullet1') %>
-        </div>
-        <br/>
-        <div class="margin-top-1">
-          <%= t('doc_auth.instructions.text1') %>
-        </div>
-      </div>
-    </li>
-    <% if liveness_checking_enabled? %>
-      <li class='padding-top-2 padding-bottom-1'>
-        <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
-          <%= step += 1 %>
-        </div>
-        <div class='margin-right-1 inline-block'>
-          <div class='h2 inline-block bold'>
-            <%= t('doc_auth.instructions.bullet1a') %>
-          </div>
-          <br/>
-          <div class="margin-top-1">
-            <%= t('doc_auth.instructions.text1a') %>
-          </div>
-        </div>
-      </li>
+  <%= render ProcessListComponent.new do |c| %>
+    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet1')) do %>
+      <p><%= t('doc_auth.instructions.text1') %></p>
     <% end %>
-    <li class='padding-top-2 padding-bottom-1'>
-      <div class="grid-row">
-        <div class='inline-block margin-right-2 text-top circle-number bg-primary text-white'>
-          <%= step += 1 %>
-        </div>
-        <div class='grid-col-10'>
-          <div class='h2 inline-block bold'>
-            <%= t('doc_auth.instructions.bullet2') %>
-          </div>
-          <br/>
-          <div class="margin-top-1">
-            <%= t('doc_auth.instructions.text2') %>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li class='padding-top-2'>
-      <div class="grid-row">
-        <div class='grid-col-2 margin-right-2 text-top circle-number bg-primary text-white'>
-          <%= step += 1 %>
-        </div>
-        <div class='grid-col-10'>
-          <div class='h2 inline-block bold'>
-            <%= t('doc_auth.instructions.bullet3') %>
-          </div>
-          <br/>
-          <div class="margin-top-1">
-            <%= t('doc_auth.instructions.text3') %>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
+    <% if liveness_checking_enabled? %>
+      <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet1a')) do %>
+        <p><%= t('doc_auth.instructions.text1a') %></p>
+      <% end %>
+    <% end %>
+    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet2')) do %>
+      <p><%= t('doc_auth.instructions.text2') %></p>
+    <% end %>
+    <%= c.item(heading_level: :h3, heading: t('doc_auth.instructions.bullet3')) do %>
+      <p><%= t('doc_auth.instructions.text3') %></p>
+    <% end %>
+  <% end %>
 
   <%= validated_form_for :doc_auth,
                          url: url_for,
                          method: 'put',
-                         html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+                         html: { autocomplete: 'off', class: 'margin-top-1 margin-bottom-5 js-consent-continue-form' } do |f| %>
     <%= f.button :button,
                  t('doc_auth.buttons.continue'),
                  type: :submit,

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -12,9 +12,7 @@
   <h2 class='margin-bottom-0'><%= t('doc_auth.instructions.welcome') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3) do |c| %>
-    <%= c.item(heading: t('doc_auth.instructions.bullet1')) do %>
-      <p><%= t('doc_auth.instructions.text1') %></p>
-    <% end %>
+    <%= c.item(heading: t('doc_auth.instructions.bullet1')) %>
     <% if liveness_checking_enabled? %>
       <%= c.item(heading: t('doc_auth.instructions.bullet1a')) do %>
         <p><%= t('doc_auth.instructions.text1a') %></p>

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -15,22 +15,23 @@ locals:
    classes = ['field font-family-mono usa-input one-time-code-input']
    classes << local_assigns.delete(:class) if local_assigns[:class] %>
 
-
-<%= text_field_tag(
-      name,
-      nil,
-      'aria-invalid': 'false',
-      'data-transport': transport,
-      pattern: numeric ? '[0-9]*' : '[a-zA-Z0-9]*',
-      maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
-      autocomplete: 'one-time-code',
-      inputmode: numeric ? 'numeric' : 'text',
-      type: 'text',
-      **local_assigns,
-      class: classes,
-    ) %>
-<span class='usa-error-message display-if-invalid display-if-invalid--value-missing margin-top-1' role='alert'>
-  <%= t('simple_form.required.text') %>
-</span>
+<div>
+  <%= text_field_tag(
+        name,
+        nil,
+        'aria-invalid': 'false',
+        'data-transport': transport,
+        pattern: numeric ? '[0-9]*' : '[a-zA-Z0-9]*',
+        maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+        autocomplete: 'one-time-code',
+        inputmode: numeric ? 'numeric' : 'text',
+        type: 'text',
+        **local_assigns,
+        class: classes,
+      ) %>
+  <span class='usa-error-message display-if-invalid display-if-invalid--value-missing margin-top-1' role='alert'>
+    <%= t('simple_form.required.text') %>
+  </span>
+</div>
 
 <%= javascript_packs_tag_once 'one-time-code-input' %>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -6,7 +6,7 @@
   Either enter a subject for a certificate or select an error to simulate a piv/cac response.
 </p>
 
-<div class="sm-col-9 sm-ml-28p">
+<div class="sm-col-9">
   <%= form_tag do %>
     <%= hidden_field_tag(:redirect_uri, @referrer) %>
     <div class="clearfix margin-x-neg-1">

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -1,7 +1,8 @@
 <% title @presenter.title %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
-<p class='mt-tiny margin-bottom-4'><%= t('headings.piv_cac_login.add') %></p>
+
+<p><%= t('headings.piv_cac_login.add') %></p>
 
 <%= simple_form_for('', url: submit_new_piv_cac_url) do |f| %>
   <%= render ProcessListComponent.new(connected: true) do |c| %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -5,7 +5,7 @@
 <p><%= t('headings.piv_cac_login.add') %></p>
 
 <%= simple_form_for('', url: submit_new_piv_cac_url) do |f| %>
-  <%= render ProcessListComponent.new(connected: true) do |c| %>
+  <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
     <%= c.item(heading: t('instructions.mfa.piv_cac.step_1')) do %>
       <p>
         <%= t('instructions.mfa.piv_cac.step_1_info') %>
@@ -33,7 +33,7 @@
 
   <%= f.submit(
         t('forms.piv_cac_setup.submit'),
-        class: 'display-block usa-button usa-button--wide usa-button--big margin-top-1 margin-bottom-5',
+        class: 'display-block usa-button usa-button--wide usa-button--big margin-y-5',
       ) %>
 <% end %>
 

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -3,51 +3,37 @@
 <%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
 <p class='mt-tiny margin-bottom-4'><%= t('headings.piv_cac_login.add') %></p>
 
-<%= form_tag(submit_new_piv_cac_url) do %>
-<ul class='list-reset'>
-  <li class='padding-top-0 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
-      1
-    </div>
-    <label class="font-sans-lg margin-right-1 display-inline-block margin-bottom-1 text-bold" for="nickname">
-      <%= t('instructions.mfa.piv_cac.step_1') %>
-    </label>
-    <div class='margin-left-6 margin-bottom-1'>
-      <%= t('instructions.mfa.piv_cac.step_1_info') %>
-    </div>
-    <div class='margin-left-6 margin-bottom-4'>
-      <input type="text" name="name" id="nickname" value="" required="required" aria-invalid="false" class="block col-12 field font-family-mono" size="16" maxlength="20" />
-    </div>
-    <hr>
-  </li>
-  <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
-      2
-    </div>
-    <div class='margin-right-1 inline-block margin-bottom-2'>
-      <div class="font-sans-lg display-inline-block text-bold">
-        <%= t('instructions.mfa.piv_cac.step_2') %>
-      </div>
-    </div>
-    <hr>
-  </li>
-  <li class='padding-top-1 padding-bottom-1'>
-    <div class='inline-block margin-right-2 margin-top-1 text-top circle-number bg-primary text-white'>
-      3
-    </div>
-    <div class='margin-right-1 inline-block'>
-      <div class="font-sans-lg display-inline-block text-bold">
-        <%= t('instructions.mfa.piv_cac.step_3') %>
-      </div>
-    </div>
-    <div class='margin-left-6 margin-bottom-1'>
-      <div class="margin-bottom-4">
+<%= simple_form_for('', url: submit_new_piv_cac_url) do |f| %>
+  <%= render ProcessListComponent.new(connected: true) do |c| %>
+    <%= c.item(heading: t('instructions.mfa.piv_cac.step_1')) do %>
+      <p>
+        <%= t('instructions.mfa.piv_cac.step_1_info') %>
+      </p>
+      <%= render ValidatedFieldComponent.new(
+            form: f,
+            name: :name,
+            label: false,
+            required: true,
+            wrapper_html: { class: 'margin-bottom-0' },
+            input_html: {
+              aria: { label: t('instructions.mfa.piv_cac.step_1') },
+              size: 16,
+              maxlength: 20,
+            },
+          ) %>
+    <% end %>
+    <%= c.item(heading: t('instructions.mfa.piv_cac.step_2')) %>
+    <%= c.item(heading: t('instructions.mfa.piv_cac.step_3')) do %>
+      <p>
         <%= t('instructions.mfa.piv_cac.step_3_info_html') %>
-      </div>
-      <input type="submit" name="commit" value="<%= t('forms.piv_cac_setup.submit') %>" class="usa-button usa-button--wide usa-button--big" data-disable-with="Add PIV/CAC card" />
-    </div>
-  </li>
-</ul>
+      </p>
+    <% end %>
+  <% end %>
+
+  <%= f.submit(
+        t('forms.piv_cac_setup.submit'),
+        class: 'display-block usa-button usa-button--wide usa-button--big margin-top-1 margin-bottom-5',
+      ) %>
 <% end %>
 
 

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -5,63 +5,44 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
 <p class="mt-tiny margin-bottom-4"><%= t('forms.totp_setup.totp_intro_html', link: help_link) %></p>
 <%= validated_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
-  <ul class="list-reset margin-bottom-0">
-    <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-primary text-white">1</div>
-        <div class="inline-block bold" id="totp-nickname"><%= t('forms.totp_setup.totp_step_1') %></div>
-        <div class="inline-block margin-left-4"><%= t('forms.totp_setup.totp_step_1a') %></div>
+  <%= render ProcessListComponent.new(connected: true) do |c| %>
+    <%= c.item(heading: t('forms.totp_setup.totp_step_1')) do %>
+      <p><%= t('forms.totp_setup.totp_step_1a') %></p>
+      <%= render ValidatedFieldComponent.new(
+            form: f,
+            name: :name,
+            required: true,
+            label: false,
+            wrapper_html: { class: 'margin-bottom-0' },
+            input_html: {
+              aria: { label: t('forms.totp_setup.totp_step_1') },
+              maxlength: 20,
+            },
+          ) %>
+    <% end %>
+    <%= c.item(heading: t('forms.totp_setup.totp_step_2')) %>
+    <%= c.item(heading: t('forms.totp_setup.totp_step_3')) do %>
+      <div class="text-center">
+        <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
       </div>
-      <div class="sm-col-9 sm-ml-28p">
-        <div class="clearfix margin-x-neg-1">
-          <div class="col col-6 sm-col-7 padding-x-1">
-            <%= text_field_tag :name, '', required: true, aria: { invalid: false }, class: 'block col-12 field font-family-mono',
-                                          maxlength: 20, 'aria-labelledby': 'totp-nickname' %>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-right-1 inline-block circle-number bg-primary text-white">2</div>
-      <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_2') %></div>
-    </li>
-    <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-primary text-white">3</div>
-        <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_3') %></div>
-      </div>
-      <div class="sm-col-9 sm-ml-28p">
-        <div class="center">
-          <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
-        </div>
-        <%= t('instructions.mfa.authenticator.manual_entry') %>
-        <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
-          <%= @code %>
-        </code>
-        <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
-      </div>
-    </li>
-    <li class="padding-y-2 border-top border-primary-light">
-      <div class="margin-bottom-2">
-        <div class="margin-right-1 inline-block circle-number bg-primary text-white">4</div>
-        <div class="inline-block bold" id="totp-label"><%= t('forms.totp_setup.totp_step_4') %></div>
-      </div>
-      <div class="sm-col-9 sm-ml-28p">
-        <div class="clearfix margin-x-neg-1">
-          <div class="col col-6 sm-col-7 padding-x-1">
-            <%= render(
-                  'shared/one_time_code_input',
-                  transport: nil,
-                  name: :code,
-                  'aria-labelledby': 'totp-label',
-                  required: true,
-                  class: 'block col-12',
-                ) %>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
+      <p><%= t('instructions.mfa.authenticator.manual_entry') %></p>
+      <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
+        <%= @code %>
+      </code>
+      <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
+    <% end %>
+    <%= c.item(heading: t('forms.totp_setup.totp_step_4')) do %>
+      <%= render(
+            'shared/one_time_code_input',
+            transport: nil,
+            name: :code,
+            required: true,
+            aria: { label: t('forms.totp_setup.totp_step_4') },
+            size: 18,
+            class: 'width-auto',
+          ) %>
+    <% end %>
+  <% end %>
   <%= f.input(
         :remember_device,
         as: :boolean,

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -10,7 +10,7 @@
 </p>
 
 <%= validated_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
-  <%= render ProcessListComponent.new(connected: true) do |c| %>
+  <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
     <%= c.item(heading: t('forms.totp_setup.totp_step_1')) do %>
       <p><%= t('forms.totp_setup.totp_step_1a') %></p>
       <%= render ValidatedFieldComponent.new(

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -31,7 +31,7 @@
         <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
       </div>
       <p><%= t('instructions.mfa.authenticator.manual_entry') %></p>
-      <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold" id="qr-code">
+      <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold text-wrap-anywhere" id="qr-code">
         <%= @code %>
       </code>
       <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -1,9 +1,14 @@
 <% title t('titles.totp_setup.new') %>
 
-<% help_link = new_window_link_to t('links.what_is_totp'),
-                                  MarketingSite.help_authentication_app_url %>
 <%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
-<p class="mt-tiny margin-bottom-4"><%= t('forms.totp_setup.totp_intro_html', link: help_link) %></p>
+
+<p>
+  <%= t(
+        'forms.totp_setup.totp_intro_html',
+        link: new_window_link_to(t('links.what_is_totp'), MarketingSite.help_authentication_app_url),
+      ) %>
+</p>
+
 <%= validated_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <%= render ProcessListComponent.new(connected: true) do |c| %>
     <%= c.item(heading: t('forms.totp_setup.totp_step_1')) do %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -226,7 +226,6 @@ en:
       switch_back: Switch back to your computer to finish verifying your identity.
       test_ssn: In the test environment only SSNs that begin with “900-” or “666-” are
         considered valid. Do not enter real PII in this field.
-      text1: ''
       text1a: such as a phone or computer.
       text2: You will not need the card with you.
       text3: You do not need to be the primary account holder on your phone plan. If

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -261,7 +261,6 @@ es:
         identidad.
       test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” o “666-”
         se consideran válidos. No ingrese PII real en este campo.
-      text1: ''
       text1a: como un teléfono o una computadora.
       text2: No es necesario disponer de la credencial.
       text3: No es necesario que usted sea el titular principal de la cuenta de su

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -275,7 +275,6 @@ fr:
       test_ssn: Dans l’environnement de test seuls les SSN commençant par “900-” ou
         “900-” sont considérés comme valides. N’entrez pas de vrais PII dans ce
         champ.
-      text1: ''
       text1a: tel qu’un téléphone ou un ordinateur
       text2: Vous n’aurez pas besoin de la carte avec vous.
       text3: Il n’est pas nécessaire que vous soyez le titulaire principal du compte

--- a/spec/components/process_list_component_spec.rb
+++ b/spec/components/process_list_component_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ProcessListComponent, type: :component do
+  it 'renders with css class' do
+    rendered = render_inline ProcessListComponent.new
+
+    expect(rendered).to have_css('.usa-process-list')
+  end
+
+  it 'renders items slot content at default heading level' do
+    rendered = render_inline ProcessListComponent.new do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+
+    expect(rendered).to have_css('h2.usa-process-list__heading', text: 'Item 1')
+    expect(rendered).to have_css('.usa-process-list__item', text: 'Item 1 Content')
+    expect(rendered).to have_css('h2.usa-process-list__heading', text: 'Item 2')
+    expect(rendered).to have_css('.usa-process-list__item', text: 'Item 2 Content')
+  end
+
+  context 'custom heading level' do
+    it 'renders items slot content at custom heading level' do
+      rendered = render_inline ProcessListComponent.new(heading_level: :h3) do |c|
+        c.item(heading: 'Item') { '' }
+      end
+
+      expect(rendered).to have_css('h3.usa-process-list__heading', text: 'Item')
+    end
+  end
+
+  context 'big' do
+    it 'renders with css class' do
+      rendered = render_inline ProcessListComponent.new(big: true)
+
+      expect(rendered).to have_css('.usa-process-list--big')
+    end
+  end
+
+  context 'connected' do
+    it 'renders with css class' do
+      rendered = render_inline ProcessListComponent.new(connected: true)
+
+      expect(rendered).to have_css('.usa-process-list--connected')
+    end
+  end
+
+  context 'custom class' do
+    it 'renders with css class' do
+      rendered = render_inline ProcessListComponent.new(class: 'my-custom-class')
+
+      expect(rendered).to have_css('.usa-process-list.my-custom-class')
+    end
+  end
+
+  context 'tag options' do
+    it 'applies tag options to wrapper element' do
+      rendered = render_inline ProcessListComponent.new(data: { foo: 'bar' })
+
+      expect(rendered).to have_css('.usa-process-list[data-foo="bar"]')
+    end
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -44,6 +44,7 @@ Capybara.default_max_wait_time = (ENV['CAPYBARA_WAIT_TIME_SECONDS'] || '0.5').to
 Capybara::Screenshot.autosave_on_failure = false
 Capybara.asset_host = ENV['RAILS_ASSET_HOST'] || 'http://localhost:3000'
 Capybara.automatic_label_click = true # USWDS styles native checkbox/radio as offscreen
+Capybara.enable_aria_label = true
 
 Capybara.register_driver(:mobile_rack_test) do |app|
   user_agent_string = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) ' \

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -45,14 +45,11 @@ describe 'users/totp_setup/new.html.erb' do
       expect(rendered).to have_button(t('links.copy'), type: 'button')
     end
 
-    it 'has the correct aria-labelledby on the nickname field' do
+    it 'has labelled fields' do
       render
-      page = Capybara.string(rendered)
 
-      nickname_field = page.find_field(:name)
-      label = page.find(:id, nickname_field['aria-labelledby'])
-
-      expect(label.text).to include(t('forms.totp_setup.totp_step_1'))
+      expect(rendered).to have_field(t('forms.totp_setup.totp_step_1'))
+      expect(rendered).to have_field(t('forms.totp_setup.totp_step_4'))
     end
   end
 


### PR DESCRIPTION
**Why**: As a user, I want to see the steps of instructions or processes presented in a consistent visual way, so that I clearly understand what I need to do next and am not distracted by visual issues.

Component reference: https://design.login.gov/components/process-list/

For review, split diff may be easiest: [?diff=split](https://github.com/18F/identity-idp/pull/5863/files?diff=split&w=0)

**Screenshots:**

Screen|Before|After
---|---|---
TOTP Setup|![localhost_3000_authenticator_setup (1)](https://user-images.githubusercontent.com/1779930/151558805-bd2c2b98-f87a-4228-aff7-e45923bb72f7.png)|![localhost_3000_authenticator_setup](https://user-images.githubusercontent.com/1779930/151558807-2bcab077-5754-4988-a447-7cd27f993139.png)
PIV Setup|![localhost_3000_piv_cac (1)](https://user-images.githubusercontent.com/1779930/151558809-d13a938a-a3e6-4f33-8b61-dd37a8fd17e9.png)|![localhost_3000_piv_cac](https://user-images.githubusercontent.com/1779930/151558811-82909fa9-b85c-48ff-af98-378ffeb144a1.png)
IAL2 Welcome|![localhost_3000_verify_doc_auth_welcome (1)](https://user-images.githubusercontent.com/1779930/151558812-7b13ec8e-d0df-4032-b9b2-e2ba97f17cb0.png)|![localhost_3000_verify_doc_auth_welcome](https://user-images.githubusercontent.com/1779930/151558813-af691535-e4e6-4caf-97b3-bf37002ed3cf.png)