### PR TITLE
Use design system mixins for media queries

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -9,7 +9,7 @@
     padding-right: 0;
   }
 
-  @media #{$breakpoint-sm} {
+  @include at-media('tablet') {
     @include u-padding-x(10);
     @include u-margin-bottom(8);
     border-radius: 5px;

--- a/app/assets/stylesheets/components/_container.scss
+++ b/app/assets/stylesheets/components/_container.scss
@@ -5,7 +5,7 @@
   max-width: $container-xxskinny-width;
 }
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   .cntnr-xxskinny {
     max-width: $container-xskinny-width;
   }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,6 +1,6 @@
 $radio-checkbox-space: 1.5rem;
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   input,
   select,
   textarea {
@@ -81,7 +81,7 @@ input::-webkit-inner-spin-button {
 
 .usa-radio__input--tile + .usa-radio__label--illustrated .usa-radio__image {
   width: 1.5rem;
-  @media #{$breakpoint-sm} {
+  @include at-media('tablet') {
     width: 2.625rem;
     padding-top: 0.25rem;
   }

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -62,7 +62,7 @@
   }
 }
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   .modal-content {
     vertical-align: middle;
   }

--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -28,7 +28,7 @@
   }
 }
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   .separator-text > div {
     &::after {
       color: #000;
@@ -56,7 +56,7 @@
   width: 110%;
 }
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   .full-width-box {
     margin-left: -5rem;
     width: 135%;

--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -14,7 +14,7 @@ html.js .no-js {
   transform: scale(0.7);
 }
 
-@media #{$breakpoint-sm} {
+@include at-media('tablet') {
   .sm-left-align {
     text-align: left;
   }

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -91,13 +91,6 @@ $width-2: 6rem !default;
 $width-3: 12rem !default;
 $width-4: 24rem !default;
 
-$breakpoint-sm: '(min-width: 40em)' !default;
-$breakpoint-md: '(min-width: 52em)' !default;
-$breakpoint-lg: '(min-width: 64em)' !default;
-$breakpoint-xl: '(min-width: 96em)' !default;
-$breakpoint-sm-md: '(min-width: 40em) and (max-width: 52em)' !default;
-$breakpoint-md-lg: '(min-width: 52em) and (max-width: 64em)' !default;
-
 $container-width: 940px !default;
 $container-skinny-width: 620px !default;
 $container-xskinny-width: 416px !default;


### PR DESCRIPTION
**Why**: So that we're using a consistent syntax and breakpoints for responsive styles, and so that we can remove Sass variables [originating from](https://github.com/basscss/basscss-sass/blob/8edc9d2f0df5aec43dab31db3fcfbce7e35a0a7e/_responsive-white-space.scss#L9-L13) the now-removed BassCSS.