### PR TITLE
Use ButtonComponent for new account actions

### DIFF
--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -1,3 +1,5 @@
+$icon-min-padding: 2px;
+
 // Upstream: https://github.com/uswds/uswds/pull/4493
 .usa-icon {
   .usa-button > &:first-child {
@@ -11,8 +13,8 @@
   }
 
   .usa-button:not(.usa-button--unstyled) > &:first-child {
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-left: -1 * $icon-min-padding;
+    margin-right: #{0.5rem - px-to-rem($icon-min-padding)};
   }
 }
 

--- a/app/components/button_component.html.erb
+++ b/app/components/button_component.html.erb
@@ -1,6 +1,5 @@
 <%= action.call(
-      safe_join([icon_content, content&.strip].compact),
       **tag_options,
       type: tag_type,
       class: css_class,
-    ) %>
+    ) { safe_join([icon_content, content&.strip].compact) } %>

--- a/app/components/button_component.html.erb
+++ b/app/components/button_component.html.erb
@@ -1,5 +1,4 @@
 <%= action.call(
       **tag_options,
-      type: tag_type,
       class: css_class,
     ) { safe_join([icon_content, content&.strip].compact) } %>

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -1,8 +1,6 @@
 class ButtonComponent < BaseComponent
   attr_reader :action, :icon, :outline, :tag_options
 
