### PR TITLE
Fix IAL2 Start Over/Cancel visual margin regression

### DIFF
--- a/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
+++ b/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
@@ -11,5 +11,7 @@ locals:
           class: 'usa-button usa-button--unstyled',
         ) { t('doc_auth.buttons.start_over') } %>
   <% end %>
-  <%= render 'shared/cancel', link: idv_cancel_path(step: local_assigns[:step]) %>
+  <div class="margin-top-2 padding-top-1 border-top border-primary-light">
+    <%= link_to cancel_link_text, idv_cancel_path(step: local_assigns[:step]) %>
+  </div>
 </div>


### PR DESCRIPTION
Regression introduced in: #5845

"Cancel" partial top margin was increased from `1rem` to `2rem` in #5845. This is correct, though had the unintended side-effect of creating a bigger-than-intended gap in the "Start over or cancel" partial.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/151626651-9caf5b07-ddab-4523-9f40-b4d1b7bf2562.png)|![image](https://user-images.githubusercontent.com/1779930/151626639-39e42288-0f03-4fa3-80eb-73be34074360.png)
