### PR TITLE
LG-3879: Remove BassCSS layout utilities

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -50,6 +50,12 @@ linters:
           - 'btn(-(small|big|narrow|wide|link|primary|secondary|danger|disabled|big|narrow|transparent|border))?'
           - '(border|bg)-(none|black|gray|silver|aqua|blue|navy|teal|green|olive|lime|orange|red|fuchsia|purple|maroon|darken-[1-4]|lighten-[1-4])'
           - 'bg-(cover|contain|center|top|right|bottom|left)'
+          - inline(-block)?
+          - block
+          - table(-cell)?
+          - overflow-(hidden|scroll|auto)
+          - (left|right)
+          - border-box
         suggestion: 'Use USWDS classes instead of BassCSS.'
       - deprecated:
           - 'js-consent-form'

--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -8,7 +8,6 @@
 @import 'basscss-sass/color-tables';
 @import 'basscss-sass/type-scale';
 @import 'basscss-sass/utility-typography';
-@import 'basscss-sass/utility-layout';
 @import 'basscss-sass/white-space';
 @import 'basscss-sass/positions';
 @import 'basscss-sass/grid';

--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -1,32 +1,11 @@
-.nav-branded {
-  height: 56px;
+.main-navigation {
+  @include u-flex('align-center', 'justify-center');
+  @include u-display('flex');
+  @include u-minh(7);
+  @include u-bg('primary-lighter');
 
-  a {
-    line-height: 14px;
-  }
-}
-
-.nav-nonbranded {
-  height: 38px;
-
-  a {
-    line-height: 14px;
-  }
-}
-
-@media #{$breakpoint-sm} {
-  .nav-branded,
-  .nav-nonbranded {
-    height: 72px;
-  }
-
-  .nav-nonbranded {
-    a {
-      line-height: 17px;
-    }
-    img {
-      height: 17px;
-    }
+  @include at-media('tablet') {
+    @include u-minh(9);
   }
 }
 

--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -9,7 +9,6 @@ $great: #00b200;
   background-color: #e9e9e9;
   border: $space-tiny solid #fff;
   border-radius: 6px;
-  box-sizing: border-box;
   float: left;
   height: 16px;
   width: 25%;

--- a/app/assets/stylesheets/variables/_vendor.scss
+++ b/app/assets/stylesheets/variables/_vendor.scss
@@ -2,3 +2,4 @@ $theme-font-path: 'identity-style-guide/dist/assets/fonts';
 $theme-font-type-sans: 'source-sans-pro';
 $theme-font-type-serif: 'merriweather';
 $theme-image-path: 'identity-style-guide/dist/assets/img';
+$theme-global-border-box-sizing: true;

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white">
+<div class="bg-white width-full">
   <div class="container tablet:padding-x-2 tablet:padding-y-4">
     <div class="clearfix">
       <div class="margin-y-105 margin-left-2 tablet:margin-0 col col-4">

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white width-full">
+<div class="bg-white width-full flex-align-self-start">
   <div class="container tablet:padding-x-2 tablet:padding-y-4">
     <div class="clearfix">
       <div class="margin-y-105 margin-left-2 tablet:margin-0 col col-4">

--- a/app/views/accounts/_personal_key.html.erb
+++ b/app/views/accounts/_personal_key.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('idv.messages.personal_key') %>
   </p>
-  <div class="margin-bottom-1 padding-y-1 padding-x-2 inline-block fs-20p text-normal font-family-mono bg-white radius-sm">
+  <div class="margin-bottom-1 padding-y-1 padding-x-2 display-inline-block font-mono-lg bg-white radius-sm">
     <%= presenter.personal_key %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/_return_to_service_provider.html.erb
+++ b/app/views/devise/sessions/_return_to_service_provider.html.erb
@@ -1,10 +1,4 @@
-<div class='sm-col padding-y-1 tablet:padding-0'>
-  <%= link_to(
-        "‹ #{t(
-          'links.back_to_sp',
-          sp: decorated_session.sp_name,
-        )}",
-        return_to_sp_cancel_path,
-        class: 'inline-block text-bottom',
-      ) %>
-</div>
+<%= link_to(
+      "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
+      return_to_sp_cancel_path,
+    ) %>

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -13,7 +13,7 @@
 
 <%= image_tag(
       asset_url('come-back.svg'),
-      size: '140', class: 'block margin-x-auto margin-bottom-2',
+      size: '140', class: 'display-block margin-x-auto margin-bottom-2',
       alt: ''
     ) %>
 

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -71,7 +71,7 @@
           :doc_auth,
           url: url_for(type: :desktop),
           method: 'PUT',
