### PR TITLE
Remove a few legacy date parsing instances

### DIFF
--- a/app/services/expired_license_allower.rb
+++ b/app/services/expired_license_allower.rb
@@ -48,8 +48,7 @@ class ExpiredLicenseAllower
     !!(
       only_error_was_document_expired? &&
         response.pii_from_doc[:state_id_expiration] &&
-        # Can switch to Date.parse after next deploy
-        (state_id_exp = DateParser.parse_legacy(response.pii_from_doc[:state_id_expiration])) &&
+        (state_id_exp = Date.parse(response.pii_from_doc[:state_id_expiration])) &&
         state_id_exp >= IdentityConfig.store.proofing_expired_license_after
     )
   end

--- a/app/services/proofing/lexis_nexis/date_formatter.rb
+++ b/app/services/proofing/lexis_nexis/date_formatter.rb
@@ -4,8 +4,7 @@ module Proofing
       attr_reader :date
 
       def initialize(date_string)
-        # Can switch to Date.parse after next deploy
-        @date = DateParser.parse_legacy(date_string)
+        @date = Date.parse(date_string)
       end
 
       def formatted_date

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -497,7 +497,7 @@ feature 'doc auth document capture step' do
           response: DocAuth::Response.new(
             success: false,
             pii_from_doc: DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
-              state_id_expiration: '04/01/2020',
+              state_id_expiration: '2020-04-01',
             ),
             errors: {
               id: [DocAuth::Errors::DOCUMENT_EXPIRED_CHECK],

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -364,7 +364,7 @@ feature 'doc auth document capture step' do
         method: :post_images,
         response: DocAuth::Response.new(
           pii_from_doc: DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
-            state_id_expiration: '04/01/2020',
+            state_id_expiration: '2020-04-01',
           ),
           success: false,
           errors: {

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe DocumentProofingJob, type: :job do
           response: DocAuth::Response.new(
             success: false,
             pii_from_doc: DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
-              state_id_expiration: '04/01/2020',
+              state_id_expiration: '2020-04-01',
             ),
             errors: {
               id: [DocAuth::Errors::DOCUMENT_EXPIRED_CHECK],

--- a/spec/services/expired_license_allower_spec.rb
+++ b/spec/services/expired_license_allower_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ExpiredLicenseAllower do
           let(:proofing_expired_license_after) { Date.new(2021, 3, 1) }
 
           context 'when the state_id_expiration is before proofing_expired_license_after' do
-            let(:pii_from_doc) { { state_id_expiration: '01/01/2021' } }
+            let(:pii_from_doc) { { state_id_expiration: '2021-01-01' } }
 
             it 'does not change the success' do
               expect(processed_response.success?).to eq(false)
@@ -88,7 +88,7 @@ RSpec.describe ExpiredLicenseAllower do
           end
 
           context 'when the state_id_expiration is after proofing_expired_license_after' do
-            let(:pii_from_doc) { { state_id_expiration: '04/01/2021' } }
+            let(:pii_from_doc) { { state_id_expiration: '2021-04-01' } }
 
             it 'returns a successful response with document_expired' do
               expect(processed_response).to_not eq(response)
@@ -112,7 +112,7 @@ RSpec.describe ExpiredLicenseAllower do
         end
 
         context 'when the state_id_expiration is before proofing_expired_license_after' do
-          let(:pii_from_doc) { { state_id_expiration: '01/01/2021' } }
+          let(:pii_from_doc) { { state_id_expiration: '2021-01-01' } }
 
           it 'has would_have_passed false' do
             expect(processed_response.extra).to include(
@@ -123,7 +123,7 @@ RSpec.describe ExpiredLicenseAllower do
         end
 
         context 'when the state_id_expiration is after proofing_expired_license_after' do
-          let(:pii_from_doc) { { state_id_expiration: '04/01/2021' } }
+          let(:pii_from_doc) { { state_id_expiration: '2021-04-01' } }
 
           it 'has would_have_passed true' do
             expect(processed_response.extra).to include(

--- a/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
+++ b/spec/services/proofing/lexis_nexis/date_formatter_spec.rb
@@ -6,12 +6,6 @@ describe Proofing::LexisNexis::DateFormatter do
   describe '#date' do
     subject(:date) { date_formatter.date }
 
-    context 'with a MM/DD/YYYY formatted date' do
-      let(:date_string) { '01/02/1993' }
-
-      it { is_expected.to eq(Date.new(1993, 1, 2)) }
-    end
-
     context 'with a YYYYMMDD formatted date' do
       let(:date_string) { '19930102' }
 
@@ -26,7 +20,7 @@ describe Proofing::LexisNexis::DateFormatter do
   end
 
   describe '#formatted_date' do
-    let(:date_string) { '04/15/2020' }
+    let(:date_string) { '2020-04-15' }
 
     it 'is a hash' do
       expect(date_formatter.formatted_date).to eq(


### PR DESCRIPTION
**Why**: Since #5191, data in pii_from_doc should be the
international/ISO YYYY-MM-DD format

Thanks for [the reminder](https://github.com/18F/identity-idp/pull/5191#discussion_r817919645) @aduth 