### PR TITLE
Add use and alg keys to OIDC certificate endpoint

### DIFF
--- a/app/presenters/openid_connect_certs_presenter.rb
+++ b/app/presenters/openid_connect_certs_presenter.rb
@@ -1,13 +1,18 @@
 class OpenidConnectCertsPresenter
   def certs
     {
-      keys: keys.map { |key| JWT::JWK.new(key).export },
+      keys: keys,
     }
   end
 
   private
 
   def keys
-    [AppArtifacts.store.oidc_public_key]
+    [AppArtifacts.store.oidc_public_key].map do |key|
+      {
+        alg: 'RS256',
+        use: 'sig',
+      }.merge(JWT::JWK.new(key).export)
+    end
   end
 end

--- a/spec/presenters/openid_connect_certs_presenter_spec.rb
+++ b/spec/presenters/openid_connect_certs_presenter_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe OpenidConnectCertsPresenter do
       json = presenter.certs
 
       expect(json[:keys].size).to eq(1)
+      expect(json[:keys].all? { |k| k[:alg] == 'RS256' }).to eq(true)
+      expect(json[:keys].all? { |k| k[:use] == 'sig' }).to eq(true)
 
       key_from_response = JWT::JWK.import(json[:keys].first).public_key
       public_key = AppArtifacts.store.oidc_public_key


### PR DESCRIPTION
The JWK spec supports optionally including the [use](https://datatracker.ietf.org/doc/html/rfc7517#section-4.2) and [alg](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4) attributes, but we don't currently send them

Our key is RS256 and is intended for use in verifying the signature of our tokens, so this PR adds those attributes to the response!