-  DEFAULT_BUTTON_TYPE = :button
-
   def initialize(
     action: ->(**tag_options, &block) { button_tag(**tag_options, &block) },
     icon: nil,
@@ -19,10 +17,6 @@ class ButtonComponent < BaseComponent
     classes = ['usa-button', *tag_options[:class]]
     classes << 'usa-button--outline' if outline
     classes
-  end
-
-  def tag_type
-    tag_options.fetch(:type, DEFAULT_BUTTON_TYPE)
   end
 
   def icon_content

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -4,7 +4,7 @@ class ButtonComponent < BaseComponent
   DEFAULT_BUTTON_TYPE = :button
 
   def initialize(
-    action: ->(content, **tag_options) { button_tag(content, **tag_options) },
+    action: ->(**tag_options, &block) { button_tag(**tag_options, &block) },
     icon: nil,
     outline: false,
     **tag_options

--- a/app/components/clipboard_button_component.rb
+++ b/app/components/clipboard_button_component.rb
@@ -2,7 +2,7 @@ class ClipboardButtonComponent < ButtonComponent
   attr_reader :clipboard_text, :tag_options
 
   def initialize(clipboard_text:, **tag_options)
-    super(**tag_options, icon: :content_copy)
+    super(**tag_options, type: :button, icon: :content_copy)
 
     @clipboard_text = clipboard_text
   end

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -32,7 +32,7 @@
 </div>
 <% if EmailPolicy.new(current_user).can_add_email? %>
   <%= render ButtonComponent.new(
-        action: ->(type:, **tag_options, &block) { link_to(add_email_path, **tag_options, &block) },
+        action: ->(**tag_options, &block) { link_to(add_email_path, **tag_options, &block) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -32,7 +32,7 @@
 </div>
 <% if EmailPolicy.new(current_user).can_add_email? %>
   <%= render ButtonComponent.new(
-        action: ->(content, type:, **tag_options) { link_to(content, add_email_path, **tag_options) },
+        action: ->(type:, **tag_options, &block) { link_to(add_email_path, **tag_options, &block) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -32,7 +32,7 @@
 </div>
 <% if EmailPolicy.new(current_user).can_add_email? %>
   <%= render ButtonComponent.new(
-        action: ->(content, **tag_options) { link_to(content, add_email_path, **tag_options) },
+        action: ->(content, type:, **tag_options) { link_to(content, add_email_path, **tag_options) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -31,9 +31,10 @@
   <% end %>
 </div>
 <% if EmailPolicy.new(current_user).can_add_email? %>
-  <%= link_to(
-        prefix_with_plus(t('account.index.email_add')),
-        add_email_path,
-        class: 'usa-button usa-button--outline margin-top-2',
-      ) %>
+  <%= render ButtonComponent.new(
+        action: ->(content, **tag_options) { link_to(content, add_email_path, **tag_options) },
+        outline: true,
+        icon: :add,
+        class: 'margin-top-2',
+      ).with_content(t('account.index.email_add')) %>
 <% end %>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -25,7 +25,7 @@
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(content, type:, **tag_options) { link_to(content, add_phone_path, **tag_options) },
+        action: ->(type:, **tag_options, &block) { link_to(content, add_phone_path, **tag_options, &block) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -25,7 +25,7 @@
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(type:, **tag_options, &block) { link_to(content, add_phone_path, **tag_options, &block) },
+        action: ->(**tag_options, &block) { link_to(content, add_phone_path, **tag_options, &block) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -24,9 +24,10 @@
   <% end %>
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
-  <%= link_to(
-        prefix_with_plus(t('account.index.phone_add')),
-        add_phone_path,
-        class: 'usa-button usa-button--outline margin-top-2',
-      ) %>
+  <%= render ButtonComponent.new(
+        action: ->(content, **tag_options) { link_to(content, add_phone_path, **tag_options) },
+        outline: true,
+        icon: :add,
+        class: 'margin-top-2',
+      ).with_content(t('account.index.phone_add')) %>
 <% end %>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -25,7 +25,7 @@
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) { link_to(content, add_phone_path, **tag_options, &block) },
+        action: ->(**tag_options, &block) { link_to(add_phone_path, **tag_options, &block) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -25,7 +25,7 @@
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(content, **tag_options) { link_to(content, add_phone_path, **tag_options) },
+        action: ->(content, type:, **tag_options) { link_to(content, add_phone_path, **tag_options) },
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -37,8 +37,8 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(content, **tag_options) do
-        button_to(idv_resend_otp_path, method: :post, **tag_options) { content }
+      action: ->(**tag_options, &block) do
+        button_to(idv_resend_otp_path, method: :post, **tag_options, &block)
       end,
       outline: true,
       icon: :loop,

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -9,7 +9,7 @@
   <%= render 'partials/personal_key/key', code: code %>
 </div>
 <%= render ButtonComponent.new(
-      action: ->(type:, **tag_options, &block) do
+      action: ->(**tag_options, &block) do
         link_to(idv_download_personal_key_path, **tag_options, &block)
       end,
       icon: :file_download,
@@ -19,6 +19,7 @@
 <%= render ButtonComponent.new(
       icon: :print,
       outline: true,
+      type: :button,
       data: { print: '' },
       class: 'margin-right-2 margin-bottom-2 tablet:margin-bottom-0',
     ).with_content(t('users.personal_key.print')) %>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -9,8 +9,8 @@
   <%= render 'partials/personal_key/key', code: code %>
 </div>
 <%= render ButtonComponent.new(
-      action: ->(content, type:, **tag_options) do
-        link_to(idv_download_personal_key_path, **tag_options) { content }
+      action: ->(type:, **tag_options, &block) do
+        link_to(idv_download_personal_key_path, **tag_options, &block)
       end,
       icon: :file_download,
       outline: true,

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -9,7 +9,7 @@
   <%= render 'partials/personal_key/key', code: code %>
 </div>
 <%= render ButtonComponent.new(
-      action: ->(content, **tag_options) do
+      action: ->(content, type:, **tag_options) do
         link_to(idv_download_personal_key_path, **tag_options) { content }
       end,
       icon: :file_download,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -46,7 +46,7 @@
               },
             ),
             **tag_options,
-            &block,
+            &block
           )
         end,
         outline: true,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -37,7 +37,7 @@
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
   <%= render ButtonComponent.new(
-        action: ->(type:, **tag_options, &block) do
+        action: ->(**tag_options, &block) do
           link_to(
             otp_send_path(
               otp_delivery_selection_form: {

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -37,7 +37,7 @@
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
   <%= render ButtonComponent.new(
-        action: ->(content, **tag_options) do
+        action: ->(content, type:, **tag_options) do
           link_to(
             otp_send_path(
               otp_delivery_selection_form: {

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -37,7 +37,7 @@
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
   <%= render ButtonComponent.new(
-        action: ->(content, type:, **tag_options) do
+        action: ->(type:, **tag_options, &block) do
           link_to(
             otp_send_path(
               otp_delivery_selection_form: {
@@ -46,7 +46,8 @@
               },
             ),
             **tag_options,
-          ) { content }
+            &block,
+          )
         end,
         outline: true,
         icon: :loop,

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -33,7 +33,7 @@
   <div class="margin-top-0">
     <% if desktop_device? %>
       <%= render ButtonComponent.new(
-            action: ->(type:, **tag_options, &block) do
+            action: ->(**tag_options, &block) do
               link_to(backup_code_download_path, **tag_options, &block)
             end,
             outline: true,
@@ -43,6 +43,7 @@
     <%= render ButtonComponent.new(
           icon: :print,
           outline: true,
+          type: :button,
           data: { print: '' },
           class: 'margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2',
         ).with_content(t('forms.backup_code.print')) %>

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -33,7 +33,7 @@
   <div class="margin-top-0">
     <% if desktop_device? %>
       <%= render ButtonComponent.new(
-            action: ->(content, **tag_options) do
+            action: ->(content, type:, **tag_options) do
               link_to(backup_code_download_path, **tag_options) { content }
             end,
             outline: true,

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -33,8 +33,8 @@
   <div class="margin-top-0">
     <% if desktop_device? %>
       <%= render ButtonComponent.new(
-            action: ->(content, type:, **tag_options) do
-              link_to(backup_code_download_path, **tag_options) { content }
+            action: ->(type:, **tag_options, &block) do
+              link_to(backup_code_download_path, **tag_options, &block)
             end,
             outline: true,
             icon: :file_download,

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -4,25 +4,15 @@ RSpec.describe ButtonComponent, type: :component do
   include ActionView::Context
   include ActionView::Helpers::TagHelper
 
-  let(:type) { nil }
   let(:outline) { false }
   let(:content) { 'Button' }
-  let(:options) do
-    {
-      type: type,
-    }.compact
-  end
 
   subject(:rendered) do
-    render_inline ButtonComponent.new(outline: outline, **options).with_content(content)
+    render_inline ButtonComponent.new(outline: outline).with_content(content)
   end
 
   it 'renders button content' do
     expect(rendered).to have_content(content)
-  end
-
-  it 'renders as type=button' do
-    expect(rendered).to have_css('button[type=button]')
   end
 
   it 'renders with design system classes' do
@@ -37,11 +27,15 @@ RSpec.describe ButtonComponent, type: :component do
     end
   end
 
-  context 'with type' do
-    let(:type) { :submit }
+  context 'with tag options' do
+    it 'renders as attributes' do
+      rendered = render_inline ButtonComponent.new(
+        type: :button,
+        class: 'my-custom-class',
+        data: { foo: 'bar' },
+      )
 
-    it 'renders as type' do
-      expect(rendered).to have_css('button[type=submit]')
+      expect(rendered).to have_css('.usa-button.my-custom-class[type="button"][data-foo="bar"]')
     end
   end
 
@@ -64,7 +58,7 @@ RSpec.describe ButtonComponent, type: :component do
       ).with_content(content)
 
       expect(rendered).to have_css(
-        'lg-custom-button[type="button"][data-extra].custom-class',
+        'lg-custom-button[data-extra].custom-class',
         text: content,
       )
     end

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe ButtonComponent, type: :component do
   context 'with custom button action' do
     it 'calls the action with content and tag_options' do
       rendered = render_inline ButtonComponent.new(
-        action: ->(content, **tag_options) do
-          content_tag(:'lg-custom-button', **tag_options, data: { extra: '' }) { content }
+        action: ->(**tag_options, &block) do
+          content_tag(:'lg-custom-button', **tag_options, data: { extra: '' }, &block)
         end,
         class: 'custom-class',
       ).with_content(content)

--- a/spec/components/clipboard_button_component_spec.rb
+++ b/spec/components/clipboard_button_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ClipboardButtonComponent, type: :component do
     let(:tag_options) { { outline: true, data: { foo: 'bar' } } }
 
     it 'renders button given the tag options' do
-      expect(rendered).to have_css('button.usa-button[data-foo="bar"]')
+      expect(rendered).to have_css('button.usa-button[type="button"][data-foo="bar"]')
     end
 
     it 'respects keyword arguments of button component' do

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -111,7 +111,7 @@ feature 'adding email address' do
     user = create(:user, :signed_up)
     sign_in_and_2fa_user(user)
 
-    expect(page).to_not have_link('+ ' + t('account.index.email_add'))
+    expect(page).to_not have_link(t('account.index.email_add'))
     visit add_email_path
     expect(page).to have_current_path(account_path)
     expect(page).to have_content t('email_addresses.add.limit')
@@ -207,7 +207,7 @@ feature 'adding email address' do
 
     visit account_path
 
-    expect(page).to have_link('+ ' + t('account.index.email_add'))
+    expect(page).to have_link(t('account.index.email_add'))
     within('.sidenav') do
       click_on t('account.navigation.add_email')
     end

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -6,7 +6,7 @@ describe 'Add a new phone number' do
     phone = '+1 (225) 278-1234'
 
     sign_in_and_2fa_user(user)
-    expect(page).to have_link('+ ' + t('account.index.phone_add'))
+    expect(page).to have_link(t('account.index.phone_add'), normalize_ws: true, exact: true)
     within('.sidenav') do
       click_on t('account.navigation.add_phone_number')
     end
@@ -108,7 +108,7 @@ describe 'Add a new phone number' do
     allow(IdentityConfig.store).to receive(:max_phone_numbers_per_account).and_return(1)
     user = create(:user, :signed_up)
     sign_in_and_2fa_user(user)
-    expect(page).to_not have_link('+ ' + t('account.index.phone_add'))
+    expect(page).to_not have_link(t('account.index.phone_add'), normalize_ws: true, exact: true)
     within('.sidenav') do
       click_on t('account.navigation.add_phone_number')
     end


### PR DESCRIPTION
**Why**: So that we're consistently using icons in buttons, and toward an eventual removal of the `prefix_with_plus` helper.

Also fixes an issue where `type` attribute was being wrongly assigned to link implementations of these icon buttons.

Before|After
---|---
![localhost_3000_account (1)](https://user-images.githubusercontent.com/1779930/152402141-dea5ec9f-fcbd-4fd8-8175-43682e53ac93.png)|![localhost_3000_account](https://user-images.githubusercontent.com/1779930/152402146-db359d82-2944-4dc3-92f9-28239b1e62de.png)