### PR TITLE
OpenID Connect: Update street_address claim

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -101,7 +101,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def street_address
-    [ial2_data.address1, ial2_data.address2].compact.join(' ')
+    [ial2_data.address1, ial2_data.address2].compact.join("\n")
   end
 
   def stringify_attr(attribute)

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:phone]).to eq('+17035555555')
               expect(user_info[:phone_verified]).to eq(true)
               expect(user_info[:address]).to eq(
-                formatted: "123 Fake St Apt 456\nWashington, DC 12345",
-                street_address: '123 Fake St Apt 456',
+                formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+                street_address: "123 Fake St\nApt 456",
                 locality: 'Washington',
                 region: 'DC',
                 postal_code: '12345',


### PR DESCRIPTION
**Why**: Clearer separation between parts, also matches the OIDC address claim spec better

The OIDC Spec has this to say about the [address claim](https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim)

> Full street address component, which MAY include house number, street name, Post Office Box, and multi-line extended street address information. This field MAY contain multiple lines, separated by newlines. Newlines can be represented either as a carriage return/line feed pair ("\r\n") or as a single line feed character ("\n").

cc @pkarman 

Back in 2017, [some clown 🤡](https://github.com/zachmargolis) added our early OIDC code and clearly misread the spec  https://github.com/18F/identity-idp/pull/1022, so today, we fix that long-standing bug