### PR TITLE
Remove unnecessary MFA "_html" unescape suffixes

### DIFF
--- a/app/presenters/two_factor_authentication/phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/phone_selection_presenter.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
         end
 
         safe_join(
-          [t('two_factor_authentication.two_factor_choice_options.phone_info_html'), *voip_note],
+          [t('two_factor_authentication.two_factor_choice_options.phone_info'), *voip_note],
           ' ',
         )
       end

--- a/app/presenters/two_factor_authentication/selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/selection_presenter.rb
@@ -89,21 +89,21 @@ module TwoFactorAuthentication
     def login_info(type)
       case type
       when 'auth_app'
-        t('two_factor_authentication.login_options.auth_app_info_html')
+        t('two_factor_authentication.login_options.auth_app_info')
       when 'backup_code'
-        t('two_factor_authentication.login_options.backup_code_info_html')
+        t('two_factor_authentication.login_options.backup_code_info')
       when 'personal_key'
-        t('two_factor_authentication.login_options.personal_key_info_html')
+        t('two_factor_authentication.login_options.personal_key_info')
       when 'piv_cac'
-        t('two_factor_authentication.login_options.piv_cac_info_html')
+        t('two_factor_authentication.login_options.piv_cac_info')
       when 'sms'
         t('two_factor_authentication.login_options.sms_info_html')
       when 'voice'
         t('two_factor_authentication.login_options.voice_info_html')
       when 'webauthn'
-        t('two_factor_authentication.login_options.webauthn_info_html')
+        t('two_factor_authentication.login_options.webauthn_info')
       when 'webauthn_platform'
-        t('two_factor_authentication.login_options.webauthn_platform_info_html', app_name: APP_NAME)
+        t('two_factor_authentication.login_options.webauthn_platform_info', app_name: APP_NAME)
       else
         raise "Unsupported login method: #{type}"
       end
@@ -112,22 +112,22 @@ module TwoFactorAuthentication
     def setup_info(type)
       case type
       when 'auth_app'
-        t('two_factor_authentication.two_factor_choice_options.auth_app_info_html')
+        t('two_factor_authentication.two_factor_choice_options.auth_app_info')
       when 'backup_code'
-        t('two_factor_authentication.two_factor_choice_options.backup_code_info_html')
+        t('two_factor_authentication.two_factor_choice_options.backup_code_info')
       when 'phone'
-        t('two_factor_authentication.two_factor_choice_options.phone_info_html')
+        t('two_factor_authentication.two_factor_choice_options.phone_info')
       when 'piv_cac'
-        t('two_factor_authentication.two_factor_choice_options.piv_cac_info_html')
+        t('two_factor_authentication.two_factor_choice_options.piv_cac_info')
       when 'sms'
-        t('two_factor_authentication.two_factor_choice_options.sms_info_html')
+        t('two_factor_authentication.two_factor_choice_options.sms_info')
       when 'voice'
-        t('two_factor_authentication.two_factor_choice_options.voice_info_html')
+        t('two_factor_authentication.two_factor_choice_options.voice_info')
       when 'webauthn'
-        t('two_factor_authentication.two_factor_choice_options.webauthn_info_html')
+        t('two_factor_authentication.two_factor_choice_options.webauthn_info')
       when 'webauthn_platform'
         t(
-          'two_factor_authentication.two_factor_choice_options.webauthn_platform_info_html',
+          'two_factor_authentication.two_factor_choice_options.webauthn_platform_info',
           app_name: APP_NAME,
         )
       else

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -34,7 +34,7 @@
     <label for="otp_delivery_preference_sms" class="usa-radio__label">
       <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
       <span class="usa-radio__label-description">
-        <%= t('two_factor_authentication.two_factor_choice_options.sms_info_html') %>
+        <%= t('two_factor_authentication.two_factor_choice_options.sms_info') %>
       </span>
     </label>
 
@@ -48,7 +48,7 @@
     <label for="otp_delivery_preference_voice" class="usa-radio__label">
       <%= t('two_factor_authentication.otp_delivery_preference.voice') %>
       <span class="usa-radio__label-description">
