### PR TITLE
Fix Stylelint enforcement consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint: ## Runs all lint tests
 	@echo "--- check assets are optimized ---"
 	make lint_optimized_assets
 	@echo "--- stylelint ---"
-	yarn run stylelint app/assets/stylesheets/**/*.scss app/javascript/**/*.scss
+	yarn lint:css
 
 lint_erb: ## Lints ERB files
 	bundle exec erblint app/views app/components

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -2,9 +2,7 @@
 @import 'variables/app';
 @import 'required';
 @import 'vendor';
-// To be removed once design system incorporates styles included below.
-@import 'design-system-waiting-room.scss';
-// ----------------------------------------
+@import 'design-system-waiting-room';
 @import 'identity-style-guide/dist/assets/scss/packages/required';
 @import 'identity-style-guide/dist/assets/scss/packages/global';
 @import 'identity-style-guide/dist/assets/scss/packages/components';

--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -2,33 +2,38 @@
 
 // basscss-base-forms
 //------------------------------------------------
-input[type=text],
-input[type=date],
-input[type=datetime],
-input[type=datetime-local],
-input[type=email],
-input[type=month],
-input[type=number],
-input[type=password],
-input[type=search],
-input[type=tel],
-input[type=time],
-input[type=url],
-input[type=week] {
+input[type='text'],
+input[type='date'],
+input[type='datetime'],
+input[type='datetime-local'],
+input[type='email'],
+input[type='month'],
+input[type='number'],
+input[type='password'],
+input[type='search'],
+input[type='tel'],
+input[type='time'],
+input[type='url'],
+input[type='week'] {
   height: 3rem;
   padding: 0.5rem 1rem;
   vertical-align: middle;
   -webkit-appearance: none;
 }
 
-//basscss-base-topography
+//basscss-base-typography
 //------------------------------------------------
 body {
   font-family: $font-family;
   line-height: $line-height;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: $heading-font-family;
   line-height: $heading-line-height;
   margin-top: 1em;
@@ -40,7 +45,9 @@ p {
   margin-bottom: $space-2;
 }
 
-dl, ol, ul {
+dl,
+ol,
+ul {
   margin-top: 0;
   margin-bottom: $space-2;
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "typecheck": "tsc",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:css": "stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss'",
     "test": "mocha 'spec/javascripts/**/**spec.+(j|t)s?(x)' 'app/javascript/packages/**/*.spec.+(j|t)s?(x)'",
     "es5-safe": "is-es5-safe 'public/packs?(-test)/js/*.js'",
     "normalize-yaml": "normalize-yaml",


### PR DESCRIPTION
**Why**: The way that we are passing paths using globstars does not behave the same in CircleCI as it does locally, likely due to differences in shell / shell options. This results in some files (at least those in the root `stylesheets/` directory) not being linted.

~Draft while initial commit verifies that errors are found.~