### PR TITLE
LG-5990: Replace BassCSS space variables with design system tokens

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -15,7 +15,7 @@
     border-radius: 5px;
 
     &-wide {
-      margin-top: $space-4;
+      margin-top: units(6);
       max-width: 100%;
       padding-bottom: 0;
       padding-left: 0;

--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -29,7 +29,7 @@ $icon-min-padding: 2px;
       content: '';
       display: block;
       height: $h4;
-      left: -$space-3;
+      left: units(neg-4);
       position: absolute;
       top: (lh('body', $theme-body-line-height) - $h4) * 0.5;
       width: $h4;

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -51,7 +51,7 @@
       content: '';
       display: block;
       height: 48px;
-      margin: $space-2 auto $space-3;
+      margin: units(2) auto units(4);
       position: relative;
       width: 48px;
     }

--- a/app/assets/stylesheets/components/_profile-section.scss
+++ b/app/assets/stylesheets/components/_profile-section.scss
@@ -3,12 +3,12 @@
   border-radius: 0;
   margin-bottom: 0;
   overflow: hidden;
-  padding: $space-3;
+  padding: units(4);
 }
 
 @include at-media('mobile') {
   .profile-info-box {
     border-radius: $border-radius-md;
-    margin-bottom: $space-3;
+    margin-bottom: units(4);
   }
 }

--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -35,14 +35,14 @@ h6 {
 
 p {
   margin-top: 0;
-  margin-bottom: $space-2;
+  margin-bottom: units(2);
 }
 
 dl,
 ol,
 ul {
   margin-top: 0;
-  margin-bottom: $space-2;
+  margin-bottom: units(2);
 }
 
 // basscss-utility-typography

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -16,10 +16,6 @@ $sm-h4: 1rem !default;
 $sm-h5: 0.875rem !default;
 $sm-h6: 0.75rem !default;
 
-$space-2: 1rem !default;
-$space-3: 2rem !default;
-$space-4: 3rem !default;
-
 $form-field-font-size-sm: 1.25rem !default;
 
 $border-width: 1px !default;


### PR DESCRIPTION
**Why**: So we use the design system consistently, and to avoid confusion from multiple available options.

Reference: https://designsystem.digital.gov/design-tokens/spacing-units/

tl;dr `1 unit = 0.5rem`