### PR TITLE
Use correct git range operator for changelog

### DIFF
--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -35,7 +35,7 @@ end
 def get_git_log(base_branch, source_branch)
   format = '--pretty=title: %s%nbody:%b%nDELIMITER'
   log, status = Open3.capture2(
-    'git', 'log', format, "#{base_branch}...#{source_branch}"
+    'git', 'log', format, "#{base_branch}..#{source_branch}"
   )
 
   raise 'git log failed' unless status.success?
@@ -56,7 +56,7 @@ end
 
 def commit_messages_contain_skip_changelog?(base_branch, source_branch)
   log, status = Open3.capture2(
-    'git', 'log', '--pretty=\'%B\'', "#{base_branch}...#{source_branch}"
+    'git', 'log', '--pretty=\'%B\'', "#{base_branch}..#{source_branch}"
   )
   raise 'git log failed' unless status.success?
 


### PR DESCRIPTION
https://stackoverflow.com/questions/7251477/what-are-the-differences-between-double-dot-and-triple-dot-in-git-dif shows the difference between `..` and `...`

`...` includes the commits on `main` that are not yet on `feature-branch`, and since the changelog is only interested in including changes on the current branch regardless common ancestor commit is, it seems like `..` is more appropriate, otherwise we may be checking the wrong commits.

Example of this bug in the wild: https://app.circleci.com/pipelines/github/18F/identity-idp/70199/workflows/05c4446a-b92d-47d7-9442-0282589beaad/jobs/111262