### PR TITLE
Fix stylesheet missing mixin raw output

### DIFF
--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -35,14 +35,14 @@ h6 {
 
 p {
   margin-top: 0;
-  margin-bottom: units(2);
+  margin-bottom: 1rem;
 }
 
 dl,
 ol,
 ul {
   margin-top: 0;
-  margin-bottom: units(2);
+  margin-bottom: 1rem;
 }
 
 // basscss-utility-typography


### PR DESCRIPTION
Regression of #6092

**Why**: So that stylesheets only include valid syntax.

In practice, this likely would not have had any noticeable impact, since (a) browsers ignore the invalid syntax, and (b) the inherited default value for the style is equivalent (`margin-block-end: 1em`, [source](https://browserdefaultstyles.com/#p)).

This happened because the `design-system-waiting-room.scss` stylesheet is [loaded before the design system mixins](https://github.com/18F/identity-idp/blob/5ca8bb65e9f81db8a834699f597799472654c3be/app/assets/stylesheets/application.css.scss#L4-L5). Since the only other stylesheets loaded before the design system are variable definitions which don't call any mixins, the impact should be limited to this one file.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/1779930/159270461-da4e7f24-a170-4154-ba73-20ecac1b3ffd.png">

```
NODE_ENV=production yarn build:css && grep 'units(' -q app/assets/builds/application.css && echo $?
```

Before: 0 (raw mixin text found)
After: 1 (raw mixin text omitted)

Follow-up: Migrate styles to [design system styles](https://github.com/uswds/uswds/blob/7349ddfc07f3814be51f6e6143fd16b0530771f8/src/stylesheets/core/mixins/_typography.scss#L44-L57).