### PR TITLE
Include skip trigger in CHANGELOG warning messge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Unreleased
 -----------
 
 ### Improvements/Changes
+
+### Accessibility
+
+### Bug Fixes Users Might Notice
+
+### Behind the Scenes Changes Users Probably Won't Notice
+- Maintenance: Improve changelog CI check to detail opt-out behavior (#5897)
+
+RC 176 - 2022-02-03
+----------------------
+
+### Improvements/Changes
 - Layout: Improve layout margins and typographical consistency across several content pages. (#5857, #5869, #5885)
 - Typography: Updated monospace font to Roboto Mono for consistency across login.gov sites. (#5891)
 

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -74,6 +74,8 @@ def main(args)
       <<~ERROR,
         A valid changelog line was not found.
         Changelog entries should be formatted as: - CATEGORY: CHANGE_DESCRIPTION (#PULL_REQUEST_NUMBER)
+
+        Include "[skip changelog]" in a commit message to bypass this check.
       ERROR
     )
 


### PR DESCRIPTION
**Why**: So that developers are aware of this workaround.