### PR TITLE
Update feature specs to target field by label

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -54,7 +54,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_path
       complete_all_doc_auth_steps
       click_idv_continue
-      fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+      fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
       expect(current_path).to eq idv_personal_key_path
@@ -68,7 +68,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
       click_idv_continue
-      fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+      fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
       expect(current_path).to eq idv_personal_key_path
@@ -82,7 +82,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_path
       complete_all_doc_auth_steps(expect_accessible: true)
       click_idv_continue
-      fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+      fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
       expect(current_path).to eq idv_personal_key_path

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe 'Account email language' do
         within(page.find('.profile-info-box', text: 'Password')) do
           click_link('Edit')
         end
-        fill_in 'update_user_password_form_password', with: Features::SessionHelper::VALID_PASSWORD
+        fill_in t('forms.passwords.edit.labels.password'),
+                with: Features::SessionHelper::VALID_PASSWORD
         click_button 'Update'
 
         mail = ActionMailer::Base.deliveries.last

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -19,7 +19,7 @@ feature 'doc auth ssn step' do
 
     it 'proceeds to the next page with valid info', js: true do
       fill_out_ssn_form_ok
-      expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('false')
+      expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('false')
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_verify_step)
@@ -29,7 +29,7 @@ feature 'doc auth ssn step' do
       fill_out_ssn_form_fail
       click_idv_continue
 
-      expect(page.find('#doc_auth_ssn')['aria-invalid']).to eq('true')
+      expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('true')
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
@@ -64,7 +64,7 @@ feature 'doc auth ssn step' do
     end
 
     it 'proceeds to the next page if the user enters extra digits' do
-      fill_in 'doc_auth_ssn', with: '666-66-12345'
+      fill_in t('idv.form.ssn_label_html'), with: '666-66-12345'
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_verify_step)

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -50,7 +50,7 @@ describe 'Hybrid Flow' do
       fill_out_phone_form_mfa_phone(user)
       click_idv_continue
 
-      fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+      fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_idv_continue
 
       acknowledge_and_confirm_personal_key

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -267,7 +267,7 @@ describe 'OpenID Connect' do
         fill_out_phone_form_mfa_phone(user)
         click_idv_continue
 
-        fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+        fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
         click_continue
 
         acknowledge_and_confirm_personal_key(js: false)

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -27,7 +27,7 @@ feature 'IAL2 Single Sign On' do
     complete_all_doc_auth_steps
     click_on t('idv.troubleshooting.options.verify_by_mail')
     click_on t('idv.buttons.mail.send')
-    fill_in :user_password, with: user.password
+    fill_in t('idv.form.password'), with: user.password
     click_continue
     click_acknowledge_personal_key
     click_link t('idv.buttons.continue_plain')
@@ -46,7 +46,7 @@ feature 'IAL2 Single Sign On' do
 
   def update_mailing_address
     click_on t('idv.buttons.mail.resend')
-    fill_in :user_password, with: user.password
+    fill_in t('idv.form.password'), with: user.password
     click_continue
     click_acknowledge_personal_key
     click_link t('idv.buttons.continue_plain')

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -44,7 +44,7 @@ feature 'View personal key' do
         click_on(t('account.links.regenerate_personal_key'), match: :prefer_exact)
 
         # reauthn
-        fill_in :user_password, with: user.password
+        fill_in t('account.index.password'), with: user.password
         click_continue
         fill_in_code_with_last_phone_otp
         click_submit_default

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -118,7 +118,7 @@ feature 'User profile' do
       expect(page).to_not have_css('#pw-strength-cntnr.display-none')
       expect(page).to have_content '...'
 
-      fill_in 'update_user_password_form_password', with: 'this is a great sentence'
+      fill_in t('forms.passwords.edit.labels.password'), with: 'this is a great sentence'
       expect(page).to have_content 'Great'
 
       check t('forms.passwords.show')
@@ -137,7 +137,7 @@ feature 'User profile' do
         sign_in_live_with_2fa(profile.user)
 
         visit manage_password_path
-        fill_in 'update_user_password_form_password', with: 'this is a great sentence'
+        fill_in t('forms.passwords.edit.labels.password'), with: 'this is a great sentence'
         click_button 'Update'
 
         expect(current_path).to eq account_path

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -14,7 +14,7 @@ feature 'Email confirmation during sign up' do
     expect(page).to have_title t('titles.confirmations.show')
     expect(page).to have_content t('forms.confirmation.show_hdr')
 
-    fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
+    fill_in t('forms.password'), with: Features::SessionHelper::VALID_PASSWORD
     click_button t('forms.buttons.continue')
 
     expect(current_url).to eq two_factor_options_url

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -4,7 +4,7 @@ feature 'Visitor sets password during signup' do
   scenario 'visitor is redirected back to password form when password is blank' do
     create(:user, :unconfirmed)
     confirm_last_user
-    fill_in 'password_form_password', with: ''
+    fill_in t('forms.password'), with: ''
     click_button t('forms.buttons.continue')
 
     expect(page).to have_content t('errors.messages.blank')
@@ -18,7 +18,7 @@ feature 'Visitor sets password during signup' do
     end
 
     it 'does not allow the user to submit the form' do
-      fill_in 'password_form_password', with: ''
+      fill_in t('forms.password'), with: ''
 
       expect(page).to_not have_button(t('forms.buttons.continue'))
     end
@@ -44,17 +44,17 @@ feature 'Visitor sets password during signup' do
     it 'updates as password changes' do
       expect(page).to have_content '...'
 
-      fill_in 'password_form_password', with: 'password'
+      fill_in t('forms.password'), with: 'password'
       expect(page).to have_content 'Very weak'
 
