### PR TITLE
Produce non-0 exit code on Sass build failure

### DIFF
--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -30,4 +30,7 @@ Promise.all(
       watch(loadedPaths).on('change', () => buildFile(file, options));
     }
   }),
-).catch(console.error);
+).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
**Why**: So that the build does not pass if Sass cannot be compiled (e.g. syntax error).

Discovered in pairing with @solipet . Regression of #5915.