### PR TITLE
Add design system overlay wrapper

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -1,3 +1,9 @@
+.usa-modal-wrapper {
+  // Temporary styles to avoid inheriting too much of the USWDS opinionated modal styling until
+  // modal styles are settled in the Login.gov Design System.
+  text-align: left;
+}
+
 .modal {
   bottom: 0;
   display: block;

--- a/app/views/shared/_modal_layout.html.erb
+++ b/app/views/shared/_modal_layout.html.erb
@@ -1,14 +1,16 @@
-<div class="usa-modal-overlay is-visible">
-  <%= tag.div(
-        role: 'dialog',
-        class: 'padding-x-2 padding-y-6 modal',
-        aria: { describedby: (description_id = SecureRandom.uuid),
-                labelledby: (label_id = SecureRandom.uuid) },
-      ) do %>
-    <div class="modal-center">
-      <div class="modal-content">
-        <%= yield label_id, description_id %>
+<div class="usa-modal-wrapper is-visible">
+  <div class="usa-modal-overlay">
+    <%= tag.div(
+          role: 'dialog',
+          class: 'padding-x-2 padding-y-6 modal',
+          aria: { describedby: (description_id = SecureRandom.uuid),
+                  labelledby: (label_id = SecureRandom.uuid) },
+        ) do %>
+      <div class="modal-center">
+        <div class="modal-content">
+          <%= yield label_id, description_id %>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/spec/javascripts/app/components/modal-spec.js
+++ b/spec/javascripts/app/components/modal-spec.js
@@ -19,13 +19,15 @@ describe('components/modal', () => {
     container.id = id;
     container.className = 'modal display-none';
     container.innerHTML = `
-      <div class="usa-modal-overlay is-visible">
-        <div class="padding-x-2 padding-y-6 modal" role="dialog">
-          <div class="modal-center">
-            <div class="modal-content">
-              <p>Do action?</p>
-              <button type="button">Yes</button>
-              <button type="button">No</button>
+      <div class="usa-modal-wrapper is-visible">
+        <div class="usa-modal-overlay">
+          <div class="padding-x-2 padding-y-6 modal" role="dialog">
+            <div class="modal-center">
+              <div class="modal-content">
+                <p>Do action?</p>
+                <button type="button">Yes</button>
+                <button type="button">No</button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes regression of: #5928 (not yet live in production)

Related discussion: https://github.com/18F/identity-idp/pull/5947#discussion_r806210414

**Why**: To fix an issue where body content which is styled with a (small) z-index can appear above the modal, and so that the markup of  the modal follows design system guidance.

Before|After
---|---
![Screen Shot 2022-02-14 at 3 29 35 PM](https://user-images.githubusercontent.com/1779930/153941585-2aa4b112-4c7d-49a8-be08-f5d9a30421dc.png)|![Screen Shot 2022-02-14 at 3 28 39 PM](https://user-images.githubusercontent.com/1779930/153941581-316e1318-df6d-400f-9dc9-b68bd358a704.png)