### PR TITLE
Validate Email Language on Registration

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -4,6 +4,7 @@ class RegisterUserEmailForm
   include FormEmailValidator
 
   validate :validate_terms_accepted
+  validates_inclusion_of :email_language, in: I18n.available_locales.map(&:to_s).append(nil)
 
   attr_reader :email_address, :terms_accepted
   attr_accessor :email_language

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -240,5 +240,26 @@ describe RegisterUserEmailForm do
         expect(submit_form.errors).to eq errors
       end
     end
+
+    context 'when user provides invalid email_language' do
+      it 'returns failure with errors' do
+        errors = { email_language: [t('errors.messages.inclusion')] }
+        extra = {
+          domain_name: 'gmail.com',
+          email_already_exists: false,
+          throttled: false,
+          user_id: 'anonymous-uuid',
+        }
+        submit_form = subject.submit(
+          email: 'not_taken@gmail.com',
+          terms_accepted: '1',
+          email_language: '01234567890'
+        )
+
+        expect(submit_form.success?).to eq false
+        expect(submit_form.extra).to eq extra
+        expect(submit_form.errors).to eq errors
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, we do not validate the email language, but the database has a limited size of varchar(10), and invalid submissions longer than that cause a 500

We do validate similarly in https://github.com/18F/identity-idp/blob/9b87bd75f30b72249057f59de901b4241dd365cb/app/forms/update_email_language_form.rb#L6, so this is mostly copied from there