### PR TITLE
Avoid duplicated hot-path User and ServiceProvider queries

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -106,6 +106,10 @@ class ApplicationController < ActionController::Base
     user_session[:context] || UserSessionContext::DEFAULT_CONTEXT
   end
 
+  def current_sp
+    @current_sp ||= sp_from_sp_session || sp_from_request_id || sp_from_request_issuer_logout
+  end
+
   private
 
   # These attributes show up in New Relic traces for all requests.
@@ -153,10 +157,6 @@ class ApplicationController < ActionController::Base
 
   def permitted_timeout_params
     params.permit(:request_id)
-  end
-
-  def current_sp
-    @current_sp ||= sp_from_sp_session || sp_from_request_id || sp_from_request_issuer_logout
   end
 
   def sp_from_sp_session
@@ -422,11 +422,11 @@ class ApplicationController < ActionController::Base
 
   def add_sp_cost(token)
     Db::SpCost::AddSpCost.call(
-      sp_session[:issuer].to_s,
+      current_sp,
       sp_session_ial,
       token,
       transaction_id: nil,
-      user_id: current_user.id,
+      user: current_user,
     )
   end
 

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -36,7 +36,7 @@ module IdvSession
     @idv_session ||= Idv::Session.new(
       user_session: user_session,
       current_user: effective_user,
-      issuer: sp_session[:issuer],
+      service_provider: current_sp,
     )
   end
 

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -118,7 +118,7 @@ module Idv
     def confirmation_maker_perform
       confirmation_maker = GpoConfirmationMaker.new(
         pii: Pii::Cacher.new(current_user, user_session).fetch,
-        issuer: sp_session[:issuer],
+        service_provider: current_sp,
         profile: current_user.pending_profile,
       )
       confirmation_maker.perform
@@ -241,7 +241,7 @@ module Idv
 
     def async_state_done_analytics(result)
       analytics.track_event(Analytics::IDV_GPO_ADDRESS_SUBMITTED, result.to_h)
-      Db::SpCost::AddSpCost.call(sp_session[:issuer].to_s, 2, :lexis_nexis_resolution)
+      Db::SpCost::AddSpCost.call(current_sp, 2, :lexis_nexis_resolution)
       Db::ProofingCost::AddUserProofingCost.call(current_user.id, :lexis_nexis_resolution)
     end
 

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -21,7 +21,7 @@ module Idv
       @image_upload_form ||= Idv::ApiImageUploadForm.new(
         params,
         liveness_checking_enabled: liveness_checking_enabled?,
-        issuer: sp_session[:issuer].to_s,
+        service_provider: current_sp,
         analytics: analytics,
         uuid_prefix: current_sp&.app_id,
       )

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -11,10 +11,11 @@ module Idv
     validate :validate_images
     validate :throttle_if_rate_limited
 
-    def initialize(params, liveness_checking_enabled:, issuer:, analytics: nil, uuid_prefix: nil)
+    def initialize(params, liveness_checking_enabled:, service_provider:, analytics: nil,
+                   uuid_prefix: nil)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
-      @issuer = issuer
+      @service_provider = service_provider
       @analytics = analytics
       @readable = {}
       @uuid_prefix = uuid_prefix
@@ -42,7 +43,7 @@ module Idv
 
     private
 
-    attr_reader :params, :analytics, :issuer, :form_response, :uuid_prefix
+    attr_reader :params, :analytics, :service_provider, :form_response, :uuid_prefix
 
     def throttled_else_increment
       return unless document_capture_session
@@ -249,7 +250,7 @@ module Idv
     def add_costs(response)
       Db::AddDocumentVerificationAndSelfieCosts.
         new(user_id: user_id,
-            issuer: issuer,
+            service_provider: service_provider,
             liveness_checking_enabled: liveness_checking_enabled?).
         call(response)
     end
@@ -258,7 +259,7 @@ module Idv
       steps = %i[front_image back_image]
       steps << :selfie if liveness_checking_enabled?
       steps.each do |step|
