### PR TITLE
Remove BassCSS white-space stylesheet import

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -1,5 +1,4 @@
 @import 'basscss-sass/color-base';
 @import 'basscss-sass/color-forms';
 @import 'basscss-sass/color-tables';
-@import 'basscss-sass/white-space';
 @import 'basscss-sass/grid';


### PR DESCRIPTION
**Why**: Because these styles were deprecated and removed as of #4650 (LG-3864), but the import remained.