### PR TITLE
LG-3879: Use design system grid for completion screen

### DIFF
--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -1,35 +1,33 @@
 <% title @presenter.heading %>
-<div class="clearfix col-10 sm-col-12 margin-x-auto">
-  <div class="center">
-    <%= image_tag asset_url(@presenter.image_name), width: 140, alt: '', class: 'margin-bottom-2' %>
-  </div>
-
-  <%= render PageHeadingComponent.new(class: 'tablet:margin-right-1 tablet:margin-left-1 text-center') do %>
-    <%= @presenter.heading %>
-  <% end %>
-
-  <p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
-    <%= t(
-          'help_text.requested_attributes.intro_html',
-          app_name: APP_NAME,
-          sp: content_tag(:strong, decorated_session.sp_name),
-        ) %>
-  </p>
-  <div class='tablet:margin-left-1 tablet:margin-right-1' >
-    <%= render 'sign_up/completions/requested_attributes', pii: @presenter.pii %>
-  </div>
-  <p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
-    <%= t(
-          'help_text.requested_attributes.outro_html',
-          app_name: APP_NAME,
-          sp: content_tag(:strong, decorated_session.sp_name),
-        ) %>
-  </p>
-  <p>
-    <div class="center">
-      <%= validated_form_for(:idv_form, url: sign_up_completed_path) do %>
-        <%= submit_tag t('sign_up.agree_and_continue'), class: 'usa-button usa-button--big usa-button--wide' %>
-      <% end %>
-    </div>
-  </p>
+<div class="center">
+  <%= image_tag asset_url(@presenter.image_name), width: 140, alt: '', class: 'margin-bottom-2' %>
 </div>
+
+<%= render PageHeadingComponent.new(class: 'tablet:margin-right-1 tablet:margin-left-1 text-center') do %>
+  <%= @presenter.heading %>
+<% end %>
+
+<p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
+  <%= t(
+        'help_text.requested_attributes.intro_html',
+        app_name: APP_NAME,
+        sp: content_tag(:strong, decorated_session.sp_name),
+      ) %>
+</p>
+<div class='tablet:margin-left-1 tablet:margin-right-1'>
+  <%= render 'sign_up/completions/requested_attributes', pii: @presenter.pii %>
+</div>
+<p class="tablet:margin-right-1 tablet:margin-left-1 margin-top-4 margin-bottom-4">
+  <%= t(
+        'help_text.requested_attributes.outro_html',
+        app_name: APP_NAME,
+        sp: content_tag(:strong, decorated_session.sp_name),
+      ) %>
+</p>
+<p>
+  <div class="center">
+    <%= validated_form_for(:idv_form, url: sign_up_completed_path) do %>
+      <%= submit_tag t('sign_up.agree_and_continue'), class: 'usa-button usa-button--big usa-button--wide' %>
+    <% end %>
+  </div>
+</p>


### PR DESCRIPTION
**Why**: To simplify markup and to standardize on design system utilities.

**Visual change:** Previously, the page was constrained to be centered 10 column (of 12) on mobile. It's not clear to me what's unique about this page to justify deviating from standard mobile content padding, so I'm proposing to remove this grid. Thoughts, @anniehirshman-gsa ?

**Review notes:** Change is much more trivial than it appears when [hiding whitespace](https://github.com/18F/identity-idp/pull/5957/files?&w=1), as it's simply removing the grid wrapper element.

**Screenshots:**

Size|Before|After
---|---|--
Desktop|![grid-completion-desktop-before](https://user-images.githubusercontent.com/1779930/154287041-e70a8cc2-0e9e-4781-8dfd-5c3e823cfe8f.png)|![grid-completion-desktop-after](https://user-images.githubusercontent.com/1779930/154287038-c8506f1c-e3af-46d5-9cdd-0de6e4a241e0.png)
Mobile|![grid-completion-mobile-before](https://user-images.githubusercontent.com/1779930/154287044-1108c0da-4d56-49b9-af01-00ae64504443.png)|![grid-completion-mobile-after](https://user-images.githubusercontent.com/1779930/154287042-b5d7d7fb-7346-4be3-8db6-2f8240857b37.png)