### PR TITLE
Improve support for JS string extraction from dynamic imports

### DIFF
--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
@@ -1,5 +1,8 @@
 const sources = require('webpack-sources');
 
+/** @typedef {import('webpack/lib/ChunkGroup')} ChunkGroup */
+/** @typedef {import('webpack/lib/Entrypoint')} Entrypoint */
+
 /**
  * Webpack plugin name.
  *
@@ -51,6 +54,17 @@ const getTranslationKeys = (source) =>
 const isJavaScriptFile = (filename) => filename.endsWith('.js');
 
 /**
+ * Adds the given asset file name to the list of files of the group's parent entrypoint.
+ *
+ * @param {string} filename Asset filename.
+ * @param {ChunkGroup|Entrypoint} group Chunk group.
+ */
+const addFileToEntrypoint = (filename, group) =>
+  typeof group.getEntrypointChunk === 'function'
+    ? group.getEntrypointChunk().files.add(filename)
+    : group.parentsIterable.forEach((parent) => addFileToEntrypoint(filename, parent));
+
+/**
  * @template {Record<string,any>} Options
  */
 class ExtractKeysWebpackPlugin {
@@ -87,7 +101,9 @@ class ExtractKeysWebpackPlugin {
                 for (const [locale, content] of Object.entries(additionalAssets)) {
                   const assetFilename = getAdditionalAssetFilename(filename, locale);
                   compilation.emitAsset(assetFilename, new sources.RawSource(content));
-                  chunk.files.add(assetFilename);
+                  chunk.groupsIterable.forEach((group) =>
+                    addFileToEntrypoint(assetFilename, group),
+                  );
                 }
               }),
             ),

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const path = require('path');
 const { promises: fs } = require('fs');
 const webpack = require('webpack');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
 const RailsI18nWebpackPlugin = require('./rails-i18n-webpack-plugin.js');
 
 const {
@@ -29,6 +30,12 @@ describe('RailsI18nWebpackPlugin', () => {
             configPath: path.resolve(__dirname, 'spec/fixtures/locales'),
             onMissingString,
           }),
+          new WebpackAssetsManifest({
+            entrypoints: true,
+            publicPath: true,
+            writeToDisk: true,
+            output: 'actualmanifest.json',
+          }),
         ],
         externals: {
           '@18f/identity-i18n': '_i18n_',
@@ -52,7 +59,7 @@ describe('RailsI18nWebpackPlugin', () => {
         try {
           expect(webpackError).to.be.null();
 
-          for (const chunkSuffix of ['1', '946']) {
+          for (const chunkSuffix of ['1', '946', '452']) {
             // eslint-disable-next-line no-await-in-loop
             const [script, en, es, fr] = await Promise.all([
               fs.readFile(path.resolve(__dirname, `spec/fixtures/actual${chunkSuffix}.js`)),
@@ -82,6 +89,37 @@ describe('RailsI18nWebpackPlugin', () => {
           expect(onMissingString).to.have.been.calledWithExactly('item.2', 'fr');
           expect(onMissingString).to.have.been.calledWithExactly('item.3', 'fr');
           expect(onMissingString).to.have.been.calledWithExactly('item.3', 'en');
+
+          const manifest = JSON.parse(
+            await fs.readFile(
+              path.resolve(__dirname, 'spec/fixtures/actualmanifest.json'),
+              'utf-8',
+            ),
+          );
+
+          expect(manifest.entrypoints['1'].assets.js).to.include.all.members([
+            'actual1.js',
+            'actual1.en.js',
+            'actual1.es.js',
+            'actual1.fr.js',
+            'actual452.en.js',
+            'actual452.es.js',
+            'actual452.fr.js',
+            'actual946.js',
+            'actual946.en.js',
+            'actual946.es.js',
+            'actual946.fr.js',
+          ]);
+          expect(manifest.entrypoints['2'].assets.js).to.include.all.members([
+            'actual2.js',
+            'actual452.en.js',
+            'actual452.es.js',
+            'actual452.fr.js',
+            'actual946.js',
+            'actual946.en.js',
+            'actual946.es.js',
+            'actual946.fr.js',
+          ]);
 
           done();
         } catch (error) {

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js
@@ -1,3 +1,5 @@
 import { t } from '@18f/identity-i18n';
 
+import('./dynamic');
+
 const text = t('forms.button.cancel');

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/dynamic.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/dynamic.js
@@ -1,0 +1,1 @@
+t('forms.dynamic');

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.en.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.en.js
@@ -1,0 +1,1 @@
+!function(){var a,n={"forms.dynamic":"Dynamic"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.es.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.es.js
@@ -1,0 +1,1 @@
+!function(){var a,o={"forms.dynamic":"Dinámico"},i=window._locale_data=window._locale_data||{};for(a in o)i[a]=o[a]}();

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.fr.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.fr.js
@@ -1,0 +1,1 @@
+!function(){var a,n={"forms.dynamic":"Dynamique"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/en.yml
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/en.yml
@@ -3,6 +3,7 @@ en:
     messages:
       one: 'One message'
       other: '%{count} messages'
+    dynamic: Dynamic
     button:
       submit: Submit
       cancel: Cancel

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/es.yml
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/es.yml
@@ -3,6 +3,7 @@ es:
     messages:
       one: 'Un mensaje'
       other: '%{count} mensajes'
+    dynamic: Dinámico
     button:
       submit: Enviar
       cancel: Cancelar

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/fr.yml
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/locales/forms/fr.yml
@@ -3,6 +3,7 @@ fr:
     messages:
       one: 'Un message'
       other: '%{count} messages'
+    dynamic: Dynamique
     button:
       cancel: Annuler
       reset: Réinitialiser


### PR DESCRIPTION
**Why**: To allow translations occurring in dynamically-imported scripts to be loaded.

Currently, string extraction works by adding additional assets associated with the Webpack chunk immediately associated with where the translation occurs. However, the runtime script loader responsible for dynamic script imports is not aware of these assets, therefore translations would not be loaded. The workaround is to associate the extracted translations with the closest entrypoint(s) from where the translation is found, so that the translations are loaded alongside the script which would perform the dynamic script import, via [`AssetSources.get_sources`](https://github.com/18F/identity-idp/blob/060e6fc25226891bb69334d015f17ba2c52a6218/lib/asset_sources.rb#L14-L21).

Specifically, this will support translations to be used in web component implementations (e.g. [`TimeElement`](https://github.com/18F/identity-idp/blob/main/app/javascript/packages/time-element/index.ts)), since those are [imported dynamically after ensuring the custom element polyfill](https://github.com/18F/identity-idp/blob/060e6fc25226891bb69334d015f17ba2c52a6218/app/components/time_component.js#L4).

A better implementation might find a way to hook into the Webpack runtime loader to ensure that the locale files are loaded at the same time as the dynamic import script.