### PR TITLE
Bypass asset_host configuration for icon sprite

### DIFF
--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -260,6 +260,16 @@ class IconComponent < BaseComponent
   def icon_path
     # Revert back to using design system image once upstream CSP fix has been patched.
     # See: https://github.com/uswds/uswds/pull/4487
-    [image_path('sprite.svg'), '#', icon].join
+    [image_path('sprite.svg', host: asset_host), '#', icon].join
+  end
+
+  private
+
+  def asset_host
+    if Rails.env.production?
+      IdentityConfig.store.domain_name
+    elsif request
+      request.base_url
+    end
   end
 end

--- a/spec/components/icon_component_spec.rb
+++ b/spec/components/icon_component_spec.rb
@@ -1,10 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe IconComponent, type: :component do
+  let(:asset_host) { 'http://wrong.example.com' }
+  let(:domain_name) { 'http://correct.example.com' }
+
+  before do
+    allow(IdentityConfig.store).to receive(:asset_host).and_return(asset_host)
+    allow(IdentityConfig.store).to receive(:domain_name).and_return(domain_name)
+  end
+
   it 'renders icon svg' do
     rendered = render_inline IconComponent.new(icon: :print)
 
-    expect(rendered).to have_css('.usa-icon use[href$=".svg#print"]')
+    expect(rendered).to have_css(".usa-icon use[href^='#{request.base_url}'][href$='.svg#print']")
   end
 
   context 'with invalid icon' do
@@ -26,6 +34,20 @@ RSpec.describe IconComponent, type: :component do
       rendered = render_inline IconComponent.new(icon: :print, data: { foo: 'bar' })
 
       expect(rendered).to have_css('.usa-icon[data-foo="bar"]')
+    end
+  end
+
+  context 'in production' do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it 'bypasses configured asset_host and uses domain_name instead' do
+      rendered = render_inline IconComponent.new(icon: :print)
+
+      href = rendered.css('use').first['href']
+
+      expect(href).to start_with(domain_name)
     end
   end
 end


### PR DESCRIPTION
**Why**: Icon sprites consumed via SVG `<use>` [cannot reference cross-domain resources](https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html), so it must be served from the same host.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1643749421139809

_Draft and configured to merge to `aduth-process-list` while testing._