-        <%= t('two_factor_authentication.two_factor_choice_options.voice_info_html') %>
+        <%= t('two_factor_authentication.two_factor_choice_options.voice_info') %>
       </span>
     </label>
   </fieldset>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -32,24 +32,24 @@ en:
     login_intro: You set these up when you created your account.
     login_options:
       auth_app: Authentication app
-      auth_app_info_html: Use your authentication application to get a security code.
+      auth_app_info: Use your authentication application to get a security code.
       backup_code: Backup codes
-      backup_code_info_html: Use a backup code from your list of backup codes to sign in.
+      backup_code_info: Use a backup code from your list of backup codes to sign in.
       personal_key: Personal Key
-      personal_key_info_html: Use the 16 character personal key you received at account creation.
+      personal_key_info: Use the 16 character personal key you received at account creation.
       phone_info_html: Get security code via text/SMS or phone call to
         <strong>%{phone}</strong>.
       piv_cac: Government employee ID
-      piv_cac_info_html: Use your PIV/CAC card instead of a security code.
+      piv_cac_info: Use your PIV/CAC card instead of a security code.
       sms: Text message
       sms_info_html: Get security code via text message to <strong>%{phone}</strong>.
       voice: Automated phone call
       voice_info_html: Get security code via phone call to <strong>%{phone}</strong>
         (North America phone numbers only).
       webauthn: Security key
-      webauthn_info_html: Use your security key to access your account.
+      webauthn_info: Use your security key to access your account.
       webauthn_platform: Face or Touch Unlock
-      webauthn_platform_info_html: Use your device (phone, tablet or desktop) to add
+      webauthn_platform_info: Use your device (phone, tablet or desktop) to add
         another level of security to your %{app_name} account. Recommended
         because it is more phishing resistant.
     login_options_link_text: Choose another authentication method
@@ -127,32 +127,32 @@ en:
     two_factor_choice_intro: Add a second layer of security so only you can sign in to your account.
     two_factor_choice_options:
       auth_app: Authentication application
-      auth_app_info_html: Get codes from an app on your phone, computer, or tablet.
+      auth_app_info: Get codes from an app on your phone, computer, or tablet.
         Recommended because it is harder to intercept than texts or phone calls.
       backup_code: Backup codes
-      backup_code_info_html: We’ll give you 10 codes. You can use backup codes as your
-        only authentication method, but it is the least recommended method since
+      backup_code_info: We’ll give you 10 codes. You can use backup codes as your only
+        authentication method, but it is the least recommended method since
         notes can get lost. Keep them in a safe place.
       least_secure_label: Least secure
       less_secure_label: Less secure
       more_secure_label: More Secure
       phone: Text or Voice Message
-      phone_info_html: Get security codes by text message (SMS) or phone call.
+      phone_info: Get security codes by text message (SMS) or phone call.
       phone_info_no_voip: Please do not use web-based (VOIP) phone services.
       piv_cac: Government employee ID
-      piv_cac_info_html: Insert your government or military PIV or CAC card and enter your PIN.
+      piv_cac_info: Insert your government or military PIV or CAC card and enter your PIN.
       secure_label: Secure
       sms: Text message / SMS
-      sms_info_html: Get your security code via text message / SMS.
+      sms_info: Get your security code via text message / SMS.
       voice: Phone call
-      voice_info_html: Get your security code via phone call.
+      voice_info: Get your security code via phone call.
       webauthn: Security key
-      webauthn_info_html: Use a security key that you have. It’s a physical device
-        that you plug in or that is built in to your computer or phone (it often
-        looks like a USB flash drive). Recommended because it is more phishing
+      webauthn_info: Use a security key that you have. It’s a physical device that you
+        plug in or that is built in to your computer or phone (it often looks
+        like a USB flash drive). Recommended because it is more phishing
         resistant.
       webauthn_platform: Face or Touch Unlock
