### PR TITLE
Fix password strength feedback for empty password

### DIFF
--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -35,7 +35,7 @@ function getStrength(z) {
   return z && z.password.length ? scale[z.score] : fallback;
 }
 
-function getFeedback(z) {
+export function getFeedback(z) {
   if (!z || !z.password || z.score > 2) {
     return '&nbsp;';
   }

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -82,7 +82,7 @@ function getFeedback(z) {
     return lookup(warning);
   }
 
-  return `${suggestions.map((s) => lookup(s)).join('')}`;
+  return `${suggestions.map((s) => lookup(s)).join('. ')}`;
 }
 
 function disableSubmit(submitEl, length = 0, score = 0) {

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -36,7 +36,7 @@ function getStrength(z) {
 }
 
 function getFeedback(z) {
-  if (!z || z.score > 2) {
+  if (!z || !z.password || z.score > 2) {
     return '&nbsp;';
   }
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -56,6 +56,7 @@ function getFeedback(z) {
     // i18n-tasks-use t('zxcvbn.feedback.dates_are_often_easy_to_guess')
     // i18n-tasks-use t('zxcvbn.feedback.for_a_stronger_password_use_a_few_words_separated_by_spaces_but_avoid_common_phrases')
     // i18n-tasks-use t('zxcvbn.feedback.names_and_surnames_by_themselves_are_easy_to_guess')
+    // i18n-tasks-use t('zxcvbn.feedback.no_need_for_symbols_digits_or_uppercase_letters')
     // i18n-tasks-use t('zxcvbn.feedback.predictable_substitutions_like__instead_of_a_dont_help_very_much')
     // i18n-tasks-use t('zxcvbn.feedback.recent_years_are_easy_to_guess')
     // i18n-tasks-use t('zxcvbn.feedback.repeats_like_aaa_are_easy_to_guess')
@@ -69,6 +70,7 @@ function getFeedback(z) {
     // i18n-tasks-use t('zxcvbn.feedback.this_is_a_top_10_common_password')
     // i18n-tasks-use t('zxcvbn.feedback.this_is_a_very_common_password')
     // i18n-tasks-use t('zxcvbn.feedback.this_is_similar_to_a_commonly_used_password')
+    // i18n-tasks-use t('zxcvbn.feedback.use_a_few_words_avoid_common_phrases')
     // i18n-tasks-use t('zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns')
     return t(`zxcvbn.feedback.${snakeCase(str)}`);
   }

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -1,4 +1,5 @@
-import { getForbiddenPasswords } from '../../../app/javascript/packs/pw-strength';
+import zxcvbn from 'zxcvbn';
+import { getForbiddenPasswords, getFeedback } from '../../../app/javascript/packs/pw-strength';
 
 describe('pw-strength', () => {
   describe('getForbiddenPasswords', () => {
@@ -30,6 +31,28 @@ describe('pw-strength', () => {
       const result = getForbiddenPasswords(element);
 
       expect(result).to.be.deep.equal(['foo', 'bar', 'baz']);
+    });
+  });
+
+  describe('getFeedback', () => {
+    const EMPTY_RESULT = '&nbsp;';
+
+    it('returns an empty result for empty password', () => {
+      const z = zxcvbn('');
+
+      expect(getFeedback(z)).to.equal(EMPTY_RESULT);
+    });
+
+    it('returns an empty result for a strong password', () => {
+      const z = zxcvbn('!Juq2Uk2**RBEsA8');
+
+      expect(getFeedback(z)).to.equal(EMPTY_RESULT);
+    });
+
+    it('returns feedback for a weak password', () => {
+      const z = zxcvbn('password');
+
+      expect(getFeedback(z)).to.equal('zxcvbn.feedback.this_is_a_top_10_common_password');
     });
   });
 });


### PR DESCRIPTION
Previously: #5776 (LG-5461)

This improves a few things around password strength feedback:

- Marks the password strings as used in the JavaScript bundles, to ensure they're included in the locale bundles generated by `RailsI18nWebpackPlugin` (29021415d378de0eb900f4e56991efe9cc97b278)
- Joins multiple password strength feedback strings as individual sentences, so that they don't create a run-on sentence (24b2ddca750ecb4aa44d210f9de4381ed901b0dd, [before](https://user-images.githubusercontent.com/1779930/156021247-8a1f234f-58c4-451e-9ae8-e213fa31fd62.png), [after](https://user-images.githubusercontent.com/1779930/156021275-bd536bce-8c97-4054-8087-adc38b7098c0.png))
- Generates password strength feedback only if password is non-empty, so that the feedback matches the initial state on a new page load, per the expectation of LG-5461 (ca733095f309593f2fd5fad8a7adf7136d2a60e9)

**Steps to reproduce:**

1. Create a new account
2. Complete account creation up to "Create a strong password"
3. Enter some text in the field
4. Delete that text

Before|After
---|---
![Screen Shot 2022-02-28 at 11 22 24 AM](https://user-images.githubusercontent.com/1779930/156021393-c0b1b3fb-eac0-4d95-8165-7bafbe4dca15.png)|![Screen Shot 2022-02-28 at 11 28 25 AM](https://user-images.githubusercontent.com/1779930/156021404-dbd41b96-20ce-4e36-b7ec-809b16e0f684.png)