### PR TITLE
Only add "; Secure" to cookies served over HTTPS

### DIFF
--- a/lib/secure_cookies.rb
+++ b/lib/secure_cookies.rb
@@ -1,8 +1,6 @@
 # Reimplements SecureHeaders secure cookie functionality to make sure all cookies are secure
 class SecureCookies
   COOKIE_SEPARATOR = "\n".freeze
-  SECURE_COOKIE_ATTRIBUTES = ['; Secure', '; HttpOnly', '; SameSite=Lax'].freeze
-  SECURE_COOKIE_REGEXES = SECURE_COOKIE_ATTRIBUTES.map { |attr| /#{attr}/i }
 
   def initialize(app)
     @app = app

--- a/spec/requests/secure_cookies_spec.rb
+++ b/spec/requests/secure_cookies_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'secure cookies' do
   context 'with plain HTTP' do
-    it 'flags all cookies sent by the application as HttpOnly, and SameSite=Lax' do
+    it 'flags all cookies sent by the application as HttpOnly and SameSite=Lax' do
       get root_url
       cookie_count = response.headers['Set-Cookie'].split("\n").count
 
@@ -12,7 +12,7 @@ RSpec.describe 'secure cookies' do
     end
   end
 
-  context 'withs plain HTTP' do
+  context 'with HTTPS' do
     it 'flags all cookies sent by the application as Secure, HttpOnly, and SameSite=Lax' do
       get root_url, headers: { 'HTTPS' => 'on' }
       cookie_count = response.headers['Set-Cookie'].split("\n").count

--- a/spec/requests/secure_cookies_spec.rb
+++ b/spec/requests/secure_cookies_spec.rb
@@ -1,12 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe 'secure cookies' do
-  it 'flags all cookies sent by the application as Secure, HttpOnly, and SameSite=Lax' do
-    get root_url
-    cookie_count = response.headers['Set-Cookie'].split("\n").count
+  context 'with plain HTTP' do
+    it 'flags all cookies sent by the application as HttpOnly, and SameSite=Lax' do
+      get root_url
+      cookie_count = response.headers['Set-Cookie'].split("\n").count
 
-    expect(response.headers['Set-Cookie'].scan('; Secure').size).to eq(cookie_count)
-    expect(response.headers['Set-Cookie'].scan('; HttpOnly').size).to eq(cookie_count)
-    expect(response.headers['Set-Cookie'].scan('; SameSite=Lax').size).to eq(cookie_count)
+      expect(response.headers['Set-Cookie']).to_not include('; Secure')
+      expect(response.headers['Set-Cookie'].scan('; HttpOnly').size).to eq(cookie_count)
+      expect(response.headers['Set-Cookie'].scan('; SameSite=Lax').size).to eq(cookie_count)
+    end
+  end
+
+  context 'withs plain HTTP' do
+    it 'flags all cookies sent by the application as Secure, HttpOnly, and SameSite=Lax' do
+      get root_url, headers: { 'HTTPS' => 'on' }
+      cookie_count = response.headers['Set-Cookie'].split("\n").count
+
+      expect(response.headers['Set-Cookie'].scan('; Secure').size).to eq(cookie_count)
+      expect(response.headers['Set-Cookie'].scan('; HttpOnly').size).to eq(cookie_count)
+      expect(response.headers['Set-Cookie'].scan('; SameSite=Lax').size).to eq(cookie_count)
+    end
   end
 end


### PR DESCRIPTION
Reports of this breaking Safari in local development (where we don't use HTTPS normally)