-      webauthn_platform_info_html: Use your device (phone, tablet or desktop) to add
+      webauthn_platform_info: Use your device (phone, tablet or desktop) to add
         another level of security to your %{app_name} account. Recommended
         because it is more phishing resistant.
     two_factor_hspd12_choice: Additional authentication required

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -33,17 +33,17 @@ es:
     login_intro: Usted configuró esto cuando creó su cuenta.
     login_options:
       auth_app: Aplicación de autenticación
-      auth_app_info_html: Use su aplicación de autenticación para obtener el código de seguridad.
+      auth_app_info: Use su aplicación de autenticación para obtener el código de seguridad.
       backup_code: Códigos de respaldo
-      backup_code_info_html: Use un código de respaldo de su lista de códigos de
-        respaldo para iniciar sesión.
+      backup_code_info: Use un código de respaldo de su lista de códigos de respaldo
+        para iniciar sesión.
       personal_key: Clave personal
-      personal_key_info_html: Use la clave personal de 16 caracteres que usó en la
-        creación de la cuenta.
+      personal_key_info: Use la clave personal de 16 caracteres que usó en la creación
+        de la cuenta.
       phone_info_html: Obtenga su código de seguridad a través de mensajes de texto /
         SMS o de una llamada telefónica a <strong>%{phone}</strong>.
       piv_cac: Empleados del Gobierno
-      piv_cac_info_html: Use su tarjeta PIV / CAC para asegurar su cuenta.
+      piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta.
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto /
         SMS a <strong>%{phone}</strong>.
@@ -52,11 +52,11 @@ es:
         telefónica a <strong>%{phone}</strong>. (Solo números de teléfono de
         América del Norte).
       webauthn: Llave de seguridad
-      webauthn_info_html: Use su llave de seguridad para acceder a su cuenta.
+      webauthn_info: Use su llave de seguridad para acceder a su cuenta.
       webauthn_platform: Desbloqueo facial o táctil
-      webauthn_platform_info_html: Utilice su dispositivo (teléfono, tableta o
-        computadora de escritorio) para añadir otro nivel de seguridad a su
-        cuenta %{app_name}. Es recomendable porque resiste mejor el phishing.
+      webauthn_platform_info: Utilice su dispositivo (teléfono, tableta o computadora
+        de escritorio) para añadir otro nivel de seguridad a su cuenta
+        %{app_name}. Es recomendable porque resiste mejor el phishing.
     login_options_link_text: Elige otra opción de seguridad
     login_options_title: Seleccione su opción de seguridad
     max_backup_code_login_attempts_reached: Para su seguridad, su cuenta está
@@ -138,33 +138,32 @@ es:
       usted pueda iniciar sesión en su cuenta.
     two_factor_choice_options:
       auth_app: Aplicación de autenticación
-      auth_app_info_html: Obtenga códigos de una aplicación en su teléfono, computadora o tableta.
+      auth_app_info: Obtenga códigos de una aplicación en su teléfono, computadora o tableta.
       backup_code: No tengo ninguno de los anteriores
-      backup_code_info_html: Le daremos 10 códigos para usar y guardar en un lugar
-        seguro. Puede usar códigos de respaldo como su único método de
-        autenticación.
+      backup_code_info: Le daremos 10 códigos para usar y guardar en un lugar seguro.
+        Puede usar códigos de respaldo como su único método de autenticación.
       least_secure_label: Lo menos seguro
       less_secure_label: Menos seguro
       more_secure_label: Más seguro
       phone: Teléfono
-      phone_info_html: Obtenga códigos de seguridad por mensaje de texto (SMS) o
-        llamada telefónica.
+      phone_info: Obtenga códigos de seguridad por mensaje de texto (SMS) o llamada
+        telefónica.
       phone_info_no_voip: No utilice servicios telefónicos basados en web (VOIP).
       piv_cac: Identificación de empleado del gobierno
-      piv_cac_info_html: Inserte su tarjeta gubernamental o militar PIV o CAC e ingrese su PIN.
+      piv_cac_info: Inserte su tarjeta gubernamental o militar PIV o CAC e ingrese su PIN.
       secure_label: Seguro
       sms: Mensaje de texto / SMS
