### PR TITLE
changelog: Improvements, remove redundant styling with style-guide, L…

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -82,11 +82,3 @@ input::-webkit-inner-spin-button {
     margin-left: 0;
   }
 }
-
-.usa-radio__input--tile + .usa-radio__label--illustrated .usa-radio__image {
-  width: 1.5rem;
-  @include at-media('tablet') {
-    width: 2.625rem;
-    padding-top: 0.25rem;
-  }
-}

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -43,7 +43,7 @@
                   class: 'usa-checkbox__label usa-checkbox__label--illustrated',
                 ) do %>
                     <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-checkbox__image') %>
-                    <div class="usa-checkbox__label--text tablet:padding-left-1"><%= option.label %>
+                    <div class="usa-checkbox__label--text"><%= option.label %>
                       <span class="usa-checkbox__label-description">
                         <%= option.info %>
                       </span>
@@ -62,7 +62,7 @@
                   class: 'usa-radio__label usa-radio__label--illustrated',
                 ) do %>
                     <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-radio__image') %>
-                    <div class="usa-radio__label--text tablet:padding-left-1"><%= option.label %>
+                    <div class="usa-radio__label--text"><%= option.label %>
                       <span class="usa-radio__label-description">
                         <%= option.info %>
                       </span>


### PR DESCRIPTION
…G-5883

## Why
Styles were added directly to the idp in the past for mfa-icons for expediency, but we're now ready to migrate them into the style-guide. Therefore, we're removing them from the idp as they will become redundant.

Relevant style-guide pull request: https://github.com/18F/identity-style-guide/pull/309