### PR TITLE
Update rules of use timestamp with note

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -200,7 +200,7 @@ risc_notifications_rate_limit_overrides: '{"https://example.com/push":{"interval
 risc_notifications_request_timeout: '3'
 ruby_workers_idv_enabled: 'true'
 rules_of_use_horizon_years: '6'
-rules_of_use_updated_at: '2022-01-19T00:00:00Z'
+rules_of_use_updated_at: '2022-01-19T00:00:00Z' # Production has a newer timestamp than this, update directly in S3
 s3_public_reports_enabled: 'false'
 s3_reports_enabled: 'false'
 saml_secret_rotation_enabled: 'false'


### PR DESCRIPTION
Previously we had been using this value to update the one in prod and sync with a deploy.

As of this today I've updated the value in prod's S3 config directly, so this note serves to remind our future selves that updates should go to S3 because it will override the ones here