### PR TITLE
LG-3879: Use design system grid for PII accordion

### DIFF
--- a/app/views/sign_up/registrations/_required_pii_accordion.html.erb
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.erb
@@ -1,70 +1,70 @@
-<p class="clearfix">
+<p class="grid-row grid-gutter">
   <%= image_tag(
         asset_url('get-started/ID.svg'),
-        size: '40', alt: '', class: 'mt-tiny col col-1',
+        size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
       ) %>
-  <span class="col col-11 padding-left-2">
+  <span class="grid-col-fill padding-left-2">
     <%= t('idv.index.id.need_html') %>
   </span>
 </p>
 
-<div class="margin-y-2">
-  <%= render AccordionComponent.new do |c| %>
-    <% c.header { t('devise.registrations.start.accordion') } %>
-    <p class="clearfix">
-      <%= image_tag(
-            asset_url('get-started/email-password.svg'),
-            size: '40', alt: '', class: 'mt-tiny col col-1',
-          ) %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_1_html') %>
-      </span>
-    </p>
-    <p class="clearfix">
-      <%= image_tag(
-            asset_url('get-started/2FA.svg'), size: '40', alt: '',
-                                              class: 'mt-tiny col col-1'
-          ) %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_2_html') %>
-      </span>
-    </p>
-    <p class="clearfix">
-      <%= image_tag(
-            asset_url('get-started/personal-details.svg'),
-            size: '40', alt: '', class: 'mt-tiny col col-1',
-          ) %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_3_html') %>
-      </span>
-    </p>
-    <p class="clearfix">
-      <%= image_tag(
-            asset_url('get-started/personal-details.svg'),
-            size: '40', alt: '', class: 'mt-tiny col col-1',
-          ) %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_4_html') %>
-      </span>
-    </p>
-    <p class="clearfix">
-      <%= image_tag(
-            asset_url('get-started/financial.svg'),
-            size: '40', alt: '', class: 'mt-tiny col col-1',
-          ) %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_5_html') %>
-      </span>
-    </p>
-    <p class="clearfix">
-      <%= image_tag(asset_url('p-key.svg'), size: '40', alt: '', class: 'mt-tiny col col-1') %>
-      <span class="col col-11 padding-left-2">
-        <%= t('devise.registrations.start.bullet_6_html') %>
-      </span>
-    </p>
-    <p class="margin-bottom-4">
-      <%= new_window_link_to t('devise.registrations.start.learn_more'),
-                             MarketingSite.help_url %>
-    </p>
-  <% end %>
-</div>
+<%= render AccordionComponent.new(class: 'margin-y-2') do |c| %>
+  <% c.header { t('devise.registrations.start.accordion') } %>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('get-started/email-password.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_1_html') %>
+    </span>
+  </p>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('get-started/2FA.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_2_html') %>
+    </span>
+  </p>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('get-started/personal-details.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_3_html') %>
+    </span>
+  </p>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('get-started/personal-details.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_4_html') %>
+    </span>
+  </p>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('get-started/financial.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_5_html') %>
+    </span>
+  </p>
+  <p class="grid-row grid-gutter">
+    <%= image_tag(
+          asset_url('p-key.svg'),
+          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        ) %>
+    <span class="grid-col-fill padding-left-2">
+      <%= t('devise.registrations.start.bullet_6_html') %>
+    </span>
+  </p>
+  <p>
+    <%= new_window_link_to t('devise.registrations.start.learn_more'), MarketingSite.help_url %>
+  </p>
+<% end %>


### PR DESCRIPTION
**Why**: To simplify markup and to standardize on design system utilities.

Visually, should be mostly identical, with the exception that previous artificial column constraints no longer apply, so the image is slightly scaled up to its natural size. Vertical offset of images are also improved.

May be easier to review with whitespace hidden: [`?w=1`](https://github.com/18F/identity-idp/pull/5956/files?w=1)

Before|After
---|---
![localhost_3000__request_id=043d36bd-1aa6-48c2-bbca-419d31f290fa](https://user-images.githubusercontent.com/1779930/154146982-6ca75812-2caa-4160-a9b4-5013af58ef11.png)|![localhost_3000__request_id=043d36bd-1aa6-48c2-bbca-419d31f290fa (1)](https://user-images.githubusercontent.com/1779930/154146994-6c0d2ebf-65c9-4f59-95d8-2b220b04cd48.png)
