### PR TITLE
Absorb autoLogout into session timeout pack

### DIFF
--- a/app/javascript/app/utils/auto-logout.js
+++ b/app/javascript/app/utils/auto-logout.js
@@ -1,5 +1,0 @@
-export default (path) => {
-  window.onbeforeunload = null;
-  window.onunload = null;
-  window.location.href = path;
-};

--- a/app/javascript/app/utils/index.js
+++ b/app/javascript/app/utils/index.js
@@ -1,10 +1,8 @@
-import autoLogout from './auto-logout';
 import { countdownTimer } from './countdown-timer';
 import { msFormatter } from './ms-formatter';
 
 window.LoginGov = window.LoginGov || {};
 const { LoginGov } = window;
 
-LoginGov.autoLogout = autoLogout;
 LoginGov.countdownTimer = countdownTimer;
 LoginGov.msFormatter = msFormatter;

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -47,7 +47,7 @@ const initialTime = new Date();
 
 const modal = new login.Modal({ el: '#session-timeout-msg' });
 const keepaliveEl = document.getElementById('session-keepalive-btn');
-const csrfEl = document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null;
+const csrfEl: HTMLMetaElement | null = document.querySelector('meta[name="csrf-token"]');
 
 let csrfToken = '';
 if (csrfEl) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const mode = isProductionEnv ? 'production' : 'development';
 const hashSuffix = isProductionEnv ? '-[contenthash:8]' : '';
 const devServerPort = process.env.WEBPACK_PORT;
 
-const entries = glob('app/{components,javascript/packs}/*.{js,jsx}');
+const entries = glob('app/{components,javascript/packs}/*.{ts,tsx,js,jsx}');
 
 module.exports = /** @type {import('webpack').Configuration} */ ({
   mode,


### PR DESCRIPTION
**Why**:

- Avoid window globals
- Reduce size and scope of critical-path application pack
- Limit indirection