### PR TITLE
Remove i18n window global in favor of i18n package

### DIFF
--- a/app/javascript/app/pw-toggle.js
+++ b/app/javascript/app/pw-toggle.js
@@ -1,4 +1,4 @@
-const { I18n } = window.LoginGov;
+import { t } from '@18f/identity-i18n';
 
 function togglePw() {
   const inputs = document.querySelectorAll('input.password-toggle[type="password"]');
@@ -15,7 +15,7 @@ function togglePw() {
             class="usa-checkbox__input usa-checkbox__input--bordered"
           >
           <label for="pw-toggle-${i}" class="usa-checkbox__label">
-            ${I18n.t('forms.passwords.show')}
+            ${t('forms.passwords.show')}
           </label>
         </div>`;
       input.insertAdjacentHTML('afterend', el);

--- a/app/javascript/app/utils/ms-formatter.js
+++ b/app/javascript/app/utils/ms-formatter.js
@@ -1,8 +1,8 @@
-const { I18n } = window.LoginGov;
+import { t } from '@18f/identity-i18n';
 
 // i18n-tasks-use t('datetime.dotiw.seconds')
 // i18n-tasks-use t('datetime.dotiw.minutes')
-const formatTime = (time, unit) => I18n.t(`datetime.dotiw.${unit}`, { count: time });
+const formatTime = (time, unit) => t(`datetime.dotiw.${unit}`, { count: time });
 
 export function msFormatter(milliseconds) {
   const seconds = milliseconds / 1000;
@@ -12,7 +12,7 @@ export function msFormatter(milliseconds) {
   const displayMinutes = formatTime(minutes, 'minutes');
   const displaySeconds = formatTime(remainingSeconds, 'seconds');
 
-  const displayTime = `${displayMinutes}${I18n.t(
+  const displayTime = `${displayMinutes}${t(
     'datetime.dotiw.two_words_connector',
   )}${displaySeconds}`;
 

--- a/app/javascript/packages/i18n/index.ts
+++ b/app/javascript/packages/i18n/index.ts
@@ -89,4 +89,7 @@ class I18n {
   }
 }
 
-export { I18n };
+// eslint-disable-next-line no-underscore-dangle
+const { t } = new I18n({ strings: globalThis._locale_data });
+
+export { I18n, t };

--- a/app/javascript/packages/i18n/index.ts
+++ b/app/javascript/packages/i18n/index.ts
@@ -90,6 +90,7 @@ class I18n {
 }
 
 // eslint-disable-next-line no-underscore-dangle
-const { t } = new I18n({ strings: globalThis._locale_data });
+const i18n = new I18n({ strings: globalThis._locale_data });
+const { t } = i18n;
 
-export { I18n, t };
+export { I18n, i18n, t };

--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
@@ -14,7 +14,7 @@ const PLUGIN = 'ExtractKeysWebpackPlugin';
  *
  * @type {RegExp}
  */
-const TRANSLATE_CALL = /(?:^|[^\w'-])(?:I18n\.)?t\(\s*['"](.+?)['"]/g;
+const TRANSLATE_CALL = /(?:^|[^\w'-])(?:I18n\.)?t\)?\(\s*['"](.+?)['"]/g;
 
 /**
  * Given an original file name and locale, returns a modified file name with the locale injected

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
@@ -30,6 +30,9 @@ describe('RailsI18nWebpackPlugin', () => {
             onMissingString,
           }),
         ],
+        externals: {
+          '@18f/identity-i18n': '_i18n_',
+        },
         resolve: {
           extensions: ['.js', '.foo'],
         },

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js
@@ -1,1 +1,3 @@
+import { t } from '@18f/identity-i18n';
+
 const text = t('forms.button.cancel');

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,15 +1,4 @@
-import { I18n } from '@18f/identity-i18n';
-
-/**
- * @typedef {Window & {
- *   _locale_data?: Record<string, string>
- * }} WindowWithLocaleData
- */
-
-const { _locale_data: strings } = /** @type {WindowWithLocaleData} */ (window);
-
 window.LoginGov = window.LoginGov || {};
-window.LoginGov.I18n = new I18n({ strings });
 
 require('../app/components/index');
 require('../app/utils/index');

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,5 +1,3 @@
-window.LoginGov = window.LoginGov || {};
-
 require('../app/components/index');
 require('../app/utils/index');
 require('../app/pw-toggle');

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -12,6 +12,7 @@ import {
   FailedCaptureAttemptsContextProvider,
   HelpCenterContextProvider,
 } from '@18f/identity-document-capture';
+import { i18n } from '@18f/identity-i18n';
 import { loadPolyfills } from '@18f/identity-polyfill';
 import { isCameraCapableMobile } from '@18f/identity-device';
 import { trackEvent } from '@18f/identity-analytics';
@@ -30,7 +31,6 @@ import { I18nContext } from '@18f/identity-react-i18n';
 /**
  * @typedef LoginGov
  *
- * @prop {I18n} I18n
  * @prop {Record<string,string>} assets
  */
 
@@ -66,7 +66,7 @@ import { I18nContext } from '@18f/identity-react-i18n';
  * @see UploadContext
  */
 
-const { I18n: i18n, assets } = /** @type {DocumentCaptureGlobal} */ (window).LoginGov;
+const { assets } = /** @type {DocumentCaptureGlobal} */ (window).LoginGov;
 
 const appRoot = /** @type {HTMLDivElement} */ (document.getElementById('document-capture-form'));
 const isMockClient = appRoot.hasAttribute('data-mock-client');

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -1,7 +1,5 @@
+import { t } from '@18f/identity-i18n';
 import { loadPolyfills } from '@18f/identity-polyfill';
-
-/** @typedef {{t:(key:string)=>string, key:(key:string)=>string}} LoginGovI18n */
-/** @typedef {{LoginGov:{I18n:LoginGovI18n}}} LoginGovGlobal */
 
 /**
  * Given a submit event, disables all submit buttons within the target form.
@@ -52,9 +50,8 @@ function checkInputValidity(event) {
     input.focus();
   }
 
-  const { I18n } = /** @type {typeof window & LoginGovGlobal} */ (window).LoginGov;
   if (input.validity.valueMissing) {
-    input.setCustomValidity(I18n.t('simple_form.required.text'));
+    input.setCustomValidity(t('simple_form.required.text'));
     input.setAttribute('data-form-validation-message', '');
   }
 }

--- a/app/javascript/packs/otp-delivery-preference.js
+++ b/app/javascript/packs/otp-delivery-preference.js
@@ -1,12 +1,6 @@
+import { t } from '@18f/identity-i18n';
+
 /** @typedef {import('@18f/identity-phone-input').PhoneInput} PhoneInput */
-
-/**
- * @typedef {typeof window & {
- *   LoginGov: { I18n: import('@18f/identity-i18n').I18n } }
- * } GlobalWithLoginGov
- */
-
-const { t } = /** @type {GlobalWithLoginGov} */ (window).LoginGov.I18n;
 
 /**
  * Returns the OTP delivery preference element.

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -1,17 +1,16 @@
 import zxcvbn from 'zxcvbn';
-
-const { I18n } = window.LoginGov;
+import { t } from '@18f/identity-i18n';
 
 // zxcvbn returns a strength score from 0 to 4
 // we map those scores to:
 // 1. a CSS class to the pw strength module
 // 2. text describing the score
 const scale = {
-  0: ['pw-very-weak', I18n.t('instructions.password.strength.i')],
-  1: ['pw-weak', I18n.t('instructions.password.strength.ii')],
-  2: ['pw-so-so', I18n.t('instructions.password.strength.iii')],
-  3: ['pw-good', I18n.t('instructions.password.strength.iv')],
-  4: ['pw-great', I18n.t('instructions.password.strength.v')],
+  0: ['pw-very-weak', t('instructions.password.strength.i')],
+  1: ['pw-weak', t('instructions.password.strength.ii')],
+  2: ['pw-so-so', t('instructions.password.strength.iii')],
+  3: ['pw-good', t('instructions.password.strength.iv')],
+  4: ['pw-great', t('instructions.password.strength.v')],
 };
 
 const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').toLowerCase();
@@ -71,7 +70,7 @@ function getFeedback(z) {
     // i18n-tasks-use t('zxcvbn.feedback.this_is_a_very_common_password')
     // i18n-tasks-use t('zxcvbn.feedback.this_is_similar_to_a_commonly_used_password')
     // i18n-tasks-use t('zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns')
-    return I18n.t(`zxcvbn.feedback.${snakeCase(str)}`);
+    return t(`zxcvbn.feedback.${snakeCase(str)}`);
   }
 
   if (!warning && !suggestions.length) {

--- a/app/javascript/packs/ssn-field.js
+++ b/app/javascript/packs/ssn-field.js
@@ -1,6 +1,5 @@
 import Cleave from 'cleave.js';
-
-const { I18n } = window.LoginGov;
+import { t } from '@18f/identity-i18n';
 
 /* eslint-disable no-new */
 function formatSSNFieldAndLimitLength() {
@@ -16,7 +15,7 @@ function formatSSNFieldAndLimitLength() {
             class="usa-checkbox__input usa-checkbox__input--bordered"
           >
           <label for="ssn-toggle-${i}" class="usa-checkbox__label">
-            ${I18n.t('forms.ssn.show')}
+            ${t('forms.ssn.show')}
           </label>
         </div>`;
       input.insertAdjacentHTML('afterend', el);

--- a/spec/javascripts/app/utils/countdown-timer_spec.js
+++ b/spec/javascripts/app/utils/countdown-timer_spec.js
@@ -1,4 +1,6 @@
 import sinon from 'sinon';
+import { i18n } from '@18f/identity-i18n';
+import { usePropertyValue } from '@18f/identity-test-helpers';
 import { countdownTimer } from '../../../../app/javascript/app/utils/countdown-timer';
 
 describe('countdownTimer', () => {
@@ -7,6 +9,12 @@ describe('countdownTimer', () => {
   });
 
   describe('with clock', () => {
+    usePropertyValue(i18n, 'strings', {
+      'datetime.dotiw.seconds': { one: 'one second', other: '%{count} seconds' },
+      'datetime.dotiw.minutes': { one: 'one minute', other: '%{count} minutes' },
+      'datetime.dotiw.two_words_connector': ' and ',
+    });
+
     let clock;
     let el;
 
@@ -14,16 +22,10 @@ describe('countdownTimer', () => {
       clock = sinon.useFakeTimers();
       el = document.createElement('div');
       el.appendChild(document.createTextNode('test'));
-      window.LoginGov.I18n.strings = {
-        'datetime.dotiw.seconds': { one: 'one second', other: '%{count} seconds' },
-        'datetime.dotiw.minutes': { one: 'one minute', other: '%{count} minutes' },
-        'datetime.dotiw.two_words_connector': ' and ',
-      };
     });
 
     afterEach(() => {
       clock.restore();
-      window.LoginGov.I18n.strings = {};
     });
 
     it('stays at 0s when time is exhausted', () => {

--- a/spec/javascripts/app/utils/ms-formatter_spec.js
+++ b/spec/javascripts/app/utils/ms-formatter_spec.js
@@ -1,17 +1,14 @@
+import { i18n } from '@18f/identity-i18n';
+import { usePropertyValue } from '@18f/identity-test-helpers';
 import { msFormatter } from '../../../../app/javascript/app/utils/ms-formatter';
 
 describe('#msFormatter', () => {
-  beforeEach(() => {
-    window.LoginGov.I18n.strings = {
-      'datetime.dotiw.seconds': { one: 'one second', other: '%{count} seconds' },
-      'datetime.dotiw.minutes': { one: 'one minute', other: '%{count} minutes' },
-      'datetime.dotiw.two_words_connector': ' and ',
-    };
+  usePropertyValue(i18n, 'strings', {
+    'datetime.dotiw.seconds': { one: 'one second', other: '%{count} seconds' },
+    'datetime.dotiw.minutes': { one: 'one minute', other: '%{count} minutes' },
+    'datetime.dotiw.two_words_connector': ' and ',
   });
 
-  afterEach(() => {
-    window.LoginGov.I18n.strings = {};
-  });
   it('formats milliseconds as 0 minutes and 0 seconds)', () => {
     const output = msFormatter(0);
     expect(output).to.equal('0 minutes and 0 seconds');

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -1,26 +1,16 @@
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
-import { useSandbox } from '../support/sinon';
 import { initialize } from '../../../app/javascript/packs/form-validation';
 
 describe('form-validation', () => {
-  const sandbox = useSandbox();
-
   const onSubmit = (event) => event.preventDefault();
 
   beforeEach(() => {
     window.addEventListener('submit', onSubmit);
-    window.LoginGov = {
-      I18n: {
-        t: sandbox.stub().returnsArg(0),
-        key: sandbox.stub().returnsArg(0),
-      },
-    };
   });
 
   afterEach(() => {
     window.removeEventListener('submit', onSubmit);
-    delete window.LoginGov;
   });
 
   it('disables submit buttons on submit', () => {

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -1,14 +1,6 @@
+import { getForbiddenPasswords } from '../../../app/javascript/packs/pw-strength';
+
 describe('pw-strength', () => {
-  let getForbiddenPasswords;
-  before(async () => {
-    window.LoginGov = { I18n: { t() {} } };
-    ({ getForbiddenPasswords } = await import('../../../app/javascript/packs/pw-strength'));
-  });
-
-  after(() => {
-    delete window.LoginGov;
-  });
-
   describe('getForbiddenPasswords', () => {
     it('returns empty array if given argument is null', () => {
       const element = null;

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -3,7 +3,6 @@ import chai from 'chai';
 import dirtyChai from 'dirty-chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import { I18n } from '@18f/identity-i18n';
 import { createDOM, useCleanDOM } from './support/dom';
 import { chaiConsoleSpy, useConsoleLogSpy } from './support/console';
 import { sinonChaiAsPromised } from './support/sinon';

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -30,8 +30,6 @@ global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
 global.window.crypto = new Crypto(); // In the future (Node >=15), use native webcrypto: https://nodejs.org/api/webcrypto.html
 global.window.URL.createObjectURL = createObjectURLAsDataURL;
 global.window.URL.revokeObjectURL = () => {};
-global.window.LoginGov = global.window.LoginGov || {};
-global.window.LoginGov.I18n = new I18n();
 Object.defineProperty(global.window.Image.prototype, 'src', {
   set() {
     this.onload();


### PR DESCRIPTION
**Why**:

- Standardize package as interface for translations
- Avoid global variables, because:
   - They create a fragile order of dependencies
   - It creates interoperability challenges with TypeScript types
   - It is cumbersome to mock in specs

The main challenge with implementing this 'til now is that our Webpack plugin for extracting translation keys has been incompatible with how Webpack transforms calls to imported functions, e.g.

```js
(0,_18f_identity_i18n__WEBPACK_IMPORTED_MODULE_0__.t)('forms.button.cancel');
```

Our key extraction is rather naive and looks for a simple pattern of `t('string')`, thus failing to find this. While a more robust implementation would operate on either the original source code or an AST representation, initial attempts to do so were unsuccessful. Instead, the workaround here is to anticipate [the Webpack output of `(0,t)('string')`](https://github.com/webpack/webpack/blob/4abf353fbc6e702cf1768e8bbbeafe38ced33df7/lib/RuntimeTemplate.js#L897-L901) as part of the pattern matching, and rely on the incorporated test fixture to guard against potential regressions.