### PR TITLE
Resolve minimist to patched version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lint: ## Runs all lint tests
 	bundle exec bundler-audit check --update
 	# JavaScript
 	@echo "--- yarn audit ---"
-	yarn audit --groups dependencies; test $$? -le 8
+	yarn audit --groups dependencies; test $$? -le 7
 	@echo "--- eslint ---"
 	yarn run lint
 	@echo "--- typescript ---"

--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "svgo": "^2.8.0",
     "typescript": "^4.5.5",
     "webpack-dev-server": "^4.7.2"
+  },
+  "resolutions": {
+    "minimist": "1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,10 +4423,10 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^0.5.5:
   version "0.5.5"


### PR DESCRIPTION
**Why**: To resolve a prototype pollution vulnerability, and to allow us to be stricter with package auditing (flag "High" issues, in addition to "Critical").

Uses [Yarn resolutions feature](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/), since our direct dependencies which rely on it haven't all yet updated to the newest version.

Related:

- https://github.com/18F/identity-idp/pull/6101
- https://github.com/advisories/GHSA-xvch-5gv4-984h

changelog: Internal, Continuous Integration, Check for "High" severity vulnerability advisories at build step