### PR TITLE
Add tags for previous event names, migrate more events (LG-5915, LG-5944)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,4 +197,9 @@ public/api/_analytics-events.json: .yardoc .yardoc/objects/root.dat
 	bundle exec ruby lib/analytics_events_documenter.rb --json $< > $@
 
 .yardoc .yardoc/objects/root.dat: app/services/analytics_events.rb
-	bundle exec yard doc --type-tag identity.idp.event_name:"Event Name" --no-output --db $@ -- $<
+	bundle exec yard doc \
+		--type-tag identity.idp.event_name:"Event Name" \
+		--type-tag identity.idp.previous_event_name:"Previous Event Name" \
+		--no-output \
+		--db $@ \
+		-- $<

--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -14,7 +14,7 @@ module Accounts
       analytics.profile_personal_key_create
       create_user_event(:new_personal_key)
       result = send_new_personal_key_notifications
-      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS, result.to_h)
+      analytics.profile_personal_key_create_notifications(**result.to_h)
 
       flash[:info] = t('account.personal_key.old_key_will_not_work')
       redirect_to manage_personal_key_url

--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -6,12 +6,12 @@ module Accounts
     before_action :confirm_two_factor_authenticated
 
     def new
-      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_VISIT)
+      analytics.profile_personal_key_visit
     end
 
     def create
       user_session[:personal_key] = create_new_code
-      analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      analytics.profile_personal_key_create
       create_user_event(:new_personal_key)
       result = send_new_personal_key_notifications
       analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS, result.to_h)

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -21,7 +21,7 @@ module Idv
       elsif current_async_state.in_progress?
         render :wait
       elsif current_async_state.missing?
-        analytics.track_event(Analytics::PROOFING_ADDRESS_RESULT_MISSING)
+        analytics.proofing_address_result_missing
         render :index
       elsif current_async_state.done?
         async_state_done(current_async_state)

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -21,7 +21,7 @@ module Idv
       elsif async_state.in_progress?
         render :wait
       elsif async_state.missing?
-        analytics.track_event(Analytics::PROOFING_ADDRESS_RESULT_MISSING)
+        analytics.proofing_address_result_missing
         flash.now[:error] = I18n.t('idv.failure.timeout')
         render :new, locals: { gpo_letter_available: gpo_letter_available }
       elsif async_state.done?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -223,8 +223,6 @@ class Analytics
   PHONE_DELETION = 'Phone Number Deletion: Submitted'
   PIV_CAC_LOGIN = 'PIV/CAC Login'
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'
-  PROFILE_PERSONAL_KEY_VISIT = 'Profile: Visited new personal key'
-  PROFILE_PERSONAL_KEY_CREATE = 'Profile: Created new personal key'
   PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'
   PROOFING_RESOLUTION_RESULT_MISSING = 'Proofing Resolution Result Missing' # Previously "Proofing Resolution Timeout"
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -226,8 +226,6 @@ class Analytics
   PROFILE_PERSONAL_KEY_VISIT = 'Profile: Visited new personal key'
   PROFILE_PERSONAL_KEY_CREATE = 'Profile: Created new personal key'
   PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'
-  PROOFING_ADDRESS_RESULT_MISSING = 'Proofing Address Result Missing' # Previously "Proofing Address Timeout"
-  PROOFING_DOCUMENT_RESULT_MISSING = 'Proofing Document Result Missing' # Previously "Proofing Document Timeout"
   PROOFING_RESOLUTION_RESULT_MISSING = 'Proofing Resolution Result Missing' # Previously "Proofing Resolution Timeout"
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'
   REPORT_REGISTERED_USERS_COUNT = 'Report Registered Users Count'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -223,7 +223,6 @@ class Analytics
   PHONE_DELETION = 'Phone Number Deletion: Submitted'
   PIV_CAC_LOGIN = 'PIV/CAC Login'
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'
-  PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'
   PROOFING_RESOLUTION_RESULT_MISSING = 'Proofing Resolution Result Missing' # Previously "Proofing Resolution Timeout"
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'
   REPORT_REGISTERED_USERS_COUNT = 'Report Registered Users Count'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -187,4 +187,20 @@ module AnalyticsEvents
       }.compact,
     )
   end
