### PR TITLE
Fix more flaky tests

### DIFF
--- a/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
 
     context 'when loaded while adding a new phone' do
       let(:user) { create(:user) }
-      let(:phone) { Faker::PhoneNumber.cell_phone }
+      let(:phone) { Faker::PhoneNumber.cell_phone_in_e164 }
       let(:opt_out_uuid) { PhoneNumberOptOut.create_or_find_with_phone(phone).uuid }
 
       before do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -59,6 +59,10 @@ describe 'throttling requests' do
     end
 
     context 'when the number of requests is higher than the limit' do
+      around do |ex|
+        freeze_time { ex.run }
+      end
+
       it 'throttles with a custom response' do
         analytics = instance_double(Analytics)
         allow(Analytics).to receive(:new).and_return(analytics)
@@ -175,6 +179,10 @@ describe 'throttling requests' do
   end
 
   describe 'logins per email and ip' do
+    around do |ex|
+      freeze_time { ex.run }
+    end
+
     context 'when the number of requests is lower or equal to the limit' do
       it 'does not throttle' do
         (logins_per_email_and_ip_limit - 1).times do
@@ -235,6 +243,10 @@ describe 'throttling requests' do
   end
 
   describe 'otps per ip' do
+    around do |ex|
+      freeze_time { ex.run }
+    end
+
     let(:otps_per_ip_limit) { IdentityConfig.store.otps_per_ip_limit }
 
     context 'when the number of requests is under the limit' do
@@ -262,6 +274,10 @@ describe 'throttling requests' do
   end
 
   describe 'phone setups per ip' do
+    around do |ex|
+      freeze_time { ex.run }
+    end
+
     let(:phone_setups_per_ip_limit) { IdentityConfig.store.phone_setups_per_ip_limit }
 
     context 'when the number of requests is under the limit' do


### PR DESCRIPTION
Naturally the main branch test failed with a flaky test after I merged #5970 https://app.circleci.com/pipelines/github/18F/identity-idp/70230/workflows/c912e280-b664-4b11-9c7d-50c55dc86ad6/jobs/111420/parallel-runs/4?filterBy=FAILED

This PR fixes a handful more of the flaky tests

The phone test had a fix applied in #5966, but there seems to be an inconsistency in how the phones get formatted?
I got a failure with:

```
      assigns an in-memory phone configuration (FAILED - 1)

Failures:

  1) TwoFactorAuthentication::SmsOptInController#new when loaded while adding a new phone assigns an in-memory phone configuration
     Failure/Error:
       expect(PhoneFormatter.format(assigns[:phone_configuration].phone)).
         to eq(PhoneFormatter.format(phone))

       expected: "+14590108499"
            got: "+45 90 10 84 99"

```

the variables in question were:

```ruby
assigns[:phone_configuration].phone
# => "+45 90 10 84 99"
phone
# => "459-010-8499"
```

I'm not sure if the phone formatting one deserves some more scrutiny in terms of how we parse/store phone numbers