### PR TITLE
Fix Rubocop to inspect all files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,8 +24,6 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'public/**/*'
-  Include:
-    - 'lib/tasks/convert_application_yml_to_proper_types.rake'
   TargetRubyVersion: 2.7
   TargetRailsVersion: 6.0
   UseCache: true

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -253,7 +253,7 @@ describe RegisterUserEmailForm do
         submit_form = subject.submit(
           email: 'not_taken@gmail.com',
           terms_accepted: '1',
-          email_language: '01234567890'
+          email_language: '01234567890',
         )
 
         expect(submit_form.success?).to eq false


### PR DESCRIPTION
**Why**: So that our code is linted as we expect it to be.

`Include` overrides the default, meaning it _only_ scans for the specified files.

Before|After
---|---
<code>Inspecting 5 files</code>|<code>Inspecting 1733 files</code>

Example: https://app.circleci.com/pipelines/github/18F/identity-idp/70138/workflows/b8b5a0dd-4597-47c0-95b6-6e947827c2bf/jobs/110926

The `.rake` file is scanned with the default configuration ([source](https://github.com/rubocop/rubocop/blob/9f82e0fb2a581283e588a7161839a10c77a2509c/config/default.yml#L27)), confirmed locally with artificial errors.