-        Funnel::DocAuth::RegisterStep.new(user_id, issuer).
+        Funnel::DocAuth::RegisterStep.new(user_id, service_provider&.issuer).
           call(step.to_s, :update, client_response.success?)
       end
     end

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -21,8 +21,9 @@ class AddressProofingJob < ApplicationJob
       address_proofer.proof(applicant_pii)
     end
 
+    service_provider = ServiceProvider.find_by(issuer: issuer)
     Db::SpCost::AddSpCost.call(
-      issuer, 2, :lexis_nexis_address, transaction_id: proofer_result.transaction_id
+      service_provider, 2, :lexis_nexis_address, transaction_id: proofer_result.transaction_id
     )
     Db::ProofingCost::AddUserProofingCost.call(user_id, :lexis_nexis_address)
 

--- a/app/services/db/add_document_verification_and_selfie_costs.rb
+++ b/app/services/db/add_document_verification_and_selfie_costs.rb
@@ -1,7 +1,7 @@
 module Db
   class AddDocumentVerificationAndSelfieCosts
-    def initialize(user_id:, issuer:, liveness_checking_enabled:)
-      @issuer = issuer
+    def initialize(user_id:, service_provider:, liveness_checking_enabled:)
+      @service_provider = service_provider
       @liveness_checking_enabled = liveness_checking_enabled
       @user_id = user_id
     end
@@ -15,10 +15,10 @@ module Db
 
     private
 
-    attr_reader :issuer, :liveness_checking_enabled, :user_id
+    attr_reader :service_provider, :liveness_checking_enabled, :user_id
 
     def add_cost(token)
-      Db::SpCost::AddSpCost.call(issuer, 2, token)
+      Db::SpCost::AddSpCost.call(service_provider, 2, token)
       Db::ProofingCost::AddUserProofingCost.call(user_id, token)
     end
   end

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -1,8 +1,8 @@
 module Flow
   class BaseFlow
     attr_accessor :flow_session
-    attr_reader :steps, :actions, :current_user, :params, :request, :json, :http_status,
-                :controller
+    attr_reader :steps, :actions, :current_user, :current_sp, :params, :request, :json,
+                :http_status, :controller
 
     def initialize(controller, steps, actions, session)
       @controller = controller
@@ -70,7 +70,7 @@ module Flow
       FormResponse.new(success: true)
     end
 
-    delegate :flash, :session, :current_user, :params, :request, :poll_with_meta_refresh,
-             :analytics, to: :@controller
+    delegate :flash, :session, :current_user, :current_sp, :params, :request,
+             :poll_with_meta_refresh, :analytics, to: :@controller
   end
 end

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -81,7 +81,7 @@ module Flow
       request.headers['X-Amzn-Trace-Id']
     end
 
-    delegate :flash, :session, :flow_session, :current_user, :params, :steps, :request,
+    delegate :flash, :session, :flow_session, :current_user, :current_sp, :params, :steps, :request,
              :poll_with_meta_refresh, to: :@flow
   end
 end

--- a/app/services/gpo_confirmation_maker.rb
+++ b/app/services/gpo_confirmation_maker.rb
@@ -1,9 +1,9 @@
 class GpoConfirmationMaker
-  def initialize(pii:, issuer:, profile: nil, profile_id: nil, otp: nil)
+  def initialize(pii:, service_provider:, profile: nil, profile_id: nil, otp: nil)
     raise ArgumentError 'must have either profile or profile_id' if !profile && !profile_id
 
     @pii = pii
-    @issuer = issuer
+    @service_provider = service_provider
     @profile = profile
     @profile_id = profile_id
     @otp = otp
@@ -25,7 +25,7 @@ class GpoConfirmationMaker
 
   private
 
-  attr_reader :pii, :issuer, :profile, :profile_id
+  attr_reader :pii, :service_provider, :profile, :profile_id
 
   def attributes
     {
@@ -37,7 +37,7 @@ class GpoConfirmationMaker
       last_name: pii[:last_name],
       state: pii[:state],
       zipcode: pii[:zipcode],
-      issuer: issuer,
+      issuer: service_provider&.issuer,
     }
   end
 
@@ -50,6 +50,6 @@ class GpoConfirmationMaker
 
   def update_proofing_cost
     Db::ProofingCost::AddUserProofingCost.call(profile&.user&.id, :gpo_letter)