-          html: { autocomplete: 'off', class: 'inline' },
+          html: { autocomplete: 'off', class: 'display-inline' },
         ) do %>
       <button type="submit" class="usa-button usa-button--unstyled">
         <%= t('doc_auth.info.upload_computer_link') %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -47,7 +47,7 @@
 <% end %>
 
 <% if FeatureManagement.enable_gpo_verification? && !@mail_spammed %>
-  <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'block margin-bottom-2' %>
+  <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
 <% end %>
 
 <%= button_to(

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -18,7 +18,7 @@
 <%= validated_form_for(:idv_otp_verification, method: :put) do %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
+      <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block bold' %>
       <div class="margin-bottom-5">
         <%= render(
               'shared/one_time_code_input',

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -62,7 +62,7 @@
   <%= render 'shared/banner' %>
   <main class="site-wrap bg-light-blue" id="main-content">
     <div class="container">
-      <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 border-box <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
+      <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
         <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
         <%= render FlashComponent.new(flash: flash) %>
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/reactivate_account/_modal.html.erb
+++ b/app/views/reactivate_account/_modal.html.erb
@@ -1,6 +1,6 @@
 <div id="reactivate-account-modal" class="display-none" tabindex="-1">
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
-    <div class="padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-warning">
+    <div class="padding-6 cntnr-xxskinny bg-white rounded-xxl modal-warning">
       <h2 class="margin-y-2 fs-20p font-family-sans regular center" id="<%= label_id %>">
         <%= t('instructions.account.reactivate.modal.heading') %>
       </h2>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,6 +1,6 @@
 <div id='session-timeout-msg' class='display-none' tabindex='-1'>
   <%= render layout: 'shared/modal_layout' do |label_id, description_id| %>
-    <div class='padding-4 tablet:padding-6 cntnr-xxskinny border-box bg-white rounded-xxl modal-timeout'>
+    <div class='padding-4 tablet:padding-6 cntnr-xxskinny bg-white rounded-xxl modal-timeout'>
       <h2 class='margin-y-2 fs-20p font-family-sans regular center' id='<%= label_id %>'>
         <%= t('headings.session_timeout_warning') %>
       </h2>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -56,7 +56,7 @@
       </div>
     </div>
   </section>
-  <nav aria-label="<%= t('shared.navigation.landmark_label') %>">
+  <nav class="main-navigation" aria-label="<%= t('shared.navigation.landmark_label') %>">
     <% if content_for?(:nav) %>
       <%= yield(:nav) %>
     <% else %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -6,9 +6,9 @@
     <div class='tablet:display-none border-bottom border-primary-light'>
       <div class='container cntnr-wide padding-y-1 padding-x-2 desktop:padding-x-0 h5'>
         <div class="i18n-mobile-toggle display-flex flex-align-center flex-justify-center">
-            <button class='block text-decoration-none text-primary fs-13p language-mobile-button' aria-expanded='false'>
+            <button class="text-primary fs-13p language-mobile-button" aria-expanded="false">
               <%= image_tag asset_url('globe-blue.svg'), width: 12,
-                                                         class: 'margin-right-1', alt: '', 'aria-hidden': 'true' %><%= t('i18n.language') %><span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
+                                                         class: 'margin-right-1', alt: '', 'aria-hidden': 'true' %><%= t('i18n.language') %><span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
             </button>
         </div>
       </div>
@@ -17,7 +17,7 @@
       <ul class='list-reset margin-bottom-0 text-white center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'block py-12p padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block py-12p padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>
@@ -52,14 +52,14 @@
               <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
                 <%= image_tag asset_url('globe-white.svg'), width: 12,
                                                             class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
-                <span class='caret inline-block ml-tiny' aria-hidden='true'>&#9662;</span>
+                <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
               </button>
               <ul class="i18n-desktop-dropdown list-reset margin-bottom-0 text-white display-none">
                 <% I18n.available_locales.each do |locale| %>
                   <li class='border-bottom border-primary-darker'>
                     <%= link_to t("i18n.locale.#{locale}"),
                                 sanitized_requested_url.merge(locale: locale),
-                                class: 'block pl-24p padding-y-2 text-decoration-none text-white',
+                                class: 'display-block pl-24p padding-y-2 text-decoration-none text-white',
                                 lang: locale == I18n.locale ? nil : locale %>
                   </li>
                 <% end %>

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -1,13 +1,3 @@
-<nav class='nav-branded vertical-align bg-light-blue center relative'>
-  <%= image_tag(
-        asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME,
-                               class: 'inline-block text-middle'
-      ) %>
-  <div class="padding-x-105 display-inline-block">
-    <span class='absolute top-0 bottom-0 border-right border-primary-light margin-y-1 tablet:margin-y-2'></span>
-  </div>
-  <%= image_tag(
-        decorated_session.sp_logo_url, height: 40,
-                                       alt: decorated_session.sp_name, class: 'inline-block text-middle'
-      ) %>
-</nav>
+<%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME) %>
+<div class="margin-x-105 height-5 border-right border-primary-light"></div>
+<%= image_tag(decorated_session.sp_logo_url, height: 40, alt: decorated_session.sp_name) %>

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -3,7 +3,7 @@
         asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME,
                                class: 'inline-block text-middle'
       ) %>
