### PR TITLE
Remove capybara-screenshot gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,6 @@ end
 group :test do
   gem 'axe-core-rspec', '~> 4.2'
   gem 'bundler-audit', require: false
-  gem 'capybara-screenshot', '>= 1.0.23'
   gem 'capybara-selenium', '>= 0.0.6'
   gem 'simplecov', '~> 0.21.0', require: false
   gem 'simplecov-cobertura'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,9 +191,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-screenshot (1.0.25)
-      capybara (>= 1.0, < 4)
-      launchy
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
@@ -703,7 +700,6 @@ DEPENDENCIES
   browser
   bullet (>= 6.0.2)
   bundler-audit
-  capybara-screenshot (>= 1.0.23)
   capybara-selenium (>= 0.0.6)
   connection_pool
   cssbundling-rails

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,4 @@
 require 'capybara/rspec'
-require 'capybara-screenshot/rspec'
 require 'rack_session_access/capybara'
 require 'webdrivers/chromedriver'
 require 'selenium/webdriver'
@@ -41,7 +40,6 @@ end
 Capybara.server = :puma, { Silent: true }
 
 Capybara.default_max_wait_time = (ENV['CAPYBARA_WAIT_TIME_SECONDS'] || '0.5').to_f
-Capybara::Screenshot.autosave_on_failure = false
 Capybara.asset_host = ENV['RAILS_ASSET_HOST'] || 'http://localhost:3000'
 Capybara.automatic_label_click = true # USWDS styles native checkbox/radio as offscreen
 Capybara.enable_aria_label = true


### PR DESCRIPTION
**Why**: No longer used as of c2e39bf7a26, removing dependencies we no longer need

changelog: Internal, Dependencies, Remove unused dependencies