### PR TITLE
Remove view_component gem require to fix deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'uglifier', '~> 4.2'
 gem 'valid_email', '>= 0.1.3'
-gem 'view_component', '~> 2.49.1', require: 'view_component/engine'
+gem 'view_component', '~> 2.49.1'
 gem 'webauthn', '~> 2.1'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'


### PR DESCRIPTION
Warning:
> DEPRECATION WARNING: This manually engine loading is deprecated
> and will be removed in v3.0.0. Remove `require "view_component/engine"`.

