### PR TITLE
hide STDIN for users:lookup_by_email with io/console

### DIFF
--- a/lib/tasks/users_lookup.rake
+++ b/lib/tasks/users_lookup.rake
@@ -2,9 +2,7 @@ namespace :users do
   desc 'Look up a user by email address'
   task lookup_by_email: :environment do |_task, args|
     require 'io/console'
-    print 'Enter the email address to look up (input will be hidden): '
-    email = STDIN.noecho(&:gets).strip
-    puts "\n"
+    email = STDIN.getpass('Enter the email address to look up (input will be hidden): ')
     user = User.find_with_email(email)
     if user.present?
       puts "uuid: #{user.uuid}"

--- a/lib/tasks/users_lookup.rake
+++ b/lib/tasks/users_lookup.rake
@@ -1,8 +1,10 @@
 namespace :users do
   desc 'Look up a user by email address'
   task lookup_by_email: :environment do |_task, args|
-    print 'Enter the email address to look up: '
-    email = gets.strip
+    require 'io/console'
+    print 'Enter the email address to look up (input will be hidden): '
+    email = STDIN.noecho(&:gets).strip
+    puts "\n"
     user = User.find_with_email(email)
     if user.present?
       puts "uuid: #{user.uuid}"


### PR DESCRIPTION
Follow-up to https://github.com/18F/identity-idp/pull/5822 -- this is so that email addresses won't show up in the CloudWatch SSM logs.

Tested in my sandbox `idp` (hard to show, since it's obscured, but 🤷‍♂️):

Valid email:
```
$ sudo -H -u websrv env "app=idp" sh -euxc "cd '/srv/idp/current'; bundle exec rails users:lookup_by_email"
+ cd /srv/idp/current
+ bundle exec rails users:lookup_by_email
Enter the email address to look up:
uuid: <REDACTED>
```

Invalid email:
```
$ sudo -H -u websrv env "app=idp" sh -euxc "cd '/srv/idp/current'; bundle exec rails users:lookup_by_email"
+ cd /srv/idp/current
+ bundle exec rails users:lookup_by_email
Enter the email address to look up:
No user found
```