### PR TITLE
LG-3879: Update MFA rate-limit error to show troubleshooting options

### DIFF
--- a/app/presenters/failure_presenter.rb
+++ b/app/presenters/failure_presenter.rb
@@ -28,15 +28,13 @@ class FailurePresenter
     STATE_CONFIG.dig(state, :color)
   end
 
-  def message; end
-
   def title; end
 
   def header; end
 
   def description; end
 
-  def next_steps
+  def troubleshooting_options
     []
   end
 

--- a/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
+++ b/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
@@ -22,6 +22,23 @@ module TwoFactorAuthCode
     end
 
     def description
+      [locked_reason, please_try_again]
+    end
+
+    def troubleshooting_options
+      [read_about_two_factor_authentication, contact_support]
+    end
+
+    def js
+      <<~JS
+        document.addEventListener('DOMContentLoaded', function() {
+          var test = #{decorated_user.lockout_time_remaining} * 1000;
+          window.LoginGov.countdownTimer(document.getElementById('#{COUNTDOWN_ID}'), test);
+        });
+      JS
+    end
+
+    def locked_reason
       case type.to_s
       when 'backup_code_login_attempts'
         t('two_factor_authentication.max_backup_code_login_attempts_reached')
@@ -40,25 +57,6 @@ module TwoFactorAuthCode
       end
     end
 
