### PR TITLE
LG-3870: remove BassCSS Module "defaults"

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -1,4 +1,3 @@
-@import 'basscss-sass/defaults';
 @import 'basscss-sass/base-reset';
 @import 'basscss-sass/base-forms';
 @import 'basscss-sass/base-tables';


### PR DESCRIPTION
**Why:** As a user, I expect that login.gov has a consistent visual style, and that my page load times are not prolonged by loading redundant CSS. As a developer, I expect that existing references to BassCSS module classes are replaced with equivalent USWDS or ad hoc alternatives, so that we can successfully migrate away from and eliminate our dependency on BassCSS.

Styles being removed: https://github.com/basscss/basscss-sass/blob/v3.0.0/_default.scss

All of the variables defined in the `defaults` module of BassCSS have been copied/redefined in the idp stylesheets, namely `variables/_app.scss` and `variables/_colors.scss`. We can simply delete the inclusion of the BassCSS module.