-    Db::SpCost::AddSpCost.call(issuer, 2, :gpo_letter)
+    Db::SpCost::AddSpCost.call(service_provider, 2, :gpo_letter)
   end
 end

--- a/app/services/gpo_daily_test_sender.rb
+++ b/app/services/gpo_daily_test_sender.rb
@@ -4,7 +4,7 @@ class GpoDailyTestSender
     if valid_designated_receiver_pii?
       GpoConfirmationMaker.new(
         pii: IdentityConfig.store.gpo_designated_receiver_pii,
-        issuer: nil,
+        service_provider: nil,
         profile_id: -1, # profile_id can't be null on GpoConfirmationCode
         otp: otp_from_date,
       ).perform

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -1,14 +1,14 @@
 class IdentityLinker
-  attr_reader :user, :provider
+  attr_reader :user, :issuer
 
-  def initialize(user, provider)
+  def initialize(user, issuer)
     @user = user
-    @provider = provider
+    @issuer = issuer
     @ial = nil
   end
 
   def link_identity(**extra_attrs)
-    return unless user && provider.present?
+    return unless user && issuer.present?
     process_ial(extra_attrs)
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
@@ -46,11 +46,11 @@ class IdentityLinker
     identity_record = identity_relation.first
     return identity_record if identity_record
     Db::SpCost::AddSpCost.call(service_provider, @ial, :user_added)
-    user.identities.create(service_provider: provider)
+    user.identities.create(service_provider: issuer)
   end
 
   def identity_relation
-    user.identities.where(service_provider: provider)
+    user.identities.where(service_provider: issuer)
   end
 
   def merged_attributes(extra_attrs)
@@ -94,7 +94,7 @@ class IdentityLinker
   end
 
   def service_provider
-    return if provider.blank?
-    @service_provider ||= ServiceProvider.find_by(issuer: provider)
+    return if issuer.blank?
+    @service_provider ||= ServiceProvider.find_by(issuer: issuer)
   end
 end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -45,7 +45,7 @@ class IdentityLinker
   def find_or_create_identity_with_costing
     identity_record = identity_relation.first
     return identity_record if identity_record
-    Db::SpCost::AddSpCost.call(provider, @ial, :user_added)
+    Db::SpCost::AddSpCost.call(service_provider, @ial, :user_added)
     user.identities.create(service_provider: provider)
   end
 
@@ -91,5 +91,10 @@ class IdentityLinker
   def merge_attributes(verified_attributes)
     verified_attributes = verified_attributes.to_a.map(&:to_s)
     (identity.verified_attributes.to_a + verified_attributes).uniq.sort
+  end
+
+  def service_provider
+    return if provider.blank?
+    @service_provider ||= ServiceProvider.find_by(issuer: provider)
   end
 end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -74,7 +74,7 @@ module Idv
     end
 
     def uuid_prefix
-      ServiceProvider.find_by(issuer: idv_session.issuer)&.app_id
+      idv_session.service_provider&.app_id
     end
 
     def normalized_phone
@@ -143,7 +143,7 @@ module Idv
       Idv::Agent.new(applicant).proof_address(
         document_capture_session,
         trace_id: trace_id,
-        issuer: idv_session.issuer,
+        issuer: idv_session.service_provider&.issuer,
         user_id: idv_session.current_user.id,
       )
     end

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -73,7 +73,7 @@ module Idv
 
     def add_cost
       Db::ProofingCost::AddUserProofingCost.call(user.id, :phone_otp)
-      Db::SpCost::AddSpCost.call(idv_session.issuer, 2, :phone_otp)
+      Db::SpCost::AddSpCost.call(idv_session.service_provider, 2, :phone_otp)
     end
 
     def extra_analytics_attributes

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -19,13 +19,12 @@ module Idv
       resolution_successful
     ].freeze
 
-    attr_reader :current_user, :gpo_otp, :service_provider, :issuer
+    attr_reader :current_user, :gpo_otp, :service_provider
 
     def initialize(user_session:, current_user:, service_provider:)
       @user_session = user_session
       @current_user = current_user
       @service_provider = service_provider
