### PR TITLE
Fix password toggle positioning

### DIFF
--- a/app/javascript/app/pw-toggle.js
+++ b/app/javascript/app/pw-toggle.js
@@ -5,7 +5,7 @@ function togglePw() {
 
   if (inputs) {
     [].slice.call(inputs).forEach((input, i) => {
-      input.parentNode.classList.add('relative');
+      input.parentNode.classList.add('position-relative');
 
       const el = `
         <div class="password-toggle__toggle">


### PR DESCRIPTION
**Why**: So that the password toggle appears within its intended container.

Fixes regression of #5930, where "relative" class was removed. There are two separate checks for the `relative` deprecated class: one applying to ERBLint and the one that checks for the existence of a deprecated class in a monkey-patched Rails tag builder. Neither of these would have discovered this instance of the class name, since it is applied dynamically through JavaScript at runtime.

Before|After
---|---
![Screen Shot 2022-02-16 at 12 23 15 PM](https://user-images.githubusercontent.com/1779930/154321011-98a93d65-688a-4314-80ca-a055ac8bad1d.png)|![Screen Shot 2022-02-16 at 12 22 58 PM](https://user-images.githubusercontent.com/1779930/154321029-a3730e86-38dc-48d0-80e2-357d4ca81312.png)

