### PR TITLE
Create "You've created your [x] authentication method!" page

### DIFF
--- a/app/views/mfa_confirmation/index.html.erb
+++ b/app/views/mfa_confirmation/index.html.erb
@@ -1,0 +1,21 @@
+<%# All content on this page is currently set up for MFA user testing.
+ Once ready to ship to prod, translate all text content in Gengo %>
+
+<% title t('titles.mfa_setup.first_authentication_method') %>
+
+<%= render AlertComponent.new(type: :success, class: 'margin-bottom-4') do %>
+  <%= t('multi_factor_authentication.method_confirmation.face_id') %>
+<% end %>
+
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
+
+<%= render PageHeadingComponent.new.with_content(t('headings.mfa_setup.first_authentication_method')) %>
+
+<p class='margin-top-1 margin-bottom-4'><%= t('multi_factor_authentication.cta') %></p>
+
+<%= button_to(
+      account_reset_pending_cancel_path,
+      class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
+    ) { t('multi_factor_authentication.add') } %>
+
+<%= link_to t('multi_factor_authentication.skip'), root_url %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -14,9 +14,11 @@
 
 <p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
 
+<%# If it is decided that there will be an info banner on this page for MFA setup, the text will need Gengo translations %>
+
 <% if IdentityConfig.store.select_multiple_mfa_options %>
   <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4') do %>
-    <%= t('two_factor_authentication.mfa_instructions') %>
+    <%= t('multi_factor_authentication.info') %>
   <% end %>
 <% end %>
 

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -29,6 +29,8 @@ en:
     edit_info:
       password: Change your password
       phone: Manage your phone settings
+    mfa_setup:
+      first_authentication_method: You’ve added your first authentication method!
     passwords:
       change: Change your password
       confirm: Confirm your current password to continue

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -29,6 +29,8 @@ es:
     edit_info:
       password: Cambie su contraseña
       phone: Administrar la configuración de su teléfono
+    mfa_setup:
+      first_authentication_method: ¡Has agregado tu primer método de autenticación!
     passwords:
       change: Cambie su contraseña
       confirm: Confirme la contraseña actual para continuar

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -29,6 +29,8 @@ fr:
     edit_info:
       password: Changez votre mot de passe
       phone: Administrer les paramètres de votre téléphone
+    mfa_setup:
+      first_authentication_method: Vous avez ajouté votre première méthode d’authentification!
     passwords:
       change: Changez votre mot de passe
       confirm: Confirmez votre mot de passe actuel pour continuer

--- a/config/locales/multi_factor_authentication/en.yml
+++ b/config/locales/multi_factor_authentication/en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  multi_factor_authentication:
+    add: Add another method
+    cta: Adding another authentication method prevents you from getting locked out
+      of your account if you lose one of your methods.
+    info: We recommend you select at least (2) two different methods so you have a
+      backup if you lose one of your chosen authentication devices.
+    method_confirmation:
+      face_id: Face ID has been added to your account
+    skip: Skip for now

--- a/config/locales/multi_factor_authentication/es.yml
+++ b/config/locales/multi_factor_authentication/es.yml
@@ -1,0 +1,12 @@
+---
+es:
+  multi_factor_authentication:
+    add: Agregar otro método
+    cta: Agregar otro método de autenticación evita que se le bloquee el acceso a su
+      cuenta si pierde uno de sus métodos.
+    info: Le recomendamos que seleccione al menos (2) dos métodos diferentes para
+      tener una copia de seguridad si pierde uno de los dispositivos de
+      autenticación elegidos.
+    method_confirmation:
+      face_id: Se ha agregado Face ID a su cuenta
+    skip: Saltar por ahora

--- a/config/locales/multi_factor_authentication/fr.yml
+++ b/config/locales/multi_factor_authentication/fr.yml
@@ -1,0 +1,12 @@
+---
+fr:
+  multi_factor_authentication:
+    add: Agregar otro método
+    cta: L’ajout d’une autre méthode d’authentification vous empêche d’être bloqué
+      sur votre compte si vous perdez l’une de vos méthodes.
+    info: Nous vous recommandons de sélectionner au moins (2) deux méthodes
+      différentes afin d’avoir une sauvegarde si vous perdez l’un de vos
+      dispositifs d’authentification choisis.
+    method_confirmation:
+      face_id: Face ID a été ajouté à votre compte
+    skip: Ignorer pour l’instant

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -40,6 +40,8 @@ en:
       phone: Verify your phone number
       reset_password: Reset Password
       review: Re-enter your password