-      @issuer = service_provider&.issuer
       set_idv_session
     end
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -110,15 +110,14 @@ module Idv
       end
 
       def add_cost(token, transaction_id: nil)
-        issuer = sp_session[:issuer].to_s
-        Db::SpCost::AddSpCost.call(issuer, 2, token, transaction_id: transaction_id)
+        Db::SpCost::AddSpCost.call(current_sp, 2, token, transaction_id: transaction_id)
         Db::ProofingCost::AddUserProofingCost.call(user_id, token)
       end
 
       def add_costs(result)
         Db::AddDocumentVerificationAndSelfieCosts.
           new(user_id: user_id,
-              issuer: sp_session[:issuer].to_s,
+              service_provider: current_sp,
               liveness_checking_enabled: liveness_checking_enabled?).
           call(result)
       end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'IdvStepConcern' do
   let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
   let(:idv_session) do
-    Idv::Session.new(user_session: subject.user_session, current_user: user, issuer: nil)
+    Idv::Session.new(user_session: subject.user_session, current_user: user, service_provider: nil)
   end
 
   module Idv

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -132,11 +132,12 @@ describe Idv::GpoController do
     allow(pii_cacher).to receive(:fetch).and_return(pii)
     allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
 
-    session[:sp] = { issuer: '123abc' }
+    service_provider = create(:service_provider, issuer: '123abc')
+    session[:sp] = { issuer: service_provider.issuer }
 
     gpo_confirmation_maker = instance_double(GpoConfirmationMaker)
     allow(GpoConfirmationMaker).to receive(:new).
-      with(pii: pii, issuer: '123abc', profile: pending_profile).
+      with(pii: pii, service_provider: service_provider, profile: pending_profile).
       and_return(gpo_confirmation_maker)
 
     expect(gpo_confirmation_maker).to receive(:perform)

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -9,7 +9,7 @@ describe Idv::PersonalKeyController do
     idv_session = Idv::Session.new(
       user_session: subject.user_session,
       current_user: user,
-      issuer: nil,
+      service_provider: nil,
     )
     idv_session.applicant = applicant
     idv_session.resolution_successful = true

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -28,7 +28,7 @@ describe Idv::ReviewController do
     idv_session = Idv::Session.new(
       user_session: subject.user_session,
       current_user: user,
-      issuer: nil,
+      service_provider: nil,
     )
     idv_session.profile_confirmation = true
     idv_session.vendor_phone_confirmation = true

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Idv::ApiImageUploadForm do
         document_capture_session_uuid: document_capture_session_uuid,
       ),
       liveness_checking_enabled: liveness_checking_enabled?,
-      issuer: 'test_issuer',
+      service_provider: build(:service_provider, issuer: 'test_issuer'),
       analytics: fake_analytics,
     )
   end

--- a/spec/jobs/address_proofing_job_spec.rb
+++ b/spec/jobs/address_proofing_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AddressProofingJob, type: :job do
     )
   end
   let(:user_id) { SecureRandom.random_number(1000) }
-  let(:issuer) { build(:service_provider).issuer }
+  let(:service_provider) { create(:service_provider) }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -28,7 +28,7 @@ RSpec.describe AddressProofingJob, type: :job do
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
         user_id: user_id,
-        issuer: issuer,
+        issuer: service_provider.issuer,
       )
 
       result = document_capture_session.load_proofing_result[:result]
@@ -46,7 +46,7 @@ RSpec.describe AddressProofingJob, type: :job do
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
         user_id: user_id,
-        issuer: issuer,
+        issuer: service_provider.issuer,
       )
     end
 
@@ -96,7 +96,7 @@ RSpec.describe AddressProofingJob, type: :job do
           to(change { SpCost.count }.by(1).and(change { ProofingCost.count }.by(1)))
 
         sp_cost = SpCost.last
-        expect(sp_cost.issuer).to eq(issuer)
+        expect(sp_cost.issuer).to eq(service_provider.issuer)
         expect(sp_cost.transaction_id).to eq(conversation_id)
 
         proofing_cost = ProofingCost.last

--- a/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
+++ b/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Db::AddDocumentVerificationAndSelfieCosts do
   let(:user_id) { 1 }
