### PR TITLE
LG-3877: Remove BassCSS "color-base" module

### DIFF
--- a/app/assets/stylesheets/_vendor.scss
+++ b/app/assets/stylesheets/_vendor.scss
@@ -1,3 +1,2 @@
-@import 'basscss-sass/color-base';
 @import 'basscss-sass/color-forms';
 @import 'basscss-sass/color-tables';

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -3,23 +3,6 @@
   // or at the very least (a) we don't want the margins to offset full-width buttons on mobile, and
   // (b) the default margin would not be large enough on its own.
   margin-right: 0;
-
-  &.usa-button--unstyled:visited {
-    // Temporary: Links in the IdP do not currently conform to the design system and instead retain
-    // their color even if visited. Part of the work of LG-3877 will be to remove these styles, and
-    // instead allow unstyled buttons and links inherit the default design system visited color.
-    // Alternatively, consider removing unstyled button classes from links, since the intention of
-    // unstyled buttons is to take the visual appearance of a link.
-    color: $link-color;
-  }
-}
-
-.usa-button.usa-button--unstyled:hover,
-.usa-button.usa-button--hover.usa-button--unstyled {
-  // Temporary: Links in the IdP do not currently conform to the design system and instead retain
-  // their color while hovered. Part of the work of LG-3877 should be to remove these styles, and
-  // instead allow both unstyled buttons and links inherit the default design system hover color.
-  color: $link-color;
 }
 
 .usa-button--unstyled {

--- a/app/assets/stylesheets/components/_hr.scss
+++ b/app/assets/stylesheets/components/_hr.scss
@@ -1,0 +1,4 @@
+hr {
+  border: 0;
+  border-bottom: 1px solid color('primary-light');
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -8,6 +8,7 @@
 @import 'file-input';
 @import 'footer';
 @import 'form';
+@import 'hr';
 @import 'icon';
 @import 'list';
 @import 'modal';

--- a/app/assets/stylesheets/variables/_vendor.scss
+++ b/app/assets/stylesheets/variables/_vendor.scss
@@ -2,8 +2,10 @@ $theme-body-font-size: 'sm';
 $theme-font-path: 'identity-style-guide/dist/assets/fonts';
 $theme-image-path: 'identity-style-guide/dist/assets/img';
 $theme-global-border-box-sizing: true;
+$theme-global-link-styles: true;
 $theme-grid-container-max-width: 'tablet-lg';
 $theme-header-min-width: 'tablet';
+$theme-link-visited-color: 'primary';
 $theme-utility-breakpoints: (
   'card': false,
   'card-lg': false,

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -17,7 +17,7 @@
       <ul class='usa-list--unstyled margin-bottom-0 text-white text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-decoration-none text-primary fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-decoration-none fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>
@@ -27,15 +27,15 @@
     <div class="display-flex flex-align-center flex-justify-center">
       <div class="display-flex flex-auto">
         <div class="display-flex tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none h6 margin-right-2 usa-link--alt tablet:display-none',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'text-decoration-none h6 margin-right-2 tablet:display-none',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
                           width: 20, alt: '' %>
           <% end %>
         </div>
 
-        <div class="display-none tablet:display-flex">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'display-flex flex-align-center flex-justify-center text-decoration-none text-white h6 margin-right-2 usa-link--alt',
+        <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
+          <%= new_window_link_to 'https://gsa.gov', { class: 'text-decoration-none h6 margin-right-2',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
                           width: 20, class: 'float-left margin-right-1', alt: '' %>
@@ -81,18 +81,18 @@
               ) %>
         </div>
 
-        <div class="display-none tablet:display-flex">
+        <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
           <%= new_window_link_to(
                 t('links.help'), MarketingSite.help_url,
-                class: 'h6 text-white text-decoration-none margin-right-2 usa-link--alt'
+                class: 'h6 text-decoration-none margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.contact'), MarketingSite.contact_url,
-                class: 'h6 text-white text-decoration-none margin-right-2 usa-link--alt'
+                class: 'h6 text-decoration-none margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                class: 'h6 text-white text-decoration-none usa-link--alt'
+                class: 'h6 text-decoration-none'
               ) %>
         </div>
       </div>


### PR DESCRIPTION
**Why**: As a user, I expect that login.gov has a consistent visual style, and that my page load times are not prolonged by loading redundant CSS. As a developer, I expect that existing references to BassCSS module classes are replaced with equivalent USWDS or ad hoc alternatives, so that we can successfully migrate away from and eliminate our dependency on BassCSS.

Styles being removed: https://github.com/basscss/basscss-sass/blob/v3.0.0/_color-base.scss

Specific notes on style substitution:

- https://github.com/basscss/basscss-sass/blob/8edc9d2f0df5aec43dab31db3fcfbce7e35a0a7e/_color-base.scss#L78-L81
   - ➡️  Already [set by USWDS](https://github.com/uswds/uswds/blob/7349ddfc07f3814be51f6e6143fd16b0530771f8/src/stylesheets/base/_body.scss#L2)
- https://github.com/basscss/basscss-sass/blob/8edc9d2f0df5aec43dab31db3fcfbce7e35a0a7e/_color-base.scss#L83-L90
   - ➡️  Compensated by adopting design system global link styles.
- https://github.com/basscss/basscss-sass/blob/8edc9d2f0df5aec43dab31db3fcfbce7e35a0a7e/_color-base.scss#L92-L95
   - ➡️   Already [set by LGDS](https://github.com/18F/identity-style-guide/blob/c6b9e555e3cd179df1c804185d2aa9d6008f6b3b/src/scss/components/_code.scss#L17-L18)
- https://github.com/18F/identity-style-guide/blob/c6b9e555e3cd179df1c804185d2aa9d6008f6b3b/src/scss/components/_code.scss#L17-L18
   - ➡️   Ported styles to new component, since design system includes neither a `<hr>` component nor global styling.