### PR TITLE
Clean up opted out phone number iteration

### DIFF
--- a/app/jobs/phone_number_opt_out_sync_job.rb
+++ b/app/jobs/phone_number_opt_out_sync_job.rb
@@ -23,7 +23,7 @@ class PhoneNumberOptOutSyncJob < ApplicationJob
 
     all_phone_numbers = Set.new
 
-    opt_out_manager.each_opted_out_number do |phone_number|
+    opt_out_manager.opted_out_numbers.each do |phone_number|
       PhoneNumberOptOut.mark_opted_out(phone_number)
       all_phone_numbers << phone_number
     end

--- a/lib/telephony/pinpoint/opt_out_manager.rb
+++ b/lib/telephony/pinpoint/opt_out_manager.rb
@@ -35,19 +35,20 @@ module Telephony
         )
       end
 
-      # @yieldparam [String] phone_number
-      def each_opted_out_number
-        Telephony.config.pinpoint.sms_configs.each do |config|
-          client = build_client(config)
-          next if client.nil?
+      # @return [Enumerator<String>]
+      def opted_out_numbers
+        Enumerator.new do |y|
+          Telephony.config.pinpoint.sms_configs.each do |config|
+            client = build_client(config)
+            next if client.nil?
 
-          client.list_phone_numbers_opted_out.each do |response|
-            response.phone_numbers.each do |phone_number|
-              yield phone_number
+            client.list_phone_numbers_opted_out.each do |response|
+              response.phone_numbers.each do |phone_number|
+                y << phone_number
+              end
             end
           end
         end
-        nil
       end
 
       # @api private

--- a/spec/lib/telephony/pinpoint/opt_out_manager_spec.rb
+++ b/spec/lib/telephony/pinpoint/opt_out_manager_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Telephony::Pinpoint::OptOutManager do
     end
   end
 
-  describe '#each_opted_out_number' do
+  describe '#opted_out_numbers' do
     let(:phone1) { Faker::PhoneNumber.cell_phone }
     let(:phone2) { Faker::PhoneNumber.cell_phone }
     let(:phone3) { Faker::PhoneNumber.cell_phone }
@@ -122,13 +122,9 @@ RSpec.describe Telephony::Pinpoint::OptOutManager do
       )
     end
 
-    it 'yields phone numbers across regions' do
-      numbers = []
-      opt_out_manager.each_opted_out_number do |phone_number|
-        numbers << phone_number
-      end
-
-      expect(numbers).to eq([phone1, phone2, phone3, phone4, phone5, phone6])
+    it 'iterates phone numbers across regions' do
+      expect(opt_out_manager.opted_out_numbers.to_a).
+        to eq([phone1, phone2, phone3, phone4, phone5, phone6])
     end
   end
 end


### PR DESCRIPTION
**Why**: This is just syntax sugar, but it's easier to work with
when testing in the rails console (no need for a block)

```ruby
# before
numbers = []; opt_out_manager.each_opted_out_number { |n| numbers << n }; numbers
=> ['+12345']

# after
opt_out_manager.opted_out_numbers.to_a
=> ['+12345']
```

