### PR TITLE
Queue PhoneNumberOptOutSyncJob as long running

### DIFF
--- a/app/jobs/phone_number_opt_out_sync_job.rb
+++ b/app/jobs/phone_number_opt_out_sync_job.rb
@@ -1,4 +1,5 @@
 class PhoneNumberOptOutSyncJob < ApplicationJob
+  queue_as :long_running
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(


### PR DESCRIPTION
They take a bit and run on a schedule, so they should fit in the long running queue