-      fill_in 'password_form_password', with: 'this is a great sentence'
+      fill_in t('forms.password'), with: 'this is a great sentence'
       expect(page).to have_content 'Great!'
     end
 
     it 'has dynamic password strength feedback' do
       expect(page).to have_content '...'
 
-      fill_in 'password_form_password', with: '123456789'
+      fill_in t('forms.password'), with: '123456789'
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
     end
   end
@@ -75,7 +75,7 @@ feature 'Visitor sets password during signup' do
     scenario 'visitor is redirected back to password form' do
       create(:user, :unconfirmed)
       confirm_last_user
-      fill_in 'password_form_password', with: 'Q!2e'
+      fill_in t('forms.password'), with: 'Q!2e'
 
       click_button t('forms.buttons.continue')
 
@@ -86,7 +86,7 @@ feature 'Visitor sets password during signup' do
     scenario 'visitor gets password help message' do
       create(:user, :unconfirmed)
       confirm_last_user
-      fill_in 'password_form_password', with: '1234567891011'
+      fill_in t('forms.password'), with: '1234567891011'
 
       click_button t('forms.buttons.continue')
 
@@ -96,7 +96,7 @@ feature 'Visitor sets password during signup' do
     scenario 'visitor gets password pwned message' do
       create(:user, :unconfirmed)
       confirm_last_user
-      fill_in 'password_form_password', with: '3.1415926535'
+      fill_in t('forms.password'), with: '3.1415926535'
 
       click_button t('forms.buttons.continue')
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -15,19 +15,19 @@ module DocAuthHelper
   end
 
   def fill_out_ssn_form_with_ssn_that_fails_resolution
-    fill_in 'doc_auth_ssn', with: '123-45-6666'
+    fill_in t('idv.form.ssn_label_html'), with: '123-45-6666'
   end
 
   def fill_out_ssn_form_with_ssn_that_raises_exception
-    fill_in 'doc_auth_ssn', with: '000-00-0000'
+    fill_in t('idv.form.ssn_label_html'), with: '000-00-0000'
   end
 
   def fill_out_ssn_form_ok
-    fill_in 'doc_auth_ssn', with: GOOD_SSN
+    fill_in t('idv.form.ssn_label_html'), with: GOOD_SSN
   end
 
   def fill_out_ssn_form_fail
-    fill_in 'doc_auth_ssn', with: ''
+    fill_in t('idv.form.ssn_label_html'), with: ''
   end
 
   def click_doc_auth_back_link

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -104,8 +104,8 @@ module Features
     end
 
     def fill_in_credentials_and_submit(email, password)
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: password
+      fill_in t('account.index.email'), with: email
+      fill_in t('account.index.password'), with: password
       click_button t('links.next')
     end
 
@@ -121,7 +121,7 @@ module Features
     end
 
     def fill_in_password_and_submit(password)
-      fill_in 'user_password', with: password
+      fill_in t('account.index.password'), with: password
       click_button t('forms.buttons.submit.default')
     end
 
@@ -154,14 +154,14 @@ module Features
 
     def sign_up_and_set_password
       user = sign_up
-      fill_in 'password_form_password', with: VALID_PASSWORD
+      fill_in t('forms.password'), with: VALID_PASSWORD
       click_button t('forms.buttons.continue')
       user
     end
 
     def sign_up_with_backup_codes_and_set_password
       user = sign_up_with_backup_codes
-      fill_in 'password_form_password', with: VALID_PASSWORD
+      fill_in t('forms.password'), with: VALID_PASSWORD
       click_button t('forms.buttons.continue')
       user
     end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -364,12 +364,12 @@ def ial2_sign_in_with_piv_cac_gets_bad_password_error(sp)
 
   max_allowed_attempts = IdentityConfig.store.password_max_attempts
   (max_allowed_attempts - 1).times do
-    fill_in 'user_password', with: 'badpassword'
+    fill_in t('account.index.password'), with: 'badpassword'
     click_button t('forms.buttons.submit.default')
     expect(page).to have_content(t('errors.confirm_password_incorrect'))
   end
 
-  fill_in 'user_password', with: 'badpassword'
+  fill_in t('account.index.password'), with: 'badpassword'
   click_button t('forms.buttons.submit.default')
   expect(page).to have_content(t('errors.max_password_attempts_reached'))
 end

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -20,7 +20,7 @@ module SpAuthHelper
     complete_all_doc_auth_steps
     fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.detect(&:mfa_enabled?).phone)
     click_idv_continue
-    fill_in :user_password, with: user.password
+    fill_in t('idv.form.password'), with: user.password
     click_continue
     click_acknowledge_personal_key
     expect(page).to have_current_path(sign_up_completed_path)


### PR DESCRIPTION
Extracted from: #6081 (cherry-picks [2524f69](https://github.com/18F/identity-idp/pull/6081/commits/2524f692eb5e97b4e92666799984b209f59d6f15), [354cd48](https://github.com/18F/identity-idp/pull/6081/commits/354cd48bccbbe94ec19472e7a247894e8ab800ba), [45b11a0](https://github.com/18F/identity-idp/pull/6081/commits/45b11a05fa7eb6c198c19fa7c18fb90c02166741), [c58289c](https://github.com/18F/identity-idp/pull/6081/commits/c58289cb1ee390010bcd35e3047482a883cba513))

**Why**: So that our specs are testing a behavior matching the user's experience, and to guarantee that the fields are labelled correctly.

This supports #6081, where current specs assume specific element IDs, which will change as of #6081. The IDs themselves are unimportant for the purposes of the tests.