### PR TITLE
Remove unused platform authenticator layout tag

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -73,7 +73,6 @@
   <%= render 'shared/footer_lite' %>
 
   <% if current_user # Render the JS snipped that collects platform authenticator analytics %>
-    <div data-platform-authenticator-enabled="true"></div>
     <%= render partial: 'session_timeout/ping',
                locals: {
                  timeout_url: timeout_url,


### PR DESCRIPTION
**Why**: Because it's unused.

Introduced in #2609, last referenced in #4699 ([see removed file](https://github.com/18F/identity-idp/pull/4699/files#diff-ae21273cddd2e5cf65cc2dae7fa55df5aa4da18a1886526ef858b68cf34b51a7)).