-  <div class='px-12p inline-block'>
+  <div class="padding-x-105 display-inline-block">
     <span class='absolute top-0 bottom-0 border-right border-primary-light margin-y-1 tablet:margin-y-2'></span>
   </div>
   <%= image_tag(

--- a/app/views/shared/_nav_lite.html.erb
+++ b/app/views/shared/_nav_lite.html.erb
@@ -1,1 +1,3 @@
-<%= link_to image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME), root_path %>
+<%= link_to root_path do %>
+  <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME, class: 'display-block') %>
+<% end %>

--- a/app/views/shared/_nav_lite.html.erb
+++ b/app/views/shared/_nav_lite.html.erb
@@ -1,5 +1,1 @@
-<nav class='nav-nonbranded vertical-align bg-light-blue center'>
-  <%= link_to root_path, class: 'inline-block text-middle' do %>
-    <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME, class: 'text-middle') %>
-  <% end %>
-</nav>
+<%= link_to image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME), root_path %>

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -1,6 +1,6 @@
 <div id="personal-key-confirm" class="display-none" tabindex='-1'>
   <%= render layout: '/shared/modal_layout' do |label_id, description_id| %>
-    <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny border-box bg-white radius-lg key-badge">
+    <div class="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny bg-white radius-lg key-badge">
       <h2 class="margin-top-0 margin-bottom-2" id="<%= label_id %>">
         <%= t('forms.personal_key.title') %>
       </h2>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -14,7 +14,7 @@
         <legend class="margin-bottom-1">
           Certificate Subject
         </legend>
-        <%= text_field_tag(:subject, '', class: 'block col-12 field font-family-mono') %>
+        <%= text_field_tag(:subject, '', class: 'display-block col-12 field font-family-mono') %>
       </div>
       <div class="margin-bottom-4">
         <fieldset class="margin-0 padding-0 border-0">

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -11,7 +11,7 @@
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>
   <div class="grid-col-12 tablet:grid-col-6 margin-bottom-2">
-    <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
+    <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block bold' %>
     <%= render(
           'shared/one_time_code_input',
           name: :code,

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -6,18 +6,17 @@
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>
-  <%= label_tag :code, t('forms.two_factor.code'), class: 'block bold' %>
-  <div class="col-12 sm-col-5 margin-bottom-1 tablet:margin-bottom-0 sm-mr-20p inline-block">
-    <%= render(
-          'shared/one_time_code_input',
-          transport: nil,
-          name: :code,
-          value: @code,
-          required: true,
-          autofocus: true,
-          class: 'col-12',
-        ) %>
-  </div>
+  <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block bold' %>
+  <%= render(
+        'shared/one_time_code_input',
+        transport: nil,
+        name: :code,
+        value: @code,
+        required: true,
+        autofocus: true,
+        size: 16,
+        class: 'width-auto',
+      ) %>
   <%= f.input(
         :remember_device,
         as: :boolean,

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -2,19 +2,18 @@
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.subtitle')) %>
 
-<%= t(
-      'users.backup_code.generated_on_html',
-      date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
-    ) %>
+<p>
+  <%= t(
+        'users.backup_code.generated_on_html',
+        date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
+      ) %>
+</p>
 
-<br/>
-<br/>
-
-<div class="inline-block margin-bottom-4">
+<p>
   <%= t('forms.backup_code.subinfo_html') %>
-</div>
+</p>
 
-<div class="margin-bottom-6">
+<div class="margin-top-4 margin-bottom-5">
   <table>
     <tr>
       <% [ @codes.first(@codes.length / 2), @codes.last(@codes.length / 2)].each do |section| %>

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>
-<%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'inline-block padding-left-1') { t('links.resend') } %>
+<%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1') { t('links.resend') } %>
 
 <p><% link = link_to(t('notices.use_diff_email.link'), add_email_path) %></p>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -10,12 +10,19 @@
   <%= t('instructions.mfa.piv_cac.add_from_sign_in_html') %>
 </p>
 
-<%= form_tag(submit_new_piv_cac_url, class: 'margin-top-4') do %>
-  <%= label_tag 'code', t('forms.piv_cac_setup.nickname'), class: 'block bold' %>
-  <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
-                                class: 'block col-12 field font-family-mono', size: 16, maxlength: 20,
-                                'aria-labelledby': 'totp-label' %>
-    <div class="margin-top-2">
+<%= simple_form_for('', url: submit_new_piv_cac_url) do |f| %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :name,
+        label: t('forms.piv_cac_setup.nickname'),
+        required: true,
+        input_html: {
+          size: 16,
+          maxlength: 20,
+          class: 'width-auto',
+        },
+      ) %>
+  <div class="margin-top-5">
     <%= submit_tag t('forms.piv_cac_setup.submit'), class: 'usa-button usa-button--wide usa-button--big' %>
   </div>
   <div class="margin-top-2">

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -10,23 +10,19 @@
   <%= t('instructions.mfa.piv_cac.add_from_sign_in_html') %>
 </p>
 
