### PR TITLE
Add feature flag and interface for MFA prototype

### DIFF
--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -14,6 +14,12 @@
 
 <p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
 
+<% if IdentityConfig.store.select_multiple_mfa_options %>
+  <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4') do %>
+    <%= t('two_factor_authentication.mfa_instructions') %>
+  <% end %>
+<% end %>
+
 <%= validated_form_for @two_factor_options_form,
                        html: { autocomplete: 'off' },
                        method: :patch,
@@ -23,24 +29,46 @@
       <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.intro %></legend>
       <% @presenter.options.each do |option| %>
         <div id="<%= "select_#{option.type}" %>" class="<%= option.html_class %>">
-          <%= radio_button_tag(
-                'two_factor_options_form[selection]',
-                option.type,
-                false,
-                disabled: option.disabled?,
-                class: 'usa-radio__input usa-radio__input--tile',
-              ) %>
-          <%= label_tag(
-                "two_factor_options_form_selection_#{option.type}",
-                class: 'usa-radio__label usa-radio__label--illustrated',
-              ) do %>
-                  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-radio__image') %>
-                  <div class="usa-radio__label--text tablet:padding-left-1"><%= option.label %>
-                    <span class="usa-radio__label-description">
-                      <%= option.info %>
-                    </span>
-                  </div>
-                <% end %>
+          <% if IdentityConfig.store.select_multiple_mfa_options %>
+            <%= check_box_tag(
+                  'two_factor_options_form[selection][]',
+                  option.type,
+                  false,
+                  disabled: option.disabled?,
+                  class: 'usa-checkbox__input usa-checkbox__input--tile',
+                  id: "two_factor_options_form_selection_#{option.type}",
+                ) %>
+            <%= label_tag(
+                  "two_factor_options_form_selection_#{option.type}",
+                  class: 'usa-checkbox__label usa-checkbox__label--illustrated',
+                ) do %>
+                    <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-checkbox__image') %>
+                    <div class="usa-checkbox__label--text tablet:padding-left-1"><%= option.label %>
+                      <span class="usa-checkbox__label-description">
+                        <%= option.info %>
+                      </span>
+                    </div>
+                  <% end %>
+          <% else %>
+            <%= radio_button_tag(
+                  'two_factor_options_form[selection]',
+                  option.type,
+                  false,
+                  disabled: option.disabled?,
+                  class: 'usa-radio__input usa-radio__input--tile',
+                ) %>
+            <%= label_tag(
+                  "two_factor_options_form_selection_#{option.type}",
+                  class: 'usa-radio__label usa-radio__label--illustrated',
+                ) do %>
+                    <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-radio__image') %>
+                    <div class="usa-radio__label--text tablet:padding-left-1"><%= option.label %>
+                      <span class="usa-radio__label-description">
+                        <%= option.info %>
+                      </span>
+                    </div>
+                  <% end %>
+          <% end %>
         </div>
       <% end %>
     </fieldset>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -207,6 +207,7 @@ s3_public_reports_enabled: false
 s3_reports_enabled: false
 saml_secret_rotation_enabled: false
 seed_agreements_data: true
+select_multiple_mfa_options: false
 service_provider_request_ttl_hours: 24
 session_check_delay: 30
 session_check_frequency: 30
@@ -447,6 +448,7 @@ test:
   s3_report_public_bucket_prefix: ''
   saml_endpoint_configs: '[{"suffix":"2022","secret_key_passphrase":"trust-but-verify"}]'
   scrypt_cost: 800$8$1$
+  select_multiple_mfa_options: false
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -66,6 +66,8 @@ en:
     max_piv_cac_login_attempts_reached: For your security, your account is
       temporarily locked because you have presented your piv/cac credential
       incorrectly too many times.
+    mfa_instructions: We recommend you select at least (2) two different methods so
+      you have a backup if you lose one of your chosen authentication devices.
     mobile_terms_of_service: Mobile terms of service
     no_auth_option: No authentication option could be found for you to sign in.
     opt_in:

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -72,6 +72,9 @@ es:
     max_piv_cac_login_attempts_reached: Por tu seguridad, tu cuenta está bloqueada
       temporalmente dado que has presentado las credenciales de tu piv/cac de
       forma incorrecta demasiadas veces.
+    mfa_instructions: Le recomendamos que seleccione al menos (2) dos métodos
+      diferentes para tener una copia de seguridad si pierde uno de los
+      dispositivos de autenticación elegidos.
     mobile_terms_of_service: Condiciones de servicio móvil
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     opt_in:

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -72,6 +72,9 @@ fr:
     max_piv_cac_login_attempts_reached: Pour votre sécurité, votre compte a été
       temporairement bloqué en raison de la saisie de mauvais identifiants
       PIV/CAC à de trop nombreuses reprises.
+    mfa_instructions: Nous vous recommandons de sélectionner au moins (2) deux
+      méthodes différentes afin d’avoir une sauvegarde si vous perdez l’un de
+      vos dispositifs d’authentification choisis.
     mobile_terms_of_service: Conditions de service mobile
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     opt_in:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -296,6 +296,7 @@ class IdentityConfig
     config.add(:scrypt_cost, type: :string)
     config.add(:secret_key_base, type: :string)
     config.add(:seed_agreements_data, type: :boolean)
+    config.add(:select_multiple_mfa_options, type: :boolean)
     config.add(:service_provider_request_ttl_hours, type: :integer)
     config.add(:session_check_delay, type: :integer)
     config.add(:session_check_frequency, type: :integer)


### PR DESCRIPTION
This is the first step in creating a prototype for multi-factor authentication. The user test will ask users to select and provide multiple authentication methods. After testing is completed, work can/will be done to implement in production.

This PR creates the feature flag and logic on whether or not users will be shown the checkbox selection vs. radio buttons. On testing on this current PR, you should only see the radio buttons as the feature flag is currently set to false.

Future considerations for creating the feature/prototype:

- Would it be worth creating a feature branch to further develop and write tests against?

