### PR TITLE
Modify autovacuum config for devices and users tables

### DIFF
--- a/db/primary_migrate/20220307214616_postgre_sql_autovacuum_config.rb
+++ b/db/primary_migrate/20220307214616_postgre_sql_autovacuum_config.rb
@@ -1,0 +1,31 @@
+class PostgreSqlAutovacuumConfig < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      execute <<-SQL
+        ALTER TABLE "devices" SET (autovacuum_vacuum_scale_factor = 0.02,
+                                   autovacuum_analyze_scale_factor = 0.01,
+                                   autovacuum_vacuum_threshold = 0);
+
+        ALTER TABLE "users" SET (autovacuum_vacuum_scale_factor = 0.02,
+                                 autovacuum_analyze_scale_factor = 0.01,
+                                 autovacuum_vacuum_threshold = 0);
+      SQL
+    end
+  end
+
+  # restores original settings:
+  # https://github.com/18F/identity-devops/issues/4175#issuecomment-1062302198
+  def down
+    safety_assured do
+      execute <<-SQL
+        ALTER TABLE "devices" RESET (autovacuum_vacuum_scale_factor,
+                                     autovacuum_analyze_scale_factor,
+                                     autovacuum_vacuum_threshold);
+
+        ALTER TABLE "users" RESET (autovacuum_vacuum_scale_factor,
+                                   autovacuum_analyze_scale_factor,
+                                   autovacuum_vacuum_threshold);
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_224754) do
+ActiveRecord::Schema.define(version: 2022_03_07_214616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
DB config change needed to support https://github.com/18F/identity-devops/issues/4175

Tested in `pt` env
```
              == 20220307214616 PostgreSqlAutovacuumConfig: migrating =======================
              -- execute("        ALTER TABLE \"devices\" SET (autovacuum_vacuum_scale_factor = 0.02,\n                                        autovacuum_analyze_scale_factor = 0.01,\n                                        autovacuum_vacuum_threshold = 0);\n\n        ALTER TABLE \"users\" SET (autovacuum_vacuum_scale_factor = 0.02,\n                                        autovacuum_analyze_scale_factor = 0.01,\n                                        autovacuum_vacuum_threshold = 0);\n")
                 -> 0.0036s
              == 20220307214616 PostgreSqlAutovacuumConfig: migrated (0.0089s) ==============
              
              deploy/migrate finished
```
