### PR TITLE
LG-3879: Use design system grid in place of BassCSS grid

### DIFF
--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -31,9 +31,6 @@ body {
 .line-height-1 {
   line-height: $line-height-1;
 }
-.line-height-4 {
-  line-height: $line-height-4;
-}
 
 %h1 {
   line-height: 1.35;

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -17,10 +17,6 @@
   vertical-align: middle;
 }
 
-.block-center {
-  margin: 0 auto;
-}
-
 html.no-js .js {
   display: none;
 }

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -39,9 +39,6 @@ html.js .no-js {
   .sm-left-align {
     text-align: left;
   }
-  .sm-right-align {
-    text-align: right;
-  }
 }
 
 .half-center {

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -18,7 +18,6 @@ $caps-letter-spacing: 1px !default;
 
 $line-height-0: 0.75 !default; // For when a tighter-than-normal leading is desired.
 $line-height-1: 1 !default;
-$line-height-4: 2 !default;
 
 $h1: 1.5rem !default;
 $h2: 1.25rem !default;

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -1,6 +1,6 @@
-<div class="padding-1 clearfix border-top border-left border-right border-primary-light">
-  <div class="clearfix margin-x-neg-1">
-    <div class="sm-col sm-col-6 padding-x-1">
+<div class="padding-1 border-top border-left border-right border-primary-light">
+  <div class="grid-row grid-gap-2">
+    <div class="grid-col-fill">
       <div class="bold truncate">
         <% if identity.return_to_sp_url.present? %>
           <%= link_to(identity.display_name, identity.return_to_sp_url) %>
@@ -15,7 +15,7 @@
           ).html_safe %>
     </div>
     <% if identity.service_provider_id %>
-      <div class="sm-col sm-col-6 padding-x-1 sm-right-align line-height-4">
+      <div class="grid-col-12 tablet:grid-col-auto">
         <%= link_to(
               t('account.revoke_consent.link_title'),
               service_provider_revoke_url(identity.service_provider_id),

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -26,19 +26,18 @@
 
 <hr class="margin-y-4" />
 
-<div class='clearfix'>
-  <div class='sm-col sm-col-3'>
+<div class="grid-row">
+  <div class="grid-col-12 tablet:grid-col-3">
     <%= image_tag(
           asset_url('idv/phone.png'),
           alt: t('image_description.camera_mobile_phone'),
           width: 80,
         ) %>
   </div>
-  <div id="recommended-tag"
-       class='usa-tag caps text-ink bg-primary-lighter margin-top-1 display-inline-block <%= 'hidden' if liveness_checking_enabled? %>'>
-    <%= t('doc_auth.info.tag') %>
-  </div>
-  <div class='sm-col sm-col-9'>
+  <div class="grid-col-12 tablet:grid-col-9">
+    <div id="recommended-tag" class="usa-tag caps text-ink bg-primary-lighter margin-top-1 display-inline-block <%= 'hidden' if liveness_checking_enabled? %>">
+      <%= t('doc_auth.info.tag') %>
+    </div>
     <h2 class="margin-y-105">
       <% if liveness_checking_enabled? %>
         <%= t('doc_auth.headings.upload_from_phone_liveness_enabled') %>
@@ -47,7 +46,6 @@
       <% end %>
     </h2>
     <%= t('doc_auth.info.upload_from_phone') %>
-    <br/>
     <%= validated_form_for(
           :doc_auth,
           url: url_for(type: :mobile),
@@ -63,26 +61,22 @@
 
 <hr class="margin-y-4" />
 
-<div class='clearfix'>
-  <div id="upload-comp-liveness-off"
-    class='sm-col sm-col-12 <%= 'hidden' if liveness_checking_enabled? %>'>
-    <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
-    <%= validated_form_for(
-          :doc_auth,
-          url: url_for(type: :desktop),
-          method: 'PUT',
-          html: { autocomplete: 'off', class: 'display-inline' },
-        ) do %>
-      <button type="submit" class="usa-button usa-button--unstyled">
-        <%= t('doc_auth.info.upload_computer_link') %>
-      </button>
-    <% end %>
-  </div>
-  <div id="upload-comp-liveness"
-       class='sm-col sm-col-12 <%= 'hidden' unless liveness_checking_enabled? %>'>
-    <strong><%= t('doc_auth.info.upload_from_computer') %></strong>
-    <%= t('doc_auth.info.upload_from_computer_not_allowed', app_name: APP_NAME) %>
-  </div>
+<div id="upload-comp-liveness-off" class="<%= 'hidden' if liveness_checking_enabled? %>">
+  <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
+  <%= validated_form_for(
+        :doc_auth,
+        url: url_for(type: :desktop),
+        method: 'PUT',
+        html: { autocomplete: 'off', class: 'display-inline' },
+      ) do %>
+    <button type="submit" class="usa-button usa-button--unstyled">
+      <%= t('doc_auth.info.upload_computer_link') %>
+    </button>
+  <% end %>
+</div>
+<div id="upload-comp-liveness" class="<%= 'hidden' unless liveness_checking_enabled? %>">
+  <strong><%= t('doc_auth.info.upload_from_computer') %></strong>
+  <%= t('doc_auth.info.upload_from_computer_not_allowed', app_name: APP_NAME) %>
 </div>
 
 <%= render 'idv/doc_auth/start_over_or_cancel', step: 'upload' %>

--- a/app/views/idv/gpo/_new_address.html.erb
+++ b/app/views/idv/gpo/_new_address.html.erb
@@ -20,14 +20,14 @@
     </span>
   </div>
 
-  <div class="clearfix margin-x-neg-1">
-    <div class="sm-col sm-col-8 padding-x-1">
+  <div class="grid-row grid-gap-2">
+    <div class="grid-col-12 tablet:grid-col-8">
       <%= f.input :state, collection: us_states_territories,
                           label: t('idv.form.state'), required: true,
                           prompt: '- Select -' %>
     </div>
 
-    <div class="sm-col sm-col-4 padding-x-1">
+    <div class="grid-col-12 tablet:grid-col-4">
       <%# using :tel for mobile numeric keypad %>
       <%= f.input :zipcode, as: :tel,
                             label: t('idv.form.zipcode'), required: true,

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -7,15 +7,13 @@
       as: :user,
       url: capture_password_url,
       method: :post,
-      html: { autocomplete: 'off' },
+      html: { autocomplete: 'off', class: 'margin-top-6' },
     ) do |f| %>
   <%= f.input :password, label: t('account.index.password'), required: true,
                          input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
-  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide margin-bottom-4' %>
+  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'display-block margin-y-5 usa-button--big usa-button--wide' %>
 <% end %>
 
-<div class='clearfix padding-top-1 border-top border-primary-light'>
-  <div class='sm-col-right margin-x-neg-1'>
-    <%= link_to t('links.passwords.forgot'), new_user_password_url, class: 'padding-x-1' %>
-  </div>
-</div>
+<%= render PageFooterComponent.new do %>
+  <%= link_to t('links.passwords.forgot'), new_user_password_url %>
+<% end %>

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -33,16 +33,16 @@
   <%= render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX' %>
 </div>
 
-<div class="block-center center col-10">
-  <div class="col-12 margin-bottom-2">
+<div class="grid-row">
+  <div class="tablet:grid-col-10 tablet:grid-offset-1">
     <%= link_to t('links.account.reactivate.with_key'), verify_personal_key_path,
-                class: 'usa-button usa-button--big usa-button--full-width' %>
-  </div>
+                class: 'usa-button usa-button--big usa-button--full-width margin-bottom-2' %>
 
-  <%= form_tag reactivate_account_path, method: :put, class: 'col-12' do %>
-    <%= button_tag t('links.account.reactivate.without_key'), type: 'submit',
-                                                              class: 'usa-button usa-button--big usa-button--outline usa-button--full-width', id: 'no-key-reactivate' %>
-  <% end %>
+    <%= form_tag reactivate_account_path, method: :put do %>
+      <%= button_tag t('links.account.reactivate.without_key'), type: 'submit',
+                                                                class: 'usa-button usa-button--big usa-button--outline usa-button--full-width', id: 'no-key-reactivate' %>
+    <% end %>
+  </div>
 </div>
 
 <%= render 'reactivate_account/modal' %>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -8,22 +8,24 @@
     <%= render_javascript_pack_once_tags 'saml-post' %>
   </head>
   <body>
-    <div class="container tablet:padding-y-6">
-      <div class="card margin-x-auto sm-col-6">
-        <%= render PageHeadingComponent.new.with_content(t('.heading')) %>
+    <div class="grid-container tablet:padding-y-6">
+      <div class="grid-row">
+        <div class="tablet:grid-col-6 tablet:grid-offset-3">
+          <%= render PageHeadingComponent.new.with_content(t('.heading')) %>
 
-        <p>
-          <%= t('.no_js') %>
-        </p>
+          <p>
+            <%= t('.no_js') %>
+          </p>
 
-        <%= form_tag action_url, id: 'saml-post-binding' do %>
-          <%= hidden_field_tag('csp_uris', csp_uris) if Rails.env.test? %>
-          <%= hidden_field_tag(type, message) %>
-          <% if params.key?(:RelayState) %>
-            <%= hidden_field_tag('RelayState', params[:RelayState]) %>
+          <%= form_tag action_url, id: 'saml-post-binding' do %>
+            <%= hidden_field_tag('csp_uris', csp_uris) if Rails.env.test? %>
+            <%= hidden_field_tag(type, message) %>
+            <% if params.key?(:RelayState) %>
+              <%= hidden_field_tag('RelayState', params[:RelayState]) %>
+            <% end %>
+            <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
           <% end %>
-          <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
-        <% end %>
+        </div>
       </div>
     </div>
   </body>

--- a/app/views/saml_post/auth.html.erb
+++ b/app/views/saml_post/auth.html.erb
@@ -8,20 +8,22 @@
     <%= render_javascript_pack_once_tags 'saml-post' %>
   </head>
   <body>
-    <div class="container tablet:padding-y-6">
-      <div class="card margin-x-auto sm-col-6">
-        <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
+    <div class="grid-container tablet:padding-y-6">
+      <div class="grid-row">
+        <div class="tablet:grid-col-6 tablet:grid-offset-3">
+          <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
 
-        <p>
-          <%= t('saml_idp.shared.saml_post_binding.no_js') %>
-        </p>
+          <p>
+            <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+          </p>
 
-        <%= form_tag action_url, id: 'saml-post-binding' do %>
-          <% form_params.each do |key, val| %>
-            <%= hidden_field_tag(key, val) %>
+          <%= form_tag action_url, id: 'saml-post-binding' do %>
+            <% form_params.each do |key, val| %>
+              <%= hidden_field_tag(key, val) %>
+            <% end %>
+            <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
           <% end %>
-          <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
-        <% end %>
+        </div>
       </div>
     </div>
   </body>

--- a/app/views/shared/_personal_key_confirmation_modal.html.erb
+++ b/app/views/shared/_personal_key_confirmation_modal.html.erb
@@ -22,18 +22,18 @@
               class: 'margin-bottom-2',
               message: t('simple_form.required.text'),
             } %>
-        <div class="clearfix margin-x-neg-2">
-          <div class="col col-12 sm-col-6 padding-x-2 margin-bottom-2 tablet:margin-bottom-0 tablet:display-none">
+        <div class="grid-row grid-gap">
+          <div class="grid-col-12 tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0 tablet:display-none">
             <button type="submit" class="usa-button usa-button--big usa-button--full-width personal-key-confirm">
               <%= t('forms.buttons.continue') %>
             </button>
           </div>
-          <div class="col col-12 sm-col-6 padding-x-2">
+          <div class="grid-col-12 tablet:grid-col-6">
             <button class="usa-button usa-button--big usa-button--full-width usa-button--outline" type="button" data-dismiss="personal-key-confirm">
               <%= t('forms.buttons.back') %>
             </button>
           </div>
-          <div class="col col-12 sm-col-6 padding-x-2 margin-bottom-2 tablet:margin-bottom-0 display-none tablet:display-block">
+          <div class="grid-col-12 tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0 display-none tablet:display-block">
             <button type="submit" class="usa-button usa-button--big usa-button--full-width personal-key-confirm">
               <%= t('forms.buttons.continue') %>
             </button>

--- a/app/views/shared/_personal_key_input.html.erb
+++ b/app/views/shared/_personal_key_input.html.erb
@@ -1,6 +1,6 @@
 <input aria-label="<%= t('forms.personal_key.confirmation_label') %>"
        autocomplete="off"
-       class="margin-bottom-6 border-dashed field font-family-mono personal-key caps"
+       class="width-full margin-bottom-6 border-dashed field font-family-mono personal-key caps"
        maxlength="<%= PersonalKeyFormatter.code_length %>"
        name="personal_key"
        pattern="^<%= PersonalKeyFormatter.regexp_string %>$"

--- a/app/views/shared/_personal_key_input.html.erb
+++ b/app/views/shared/_personal_key_input.html.erb
@@ -1,6 +1,6 @@
 <input aria-label="<%= t('forms.personal_key.confirmation_label') %>"
        autocomplete="off"
-       class="col-12 margin-bottom-6 border-dashed field font-family-mono personal-key caps"
+       class="margin-bottom-6 border-dashed field font-family-mono personal-key caps"
        maxlength="<%= PersonalKeyFormatter.code_length %>"
        name="personal_key"
        pattern="^<%= PersonalKeyFormatter.regexp_string %>$"

--- a/app/views/test/saml_test/decode_response.html.erb
+++ b/app/views/test/saml_test/decode_response.html.erb
@@ -1,49 +1,45 @@
-<div class="container">
-  <div class="row">
-    <h3>Decoded SAML Response</h3>
+<h3>Decoded SAML Response</h3>
 
-    <p>
-      Visit the account page to demo the SP iniated email change + redirect:
-      <%= link_to 'Account page', account_path, role: 'menuitem' %>
-    </p>
+<p>
+  Visit the account page to demo the SP iniated email change + redirect:
+  <%= link_to 'Account page', account_path, role: 'menuitem' %>
+</p>
 
-    <table border="2" width="80%">
-      <tbody>
-        <tr>
-          <td>IsValid</td>
-          <td>
-            <%= is_valid %>
-          </td>
-        </tr>
-        <tr>
-          <td>Issuer</td>
-          <td>
-            <%= response.settings.idp_entity_id %>
-          </td>
-        </tr>
-        <tr>
-          <td>XML Document</td>
-          <td>
-            <% xml_doc = Base64.encode64(response.document.to_s) %>
-            <%= link_to 'Open in New Window',
-                        "data:text/xml;charset=utf-8;base64,#{xml_doc}",
-                        target: '_blank', rel: 'noopener noreferrer' %>
-          </td>
-        </tr>
-        <tr>
-          <td>Decrypted XML Document</td>
-          <% if response.decrypted_document.present? %>
-            <td>
-              <% xml_doc = Base64.encode64(response.decrypted_document.to_s) %>
-              <%= link_to 'Open in New Window',
-                          "data:text/xml;charset=utf-8;base64,#{xml_doc}",
-                          target: '_blank', rel: 'noopener noreferrer' %>
-            </td>
-          <% else %>
-            <td>Document not encrypted</td>
-          <% end %>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+<table border="2" width="80%">
+  <tbody>
+    <tr>
+      <td>IsValid</td>
+      <td>
+        <%= is_valid %>
+      </td>
+    </tr>
+    <tr>
+      <td>Issuer</td>
+      <td>
+        <%= response.settings.idp_entity_id %>
+      </td>
+    </tr>
+    <tr>
+      <td>XML Document</td>
+      <td>
+        <% xml_doc = Base64.encode64(response.document.to_s) %>
+        <%= link_to 'Open in New Window',
+                    "data:text/xml;charset=utf-8;base64,#{xml_doc}",
+                    target: '_blank', rel: 'noopener noreferrer' %>
+      </td>
+    </tr>
+    <tr>
+      <td>Decrypted XML Document</td>
+      <% if response.decrypted_document.present? %>
+        <td>
+          <% xml_doc = Base64.encode64(response.decrypted_document.to_s) %>
+          <%= link_to 'Open in New Window',
+                      "data:text/xml;charset=utf-8;base64,#{xml_doc}",
+                      target: '_blank', rel: 'noopener noreferrer' %>
+        </td>
+      <% else %>
+        <td>Document not encrypted</td>
+      <% end %>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 
   <div id='webauthn-auth-successful' class="hidden">
-    <div class="col-12 center margin-bottom-2">
+    <div class="center margin-bottom-2">
       <%= image_tag(
             asset_url('webauthn-verified.svg'),
             height: 144,

--- a/app/views/users/edit_phone/_remove_phone.html.erb
+++ b/app/views/users/edit_phone/_remove_phone.html.erb
@@ -1,8 +1,5 @@
 <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-  <br/>
-  <div class="sm-col-8 margin-bottom-4">
-    <%= button_to t('forms.phone.buttons.delete'), manage_phone_path(id: @phone_configuration.id),
-                  class: 'usa-button usa-button--big usa-button--danger usa-button--wide',
-                  method: :delete %>
-  </div>
+  <%= button_to t('forms.phone.buttons.delete'), manage_phone_path(id: @phone_configuration.id),
+                class: 'usa-button usa-button--big usa-button--danger usa-button--wide margin-top-2',
+                method: :delete %>
 <% end %>

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -66,12 +66,7 @@ describe 'Account connected applications' do
 
     visit account_connected_accounts_path
     within(find('.profile-info-box')) do
-      within(
-        find(
-          '.margin-x-neg-1',
-          text: identity_to_revoke.service_provider_record.friendly_name,
-        ),
-      ) do
+      within(find('.grid-row', text: identity_to_revoke.service_provider_record.friendly_name)) do
         click_link(t('account.revoke_consent.link_title'))
       end
     end
@@ -80,14 +75,7 @@ describe 'Account connected applications' do
     click_on t('forms.buttons.continue')
 
     # Accounts page should no longer list this app in the applications section
-    within(find('.profile-info-box')) do
-      expect(
-        has_selector?(
-          '.margin-x-neg-1',
-          text: identity_to_revoke.service_provider_record.friendly_name,
-        ),
-      ).to eq(false)
-    end
+    expect(page).to_not have_content(identity_to_revoke.service_provider_record.friendly_name)
   end
 
   def build_account_connected_apps


### PR DESCRIPTION
**Why**: To simplify markup and to standardize on design system utilities.

Doesn't yet remove / deprecate styles, since there are still lingering classes to be resolved with #5962 and #5953.

## Screenshots:

### Connected Accounts:

**Expected visual changes (cc @anniehirshman-gsa):**

- Text can expand to fill more of the available space on desktop. 

Size|Before|After
---|---|---
Desktop|![grid-connected-desktop-before](https://user-images.githubusercontent.com/1779930/154519599-08f527fc-2ee6-4852-bf7b-37436ee296ea.png)|![grid-connected-desktop-after](https://user-images.githubusercontent.com/1779930/154519594-e2f80dc9-e282-446a-8185-2031cddb8fc1.png)
Mobile|![grid-connected-mobile-before](https://user-images.githubusercontent.com/1779930/154519603-dc17527a-5c0c-441b-8ded-d9e3bb1bda7b.png)|![grid-connected-mobile-after](https://user-images.githubusercontent.com/1779930/154519602-ee9338b9-97d3-4c66-a1d1-7f5580788d74.png)

### GPO Bounced New Address:

Note: This is not enabled in any environment.

The lack of margin after the last form field is maintained from previous. I'd probably sooner delete this user flow than spend more time maintaining it though.

Size|Before|After
---|---|---
Desktop|![grid-gpo-new-desktop-before](https://user-images.githubusercontent.com/1779930/154519605-bc6e0536-8618-4bc7-9ec2-d399bad75e23.png)|![grid-gpo-new-desktop-after](https://user-images.githubusercontent.com/1779930/154519604-534c0136-37e9-4d8a-b29a-aeda84c8aa93.png)
Mobile|![grid-gpo-new-mobile-before](https://user-images.githubusercontent.com/1779930/154519608-6f279939-978c-4608-9f6f-effbfb5bbabd.png)|![grid-gpo-new-mobile-after](https://user-images.githubusercontent.com/1779930/154519607-456f9b0c-c933-40fd-b5fa-e92ef45a4005.png)

### Personal Key Confirmation:

Size|Before|After
---|---|---
Desktop|![grid-personal-key-desktop-before](https://user-images.githubusercontent.com/1779930/154519611-7157a51c-694d-4d7e-a6c9-28e3b5f53309.png)|![grid-personal-key-desktop-after png](https://user-images.githubusercontent.com/1779930/154519610-c635c448-c69a-4bff-88f4-984d15460641.png)
Mobile|![grid-personal-key-mobile-before](https://user-images.githubusercontent.com/1779930/154519616-63e5962c-b4b3-47f5-be4b-256cb87d23e9.png)|![grid-personal-key-mobile-after png](https://user-images.githubusercontent.com/1779930/154519612-3eb2a68b-7b93-4f43-a8b5-93cf36dc8ee0.png)

### Edit Phone

**Expected visual changes (cc @anniehirshman-gsa):**

- Set margin between buttons to 1rem (previously used `<br>` line break)

Size|Before|After
---|---|---
Desktop|![grid-phone-edit-desktop-before](https://user-images.githubusercontent.com/1779930/154519619-f285c2a3-8184-4ca1-927e-7cf3b5401fc9.png)|![grid-phone-edit-desktop-after](https://user-images.githubusercontent.com/1779930/154519617-f3959f7f-e183-450c-bc3e-ce2e507635c4.png)
Mobile|![grid-phone-edit-mobile-before](https://user-images.githubusercontent.com/1779930/154519621-8cf37f98-43ef-461b-800d-3e452924840b.png)|![grid-phone-edit-mobile-after](https://user-images.githubusercontent.com/1779930/154519620-58301fc8-d6d9-4b93-bffa-71d538c9ec28.png)

### Password Entry

**Expected visual changes (cc @anniehirshman-gsa):**

- Increase top margin between "Show Password" toggle and preceding text from 2rem to 3rem
- Set vertical margin around Submit button to 2.5rem
- Remove right text alignment on footer content ("Forgot your password?")

Size|Before|After
---|---|---
Desktop|![grid-pw-desktop-before](https://user-images.githubusercontent.com/1779930/154519626-f0297c6c-6b44-45d3-8ef3-a3291138ae7c.png)|![grid-pw-desktop-after](https://user-images.githubusercontent.com/1779930/154519624-e846cbe0-4b22-429b-992c-57791d603975.png)
Mobile|![grid-pw-mobile-before](https://user-images.githubusercontent.com/1779930/154519629-86894ed8-e6a0-46f4-8fdb-f359ff42024c.png)|![grid-pw-mobile-after](https://user-images.githubusercontent.com/1779930/154519627-7ce40be0-d1af-4a39-ac8d-7e1918e570e2.png)

### Reactivate Account

**Expected visual changes (cc @anniehirshman-gsa):**

- Remove button width constraint at mobile viewports (Q: Should we also remove it at desktop?)

Size|Before|After
---|---|---
Desktop|![grid-reactivate-desktop-before](https://user-images.githubusercontent.com/1779930/154519632-ae078053-a5e5-4c72-8561-fc1679ebc133.png)|![grid-reactivate-desktop-after](https://user-images.githubusercontent.com/1779930/154519630-34424d71-f29f-497f-b8f5-281087d84b9e.png)
Mobile|![grid-reactivate-mobile-before](https://user-images.githubusercontent.com/1779930/154519634-9ae70bd0-4c77-4675-8375-cc021aba6364.png)|![grid-reactivate-mobile-after](https://user-images.githubusercontent.com/1779930/154519633-e28cb4fe-2269-42ec-93ff-8e60b4c3067d.png)

### SAML No-JavaScript Redirect

Before|After
---|---
![grid-saml-desktop-before](https://user-images.githubusercontent.com/1779930/154519636-80a29b5a-9ffa-44d8-b746-115e781affcb.png)|![grid-saml-desktop-after](https://user-images.githubusercontent.com/1779930/154519635-e20a69ed-2f39-4c63-8f09-6d3cc6ac3fff.png)

### Identity Proofing Device Choice

Before|After
---|---
![grid-upload-before](https://user-images.githubusercontent.com/1779930/154519639-901e2c46-d497-4670-9440-bc6f9cec1608.png)|![grid-upload-after](https://user-images.githubusercontent.com/1779930/154519637-8dd4d276-f320-4e16-ba87-c54995fc0247.png)
