### PR TITLE
Document analytics events part 5

### DIFF
--- a/app/controllers/banned_user_controller.rb
+++ b/app/controllers/banned_user_controller.rb
@@ -1,5 +1,5 @@
 class BannedUserController < ApplicationController
   def show
-    analytics.track_event(Analytics::BANNED_USER_VISITED)
+    analytics.banned_user_visited
   end
 end

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -2,7 +2,7 @@ module Users
   class EmailConfirmationsController < ApplicationController
     def create
       result = email_confirmation_token_validator.submit
-      analytics.add_email_confirmation(result.to_h)
+      analytics.add_email_confirmation(**result.to_h)
       if result.success?
         process_successful_confirmation(email_address)
       else

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -2,7 +2,7 @@ module Users
   class EmailConfirmationsController < ApplicationController
     def create
       result = email_confirmation_token_validator.submit
-      analytics.track_event(Analytics::ADD_EMAIL_CONFIRMATION, result.to_h)
+      analytics.add_email_confirmation(result.to_h)
       if result.success?
         process_successful_confirmation(email_address)
       else

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -123,11 +123,6 @@ class Analytics
 
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
-  ADD_EMAIL = 'Add Email: Email Submitted'
-  ADD_EMAIL_CONFIRMATION = 'Add Email: Email Confirmation'
-  ADD_EMAIL_CONFIRMATION_RESEND = 'Add Email: Email Confirmation requested due to invalid token'
-  ADD_EMAIL_VISIT = 'Add Email: enter email visited'
-  BANNED_USER_VISITED = 'Banned User visited'
   BROKEN_PERSONAL_KEY_REGENERATED = 'Broken Personal Key: Regenerated'
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
   DOC_AUTH_ASYNC = 'Doc Auth Async'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -84,6 +84,13 @@ module AnalyticsEvents
     track_event('Account Page Visited')
   end
 
+  # @identity.idp.event_name Add Email: Email Confirmation
+  # @param [Integer] user_id of the email confirmation
+  # A user has been sent an email confirmation
+  def add_email_confirmation(user_id, **extra)
+    track_event('Add Email: Email Confirmation', user_id: user_id, **extra)
+  end
+
   # @identity.idp.event_name Authentication Confirmation
   # When a user views the "you are already signed in with the following email" screen
   def authentication_confirmation
@@ -109,6 +116,13 @@ module AnalyticsEvents
   # to a page showing them that they have been banned
   def banned_user_redirect
     track_event('Banned User redirected')
+  end
+
+  # @identity.idp.event_name Banned User visited
+  # A user that has been banned from an SP has authenticated, they have visited
+  # a page showing them that they have been banned
+  def banned_user_visited
+    track_event('Banned User visited')
   end
 
   # @identity.idp.event_name IdV: phone confirmation otp submitted

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -85,9 +85,9 @@ module AnalyticsEvents
   end
 
   # @identity.idp.event_name Add Email: Email Confirmation
-  # @param [Integer] user_id of the email confirmation
-  # A user has been sent an email confirmation
-  def add_email_confirmation(user_id, **extra)
+  # @param [String] user_id account the email is linked to
+  # A user has clicked the confirmation link in an email
+  def add_email_confirmation(user_id:, **extra)
     track_event('Add Email: Email Confirmation', user_id: user_id, **extra)
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -85,6 +85,7 @@ module AnalyticsEvents
   end
 
   # @identity.idp.event_name Add Email: Email Confirmation
+  # @param [Boolean] success
   # @param [String] user_id account the email is linked to
   # A user has clicked the confirmation link in an email
   def add_email_confirmation(user_id:, **extra)


### PR DESCRIPTION
This is an extension of: https://github.com/18F/identity-idp/pull/6014

The story is: https://cm-jira.usa.gov/browse/LG-5923

Please note that the events ADD_EMAIL, ADD_EMAIL_CONFIRMATION_RESEND , ADD_EMAIL_VISIT were never utilized so they have been removed from the events list.

The only events that are still there are ADD_EMAIL_CONFIRMATION and BANNED_USER_VISITED