### PR TITLE
Restore error border styling for design system fields

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -40,6 +40,10 @@ textarea {
     box-shadow: 0 0 0 2px rgba($field-focus-color, 0.5);
     outline: none;
   }
+
+  &.usa-input--error {
+    @include u-border($theme-input-state-border-width, 'error');
+  }
 }
 
 input::-webkit-outer-spin-button,


### PR DESCRIPTION
**Why**: So that the red border shows as expected.

Fixes a small regression from #6067, where rearrangement of [`.field` styles](https://github.com/18F/identity-idp/blob/4d7ccc73eb1dee61d3b341e7ca0c454e7277e902/app/assets/stylesheets/components/_form.scss#L26-L28) cause them to take precedence over design system.

**Screenshots:**

`stages/prod`|`main`|`aduth-lg-3877-error-border`
---|---|---
![Screen Shot 2022-03-17 at 8 44 57 AM](https://user-images.githubusercontent.com/1779930/158812790-3a2c93d2-c10e-44c7-8dc3-0160839b4d61.png)|![Screen Shot 2022-03-17 at 8 46 15 AM](https://user-images.githubusercontent.com/1779930/158812791-440b63b3-2124-48c1-b041-82fc42a35764.png)|![Screen Shot 2022-03-17 at 8 52 18 AM](https://user-images.githubusercontent.com/1779930/158812792-ea5287bd-9128-4c7d-a7e8-b04684616680.png)

