### PR TITLE
Switch back to mainline redis-session-store gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Unreleased
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
 - Dependencies: Upgrade the Login.gov Design System to the latest version (#5860)
 - Identity Verification: Add more phone number validation to phone confirmation (#5873)
+- Dependencies: Update various dependencies (#TBD)
 
 RC 175 - 2022-01-27
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Unreleased
 - Maintenance: Add CI check to include changelog message in change requests (#5836)
 - Dependencies: Upgrade the Login.gov Design System to the latest version (#5860)
 - Identity Verification: Add more phone number validation to phone confirmation (#5873)
-- Dependencies: Update various dependencies (#TBD)
+- Dependencies: Update various dependencies (#5877)
 
 RC 175 - 2022-01-27
 ----------------------

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'rack-timeout', require: false
 gem 'redacted_struct'
 gem 'redis', '>= 3.2.0'
 gem 'redis-namespace'
-gem 'redis-session-store', github: '18f/redis-session-store', tag: 'v0.11.4-18f'
+gem 'redis-session-store', '>= 0.11.4'
 gem 'retries'
 gem 'rotp', '~> 6.1'
 gem 'rqrcode'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,15 +36,6 @@ GIT
       pkcs11
       uuid
 
-GIT
-  remote: https://github.com/18f/redis-session-store.git
-  revision: d3f5e38d3a6173737a580d774767a0d8471b1e67
-  tag: v0.11.4-18f
-  specs:
-    redis-session-store (0.11.4.pre.18f)
-      actionpack (>= 3, < 7)
-      redis (>= 3, < 5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -503,6 +494,9 @@ GEM
     redis (4.5.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
+    redis-session-store (0.11.4)
+      actionpack (>= 3, < 8)
+      redis (>= 3, < 5)
     regexp_parser (2.2.0)
     reline (0.2.7)
       io-console (~> 0.5)
@@ -763,7 +757,7 @@ DEPENDENCIES
   redacted_struct
   redis (>= 3.2.0)
   redis-namespace
-  redis-session-store!
+  redis-session-store (>= 0.11.4)
   retries
   rotp (~> 6.1)
   rqrcode


### PR DESCRIPTION
The security patch we had in our fork was merged & released! https://github.com/roidrage/redis-session-store/pull/125
