### PR TITLE
Remove yellow border from warning page layouts

### DIFF
--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -1,18 +1,14 @@
 <% title t('forms.backup_code.confirm_delete') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'margin-bottom-2') %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.confirm_delete')) %>
 
-<div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>
-</div>
-
-<p class="margin-bottom-6">
+<p>
   <%= t('forms.backup_code.caution_delete') %>
 </p>
 
-<%= form_tag(backup_code_delete_path, method: :delete) do %>
+<%= form_tag(backup_code_delete_path, method: :delete, class: 'margin-top-5') do %>
   <%= button_tag t('account.index.backup_code_confirm_delete'), type: 'submit',
                                                                 class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -1,18 +1,14 @@
 <% title t('forms.backup_code_regenerate.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'margin-bottom-2') %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_regenerate.confirm')) %>
 
-<div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow"></hr>
-</div>
-
-<p class="margin-bottom-6">
+<p>
   <%= t('forms.backup_code_regenerate.caution') %>
 </p>
 
-<%= form_tag(backup_code_setup_path, method: :patch) do %>
+<%= form_tag(backup_code_setup_path, method: :patch, class: 'margin-top-5') do %>
   <%= button_tag t('account.index.backup_code_confirm_regenerate'), type: 'submit',
                                                                     class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -1,18 +1,14 @@
 <%= title t('forms.piv_cac_delete.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'margin-bottom-2') %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.piv_cac_delete.confirm')) %>
 
-<div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">
-</div>
-<div class="p.margin-bottom-6">
+<p>
   <%= t('forms.piv_cac_delete.caution', app_name: APP_NAME) %>
-</div>
-<br>
+</p>
 
-<%= form_tag(disable_piv_cac_url(id: params[:id]), method: :delete) do %>
+<%= form_tag(disable_piv_cac_url(id: params[:id]), method: :delete, class: 'margin-top-5') do %>
   <%= button_tag t('account.index.piv_cac_confirm_delete'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>
 <%= link_to t('links.cancel'), account_path, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -1,18 +1,14 @@
 <%= title t('forms.totp_delete.confirm') %>
 
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'margin-bottom-2') %>
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.totp_delete.confirm')) %>
 
-<div class="col-2 margin-bottom-2">
-  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow">
-</div>
-<div>
+<p>
   <%= t('forms.totp_delete.caution', app_name: APP_NAME) %>
-</div>
-<br>
+</p>
 
-<%= form_tag(disable_totp_path(id: params[:id]), method: :delete) do %>
+<%= form_tag(disable_totp_path(id: params[:id]), method: :delete, class: 'margin-top-5') do %>
   <%= button_tag t('account.index.totp_confirm_delete'), type: 'submit', class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
 <% end %>
 <%= link_to t('links.cancel'), account_path, class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>

--- a/app/views/users/webauthn_setup/delete.html.erb
+++ b/app/views/users/webauthn_setup/delete.html.erb
@@ -3,7 +3,8 @@
 <% else %>
   <% title t('forms.webauthn_delete.confirm') %>
 <% end %>
-<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'margin-bottom-2') %>
+
+<%= image_tag(asset_url('alert/warning-lg.svg'), alt: t('errors.alt.warning'), width: 54, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new do %>
   <% if @webauthn.platform_authenticator %>
@@ -13,22 +14,18 @@
   <% end %>
 <% end %>
 
-<div class="col-2">
-  <hr class="margin-top-4 margin-bottom-2 border-width-05 border-yellow" />
-</div>
-<br />
 <% if @webauthn.platform_authenticator %>
   <p><%= t('forms.webauthn_platform_delete.caution', app_name: APP_NAME) %></p>
 <% else %>
   <p><%= t('forms.webauthn_delete.caution', app_name: APP_NAME) %></p>
 <% end %>
-<br />
-<br />
 
-<% if @webauthn.platform_authenticator %>
-  <%= button_to(webauthn_setup_path(id: params[:id]), method: :delete, class: 'usa-button usa-button--big usa-button--wide margin-bottom-2') { t('account.index.webauthn_platform_confirm_delete') } %>
-<% else %>
-  <%= button_to(webauthn_setup_path(id: params[:id]), method: :delete, class: 'usa-button usa-button--big usa-button--wide margin-bottom-2') { t('account.index.webauthn_confirm_delete') } %>
+<%= button_to(webauthn_setup_path(id: params[:id]), method: :delete, class: 'usa-button usa-button--big usa-button--wide margin-top-5 margin-bottom-2') do %>
+  <% if @webauthn.platform_authenticator %>
+    <%= t('account.index.webauthn_platform_confirm_delete') %>
+  <% else %>
+    <%= t('account.index.webauthn_confirm_delete') %>
+  <% end %>
 <% end %>
 
 <%= link_to t('links.cancel'),


### PR DESCRIPTION
**Why**:

- For consistency across warning page layouts, where revised designs (notably IAL2) do not use this layout element
- For LG-3879, remove instances of BassCSS grid classes
- Improve markup semantics (avoid `br`, use `p` in place of `div` for content).

Additional context in Slack: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1644852033522339

**Screenshots:**

Screen|Before|After
---|---|---
Backup Codes Delete|![hr-backup-code-delete-before](https://user-images.githubusercontent.com/1779930/153910524-162f314d-c802-47cb-aa2e-d42b665299b7.png)|![hr-backup-code-delete-after](https://user-images.githubusercontent.com/1779930/153910522-9dea94c3-0ae4-424c-baeb-47535362bc7a.png)
Backup Codes Renegerate|![hr-backup-code-new-before](https://user-images.githubusercontent.com/1779930/153910525-27dfd8df-6516-4557-a848-7382f3fbc465.png)|![hr-backup-code-new-after](https://user-images.githubusercontent.com/1779930/153910754-27430d13-562d-43bb-8ccf-1a51184fc0f6.png)
PIV Delete|![hr-piv-delete-before](https://user-images.githubusercontent.com/1779930/153910528-e2c6a246-6da1-4ea7-94f6-a0a8049eafd7.png)|![hr-piv-delete-after](https://user-images.githubusercontent.com/1779930/153910527-bd70402e-875d-4055-a697-0aeeea138869.png)
TOTP Delete|![hr-totp-delete-before](https://user-images.githubusercontent.com/1779930/153910532-480083f0-ecb7-4fc9-8369-00b543c5e145.png)|![hr-totp-delete-after](https://user-images.githubusercontent.com/1779930/153910529-a8c6c2b9-77b0-4730-a6f8-a605976126b8.png)
Webauthn Delete|![hr-webauthn-delete-before](https://user-images.githubusercontent.com/1779930/153910535-5c2b2740-c675-41f8-904e-edddcce267f2.png)|![hr-webauthn-delete-after](https://user-images.githubusercontent.com/1779930/153910533-7ab1258e-5027-4974-9bb1-8b1c9d6aafaa.png)

