### PR TITLE
Update Nokogiri to patch vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ group :development, :test do
   gem 'erb_lint', '~> 0.1.0', require: false
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'knapsack'
-  gem 'nokogiri', '~> 1.12.5'
+  gem 'nokogiri', '~> 1.13.2'
   gem 'parallel_tests'
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,7 +379,7 @@ GEM
     method_source (1.0.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.4.2)
     multipart-post (2.1.1)
@@ -390,8 +390,8 @@ GEM
     net-ssh (6.1.0)
     newrelic_rpm (7.2.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -736,7 +736,7 @@ DEPENDENCIES
   multiset
   net-sftp
   newrelic_rpm (~> 7.0)
-  nokogiri (~> 1.12.5)
+  nokogiri (~> 1.13.2)
   octokit
   parallel_tests
   pg


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.12.5
CVE: CVE-2021-30560
GHSA: GHSA-fq42-c5rg-92c2
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
Title: Update packaged libxml2 (2.9.12 → 2.9.13) and libxslt (1.1.34 → 1.1.35)
Solution: upgrade to >= 1.13.2
```