### PR TITLE
lg-5736-stepup flow: update verified_at

### DIFF
--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -45,8 +45,6 @@ class DisplayablePiiFormatter
     timestamp = current_user.active_profile&.verified_at
     if timestamp
       I18n.l(timestamp, format: :event_timestamp)
-    else
-      I18n.t('help_text.requested_attributes.verified_at_blank')
     end
   end
 

--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -43,9 +43,7 @@ class DisplayablePiiFormatter
 
   def verified_at
     timestamp = current_user.active_profile&.verified_at
-    if timestamp
-      I18n.l(timestamp, format: :event_timestamp)
-    end
+    I18n.l(timestamp, format: :event_timestamp) if timestamp
   end
 
   def x509_subject

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -16,6 +16,5 @@ en:
       phone: Phone number
       social_security_number: Social Security Number
       verified_at: Updated on
-      verified_at_blank: Not yet verified
       x509_issuer: PIV/CAC Issuer
       x509_subject: PIV/CAC Identity

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -16,6 +16,5 @@ es:
       phone: Teléfono
       social_security_number: Número de Seguro Social
       verified_at: Actualizado en
-      verified_at_blank: Aún no verificado
       x509_issuer: Emisor PIV/CAC
       x509_subject: Identidad PIV/CAC

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -18,6 +18,5 @@ fr:
       phone: Numéro de téléphone
       social_security_number: Numéro de sécurité sociale
       verified_at: Mis à jour le
-      verified_at_blank: Pas encore vérifié
       x509_issuer: Émetteur PIV/CAC
       x509_subject: Identité associée à la carte PIV/CAC

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -195,7 +195,7 @@ describe 'OpenID Connect' do
     token_response = sign_in_get_token_response(
       scope: 'openid email profile:verified_at',
       handoff_page_steps: proc do
-        expect(page).to not_to have_content(t('help_text.requested_attributes.verified_at'))
+        expect(page).not_to have_content(t('help_text.requested_attributes.verified_at'))
 
         click_agree_and_continue
       end,

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -191,26 +191,6 @@ describe 'OpenID Connect' do
     expect(userinfo_response[:verified_at]).to eq(profile.verified_at.to_i)
   end
 
-  it 'returns a null verified_at if the account has not been proofed', driver: :mobile_rack_test do
-    token_response = sign_in_get_token_response(
-      scope: 'openid email profile:verified_at',
-      handoff_page_steps: proc do
-        click_agree_and_continue
-      end,
-    )
-
-    access_token = token_response[:access_token]
-    expect(access_token).to be_present
-
-    page.driver.get api_openid_connect_userinfo_path,
-                    {},
-                    'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
-
-    userinfo_response = JSON.parse(page.body).with_indifferent_access
-    expect(userinfo_response[:email]).to be_present
-    expect(userinfo_response[:verified_at]).to be_nil
-  end
-
   it 'errors if verified_within param is too recent', driver: :mobile_rack_test do
     client_id = 'urn:gov:gsa:openidconnect:test'
     state = SecureRandom.hex

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -196,7 +196,6 @@ describe 'OpenID Connect' do
       scope: 'openid email profile:verified_at',
       handoff_page_steps: proc do
         expect(page).to have_content(t('help_text.requested_attributes.verified_at'))
-        expect(page).to have_content(t('help_text.requested_attributes.verified_at_blank'))
 
         click_agree_and_continue
       end,

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -195,7 +195,7 @@ describe 'OpenID Connect' do
     token_response = sign_in_get_token_response(
       scope: 'openid email profile:verified_at',
       handoff_page_steps: proc do
-        expect(page).to not_have_content(t('help_text.requested_attributes.verified_at'))
+        expect(page).to not_to have_content(t('help_text.requested_attributes.verified_at'))
 
         click_agree_and_continue
       end,

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -195,8 +195,6 @@ describe 'OpenID Connect' do
     token_response = sign_in_get_token_response(
       scope: 'openid email profile:verified_at',
       handoff_page_steps: proc do
-        expect(page).to have_content(t('help_text.requested_attributes.verified_at'))
-
         click_agree_and_continue
       end,
     )

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -211,8 +211,6 @@ feature 'IAL1 Single Sign On' do
       click_submit_default
 
       expect(current_url).to match new_user_session_path
-      expect(page).to have_content(t('help_text.requested_attributes.verified_at'))
-      expect(page).to have_content(t('help_text.requested_attributes.verified_at_blank'))
 
       click_agree_and_continue
 

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -176,7 +176,6 @@ describe CompletionsPresenter do
           expect(presenter.pii).to eq(
             {
               all_emails: [current_user.email],
-              verified_at: I18n.t('help_text.requested_attributes.verified_at_blank'),
               x509_issuer: nil,
               x509_subject: nil,
             },
@@ -214,7 +213,6 @@ describe CompletionsPresenter do
               social_security_number: '900-12-3456',
               x509_subject: nil,
               x509_issuer: nil,
-              verified_at: I18n.t('help_text.requested_attributes.verified_at_blank'),
             },
           )
         end

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -176,6 +176,7 @@ describe CompletionsPresenter do
           expect(presenter.pii).to eq(
             {
               all_emails: [current_user.email],
+              verified_at: nil,
               x509_issuer: nil,
               x509_subject: nil,
             },
@@ -211,6 +212,7 @@ describe CompletionsPresenter do
               all_emails: [current_user.email],
               birthdate: 'January 01, 1990',
               social_security_number: '900-12-3456',
+              verified_at: nil,
               x509_subject: nil,
               x509_issuer: nil,
             },

--- a/spec/services/displayable_pii_formatter_spec.rb
+++ b/spec/services/displayable_pii_formatter_spec.rb
@@ -111,16 +111,6 @@ describe DisplayablePiiFormatter do
           expect(formatter.format.verified_at).to eq(formatted_date)
         end
       end
-
-      context 'for an unverified user' do
-        let(:verified_at) { nil }
-
-        it 'returns a message about the user not being verified' do
-          expect(formatter.format.verified_at).to eq(
-            I18n.t('help_text.requested_attributes.verified_at_blank'),
-          )
-        end
-      end
     end
 
     describe 'PIV/CAC attributes' do


### PR DESCRIPTION
This pull request is to not display 'Updated on' for profiles that have not been verified in the stepup flow as it confuses the user. 

Before:
![Screen Shot 2022-03-16 at 5 00 25 PM](https://user-images.githubusercontent.com/7727136/159067347-f1e025f6-f034-42d6-b79b-3423a8226c17.png)

After:
![Screen Shot 2022-03-17 at 10 26 27 AM](https://user-images.githubusercontent.com/7727136/159067376-b29a74e8-5c12-4eae-82ae-f28bba7f01b1.png)

