### PR TITLE
LG-4792: Update IAL2 layout, typography consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ RC 176 - 2022-02-03
 
 ### Improvements/Changes
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5857, #5869, #5885)
+- Layout: Improve layout margins and typographical consistency across several content pages. (#5857, #5869, #5885, #5886)
 
 ### Accessibility
 - Identity Verification: The Send a Letter "Come back soon" screen has improved grammar and content structure semantics. (#5868)

--- a/app/views/idv/doc_auth/_ssn_init.html.erb
+++ b/app/views/idv/doc_auth/_ssn_init.html.erb
@@ -36,7 +36,7 @@
 
   <p><%= flow_session[:error_message] %></p>
 
-  <button type="submit" class="usa-button usa-button--big usa-button--wide">
+  <button type="submit" class="display-block margin-y-5 usa-button usa-button--big usa-button--wide">
     <%= t('forms.buttons.continue') %>
   </button>
 <% end %>

--- a/app/views/idv/doc_auth/link_sent.html.erb
+++ b/app/views/idv/doc_auth/link_sent.html.erb
@@ -13,11 +13,11 @@
 <% end %>
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.text_message')) %>
 
-<div class='clearfix margin-x-neg-1'>
-  <div class='sm-col sm-col-3 padding-x-1'>
+<div class="grid-row">
+  <div class="grid-col-12 tablet:grid-col-3">
     <%= image_tag asset_url('idv/phone.png'), alt: t('image_description.camera_mobile_phone') %>
   </div>
-  <div class='sm-col sm-col-9 padding-x-1 h2 margin-bottom-2 margin-top-0 margin-y-0'>
+  <div class="grid-col-12 tablet:grid-col-9">
     <p><%= t('doc_auth.info.link_sent') %></p>
     <%= render AlertComponent.new(type: :warning) do %>
       <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -148,7 +148,7 @@ en:
       verify_identity: Verify your identity
       welcome: Get started verifying your identity
     info:
-      camera_required: Your mobile phone must have a camera and a web browser
+      camera_required: Your mobile phone must have a camera and a web browser.
       capture_status_capturing: Capturing
       capture_status_none: Align
       capture_status_small_document: Move Closer

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -176,7 +176,7 @@ es:
       verify_identity: Verifique su identidad
       welcome: Empiece con la verificación de su identidad
     info:
-      camera_required: Su teléfono móvil debe tener una cámara y un navegador web
+      camera_required: Su teléfono móvil debe tener una cámara y un navegador web.
       capture_status_capturing: Capturando
       capture_status_none: Alinea
       capture_status_small_document: Muévete mas cerca

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -183,7 +183,7 @@ fr:
       verify_identity: Vérifier votre identité
       welcome: Commencez à vérifier votre identité
     info:
-      camera_required: Votre téléphone portable doit avoir une caméra et un navigateur Web
+      camera_required: Votre téléphone portable doit avoir une caméra et un navigateur Web.
       capture_status_capturing: Prendre la photo
       capture_status_none: Alignez
       capture_status_small_document: Approchez-vous


### PR DESCRIPTION
**Why**: As a user, I want all information to be displayed in a clear visual hierarchy without visual design issues, so that I am not distracted while I am signing in or verifying my identity.

This is a hodgepodge of miscellaneous fixes to various screens within the IAL2 flow as we wrap up this part of LG-4792.

**Screenshots:**

Screen|Before|After
---|---|---
**Welcome**<br>Revision: "Learn more" link icon placement<br>See: https://github.com/18F/identity-style-guide/pull/289|![Screen Shot 2022-02-01 at 8 33 55 AM](https://user-images.githubusercontent.com/1779930/151980458-f06afc98-db1b-43e9-b731-66b203365ce0.png)|![Screen Shot 2022-02-01 at 8 33 13 AM](https://user-images.githubusercontent.com/1779930/151980474-0635cfac-b4fb-4ef4-84b3-1e2921fc0cc1.png)
**Hybrid Send Link**<br>Revision: Add period to sentence|![4792-send-link-before](https://user-images.githubusercontent.com/1779930/151985549-7f95d152-2acc-4b33-b16f-04d1c77f2e07.png)|![4792-send-link-after](https://user-images.githubusercontent.com/1779930/151985547-8e8234b9-edf5-499d-b783-68aea5db8096.png)
**Hybrid Link Sent**<br>Revision: Content text size as standard paragraph|![4792-link-sent-before](https://user-images.githubusercontent.com/1779930/151985546-11d62b82-428f-456e-8d93-b908e9c3c2af.png)|![4792-link-sent-after](https://user-images.githubusercontent.com/1779930/151985541-172659fe-625f-4456-b911-d99cfd2b8239.png)
**SSN**<br>Revision: Submit button margin as 2.5rem|![4792-ssn-before](https://user-images.githubusercontent.com/1779930/151985551-47f95478-b31c-4972-90fa-198b0e67629f.png)|![4792-ssn-after](https://user-images.githubusercontent.com/1779930/151985550-07d7cae0-6853-4f29-bbb2-8f24e075eb02.png)


