### PR TITLE
Fix Resend Email 500

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -26,9 +26,15 @@ module Users
 
     def resend
       email_address = EmailAddress.find_with_email(session_email)
-      SendAddEmailConfirmation.new(current_user).call(email_address)
-      flash[:success] = t('notices.resend_confirmation_email.success')
-      redirect_to add_email_verify_email_url
+
+      if email_address && !email_address.confirmed?
+        SendAddEmailConfirmation.new(current_user).call(email_address)
+        flash[:success] = t('notices.resend_confirmation_email.success')
+        redirect_to add_email_verify_email_url
+      else
+        flash[:error] = t('errors.general')
+        redirect_to add_email_url
+      end
     end
 
     def confirm_delete


### PR DESCRIPTION
Fixes a 500 in [NewRelic](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&begin=1645488886000&end=1645748086000&state=627e8ace-0e87-3bbe-331f-4c41c6a803a5)

We should probably move the email out of the session and pass the id as a parameter or something instead and do the lookup that way