### PR TITLE
LG-4795: Replace font-family classes using design system

### DIFF
--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -4,12 +4,6 @@ html {
 body {
   -webkit-font-smoothing: antialiased;
 }
-.sans-serif {
-  font-family: $sans-serif-font-family;
-}
-.serif {
-  font-family: $serif-font-family;
-}
 
 .text-decoration-none {
   text-decoration: none;

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row padding-top-2 padding-bottom-4 tablet:padding-y-0 margin-bottom-4 bg-lightest-blue sm-bg-none position-relative">
   <div class="grid-col-12 tablet:grid-col-fill">
     <h1 class="margin-0 center sm-left-align">
-      <span class="regular sans-serif tablet:display-none">
+      <span class="regular font-family-sans tablet:display-none">
         <%= t('account.welcome') %>,
         <span class="bold">
           <%= view_model.header_personalization %>
@@ -16,6 +16,6 @@
     <%= render 'accounts/badges' %>
   </div>
 </div>
-<h1 class="padding-bottom-1 bold tablet:display-none serif">
+<h1 class="padding-bottom-1 bold tablet:display-none">
   <%= t('headings.account.login_info') %>
 </h1>

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,7 +1,7 @@
 <div id="reactivate-account-modal" class="display-none" tabindex="-1">
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
-      <h2 class="margin-y-2 fs-20p sans-serif regular center" id="<%= label_id %>">
+      <h2 class="margin-y-2 fs-20p font-family-sans regular center" id="<%= label_id %>">
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>
       <hr class="margin-bottom-4 border-width-05" />

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -21,7 +21,7 @@
   <%= t('instructions.account.reactivate.begin') %>
 </h2>
 
-<h3 class="fs-20p sans-serif margin-top-6">
+<h3 class="fs-20p font-family-sans margin-top-6">
   <%= t('instructions.account.reactivate.with_key') %>
 </h3>
 

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,7 +1,7 @@
 <div id='session-timeout-msg' class='display-none' tabindex='-1'>
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
-      <h2 class='margin-y-2 fs-20p sans-serif regular center' id='<%= label_id %>'>
+      <h2 class='margin-y-2 fs-20p font-family-sans regular center' id='<%= label_id %>'>
         <%= t('headings.session_timeout_warning') %>
       </h2>
       <hr class='margin-bottom-4 border-width-05' />


### PR DESCRIPTION
**Why**: So that we standardize on design system utilities and reduce references to hard-coded font stack variables.

I had hoped to get rid of these variables altogether, but based on how these are used in BassCSS and the load order of our CSS vendor assets, it doesn't seem viable for the short-term.

There are no visual changes expected from this refactor.

(Skipping changelog for now, will group together as part of overall Public Sans work of LG-4795 once it's ready)