### PR TITLE
Update device_detector gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       thor (>= 0.19, < 2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    device_detector (1.0.6)
+    device_detector (1.0.7)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)


### PR DESCRIPTION
Mostly because https://github.com/podigee/device_detector/pull/84 was merged and significantly reduces the size of the gem

from 870400 bytes to 251392 bytes