### PR TITLE
Add config to use Rails for secure headers options (LG-5771)

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,15 @@
 require 'feature_management'
 
+if IdentityConfig.store.rails_csp_tooling_enabled
+  Rails.application.configure do
+    config.ssl_options = { hsts: { preload: true, expires: 1.year, subdomains: true } }
+
+    config.action_dispatch.default_headers.merge!(
+      'X-Frame-Options' => 'DENY',
+    )
+  end
+end
+
 SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/BlockLength
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
   config.x_frame_options = 'DENY'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,6 +1,6 @@
 require 'feature_management'
 
-if IdentityConfig.store.rails_csp_tooling_enabled
+if FeatureManagement.rails_csp_tooling_enabled?
   Rails.application.configure do
     config.ssl_options = { hsts: { preload: true, expires: 1.year, subdomains: true } }
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,6 +6,8 @@ if FeatureManagement.rails_csp_tooling_enabled?
 
     config.action_dispatch.default_headers.merge!(
       'X-Frame-Options' => 'DENY',
+      'X-XSS-Protection' => '1; mode=block',
+      'X-Download-Options' => 'noopen',
     )
   end
 end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe 'Headers' do
 
   context 'secure headers' do
     it 'includes Strict-Transport-Security (HSTS)' do
-      get root_path
-
-      pending 'seems to not get set in plain http tests'
+      get root_path, headers: { 'HTTPS' => 'on' }
 
       expect(response.headers['Strict-Transport-Security']).
         to eq('max-age=31536000; includeSubDomains; preload')

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -30,4 +30,27 @@ RSpec.describe 'Headers' do
 
     expect(response.status).to eq 200
   end
+
+  context 'secure headers' do
+    it 'includes Strict-Transport-Security (HSTS)' do
+      get root_path
+
+      pending 'seems to not get set in plain http tests'
+
+      expect(response.headers['Strict-Transport-Security']).
+        to eq('max-age=31536000; includeSubDomains; preload')
+    end
+
+    it 'sets the right values for X-headers' do
+      get root_path
+
+      aggregate_failures do
+        expect(response.headers['X-Frame-Options']).to eq('DENY')
+        expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+        expect(response.headers['X-XSS-Protection']).to eq('1; mode=block')
+        expect(response.headers['X-Download-Options']).to eq('noopen')
+        expect(response.headers['X-Permitted-Cross-Domain-Policies']).to eq('none')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The bulk of this PR is setting up regression specs so we can remove SecureHeaders gem confidently

- The configs: https://github.com/18F/identity-idp/blob/27742c514ce4c06939195445e56b00fa1f7ce881/config/initializers/secure_headers.rb#L4-L9

- Looks like most of our desired headers match with the defaults for Rails: https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-default-headers

The way SecureHeaders is implemented, it stomps on the `default_headers` config very late in the game: https://github.com/github/secure_headers/blob/ce2ad139646f9775061159fe5c4707638fbe45c1/lib/secure_headers/railtie.rb#L21-L31

so the only way to test this code was to comment out/remove secure_headers gem entirely and make sure the specs worked as expected

This does mean that this test should be good regression for when we do remove the gem entirely