### PR TITLE
Add translations for hard-coded English labels

### DIFF
--- a/app/views/accounts/_mobile_nav.html.erb
+++ b/app/views/accounts/_mobile_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="usa-nav sidenav-mobile">
+<nav class="usa-nav sidenav-mobile" aria-label="<%= t('account.navigation.landmark_label') %>">
   <button class="usa-nav__close">
     <span class="usa-sr-only">Close</span>
   </button>

--- a/app/views/accounts/_side_nav.html.erb
+++ b/app/views/accounts/_side_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="sidenav">
+<nav class="sidenav" aria-label="<%= t('account.navigation.landmark_label') %>">
   <ul class="bg-white border-x border-base-lighter usa-sidenav">
     <% NavigationPresenter.new(user: current_user, url_options: url_options).navigation_items.each do |nav_item| %>
       <li class="usa-sidenav__item">

--- a/app/views/shared/_banner-lock-icon.html.erb
+++ b/app/views/shared/_banner-lock-icon.html.erb
@@ -8,8 +8,8 @@
     role="img"
     aria-labelledby="banner-lock-title banner-lock-description"
   >
-    <title id="banner-lock-title">Lock</title>
-    <desc id="banner-lock-description">A locked padlock</desc>
+    <title id="banner-lock-title"><%= t('shared.banner.lock') %></title>
+    <desc id="banner-lock-description"><%= t('shared.banner.lock_description') %></desc>
     <path
       fill="#000000"
       fill-rule="evenodd"

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,6 +1,6 @@
 <header aria-label="banner">
   <%= render 'shared/no_pii_banner' if FeatureManagement.show_no_pii_banner? %>
-  <section class="usa-banner" aria-label="Official government website">
+  <section class="usa-banner" aria-label="<%= t('shared.banner.landmark_label') %>">
     <div class="usa-accordion">
       <div class="usa-banner__header">
         <div class="usa-banner__inner">
@@ -56,7 +56,7 @@
       </div>
     </div>
   </section>
-  <nav aria-label="main-navigation">
+  <nav aria-label="<%= t('shared.navigation.landmark_label') %>">
     <% if content_for?(:nav) %>
       <%= yield(:nav) %>
     <% else %>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -97,6 +97,7 @@ en:
       forget_browsers: Forget all browsers
       get_backup_codes: Get backup codes
       history: History
+      landmark_label: Side navigation
       learn_more: Learn more about %{app_name}
       menu: Menu
       reset_personal_key: Reset personal key

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -98,6 +98,7 @@ es:
       forget_browsers: Olvídese de todos los navegadores
       get_backup_codes: Obtener códigos de respaldo
       history: Historia
+      landmark_label: Navegación lateral
       learn_more: Obtenga más información sobre %{app_name}
       menu: Menú
       reset_personal_key: Restablecer la clave personal

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -104,6 +104,7 @@ fr:
       forget_browsers: Oubliez tous les navigateurs
       get_backup_codes: Obtenez des codes de secours
       history: L’histoire
+      landmark_label: Navigation latérale
       learn_more: En savoir plus sur %{app_name}
       menu: Menu
       reset_personal_key: Réinitialisation de la clé personnelle

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -7,6 +7,9 @@ en:
         government organization in the United States.
       gov_heading: Official websites use .gov
       how: Here’s how you know
+      landmark_label: Official government website
+      lock: Lock
+      lock_description: A locked padlock
       official_site: An official website of the United States government
       secure_description_html: A <strong>lock</strong> (%{lock_icon}) or
         <strong>https://</strong> means you’ve safely connected to the .gov
@@ -14,4 +17,6 @@ en:
       secure_heading: Secure .gov websites use HTTPS
     footer_lite:
       gsa: US General Services Administration
+    navigation:
+      landmark_label: Main navigation
     skip_link: Skip to main content

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -7,6 +7,9 @@ es:
         organización oficial del Gobierno de Estados Unidos.
       gov_heading: Los sitios web oficiales usan .gov
       how: Así es como usted puede verificarlo
+      landmark_label: Sitio web oficial del Gobierno
+      lock: Candado
+      lock_description: Un candado cerrado
       official_site: Un sitio oficial del Gobierno de Estados Unidos
       secure_description_html: Un <strong>candado</strong> (%{lock_icon}) o
         <strong>https://</strong> significa que usted se conectó de forma segura
@@ -15,4 +18,6 @@ es:
       secure_heading: Los sitios web seguros .gov usan HTTPS
     footer_lite:
       gsa: Administración General de Servicios de EE. UU.
+    navigation:
+      landmark_label: Navegación principal
     skip_link: Salte al contenido principal

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -7,6 +7,9 @@ fr:
         organisation gouvernementale officielle des États-Unis.
       gov_heading: Les sites Web officiels utilisent .gov
       how: Voici comment vous savez
+      landmark_label: Site officiel du gouvernement
+      lock: Serrure
+      lock_description: Un cadenas fermé
       official_site: Un site web officiel du gouvernement des États-Unis
       secure_description_html: Un <strong>verrou</strong> (%{lock_icon}) ou
         <strong>https://</strong> signifie que vous êtes connecté en toute
@@ -15,4 +18,6 @@ fr:
       secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     footer_lite:
       gsa: Administration des services généraux des États-Unis
+    navigation:
+      landmark_label: Navigation principale
     skip_link: Passer au contenu principal


### PR DESCRIPTION
**Why**: So that a user navigating the site in a language other than English can read the content in their preferred language.

Tangentially related to #5930, #5926.

Also improves labeling for overlapping landmark types, toward [ARIA11](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA11):

>There are cases when a particular landmark role could be used more than once on a page, such as on primary and secondary navigation menus. In these cases, identical roles should be disambiguated from each other using a valid technique for labelling region