### PR TITLE
Migrate background styles to design system

### DIFF
--- a/app/assets/stylesheets/components/_profile-section.scss
+++ b/app/assets/stylesheets/components/_profile-section.scss
@@ -4,11 +4,6 @@
   margin-bottom: 0;
   overflow: hidden;
   padding: $space-3;
-
-  .bg-lightest-blue img {
-    margin-top: -2px;
-    vertical-align: middle;
-  }
 }
 
 @include at-media('mobile') {

--- a/app/assets/stylesheets/utilities/_background.scss
+++ b/app/assets/stylesheets/utilities/_background.scss
@@ -1,21 +1,16 @@
-.bg-gray-lighter {
-  background-color: $gray-lighter;
-}
-.bg-light-blue {
-  background-color: $blue-light;
-}
-.bg-lightest-blue {
-  background-color: $blue-lightest;
-}
+@include at-media('tablet') {
+  /* stylelint-disable-next-line selector-class-pattern */
+  .tablet\:bg-primary-lighter {
+    @include u-bg('primary-lighter');
+  }
 
-@media #{$breakpoint-sm} {
-  .sm-bg-light-blue {
-    background-color: $blue-light;
+  /* stylelint-disable-next-line selector-class-pattern */
+  .tablet\:bg-primary-darker {
+    @include u-bg('primary-darker');
   }
-  .sm-bg-none {
-    background-color: transparent;
-  }
-  .sm-bg-navy {
-    background-color: $navy;
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .tablet\:bg-transparent {
+    @include u-bg('transparent');
   }
 }

--- a/app/assets/stylesheets/variables/_colors.scss
+++ b/app/assets/stylesheets/variables/_colors.scss
@@ -1,7 +1,6 @@
 $aqua: #7fdbff !default;
 $blue: #0071bb !default;
 $blue-light: #ebf3fa !default;
-$blue-lightest: #f2f9ff !default;
 $blue-mid: #1c5899;
 $navy: #112e51 !default;
 $teal: #00bfe7 !default;
@@ -18,7 +17,6 @@ $white: #ffffff !default;
 $silver: #d9dadb !default;
 $gray: #5b616a !default;
 $gray-light: #dddddd !default;
-$gray-lighter: #fafafa !default;
 $gray-dark: #040404 !default;
 $black: #111111 !default;
 $red: #ff0000 !default;

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="grid-row padding-y-2 tablet:padding-y-0 margin-bottom-4 bg-lightest-blue sm-bg-none position-relative <% if presenter.showing_any_badges? %>padding-bottom-4<% end %>">
+<div class="grid-row padding-y-2 tablet:padding-y-0 margin-bottom-4 bg-primary-lightest tablet:bg-transparent position-relative <% if presenter.showing_any_badges? %>padding-bottom-4<% end %>">
   <div class="grid-col-12 tablet:grid-col-fill">
     <h1 class="margin-0 center sm-left-align">
       <span class="regular tablet:display-none">

--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -63,7 +63,7 @@
     </div>
   </div>
   <% unless locked_for_session %>
-    <div class="grid-row bg-gray-lighter padding-x-2 padding-y-1 clearfix fs-12p">
+    <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 clearfix fs-12p">
       <div class="grid-col-12">
         <%= image_tag asset_url('lock.svg'), width: 8, class: 'margin-right-1' %>
         <%= t('account.security.text') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,3 @@
-<% background_cls 'sm-bg-light-blue' %>
+<% background_cls 'tablet:bg-primary-lighter' %>
 
 <%= render template: 'layouts/base' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -59,7 +59,7 @@
   <div class="usa-overlay"></div>
   <%= yield(:mobile_nav) if content_for?(:mobile_nav) %>
   <%= render 'shared/banner' %>
-  <main class="site-wrap bg-light-blue" id="main-content">
+  <main class="site-wrap bg-primary-lighter" id="main-content">
     <div class="container">
       <div class="padding-x-2 padding-y-4 tablet:padding-y-8 tablet:padding-x-10 margin-x-auto tablet:margin-bottom-8 <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
         <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,7 +1,7 @@
 <% show_language_dropdown = I18n.available_locales.count > 1
    sanitized_requested_url = request.query_parameters.slice(:request_id) %>
 
-<footer class='footer bg-light-blue sm-bg-navy'>
+<footer class='footer bg-primary-lighter tablet:bg-primary-darker'>
   <% if show_language_dropdown %>
     <div class='tablet:display-none border-bottom border-primary-light'>
       <div class='container cntnr-wide padding-y-1 padding-x-2 desktop:padding-x-0 h5'>


### PR DESCRIPTION
**Why**:

- Avoid duplicate styles
- Use only standard colors, by token name
- Conform to naming conventions for responsive variations (`tablet:`, not `sm-`)

There is not expected to be any visual changes here, with one exception: since the previous `bg-gray-lighter` was using a non-standard color (`#fafafa`), it was replaced with the closest equivalent value `base-lightest` (`#f0f0f0`), affecting one instance of PII "locked" messaging. (FYSA @anniehirshman-gsa @nickttng)

Before|After
---|---
![Screen Shot 2022-02-22 at 10 20 09 AM](https://user-images.githubusercontent.com/1779930/155166090-5a5e3cec-c431-4b6d-97da-8a6d00445011.png)|![Screen Shot 2022-02-22 at 10 20 43 AM](https://user-images.githubusercontent.com/1779930/155166095-2ddfbefb-23c7-4956-8437-da851e935225.png)