### PR TITLE
Fix SAML remote logout

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -104,8 +104,12 @@ module SamlIdpAuthConcern
   end
 
   def link_identity_from_session_data
-    IdentityLinker.new(current_user, current_issuer).
-      link_identity(ial: ial_context.ial_for_identity_record)
+    IdentityLinker.
+      new(current_user, current_issuer).
+      link_identity(
+        ial: ial_context.ial_for_identity_record,
+        rails_session_id: session.id,
+      )
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -22,8 +22,9 @@ module SamlIdpLogoutConcern
   end
 
   def handle_valid_sp_remote_logout_request(user_id)
-    # Remotely invalidate the user's current session, see config/initializers/session_limitable.rb
-    User.find(user_id).update!(unique_session_id: nil)
+    # Remotely delete the user's current session
+    session_id = User.find(user_id).unique_session_id
+    OutOfBandSessionAccessor.new(session_id).destroy
 
     # rubocop:disable Rails/RenderInline
     render inline: logout_response, content_type: 'text/xml'

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -28,6 +28,7 @@ module SamlIdpLogoutConcern
       rails_session_id
 
     OutOfBandSessionAccessor.new(session_id).destroy
+    sign_out
 
     # rubocop:disable Rails/RenderInline
     render inline: logout_response, content_type: 'text/xml'

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -28,7 +28,7 @@ module SamlIdpLogoutConcern
       rails_session_id
 
     OutOfBandSessionAccessor.new(session_id).destroy
-    sign_out
+    sign_out if user_signed_in?
 
     # rubocop:disable Rails/RenderInline
     render inline: logout_response, content_type: 'text/xml'

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -23,7 +23,10 @@ module SamlIdpLogoutConcern
 
   def handle_valid_sp_remote_logout_request(user_id)
     # Remotely delete the user's current session
-    session_id = User.find(user_id).unique_session_id
+    session_id = ServiceProviderIdentity.
+      find_by(user_id: user_id, service_provider: saml_request.issuer).
+      rails_session_id
+
     OutOfBandSessionAccessor.new(session_id).destroy
 
     # rubocop:disable Rails/RenderInline

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -13,8 +13,8 @@ class SamlIdpController < ApplicationController
   include BillableEventTrackable
   include SecureHeadersConcern
 
-  prepend_before_action :skip_session_load, only: :metadata
-  prepend_before_action :skip_session_expiration, only: :metadata
+  prepend_before_action :skip_session_load, only: [:metadata, :remotelogout]
+  prepend_before_action :skip_session_expiration, only: [:metadata, :remotelogout]
 
   skip_before_action :verify_authenticity_token
   before_action :handle_banned_user

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -1,0 +1,46 @@
+# Provides a wrapper for accessing the redis cache out-of-band (using only the
+# session UUID) instead of having access to the user session from Devise/Warden.
+# Should only used outside of a normal browser session (such as the OpenID
+# Connect API or remote SAML Logout).
+
+class OutOfBandSessionAccessor
+  attr_reader :session_uuid
+
+  def initialize(session_uuid)
+    @session_uuid = session_uuid
+  end
+
+  def ttl
+    uuid = session_uuid
+    session_store.instance_eval { redis.ttl(prefixed(uuid)) }
+  end
+
+  def load
+    session_store.send(:load_session_from_redis, session_uuid) || {}
+  end
+
+  def destroy
+    session_store.send(:destroy_session_from_sid, session_uuid)
+  end
+
+  # @api private
+  # Only used for convenience in tests
+  # @param [Pii::Attributes] pii
+  def put(data, expiration = 5.minutes)
+    session_data = {
+      'warden.user.user.session' => data.to_h,
+    }
+
+    session_store.
+      send(:set_session, {}, session_uuid, session_data, expire_after: expiration.to_i)
+  end
+
+  private
+
+  def session_store
+    @session_store ||= begin
+      config = Rails.application.config
+      config.session_store.new({}, config.session_options)
+    end
+  end
+end

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -20,7 +20,7 @@ class OutOfBandSessionAccessor
   end
 
   def destroy
-    session_store.send(:destroy_session_from_sid, session_uuid)
+    session_store.send(:destroy_session_from_sid, session_uuid, drop: true)
   end
 
   # @api private

--- a/app/services/pii/session_store.rb
+++ b/app/services/pii/session_store.rb
@@ -5,19 +5,16 @@
 # See Pii::Cacher for accessing PII inside of a normal browser session
 module Pii
   class SessionStore
-    attr_reader :session_uuid
+    attr_reader :session_accessor
+
+    delegate :ttl, :destroy, to: :session_accessor
 
     def initialize(session_uuid)
