### PR TITLE
List available categories in changelog help

### DIFF
--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -184,6 +184,9 @@ def main(args)
         example:
         changelog: Improvements, Authentication, Updating Authentication (LG-9998)
 
+        categories:
+        #{CATEGORIES.map { |category| "- #{category}" }.join("\n")}
+
         Include "[skip changelog]" in a commit message to bypass this check.
       ERROR
     )


### PR DESCRIPTION
**Why**: So that I, as a developer, am aware of the categories I'm expected to use.

Output:

```
A valid changelog line was not found.
A commit message should contain a line in the form of:

changelog: CATEGORY, SUBCATEGORY, CHANGE_DESCRIPTION

example:
changelog: Improvements, Authentication, Updating Authentication (LG-9998)

categories:
- Improvements
- Accessibility
- Bug Fixes
- Internal

Include "[skip changelog]" in a commit message to bypass this check.
```