-      sms_info_html: Obtenga su código de seguridad a través de mensajes de texto / SMS.
+      sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS.
       voice: Llamada telefónica
-      voice_info_html: Obtenga su código de seguridad a través de una llamada telefónica.
+      voice_info: Obtenga su código de seguridad a través de una llamada telefónica.
       webauthn: Llave de seguridad
-      webauthn_info_html: Use una llave de seguridad que tenga. Es un dispositivo
-        físico que se conecta o que está integrado en su computadora o teléfono
-        (a menudo parece una unidad flash USB).
+      webauthn_info: Use una llave de seguridad que tenga. Es un dispositivo físico
+        que se conecta o que está integrado en su computadora o teléfono (a
+        menudo parece una unidad flash USB).
       webauthn_platform: Desbloqueo facial o táctil
-      webauthn_platform_info_html: Utilice su dispositivo (teléfono, tableta o
-        computadora de escritorio) para añadir otro nivel de seguridad a su
-        cuenta %{app_name}. Es recomendable porque resiste mejor el phishing.
+      webauthn_platform_info: Utilice su dispositivo (teléfono, tableta o computadora
+        de escritorio) para añadir otro nivel de seguridad a su cuenta
+        %{app_name}. Es recomendable porque resiste mejor el phishing.
     two_factor_hspd12_choice: Se requiere autenticación adicional
     two_factor_hspd12_choice_intro: Esta aplicación requiere un mayor nivel de
       seguridad. Para poder acceder a su información, deberá verificar su

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -34,18 +34,18 @@ fr:
     login_intro: Vous les avez configurés lorsque vous avez crée votre compte.
     login_options:
       auth_app: Application d’authentification
-      auth_app_info_html: Utilisez votre application d’authentification pour obtenir
-        votre code de sécurité
+      auth_app_info: Utilisez votre application d’authentification pour obtenir votre
+        code de sécurité
       backup_code: Codes de sauvegarde
-      backup_code_info_html: Utilisez un code de sauvegarde de votre liste de codes de
+      backup_code_info: Utilisez un code de sauvegarde de votre liste de codes de
         sauvegarde pour vous connecter.
       personal_key: Clé personnelle
-      personal_key_info_html: Utilisez la clé personnelle de 16 caractères que vous
-        avez utilisée lors de la création du compte.
+      personal_key_info: Utilisez la clé personnelle de 16 caractères que vous avez
+        utilisée lors de la création du compte.
       phone_info_html: Obtenez votre code de sécurité par SMS ou Obtenez votre code de
         sécurité par SMS à <strong>%{phone}</strong>.
       piv_cac: Employés du gouvernement
-      piv_cac_info_html: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
+      piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
       sms: SMS
       sms_info_html: Obtenez votre code de sécurité par SMS à <strong>%{phone}</strong>.
       voice: Appel téléphonique
@@ -53,9 +53,9 @@ fr:
         par SMS à  à <strong>%{phone}</strong>. (Seulement les numéros de
         téléphone en Amerique du Nord)
       webauthn: Clé de sécurité
-      webauthn_info_html: Utilisez votre clé de sécurité pour accéder à votre compte.
+      webauthn_info: Utilisez votre clé de sécurité pour accéder à votre compte.
       webauthn_platform: Déverrouillage facial ou tactile
