### PR TITLE
Replace ad hoc classes with design system equivalents

### DIFF
--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -5,10 +5,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-.text-decoration-none {
-  text-decoration: none;
-}
-
 .text-wrap-anywhere {
   overflow-wrap: anywhere;
 }

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -1,9 +1,5 @@
 // supplemental utility classes
 
-.hidden {
-  display: none;
-}
-
 .vertical-align::before {
   content: ' ';
   display: inline-block;

--- a/app/javascript/packs/upload-step.js
+++ b/app/javascript/packs/upload-step.js
@@ -3,8 +3,8 @@ import { hasCamera } from '@18f/identity-device';
 
 (async () => {
   if (await hasCamera()) {
-    document.getElementById('upload-comp-liveness').classList.add('hidden');
-    document.getElementById('upload-comp-liveness-off').classList.remove('hidden');
-    document.getElementById('recommended-tag').classList.remove('hidden');
+    document.getElementById('upload-comp-liveness').classList.add('display-none');
+    document.getElementById('upload-comp-liveness-off').classList.remove('display-none');
+    document.getElementById('recommended-tag').classList.remove('display-none');
   }
 })();

--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -11,7 +11,7 @@ function webauthn() {
   const isPlatformAvailable = document.getElementById('webauthn_device').value === 'true';
 
   const spinner = document.getElementById('spinner');
-  spinner.classList.remove('hidden');
+  spinner.classList.remove('display-none');
 
   if (
     !WebAuthn.isWebAuthnEnabled() ||
@@ -31,8 +31,8 @@ function webauthn() {
         document.getElementById('authenticator_data').value = result.authenticatorData;
         document.getElementById('client_data_json').value = result.clientDataJSON;
         document.getElementById('signature').value = result.signature;
-        webauthnInProgressContainer.classList.add('hidden');
-        webauthnSuccessContainer.classList.remove('hidden');
+        webauthnInProgressContainer.classList.add('display-none');
+        webauthnSuccessContainer.classList.remove('display-none');
       })
       .catch((error) => {
         document.getElementById('errors').value = error;

--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -21,8 +21,8 @@ function webauthn() {
   }
   const continueButton = document.getElementById('continue-button');
   continueButton.addEventListener('click', () => {
-    document.getElementById('spinner').classList.remove('hidden');
-    document.getElementById('continue-button').className = 'hidden';
+    document.getElementById('spinner').classList.remove('display-none');
+    document.getElementById('continue-button').className = 'display-none';
 
     const platformAuthenticator =
       document.getElementById('platform_authenticator').value === 'true';

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -36,7 +36,7 @@
     <%= link_to(
           t('links.create_account'),
           sign_up_email_url(request_id: @request_id),
-          class: 'text-decoration-none usa-button usa-button--outline usa-button--full-width',
+          class: 'text-no-underline usa-button usa-button--outline usa-button--full-width',
         ) %>
   </div>
 <% end %>

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -35,7 +35,7 @@
         ) %>
   </div>
   <div class="grid-col-12 tablet:grid-col-9">
-    <div id="recommended-tag" class="usa-tag text-ink bg-primary-lighter margin-top-1 display-inline-block <%= 'hidden' if liveness_checking_enabled? %>">
+    <div id="recommended-tag" class="usa-tag text-ink bg-primary-lighter margin-top-1 display-inline-block <%= 'display-none' if liveness_checking_enabled? %>">
       <%= t('doc_auth.info.tag') %>
     </div>
     <h2 class="margin-y-105">
@@ -61,7 +61,7 @@
 
 <hr class="margin-y-4" />
 
-<div id="upload-comp-liveness-off" class="<%= 'hidden' if liveness_checking_enabled? %>">
+<div id="upload-comp-liveness-off" class="<%= 'display-none' if liveness_checking_enabled? %>">
   <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
   <%= validated_form_for(
         :doc_auth,
@@ -74,7 +74,7 @@
     </button>
   <% end %>
 </div>
-<div id="upload-comp-liveness" class="<%= 'hidden' unless liveness_checking_enabled? %>">
+<div id="upload-comp-liveness" class="<%= 'display-none' unless liveness_checking_enabled? %>">
   <strong><%= t('doc_auth.info.upload_from_computer') %></strong>
   <%= t('doc_auth.info.upload_from_computer_not_allowed', app_name: APP_NAME) %>
 </div>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -17,7 +17,7 @@
       <ul class='usa-list--unstyled margin-bottom-0 text-white text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-decoration-none fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-no-underline fs-13p', lang: locale == I18n.locale ? nil : locale %>
           </li>
         <% end %>
       </ul>
@@ -27,7 +27,7 @@
     <div class="display-flex flex-align-center flex-justify-center">
       <div class="display-flex flex-auto">
         <div class="display-flex tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'text-decoration-none h6 margin-right-2 tablet:display-none',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'text-no-underline h6 margin-right-2 tablet:display-none',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
                           width: 20, alt: '' %>
@@ -35,7 +35,7 @@
         </div>
 
         <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'text-decoration-none h6 margin-right-2',
+          <%= new_window_link_to 'https://gsa.gov', { class: 'text-no-underline h6 margin-right-2',
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
                           width: 20, class: 'float-left margin-right-1', alt: '' %>
@@ -48,7 +48,7 @@
       <div class="display-flex flex-align-center flex-justify-center">
         <% if show_language_dropdown %>
           <div class='i18n-desktop-toggle display-none tablet:display-flex margin-x-2 padding-y-1'>
-            <button class='text-white text-decoration-none border border-primary radius-lg padding-x-1 padding-y-05 language-desktop-button' aria-expanded='false'>
+            <button class='text-white text-no-underline border border-primary radius-lg padding-x-1 padding-y-05 language-desktop-button' aria-expanded='false'>
               <%= image_tag asset_url('globe-white.svg'), width: 12,
                                                           class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
               <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
@@ -58,7 +58,7 @@
                 <li class='border-bottom border-primary-darker'>
                   <%= link_to t("i18n.locale.#{locale}"),
                               sanitized_requested_url.merge(locale: locale),
-                              class: 'display-block padding-left-3 padding-y-2 text-decoration-none text-white',
+                              class: 'display-block padding-left-3 padding-y-2 text-no-underline text-white',
                               lang: locale == I18n.locale ? nil : locale %>
                 </li>
               <% end %>
@@ -69,30 +69,30 @@
         <div class="display-flex tablet:display-none">
           <%= new_window_link_to(
                 t('links.help'), MarketingSite.help_url,
-                class: 'h6 text-primary text-decoration-none margin-right-2'
+                class: 'h6 text-primary text-no-underline margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.contact'), MarketingSite.contact_url,
-                class: 'h6 text-primary text-decoration-none margin-right-2'
+                class: 'h6 text-primary text-no-underline margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                class: 'h6 text-primary text-decoration-none'
+                class: 'h6 text-primary text-no-underline'
               ) %>
         </div>
 
         <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
           <%= new_window_link_to(
                 t('links.help'), MarketingSite.help_url,
-                class: 'h6 text-decoration-none margin-right-2'
+                class: 'h6 text-no-underline margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.contact'), MarketingSite.contact_url,
-                class: 'h6 text-decoration-none margin-right-2'
+                class: 'h6 text-no-underline margin-right-2'
               ) %>
           <%= new_window_link_to(
                 t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                class: 'h6 text-decoration-none'
+                class: 'h6 text-no-underline'
               ) %>
         </div>
       </div>

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -34,7 +34,7 @@
           multiple_factors_enabled: @presenter.multiple_factors_enabled?,
         },
       ) do %>
-    <div class="hidden spinner text-center margin-bottom-4" id="spinner">
+    <div class="display-none spinner text-center margin-bottom-4" id="spinner">
       <%= image_tag(
             asset_url('spinner.gif'),
             srcset: asset_url('spinner@2x.gif'),
@@ -52,7 +52,7 @@
     <%= render 'shared/fallback_links', presenter: @presenter %>
   <% end %>
 
-  <div id='webauthn-auth-successful' class="hidden">
+  <div id='webauthn-auth-successful' class="display-none">
     <div class="text-center margin-bottom-2">
       <%= image_tag(
             asset_url('webauthn-verified.svg'),

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -47,7 +47,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
-  <%= submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'hidden' %>
+  <%= submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'display-none' %>
 <% end %>
 <%= button_tag(
       @presenter.button_text,
@@ -55,7 +55,7 @@
       id: 'continue-button',
     ) %>
 
-<div class="spinner hidden margin-y-4" id='spinner'>
+<div class="spinner display-none margin-y-4" id='spinner'>
   <div class='text-center'>
     <%= image_tag(
           asset_url('spinner.gif'),


### PR DESCRIPTION
**Why**: So that we don't have redundant / duplicate styles, and to avoid potential confusion by the availability of multiple options.

Replacements:

Before|After
---|---
`hidden`|[`display-none`](https://designsystem.digital.gov/utilities/display/#utility-display)
`text-decoration-none`|[`text-no-underline`](https://designsystem.digital.gov/utilities/text-styles/#text-decoration)