### PR TITLE
Fix vertical centering of logo in Internet Explorer

### DIFF
--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -1,4 +1,4 @@
-.main-navigation {
+.page-header--basic {
   @include u-flex('align-center', 'justify-center');
   @include u-display('flex');
   @include u-height(7);

--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -1,11 +1,11 @@
 .main-navigation {
   @include u-flex('align-center', 'justify-center');
   @include u-display('flex');
-  @include u-minh(7);
+  @include u-height(7);
   @include u-bg('primary-lighter');
 
   @include at-media('tablet') {
-    @include u-minh(9);
+    @include u-height(9);
   }
 }
 

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -1,27 +1,25 @@
-<div class="bg-white width-full flex-align-self-start">
-  <div class="grid-container padding-x-0 tablet:padding-x-4">
-    <div class="grid-row flex-justify tablet:padding-y-4">
-      <div class="grid-col-auto display-flex flex-align-center padding-x-2 tablet:padding-x-0">
-        <%= link_to(
-              image_tag(
-                asset_url('logo.svg'),
-                alt: APP_NAME,
-                class: 'text-bottom',
-                width: 155,
-                height: 21,
-              ),
-              root_path,
-            ) %>
-      </div>
-      <div class="grid-col-auto display-flex flex-align-center">
-        <span class="display-none tablet:display-inline padding-right-1 margin-right-1 border-right border-base-darker">
-          <%= t('account.welcome') %> <strong><%= greeting %></strong>
-        </span>
-        <%= link_to t('links.sign_out'), destroy_user_session_path %>
-        <% if enable_mobile_nav %>
-          <button class="usa-menu-btn margin-left-2"><%= t('account.navigation.menu') %></button>
-        <% end %>
-      </div>
+<div class="grid-container padding-x-0 tablet:padding-x-4">
+  <div class="grid-row flex-justify tablet:padding-y-4">
+    <div class="grid-col-auto display-flex flex-align-center padding-x-2 tablet:padding-x-0">
+      <%= link_to(
+            image_tag(
+              asset_url('logo.svg'),
+              alt: APP_NAME,
+              class: 'text-bottom',
+              width: 155,
+              height: 21,
+            ),
+            root_path,
+          ) %>
+    </div>
+    <div class="grid-col-auto display-flex flex-align-center">
+      <span class="display-none tablet:display-inline padding-right-1 margin-right-1 border-right border-base-darker">
+        <%= t('account.welcome') %> <strong><%= greeting %></strong>
+      </span>
+      <%= link_to t('links.sign_out'), destroy_user_session_path %>
+      <% if enable_mobile_nav %>
+        <button class="usa-menu-btn margin-left-2"><%= t('account.navigation.menu') %></button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:nav) do %>
+<% content_for(:header) do %>
   <%= render 'accounts/nav_auth', enable_mobile_nav: false, greeting: @presenter.header_personalization %>
 <% end %>
 

--- a/app/views/layouts/account_side_nav.html.erb
+++ b/app/views/layouts/account_side_nav.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:nav) do %>
+<% content_for(:header) do %>
   <%= render 'accounts/nav_auth', enable_mobile_nav: true, greeting: @presenter.header_personalization %>
 <% end %>
 

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -56,9 +56,9 @@
       </div>
     </div>
   </section>
-  <nav class="main-navigation" aria-label="<%= t('shared.navigation.landmark_label') %>">
-    <% if content_for?(:nav) %>
-      <%= yield(:nav) %>
+  <div class="page-header<%= ' page-header--basic' if !content_for?(:header) %>">
+    <% if content_for?(:header) %>
+      <%= yield(:header) %>
     <% else %>
       <% if decorated_session.sp_name %>
         <%= render 'shared/nav_branded' %>
@@ -66,5 +66,5 @@
         <%= render 'shared/nav_lite' %>
       <% end %>
     <% end %>
-  </nav>
+  </div>
 </header>

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -17,6 +17,4 @@ en:
       secure_heading: Secure .gov websites use HTTPS
     footer_lite:
       gsa: US General Services Administration
-    navigation:
-      landmark_label: Main navigation
     skip_link: Skip to main content

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -18,6 +18,4 @@ es:
       secure_heading: Los sitios web seguros .gov usan HTTPS
     footer_lite:
       gsa: Administración General de Servicios de EE. UU.
-    navigation:
-      landmark_label: Navegación principal
     skip_link: Salte al contenido principal

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -18,6 +18,4 @@ fr:
       secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     footer_lite:
       gsa: Administration des services généraux des États-Unis
-    navigation:
-      landmark_label: Navigation principale
     skip_link: Passer au contenu principal

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'layouts/application.html.erb' do
     it 'displays only the logo' do
       render
 
-      expect(rendered).to have_xpath('//nav[contains(@class, "main-navigation")]')
+      expect(rendered).to have_css('.page-header--basic')
       expect(rendered).to_not have_content(t('account.welcome'))
       expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
     end


### PR DESCRIPTION
**Why**: So that Login.gov looks good in all browsers (even the buggy, outdated ones).

Related: https://github.com/philipwalton/flexbugs#flexbug-3

These were [previously set to explicit heights](https://github.com/18F/identity-idp/blob/101e9b75fa78d883c9b4aac61ac6c1084b2b5688/app/assets/stylesheets/components/_nav.scss#L1-L31), updated in #5926 with the intention of improving flexibility of the container. But it shouldn't be strictly necessary to allow the containers to grow in height.

Before|After
---|---
![Screen Shot 2022-02-24 at 8 32 31 AM](https://user-images.githubusercontent.com/1779930/155537489-c54f4bdd-6b80-4a6d-bd3b-e4d67b867c29.png)|![Screen Shot 2022-02-24 at 8 32 15 AM](https://user-images.githubusercontent.com/1779930/155537498-389cce2b-4e6f-4c35-bf05-f0d86de2e373.png)

