### PR TITLE
Fix hover color for language picker dropdown

### DIFF
--- a/app/assets/stylesheets/components/_i18n-dropdown.scss
+++ b/app/assets/stylesheets/components/_i18n-dropdown.scss
@@ -35,23 +35,10 @@
 }
 
 .i18n-desktop-dropdown {
-  background-color: $blue;
   bottom: 100%;
   left: -1px;
   position: absolute;
   width: 194px;
-
-  a {
-    color: color($theme-link-reverse-color);
-
-    &:hover {
-      color: color($theme-link-reverse-hover-color);
-    }
-
-    &:active {
-      color: color($theme-link-reverse-active-color);
-    }
-  }
 }
 
 .language-desktop-button {

--- a/app/assets/stylesheets/components/_i18n-dropdown.scss
+++ b/app/assets/stylesheets/components/_i18n-dropdown.scss
@@ -40,6 +40,18 @@
   left: -1px;
   position: absolute;
   width: 194px;
+
+  a {
+    color: color($theme-link-reverse-color);
+
+    &:hover {
+      color: color($theme-link-reverse-hover-color);
+    }
+
+    &:active {
+      color: color($theme-link-reverse-active-color);
+    }
+  }
 }
 
 .language-desktop-button {

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -53,7 +53,7 @@
                                                           class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
               <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
             </button>
-            <ul class="i18n-desktop-dropdown usa-list--unstyled margin-bottom-0 display-none">
+            <ul class="i18n-desktop-dropdown usa-dark-background bg-primary usa-list--unstyled margin-bottom-0 display-none">
               <% I18n.available_locales.each do |locale| %>
                 <li class='border-bottom border-primary-darker'>
                   <%= link_to t("i18n.locale.#{locale}"),

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class='i18n-mobile-dropdown tablet:display-none display-none'>
-      <ul class='usa-list--unstyled margin-bottom-0 text-white text-center'>
+      <ul class='usa-list--unstyled margin-bottom-0 text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
             <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-no-underline fs-13p', lang: locale == I18n.locale ? nil : locale %>
@@ -53,12 +53,12 @@
                                                           class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
               <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
             </button>
-            <ul class="i18n-desktop-dropdown usa-list--unstyled margin-bottom-0 text-white display-none">
+            <ul class="i18n-desktop-dropdown usa-list--unstyled margin-bottom-0 display-none">
               <% I18n.available_locales.each do |locale| %>
                 <li class='border-bottom border-primary-darker'>
                   <%= link_to t("i18n.locale.#{locale}"),
                               sanitized_requested_url.merge(locale: locale),
-                              class: 'display-block padding-left-3 padding-y-2 text-no-underline text-white',
+                              class: 'display-block padding-left-3 padding-y-2 text-no-underline',
                               lang: locale == I18n.locale ? nil : locale %>
                 </li>
               <% end %>


### PR DESCRIPTION
**Why**: So that the link contrast is shown with enough contrast relative to its background.

Before|After
---|---
![Screen Shot 2022-03-21 at 11 10 40 AM](https://user-images.githubusercontent.com/1779930/159292820-7a7cad22-8b75-468d-b909-74201562bd15.png)|![Screen Shot 2022-03-21 at 11 12 59 AM](https://user-images.githubusercontent.com/1779930/159292822-5b0c1677-8e3d-4c43-9401-3ecc9d938ee7.png)

**Implementation notes:**

USWDS support for explicit reverse link styling isn't very consistent currently, tracked at https://github.com/uswds/uswds/issues/4582. In the meantime, ~this copies styles from [`.usa-section--dark`](https://github.com/uswds/uswds/blob/7349ddfc07f3814be51f6e6143fd16b0530771f8/src/stylesheets/components/_section.scss#L33-L43)~ **Edit:** In [5db77dc](https://github.com/18F/identity-idp/pull/6099/commits/5db77dc0f7efc71970164d17a3db2325f9397c46), changed approach to use `usa-dark-background` + `bg-` utility, for consistency with other reverse link styling in the partial.

Future work should aim to refactor/componentize the dropdown, which is tangentially tracked at LG-3684.