### PR TITLE
Remove unused account personal key partial

### DIFF
--- a/app/views/accounts/_personal_key_item_heading.html.erb
+++ b/app/views/accounts/_personal_key_item_heading.html.erb
@@ -1,4 +1,0 @@
-<div class='col'>
-  <%= image_tag asset_url('p-key.svg'), alt: '', width: 16, class: 'margin-right-1 text-middle' %>
-</div>
-<%= t('account.items.personal_key') %>


### PR DESCRIPTION
**Why**: Because it's unused, and because continuing to maintain it would cause additional work for LG-3879 to migrate non-standard CSS classes.

While I was here, i also checked to confirm that [all other partials in `app/views/accounts`](https://github.com/18F/identity-idp/tree/main/app/views/accounts) remain in use.

Last referenced in #4169.