### PR TITLE
Add unused method argument lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -574,6 +574,10 @@ Lint/UnifiedInteger:
 Lint/UnreachableCode:
   Enabled: true
 
+Lint/UnusedMethodArgument:
+  Enabled: true
+  AllowUnusedKeywordArguments: false
+
 Lint/UriEscapeUnescape:
   Enabled: true
 

--- a/app/jobs/reports/iaa_billing_report.rb
+++ b/app/jobs/reports/iaa_billing_report.rb
@@ -11,7 +11,7 @@ module Reports
       key: -> { "#{REPORT_NAME}-#{arguments.first}" },
     )
 
-    def perform(today)
+    def perform(_today)
       @sps_for_iaa = {}
       @today = Time.zone.today
       results = []

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -91,7 +91,7 @@ class ResolutionProofingJob < ApplicationJob
     state_id_success = nil
     if should_proof_state_id && result[:success] && !document_expired
       timer.time('state_id') do
-        proof_state_id(timer: timer, applicant_pii: applicant_pii, result: result)
+        proof_state_id(applicant_pii: applicant_pii, result: result)
       end
       state_id_success = result[:success]
     end
@@ -164,7 +164,7 @@ class ResolutionProofingJob < ApplicationJob
     )
   end
 
-  def proof_state_id(timer:, applicant_pii:, result:)
+  def proof_state_id(applicant_pii:, result:)
     proofer_result = state_id_proofer.proof(applicant_pii)
 
     result.merge!(proofer_result.to_h) do |key, orig, current|

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -12,7 +12,7 @@ class OpenidConnectUserInfoPresenter
     info = {
       sub: uuid_from_sp_identity(identity),
       iss: root_url,
-      email: email_from_sp_identity(identity),
+      email: email_from_sp_identity,
       email_verified: true,
       all_emails: all_emails_from_sp_identity(identity),
     }
@@ -34,7 +34,7 @@ class OpenidConnectUserInfoPresenter
     AgencyIdentityLinker.new(identity).link_identity.uuid
   end
 
-  def email_from_sp_identity(identity)
+  def email_from_sp_identity
     email_context.last_sign_in_email_address.email
   end
 

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -53,6 +53,7 @@ module DocAuth
         Requests::GetResultsRequest.new(config: config, instance_id: instance_id).fetch
       end
 
+      # rubocop:disable Lint/UnusedMethodArgument
       def post_images(
         front_image:,
         back_image:,
@@ -82,6 +83,7 @@ module DocAuth
           results_response
         end
       end
+      # rubocop:enable Lint/UnusedMethodArgument
     end
   end
 end

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -33,6 +33,7 @@ module DocAuth
         Responses::CreateDocumentResponse.new(success: true, errors: {}, instance_id: instance_id)
       end
 
+      # rubocop:disable Lint/UnusedMethodArgument
       def post_front_image(image:, instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
@@ -94,6 +95,7 @@ module DocAuth
           liveness_enabled,
         ).call
       end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       private
 

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -8,8 +8,7 @@ module Idv
       document_capture_session,
       should_proof_state_id:,
       trace_id:,
-      document_expired:,
-      flow_path: 'standard'
+      document_expired:
     )
       document_capture_session.create_proofing_session
 

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -42,7 +42,6 @@ module Idv
           should_proof_state_id: should_use_aamva?(pii_from_doc),
           trace_id: amzn_trace_id,
           document_expired: document_expired,
-          flow_path: flow_path,
         )
       end
 

--- a/lib/app_artifacts.rb
+++ b/lib/app_artifacts.rb
@@ -15,7 +15,7 @@ class AppArtifacts
 
     # @yieldparam [Store] store
     # @return [Struct] an instance of a struct, the propertes are defined by the block
-    def build(&block)
+    def build
       @artifacts = {}
 
       yield self

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -50,7 +50,7 @@ class IdentityConfig
     @written_env = {}
   end
 
-  def add(key, type: :string, is_sensitive: false, allow_nil: false, enum: nil, options: {})
+  def add(key, type: :string, allow_nil: false, enum: nil, options: {})
     value = @read_env[key]
 
     converted_value = CONVERTERS.fetch(type).call(value, options: options) if !value.nil?

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -14,6 +14,7 @@ module Telephony
       }.freeze
 
       # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Lint/UnusedMethodArgument
       # @return [Response]
       def send(message:, to:, country_code:, otp: nil)
         if Telephony.config.pinpoint.sms_configs.empty?
@@ -72,6 +73,7 @@ module Telephony
         end
         response || PinpointHelper.handle_config_failure(:sms)
       end
+      # rubocop:enable Lint/UnusedMethodArgument
       # rubocop:enable Metrics/BlockLength
 
       def phone_info(phone_number)

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -3,6 +3,7 @@ require 'time'
 module Telephony
   module Pinpoint
     class VoiceSender
