### PR TITLE
Fix 500 error when sending phone OTP

### DIFF
--- a/lib/telephony/pinpoint/aws_credential_builder.rb
+++ b/lib/telephony/pinpoint/aws_credential_builder.rb
@@ -27,7 +27,7 @@ module Telephony
         )
 
       # STS makes an HTTP call that can fail
-      rescue Seahorse::Client::NetworkingError => e
+      rescue Aws::Errors::MissingCredentialsError, Seahorse::Client::NetworkingError => e
         notify_role_failure(error: e, region: config.region)
         nil
       end


### PR DESCRIPTION
https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=86400000&state=ea97169c-da9c-9dcd-7f13-0c371551c819

https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=86400000&state=e313d64e-a16c-cf22-d7ff-c1ccb20d0836

From [this issue](https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261117898):

>Commonly this is caused by the aggressive defaults in attempting to load credentials from the instance metadata service. Once credentials expire, they must be refreshed, but if the metadata service fails to respond, a missing credentials error is raised. I've just push a small change that will go out with the next release where you can configure expanded retries and timeouts:
>```
>client = Aws::DynamoDB::Client.new(
> region: Aws.config[:region],
>  instance_profile_credentials_timeout: 5, # defaults to 1 second
>  instance_profile_credentials_retries: 5, # defaults to 0 retries
>)
>```

I don't think it's necessarily worth doing retries or extending the timeout given how rare it is, I think I'd rather display a "We ran into an error, please try again" and have the person try again