### PR TITLE
Remove some unnecessary/unused CSS

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,12 +1,3 @@
-.usa-banner,
-.usa-banner__button[aria-expanded='true']::before {
-  background-color: color('white');
-}
-
-.usa-banner {
-  box-shadow: inset 0 -1px 0 0 #ccc;
-}
-
 .usa-banner__inner {
   @include at-media('tablet') {
     justify-content: center;

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -23,11 +23,3 @@
     background-color: transparent;
   }
 }
-
-.usa-button--disabled {
-  // There exist some disabled buttons which we expect to only take the visual appearance of a
-  // disabled button, but still allow interactions (e.g. IAL2 Agreement and Document Capture steps).
-  //
-  // See: https://github.com/uswds/uswds/issues/4122
-  pointer-events: all;
-}

--- a/app/assets/stylesheets/components/_general.scss
+++ b/app/assets/stylesheets/components/_general.scss
@@ -1,3 +1,0 @@
-html {
-  background-color: initial;
-}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -1,4 +1,3 @@
-@import 'general';
 @import 'account-header';
 @import 'banner';
 @import 'block-link';

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -4,13 +4,6 @@
   display: none;
 }
 
-.vertical-align::before {
-  content: ' ';
-  display: inline-block;
-  height: 100%;
-  vertical-align: middle;
-}
-
 html.no-js .js {
   display: none;
 }


### PR DESCRIPTION
**Why**: So that our stylesheets remain lean, and so that we have as few ad hoc design system overrides as possible.

Specifics:

- `usa-banner`: Redundant, since background is applied by inner child `usa-banner__header`.
- `usa-banner__button::before`: Unused, since there is no `::before` pseudo-class styles associated with this element.
- `usa-button--disabled`: Addressed upstream in https://github.com/uswds/uswds/pull/4132
- `html`: Unnecessary, because layout of the page is such that footer will always be pushed to bottom of page viewport, thus not necessary to reset the [default "overscroll" background color](https://github.com/18F/identity-style-guide/blob/c6b9e555e3cd179df1c804185d2aa9d6008f6b3b/src/scss/components/_general.scss#L1-L4)
- `vertical-align`: Unused.