### PR TITLE
Fix 500 during proofing verify step when expected information is not present

### DIFF
--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -24,6 +24,7 @@ module Flow
     def mark_step_incomplete(step = nil)
       klass = step.nil? ? self.class : steps[step]
       flow_session.delete(klass.to_s)
+      nil
     end
 
     def self.acceptable_response_object?(obj)

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -4,6 +4,8 @@ module Idv
       STEP_INDICATOR_STEP = :verify_info
 
       def call
+        return mark_step_incomplete(:document_capture) if flow_session[:pii_from_doc].nil?
+
         flow_session[:pii_from_doc][:ssn] = flow_params[:ssn]
       end
 

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -11,6 +11,7 @@ module Idv
 
       def enqueue_job
         return if flow_session[verify_step_document_capture_session_uuid_key]
+        return mark_step_incomplete(:ssn) if pii_from_doc.nil?
 
         pii_from_doc[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 

--- a/spec/services/idv/steps/ssn_step_spec.rb
+++ b/spec/services/idv/steps/ssn_step_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Idv::Steps::SsnStep do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { build(:user) }
+  let(:service_provider) do
+    create(
+      :service_provider,
+      issuer: 'http://sp.example.com',
+      app_id: '123',
+    )
+  end
+  let(:controller) do
+    instance_double(
+      'controller',
+      session: { sp: { issuer: service_provider.issuer } },
+      current_user: user,
+      params: {},
+      analytics: FakeAnalytics.new,
+      url_options: {},
+      request: double(
+        'request',
+        headers: {
+          'X-Amzn-Trace-Id' => amzn_trace_id,
+        },
+      ),
+    )
+  end
+  let(:amzn_trace_id) { SecureRandom.uuid }
+
+  let(:pii_from_doc) do
+    {
+      first_name: Faker::Name.first_name,
+    }
+  end
+
+  let(:flow) do
+    Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+      flow.flow_session = { pii_from_doc: pii_from_doc }
+    end
+  end
+
+  subject(:step) do
+    Idv::Steps::SsnStep.new(flow)
+  end
+
+  describe '#call' do
+    context 'when pii_from_doc is not present' do
+      let(:flow) do
+        Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+          flow.flow_session = { 'Idv::Steps::DocumentCaptureStep' => true }
+        end
+      end
+
+      it 'marks previous step as incomplete' do
+        expect(flow.flow_session['Idv::Steps::DocumentCaptureStep']).to eq true
+        expect(step.call).to eq nil
+        expect(flow.flow_session['Idv::Steps::DocumentCaptureStep']).to eq nil
+      end
+    end
+  end
+end

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -65,6 +65,20 @@ describe Idv::Steps::VerifyStep do
       step.call
     end
 
+    context 'when pii_from_doc is not present' do
+      let(:flow) do
+        Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+          flow.flow_session = { 'Idv::Steps::SsnStep' => true }
+        end
+      end
+
+      it 'marks step as incomplete' do
+        expect(flow.flow_session['Idv::Steps::SsnStep']).to eq true
+        expect(step.call).to eq nil
+        expect(flow.flow_session['Idv::Steps::SsnStep']).to eq nil
+      end
+    end
+
     context 'when different users use the same SSN within the same timeframe' do
       let(:user2) { create(:user) }
       let(:flow2) do


### PR DESCRIPTION
We had a few errors in [New Relic](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=259200000&state=4ee2a622-c1a9-7d7e-cb54-5471cc110ef8)

I suspect there may be other paths to get into this state, but I was able to reproduce with:

1. Start proofing process, and proceed up to the resolution/verify step
2. Open the page in another tab
3. Click "Start over" in one of the tabs
4. In the other tab, click "Continue", and the server will 500

It's likely an uncommon path towards a 500, but the result is:

![image](https://user-images.githubusercontent.com/1430443/160675534-213af4f2-0761-4c83-8985-afdff393d2d4.png)
