### PR TITLE
Fix 500 from database error while deleting account

### DIFF
--- a/app/services/db/deleted_user/create.rb
+++ b/app/services/db/deleted_user/create.rb
@@ -4,14 +4,19 @@ module Db
       def self.call(user_id)
         user = User.find_by(id: user_id)
         return unless user
-        ::DeletedUser.create!(
-          user_id: user.id,
-          uuid: user.uuid,
-          user_created_at: user.created_at,
-          deleted_at: Time.zone.now,
-        )
-      rescue ActiveRecord::RecordNotUnique
-        ::DeletedUser.where(user_id: user_id)&.first
+
+        ActiveRecord::Base.transaction(requires_new: true) do
+          ::DeletedUser.create!(
+            user_id: user.id,
+            uuid: user.uuid,
+            user_created_at: user.created_at,
+            deleted_at: Time.zone.now,
+          )
+        rescue ActiveRecord::RecordNotUnique
+          raise ActiveRecord::Rollback
+        end
+
+        nil
       end
     end
   end

--- a/spec/services/account_reset/delete_account_spec.rb
+++ b/spec/services/account_reset/delete_account_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe AccountReset::DeleteAccount do
+  include AccountResetHelper
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    it 'can be called even if DeletedUser exists' do
+      create_account_reset_request_for(user)
+      grant_request(user)
+      token = AccountResetRequest.where(user_id: user.id).first.granted_token
+      Db::DeletedUser::Create.call(user.id)
+      AccountReset::DeleteAccount.new(token).call
+    end
+  end
+end

--- a/spec/services/db/deleted_user/create_spec.rb
+++ b/spec/services/db/deleted_user/create_spec.rb
@@ -19,8 +19,19 @@ describe Db::DeletedUser::Create do
 
   it 'fails gracefully if we try to insert the same user twice and returns the deleted user' do
     user = create(:user)
-    deleted_user1 = subject.call(user.id)
-    deleted_user2 = subject.call(user.id)
-    expect(deleted_user1).to eq(deleted_user2)
+    subject.call(user.id)
+    subject.call(user.id)
+    expect(DeletedUser.find_by!(user_id: user.id)).to_not be_nil
+  end
+
+  it 'fails gracefully if we try to insert the same user while in a transaction' do
+    user = create(:user)
+    ActiveRecord::Base.transaction do
+      subject.call(user.id)
+    end
+    ActiveRecord::Base.transaction do
+      subject.call(user.id)
+    end
+    expect(DeletedUser.find_by!(user_id: user.id)).to_not be_nil
   end
 end


### PR DESCRIPTION
We see uncommon transaction errors around account deletion in NewRelic in a couple different ways ([here](https://onenr.io/0EPwJ422Dj7) and [here](https://onenr.io/0VKQXqPPawa)) which can cause 500 errors when resetting an account or deleting an account while authenticated.

We have a test intended to catch this case [here](https://github.com/18F/identity-idp/blob/886e98db6d3a81d3804963d9d039cb768675ab96/spec/services/db/deleted_user/create_spec.rb#L20-L25), but according to the [ActiveRecord docs](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions) trying to rescue while executing in a database transaction requires a separate savepoint and re-raising to rollback.

This PR adds failing tests around that behavior and implements the savepoint and rollback to avoid `ActiveRecord::StatementInvalid` errors