### PR TITLE
Use design system for base typography styles

### DIFF
--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -23,19 +23,12 @@ input[type='week'] {
 
 //basscss-base-typography
 //------------------------------------------------
-body {
-  font-family: $font-family;
-  line-height: $line-height;
-}
-
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: $heading-font-family;
-  line-height: $heading-line-height;
   margin-top: 1em;
   margin-bottom: 0.5em;
 }

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -1,6 +1,3 @@
-html {
-  font-size: $base-font-size;
-}
 body {
   -webkit-font-smoothing: antialiased;
 }

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -1,20 +1,9 @@
-$sans-serif-font-family: Public Sans Web, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-  Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol !default;
-$serif-font-family: $sans-serif-font-family !default;
-
-$base-font-size: 16px !default;
-$small-font-size: 14px !default;
-
 $body-color: $gray !default;
 $body-background-color: $white !default;
 
-$font-family: $sans-serif-font-family !default;
 $line-height: 1.5 !default;
 $bold-font-weight: bold !default;
-$heading-font-family: $serif-font-family !default;
 $heading-font-weight: bold !default;
-$heading-line-height: 1.5 !default;
-$caps-letter-spacing: 1px !default;
 
 $line-height-0: 0.75 !default; // For when a tighter-than-normal leading is desired.
 $line-height-1: 1 !default;

--- a/app/assets/stylesheets/variables/_vendor.scss
+++ b/app/assets/stylesheets/variables/_vendor.scss
@@ -6,6 +6,7 @@ $theme-global-link-styles: true;
 $theme-grid-container-max-width: 'tablet-lg';
 $theme-header-min-width: 'tablet';
 $theme-link-visited-color: 'primary';
+$theme-style-body-element: true;
 $theme-utility-breakpoints: (
   'card': false,
   'card-lg': false,


### PR DESCRIPTION
**Why**: So that we're using the design system consistently, to reduce our maintenance burden, and to remove redundant styling.

References:

- [Theme variable sets typeset on `body` element](https://github.com/uswds/uswds/blob/7349ddfc07f3814be51f6e6143fd16b0530771f8/src/stylesheets/global/_typography.scss#L7-L11)
- [We override heading typography elsewhere](https://github.com/18F/identity-idp/blob/4d7ccc73eb1dee61d3b341e7ca0c454e7277e902/app/assets/stylesheets/utilities/_typography.scss#L26-L108)
   - Future task: This should be adapted into design system