-    def message
-      t('headings.lock_failure')
-    end
-
-    def next_steps
-      [please_try_again, read_about_two_factor_authentication]
-    end
-
-    def js
-      <<~JS
-        document.addEventListener('DOMContentLoaded', function() {
-          var test = #{decorated_user.lockout_time_remaining} * 1000;
-          window.LoginGov.countdownTimer(document.getElementById('#{COUNTDOWN_ID}'), test);
-        });
-      JS
-    end
-
-    private
-
     def please_try_again
       t(
         'two_factor_authentication.please_try_again_html',
@@ -68,12 +66,19 @@ module TwoFactorAuthCode
     end
 
     def read_about_two_factor_authentication
-      link = link_to(
-        t('two_factor_authentication.read_about_two_factor_authentication.link'),
-        MarketingSite.help_url,
-      )
+      {
+        text: t('two_factor_authentication.read_about_two_factor_authentication'),
+        url: MarketingSite.help_url,
+        new_tab: true,
+      }
+    end
 
-      t('two_factor_authentication.read_about_two_factor_authentication.text_html', link: link)
+    def contact_support
+      {
+        url: MarketingSite.contact_url,
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+        new_tab: true,
+      }
     end
   end
 end

--- a/app/views/shared/_failure.html.erb
+++ b/app/views/shared/_failure.html.erb
@@ -1,27 +1,21 @@
 <% title presenter.title %>
 
-<%= image_tag(asset_url(presenter.state_icon), alt: '', width: 54, class: 'margin-bottom-2') %>
+<%= image_tag(asset_url(presenter.state_icon), alt: '', width: 54, class: 'display-block margin-bottom-4') %>
 
-<%= render PageHeadingComponent.new.with_content(presenter.header) %>
-
-<p>
-  <%= presenter.description %>
-</p>
-
-<% if presenter.message.present? %>
-  <div class="col-2">
-    <hr class="margin-top-4 margin-bottom-2 border-width-05 border-<%= presenter.state_color %>" />
-  </div>
-
-  <h2 class="h4 margin-bottom-2 margin-top-4 margin-y-0">
-    <%= presenter.message %>
-  </h2>
+<% if presenter.header %>
+  <%= render PageHeadingComponent.new.with_content(presenter.header) %>
 <% end %>
 
-<hr>
+<% Array(presenter.description).each do |description_p| %>
+  <p><%= description_p %></p>
+<% end %>
 
-<% presenter.next_steps.each do |step| %>
-  <p><%== step %></p>
-<% end; if presenter.js %>
+<%= render(
+      'shared/troubleshooting_options',
+      heading: t('components.troubleshooting_options.default_heading'),
+      options: presenter.troubleshooting_options,
+    ) %>
+
+<% if presenter.js %>
   <%= backwards_compatible_javascript_tag presenter.js %>
 <% end %>

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -29,7 +29,6 @@ en:
     edit_info:
       password: Change your password
       phone: Manage your phone settings
-    lock_failure: Here’s what you can do
     passwords:
       change: Change your password
       confirm: Confirm your current password to continue

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -29,7 +29,6 @@ es:
     edit_info:
       password: Cambie su contraseña
       phone: Administrar la configuración de su teléfono
-    lock_failure: Esto es lo que puedes hacer
     passwords:
       change: Cambie su contraseña
       confirm: Confirme la contraseña actual para continuar

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -29,7 +29,6 @@ fr:
     edit_info:
       password: Changez votre mot de passe
       phone: Administrer les paramètres de votre téléphone
-    lock_failure: Voici ce que vous pouvez faire
     passwords:
       change: Changez votre mot de passe
       confirm: Confirmez votre mot de passe actuel pour continuer

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -115,9 +115,7 @@ en:
     piv_cac_header_text: Present your PIV/CAC
     piv_cac_webauthn_available: Use your security key
     please_try_again_html: Please try again in <strong id=%{id}>%{time_remaining}</strong>.
-    read_about_two_factor_authentication:
-      link: read about two-factor authentication
-      text_html: You can %{link} and why we use it at our Help page.
+    read_about_two_factor_authentication: Read about two-factor authentication
     totp_fallback:
       question: Don’t have your authenticator app?
     totp_header_text: Enter your authentication app code

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -124,9 +124,7 @@ es:
     piv_cac_header_text: Presenta tu PIV/CAC
     piv_cac_webauthn_available: Utilice su llave de seguridad
     please_try_again_html: Inténtelo de nuevo en <strong id=%{id}>%{time_remaining}</strong>.
-    read_about_two_factor_authentication:
-      link: leer acerca de la autenticación de dos factores
-      text_html: Puede %{link} y por qué la utilizamos en nuestra página de Ayuda.
+    read_about_two_factor_authentication: Conozca la autenticación de dos factores
     totp_fallback:
       question: '¿No tiene su aplicación de autenticación?'
     totp_header_text: Ingrese su código de la app de autenticación

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -130,9 +130,7 @@ fr:
     piv_cac_webauthn_available: Utilisez votre clé de sécurité
     please_try_again_html: Veuillez essayer de nouveau dans <strong
       id=%{id}>%{time_remaining}</strong>.
-    read_about_two_factor_authentication:
-      link: lire sur l’authentification à deux facteurs
-      text_html: Vous pouvez %{link} et pourquoi nous l’utilisons sur notre page d’aide.
+    read_about_two_factor_authentication: En savoir plus sur l’authentification à deux facteurs
     totp_fallback:
       question: Vous n’avez pas votre application d’authentification?
     totp_header_text: Entrez votre code d’application d’authentification

--- a/spec/presenters/failure_presenter_spec.rb
+++ b/spec/presenters/failure_presenter_spec.rb
@@ -11,7 +11,7 @@ describe FailurePresenter do
   end
 
   context 'methods with default values of `nil`' do
-    %i[message title header description].each do |method|
+    %i[title header description].each do |method|
       describe "##{method}" do
         subject { presenter.send(method) }
 
@@ -20,8 +20,8 @@ describe FailurePresenter do
     end
   end
 
-  describe '#next_steps' do
-    subject { presenter.next_steps }
+  describe '#troubleshooting_options' do
+    subject { presenter.troubleshooting_options }
 
     it { is_expected.to be_empty }
   end

--- a/spec/presenters/max_attempts_reached_presenter_spec.rb
+++ b/spec/presenters/max_attempts_reached_presenter_spec.rb
@@ -24,7 +24,7 @@ describe TwoFactorAuthCode::MaxAttemptsReachedPresenter do
   end
 
   context 'methods are overriden' do
-    %i[message title header description js].each do |method|
+    %i[title header description js].each do |method|
       describe "##{method}" do
         subject { presenter.send(method) }
 
@@ -33,16 +33,45 @@ describe TwoFactorAuthCode::MaxAttemptsReachedPresenter do
     end
   end
 
-  describe '#next_steps' do
-    subject { presenter.next_steps }
+  describe '#description' do
+    subject(:description) { presenter.description }
 
-    it 'includes `please_try_again` and `read_about_two_factor_authentication`' do
+    it 'includes failure type and time remaining' do
       expect(subject).to eq(
         [
-          presenter.send(:please_try_again),
-          presenter.send(:read_about_two_factor_authentication),
+          presenter.locked_reason,
+          presenter.please_try_again,
         ],
       )
+    end
+  end
+
+  describe '#troubleshooting_options' do
+    subject { presenter.troubleshooting_options }
+
+    it 'includes links to read more and get help' do
+      expect(subject).to eq(
+        [
+          presenter.read_about_two_factor_authentication,
+          presenter.contact_support,
+        ],
+      )
+    end
+  end
+
+  describe '#locked_reason' do
+    subject(:locked_reason) { presenter.locked_reason }
+
+    it 'returns locked reason' do
+      expect(locked_reason).to eq(t('two_factor_authentication.max_otp_requests_reached'))
+    end
+
+    context 'with unsupported type' do
+      let(:type) { :unsupported }
+
+      it 'raises error' do
+        expect { locked_reason }.to raise_error
+      end
     end
   end
 
@@ -51,6 +80,30 @@ describe TwoFactorAuthCode::MaxAttemptsReachedPresenter do
 
     it 'includes time remaining' do
       expect(subject).to include('1000 years')
+    end
+  end
+
+  describe '#read_about_two_factor_authentication' do
+    subject(:link) { presenter.read_about_two_factor_authentication }
+
+    it 'includes troubleshooting option link details' do
+      expect(link).to match(
+        text: kind_of(String),
+        url: kind_of(String),
+        new_tab: true,
+      )
+    end
+  end
+
+  describe '#contact_support' do
+    subject(:link) { presenter.contact_support }
+
+    it 'includes troubleshooting option link details' do
+      expect(link).to match(
+        text: kind_of(String),
+        url: kind_of(String),
+        new_tab: true,
+      )
     end
   end
 

--- a/spec/views/shared/_failure.html.erb_spec.rb
+++ b/spec/views/shared/_failure.html.erb_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'shared/_failure.html.erb' do
+  let(:presenter) { FailurePresenter.new(:failure) }
+  subject(:rendered) { render 'shared/failure', presenter: presenter }
+
+  it 'renders icon' do
+    expect(rendered).to have_css("img[src*='fail-x']")
+    expect(rendered).not_to have_css('.page-heading')
+    expect(rendered).not_to have_css('p')
+    expect(rendered).not_to have_css('.troubleshooting-options')
+    expect(rendered).not_to have_css('script', visible: :all)
+  end
+
+  context 'with content' do
+    let(:header) { 'header' }
+    let(:description) { 'description' }
+    let(:troubleshooting_options) { [{ text: 'option', url: 'https://example.com' }] }
+    let(:js) { '/* */' }
+
+    before do
+      allow(presenter).to receive(:header).and_return(header)
+      allow(presenter).to receive(:description).and_return(description)
+      allow(presenter).to receive(:troubleshooting_options).and_return(troubleshooting_options)
+      allow(presenter).to receive(:js).and_return(js)
+    end
+
+    it 'renders content' do
+      expect(rendered).to have_css("img[src*='fail-x']")
+      expect(rendered).to have_css('.page-heading', text: header)
+      expect(rendered).to have_css('p', text: description)
+      expect(rendered).to have_css('.troubleshooting-options')
+      expect(rendered).to have_link(
+        troubleshooting_options[0][:text],
+        href: troubleshooting_options[0][:url],
+      )
+      expect(rendered).to have_css('script', visible: :all)
+    end
+
+    context 'with array description' do
+      let(:description_2) { 'description_2' }
+
+      before do
+        allow(presenter).to receive(:description).and_return([description, description_2])
+      end
+
+      it 'renders content' do
+        expect(rendered).to have_css('p', text: description)
+        expect(rendered).to have_css('p', text: description_2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:

- For consistency of error messages
- Per LG-3879, reduce dependency on BassCSS grid classes

Related: #5941
Additional context in Slack: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1644852033522339

**Screenshots:**

Screen|Before|After
---|---|---
Account Locked|![hr-account-locked-before](https://user-images.githubusercontent.com/1779930/153922154-3925c0d1-fd7b-43af-95b3-fc69aceeca4d.png)|![hr-account-locked-after](https://user-images.githubusercontent.com/1779930/153922673-c87e597f-ef6f-4631-a267-99be276d7725.png)
Signup Cancel|![hr-signup-cancel-before](https://user-images.githubusercontent.com/1779930/153922315-5d2eaa6a-9bfd-4b45-add9-ea5317ffdaa4.png)|![hr-signup-cancel-after](https://user-images.githubusercontent.com/1779930/153922303-89e597d5-fc34-4eff-b946-c42a3e3d1994.png)