-      @session_uuid = session_uuid
-    end
-
-    def ttl
-      uuid = session_uuid
-      session_store.instance_eval { redis.ttl(prefixed(uuid)) }
+      @session_accessor = OutOfBandSessionAccessor.new(session_uuid)
     end
 
     def load
-      session = session_store.send(:load_session_from_redis, session_uuid) || {}
+      session = session_accessor.load
       Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
     end
 
@@ -26,26 +23,10 @@ module Pii
     # @param [Pii::Attributes] pii
     def put(pii, expiration = 5.minutes)
       session_data = {
-        'warden.user.user.session' => {
-          decrypted_pii: pii.to_h.to_json,
-        },
+        decrypted_pii: pii.to_h.to_json,
       }
 
-      session_store.
-        send(:set_session, {}, session_uuid, session_data, expire_after: expiration.to_i)
-    end
-
-    # @api private
-    # Only used for convenience in tests
-    def destroy
-      session_store.send(:destroy_session_from_sid, session_uuid)
-    end
-
-    private
-
-    def session_store
-      config = Rails.application.config
-      config.session_store.new({}, config.session_options)
+      session_accessor.put(session_data, expiration)
     end
   end
 end

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -363,6 +363,7 @@ development:
     friendly_name: 'Awesome test SP'
 
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
+    agency_id: 1
     friendly_name: 'Test SAML SP'
     acs_url: 'http://localhost:4567/consume'
     sp_initiated_login_url: 'http://localhost:4567/test/saml'

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -134,13 +134,14 @@ describe SamlIdpController do
     let(:other_sp) { create(:service_provider, active: true, agency_id: agency.id) }
 
     let(:session_id) { 'abc123' }
-    let(:user) { create(:user, :signed_up, unique_session_id: session_id) }
+    let(:user) { create(:user, :signed_up) }
     let(:other_user) { create(:user, :signed_up) }
 
     let!(:identity) do
       ServiceProviderIdentity.create(
         service_provider: service_provider.issuer,
         user: user,
+        rails_session_id: session_id,
       )
     end
     let!(:other_identity) do
@@ -249,7 +250,7 @@ describe SamlIdpController do
       delete :remotelogout, params: payload.to_h.merge(Signature: Base64.encode64(signature))
 
       expect(response).to be_ok
-      expect(session_accessor.load).to eq({})
+      expect(session_accessor.load).to be_empty
 
       logout_response = OneLogin::RubySaml::Logoutresponse.new(response.body)
       expect(logout_response.success?).to eq(true)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -133,7 +133,8 @@ describe SamlIdpController do
     end
     let(:other_sp) { create(:service_provider, active: true, agency_id: agency.id) }
 
-    let(:user) { create(:user, :signed_up, unique_session_id: 'abc123') }
+    let(:session_id) { 'abc123' }
+    let(:user) { create(:user, :signed_up, unique_session_id: session_id) }
     let(:other_user) { create(:user, :signed_up) }
 
     let!(:identity) do
@@ -216,6 +217,9 @@ describe SamlIdpController do
     end
 
     it 'accepts requests with correct cert and correct session index and renders logout response' do
