### PR TITLE
Disable ESLint no-undef for TypeScript files

### DIFF
--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -37,6 +37,7 @@ const config = {
     'operator-linebreak': 'off',
     'require-await': 'error',
   },
+  overrides: /** @type {Array<import('eslint').Linter.ConfigOverride>} */ ([]),
 };
 
 if (isInstalled('eslint-plugin-prettier')) {
@@ -88,6 +89,12 @@ if (isInstalled('@typescript-eslint/parser') && isInstalled('@typescript-eslint/
     'no-shadow': 'off',
     'no-unused-vars': 'off',
     'no-use-before-define': 'off',
+  });
+  config.overrides.push({
+    files: ['*.ts'],
+    rules: {
+      'no-undef': 'off',
+    },
   });
 }
 

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -91,7 +91,7 @@ if (isInstalled('@typescript-eslint/parser') && isInstalled('@typescript-eslint/
     'no-use-before-define': 'off',
   });
   config.overrides.push({
-    files: ['*.ts'],
+    files: '*.{ts,tsx}',
     rules: {
       'no-undef': 'off',
     },

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -37,7 +37,6 @@ const config = {
     'operator-linebreak': 'off',
     'require-await': 'error',
   },
-  overrides: /** @type {Array<import('eslint').Linter.ConfigOverride>} */ ([]),
 };
 
 if (isInstalled('eslint-plugin-prettier')) {
@@ -87,14 +86,9 @@ if (isInstalled('@typescript-eslint/parser') && isInstalled('@typescript-eslint/
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': 'error',
     'no-shadow': 'off',
+    'no-undef': 'off',
     'no-unused-vars': 'off',
     'no-use-before-define': 'off',
-  });
-  config.overrides.push({
-    files: ['*.ts'],
-    rules: {
-      'no-undef': 'off',
-    },
   });
 }
 

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -37,6 +37,7 @@ const config = {
     'operator-linebreak': 'off',
     'require-await': 'error',
   },
+  overrides: /** @type {Array<import('eslint').Linter.ConfigOverride>} */ ([]),
 };
 
 if (isInstalled('eslint-plugin-prettier')) {
@@ -86,9 +87,14 @@ if (isInstalled('@typescript-eslint/parser') && isInstalled('@typescript-eslint/
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': 'error',
     'no-shadow': 'off',
-    'no-undef': 'off',
     'no-unused-vars': 'off',
     'no-use-before-define': 'off',
+  });
+  config.overrides.push({
+    files: ['*.ts'],
+    rules: {
+      'no-undef': 'off',
+    },
   });
 }
 


### PR DESCRIPTION
**Why:** So that we don't get [`no-undef`](https://eslint.org/docs/rules/no-undef) lint errors when using e.g. DOM TypeScript helpers, and because the sorts of issues which would be identified through `no-undef` are already accounted for by TypeScript.

Example:

```ts
const inputs: NodeListOf<HTMLInputElement> = document.querySelectorAll('input');
// error  'NodeListOf' is not defined  no-undef
```

See: https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

I intentionally did not add a note to the [package changelog](https://github.com/18F/identity-idp/blob/main/app/javascript/packages/eslint-plugin/CHANGELOG.md), since this could be counted as part of the yet-unreleased note regarding "Added new TypeScript opt-in automatic configuration".