### PR TITLE
Update Yarn audit build step to check critical production dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lint: ## Runs all lint tests
 	bundle exec bundler-audit check --update
 	# JavaScript
 	@echo "--- yarn audit ---"
-	yarn audit
+	yarn audit --groups dependencies; test $? -le 8
 	@echo "--- eslint ---"
 	yarn run lint
 	@echo "--- typescript ---"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lint: ## Runs all lint tests
 	bundle exec bundler-audit check --update
 	# JavaScript
 	@echo "--- yarn audit ---"
-	yarn audit --groups dependencies; test $? -le 8
+	yarn audit --groups dependencies; test $$? -le 8
 	@echo "--- eslint ---"
 	yarn run lint
 	@echo "--- typescript ---"


### PR DESCRIPTION
**Why**:

- Since we're primarily concerned with dependencies which are part of the production toolchain
- To unblock current branches, which are affected by [unpatched prototype pollution in "minimist" dependency](https://www.npmjs.com/advisories/1067259) (transitive dependency via `@babel/core`, `babel-loader`, `eslint-plugin-import`)

**Implementation notes:**

`yarn audit` returns a status code depending on severity level of vulnerabilities. Checking `<= 8` means to only fail on critical vulnerabilities. We may want to change this to `<= 4` (moderate) once a patched version of `minimist` is available, or remove the `test` altogether.

See: https://classic.yarnpkg.com/lang/en/docs/cli/audit/