### PR TITLE
Improve JS string extraction to exclude template literals

### DIFF
--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
@@ -14,7 +14,7 @@ const PLUGIN = 'ExtractKeysWebpackPlugin';
  *
  * @type {RegExp}
  */
-const TRANSLATE_CALL = /(?:^|[^\w'-])(?:I18n\.)?t\)?\(\s*['"](.+?)['"]/g;
+const TRANSLATE_CALL = /(?:^|[^\w'-])(?:I18n\.)?t\)?\(\s*['"](.+?)['"][,\s)]/g;
 
 /**
  * Given an original file name and locale, returns a modified file name with the locale injected

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/in1.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/in1.js
@@ -10,3 +10,6 @@ const message = t('forms.messages', { count: 2 });
  * i18n-tasks-use t('item.3')
  */
 Array.from({ length: 3 }, (_, i) => t(`item.${i + 1}`));
+// Emulate Babel template literal transpilation
+// See: https://babeljs.io/repl#?browsers=ie%2011&code_lz=C4CgBglsCmC2B0ASA3hABAajQRgL5gEog
+Array.from({ length: 3 }, (_, i) => t('item.'.concat(i + 1)));


### PR DESCRIPTION
**Why**: Due to how the plugin operates on the post-transpiled code, string template literals may be wrongly considered as candidates for extraction, despite the fact that the complete string includes runtime logic (`String#concat`) which cannot be accounted for at the extraction phase.

The changes here expect to see an additional argument or closing parenthesis of the `t()` call.

I noticed this by the presence of a `"datetime.dotiw."` key in: https://static.secure.login.gov/packs/js/application-26ddcb1a.en.js

Robustness commentary from #6001 still applies here, re: operating on built output.