+
+  # @identity.idp.event_name Proofing Address Result Missing
+  # @identity.idp.previous_event_name Proofing Address Timeout
+  # The job for address verification (PhoneFinder) did not record a result in the expected
+  # place during the expected time frane
+  def proofing_address_result_missing
+    track_event('Proofing Address Result Missing')
+  end
+
+  # @identity.idp.event_name Proofing Document Result Missing
+  # @identity.idp.previous_event_name Proofing Document Timeout
+  # The job for document authentication did not record a result in the expected
+  # place during the expected time frane
+  def proofing_document_result_missing
+    track_event('Proofing Document Result Missing')
+  end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -188,6 +188,18 @@ module AnalyticsEvents
     )
   end
 
+  # @identity.idp.event_name Profile: Visited new personal key
+  # User has visited the page that lets them confirm if they want a new personal key
+  def profile_personal_key_visit
+    track_event('Profile: Visited new personal key')
+  end
+
+  # @identity.idp.event_name Profile: Created new personal key
+  # User has chosen to receive a new personal key
+  def profile_personal_key_create
+    track_event('Profile: Created new personal key')
+  end
+
   # @identity.idp.event_name Proofing Address Result Missing
   # @identity.idp.previous_event_name Proofing Address Timeout
   # The job for address verification (PhoneFinder) did not record a result in the expected

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -195,9 +195,28 @@ module AnalyticsEvents
   end
 
   # @identity.idp.event_name Profile: Created new personal key
+  # @see #profile_personal_key_create_notifications
   # User has chosen to receive a new personal key
   def profile_personal_key_create
     track_event('Profile: Created new personal key')
+  end
+
+  PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'
+  # @identity.idp.event_name Profile: Created new personal key notifications
+  # @param [true] success this event always succeeds
+  # @param [Integer] emails number of email addresses the notification was sent to
+  # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
+  # was notified
+  # User has chosen to receive a new personal key, contains stats about notifications that
+  # were sent to phone numbers and email addresses for the user
+  def profile_personal_key_create_notifications(success:, emails:, sms_message_ids:, **extra)
+    track_event(
+      'Profile: Created new personal key notifications',
+      success: success,
+      emails: emails,
+      sms_message_ids: sms_message_ids,
+      **extra,
+    )
   end
 
   # @identity.idp.event_name Proofing Address Result Missing

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -201,7 +201,6 @@ module AnalyticsEvents
     track_event('Profile: Created new personal key')
   end
 
-  PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS = 'Profile: Created new personal key notifications'
   # @identity.idp.event_name Profile: Created new personal key notifications
   # @param [true] success this event always succeeds
   # @param [Integer] emails number of email addresses the notification was sent to

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -108,7 +108,7 @@ module Idv
 
       def missing
         delete_async
-        @flow.analytics.track_event(Analytics::PROOFING_DOCUMENT_RESULT_MISSING)
+        @flow.analytics.proofing_document_result_missing
         DocumentCaptureSessionAsyncResult.missing
       end
 

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -8,7 +8,8 @@ require 'active_support/core_ext/object/blank'
 # Parses YARD output for AnalyticsEvents methods
 class AnalyticsEventsDocumenter
   DEFAULT_DATABASE_PATH = '.yardoc'
-  EVENT_NAME_TAG = 'identity.idp.event_name'
+  EVENT_NAME_TAG = :'identity.idp.event_name'
+  PREVIOUS_EVENT_NAME_TAG = :'identity.idp.previous_event_name'
 
   DOCUMENTATION_OPTIONAL_PARAMS = %w[
     pii_like_keypaths
@@ -104,6 +105,7 @@ class AnalyticsEventsDocumenter
 
       {
         event_name: method_object.tag(EVENT_NAME_TAG)&.text,
+        previous_event_names: method_object.tags(PREVIOUS_EVENT_NAME_TAG).map(&:text),
         description: method_object.docstring.presence,
         attributes: attributes,
       }

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Accounts::PersonalKeysController do
       expect(generator).to receive(:create)
       expect(@analytics).to receive(:track_event).with('Profile: Created new personal key')
       expect(@analytics).to receive(:track_event).with(
-        Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS,
+        'Profile: Created new personal key notifications',
         hash_including(emails: 1, sms_message_ids: ['fake-message-id']),
       )
 

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Accounts::PersonalKeysController do
       stub_sign_in(create(:user, :with_phone))
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_VISIT)
+      expect(@analytics).to receive(:track_event).with('Profile: Visited new personal key')
 
       get :new
     end
