### PR TITLE
Add LOGIN_TASK_LOG_LEVEL env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,14 @@ APP_NAME = 'Login.gov'.freeze
 
 module Upaya
   class Application < Rails::Application
-    configuration = Identity::Hostdata::ConfigReader.new(app_root: Rails.root).read_configuration(
+    if (log_level = ENV['LOGIN_TASK_LOG_LEVEL'])
+      Identity::Hostdata.logger.level = log_level
+    end
+
+    configuration = Identity::Hostdata::ConfigReader.new(
+      app_root: Rails.root,
+      logger: Identity::Hostdata.logger
+    ).read_configuration(
       Rails.env, write_copy_to: Rails.root.join('tmp', 'application.yml')
     )
     IdentityConfig.build_store(configuration)

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Upaya
 
     configuration = Identity::Hostdata::ConfigReader.new(
       app_root: Rails.root,
-      logger: Identity::Hostdata.logger
+      logger: Identity::Hostdata.logger,
     ).read_configuration(
       Rails.env, write_copy_to: Rails.root.join('tmp', 'application.yml')
     )


### PR DESCRIPTION
- Lets us set log level to minimize STDOUT output
  from Identity::Hostdata (downloading files from S3, etc)