### PR TITLE
Create common interface for accessing PII bundle in session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -193,7 +193,7 @@ class ApplicationController < ActionController::Base
 
     flash[:info] = t('account.personal_key.needs_new')
 
-    pii_unlocked = Pii::Cacher.new(current_user, user_session).fetch.present?
+    pii_unlocked = Pii::Cacher.new(current_user, user_session).exists_in_session?
 
     if pii_unlocked
       cacher = Pii::Cacher.new(current_user, user_session)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -193,7 +193,7 @@ class ApplicationController < ActionController::Base
 
     flash[:info] = t('account.personal_key.needs_new')
 
-    pii_unlocked = user_session[:decrypted_pii].present?
+    pii_unlocked = Pii::Cacher.new(current_user, user_session).fetch.present?
 
     if pii_unlocked
       cacher = Pii::Cacher.new(current_user, user_session)

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -74,7 +74,9 @@ module Idv
     end
 
     def pii_to_h
-      JSON.parse(user_session[:decrypted_pii])
+      JSON.parse(
+        Pii::Cacher.new(current_user, user_session).fetch_string,
+      )
     end
 
     def resolution_success(hash)

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -9,7 +9,7 @@ module Idv
       analytics.track_event(Analytics::IDV_START_OVER, **location_params)
       user_session['idv/doc_auth'] = {}
       idv_session.clear
-      user_session.delete(:decrypted_pii)
+      Pii::Cacher.new(current_user, user_session).delete
       redirect_to idv_url
     end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -137,7 +137,7 @@ module OpenidConnect
     def pii_requested_but_locked?
       sp_session && sp_session_ial > 1 &&
         UserDecorator.new(current_user).identity_verified? &&
-        Pii::Cacher.new(current_user, user_session).fetch.blank?
+        !Pii::Cacher.new(current_user, user_session).exists_in_session?
     end
 
     def track_events

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -137,7 +137,7 @@ module OpenidConnect
     def pii_requested_but_locked?
       sp_session && sp_session_ial > 1 &&
         UserDecorator.new(current_user).identity_verified? &&
-        user_session[:decrypted_pii].blank?
+        Pii::Cacher.new(current_user, user_session).fetch.blank?
     end
 
     def track_events

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -95,7 +95,8 @@ class SamlIdpController < ApplicationController
   end
 
   def identity_needs_decryption?
-    UserDecorator.new(current_user).identity_verified? && user_session[:decrypted_pii].blank?
+    UserDecorator.new(current_user).identity_verified? &&
+      Pii::Cacher.new(current_user, user_session).fetch.blank?
   end
 
   def capture_analytics

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -96,7 +96,7 @@ class SamlIdpController < ApplicationController
 
   def identity_needs_decryption?
     UserDecorator.new(current_user).identity_verified? &&
-      Pii::Cacher.new(current_user, user_session).fetch.blank?
+      !Pii::Cacher.new(current_user, user_session).exists_in_session?
   end
 
   def capture_analytics

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -81,7 +81,8 @@ module SignUp
     end
 
     def pii
-      JSON.parse(user_session.fetch('decrypted_pii', '{}')).symbolize_keys
+      pii_string = Pii::Cacher.new(current_user, user_session).fetch_string
+      JSON.parse(pii_string || '{}').symbolize_keys
     end
   end
 end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -82,7 +82,7 @@ module SignUp
 
     def pii
       pii_string = Pii::Cacher.new(current_user, user_session).fetch_string
-      JSON.parse(pii_string || '{}').symbolize_keys
+      JSON.parse(pii_string || '{}', symbolize_names: true)
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -27,7 +27,8 @@ module Users
     private
 
     def capture_password_if_pii_requested_but_locked
-      return unless current_user.decorate.identity_verified? && user_session[:decrypted_pii].blank?
+      return unless current_user.decorate.identity_verified? &&
+                    Pii::Cacher.new(current_user, user_session).fetch.blank?
       user_session[:stored_location] = request.url
       redirect_to capture_password_url
     end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -28,7 +28,7 @@ module Users
 
     def capture_password_if_pii_requested_but_locked
       return unless current_user.decorate.identity_verified? &&
-                    Pii::Cacher.new(current_user, user_session).fetch.blank?
+                    !Pii::Cacher.new(current_user, user_session).exists_in_session?
       user_session[:stored_location] = request.url
       redirect_to capture_password_url
     end

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -29,6 +29,10 @@ module Pii
       user_session[:decrypted_pii]
     end
 
+    def exists_in_session?
+      fetch_string.present?
+    end
+
     def delete
       user_session.delete(:decrypted_pii)
     end

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -19,9 +19,18 @@ module Pii
     end
 
     def fetch
-      decrypted_pii = user_session[:decrypted_pii]
-      return unless decrypted_pii
-      Pii::Attributes.new_from_json(decrypted_pii)
+      pii_string = fetch_string
+      return nil unless pii_string
+
+      Pii::Attributes.new_from_json(pii_string)
+    end
+
+    def fetch_string
+      user_session[:decrypted_pii]
+    end
+
+    def delete
+      user_session.delete(:decrypted_pii)
     end
 
     private

--- a/app/services/pii/session_store.rb
+++ b/app/services/pii/session_store.rb
@@ -15,7 +15,8 @@ module Pii
 
     def load
       session = session_accessor.load
-      Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+
+      Pii::Cacher.new(nil, session.dig('warden.user.user.session')).fetch
     end
 
     # @api private

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -452,6 +452,7 @@ describe SamlIdpController do
           zipcode: '12345',
         )
       end
+      let(:pii_json) { pii.present? ? pii.to_json : nil }
       let(:this_authn_request) do
         ial2_authnrequest = saml_authn_request_url(
           overrides: {
@@ -481,7 +482,7 @@ describe SamlIdpController do
         )
         allow(subject).to receive(:attribute_asserter) { asserter }
 
-        controller.user_session[:decrypted_pii] = pii
+        controller.user_session[:decrypted_pii] = pii_json
       end
 
       it 'calls AttributeAsserter#build' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -112,7 +112,7 @@ describe Users::PasswordsController do
       end
 
       it 'renders form if PII is decrypted' do
-        controller.user_session[:decrypted_pii] = pii
+        controller.user_session[:decrypted_pii] = pii.to_json
 
         get :edit
 


### PR DESCRIPTION
On the road to different methods of encrypting/decrypting user data and being more precise in our usage of KMS, changing how we interface with accessing PII bundles opens up some more opportunities with how we can handle it.

With a common interface, it becomes possible for us to do things like lazily decrypt sensitive data, which will reduce the amount of time and number of times where a request is holding sensitive decrypted data.

These changes remove all of the instances where `decrypted_pii` is checked in place of using the `Pii::Cacher#fetch`. Some areas still need to use the decrypted string rather than `Pii::Attributes`, so a `fetch_string` method was added to support those cases.