### PR TITLE
Fix account header spacing when badges present

### DIFF
--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -39,9 +39,20 @@ class AccountShowPresenter
   end
 
   def showing_any_partials?
-    show_service_provider_continue_partial? ||
-      show_pii_partial? || show_password_reset_partial? || show_personal_key_partial? ||
-      show_gpo_partial?
+    show_service_provider_continue_partial? || show_password_reset_partial? ||
+      show_personal_key_partial? || show_gpo_partial?
+  end
+
+  def show_unphishable_badge?
+    MfaPolicy.new(decorated_user.user).unphishable?
+  end
+
+  def show_verified_badge?
+    decorated_user.identity_verified?
+  end
+
+  def showing_any_badges?
+    show_unphishable_badge? || show_verified_badge?
   end
 
   def backup_codes_generated_at

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -39,8 +39,10 @@ class AccountShowPresenter
   end
 
   def showing_any_partials?
-    show_service_provider_continue_partial? || show_password_reset_partial? ||
-      show_personal_key_partial? || show_gpo_partial?
+    show_service_provider_continue_partial? ||
+      show_password_reset_partial? ||
+      show_personal_key_partial? ||
+      show_gpo_partial?
   end
 
   def show_unphishable_badge?

--- a/app/views/accounts/_badges.html.erb
+++ b/app/views/accounts/_badges.html.erb
@@ -1,7 +1,7 @@
-<% if MfaPolicy.new(@presenter.decorated_user.user).unphishable? %>
+<% if @presenter.show_unphishable_badge? %>
   <%= render 'accounts/unphishable_badge' %>
 <% end %>
 
-<% if @presenter.decorated_user.identity_verified? %>
+<% if @presenter.show_verified_badge? %>
   <%= render 'accounts/verified_account_badge' %>
 <% end %>

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="grid-row padding-y-2 tablet:padding-y-0 margin-bottom-4 bg-lightest-blue sm-bg-none position-relative">
+<div class="grid-row padding-y-2 tablet:padding-y-0 margin-bottom-4 bg-lightest-blue sm-bg-none position-relative <% if presenter.showing_any_badges? %>padding-bottom-4<% end %>">
   <div class="grid-col-12 tablet:grid-col-fill">
     <h1 class="margin-0 center sm-left-align">
       <span class="regular tablet:display-none">

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.account') %>
 
 <% if @presenter.showing_any_partials? %>
-  <div class="margin-bottom-8">
+  <div class="margin-bottom-4">
     <% if @presenter.show_personal_key_partial? %>
       <%= render 'accounts/personal_key', presenter: @presenter %>
     <% end %>


### PR DESCRIPTION
Partly a regression of #5900

This fixes a handful of issues related to how the account header is shown:

- Removes empty space for identity-verified accounts, since previously `showing_any_partials?` would account for `show_pii_partial?` despite the fact this is not rendered in the account header
- Restores extra spacing on mobile for "Welcome" message when badge is visible, regressed in #5900
   - This time, however, the extra spacing is **only** added when badges are visible. Previously, it was always shown.
- Reduces margin between account header and the subsequent page heading, from 4rem to 2rem.

**Screenshots:**

_Desktop:_

State|Before|After
---|---|---
Verified|![localhost_3000_account (2)](https://user-images.githubusercontent.com/1779930/154120943-7bd72143-9798-4f96-92c7-c3b5b855e268.png)|![localhost_3000_account (3)](https://user-images.githubusercontent.com/1779930/154120944-50dd7f92-4a52-4b3e-8614-39b984b3f7db.png)
With message|![localhost_3000_account (1)](https://user-images.githubusercontent.com/1779930/154120941-b53e614a-dccf-4091-88fd-48c38e571e34.png)|![localhost_3000_account](https://user-images.githubusercontent.com/1779930/154120946-d43d2fb9-f777-40bd-b3d8-e315f515d5e7.png)

_Mobile:_

State|Before|After
---|---|---
Verified|![localhost_3000_account(iPhone XR) (2)](https://user-images.githubusercontent.com/1779930/154121087-0595e081-ccbf-4743-b2cd-c07e834572ec.png)|![localhost_3000_account(iPhone XR) (3)](https://user-images.githubusercontent.com/1779930/154121089-a991ca71-5188-40c8-8e52-0ec201c595ca.png)
With message|![localhost_3000_account(iPhone XR)](https://user-images.githubusercontent.com/1779930/154121090-178a52cf-db76-40e9-9a36-af90e8006cc8.png)|![localhost_3000_account(iPhone XR) (1)](https://user-images.githubusercontent.com/1779930/154121086-0857630f-0812-4eb8-9b3a-40be372cc317.png)