### PR TITLE
Do not save additional PII to session when not needed

### DIFF
--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -53,7 +53,7 @@ module Idv
 
         delete_async
         if doc_pii_form_result.success?
-          extract_pii_from_doc(async_result)
+          extract_pii_from_doc(async_result, store_in_session: !hybrid_flow_mobile?)
 
           mark_step_complete(:document_capture)
           save_proofing_components

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -54,7 +54,7 @@ module Idv
 
         save_proofing_components
         document_capture_session.store_result_from_response(response)
-        extract_pii_from_doc(response)
+        extract_pii_from_doc(response, store_in_session: !hybrid_flow_mobile?)
         response
       end
 
@@ -97,7 +97,7 @@ module Idv
       def handle_stored_result
         if stored_result.success?
           save_proofing_components
-          extract_pii_from_doc(stored_result)
+          extract_pii_from_doc(stored_result, store_in_session: !hybrid_flow_mobile?)
         else
           extra = { stored_result_present: stored_result.present? }
           failure(I18n.t('doc_auth.errors.general.network_error'), extra)

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -18,7 +18,7 @@ module Idv
 
       def handle_document_verification_success(get_results_response)
         save_proofing_components
-        extract_pii_from_doc(get_results_response)
+        extract_pii_from_doc(get_results_response, store_in_session: true)
         mark_steps_complete
       end
 

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -24,15 +24,20 @@ module Idv
         )
       end
 
-      def check_ssn(pii_from_doc)
+      def check_ssn
+        pii_from_doc = flow_session[:pii_from_doc]
         result = Idv::SsnForm.new(current_user).submit(ssn: pii_from_doc[:ssn])
-        save_legacy_state(pii_from_doc) if result.success?
+
+        if result.success?
+          save_legacy_state(pii_from_doc)
+          flow_session.delete(:pii_from_doc)
+        end
+
         result
       end
 
       def save_legacy_state(pii_from_doc)
         skip_legacy_steps
-        idv_session['params'] = pii_from_doc
         idv_session['applicant'] = pii_from_doc
         idv_session['applicant']['uuid'] = current_user.uuid
       end

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -39,7 +39,7 @@ module Idv
         )
 
         if form_response.success?
-          response = check_ssn(flow_session[:pii_from_doc]) if form_response.success?
+          response = check_ssn if form_response.success?
           form_response = form_response.merge(response)
         end
         summarize_result_and_throttle_failures(form_response)


### PR DESCRIPTION
In working on #6054, I noticed that we save the PII bundle in partial or whole states during the proofing process in places where it will never be read. This is not a significant change from a security or privacy perspective, except in that it reduces the copies of PII held in the session during the proofing process.

This PR addresses two of those instances. The first is when calling `extract_pii_from_doc`, which puts the PII from doc auth into the `pii_from_doc` key in `flow_session`. If we are in the hybrid flow, we are in a separate and temporary session, and `extract_pii_from_doc` will be called in the `LinkSentStep` and stored properly there. With that, we don't need to save it twice.

The other instance is in the transition from the [DocAuthFlow](https://github.com/18F/identity-idp/blob/fe697e810b6877d39195688da055a55b2ac1ff37/app/services/idv/flows/doc_auth_flow.rb#L5-L14) to the address proofing step, where PII is moved from `user_session['idv/doc_auth']['pii_from_doc']` to `user_session['idv']['applicant']`. The storage in `user_session['idv']['params']` seems to be leftover from previous work, as I can't find a place it is used.