### PR TITLE
changelog-check: Auto-capitalize message

### DIFF
--- a/scripts/changelog-check
+++ b/scripts/changelog-check
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?changelog: (?<category>[\w -/]{2,}), (?<subcategory>[A-Z][\w -]{2,}), (?<change>.+)$}
+  %r{^(?:\* )?changelog: (?<category>[\w -/]{2,}), (?<subcategory>[\w -]{2,}), (?<change>.+)$}
 CATEGORIES = [
   'Improvements', 'Accessibility', 'Bug Fixes', 'Internal'
 ]
@@ -97,9 +97,9 @@ def generate_changelog(base_branch, source_branch)
 
     changelog_entry = ChangelogEntry.new(
       category: category,
-      subcategory: change[:subcategory],
+      subcategory: change[:subcategory].capitalize,
       pr_number: pr_number&.named_captures&.fetch('pr'),
-      change: change[:change],
+      change: change[:change].capitalize,
     )
 
     changelog_entries << changelog_entry


### PR DESCRIPTION
**Why**: To reduce toil for changelog checks ([example](https://github.com/18F/identity-idp/pull/6088#event-6268164227)).

```
scripts/changelog-check -b 3d7455f~1 -s 3d7455f
```

Before:

```
A valid changelog line was not found.
```

After:

```
## Improvements
- Content: Make the content more clear
```
