### PR TITLE
Migrate spacing styles to design system

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -14,7 +14,7 @@ legend {
 
 label {
   display: inline-block;
-  margin-bottom: $space-tiny;
+  margin-bottom: units(0.5);
 }
 
 textarea {

--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -7,7 +7,7 @@ $great: #00b200;
 
 .pw-bar {
   background-color: #e9e9e9;
-  border: $space-tiny solid #fff;
+  border: units(0.5) solid #fff;
   border-radius: 6px;
   float: left;
   height: 16px;

--- a/app/assets/stylesheets/utilities/_space-misc.scss
+++ b/app/assets/stylesheets/utilities/_space-misc.scss
@@ -1,42 +1,5 @@
 // additional, ad-hoc spacing utilities added as needed
 
-.mxn-tiny {
-  margin-left: -$space-tiny;
-  margin-right: -$space-tiny;
-}
-.ml-tiny {
-  margin-left: $space-tiny;
-}
-.mt-tiny {
-  margin-top: $space-tiny;
-}
-.pt-tiny {
-  padding-top: $space-tiny;
-}
-.py-tiny {
-  padding-bottom: $space-tiny;
-  padding-top: $space-tiny;
-}
-
-.px-12p {
-  padding-left: 12px;
-  padding-right: 12px;
-}
-.py-12p {
-  padding-bottom: 12px;
-  padding-top: 12px;
-}
-
-.pl-24p {
-  padding-left: 24px;
-}
-
 .minw-full {
   min-width: 100%;
-}
-
-@media #{$breakpoint-sm} {
-  .sm-mr-20p {
-    margin-right: 20px;
-  }
 }

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -33,8 +33,6 @@ $sm-h4: 1rem !default;
 $sm-h5: 0.875rem !default;
 $sm-h6: 0.75rem !default;
 
-$space-tiny: 0.25rem !default;
-
 $space-1: 0.5rem !default;
 $space-2: 1rem !default;
 $space-3: 2rem !default;

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,6 +1,6 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
   <div class='margin-top-neg-3 margin-bottom-4'>
-    <div class='clearfix mxn-tiny pt-tiny'>
+    <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>
       <div class='pw-bar'></div>
       <div class='pw-bar'></div>

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -24,7 +24,7 @@
   <%= f.input :resend, as: :hidden, wrapper: false %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>
-  <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
+  <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled margin-left-05' %></p>
 
   <% link = link_to(
        t('notices.forgot_password.use_diff_email.link'),

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -17,7 +17,7 @@
       <ul class='usa-list--unstyled margin-bottom-0 text-white text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block py-12p padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>
@@ -48,7 +48,7 @@
       <div class="display-flex flex-align-center flex-justify-center">
         <% if show_language_dropdown %>
           <div class='i18n-desktop-toggle display-none tablet:display-flex margin-x-2 padding-y-1'>
-            <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 py-tiny language-desktop-button' aria-expanded='false'>
+            <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 padding-y-05 language-desktop-button' aria-expanded='false'>
               <%= image_tag asset_url('globe-white.svg'), width: 12,
                                                           class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
               <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
@@ -58,7 +58,7 @@
                 <li class='border-bottom border-primary-darker'>
                   <%= link_to t("i18n.locale.#{locale}"),
                               sanitized_requested_url.merge(locale: locale),
-                              class: 'display-block pl-24p padding-y-2 text-decoration-none text-white',
+                              class: 'display-block padding-left-3 padding-y-2 text-decoration-none text-white',
                               lang: locale == I18n.locale ? nil : locale %>
                 </li>
               <% end %>

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -26,7 +26,7 @@
   <%= f.input :resend, as: :hidden, wrapper: false %>
   <%= f.input :request_id, as: :hidden, wrapper: false %>
   <p><%= t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start') %>
-  <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled ml-tiny' %></p>
+  <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled margin-left-05' %></p>
 
   <% link = link_to(
        t('notices.use_diff_email.link'),


### PR DESCRIPTION
**Why**:

- Remove duplicate styles
- Use only standard sizes, by unit
- Avoid pixel-based sizing, leverage rem-based instead

There should not be any visual changes with these revisions.

Additional context for review:

- In the design system, `1 unit` = `0.5rem`
- In the design system, half-units are reflected in utility classes with `05` suffix
   - e.g. `margin-105` = `margin: units(1.5)` = `margin: 0.75rem;`
- The previous "tiny" size was `0.25rem`, which is equivalent to 0.5 units in the design system
   - Unlike other "`$space-`" variables which are inherited from BassCSS, `$space-tiny` is custom to the IdP
- `1rem` = `16px`