### PR TITLE
Fix flaky test

### DIFF
--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -12,16 +12,17 @@ feature 'webauthn sign in' do
       :webauthn_configuration,
       credential_id: credential_id,
       credential_public_key: credential_public_key,
+      user: user,
     )
   end
   let(:user) do
-    create(:user, :with_backup_code, webauthn_configurations: [webauthn_configuration])
+    create(:user, :with_backup_code)
   end
 
   it 'allows the user to sign in if webauthn is successful' do
     mock_webauthn_verification_challenge
 
-    sign_in_user(user)
+    sign_in_user(webauthn_configuration.user)
     mock_press_button_on_hardware_key_on_verification
     click_button t('forms.buttons.continue')
 
@@ -31,7 +32,7 @@ feature 'webauthn sign in' do
   it 'does not allow the user to sign in if the challenge/secret is incorrect' do
     # Not calling `mock_challenge` here means the challenge won't match the signature that is set
     # when the button is pressed.
-    sign_in_user(user)
+    sign_in_user(webauthn_configuration.user)
     mock_press_button_on_hardware_key_on_verification
     click_button t('forms.buttons.continue')
 
@@ -42,7 +43,7 @@ feature 'webauthn sign in' do
   it 'does not allow the user to sign in if the hardware button has not been pressed' do
     mock_webauthn_verification_challenge
 
-    sign_in_user(user)
+    sign_in_user(webauthn_configuration.user)
     click_button t('forms.buttons.continue')
 
     expect(page).to have_content(t('errors.invalid_authenticity_token'))


### PR DESCRIPTION
A test failed on main yesterday due to a non-unique email in a test that should only be creating one user

https://app.circleci.com/pipelines/github/18F/identity-idp/70205/workflows/52775fc0-fa6c-42ae-a86f-635e39cc7c94/jobs/111293/parallel-runs/1?filterBy=FAILED

`create(:webauthn_configuration)` creates an associated user by default, and we then were creating another user and re-associating the webauthn configuration. This PR reorders that so only one user is created. Two users being created with the same email address should be very rare, so I'm surprised it happened.