### PR TITLE
Add build-sass to `yarn build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "normalize-yaml": "normalize-yaml",
     "clean": "rm -rf public/packs/*",
     "prebuild": "yarn run clean",
-    "build": "webpack",
+    "build": "webpack && yarn build:css",
     "build:css": "build-sass app/assets/stylesheets/*.css.scss --out-dir=app/assets/builds"
   },
   "dependencies": {


### PR DESCRIPTION
**Why**: So that `yarn build` both CSS and JS. Otherwise it tries to compile the CSS with SASSC which is no longer there.