### PR TITLE
call phone_info check on idv otp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
 - Dependencies: Upgrade the Login.gov Design System to the latest version (#5860)
+- Identity Verification: Add more phone number validation to phone confirmation (#5873)
 
 RC 175 - 2022-01-27
 ----------------------

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -168,6 +168,9 @@ describe Idv::PhoneController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
           country_code: nil,
           area_code: nil,
+          carrier: 'Test Mobile Carrier',
+          phone_type: :mobile,
+          types: [],
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -195,6 +198,9 @@ describe Idv::PhoneController do
           area_code: '703',
           country_code: 'US',
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
+          carrier: 'Test Mobile Carrier',
+          phone_type: :mobile,
+          types: [:fixed_or_mobile],
         }
 
         expect(@analytics).to have_received(:track_event).with(


### PR DESCRIPTION
This adds the Pinpoint Phone Info call to the IdV OTP form. It will give us more context, but does not implement any change in behavior