### PR TITLE
Adopt design system overlay backdrop styles for modal

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -1,27 +1,3 @@
-.modal-backdrop {
-  background-color: rgba(91, 97, 106, 0.95);
-  display: table;
-  height: 100%;
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 1000;
-}
-
-.modal-open {
-  left: 0;
-  overflow: hidden;
-  position: fixed;
-  right: 0;
-  width: 100%;
-
-  .modal {
-    overflow-x: hidden;
-    overflow-y: scroll;
-  }
-}
-
 .modal {
   bottom: 0;
   display: block;
@@ -104,4 +80,12 @@
   hr {
     border-color: $yellow;
   }
+}
+
+// ===============================================
+// Pending upstream Login Design System revisions:
+// ===============================================
+
+.usa-modal-overlay {
+  background: rgba(color('base-darker'), 50%);
 }

--- a/app/javascript/app/components/modal.js
+++ b/app/javascript/app/components/modal.js
@@ -37,7 +37,7 @@ class Modal extends Events {
   setElementVisibility(target, showing) {
     this.shown = showing;
     target.classList[showing ? 'remove' : 'add']('display-none');
-    document.body.classList[showing ? 'add' : 'remove']('modal-open');
+    document.body.classList[showing ? 'add' : 'remove']('usa-js-modal--active');
     this.trap[showing ? 'activate' : 'deactivate']();
   }
 }

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -1,5 +1,4 @@
-<div class="modal-backdrop">
-</div>
+<div class="usa-modal-overlay is-visible">
   <%= tag.div(
         role: 'dialog',
         class: 'padding-x-2 padding-y-6 modal',

--- a/spec/javascripts/app/components/modal-spec.js
+++ b/spec/javascripts/app/components/modal-spec.js
@@ -19,8 +19,8 @@ describe('components/modal', () => {
     container.id = id;
     container.className = 'modal display-none';
     container.innerHTML = `
-      <div class="modal-backdrop">
-        <div class="px2 py4 modal" role="dialog">
+      <div class="usa-modal-overlay is-visible">
+        <div class="padding-x-2 padding-y-6 modal" role="dialog">
           <div class="modal-center">
             <div class="modal-content">
               <p>Do action?</p>
@@ -59,7 +59,7 @@ describe('components/modal', () => {
     expect(document.activeElement.textContent).to.equal('Yes');
     const container = document.activeElement.closest('#modal');
     expect(container.classList.contains('display-none')).to.be.false();
-    expect(document.body.classList.contains('modal-open')).to.be.true();
+    expect(document.body.classList.contains('usa-js-modal--active')).to.be.true();
   });
 
   it('allows interaction in most recently activated focus trap', async () => {


### PR DESCRIPTION
**Why**:

- For consistency of backdrop overlay styling
- As an incremental step toward replacing ad hoc modal implementation with [equivalent design system component](https://designsystem.digital.gov/components/modal/)
- To reduce the size of our stylesheet bundle, for faster end-user page load experience
- To fix a markup error with stray `</div>` in `app/views/shared/_modal_layout.html.erb`

Eventually, we should aim to customize this component to use it as provided by the design system. This pull request is aimed only at the overlay, and includes necessary styles to match the overlay shown when mobile side navigation is visible. 

**Screenshots:**

Behavior|Before|After
---|---|---
Mobile navigation|![Screen Shot 2022-02-10 at 9 05 08 AM](https://user-images.githubusercontent.com/1779930/153424675-2566f678-6a08-4d4f-b2fb-45140163b5cc.png)|![Screen Shot 2022-02-10 at 9 05 08 AM](https://user-images.githubusercontent.com/1779930/153424675-2566f678-6a08-4d4f-b2fb-45140163b5cc.png)
Modal|![Screen Shot 2022-02-10 at 9 02 24 AM](https://user-images.githubusercontent.com/1779930/153424673-e7a62362-0f7d-41f7-8f42-87e797ee08fc.png)|![Screen Shot 2022-02-10 at 9 00 55 AM](https://user-images.githubusercontent.com/1779930/153424667-964d78a3-54df-4d83-8159-e997c16a5c2d.png)