### PR TITLE
Remove custom line-height CSS utility class

### DIFF
--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -16,10 +16,6 @@ body {
   font-size: 20px;
 }
 
-.line-height-1 {
-  line-height: $line-height-1;
-}
-
 %h1 {
   line-height: 1.35;
   font-size: $h1;

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -2,8 +2,6 @@ $line-height: 1.5 !default;
 $bold-font-weight: bold !default;
 $heading-font-weight: bold !default;
 
-$line-height-1: 1 !default;
-
 $h1: 1.5rem !default;
 $h2: 1.25rem !default;
 $h3: 1.125rem !default;

--- a/app/views/shared/_no_pii_banner.html.erb
+++ b/app/views/shared/_no_pii_banner.html.erb
@@ -1,3 +1,3 @@
-<div class="font-sans-lg padding-y-4 bg-secondary-darker text-white line-height-1 text-center">
+<div class="font-sans-lg padding-y-3 bg-secondary-darker text-white text-center">
   <%= t('idv.messages.sessions.no_pii') %>
 </div>


### PR DESCRIPTION
**Why**: So that we're leveraging the design system as much as possible.

It's only used for the "No PII" banner shown in lower environments.

Before|After
---|---
![Screen Shot 2022-03-18 at 8 56 54 AM](https://user-images.githubusercontent.com/1779930/159007116-0e04902c-cf25-4725-b0e4-1bfe3143b797.png)|![Screen Shot 2022-03-18 at 8 56 56 AM](https://user-images.githubusercontent.com/1779930/159007122-086d10d8-f276-4a5d-9823-a13f42f208a8.png)

