### PR TITLE
Remove safe collapsed margins

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,7 +5,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.forgot')) %>
 
-<p class="mt-tiny margin-bottom-0" id="email-description">
+<p id="email-description">
   <%= t('instructions.password.forgot') %>
 </p>
 

--- a/app/views/idv/activated.html.erb
+++ b/app/views/idv/activated.html.erb
@@ -1,7 +1,8 @@
 <% title t('idv.titles.activated') %>
 
 <%= render PageHeadingComponent.new.with_content(t('idv.titles.activated')) %>
-<p class='mt-tiny margin-bottom-0'>
+
+<p class="margin-bottom-0">
   <%= t(
         'idv.messages.activated_html',
         link: link_to(t('idv.messages.activated_link'), MarketingSite.contact_url),

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -12,9 +12,11 @@
 <% title t('titles.verify_profile') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.title')) %>
-<p class="mt-tiny margin-bottom-0">
+
+<p>
   <%= t('forms.verify_profile.instructions') %>
 </p>
+
 <%= validated_form_for(
       @gpo_verify_form,
       url: idv_gpo_verify_path,

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -1,11 +1,13 @@
 <% title t('titles.passwords.confirm') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.confirm')) %>
-<p class='mt-tiny margin-bottom-0'>
+
+<p>
   <%# for follow up: translate factor_to_change (LG-5701) %>
   <%= user_session[:no_factor_message] ||
         t('help_text.change_factor', factor: user_session[:factor_to_change]) %>
 </p>
+
 <%= validated_form_for(
       current_user,
       url: reauthn_user_password_path,

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content('Enter PIV/CAC Test Information') %>
 
-<p class="mt-tiny margin-bottom-4">
+<p>
   Either enter a subject for a certificate or select an error to simulate a piv/cac response.
 </p>
 

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.backup_code_header_text')) %>
 
-<p class='mt-tiny margin-bottom-0'>
+<p>
   <%= t('two_factor_authentication.backup_code_prompt') %>
 </p>
 

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.personal_key_header_text')) %>
 
-<p class='mt-tiny margin-bottom-0'>
+<p>
   <%= t('two_factor_authentication.personal_key_prompt') %>
 </p>
 

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
-<p class='mt-tiny margin-bottom-4'>
+<p>
   <%= @presenter.piv_cac_help %>
 </p>
 

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -1,5 +1,6 @@
 <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
-<p class="mt-tiny margin-bottom-4"><%== @presenter.description %></p>
+
+<p class="margin-bottom-4"><%== @presenter.description %></p>
 
 <% if @presenter.other_option_display %>
   <%= form_tag(backup_code_setup_path, method: :patch) do %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.edit_info.password')) %>
 
-<p class="mt-tiny margin-bottom-0" id="password-description">
+<p id="password-description">
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
 </p>
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -12,7 +12,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<p><%== @presenter.intro %></p>
+<p><%= @presenter.intro %></p>
 
 <%= render(AlertComponent.new) { t('two_factor_authentication.lockout_information') } %>
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -12,7 +12,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<p class="mt-tiny"><%== @presenter.intro %></p>
+<p><%== @presenter.intro %></p>
 
 <%= render(AlertComponent.new) { t('two_factor_authentication.lockout_information') } %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -4,7 +4,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<p class='mt-tiny margin-bottom-4'>
+<p>
   <%= @presenter.intro %>
 </p>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -13,7 +13,7 @@
       url: webauthn_setup_path,
       method: :patch,
       html: {
-        class: 'margin-bottom-1 read-after-submit',
+        class: 'margin-top-4 margin-bottom-1 read-after-submit',
         id: 'webauthn_form',
       },
     ) do |f| %>


### PR DESCRIPTION
**Why**: To simplify markup, and toward removal of non-standard utility classes like `mt-tiny`.

These classes are unnecessary/redundant due to how [margin collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) will behave in these contexts.

- A `p.mt-tiny` preceded by `PageHeadingComponent` would always have 1rem margin between, from [the heading's bottom margin](https://github.com/18F/identity-idp/blob/69e9db5d4a683a38456ce4455fa0dd4d07109a18/app/assets/stylesheets/components/_page-heading.scss#L3)
- A `p.margin-bottom-0` or `p.margin-bottom-4` followed by a `simple_form_for` or `validated_form_for` would always have 2rem margin between, from [the configured SimpleForm default top margin](https://github.com/18F/identity-idp/blob/69e9db5d4a683a38456ce4455fa0dd4d07109a18/config/initializers/simple_form.rb#L8)