-  let(:issuer) { 'foo' }
+  let(:service_provider) { build(:service_provider, issuer: 'foo') }
   let(:liveness_checking_enabled) { false }
   let(:billed_response) do
     DocAuth::Response.new(
@@ -30,7 +30,7 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
   subject do
     described_class.new(
       user_id: user_id,
-      issuer: issuer,
+      service_provider: service_provider,
       liveness_checking_enabled: liveness_checking_enabled,
     )
   end
@@ -88,6 +88,9 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
   end
 
   def costing_for(cost_type)
-    SpCost.where(ial: 2, issuer: issuer, agency_id: 0, cost_type: cost_type.to_s).first
+    SpCost.where(
+      ial: 2, issuer: service_provider.issuer, agency_id: service_provider.agency_id,
+      cost_type: cost_type.to_s
+    ).first
   end
 end

--- a/spec/services/gpo_confirmation_maker_spec.rb
+++ b/spec/services/gpo_confirmation_maker_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe GpoConfirmationMaker do
   let(:otp) { '123ABC' }
   let(:issuer) { 'this-is-an-issuer' }
+  let(:service_provider) { build(:service_provider, issuer: issuer) }
   let(:decrypted_attributes) do
     {
       address1: '123 main st', address2: '',
@@ -21,7 +22,7 @@ describe GpoConfirmationMaker do
   end
   let(:profile) { create(:profile) }
 
-  subject { described_class.new(pii: pii, issuer: issuer, profile: profile) }
+  subject { described_class.new(pii: pii, service_provider: service_provider, profile: profile) }
 
   describe '#perform' do
     before do

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -15,7 +15,7 @@ describe Idv::PhoneStep do
     idvs = Idv::Session.new(
       user_session: {},
       current_user: user,
-      issuer: service_provider.issuer,
+      service_provider: service_provider,
     )
     idvs.applicant = { first_name: 'Some' }
     idvs

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -12,7 +12,9 @@ describe Idv::SendPhoneConfirmationOtp do
       delivery_method: delivery_preference,
     )
   end
-  let(:idv_session) { Idv::Session.new(user_session: {}, current_user: user, issuer: '') }
+  let(:idv_session) {
+    Idv::Session.new(user_session: {}, current_user: user, service_provider: nil)
+  }
 
   let(:user) { create(:user, :signed_up) }
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -4,7 +4,9 @@ describe Idv::Session do
   let(:user) { build(:user) }
   let(:user_session) { {} }
 
-  subject { Idv::Session.new(user_session: user_session, current_user: user, issuer: nil) }
+  subject {
+    Idv::Session.new(user_session: user_session, current_user: user, service_provider: nil)
+  }
 
   describe '#method_missing' do
     it 'disallows un-supported attributes' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -36,7 +36,10 @@ module ControllerHelper
   def stub_verify_steps_one_and_two(user)
     user_session = {}
     stub_sign_in(user)
-    idv_session = Idv::Session.new(user_session: user_session, current_user: user, issuer: nil)
+    idv_session = Idv::Session.new(
+      user_session: user_session, current_user: user,
+      service_provider: nil
+    )
     idv_session.applicant = { first_name: 'Some', last_name: 'One' }.with_indifferent_access
     idv_session.profile_confirmation = true
     allow(subject).to receive(:confirm_idv_session_started).and_return(true)


### PR DESCRIPTION
`User.find` and `ServiceProvider.find` are two of our most frequent queries. Though they're fast, they make up a [significant portion](https://onenr.io/0qwL2xZKgj5) of total Postgres time

Part of that is due to querying for a ServiceProvider by issuer and User by id when adding SP cost. This PR lifts the queries out of `Db::SpCost::AddSpCost` and puts the responsibility on callers of the function to provide all of the data ahead of time. For the most part, we are querying the issuer in `sp_session`, which `current_sp` has probably already done.

It gets a little weird in doc auth with having to adjust the delegation and moving `current_sp` to a public method, but I think it's worth it.

There's opportunity to apply a similar pattern to `IdentityLinker` which accepts an `issuer`, but that can be saved for a followup if we're happy with the kind of adjustments being made here.