### PR TITLE
build-sass: Catch Sass compilation errors

### DIFF
--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-console */
+
 import { watch } from 'chokidar';
 import { fileURLToPath } from 'url';
 import { buildFile } from './index.js';
@@ -28,4 +30,4 @@ Promise.all(
       watch(loadedPaths).on('change', () => buildFile(file, options));
     }
   }),
-);
+).catch(console.error);


### PR DESCRIPTION
**Why**: To avoid warnings related to deprecated promise rejection behavior, which could change in the future and break the compilation altogether.

For the moment, this effectively doesn't change much beyond silencing the warnings, since it was already gracefully recovering from failure and logging the contents of the Sass compilation error message.

>(node:27280) UnhandledPromiseRejectionWarning: Error: expected "{".
>
> ...
>
>(Use `node --trace-warnings ...` to show where the warning was created)
>(node:27280) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
>(node:27280) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.