### PR TITLE
Validate zipcode is a string in PII bundle

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -4,13 +4,14 @@ module Idv
 
     validate :validate_pii
 
-    attr_reader :first_name, :last_name, :dob, :state
+    attr_reader :first_name, :last_name, :dob, :state, :zipcode
 
     def initialize(pii)
       @first_name = pii[:first_name]
       @last_name = pii[:last_name]
       @dob = pii[:dob]
       @state = pii[:state]
+      @zipcode = pii[:zipcode]
     end
 
     def submit
@@ -35,6 +36,8 @@ module Idv
       elsif !dob_meets_min_age?
         errors.add(:pii, dob_min_age_error, type: :dob_min_age_error)
       elsif !state_valid?
+        errors.add(:pii, generic_error, type: :generic_error)
+      elsif !zipcode_valid?
         errors.add(:pii, generic_error, type: :generic_error)
       end
     end
@@ -61,6 +64,10 @@ module Idv
 
     def error_count
       [name_valid?, dob_valid?, state_valid?].count(&:blank?)
+    end
+
+    def zipcode_valid?
+      zipcode.nil? || zipcode.is_a?(String)
     end
 
     def generic_error

--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -96,6 +96,10 @@ module DocAuth
             data['document']['dob'] = Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
           end
 
+          if data.dig('document', 'zipcode')
+            data['document']['zipcode'] = data.dig('document', 'zipcode').to_s
+          end
+
           JSON.parse(data.to_json) # converts Dates back to strings
         else
           { general: ["YAML data should have been a hash, got #{data.class}"] }

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -12,6 +12,7 @@ describe Idv::DocPiiForm do
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       dob: valid_dob,
+      zipcode: Faker::Address.zip_code,
       state: Faker::Address.state_abbr,
     }
   end
@@ -73,6 +74,26 @@ describe Idv::DocPiiForm do
         expect(result.success?).to eq(false)
         expect(result.errors[:pii]).to eq [
           t('doc_auth.errors.pii.birth_date_min_age'),
+        ]
+      end
+    end
+
+    context 'when there is a non-string zipcode' do
+      it 'returns a single generic pii error' do
+        invalid_pii = {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          dob: valid_dob,
+          state: Faker::Address.state_abbr,
+          zipcode: 12345,
+        }
+
+        result = subject.new(invalid_pii).submit
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors[:pii]).to eq [
+          t('doc_auth.errors.general.no_liveness'),
         ]
       end
     end

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -268,5 +268,47 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         expect(response.pii_from_doc).to eq({})
       end
     end
+
+    context 'with a yaml file containing integer zipcode' do
+      let(:input) do
+        <<~YAML
+          document:
+            first_name: Susan
+            last_name: Smith
+            middle_name: Q
+            address1: 1 Microsoft Way
+            address2: Apt 3
+            city: Bayside
+            state: NY
+            zipcode: 11364
+            dob: 1938-10-06
+            state_id_number: '111111111'
+            state_id_jurisdiction: ND
+            state_id_type: drivers_license
+        YAML
+      end
+
+      it 'returns a result with string zipcode' do
+        response = builder.call
+
+        expect(response.success?).to eq(true)
+        expect(response.errors).to eq({})
+        expect(response.exception).to eq(nil)
+        expect(response.pii_from_doc).to eq(
+          first_name: 'Susan',
+          middle_name: 'Q',
+          last_name: 'Smith',
+          address1: '1 Microsoft Way',
+          address2: 'Apt 3',
+          city: 'Bayside',
+          state: 'NY',
+          zipcode: '11364',
+          dob: '1938-10-06',
+          state_id_number: '111111111',
+          state_id_jurisdiction: 'ND',
+          state_id_type: 'drivers_license',
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
There is an issue in sandbox environments where we accept YAML files, which can parse to return integers where we expect strings [New Relic error](https://onenr.io/0dBj3g4axjX)

We perform some string operations on zipcode later in the login process when passing the PII bundle [here](https://github.com/18F/identity-idp/blob/da8dde0718594a92f1b6be3195a7e4c9d01ba3ac/app/presenters/openid_connect_user_info_presenter.rb#L100) or [here](https://github.com/18F/identity-idp/blob/da8dde0718594a92f1b6be3195a7e4c9d01ba3ac/app/services/attribute_asserter.rb#L98) so we should ensure that it is a String