### PR TITLE
LG-4795: Switch monospace font to design system default (Roboto Mono)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Unreleased
 
 ### Improvements/Changes
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5857, #5869, #5885)
-- Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#TBD)
+- Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#5891)
 
 ### Accessibility
 - Identity Verification: The Send a Letter "Come back soon" screen has improved grammar and content structure semantics. (#5868)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 
 ### Improvements/Changes
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5857, #5869, #5885)
+- Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#TBD)
 
 ### Accessibility
 - Identity Verification: The Send a Letter "Come back soon" screen has improved grammar and content structure semantics. (#5868)

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -28,7 +28,7 @@ textarea {
 
   &[type='number'],
   &.phone {
-    font-family: $monospace-font-family;
+    @include u-font-family('mono');
   }
 
   &:focus {

--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -10,6 +10,7 @@
 }
 
 .separator-text__code {
+  @include u-font-family('mono');
   font-size: 1.5rem;
 
   &::after {

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -4,10 +4,6 @@ html {
 body {
   -webkit-font-smoothing: antialiased;
 }
-
-.monospace {
-  font-family: $monospace-font-family;
-}
 .sans-serif {
   font-family: $sans-serif-font-family;
 }

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -1,7 +1,6 @@
 $serif-font-family: 'Merriweather Web', 'Georgia', 'Cambria', 'Times New Roman', 'Times', serif !default;
 $sans-serif-font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial',
   sans-serif !default;
-$monospace-font-family: 'Source Code Pro', 'Consolas', monospace !default;
 
 $base-font-size: 16px !default;
 $small-font-size: 14px !default;

--- a/app/views/accounts/_personal_key.html.erb
+++ b/app/views/accounts/_personal_key.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('idv.messages.personal_key') %>
   </p>
-  <div class="margin-bottom-1 padding-y-1 padding-x-2 inline-block fs-20p text-normal monospace bg-white radius-sm">
+  <div class="margin-bottom-1 padding-y-1 padding-x-2 inline-block fs-20p text-normal font-family-mono bg-white radius-sm">
     <%= view_model.personal_key %>
   </div>
 <% end %>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -5,7 +5,7 @@
   <div class="bg-personal-key padding-top-4 margin-y-2">
     <div class="padding-x-0 tablet:padding-x-1 padding-y-2 separator-text bg-pk-box">
       <% code.split('-').each do |word| %>
-        <% concat(content_tag(:strong, word, class: 'separator-text__code monospace', data: { personal_key: '' })) %>
+        <% concat(content_tag(:strong, word, class: 'separator-text__code', data: { personal_key: '' })) %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -12,7 +12,7 @@ locals:
 <% name = local_assigns.delete(:name) { :code }
    numeric =local_assigns.delete(:numeric) { true }
    transport = local_assigns.delete(:transport) { 'sms' }
-   classes = ['field monospace usa-input one-time-code-input']
+   classes = ['field font-family-mono usa-input one-time-code-input']
    classes << local_assigns.delete(:class) if local_assigns[:class] %>
 
 

--- a/app/views/shared/_personal_key_input.html.erb
+++ b/app/views/shared/_personal_key_input.html.erb
@@ -1,6 +1,6 @@
 <input aria-label="<%= t('forms.personal_key.confirmation_label') %>"
        autocomplete="off"
-       class="col-12 margin-bottom-6 border-dashed field monospace personal-key caps"
+       class="col-12 margin-bottom-6 border-dashed field font-family-mono personal-key caps"
        maxlength="<%= PersonalKeyFormatter.code_length %>"
        name="personal_key"
        pattern="^<%= PersonalKeyFormatter.regexp_string %>$"

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -14,7 +14,7 @@
         <legend class="margin-bottom-1">
           Certificate Subject
         </legend>
-        <%= text_field_tag(:subject, '', class: 'block col-12 field monospace') %>
+        <%= text_field_tag(:subject, '', class: 'block col-12 field font-family-mono') %>
       </div>
       <div class="margin-bottom-4">
         <fieldset class="margin-0 padding-0 border-0">

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -16,7 +16,7 @@
       <%= t('instructions.mfa.piv_cac.step_1_info') %>
     </div>
     <div class='margin-left-6 margin-bottom-4'>
-      <input type="text" name="name" id="nickname" value="" required="required" aria-invalid="false" class="block col-12 field monospace" size="16" maxlength="20" />
+      <input type="text" name="name" id="nickname" value="" required="required" aria-invalid="false" class="block col-12 field font-family-mono" size="16" maxlength="20" />
     </div>
     <hr>
   </li>

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -15,7 +15,7 @@
     <%= form_tag(submit_new_piv_cac_url) do %>
       <%= label_tag 'code', t('forms.piv_cac_setup.nickname'), class: 'block bold' %>
       <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
-                                    class: 'block col-12 field monospace', size: 16, maxlength: 20,
+                                    class: 'block col-12 field font-family-mono', size: 16, maxlength: 20,
                                     'aria-labelledby': 'totp-label' %>
        <div class="margin-top-2">
         <%= submit_tag t('forms.piv_cac_setup.submit'), class: 'usa-button usa-button--wide usa-button--big' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -15,7 +15,7 @@
       <div class="sm-col-9 sm-ml-28p">
         <div class="clearfix margin-x-neg-1">
           <div class="col col-6 sm-col-7 padding-x-1">
-            <%= text_field_tag :name, '', required: true, aria: { invalid: false }, class: 'block col-12 field monospace',
+            <%= text_field_tag :name, '', required: true, aria: { invalid: false }, class: 'block col-12 field font-family-mono',
                                           maxlength: 20, 'aria-labelledby': 'totp-nickname' %>
           </div>
         </div>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -33,7 +33,7 @@
         required: true,
         aria: { invalid: false },
         id: 'nickname',
-        class: 'block col-12 field monospace',
+        class: 'block col-12 field font-family-mono',
         size: 16,
         maxlength: 20,
       ) %>


### PR DESCRIPTION
**Why**: As a user, I want to see a consistent font and brand across all login.gov sites, including the IdP, so that I can trust that this website is legitimate.

Before|After
---|---
![Screen Shot 2022-02-01 at 2 40 49 PM](https://user-images.githubusercontent.com/1779930/152039484-0e681c6f-9200-45b9-a0a6-66c25ec80f40.png)|![Screen Shot 2022-02-01 at 2 41 44 PM](https://user-images.githubusercontent.com/1779930/152039489-0d9bb2fa-d9fb-4654-b037-5dc5046b9d34.png)

