### PR TITLE
Avoid duplicated ServiceProvider queries in IdentityLinker

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -105,7 +105,7 @@ module SamlIdpAuthConcern
 
   def link_identity_from_session_data
     IdentityLinker.
-      new(current_user, current_issuer).
+      new(current_user, current_service_provider).
       link_identity(
         ial: ial_context.ial_for_identity_record,
         rails_session_id: session.id,

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -24,7 +24,7 @@ module SamlIdpAuthConcern
   end
 
   def check_sp_active
-    return if current_service_provider&.active?
+    return if saml_request_service_provider&.active?
     redirect_to sp_inactive_error_url
   end
 
@@ -32,7 +32,7 @@ module SamlIdpAuthConcern
     @saml_request_validator = SamlRequestValidator.new
 
     @result = @saml_request_validator.call(
-      service_provider: current_service_provider,
+      service_provider: saml_request_service_provider,
       authn_context: requested_authn_contexts,
       authn_context_comparison: saml_request.requested_authn_context_comparison,
       nameid_format: name_id_format,
@@ -49,7 +49,7 @@ module SamlIdpAuthConcern
   end
 
   def specified_name_id_format
-    if recognized_name_id_format? || current_service_provider&.use_legacy_name_id_behavior
+    if recognized_name_id_format? || saml_request_service_provider&.use_legacy_name_id_behavior
       saml_request.name_id_format
     end
   end
@@ -59,7 +59,7 @@ module SamlIdpAuthConcern
   end
 
   def default_name_id_format
-    if current_service_provider&.email_nameid_format_allowed
+    if saml_request_service_provider&.email_nameid_format_allowed
       return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     end
     Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
@@ -80,16 +80,16 @@ module SamlIdpAuthConcern
   end
 
   def default_aal_context
-    if current_service_provider&.default_aal
-      Saml::Idp::Constants::AUTHN_CONTEXT_AAL_TO_CLASSREF[current_service_provider.default_aal]
+    if saml_request_service_provider&.default_aal
+      Saml::Idp::Constants::AUTHN_CONTEXT_AAL_TO_CLASSREF[saml_request_service_provider.default_aal]
     else
       Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
     end
   end
 
   def default_ial_context
-    if current_service_provider&.ial
-      Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[current_service_provider.ial]
+    if saml_request_service_provider&.ial
+      Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[saml_request_service_provider.ial]
     else
       Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
     end
@@ -105,7 +105,7 @@ module SamlIdpAuthConcern
 
   def link_identity_from_session_data
     IdentityLinker.
-      new(current_user, current_service_provider).
+      new(current_user, saml_request_service_provider).
       link_identity(
         ial: ial_context.ial_for_identity_record,
         rails_session_id: session.id,
@@ -121,7 +121,7 @@ module SamlIdpAuthConcern
   def ial_context
     @ial_context ||= IalContext.new(
       ial: requested_ial_authn_context,
-      service_provider: current_service_provider,
+      service_provider: saml_request_service_provider,
     )
   end
 
@@ -137,7 +137,7 @@ module SamlIdpAuthConcern
   def attribute_asserter(principal)
     AttributeAsserter.new(
       user: principal,
-      service_provider: current_service_provider,
+      service_provider: saml_request_service_provider,
       name_id_format: name_id_format,
       authn_request: saml_request,
       decrypted_pii: decrypted_pii,
@@ -163,20 +163,21 @@ module SamlIdpAuthConcern
       reference_id: active_identity.session_uuid,
       encryption: encryption_opts,
       signature: saml_response_signature_options,
-      signed_response_message: current_service_provider&.signed_response_message_requested,
+      signed_response_message: saml_request_service_provider&.signed_response_message_requested,
     )
   end
 
   def encryption_opts
     query_params = UriService.params(request.original_url)
-    if query_params[:skip_encryption].present? && current_service_provider&.skip_encryption_allowed
+    if query_params[:skip_encryption].present? &&
+       saml_request_service_provider&.skip_encryption_allowed
       nil
-    elsif current_service_provider&.encrypt_responses?
+    elsif saml_request_service_provider&.encrypt_responses?
       cert = saml_request.service_provider.matching_cert ||
-             current_service_provider&.ssl_certs&.first
+             saml_request_service_provider&.ssl_certs&.first
       {
         cert: cert,
-        block_encryption: current_service_provider&.block_encryption,
+        block_encryption: saml_request_service_provider&.block_encryption,
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
@@ -190,9 +191,9 @@ module SamlIdpAuthConcern
     }
   end
 
-  def current_service_provider
-    return @current_service_provider if defined?(@current_service_provider)
-    @current_service_provider = ServiceProvider.find_by(issuer: current_issuer)
+  def saml_request_service_provider
+    return @saml_request_service_provider if defined?(@saml_request_service_provider)
+    @saml_request_service_provider = ServiceProvider.find_by(issuer: current_issuer)
   end
 
   def current_issuer

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -16,7 +16,7 @@ module VerifySpAttributesConcern
   def update_verified_attributes
     IdentityLinker.new(
       current_user,
-      sp_session[:issuer],
+      current_sp,
     ).link_identity(
       ial: sp_session_ial,
       verified_attributes: sp_session[:requested_attributes],

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -70,7 +70,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def link_identity_to_service_provider(current_user, rails_session_id)
-    identity_linker = IdentityLinker.new(current_user, client_id)
+    identity_linker = IdentityLinker.new(current_user, service_provider)
     @identity = identity_linker.link_identity(
       nonce: nonce,
       rails_session_id: rails_session_id,

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
   end
 
   let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
+  let(:service_provider) { build(:service_provider, issuer: client_id) }
   let(:params) do
     {
       acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -34,7 +35,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
       context 'with valid params' do
         it 'redirects back to the client app with a code' do
-          IdentityLinker.new(user, client_id).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -61,7 +62,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with(Analytics::SP_REDIRECT_INITIATED,
                  ial: 1)
 
-          IdentityLinker.new(user, client_id).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
           action
@@ -77,7 +78,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             let(:user) { create(:profile, :active, :verified).user }
 
             it 'redirects to the redirect_uri immediately when pii is unlocked' do
-              IdentityLinker.new(user, client_id).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -88,7 +89,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'redirects to the password capture url when pii is locked' do
-              IdentityLinker.new(user, client_id).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -113,7 +114,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 with(Analytics::SP_REDIRECT_INITIATED,
                      ial: 2)
 
-              IdentityLinker.new(user, client_id).link_identity(ial: 2)
+              IdentityLinker.new(user, service_provider).link_identity(ial: 2)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -131,7 +132,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'creates an IAL2 SpReturnLog record' do
-                IdentityLinker.new(user, client_id).link_identity(ial: 22)
+                IdentityLinker.new(user, service_provider).link_identity(ial: 22)
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -176,7 +177,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
         context 'user has already approved this application' do
           before do
-            IdentityLinker.new(user, client_id).link_identity
+            IdentityLinker.new(user, service_provider).link_identity
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           end
 

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe OpenidConnect::TokenController do
     let(:grant_type) { 'authorization_code' }
     let(:code) { identity.session_uuid }
     let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
+    let(:service_provider) { build(:service_provider, issuer: client_id) }
     let(:client_assertion) do
       jwt_payload = {
         iss: client_id,
@@ -33,7 +34,10 @@ RSpec.describe OpenidConnect::TokenController do
     end
 
     let!(:identity) do
-      IdentityLinker.new(user, client_id).link_identity(rails_session_id: SecureRandom.hex, ial: 1)
+      IdentityLinker.new(user, service_provider).link_identity(
+        rails_session_id: SecureRandom.hex,
+        ial: 1,
+      )
     end
 
     context 'with valid params' do

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Risc::SecurityEventsController do
   include Rails.application.routes.url_helpers
 
   let(:user) { create(:user) }
-  let(:identity) { IdentityLinker.new(user, service_provider.issuer).link_identity }
+  let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
   let(:service_provider) { create(:service_provider) }
 
   let(:rp_private_key) do

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Users::ServiceProviderRevokeController do
   before do
     stub_sign_in(user)
 
-    @identity = IdentityLinker.new(user, service_provider.issuer).link_identity
+    @identity = IdentityLinker.new(user, service_provider).link_identity
   end
 
   describe '#show' do

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -62,7 +62,8 @@ describe 'Account Reset Request: Delete Account', email: true do
     end
 
     it 'sends push notifications if push_notifications_enabled is true' do
-      identity = IdentityLinker.new(user, 'urn:gov:gsa:openidconnect:test').link_identity
+      service_provider = build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:test')
+      identity = IdentityLinker.new(user, service_provider).link_identity
       agency_identity = AgencyIdentityLinker.new(identity).link_identity
 
       signin(user_email, user.password)

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -87,9 +87,10 @@ describe 'OpenID Connect' do
 
     it 'auto-allows with a second authorization and includes redirect_uris in CSP headers' do
       client_id = 'urn:gov:gsa:openidconnect:sp:server'
+      service_provider = build(:service_provider, issuer: client_id)
       user = user_with_2fa
 
-      IdentityLinker.new(user, client_id).link_identity
+      IdentityLinker.new(user, service_provider).link_identity
       user.identities.last.update!(verified_attributes: ['email'])
 
       visit_idp_from_ial1_oidc_sp(client_id: client_id, prompt: 'select_account')
@@ -107,9 +108,10 @@ describe 'OpenID Connect' do
 
     it 'auto-allows and includes redirect_uris in CSP headers after an incorrect OTP' do
       client_id = 'urn:gov:gsa:openidconnect:sp:server'
+      service_provider = build(:service_provider, issuer: client_id)
       user = user_with_2fa
 
-      IdentityLinker.new(user, client_id).link_identity
+      IdentityLinker.new(user, service_provider).link_identity
       user.identities.last.update!(verified_attributes: ['email'])
 
       visit_idp_from_ial1_oidc_sp(client_id: client_id, prompt: 'select_account')
@@ -292,7 +294,7 @@ describe 'OpenID Connect' do
   it 'prompts for consent if last consent time was over a year ago', driver: :mobile_rack_test do
     client_id = 'urn:gov:gsa:openidconnect:test'
     user = user_with_2fa
-    link_identity(user, client_id)
+    link_identity(user, build(:service_provider, issuer: client_id))
 
     user.identities.last.update(
       last_consented_at: 2.years.ago,
@@ -314,7 +316,7 @@ describe 'OpenID Connect' do
   it 'prompts for consent if consent was revoked/soft deleted', driver: :mobile_rack_test do
     client_id = 'urn:gov:gsa:openidconnect:test'
     user = user_with_2fa
-    link_identity(user, client_id)
+    link_identity(user, build(:service_provider, issuer: client_id))
 
     user.identities.last.update!(
       last_consented_at: 2.years.ago,
@@ -343,7 +345,7 @@ describe 'OpenID Connect' do
       code_challenge = Digest::SHA256.base64digest(code_verifier)
       user = user_with_2fa
 
-      link_identity(user, client_id)
+      link_identity(user, build(:service_provider, issuer: client_id))
       user.identities.last.update!(verified_attributes: ['email'])
 
       visit openid_connect_authorize_path(
@@ -386,7 +388,7 @@ describe 'OpenID Connect' do
     it 'returns the most recent nonce when there are multiple authorize calls' do
       client_id = 'urn:gov:gsa:openidconnect:test'
       user = user_with_2fa
-      link_identity(user, client_id)
+      link_identity(user, build(:service_provider, issuer: client_id))
       user.identities.last.update!(verified_attributes: ['email'])
 
       state1 = SecureRandom.hex
@@ -650,7 +652,7 @@ describe 'OpenID Connect' do
     code_verifier = SecureRandom.hex
     code_challenge = Digest::SHA256.base64digest(code_verifier)
 
-    link_identity(user, client_id)
+    link_identity(user, build(:service_provider, issuer: client_id))
     user.identities.last.update!(verified_attributes: ['email'])
 
     visit openid_connect_authorize_path(

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -18,7 +18,7 @@ describe 'signing in with remember device and idling on the sign in page' do
     first(:link, t('links.sign_out')).click
 
     IdentityLinker.new(
-      user, 'urn:gov:gsa:openidconnect:sp:server'
+      user, build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:server')
     ).link_identity(verified_attributes: %w[email])
 
     visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -43,8 +43,9 @@ feature 'User profile' do
     it 'deletes the account and pushes notifications if push_notifications_enabled is true' do
       allow(IdentityConfig.store).to receive(:push_notifications_enabled).and_return(true)
 
+      service_provider = build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:test')
       user = sign_in_and_2fa_user
-      identity = IdentityLinker.new(user, 'urn:gov:gsa:openidconnect:test').link_identity
+      identity = IdentityLinker.new(user, service_provider).link_identity
       agency_identity = AgencyIdentityLinker.new(identity).link_identity
 
       visit account_path

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OpenidConnectTokenForm do
   let(:user) { create(:user) }
 
   let!(:identity) do
-    IdentityLinker.new(user, client_id).
+    IdentityLinker.new(user, service_provider).
       link_identity(
         nonce: nonce,
         rails_session_id: SecureRandom.hex,

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SecurityEventForm do
       File.read(Rails.root.join('keys', 'saml_test_sp.key')),
     )
   end
-  let(:identity) { IdentityLinker.new(user, service_provider.issuer).link_identity }
+  let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
   let(:jti) { SecureRandom.urlsafe_base64 }
 
   let(:event_type) { SecurityEvent::AUTHORIZATION_FRAUD_DETECTED }

--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe PushNotification::HttpPush do
   let(:sp_no_push_url) { create(:service_provider, push_notification_url: nil) }
 
   let!(:sp_with_push_url_identity) do
-    IdentityLinker.new(user, sp_with_push_url.issuer).link_identity
+    IdentityLinker.new(user, sp_with_push_url).link_identity
   end
   let!(:sp_no_push_url_identity) do
-    IdentityLinker.new(user, sp_no_push_url.issuer).link_identity
+    IdentityLinker.new(user, sp_no_push_url).link_identity
   end
 
   let(:event) do
@@ -109,7 +109,7 @@ RSpec.describe PushNotification::HttpPush do
       let(:third_sp) { create(:service_provider, push_notification_url: 'http://sp.url/push') }
 
       before do
-        IdentityLinker.new(user, third_sp.issuer).link_identity
+        IdentityLinker.new(user, third_sp).link_identity
 
         stub_request(:post, sp_with_push_url.push_notification_url).to_timeout
         stub_request(:post, third_sp.push_notification_url).to_return(status: 200)

--- a/spec/services/uuid_reporter_spec.rb
+++ b/spec/services/uuid_reporter_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe UuidReporter do
       let!(:user2) { create(:user, :signed_up, email: 'user2@example.com') }
       let!(:user3) { create(:user, :signed_up, email: 'user3@example.com') }
       let!(:uuid1) do
-        IdentityLinker.new(user1, sp1.issuer).link_identity
+        IdentityLinker.new(user1, sp1).link_identity
         AgencyIdentity.find_by(user_id: user1.id, agency_id: agency.id).uuid
       end
       let!(:uuid2) do
-        IdentityLinker.new(user2, sp2.issuer).link_identity
+        IdentityLinker.new(user2, sp2).link_identity
         AgencyIdentity.find_by(user_id: user2.id, agency_id: agency.id).uuid
       end
 
@@ -104,7 +104,7 @@ RSpec.describe UuidReporter do
       end
 
       before(:each) do
-        IdentityLinker.new(user3, create(:service_provider).issuer).link_identity
+        IdentityLinker.new(user3, create(:service_provider)).link_identity
       end
 
       after(:each) { File.delete(valid_output) }

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -615,10 +615,10 @@ module Features
       nonce
     end
 
-    def link_identity(user, client_id, ial = nil)
+    def link_identity(user, service_provider, ial = nil)
       IdentityLinker.new(
         user,
-        client_id,
+        service_provider,
       ).link_identity(
         ial: ial,
       )

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -125,6 +125,10 @@ module SamlAuthHelper
 
   public
 
+  def sp1
+    build(:service_provider, issuer: sp1_issuer)
+  end
+
   def sp1_issuer
     'https://rp1.serviceprovider.com/auth/saml/metadata'
   end
@@ -175,7 +179,7 @@ module SamlAuthHelper
 
     IdentityLinker.new(
       user,
-      settings.issuer,
+      build(:service_provider, issuer: settings.issuer),
     ).link_identity(
       ial: ial2_requested?(settings) ? true : nil,
       verified_attributes: ['email'],

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -51,7 +51,7 @@ shared_examples 'remember device' do
     user = remember_device_and_sign_out_user
 
     IdentityLinker.new(
-      user, 'urn:gov:gsa:openidconnect:sp:server'
+      user, build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:server')
     ).link_identity(verified_attributes: %w[email])
 
     visit oidc_url


### PR DESCRIPTION
Builds on #6058 to avoid duplicating a `ServiceProvider.find` query in `IdentityLinker`