### PR TITLE
Log ACR values and scopes form the OIDC auth request

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -207,8 +207,8 @@ class OpenidConnectAuthorizeForm
     {
       client_id: client_id,
       redirect_uri: result_uri,
-      scope: scope,
-      acr_values: acr_values,
+      scope: scope&.sort&.join(' '),
+      acr_values: acr_values&.sort&.join(' '),
       unauthorized_scope: @unauthorized_scope,
     }
   end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -207,6 +207,8 @@ class OpenidConnectAuthorizeForm
     {
       client_id: client_id,
       redirect_uri: result_uri,
+      scope: scope,
+      acr_values: acr_values,
       unauthorized_scope: @unauthorized_scope,
     }
   end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  client_id: client_id,
                  errors: {},
                  unauthorized_scope: true,
-                 user_fully_authenticated: true)
+                 user_fully_authenticated: true,
+                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
+                 scope: "openid")
           expect(@analytics).to receive(:track_event).
             with(Analytics::SP_REDIRECT_INITIATED,
                  ial: 1)
@@ -104,7 +106,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      client_id: client_id,
                      errors: {},
                      unauthorized_scope: false,
-                     user_fully_authenticated: true)
+                     user_fully_authenticated: true,
+                     acr_values: "http://idmanagement.gov/ns/assurance/ial/2",
+                     scope: "openid profile")
               expect(@analytics).to receive(:track_event).
                 with(Analytics::SP_REDIRECT_INITIATED,
                      ial: 2)
@@ -213,7 +217,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  unauthorized_scope: true,
                  errors: hash_including(:prompt),
                  error_details: hash_including(:prompt),
-                 user_fully_authenticated: true)
+                 user_fully_authenticated: true,
+                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
+                 scope: "openid")
           expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action
@@ -239,7 +245,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  unauthorized_scope: true,
                  errors: hash_including(:client_id),
                  error_details: hash_including(:client_id),
-                 user_fully_authenticated: true)
+                 user_fully_authenticated: true,
+                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
+                 scope: "openid")
           expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  errors: {},
                  unauthorized_scope: true,
                  user_fully_authenticated: true,
-                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
-                 scope: "openid")
+                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+                 scope: 'openid')
           expect(@analytics).to receive(:track_event).
             with(Analytics::SP_REDIRECT_INITIATED,
                  ial: 1)
@@ -107,8 +107,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      errors: {},
                      unauthorized_scope: false,
                      user_fully_authenticated: true,
-                     acr_values: "http://idmanagement.gov/ns/assurance/ial/2",
-                     scope: "openid profile")
+                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
+                     scope: 'openid profile')
               expect(@analytics).to receive(:track_event).
                 with(Analytics::SP_REDIRECT_INITIATED,
                      ial: 2)
@@ -218,8 +218,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  errors: hash_including(:prompt),
                  error_details: hash_including(:prompt),
                  user_fully_authenticated: true,
-                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
-                 scope: "openid")
+                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+                 scope: 'openid')
           expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action
@@ -246,8 +246,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  errors: hash_including(:client_id),
                  error_details: hash_including(:client_id),
                  user_fully_authenticated: true,
-                 acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
-                 scope: "openid")
+                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+                 scope: 'openid')
           expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
           client_id: client_id,
           redirect_uri: nil,
           unauthorized_scope: true,
+          acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
+          scope: "openid",
         )
       end
     end
@@ -62,6 +64,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
             redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
                           "Response+type+is+not+included+in+the+list&state=#{state}",
             unauthorized_scope: true,
+            acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
+            scope: "openid",
           )
         end
       end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
           client_id: client_id,
           redirect_uri: nil,
           unauthorized_scope: true,
-          acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
-          scope: "openid",
+          acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+          scope: 'openid',
         )
       end
     end
@@ -64,8 +64,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
             redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
                           "Response+type+is+not+included+in+the+list&state=#{state}",
             unauthorized_scope: true,
-            acr_values: "http://idmanagement.gov/ns/assurance/ial/1",
-            scope: "openid",
+            acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+            scope: 'openid',
           )
         end
       end


### PR DESCRIPTION
**Why**: So we can use the event log to see what SPs are requesting