### PR TITLE
Do not 500 when resetting password for account with an unconfirmed email address that has since been confirmed by another account

### DIFF
--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -30,9 +30,7 @@ class ResetPasswordForm
       # If the user is not saved in the database, that means looking them up by
       # their token failed
       errors.add(:reset_password_token, 'invalid_token', type: :invalid_token)
-    elsif invalid_account?
-      errors.add(:reset_password_token, 'token_expired', type: :token_expired)
-    elsif !user.reset_password_period_valid?
+    elsif !user.reset_password_period_valid? || invalid_account?
       errors.add(:reset_password_token, 'token_expired', type: :token_expired)
     end
   end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -30,6 +30,8 @@ class ResetPasswordForm
       # If the user is not saved in the database, that means looking them up by
       # their token failed
       errors.add(:reset_password_token, 'invalid_token', type: :invalid_token)
+    elsif invalid_account?
+      errors.add(:reset_password_token, 'token_expired', type: :token_expired)
     elsif !user.reset_password_period_valid?
       errors.add(:reset_password_token, 'token_expired', type: :token_expired)
     end
@@ -54,6 +56,21 @@ class ResetPasswordForm
     profile&.deactivate(:password_reset)
     Funnel::DocAuth::ResetSteps.call(user.id)
     user.proofing_component&.destroy
+  end
+
+  # It is possible for an account that is resetting their password to be "invalid".
+  # If an unconfirmed account (which must have one unconfirmed email address) resets their
+  # password and a different account then adds and confirms that same email address,
+  # the initial account is no longer able to confirm their email address and is effectively invalid.
+  #
+  # They may still have a valid forgot password link for the initial account, which would normally
+  # mark their email as confirmed when they set a new password, but we do not want to allow it
+  # because we only allow an email address to be confirmed on one account.
+  def invalid_account?
+    !user.confirmed? &&
+      EmailAddress.confirmed.exists?(
+        email_fingerprint: user.email_addresses.map(&:email_fingerprint),
+      )
   end
 
   def extra_analytics_attributes

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -150,6 +150,25 @@ describe ResetPasswordForm, type: :model do
       end
     end
 
+    context 'when the unconfirmed email address has been confirmed by another account' do
+      it 'does not raise an error and is not successful' do
+        user = create(:user, :unconfirmed)
+        user.update(reset_password_sent_at: Time.zone.now)
+        user2 = create(:user)
+        create(
+          :email_address, email: user.email_addresses.first.email, user_id: user2.id,
+                          confirmed_at: Time.zone.now
+        )
+
+        form = ResetPasswordForm.new(user)
+
+        result = form.submit(password: 'a good and powerful password')
+
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq({ reset_password_token: ['token_expired'] })
+      end
+    end
+
     it_behaves_like 'strong password', 'ResetPasswordForm'
   end
 end


### PR DESCRIPTION
Kind of circuitous, but very possible way to get a 500 ([NewRelic](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=ba16a0da-9bd2-2291-376c-21844327d596))

1. Register with EMAIL1 (do not confirm)
2. Reset password on EMAIL1
3. Register with EMAIL2
4. Confirm EMAIL2 via email received
5. Add 2FA
6. Go to account page logged in as EMAIL2
7. Click add email
8. Add EMAIL1
9. Open the recently received EMAIL1 confirmation email sent on behalf of EMAIL2
10. Log out
11. Open reset password email received in step 2
12. Enter new password and submit
13. 500

The index collision happens because we only allow one record with a given email address to be confirmed. The reset password token is generated for the first account which hasn't yet confirmed the email address. In the meantime, a second account is created that adds and confirms the same email address. When the first account opens the password reset email, and enters a password, we attempt to update the email address as being confirmed (and correctly fail).