### PR TITLE
Add view component previews using Lookbook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'uglifier', '~> 4.2'
 gem 'valid_email', '>= 0.1.3'
-gem 'view_component', '~> 2.43.1', require: 'view_component/engine'
+gem 'view_component', '~> 2.49.0'
 gem 'webauthn', '~> 2.1'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem 'xmlenc', '~> 0.7', '>= 0.7.1'
 # It should not be updated without verifying that the behavior still matches JS version 4.4.2.
 gem 'zxcvbn', '0.1.7'
 
+# Lookbook must be listed after ViewComponent, so listed here out of default alphabetical order.
+gem 'lookbook', '~> 0.6.0'
+
 group :development do
   gem 'better_errors', '>= 2.5.1'
   gem 'binding_of_caller'

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'xmlenc', '~> 0.7', '>= 0.7.1'
 gem 'zxcvbn', '0.1.7'
 
 # Lookbook must be listed after ViewComponent, so listed here out of default alphabetical order.
-gem 'lookbook', '~> 0.6.0'
+gem 'lookbook', '~> 0.6.1'
 
 group :development do
   gem 'better_errors', '>= 2.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,7 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
-    view_component (2.43.1)
+    view_component (2.49.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     virtus (2.0.0)
@@ -786,7 +786,7 @@ DEPENDENCIES
   subprocess
   uglifier (~> 4.2)
   valid_email (>= 0.1.3)
-  view_component (~> 2.43.1)
+  view_component (~> 2.49.0)
   webauthn (~> 2.1)
   webdrivers (~> 4.0)
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,7 @@ GEM
     highline (2.0.3)
     hiredis (0.6.3)
     html_tokenizer (0.0.7)
+    htmlbeautifier (1.4.1)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
     i18n (1.9.1)
@@ -367,6 +368,15 @@ GEM
     loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lookbook (0.6.0)
+      actioncable
+      htmlbeautifier (~> 1.3)
+      listen (~> 3.0)
+      railties (>= 5.0)
+      redcarpet (~> 3.5)
+      rouge (~> 3.26)
+      view_component (~> 2.0)
+      yard (~> 0.9.25)
     lru_redux (1.1.0)
     lumberjack (1.2.8)
     macaddr (1.7.2)
@@ -494,6 +504,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redacted_struct (1.1.0)
+    redcarpet (3.5.1)
     redis (4.5.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
@@ -511,6 +522,7 @@ GEM
     retries (0.0.5)
     rexml (3.2.5)
     rotp (6.2.0)
+    rouge (3.28.0)
     rqrcode (2.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -731,6 +743,7 @@ DEPENDENCIES
   knapsack
   local_time
   lograge (>= 0.11.2)
+  lookbook (~> 0.6.0)
   lru_redux
   maxminddb
   multiset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (0.6.0)
+    lookbook (0.6.1)
       actioncable
       htmlbeautifier (~> 1.3)
       listen (~> 3.0)
@@ -743,7 +743,7 @@ DEPENDENCIES
   knapsack
   local_time
   lograge (>= 0.11.2)
-  lookbook (~> 0.6.0)
+  lookbook (~> 0.6.1)
   lru_redux
   maxminddb
   multiset

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Component Preview</title>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+  </head>
+  <body class="padding-2">
+    <%= yield %>
+  </body>
+</html>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -50,6 +50,7 @@ aws_logo_bucket: ''
 aws_region: 'us-west-2'
 aws_kms_multi_region_enabled: false
 backup_code_cost: '2000$8$1$'
+component_previews_enabled: false
 country_phone_number_overrides: '{}'
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_sharpness_threshold: 40
@@ -251,6 +252,7 @@ development:
   attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111" }, { "key": "22222222222222222222222222222222" }]'
   aws_logo_bucket: ''
   aws_kms_regions: '["us-west-2", "us-east-1"]'
+  component_previews_enabled: true
   dashboard_api_token: test_token
   dashboard_url: http://localhost:3001/api/service_providers
   database_host: ''

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,13 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
   config.action_mailer.show_previews = IdentityConfig.store.rails_mailer_previews_enabled
 
+  config.view_component.show_previews = IdentityConfig.store.component_previews_enabled
+  if IdentityConfig.store.component_previews_enabled
+    config.view_component.preview_paths = [Rails.root.join('spec', 'components', 'previews')]
+    config.view_component.default_preview_layout = 'component_preview'
+    config.lookbook.auto_refresh = false
+  end
+
   routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'
 
   config.lograge.ignore_actions = ['Users::SessionsController#active']

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -46,6 +46,8 @@ if FeatureManagement.rails_csp_tooling_enabled?
       policy.frame_ancestors :self
     end
 
+    policy.frame_ancestors :self if IdentityConfig.store.component_previews_enabled
+
     policy.default_src :self
     policy.child_src :self # CSP 2.0 only; replaces frame_src
     policy.form_action :self

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,6 +5,7 @@ if FeatureManagement.rails_csp_tooling_enabled?
     config.ssl_options = { hsts: { preload: true, expires: 1.year, subdomains: true } }
 
     config.action_dispatch.default_headers.merge!(
+      'X-Frame-Options' => 'DENY',
       'X-XSS-Protection' => '1; mode=block',
       'X-Download-Options' => 'noopen',
     )
@@ -13,6 +14,7 @@ end
 
 SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/BlockLength
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
+  config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'
@@ -54,6 +56,10 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   if IdentityConfig.store.rails_mailer_previews_enabled
     default_csp_config[:style_src] << "'unsafe-inline'"
     # CSP 2.0 only; overriden by x_frame_options in some browsers
+    default_csp_config[:frame_ancestors] = %w['self']
+  end
+
+  if IdentityConfig.store.component_previews_enabled
     default_csp_config[:frame_ancestors] = %w['self']
   end
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,7 +5,6 @@ if FeatureManagement.rails_csp_tooling_enabled?
     config.ssl_options = { hsts: { preload: true, expires: 1.year, subdomains: true } }
 
     config.action_dispatch.default_headers.merge!(
-      'X-Frame-Options' => 'DENY',
       'X-XSS-Protection' => '1; mode=block',
       'X-Download-Options' => 'noopen',
     )
@@ -14,7 +13,6 @@ end
 
 SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/BlockLength
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
-  config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,8 @@ Rails.application.routes.draw do
       end
     end
 
+    mount Lookbook::Engine, at: '/components' if IdentityConfig.store.component_previews_enabled
+
     # Non-devise-controller routes. Alphabetically sorted.
     get '/.well-known/openid-configuration' => 'openid_connect/configuration#index',
         as: :openid_connect_configuration

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -107,6 +107,7 @@ class IdentityConfig
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)
+    config.add(:component_previews_enabled, type: :boolean)
     config.add(:country_phone_number_overrides, type: :json)
     config.add(:dashboard_api_token, type: :string)
     config.add(:dashboard_url, type: :string)

--- a/spec/components/previews/alert_component_preview.rb
+++ b/spec/components/previews/alert_component_preview.rb
@@ -1,0 +1,41 @@
+class AlertComponentPreview < ViewComponent::Preview
+  # @!group Kitchen Sink
+  def default
+    render(AlertComponent.new(message: 'A default message'))
+  end
+
+  def info
+    render(AlertComponent.new(message: 'An info message', type: :info))
+  end
+
+  def success
+    render(AlertComponent.new(message: 'A success message', type: :success))
+  end
+
+  def warning
+    render(AlertComponent.new(message: 'A warning message', type: :warning))
+  end
+
+  def error
+    render(AlertComponent.new(message: 'An error message', type: :error))
+  end
+
+  def emergency
+    render(AlertComponent.new(message: 'An emergency message', type: :emergency))
+  end
+
+  def other
+    render(AlertComponent.new(message: 'An other message', type: :other))
+  end
+
+  def with_custom_text_tag
+    render(AlertComponent.new(type: :success, message: 'A custom message', text_tag: 'div'))
+  end
+  # @!endgroup
+
+  # @param message text
+  # @param type select [info, success, warning, error, emergency, other]
+  def playground(message: 'An important message', type: :info)
+    render(AlertComponent.new(message: message, type: type))
+  end
+end

--- a/spec/components/previews/button_component_preview.rb
+++ b/spec/components/previews/button_component_preview.rb
@@ -1,0 +1,37 @@
+class ButtonComponentPreview < ViewComponent::Preview
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+
+  # @!group Kitchen Sink
+  def default
+    render(ButtonComponent.new.with_content('Button'))
+  end
+
+  def outline
+    render(ButtonComponent.new(outline: true).with_content('Button'))
+  end
+
+  def with_icon
+    render(ButtonComponent.new(icon: :content_copy).with_content('Button'))
+  end
+
+  def with_custom_action
+    render(
+      ButtonComponent.new(
+        action: ->(**tag_options, &block) do
+          content_tag(:'lg-custom-button', **tag_options, &block)
+        end,
+      ).with_content('Button'),
+    )
+  end
+  # @!endgroup
+
+  # rubocop:disable Layout/LineLength
+  # @param content text
+  # @param outline toggle
+  # @param icon select [~,accessibility_new,accessible_forward,account_balance,account_box,account_circle,add,add_circle,add_circle_outline,alarm,alternate_email,announcement,api,arrow_back,arrow_downward,arrow_drop_down,arrow_drop_up,arrow_forward,arrow_upward,assessment,attach_file,attach_money,autorenew,backpack,bathtub,bedding,bookmark,bug_report,build,calendar_today,campaign,camping,cancel,chat,check,check_box_outline_blank,check_circle,check_circle_outline,checkroom,chevron_left,chevron_right,clean_hands,close,closed_caption,clothes,cloud,code,comment,connect_without_contact,construction,construction_worker,contact_page,content_copy,coronavirus,credit_card,deck,delete,device_thermostat,directions,directions_bike,directions_bus,directions_car,directions_walk,do_not_disturb,do_not_touch,drag_handle,eco,edit,electrical_services,emoji_events,error,error_outline,event,expand_less,expand_more,facebook,fast_forward,fast_rewind,favorite,favorite_border,file_download,file_present,file_upload,filter_alt,filter_list,fingerprint,first_page,flag,flickr,flight,flooding,folder,folder_open,format_quote,format_size,forum,github,grid_view,group_add,groups,hearing,help,help_outline,highlight_off,history,home,hospital,hotel,hourglass_empty,hurricane,identification,image,info,info_outline,insights,instagram,keyboard,label,language,last_page,launch,lightbulb,lightbulb_outline,link,link_off,list,local_cafe,local_fire_department,local_gas_station,local_grocery_store,local_hospital,local_laundry_service,local_library,local_offer,local_parking,local_pharmacy,local_police,local_taxi,location_city,location_on,lock,lock_open,lock_outline,login,logout,loop,mail,mail_outline,map,masks,medical_services,menu,military_tech,more_horiz,more_vert,my_location,navigate_before,navigate_far_before,navigate_far_next,navigate_next,near_me,notifications,notifications_active,notifications_none,notifications_off,park,people,person,pets,phone,photo_camera,print,priority_high,public,push_pin,radio_button_unchecked,rain,reduce_capacity,remove,report,restaurant,rss_feed,safety_divider,sanitizer,save_alt,schedule,school,science,search,security,send,sentiment_dissatisfied,sentiment_neutral,sentiment_satisfied,sentiment_satisfied_alt,sentiment_very_dissatisfied,settings,severe_weather,share,shield,shopping_basket,snow,soap,social_distance,sort_arrow,spellcheck,star,star_half,star_outline,store,support,support_agent,text_fields,thumb_down_alt,thumb_up_alt,timer,toggle_off,toggle_on,topic,tornado,translate,trending_down,trending_up,twitter,undo,unfold_less,unfold_more,update,upload_file,verified,verified_user,visibility,visibility_off,volume_off,warning,wash,wifi,work,youtube,zoom_in,zoom_out,zoom_out_map]
+  def playground(content: 'Button', icon: nil, outline: false)
+    render(ButtonComponent.new(icon: icon&.to_sym, outline: outline).with_content(content))
+  end
+  # rubocop:enable Layout/LineLength
+end

--- a/spec/components/previews/process_list_component_preview.rb
+++ b/spec/components/previews/process_list_component_preview.rb
@@ -1,0 +1,40 @@
+class ProcessListComponentPreview < ViewComponent::Preview
+  # @!group Kitchen Sink
+  def default
+    render(ProcessListComponent.new) do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+  end
+
+  def connected
+    render(ProcessListComponent.new(connected: true)) do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+  end
+
+  def big
+    render(ProcessListComponent.new(big: true)) do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+  end
+
+  def big_and_connected
+    render(ProcessListComponent.new(big: true, connected: true)) do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+  end
+  # @!endgroup
+
+  # @param connected toggle
+  # @param big toggle
+  def playground(big: false, connected: false)
+    render(ProcessListComponent.new(big: big, connected: connected)) do |c|
+      c.item(heading: 'Item 1') { 'Item 1 Content' }
+      c.item(heading: 'Item 2') { 'Item 2 Content' }
+    end
+  end
+end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Headers' do
       get root_path
 
       aggregate_failures do
-        expect(response.headers['X-Frame-Options']).to eq('sameorigin')
+        expect(response.headers['X-Frame-Options']).to eq('DENY')
         expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
         expect(response.headers['X-XSS-Protection']).to eq('1; mode=block')
         expect(response.headers['X-Download-Options']).to eq('noopen')

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Headers' do
       get root_path
 
       aggregate_failures do
-        expect(response.headers['X-Frame-Options']).to eq('DENY')
+        expect(response.headers['X-Frame-Options']).to eq('sameorigin')
         expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
         expect(response.headers['X-XSS-Protection']).to eq('1; mode=block')
         expect(response.headers['X-Download-Options']).to eq('noopen')


### PR DESCRIPTION
**Why:** So that as a developer or UX designer, I can see what options are available to me for using a view component, including interactive previews and copy-able source code.

This uses [Lookbook](https://github.com/allmarkedup/lookbook), a [Storybook](https://storybook.js.org/)-like preview environment that extends [ViewComponent's default component previews](https://viewcomponent.org/guide/previews.html). I've been eager to explore something like Storybook, especially with how these components are implemented in the design system. Lookbook is obviously tied specifically to ViewComponent/Rails and therefore not broadly applicable to static markup implementations of components. However, given how simple it is to integrate the tool, it's an easy enough lift to implement without too much commitment to reconsider later. Additionally, it's unclear whether alternatives like [ViewComponent Storybook](https://jonspalmer.github.io/view_component_storybook/) would support the option to create previews for ViewComponent and static (and possibly React or Web Component) implementation variants. Worst-case, we either move toward something else in the future, or maintain separate preview environments: one for static implementations, another for ViewComponent.

Preview locally: http://localhost:3000/components/

**Screenshot:**

![Screen Shot 2022-02-22 at 3 56 58 PM](https://user-images.githubusercontent.com/1779930/155218253-5c539515-11d5-4b55-ba5f-cacb36a0d000.png)

**Interactive preview screen recording:**

https://user-images.githubusercontent.com/1779930/155222024-9d79c72c-a767-4fcd-b11a-47e0323be8a9.mov

(FYSA @nickttng @anniehirshman-gsa based on recent discussion)