### PR TITLE
Switch remember device cookie to session expiration

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -77,6 +77,10 @@ module RememberDeviceConcern
   end
 
   def remember_device_cookie_expiration
-    IdentityConfig.store.remember_device_expiration_hours_aal_1.hours.from_now
+    if IdentityConfig.store.set_remember_device_session_expiration
+      nil
+    else
+      IdentityConfig.store.remember_device_expiration_hours_aal_1.hours.from_now
+    end
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -213,6 +213,7 @@ session_check_frequency: 30
 session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
+set_remember_device_session_expiration: false
 show_select_account_on_repeat_sp_visits: false
 sp_context_needed_environment: 'prod'
 sp_handoff_bounce_max_seconds: 2

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -303,6 +303,7 @@ class IdentityConfig
     config.add(:session_timeout_in_minutes, type: :integer)
     config.add(:session_timeout_warning_seconds, type: :integer)
     config.add(:session_total_duration_timeout_in_minutes, type: :integer)
+    config.add(:set_remember_device_session_expiration, type: :boolean)
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:show_select_account_on_repeat_sp_visits, type: :boolean)

--- a/spec/features/remember_device/cookie_expiration_spec.rb
+++ b/spec/features/remember_device/cookie_expiration_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'signing in with remember device and closing browser' do
+  include SamlAuthHelper
+
+  let(:user) { user_with_2fa }
+
+  context 'with feature flag set' do
+    before do
+      allow(IdentityConfig.store).to receive(:set_remember_device_session_expiration).
+        and_return(true)
+    end
+
+    it 'expires the remember device cookie' do
+      sign_in_user_with_remember_device
+      expire_cookies
+      sign_in_user(user)
+
+      expect(current_url).to match(%r{/login/two_factor/})
+    end
+  end
+
+  context 'with feature flag unset' do
+    before do
+      allow(IdentityConfig.store).to receive(:set_remember_device_session_expiration).
+        and_return(false)
+    end
+
+    it 'does not expire the remember device cookie' do
+      sign_in_user_with_remember_device
+      expire_cookies
+      sign_in_user(user)
+
+      expect(current_url).to match(%r{/account})
+    end
+  end
+
+  def sign_in_user_with_remember_device
+    sign_in_user(user)
+    check t('forms.messages.remember_device')
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+  end
+
+  # see http://jamesferg.com/testing/bdd/hacking-capybara-cookies/
+  def expire_cookies
+    cookies = Capybara.
+      current_session.
+      driver.
+      browser.
+      current_session.
+      instance_variable_get(:@rack_mock_session).
+      cookie_jar.
+      instance_variable_get(:@cookies)
+
+    cookies.reject! { |c| c.expired? != false }
+  end
+end


### PR DESCRIPTION
**Why:** Our current implementation sets a 30-day expiration on the
remember device cookie, which means that it persists even after the
browser is closed. This switches the cookie to session expiration so
that it expires when the browser closes to conform with 800-63B section
7.2:

> "Session secrets SHALL be non-persistent. That is, they SHALL NOT be
> retained across a restart of the associated application or a reboot of
> the host device."