### PR TITLE
SMS opt-in fixes

### DIFF
--- a/app/views/shared/_troubleshooting_options.html.erb
+++ b/app/views/shared/_troubleshooting_options.html.erb
@@ -2,7 +2,7 @@
 locals:
 * heading_tag: Tag name for heading. Does not affect visual appearance. Defaults to :h2.
 * heading: Heading text.
-* options: List of link options to display, as an array of hashes with `url`, `text`, `external` values.
+* options: List of link options to display, as an array of hashes with `url`, `text`, `new_tab` values.
 * class: Additional class names to add to wrapper element.
 %>
 <% if local_assigns[:options].presence %>

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -26,6 +26,7 @@
         decorated_session.sp_name && {
           url: return_to_sp_cancel_path(location: 'sms_resubscribe_error'),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+          new_tab: true,
         },
         {
           url: MarketingSite.contact_url,

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -26,11 +26,11 @@
         decorated_session.sp_name && {
           url: return_to_sp_cancel_path(location: 'sms_resubscribe_error'),
           text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
         },
         {
           url: MarketingSite.contact_url,
           text: t('links.contact_support', app_name: APP_NAME),
+          new_tab: true,
         },
       ].select(&:present?),
     ) %>

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -45,7 +45,11 @@ module Telephony
           )
           finish = Time.zone.now
           response = build_response(pinpoint_response, start: start, finish: finish)
-          return response if response.success?
+          if response.success? ||
+             response.error.is_a?(OptOutError) ||
+             response.error.is_a?(PermanentFailureError)
+            return response
+          end
           PinpointHelper.notify_pinpoint_failover(
             error: response.error,
             region: sms_config.region,

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -252,7 +252,7 @@ describe Telephony::Pinpoint::SmsSender do
         end
       end
 
-      context 'when the first config errors' do
+      context 'when the first config errors with a transient error' do
         before do
           Pinpoint::MockClient.message_response_result_status_code = 400
           Pinpoint::MockClient.message_response_result_delivery_status = 'DUPLICATE'
@@ -268,6 +268,44 @@ describe Telephony::Pinpoint::SmsSender do
           )
 
           expect(response.success?).to eq(false)
+        end
+      end
+
+      context 'when the first config errors with an opt out error' do
+        before do
+          Pinpoint::MockClient.message_response_result_status_code = 400
+          Pinpoint::MockClient.message_response_result_delivery_status = 'OPT_OUT'
+        end
+
+        it 'only tries one region and returns an error' do
+          expect(backup_mock_client).to_not receive(:send_messages)
+
+          response = subject.send(
+            message: 'This is a test!',
+            to: '+1 (123) 456-7890',
+            country_code: 'US',
+          )
+          expect(response.success?).to eq(false)
+          expect(response.error).to be_present
+        end
+      end
+
+      context 'when the first config errors with a permanent error' do
+        before do
+          Pinpoint::MockClient.message_response_result_status_code = 400
+          Pinpoint::MockClient.message_response_result_delivery_status = 'PERMANENT_FAILURE'
+        end
+
+        it 'only tries one region and returns an error' do
+          expect(backup_mock_client).to_not receive(:send_messages)
+
+          response = subject.send(
+            message: 'This is a test!',
+            to: '+1 (123) 456-7890',
+            country_code: 'US',
+          )
+          expect(response.success?).to eq(false)
+          expect(response.error).to be_present
         end
       end
 

--- a/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
@@ -50,11 +50,12 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
     context 'with an sp' do
       let(:sp_name) { 'An Example SP' }
 
-      it 'links to the sp' do
+      it 'links to the sp in a new window' do
         render
 
         expect(rendered).to have_link(
           t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+          class: 'usa-link--external',
         )
       end
     end

--- a/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
   end
 
   context 'troubleshooting links' do
+    it 'links to the contact form in a new window' do
+      render
+
+      expect(rendered).to have_link(
+        t('links.contact_support', app_name: APP_NAME),
+        href: MarketingSite.contact_url,
+        class: 'usa-link--external',
+      )
+    end
+
     context 'without an other_mfa_options_url' do
       let(:other_mfa_options_url) { nil }
 
@@ -50,12 +60,11 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
     context 'with an sp' do
       let(:sp_name) { 'An Example SP' }
 
-      it 'links to the sp in a new window' do
+      it 'links to the sp' do
         render
 
         expect(rendered).to have_link(
           t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-          class: 'usa-link--external',
         )
       end
     end


### PR DESCRIPTION
Some follow-ups to #5894 based on testing we did today

- Update links to help at SP to be external (give them the little ➡️ and open in new tab)
- Update SmsSender to fail faster (don't retry OPT_OUT errors across regions)