### PR TITLE
Fix 500 on prompting deletion of invalid webauthn configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -224,7 +224,7 @@ class ApplicationController < ActionController::Base
       controller: controller_info,
       user_signed_in: user_signed_in?,
     )
-    flash[:error] = t('errors.invalid_authenticity_token')
+    flash[:error] = t('errors.general')
     redirect_back fallback_location: new_user_session_url, allow_other_host: false
   end
 

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -26,7 +26,7 @@ module PersonalKeyConcern
       user_signed_in: user_signed_in?,
     )
     sign_out
-    flash[:error] = t('errors.invalid_authenticity_token')
+    flash[:error] = t('errors.general')
     redirect_to new_user_session_url
   end
 end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -47,7 +47,7 @@ module TwoFactorAuthentication
     end
 
     def handle_invalid_webauthn
-      flash[:error] = t('errors.invalid_authenticity_token')
+      flash[:error] = t('errors.general')
       redirect_to login_two_factor_webauthn_url
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -99,7 +99,7 @@ module Users
       controller_info = 'users/sessions#create'
       analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN, controller: controller_info)
       sign_out
-      flash[:error] = t('errors.invalid_authenticity_token')
+      flash[:error] = t('errors.general')
       redirect_back fallback_location: new_user_session_url, allow_other_host: false
     end
 

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -58,7 +58,13 @@ module Users
       @webauthn = WebauthnConfiguration.where(
         user_id: current_user.id, id: delete_params[:id],
       ).first
-      render 'users/webauthn_setup/delete'
+
+      if @webauthn
+        render 'users/webauthn_setup/delete'
+      else
+        flash[:error] = t('errors.general')
+        redirect_back fallback_location: new_user_session_url, allow_other_host: false
+      end
     end
 
     private

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -38,7 +38,7 @@ en:
       throttled_text_html: '<strong>Please try again in %{timeout}.</strong> For your
         security, we limit the number of times you can attempt to verify a
         document online.'
-    invalid_authenticity_token: Oops, something went wrong. Please try again.
+    general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You
       can reset your password using the “Forgot your password?” link.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -40,7 +40,7 @@ es:
       throttled_text_html: '<strong>Por favor, inténtelo de nuevo en
         %{timeout}.</strong> Por su seguridad, limitamos el número de veces que
         puede intentar verificar un documento en línea.'
-    invalid_authenticity_token: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
+    general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.
       Puede restablecer su contraseña usando el enlace “¿Olvidó su contraseña?”.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -44,7 +44,7 @@ fr:
       throttled_text_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
         votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de
         vérifier un document en ligne.'
-    invalid_authenticity_token: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
+    general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects un
       trop grand nombre de fois. Vous pouvez réinitialiser votre mot de passe en

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Accounts::PersonalKeysController do
       post :create
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.general')
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -110,7 +110,7 @@ describe ApplicationController do
 
       get :index
 
-      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.general')
       expect(response).to redirect_to(root_url)
       expect(subject.current_user).to be_present
     end

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Users::PersonalKeysController do
       post :update
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.general')
     end
   end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -355,7 +355,7 @@ describe Users::SessionsController, devise: true do
       post :create, params: { user: { email: user.email, password: user.password } }
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.general')
     end
 
     it 'returns to sign in page if email is a Hash' do

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -118,5 +118,20 @@ describe Users::WebauthnSetupController do
         delete :delete, params: { id: webauthn_configuration.id }
       end
     end
+
+    describe 'show_delete' do
+      let(:webauthn_configuration) { create(:webauthn_configuration, user: user) }
+
+      it 'renders page when configuration exists' do
+        get :show_delete, params: { id: webauthn_configuration.id }
+        expect(response).to render_template :delete
+      end
+
+      it 'redirects when the configuration does not exist' do
+        get :show_delete, params: { id: '_' }
+        expect(response).to redirect_to(new_user_session_url)
+        expect(flash[:error]).to eq t('errors.general')
+      end
+    end
   end
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -339,7 +339,7 @@ feature 'Sign in' do
         session_store.send(:destroy_session_from_sid, session_cookie.value)
 
         fill_in_credentials_and_submit(user.email, user.password)
-        expect(page).to have_content t('errors.invalid_authenticity_token')
+        expect(page).to have_content t('errors.general')
 
         fill_in_credentials_and_submit(user.email, user.password)
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
@@ -528,7 +528,7 @@ feature 'Sign in' do
       fill_in_credentials_and_submit(user.email, user.password)
 
       expect(current_url).to eq new_user_session_url(request_id: '123')
-      expect(page).to have_content t('errors.invalid_authenticity_token')
+      expect(page).to have_content t('errors.general')
     end
   end
 

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -36,7 +36,7 @@ feature 'webauthn sign in' do
     mock_press_button_on_hardware_key_on_verification
     click_button t('forms.buttons.continue')
 
-    expect(page).to have_content(t('errors.invalid_authenticity_token'))
+    expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
@@ -46,7 +46,7 @@ feature 'webauthn sign in' do
     sign_in_user(webauthn_configuration.user)
     click_button t('forms.buttons.continue')
 
-    expect(page).to have_content(t('errors.invalid_authenticity_token'))
+    expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 end

--- a/spec/requests/i18n_spec.rb
+++ b/spec/requests/i18n_spec.rb
@@ -19,8 +19,8 @@ describe 'i18n requests' do
       )
       get response.headers['Location']
 
-      expect(response.body).to include(t('errors.invalid_authenticity_token', locale: :en))
-      expect(response.body).to_not include(t('errors.invalid_authenticity_token', locale: :es))
+      expect(response.body).to include(t('errors.general', locale: :en))
+      expect(response.body).to_not include(t('errors.general', locale: :es))
     end
   end
 end


### PR DESCRIPTION
[New Relic Error](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=11ba84d7-9a2e-2404-5540-553bcc32fc61)

This fixes a 500 where the webauthn configuration queried from the database is `nil`

I also renamed the "invalid_authenticity_token" error message to `general` to reflect its more general usage