### PR TITLE
Remove no-op line in AAMVA verification request

### DIFF
--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -100,7 +100,6 @@ module Proofing
         end
 
         def user_provided_data_map
-          applicant_address = applicant.address
           {
             '//ns2:IdentificationID' => applicant.state_id_data.state_id_number,
             '//ns1:MessageDestinationId' => message_destination_id,


### PR DESCRIPTION
This line makes it look like we send the address to this vendor...but we do not