+    mfa_setup:
+      first_authentication_method: You’ve added your first authentication method!
     no_auth_option: No sign-in method found
     openid_connect:
       authorization: OpenID Connect Authorization

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -40,6 +40,8 @@ es:
       phone: Verifica tu número telefónico
       reset_password: Restablecer la contraseña
       review: Vuelve a ingresar tu contraseña
+    mfa_setup:
+      first_authentication_method: ¡Has agregado tu primer método de autenticación!
     no_auth_option: No se encontró mensaje de inicio de sesión
     openid_connect:
       authorization: Autorización de OpenID Connect

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -40,6 +40,8 @@ fr:
       phone: Vérifiez votre numéro de téléphone
       reset_password: Réinitialisez le mot de passe
       review: Saisissez à nouveau votre mot de passe
+    mfa_setup:
+      first_authentication_method: Vous avez ajouté votre première méthode d’authentification!
     no_auth_option: Aucun message de connexion trouvé
     openid_connect:
       authorization: Autorisation OpenID Connect

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -66,8 +66,6 @@ en:
     max_piv_cac_login_attempts_reached: For your security, your account is
       temporarily locked because you have presented your piv/cac credential
       incorrectly too many times.
-    mfa_instructions: We recommend you select at least (2) two different methods so
-      you have a backup if you lose one of your chosen authentication devices.
     mobile_terms_of_service: Mobile terms of service
     no_auth_option: No authentication option could be found for you to sign in.
     opt_in:

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -72,9 +72,6 @@ es:
     max_piv_cac_login_attempts_reached: Por tu seguridad, tu cuenta está bloqueada
       temporalmente dado que has presentado las credenciales de tu piv/cac de
       forma incorrecta demasiadas veces.
-    mfa_instructions: Le recomendamos que seleccione al menos (2) dos métodos
-      diferentes para tener una copia de seguridad si pierde uno de los
-      dispositivos de autenticación elegidos.
     mobile_terms_of_service: Condiciones de servicio móvil
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     opt_in:

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -72,9 +72,6 @@ fr:
     max_piv_cac_login_attempts_reached: Pour votre sécurité, votre compte a été
       temporairement bloqué en raison de la saisie de mauvais identifiants
       PIV/CAC à de trop nombreuses reprises.
-    mfa_instructions: Nous vous recommandons de sélectionner au moins (2) deux
-      méthodes différentes afin d’avoir une sauvegarde si vous perdez l’un de
-      vos dispositifs d’authentification choisis.
     mobile_terms_of_service: Conditions de service mobile
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     opt_in:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,10 @@ Rails.application.routes.draw do
       end
     end
 
+    if IdentityConfig.store.select_multiple_mfa_options
+      get '/auth_method_confirmation' => 'mfa_confirmation#show'
+    end
+
     # Non-devise-controller routes. Alphabetically sorted.
     get '/.well-known/openid-configuration' => 'openid_connect/configuration#index',
         as: :openid_connect_configuration

--- a/spec/views/mfa_confirmation/index.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/index.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'mfa_confirmation/index.html.erb' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.mfa_setup.first_authentication_method'))
+
+    render
+  end
+
+  it 'has a localized header' do
+    render
+
+    expect(rendered).to have_content(t('headings.mfa_setup.first_authentication_method'))
+  end
+
+  it 'provides a call to action to add another MFA method' do
+    render
+
+    expect(rendered).to have_selector('p', text: t('multi_factor_authentication.cta'))
+  end
+
+  it 'has a button with the next step' do
+    render
+
+    expect(rendered).to have_selector('button', text: t('multi_factor_authentication.add'))
+  end
+end


### PR DESCRIPTION
This PR creates the confirmation page that will inform the user that they have successfully set up one of their selected MFA methods.

Notes:
- Currently, there is no path to go from the "Choose your method page" to "You've created your first authentication method". This is expected because [routing is the next piece of the functionality](https://cm-jira.usa.gov/browse/LG-5988) that we are adding for the MFA feature.
- Another next step is to add "You've added your second method", "You've added your third method", etc. The logic is not here because the routing has not been set up. A presenter will be added to facilitate that logic once routing and the data structure is in place
- "You've added your first authentication method", "Add phone", and "Face ID has been added to your account" is dummy data for the purpose of this ticket
- We are implementing small commits for this feature for ease of testing and to make sure that we have not broken the functionality of two-factor authentication setup.
- **EDIT**: The button and the "Skip for now" links do not lead the user to the correct page at this time as we still need to set up the router.