### PR TITLE
Disable mobile-lg design system utility breakpoint

### DIFF
--- a/app/assets/stylesheets/variables/_vendor.scss
+++ b/app/assets/stylesheets/variables/_vendor.scss
@@ -11,7 +11,7 @@ $theme-utility-breakpoints: (
   'card': false,
   'card-lg': false,
   'mobile': false,
-  'mobile-lg': true,
+  'mobile-lg': false,
   'tablet': true,
   'tablet-lg': false,
   'desktop': false,

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -5,7 +5,7 @@
   <% MfaContext.new(current_user).auth_app_configurations.each do |auth_app_configuration| %>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="grid-col-8">
-        <div class="grid-col-12 mobile-lg:grid-col-6">
+        <div class="grid-col-12 tablet:grid-col-6">
           <%= auth_app_configuration.name %>
         </div>
       </div>

--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -22,42 +22,42 @@
   </div>
   <div class="border-bottom border-primary-light">
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-      <div class="mobile-lg:grid-col-4 text-bold">
+      <div class="tablet:grid-col-4 text-bold">
         <%= t('account.index.full_name') %>
       </div>
-      <div class="mobile-lg:grid-col-8 padding-x-1 truncate">
+      <div class="tablet:grid-col-8 padding-x-1 truncate">
         <%= pii.full_name %>
       </div>
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-      <div class="mobile-lg:grid-col-4 text-bold">
+      <div class="tablet:grid-col-4 text-bold">
         <%= t('account.index.address') %>
       </div>
-      <div class="mobile-lg:grid-col-8 padding-x-1">
+      <div class="tablet:grid-col-8 padding-x-1">
         <%= render 'shared/address', address: pii %>
       </div>
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-      <div class="mobile-lg:grid-col-4 text-bold">
+      <div class="tablet:grid-col-4 text-bold">
         <%= t('account.index.dob') %>
       </div>
-      <div class="mobile-lg:grid-col-8 padding-x-1">
+      <div class="tablet:grid-col-8 padding-x-1">
         <%= pii.dob %>
       </div>
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-      <div class="mobile-lg:grid-col-4 text-bold">
+      <div class="tablet:grid-col-4 text-bold">
         <%= t('account.index.ssn') %>
       </div>
-      <div class="mobile-lg:grid-col-8 padding-x-1">
+      <div class="tablet:grid-col-8 padding-x-1">
         ***-**-****
       </div>
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
-      <div class="mobile-lg:grid-col-4 text-bold">
+      <div class="tablet:grid-col-4 text-bold">
         <%= t('account.index.phone') %>
       </div>
-      <div class="mobile-lg:grid-col-8 padding-x-1">
+      <div class="tablet:grid-col-8 padding-x-1">
         <%= PhoneFormatter.format(pii.phone) %>
       </div>
     </div>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -6,7 +6,7 @@
   <% MfaContext.new(current_user).piv_cac_configurations.each do |piv_cac_configuration| %>
     <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
       <div class="grid-col-8">
-        <div class="grid-col-12 mobile-lg:grid-col-6">
+        <div class="grid-col-12 tablet:grid-col-6">
           <%= piv_cac_configuration.name %>
         </div>
       </div>

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -5,11 +5,11 @@
 <div class="border-bottom border-primary-light">
   <% MfaContext.new(current_user).webauthn_platform_configurations.each do |cfg| %>
     <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-      <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
+      <div class="grid-col-8 tablet:grid-col-6 truncate">
         <%= cfg.name %>
       </div>
       <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-        <div class="grid-col-4 mobile-lg:grid-col-6 text-right">
+        <div class="grid-col-4 tablet:grid-col-6 text-right">
           <%= link_to(
                 t('account.index.webauthn_platform_delete'),
                 webauthn_setup_delete_path(id: cfg.id),

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -5,11 +5,11 @@
 <div class="border-bottom border-primary-light">
   <% MfaContext.new(current_user).webauthn_roaming_configurations.each do |cfg| %>
     <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-      <div class="grid-col-8 mobile-lg:grid-col-6 truncate">
+      <div class="grid-col-8 tablet:grid-col-6 truncate">
         <%= cfg.name %>
       </div>
       <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-        <div class="grid-col-4 mobile-lg:grid-col-6 text-right">
+        <div class="grid-col-4 tablet:grid-col-6 text-right">
           <%= link_to(
                 t('account.index.webauthn_delete'),
                 webauthn_setup_delete_path(id: cfg.id),

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -42,12 +42,12 @@
           outline: true,
           type: :button,
           data: { print: '' },
-          class: 'margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2',
+          class: 'margin-top-2 tablet:margin-top-0 tablet:margin-left-2',
         ).with_content(t('forms.backup_code.print')) %>
     <%= render ClipboardButtonComponent.new(
           clipboard_text: @codes.join(' '),
           outline: true,
-          class: 'margin-top-2 mobile-lg:margin-top-0 mobile-lg:margin-left-2',
+          class: 'margin-top-2 tablet:margin-top-0 tablet:margin-left-2',
         ) %>
   </div>
 </div>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -15,5 +15,5 @@
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
   <%= render partial: 'shared/email_languages',
              locals: { f: f, hint: false, selection: current_user.email_language } %>
-  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide grid-col-8 mobile-lg:grid-col-6' %>
+  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'usa-button--big usa-button--wide grid-col-8 tablet:grid-col-6' %>
 <% end %>


### PR DESCRIPTION
**Why**:

- So that we're consistently using "tablet" (640px) as breakpoint to switch from small-screen to large-screen styling
- To improve performance of bundled CSS, both build-time (generating fewer styles) and user-facing runtime download size

This is similar to what we did in #5953 to disable `desktop` utility class generation.

This impacts the following screens:

- Account: TOTP listing table grid (collapses to 2 column at larger size)
- Account: IAL2 verified PII details table grid (collapses to 2 column at larger size)
- Account: PIV listing table grid (collapses to 2 column at larger size)
- Account: Security key listing table grid (collapses to 2 column at larger size)
- Account: Touch unlock listing table grid (collapses to 2 column at larger size)
- Account: Backup code setup (increased horizontal margin between Download/Print/Copy at larger size)
- Account: Edit email language (radio options narrower at larger screen size)

**Performance:**

```
yarn build:css && \
  brotli-size app/assets/builds/application.css && \
  gzip-size app/assets/builds/application.css && \
  du -k app/assets/builds/application.css
```

Measure|Before|After|Diff%
---|---|---|---
raw|1157.3kb|936.5kb|-19.1%
gzip|74.4kb|67.1kb|-9.9%
brotli|52.8kb|50.5kb|-4.3%