### PR TITLE
Strip the fragment from URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Unreleased
 - Logging: Fix logging of transport attribute in RISC event delivery (#5881)
 - Security: Update JavaScript packages with known vulnerabilities (#5889)
 
+RC 175.3 - 2022-02-02
+
+### Bug Fixes Users Might Notice
+
+- Content security policy: An issue with the form action that prevented redirect to service providers was fixed (#5899)
+
 RC 175.2 - 2022-01-29
 ----------------------
 

--- a/app/services/secure_headers_allow_list.rb
+++ b/app/services/secure_headers_allow_list.rb
@@ -42,8 +42,9 @@ class SecureHeadersAllowList
   end
 
   def self.reduce_web_sp_uri(uri)
-    uri.path = ''
+    uri.fragment = nil
     uri.query = nil
+    uri.path = ''
     uri.to_s
   end
 

--- a/spec/services/secure_headers_allow_list_spec.rb
+++ b/spec/services/secure_headers_allow_list_spec.rb
@@ -62,5 +62,18 @@ RSpec.describe SecureHeadersAllowList do
         ["'self'", 'https://example1.com', 'http://example2.com'],
       )
     end
+
+    it 'handles URLs that include URL fragments' do
+      redirect_uri = 'https://auth.example.com/#/redirect'
+      allowed_redirect_uris = [
+        'https://example.com/#/another_one',
+      ]
+
+      result = csp_with_sp_redirect_uris(redirect_uri, allowed_redirect_uris)
+
+      expect(result).to match_array(
+        ["'self'", 'https://auth.example.com', 'https://example.com'],
+      )
+    end
   end
 end


### PR DESCRIPTION
**Why**: So that apps that use hash routing will have their redirect URIs properly reduced.