-<div class="margin-top-4">
-  <div class="inline-block">
-    <%= form_tag(submit_new_piv_cac_url) do %>
-      <%= label_tag 'code', t('forms.piv_cac_setup.nickname'), class: 'block bold' %>
-      <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
-                                    class: 'block col-12 field font-family-mono', size: 16, maxlength: 20,
-                                    'aria-labelledby': 'totp-label' %>
-       <div class="margin-top-2">
-        <%= submit_tag t('forms.piv_cac_setup.submit'), class: 'usa-button usa-button--wide usa-button--big' %>
-      </div>
-      <div class="margin-top-2">
-        <%= link_to t('forms.piv_cac_setup.no_thanks'),
-                    new_user_session_url,
-                    class: 'usa-button usa-button--wide usa-button--big usa-button--outline' %>
-      </div>
-    <% end %>
+<%= form_tag(submit_new_piv_cac_url, class: 'margin-top-4') do %>
+  <%= label_tag 'code', t('forms.piv_cac_setup.nickname'), class: 'block bold' %>
+  <%= text_field_tag :name, '', required: true, aria: { invalid: false }, id: 'nickname',
+                                class: 'block col-12 field font-family-mono', size: 16, maxlength: 20,
+                                'aria-labelledby': 'totp-label' %>
+    <div class="margin-top-2">
+    <%= submit_tag t('forms.piv_cac_setup.submit'), class: 'usa-button usa-button--wide usa-button--big' %>
   </div>
-</div>
+  <div class="margin-top-2">
+    <%= link_to t('forms.piv_cac_setup.no_thanks'),
+                new_user_session_url,
+                class: 'usa-button usa-button--wide usa-button--big usa-button--outline' %>
+  </div>
+<% end %>
 
 <%= render 'shared/cancel', link: new_user_session_url %>

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -21,7 +21,7 @@
   <%= t('forms.personal_key.alternative') %>
   <%= button_to(
         reactivate_account_path, method: :put,
-                                 class: 'usa-button usa-button--unstyled', form_class: 'inline-block padding-left-1'
+                                 class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1'
       ) { t('links.reverify') } %>
 </div>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -26,14 +26,14 @@
   <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
   <%= hidden_field_tag :platform_authenticator, @platform_authenticator, id: 'platform_authenticator' %>
-  <%= label_tag 'code', @presenter.nickname_label, class: 'block bold', for: 'nickname' %>
+  <%= label_tag 'code', @presenter.nickname_label, class: 'display-block bold', for: 'nickname' %>
   <%= text_field_tag(
         :name,
         '',
         required: true,
         aria: { invalid: false },
         id: 'nickname',
-        class: 'block col-12 field font-family-mono',
+        class: 'display-block col-12 field font-family-mono',
         size: 16,
         maxlength: 20,
       ) %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -24,7 +24,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'bold'
     b.use :hint,  wrap_with: { tag: 'div', class: 'usa-hint' }
-    b.use :input, class: 'block col-12 field', error_class: 'usa-input--error'
+    b.use :input, class: 'display-block col-12 field', error_class: 'usa-input--error'
     b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
   end
 

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'layouts/application.html.erb' do
     it 'displays only the logo' do
       render
 
-      expect(rendered).to have_xpath('//nav[contains(@class, "bg-light-blue")]')
+      expect(rendered).to have_xpath('//nav[contains(@class, "main-navigation")]')
       expect(rendered).to_not have_content(t('account.welcome'))
       expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
     end


### PR DESCRIPTION
**Why**: As a user, I expect that login.gov has a consistent visual style, and that my page load times are not prolonged by loading redundant CSS. As a developer, I expect that existing references to BassCSS module classes are replaced with equivalent USWDS or ad hoc alternatives, so that we can successfully migrate away from and eliminate our dependency on BassCSS.

Styles being removed: https://github.com/basscss/basscss-sass/blob/v3.0.0/_utility-layout.scss