@@ -31,7 +31,7 @@ RSpec.describe Accounts::PersonalKeysController do
         with(subject.current_user).and_return(generator)
 
       expect(generator).to receive(:create)
-      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      expect(@analytics).to receive(:track_event).with('Profile: Created new personal key')
       expect(@analytics).to receive(:track_event).with(
         Analytics::PROFILE_PERSONAL_KEY_CREATE_NOTIFICATIONS,
         hash_including(emails: 1, sms_message_ids: ['fake-message-id']),

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -70,7 +70,7 @@ describe Idv::GpoController do
       )
 
       get :index
-      expect(@analytics).to have_logged_event(Analytics::PROOFING_ADDRESS_RESULT_MISSING, {})
+      expect(@analytics).to have_logged_event('Proofing Address Result Missing', {})
     end
 
     context 'with letter already sent' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -104,9 +104,7 @@ describe Idv::PhoneController do
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
 
       get :new
-      expect(@analytics).to have_received(:track_event).with(
-        Analytics::PROOFING_ADDRESS_RESULT_MISSING,
-      )
+      expect(@analytics).to have_received(:track_event).with('Proofing Address Result Missing')
       expect(flash[:error]).to include t('idv.failure.timeout')
       expect(response).to render_template :new
       put :create, params: { idv_phone_form: { phone: good_phone } }

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe AnalyticsEventsDocumenter do
       @database_dir = database_dir
 
       YARD::Registry.clear
-      YARD::Tags::Library.define_tag('Event Name', :'identity.idp.event_name')
+      YARD::Tags::Library.define_tag('Event Name', AnalyticsEventsDocumenter::EVENT_NAME_TAG)
+      YARD::Tags::Library.define_tag(
+        'Previous Event Name', AnalyticsEventsDocumenter::PREVIOUS_EVENT_NAME_TAG
+      )
       YARD.parse_string(source_code)
       YARD::Registry.save(false, database_dir)
 
@@ -146,6 +149,8 @@ RSpec.describe AnalyticsEventsDocumenter do
         def some_event(success:, count:); end
 
         # @identity.idp.event_name Other Event
+        # @identity.idp.previous_event_name The Old Other Event
+        # @identity.idp.previous_event_name Even Older Other Event
         def other_event; end
       end
     RUBY
@@ -155,6 +160,7 @@ RSpec.describe AnalyticsEventsDocumenter do
         [
           {
             event_name: 'Some Event',
+            previous_event_names: [],
             description: 'The event that does something with stuff',
             attributes: [
               { name: 'success', types: ['Boolean'], description: nil },
@@ -163,6 +169,10 @@ RSpec.describe AnalyticsEventsDocumenter do
           },
           {
             event_name: 'Other Event',
+            previous_event_names: [
+              'The Old Other Event',
+              'Even Older Other Event',
+            ],
             description: nil,
             attributes: [],
           },

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -48,7 +48,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
     it 'calls analytics if missing from no document capture session' do
       response = subject.call
 
-      expect(analytics).to have_logged_event(Analytics::PROOFING_DOCUMENT_RESULT_MISSING, {})
+      expect(analytics).to have_logged_event('Proofing Document Result Missing', {})
       expect(analytics).to have_logged_event(
         Analytics::DOC_AUTH_ASYNC,
         error: 'failed to load verify_document_capture_session',
@@ -67,7 +67,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
         and_return(verify_document_capture_session).at_least(:once)
       response = subject.call
 
-      expect(analytics).to have_logged_event(Analytics::PROOFING_DOCUMENT_RESULT_MISSING, {})
+      expect(analytics).to have_logged_event('Proofing Document Result Missing', {})
       expect(analytics).to have_logged_event(
         Analytics::DOC_AUTH_ASYNC,
         error: 'failed to load async result',


### PR DESCRIPTION
- Adds new `@identity.idp.previous_event_name` tag, exports it for documentation (LG-5915)
- Migrates a batch of events, including 2 with previous names (LG-5944)