### PR TITLE
Fix flaky specs around phone formatting

### DIFF
--- a/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
       it 'assigns an in-memory phone configuration' do
         expect { action }.to_not change { user.reload.phone_configurations.count }
 
-        expect(assigns[:phone_configuration].formatted_phone).to eq(PhoneFormatter.format(phone))
+        expect(PhoneFormatter.format(assigns[:phone_configuration].phone)).
+          to eq(PhoneFormatter.format(phone))
       end
     end
 


### PR DESCRIPTION
- PhoneFormatter adds a default country vs #formatted_phone which does not


See: https://github.com/18F/identity-idp/pull/5939#discussion_r809221076