### PR TITLE
Fix 500 during account reset

### DIFF
--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -26,7 +26,7 @@ module AccountReset
     private
 
     def track_event(result)
-      analytics.account_reset(**result.to_h)
+      analytics.track_event(Analytics::ACCOUNT_RESET, result.to_h)
     end
 
     def handle_valid_token

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -122,6 +122,7 @@ class Analytics
   end
 
   # rubocop:disable Layout/LineLength
+  ACCOUNT_RESET = 'Account Reset'
   ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
   ADD_EMAIL = 'Add Email: Email Submitted'
   ADD_EMAIL_CONFIRMATION = 'Add Email: Email Confirmation'


### PR DESCRIPTION
Partially reverts to fix a bug introduced in #6014 that causes a 500 during account reset