### PR TITLE
Update GitLab CI Pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,16 +51,10 @@ stages:
   - test
   - after_test
 
-workflow:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "stages/prod"'
-
 check_changelog:
   stage: build
   script:
+    - echo "$CI_PIPELINE_SOURCE"
     - |
       if [ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" == "main" ]
       then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,11 @@ stages:
   - test
   - after_test
 
+workflow:
+  rules:
+      - if: $CI_COMMIT_REF_NAME
+        when: always
+
 check_changelog:
   stage: build
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,3 @@
-# When adding a new job, you'll want to add `extends: .on_push` to ignore
-# scheduled executions, unless you're specifically adding something that should
-# be run periodically, like metric exporters or syncs.
-
 default:
   image: mitchh/ruby-node-yarn-chrome-chromedriver:3.0.3
 
@@ -17,7 +13,7 @@ variables:
 .yarn_production_install: &yarn_production_install
   - yarn install --production --frozen-lockfile --ignore-engines --cache-folder .yarn-cache
 
-cache:
+.build_cache:
   - &ruby_cache
     key:
       files:
@@ -55,30 +51,30 @@ stages:
   - test
   - after_test
 
-.on_push:
+workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: $CI_MERGE_REQUEST_IID
-    - if: $CI_OPEN_MERGE_REQUESTS
-      when: never
-    - if: $CI_COMMIT_BRANCH
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "stages/prod"'
 
 check_changelog:
-  extends: .on_push
   stage: build
   script:
     - |
-      if [ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]
+      if [ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" == "main" ]
       then
-        echo "Skipping because this is not a PR or is not targeting main"
-        exit 0
-      else
         git fetch origin --quiet
         ./scripts/changelog_check.rb -b origin/"${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" -s origin/"${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
+      elif [ "$CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME" == "main" ]
+      then
+        git fetch origin --quiet
+        ./scripts/changelog_check.rb -b origin/"${CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME}" -s origin/"${CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME}"
+      else
+        echo "Skipping because this is not a PR or is not targeting main"
+        exit 0
       fi
 install:
-  extends: .on_push
   stage: build
   variables:
     RAILS_ENV: test
@@ -96,7 +92,6 @@ install:
     - bundle exec rake assets:precompile
 
 specs:
-  extends: .on_push
   stage: test
   parallel: 5
   cache:
@@ -148,7 +143,6 @@ specs:
     - bundle exec rake knapsack:rspec
 
 lint:
-  extends: .on_push
   stage: test
   cache:
     - <<: *ruby_cache
@@ -160,7 +154,6 @@ lint:
     - make lint
 
 js_build:
-  extends: .on_push
   stage: test
   cache:
     - <<: *ruby_cache
@@ -173,7 +166,6 @@ js_build:
     - bundle exec rake assets:precompile
 
 js_tests:
-  extends: .on_push
   stage: test
   cache:
     - <<: *yarn_cache
@@ -182,7 +174,6 @@ js_tests:
     - yarn test
 
 coverage:
-  extends: .on_push
   stage: after_test
   script:
     - *bundle_install
@@ -199,10 +190,9 @@ coverage:
       - coverage/coverage.xml
 
 artifact:
-  extends: .on_push
   stage: after_test
-  cache:
-    - <<: *yarn_production_cache
+  tags:
+    - build-pool
   variables:
     NODE_ENV: 'production'
     RAILS_ENV: 'production'
@@ -211,9 +201,3 @@ artifact:
     - ./deploy/build
     - ./deploy/build-post-config
     - make build_artifact ARTIFACT_DESTINATION_FILE='./tmp/idp.tar.gz'
-
-# Sync from GitHub
-include:
-  project: 'lg/identity-gitlab'
-  ref: 'main'
-  file: '.gitlab-ci-sync.yml'

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ build_artifact $(ARTIFACT_DESTINATION_FILE): ## Builds zipped tar file artifact 
 	  --exclude='./certs/sp' \
 	  --exclude='./identity-idp-config' \
 	  --exclude='./tmp' \
+	  --exclude='./log' \
+	  --exclude='./app/javascript/packages/**/node_modules' \
 	  --exclude='./node_modules' \
 	  --exclude='./geo_data/GeoLite2-City.mmdb' \
 	  --exclude='./pwned_passwords/pwned_passwords.txt' \


### PR DESCRIPTION
Updates the pipeline to:

- Only run for PRs/MRs and `main` or `stages/prod`
- Removes scheduled/on_push rules since we don't need them anymore
- Switches the artifact building to use the build pool
- Renames the cache key to avoid applying the cache by default