-      webauthn_platform_info_html: Utilisez votre appareil (téléphone, tablette ou
+      webauthn_platform_info: Utilisez votre appareil (téléphone, tablette ou
         ordinateur de bureau) pour ajouter un autre niveau de sécurité à votre
         compte %{app_name}. Recommandé, car il est plus résistant aux
         hameçonnages.
@@ -144,33 +144,33 @@ fr:
       puissiez vous connecter à votre compte.
     two_factor_choice_options:
       auth_app: Application d’authentification
-      auth_app_info_html: Obtenir des codes d’une application sur votre téléphone,
-        votre ordinateur ou votre tablette.
+      auth_app_info: Obtenir des codes d’une application sur votre téléphone, votre
+        ordinateur ou votre tablette.
       backup_code: Je n’ai rien de ce qui précède
-      backup_code_info_html: Nous vous donnerons 10 codes à utiliser et à conserver
-        dans un endroit sûr. Vous pouvez utiliser des codes de sauvegarde comme
-        seule méthode d’authentification.
+      backup_code_info: Nous vous donnerons 10 codes à utiliser et à conserver dans un
+        endroit sûr. Vous pouvez utiliser des codes de sauvegarde comme seule
+        méthode d’authentification.
       least_secure_label: Le moins sécurisé
       less_secure_label: Moins sécurisé
       more_secure_label: Plus sécurisé
       phone: Téléphone
-      phone_info_html: Obtenir les codes de sécurité par SMS ou appel téléphonique.
+      phone_info: Obtenir les codes de sécurité par SMS ou appel téléphonique.
       phone_info_no_voip: Veuillez ne pas utiliser les services téléphoniques basés
         sur le Web (VOIP).
       piv_cac: Numéro d’employé du gouvernement
-      piv_cac_info_html: Insérez votre carte PIV ou CAC du gouvernement ou militaire
-        et entrez votre code PIN.
+      piv_cac_info: Insérez votre carte PIV ou CAC du gouvernement ou militaire et
+        entrez votre code PIN.
       secure_label: Sécurisé
       sms: SMS
-      sms_info_html: Obtenez votre code de sécurité par SMS.
+      sms_info: Obtenez votre code de sécurité par SMS.
       voice: Appel téléphonique
-      voice_info_html: Obtenez votre code de sécurité par appel téléphonique.
+      voice_info: Obtenez votre code de sécurité par appel téléphonique.
       webauthn: Clé de sécurité
-      webauthn_info_html: Utilisez une clé de sécurité que vous avez. C’est un
-        périphérique physique que vous branchez ou qui est intégré à votre
-        ordinateur ou à votre téléphone (il ressemble souvent à une clé USB).
+      webauthn_info: Utilisez une clé de sécurité que vous avez. C’est un périphérique
+        physique que vous branchez ou qui est intégré à votre ordinateur ou à
+        votre téléphone (il ressemble souvent à une clé USB).
       webauthn_platform: Déverrouillage facial ou tactile
-      webauthn_platform_info_html: Utilisez votre appareil (téléphone, tablette ou
+      webauthn_platform_info: Utilisez votre appareil (téléphone, tablette ou
         ordinateur de bureau) pour ajouter un autre niveau de sécurité à votre
         compte %{app_name}. Recommandé, car il est plus résistant aux
         hameçonnages.

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -7,7 +7,7 @@ feature 'sign up with backup code' do
   it 'allows backup code only MFA configurations' do
     user = sign_up_and_set_password
     expect(page).to_not \
-      have_content t('two_factor_authentication.login_options.backup_code_info_html')
+      have_content t('two_factor_authentication.login_options.backup_code_info')
     select_2fa_option('backup_code')
 
     expect(page).to have_link(t('forms.backup_code.download'))
@@ -40,7 +40,7 @@ feature 'sign up with backup code' do
       signin(user.email, user.password)
       visit login_two_factor_options_path
       expect(page).to \
-        have_content t('two_factor_authentication.login_options.backup_code_info_html')
+        have_content t('two_factor_authentication.login_options.backup_code_info')
       visit login_two_factor_backup_code_path
       fill_in :backup_code_verification_form_backup_code, with: codes[index]
       click_on 'Submit'

--- a/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TwoFactorAuthentication::PhoneSelectionPresenter do
 
       it 'includes a note about choosing voice or sms' do
         expect(presenter.info).
-          to include(t('two_factor_authentication.two_factor_choice_options.phone_info_html'))
+          to include(t('two_factor_authentication.two_factor_choice_options.phone_info'))
       end
 
       it 'does not include a masked number' do


### PR DESCRIPTION
Follow-up to: https://github.com/18F/identity-idp/pull/5937#discussion_r805006993

**Why**: To limit HTML unescaping of strings to only those which require it, and as a clean-up task to #5706, where previously these strings needed to be named consistently due to being referenced using string interpolation.