### PR TITLE
Allow target attribute in SP help text

### DIFF
--- a/app/views/shared/_sp_alert.html.erb
+++ b/app/views/shared/_sp_alert.html.erb
@@ -1,6 +1,6 @@
 <% alert = decorated_session.sp_alert(request.path) %>
 <% if alert %>
   <%= render AlertComponent.new(text_tag: 'div') do %>
-    <%= raw sanitize(alert, tags: %w[a b br p], attributes: %w[href]) %>
+    <%= raw sanitize(alert, tags: %w[a b br p], attributes: %w[href target]) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
**Why:** partners will likely want links to go to a new page/tab.