### PR TITLE
Fix links on SMS opt-in pages

### DIFF
--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -23,10 +23,6 @@
           url: @other_mfa_options_url,
           text: t('two_factor_authentication.login_options_link_text'),
         },
-        decorated_session.sp_name && {
-          url: return_to_sp_cancel_path(location: 'sms_resubscribe_error'),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-        },
         {
           url: MarketingSite.contact_url,
           text: t('links.contact_support', app_name: APP_NAME),

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -31,4 +31,6 @@
       ].select(&:present?),
     ) %>
 
-<%= render 'shared/cancel', link: sign_out_path %>
+<div class="margin-top-4 padding-top-1 border-top border-primary-light">
+  <%= link_to cancel_link_text, @cancel_url %>
+</div>

--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -28,4 +28,6 @@
               @other_mfa_options_url %>
 <% end %>
 
-<%= render 'shared/cancel', link: @cancel_url %>
+<div class="margin-top-4 padding-top-1 border-top border-primary-light">
+  <%= link_to cancel_link_text, @cancel_url %>
+</div>

--- a/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
   let(:phone_configuration) { build(:phone_configuration, phone: '1 888-867-5309') }
   let(:other_mfa_options_url) { nil }
-  let(:cancel_url) { nil }
+  let(:cancel_url) { '/account' }
 
   before do
     assign(:phone_configuration, phone_configuration)

--- a/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
@@ -5,14 +5,10 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
   let(:other_mfa_options_url) { nil }
   let(:cancel_url) { nil }
 
-  let(:sp_name) { nil }
-  let(:decorated_session) { instance_double('SessionDecorator', sp_name: sp_name) }
-
   before do
     assign(:phone_configuration, phone_configuration)
     assign(:other_mfa_options_url, other_mfa_options_url)
     assign(:cancel_url, cancel_url)
-    allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:user_signing_up?).and_return(false)
   end
 
@@ -54,34 +50,6 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
           t('two_factor_authentication.login_options_link_text'),
           href: other_mfa_options_url,
         )
-      end
-    end
-
-    context 'with an sp' do
-      let(:sp_name) { 'An Example SP' }
-
-      it 'links to the sp' do
-        render
-
-        expect(rendered).to have_link(
-          t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        )
-      end
-    end
-
-    context 'without an sp' do
-      let(:sp_name) { nil }
-
-      it 'has a contact support but not a "Get Help At" link' do
-        render
-
-        expect(rendered).to have_link(
-          t('links.contact_support', app_name: APP_NAME),
-          href: MarketingSite.contact_url,
-        )
-
-        doc = Nokogiri::HTML(rendered)
-        expect(doc.css('.troubleshooting-options__options li').length).to eq(1)
       end
     end
   end

--- a/spec/views/two_factor_authentication/sms_opt_in/new.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/new.html.erb' do
   let(:phone_configuration) { build(:phone_configuration, phone: phone) }
   let(:phone_number_opt_out) { PhoneNumberOptOut.create_or_find_with_phone(phone) }
   let(:other_mfa_options_url) { nil }
-  let(:cancel_url) { nil }
+  let(:cancel_url) { '/account' }
 
   before do
     assign(:phone_configuration, phone_configuration)


### PR DESCRIPTION
Two changes from testing:
- Remove "get help at SP" link
- Fix cancel link location (the partial is aimed at IDV, this is not the same thing)
    