### PR TITLE
add check and user creation to grant_readonly_access task

### DIFF
--- a/lib/tasks/db_readonly_user.rake
+++ b/lib/tasks/db_readonly_user.rake
@@ -1,5 +1,5 @@
 namespace :db do
-  desc 'Grant readonly database user read access to all tables'
+  desc 'Create readonly database user and grant read access to all tables'
   task grant_readonly_access: :environment do
     username = IdentityConfig.store.database_readonly_username
 
@@ -8,32 +8,29 @@ namespace :db do
       next
     end
 
-    sql = "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}"
+    readonly_user_present = ActiveRecord::Base.connection.execute(
+      "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}"
+    )
 
-    ActiveRecord::Base.connection.execute(sql)
-  end
-
-  desc 'Create a readonly database user'
-  task create_readonly_user: :environment do
-    username = IdentityConfig.store.database_readonly_username
-
-    if username.blank?
-      warn 'Skipping readonly db setup because read only user is not present'
-      next
-    end
-
-    password = IdentityConfig.store.database_readonly_password
     sql_statements = [
-      format(
-        "CREATE USER %s WITH ENCRYPTED PASSWORD '%s'",
-        username,
-        password,
-      ),
       format(
         'GRANT SELECT ON ALL TABLES IN SCHEMA public TO %s',
         username,
-      ),
+      )
     ]
+
+    password = IdentityConfig.store.database_readonly_password
+
+    if !password.blank? && readonly_user_present.values.empty?
+      sql_statements.unshift(
+        format(
+          "CREATE USER %s WITH ENCRYPTED PASSWORD '%s'",
+          username,
+          password,
+        )
+      )
+    end
+
     sql_statements.each { |sql| ActiveRecord::Base.connection.execute(sql) }
   end
 end

--- a/lib/tasks/db_readonly_user.rake
+++ b/lib/tasks/db_readonly_user.rake
@@ -9,7 +9,7 @@ namespace :db do
     end
 
     readonly_user_present = ActiveRecord::Base.connection.execute(
-      "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}"
+      "SELECT 1 FROM pg_roles WHERE rolname='#{username}'"
     )
 
     sql_statements = [

--- a/lib/tasks/db_readonly_user.rake
+++ b/lib/tasks/db_readonly_user.rake
@@ -9,14 +9,14 @@ namespace :db do
     end
 
     readonly_user_present = ActiveRecord::Base.connection.execute(
-      "SELECT 1 FROM pg_roles WHERE rolname='#{username}'"
+      "SELECT 1 FROM pg_roles WHERE rolname='#{username}'",
     )
 
     sql_statements = [
       format(
         'GRANT SELECT ON ALL TABLES IN SCHEMA public TO %s',
         username,
-      )
+      ),
     ]
 
     password = IdentityConfig.store.database_readonly_password
@@ -27,7 +27,7 @@ namespace :db do
           "CREATE USER %s WITH ENCRYPTED PASSWORD '%s'",
           username,
           password,
-        )
+        ),
       )
     end
 


### PR DESCRIPTION
IFF a read replica of the `idp` RDS database is stood up in an environment (which previously did not have one/is being newly created), the readonly user is not created by default, as the `db:create_readonly_user` task does not run. `deploy/migrate` does attempt to run `db:grant_readonly_access`, but this fails since the readonly user doesn't exist:

```
ActiveRecord::StatementInvalid: PG::UndefinedObject: ERROR:  role "[READONLY_USERNAME]" does not exist
```

This PR updates `db:grant_readonly_access` to check for the readonly user (via both `username` key and existence in `pg_roles`), and create it if it doesn't already exist, before granting `SELECT` to it. If the readonly user already exists, the task simply executes the `GRANT SELECT` action, as it normally does.

Deployed and tested in `bleachbyte` environment via `"deploy_branch": {"identity-idp": "jp/create-readonly-replica"}`.

From `migration` host log:

```
  * execute[deploy migrate step] action run[2022-03-17T15:11:07+00:00] INFO: Processing execute[deploy migrate step] action run

    [execute] deploy/migrate starting
              HOME: /root
              + id
              uid=998(appinstall) gid=998(appinstall) groups=998(appinstall)
              + which bundle
              /opt/ruby_build/shims/bundle
              + export RAILS_ENV=production
              + RAILS_ENV=production
              + export MIGRATION_STATEMENT_TIMEOUT=600000
              + MIGRATION_STATEMENT_TIMEOUT=600000
              + bundle exec rake db:create db:migrate db:seed db:grant_readonly_access --trace
              ** Invoke db:create (first_time)
              ** Invoke db:load_config (first_time)
              ** Invoke environment (first_time)
              ** Execute environment
              hostname: No address associated with hostname
              ** Execute db:load_config
              ** Execute db:create
              Database 'idp' already exists
              Database 'idp-worker-jobs' already exists
              ** Invoke db:migrate (first_time)
              ** Invoke db:load_config 
              ** Execute db:migrate
              ** Invoke db:_dump (first_time)
              ** Execute db:_dump
              ** Invoke db:seed (first_time)
              ** Invoke db:load_config 
              ** Execute db:seed
              ** Invoke db:abort_if_pending_migrations (first_time)
              ** Invoke db:load_config 
              ** Execute db:abort_if_pending_migrations
              ** Invoke db:grant_readonly_access (first_time)
              ** Invoke environment 
              ** Execute db:grant_readonly_access
              + set +x
              deploy/migrate finished
[2022-03-17T15:11:14+00:00] INFO: execute[deploy migrate step] ran successfully
```

Given a readonly database user declared in `application.yml` under `database_readonly_username`:

```
irb(main):001:0> ActiveRecord::Base.connection.execute("SELECT 1 FROM pg_roles WHERE rolname='[REDACTED-USERNAME]'")
=> #<PG::Result:0x000055d4c0889e70 status=PGRES_TUPLES_OK ntuples=1 nfields=1 cmd_tuples=1>
```