### PR TITLE
Update phone number masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 - Document capture: The image file field label is no longer set to file names so that screen readers do not read the filenames to users. (#5858)
 
 ### Bug Fixes Users Might Notice
+- Phone numbers: Improve formatting of masked numbers for international phone numbers (#5895)
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 ### Accessibility
 
 ### Bug Fixes Users Might Notice
+- Phone numbers: Improve formatting of masked numbers for international phone numbers (#5895)
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Improve changelog CI check to detail opt-out behavior (#5897)
@@ -26,7 +27,6 @@ RC 176 - 2022-02-03
 - Document capture: The image file field label is no longer set to file names so that screen readers do not read the filenames to users. (#5858)
 
 ### Bug Fixes Users Might Notice
-- Phone numbers: Improve formatting of masked numbers for international phone numbers (#5895)
 
 ### Behind the Scenes Changes Users Probably Won't Notice
 - Maintenance: Add CI check to include changelog message in change requests (#5836)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -281,7 +281,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
   def display_phone_to_deliver_to
     if UserSessionContext.authentication_context?(context)
-      masked_number(phone_configuration.phone)
+      phone_configuration.masked_phone
     else
       user_session[:unconfirmed_phone]
     end
@@ -320,10 +320,5 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
   def phone_configuration
     MfaContext.new(current_user).phone_configuration(user_session[:phone_id])
-  end
-
-  def masked_number(number)
-    return '' if number.blank?
-    "***-***-#{number[-4..-1]}"
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -65,7 +65,7 @@ class UserDecorator
   end
 
   def masked_two_factor_phone_number
-    masked_number(MfaContext.new(user).phone_configurations.take&.phone)
+    MfaContext.new(user).phone_configurations.take&.masked_phone
   end
 
   def active_identity_for(service_provider)
@@ -158,11 +158,6 @@ class UserDecorator
   end
 
   private
-
-  def masked_number(number)
-    return '' if number.blank?
-    "***-***-#{number[-4..-1]}"
-  end
 
   def lockout_period
     return DEFAULT_LOCKOUT_PERIOD if lockout_period_config.blank?

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -64,10 +64,6 @@ class UserDecorator
     )
   end
 
-  def masked_two_factor_phone_number
-    MfaContext.new(user).phone_configurations.take&.masked_phone
-  end
-
   def active_identity_for(service_provider)
     user.active_identities.find_by(service_provider: service_provider.issuer)
   end

--- a/app/forms/edit_phone_form.rb
+++ b/app/forms/edit_phone_form.rb
@@ -5,6 +5,8 @@ class EditPhoneForm
 
   attr_reader :user, :phone_configuration, :delivery_preference, :make_default_number
 
+  delegate :masked_phone, to: :phone_configuration
+
   def initialize(user, phone_configuration)
     @user = user
     @phone_configuration = phone_configuration
@@ -17,12 +19,6 @@ class EditPhoneForm
     success = valid?
     update_phone_configuration if success
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
-  end
-
-  def masked_number
-    phone_number = phone_configuration.phone
-    return '' if !phone_number || phone_number.blank?
-    "***-***-#{phone_number[-4..-1]}"
   end
 
   def delivery_preference_sms?

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -12,6 +12,13 @@ class PhoneConfiguration < ApplicationRecord
     Phonelib.parse(phone).international
   end
 
+  def masked_phone
+    return '' if phone.blank?
+
+    formatted = Phonelib.parse(phone).national
+    formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+  end
+
   def selection_presenters
     options = []
 

--- a/app/presenters/two_factor_authentication/phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/phone_selection_presenter.rb
@@ -16,7 +16,7 @@ module TwoFactorAuthentication
       if configuration.present?
         t(
           'two_factor_authentication.login_options.phone_info_html',
-          phone: masked_number(configuration.phone),
+          phone: configuration.masked_phone,
         )
       else
         voip_note = if IdentityConfig.store.voip_block
@@ -36,13 +36,6 @@ module TwoFactorAuthentication
 
     def disabled?
       VendorStatus.new.all_phone_vendor_outage?
-    end
-
-    private
-
-    def masked_number(number)
-      return '' if number.blank?
-      "***-***-#{number[-4..-1]}"
     end
   end
 end

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -9,7 +9,7 @@
 
   <div class="margin-bottom-1 h4">
     <%= t('two_factor_authentication.phone_label') %>:&nbsp;
-    <strong><%= @edit_phone_form.masked_number %></strong>
+    <strong><%= @edit_phone_form.masked_phone %></strong>
   </div><br/>
 
   <%= render 'delivery_preference_selection' %>

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -91,14 +91,6 @@ describe UserDecorator do
     end
   end
 
-  describe '#masked_number' do
-    it 'returns blank for a nil number' do
-      user = build_stubbed(:user)
-      user_decorator = UserDecorator.new(user)
-      expect(user_decorator.send(:masked_number, nil)).to eq ''
-    end
-  end
-
   describe '#active_identity_for' do
     it 'returns Identity matching ServiceProvider' do
       sp = create(:service_provider, issuer: 'http://sp.example.com')

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -16,7 +16,7 @@ describe 'default phone selection' do
         sign_in_before_2fa(user)
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
-          number: '***-***-1212',
+          number: '(***) ***-1212',
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
@@ -45,7 +45,7 @@ describe 'default phone selection' do
         sign_in_before_2fa(user)
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
-          number: '***-***-3434',
+          number: '(***) ***-3434',
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
@@ -84,7 +84,7 @@ describe 'default phone selection' do
         sign_in_before_2fa(user)
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
-          number: '***-***-3111',
+          number: '(***) ***-3111',
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
@@ -115,7 +115,7 @@ describe 'default phone selection' do
         sign_in_before_2fa(user)
         expect(page).to have_content t(
           'instructions.mfa.voice.number_message_html',
-          number: '***-***-3434',
+          number: '(***) ***-3434',
         )
       end
     end

--- a/spec/features/sign_in/two_factor_options_spec.rb
+++ b/spec/features/sign_in/two_factor_options_spec.rb
@@ -275,8 +275,8 @@ describe '2FA options when signing in' do
         to have_selector("#two_factor_options_form_selection_sms_#{second_id}", count: 1)
       expect(page).to_not have_content('+1 202-555-1212')
       expect(page).to_not have_content('+1 202-555-1213')
-      expect(page).to have_content('***-***-1212')
-      expect(page).to have_content('***-***-1213')
+      expect(page).to have_content('(***) ***-1212')
+      expect(page).to have_content('(***) ***-1213')
       expect(page).
         to have_selector("#two_factor_options_form_selection_voice_#{first_id}", count: 1)
       expect(page).

--- a/spec/models/phone_configuration_spec.rb
+++ b/spec/models/phone_configuration_spec.rb
@@ -30,4 +30,31 @@ describe PhoneConfiguration do
       end
     end
   end
+
+  describe '#masked_phone' do
+    let(:phone_configuration) { build(:phone_configuration, phone: phone) }
+    let(:phone) { '+1 703 555 1212' }
+
+    subject(:masked_phone) { phone_configuration.masked_phone }
+
+    it 'masks the phone number, leaving the last 4 digits' do
+      expect(masked_phone).to eq('(***) ***-1212')
+    end
+
+    context 'with a blank phone number' do
+      let(:phone) { '   ' }
+
+      it 'is the empty string' do
+        expect(masked_phone).to eq('')
+      end
+    end
+
+    context 'with an international number' do
+      let(:phone) { '+212 636-023853' }
+
+      it 'keeps the groupings and leaves the last 4 digits' do
+        expect(masked_phone).to eq('****-**3853')
+      end
+    end
+  end
 end

--- a/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TwoFactorAuthentication::PhoneSelectionPresenter do
       let(:phone) { build(:phone_configuration, phone: '+1 888 867-5309') }
 
       it 'includes the masked the number' do
-        expect(presenter.info).to include('***-***-5309')
+        expect(presenter.info).to include('(***) ***-5309')
       end
     end
 
@@ -21,7 +21,7 @@ RSpec.describe TwoFactorAuthentication::PhoneSelectionPresenter do
       end
 
       it 'does not include a masked number' do
-        expect(presenter.info).to_not include('***-***')
+        expect(presenter.info).to_not include('***')
       end
 
       context 'when VOIP numbers are blocked' do

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
   let(:presenter_data) do
     {
       otp_delivery_preference: 'sms',
-      phone_number: '***-***-1212',
+      phone_number: '(***) ***-1212',
       code_value: '12777',
       unconfirmed_user: false,
     }


### PR DESCRIPTION
(broken out of https://github.com/18F/identity-idp/pull/5894)

- Method was defined 4 times before, now it's only defined once
- Updated it to leverage Phonelib for better grouping of digits
  (improves support for international numbers, removes USA assumption)

The phone gem knows to add parens around US area codes, so we get a nice pretty change like this:

| before | after |
| --- | --- |
| <img width="621" alt="Screen Shot 2022-02-01 at 8 29 25 PM" src="https://user-images.githubusercontent.com/458784/152093341-08854872-f2a8-4329-a6ec-39d95c59cc56.png"> |  <img width="621" alt="Screen Shot 2022-02-01 at 8 29 03 PM" src="https://user-images.githubusercontent.com/458784/152093368-b7e54220-377f-48c2-91cc-3c19a64600da.png"> |