+      REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+      session_accessor = OutOfBandSessionAccessor.new(session_id)
+      session_accessor.put(foo: 'bar')
       saml_request = OneLogin::RubySaml::Logoutrequest.new
       encoded_saml_request = UriService.params(
         saml_request.create(right_cert_settings),
@@ -245,11 +249,12 @@ describe SamlIdpController do
       delete :remotelogout, params: payload.to_h.merge(Signature: Base64.encode64(signature))
 
       expect(response).to be_ok
-      expect(User.find(user.id).unique_session_id).to be_nil
+      expect(session_accessor.load).to eq({})
 
       logout_response = OneLogin::RubySaml::Logoutresponse.new(response.body)
       expect(logout_response.success?).to eq(true)
       expect(logout_response.in_response_to).to eq(saml_request.uuid)
+      REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
     end
 
     it 'rejects requests from a correct cert but no session index' do

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -144,4 +144,31 @@ feature 'SAML logout' do
       expect(page).to have_current_path(root_path)
     end
   end
+
+  context 'remote logout' do
+    let(:sp) { ServiceProvider.find_by(issuer: saml_settings.issuer) }
+    let(:agency) { sp.agency }
+
+    it "terminates the user's session remotely" do
+      # set up SP identity and agency identity
+      user = sign_up_and_2fa_ial1_user
+      visit_saml_authn_request_url
+      click_continue
+      click_agree_and_continue
+
+      agency_uuid = AgencyIdentity.find_by(user_id: user.id, agency_id: agency.id).uuid
+      # Confirmed that this actually hits the controller action
+      send_saml_remote_logout_request(overrides: { sessionindex: agency_uuid })
+
+      # THIS SHOULD PASS
+      identity = ServiceProviderIdentity.
+        find_by(user_id: user.id, service_provider: saml_settings.issuer)
+      session_id = identity.rails_session_id
+      expect(OutOfBandSessionAccessor.new(session_id).load).to eq({})
+
+      # should be logged out...
+      visit account_path
+      expect(page).to have_current_path(root_path)
+    end
+  end
 end

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -151,7 +151,7 @@ feature 'SAML logout' do
 
     it "terminates the user's session remotely" do
       # set up SP identity and agency identity
-      user = sign_up_and_2fa_ial1_user
+      user = sign_in_live_with_2fa
       visit_saml_authn_request_url
       click_continue
       click_agree_and_continue

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -157,13 +157,14 @@ feature 'SAML logout' do
       click_agree_and_continue
 
       agency_uuid = AgencyIdentity.find_by(user_id: user.id, agency_id: agency.id).uuid
-      # Confirmed that this actually hits the controller action
+
+      # simulate a remote request
       send_saml_remote_logout_request(overrides: { sessionindex: agency_uuid })
 
       identity = ServiceProviderIdentity.
         find_by(user_id: user.id, service_provider: saml_settings.issuer)
       session_id = identity.rails_session_id
-      expect(OutOfBandSessionAccessor.new(session_id).load).to eq({})
+      expect(OutOfBandSessionAccessor.new(session_id).load).to be_empty
 
       # should be logged out...
       visit account_path

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -160,7 +160,6 @@ feature 'SAML logout' do
       # Confirmed that this actually hits the controller action
       send_saml_remote_logout_request(overrides: { sessionindex: agency_uuid })
 
-      # THIS SHOULD PASS
       identity = ServiceProviderIdentity.
         find_by(user_id: user.id, service_provider: saml_settings.issuer)
       session_id = identity.rails_session_id

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put({ foo: 'bar' }, 5.minutes.to_i)
       store.destroy
 
-      expect(store.load).to eq({})
+      expect(store.load).to be_empty
     end
   end
 end

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe OutOfBandSessionAccessor do
+  let(:session_uuid) { SecureRandom.uuid }
+
+  subject(:store) { described_class.new(session_uuid) }
+
+  around do |ex|
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    ex.run
+    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+  end
+
+  describe '#ttl' do
+    it 'returns the remaining time-to-live of the session data in redis' do
+      store.put({ foo: 'bar' }, 5.minutes.to_i)
+
+      expect(store.ttl).to eq(5.minutes.to_i)
+    end
+  end
+
+  describe '#load' do
+    it 'loads the session' do
+      store.put({ foo: 'bar' }, 5.minutes.to_i)
+
+      session = store.load
+      expect(session.dig('warden.user.user.session')).to eq('foo' => 'bar')
+    end
+  end
+
+  describe '#destroy' do
+    it 'destroys the session' do
+      store.put({ foo: 'bar' }, 5.minutes.to_i)
+      store.destroy
+
+      expect(store.load).to eq({})
+    end
+  end
+end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -74,6 +74,14 @@ module SamlAuthHelper
     )
   end
 
+  def saml_remote_logout_request_url(overrides: {}, params: {})
+    overrides[:idp_slo_target_url] = "http://#{IdentityConfig.store.domain_name}/api/saml/remotelogout2022"
+    logout_request.create(
+      saml_settings(overrides: overrides),
+      params,
+    )
+  end
+
   def visit_saml_authn_request_url(overrides: {}, params: {})
     authn_request_url = saml_authn_request_url(overrides: overrides, params: params)
     visit authn_request_url
@@ -82,6 +90,11 @@ module SamlAuthHelper
   def visit_saml_logout_request_url(overrides: {}, params: {})
     logout_request_url = saml_logout_request_url(overrides: overrides, params: params)
     visit logout_request_url
+  end
+
+  def send_saml_remote_logout_request(overrides: {}, params: {})
+    remote_logout_request_url = saml_remote_logout_request_url(overrides: overrides, params: params)
+    page.driver.post remote_logout_request_url
   end
 
   def saml_get_auth(settings)


### PR DESCRIPTION
**Why:** The recent updates were not actually working - we were using
the incorrect session key to invalidate the session in redis. This
update stores the session ID on the SP identity record during SAML
authentication (similar to OIDC) so that it can be retrieved during
remote logout. This is actually a safer behavior since it means that a
user will only be logged out if the session they logged in with is still
valid (whereas before they would have been logged out regardless if they
had started a new Login.gov session after authenticating to the SP).

[skip changelog] # covered by entry in #5990