+      # rubocop:disable Lint/UnusedMethodArgument
       # rubocop:disable Metrics/BlockLength
       def send(message:, to:, country_code:, otp: nil)
         if Telephony.config.pinpoint.voice_configs.empty?
@@ -54,6 +55,7 @@ module Telephony
         last_error || PinpointHelper.handle_config_failure(:voice)
       end
       # rubocop:enable Metrics/BlockLength
+      # rubocop:enable Lint/UnusedMethodArgument
 
       # @api private
       # @param [PinpointVoiceConfiguration] voice_config

--- a/lib/telephony/test/sms_sender.rb
+++ b/lib/telephony/test/sms_sender.rb
@@ -1,6 +1,7 @@
 module Telephony
   module Test
     class SmsSender
+      # rubocop:disable Lint/UnusedMethodArgument
       def send(message:, to:, country_code:, otp: nil)
         error = ErrorSimulator.new.error_for_number(to)
         if error.nil?
@@ -12,6 +13,7 @@ module Telephony
           )
         end
       end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       def phone_info(phone_number)
         error = ErrorSimulator.new.error_for_number(phone_number)

--- a/lib/telephony/test/voice_sender.rb
+++ b/lib/telephony/test/voice_sender.rb
@@ -1,6 +1,7 @@
 module Telephony
   module Test
     class VoiceSender
+      # rubocop:disable Lint/UnusedMethodArgument
       def send(message:, to:, country_code:, otp: nil)
         error = ErrorSimulator.new.error_for_number(to)
         if error.nil?
@@ -12,6 +13,7 @@ module Telephony
           )
         end
       end
+      # rubocop:enable Lint/UnusedMethodArgument
     end
   end
 end

--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -165,7 +165,7 @@ def main(args)
     end
   end
 
-  optparse.parse!
+  optparse.parse!(args)
 
   abort(optparse.help) if options[:source_branch].nil?
 

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -193,7 +193,6 @@ feature 'doc auth verify step' do
         should_proof_state_id: true,
         document_expired: nil,
         trace_id: anything,
-        flow_path: 'standard',
       )
     end
   end
@@ -220,7 +219,6 @@ feature 'doc auth verify step' do
         should_proof_state_id: false,
         document_expired: nil,
         trace_id: anything,
-        flow_path: 'standard',
       )
       expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
     end
@@ -247,7 +245,6 @@ feature 'doc auth verify step' do
         should_proof_state_id: false,
         document_expired: nil,
         trace_id: anything,
-        flow_path: 'standard',
       )
     end
   end

--- a/spec/models/backup_code_configuration_spec.rb
+++ b/spec/models/backup_code_configuration_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe BackupCodeConfiguration, type: :model do
       expect(BackupCodeConfiguration.find_with_code(code: '9999', user_id: user.id)).to_not be
     end
 
-    def save_and_find(find:, save: 'just-some-not-null-value', fingerprint: nil)
+    def save_and_find(find:, save: 'just-some-not-null-value')
       user.backup_code_configurations.build(
         code_cost: '10$8$4$',
         code_salt: 'abcdefg',

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -61,7 +61,6 @@ describe Idv::Steps::VerifyStep do
           should_proof_state_id: anything,
           trace_id: amzn_trace_id,
           document_expired: nil,
-          flow_path: 'standard',
         )
 
       step.call

--- a/spec/support/features/doc_capture_helper.rb
+++ b/spec/support/features/doc_capture_helper.rb
@@ -24,7 +24,7 @@ module DocCaptureHelper
     visit request_uri
   end
 
-  def using_doc_capture_session(user = user_with_2fa, &block)
+  def using_doc_capture_session(user = user_with_2fa)
     request_uri = doc_capture_request_uri(user)
     Capybara.using_session('mobile') do
       visit request_uri
@@ -38,7 +38,7 @@ module DocCaptureHelper
   end
 
   def complete_doc_capture_steps_before_capture_complete_step(user = user_with_2fa)
-    complete_doc_capture_steps_before_document_capture_step
+    complete_doc_capture_steps_before_document_capture_step(user)
     attach_and_submit_images
   end
 

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -5,7 +5,7 @@ module PersonalKeyHelper
     fill_in_credentials_and_submit(user.email, password)
   end
 
-  def reset_password(user, password = 'a really long password')
+  def reset_password(_user, password = 'a really long password')
     fill_in t('forms.passwords.edit.labels.password'), with: password
     click_button t('forms.passwords.edit.buttons.submit')
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -2,7 +2,7 @@ require 'saml_idp_constants'
 
 ## GET /api/saml/auth helper methods
 module SamlAuthHelper
-  def saml_settings(overrides: {}, security_overrides: {})
+  def saml_settings(overrides: {})
     settings = OneLogin::RubySaml::Settings.new
 
     # SP settings


### PR DESCRIPTION
I thought we had this enabled, but I guess not!

I'm doing some experimentation on analytics logging, and I assumed some errors would be caught by this, but they weren't! So I fixed it