### PR TITLE
changelog: accessibility change, prevent safari from reading idle ses…

### DIFF
--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -1,5 +1,5 @@
 <div id='session-timeout-msg' class='display-none' tabindex='-1'>
-  <%= render layout: 'shared/modal_layout', locals: { role: 'alertdialog' } do |label_id, description_id| %>
+  <%= render layout: 'shared/modal_layout', locals: { role: 'dialog' } do |label_id, description_id| %>
     <div class='padding-4 tablet:padding-6 cntnr-xxskinny bg-white rounded-xxl modal-timeout'>
       <h2 class='margin-y-2 fs-20p text-normal text-center' id='<%= label_id %>'>
         <%= t('headings.session_timeout_warning') %>


### PR DESCRIPTION
…sion timeout warning every second, LG-5978

## Why
In Safari, the voice over utility was reading the countdown timer of the idle session timeout modal every second, which was maddening.

I reverted from the role='alertdialog' to role='dialog.' Unfortunately, role='alertdialog' is, in my understanding of aria roles, more accurate, but... well... safari.

You can see the code live here: https://idp.ssteiner.identitysandbox.gov/