### PR TITLE
Add crossorigin script attribute for local development Webpack assets

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -31,7 +31,7 @@ module ScriptHelper
   private
 
   def local_crossorigin_sources?
-    Rails.env.development? && ENV.key?('WEBPACK_PORT')
+    Rails.env.development? && ENV['WEBPACK_PORT'].present?
   end
 
   def javascript_polyfill_pack_tag

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -19,14 +19,27 @@ module ScriptHelper
   def render_javascript_pack_once_tags(*names)
     javascript_packs_tag_once(*names) if names.present?
     if @scripts && (sources = AssetSources.get_sources(*@scripts)).present?
-      safe_join([javascript_polyfill_pack_tag, javascript_include_tag(*sources)])
+      safe_join(
+        [
+          javascript_polyfill_pack_tag,
+          javascript_include_tag(*sources, crossorigin: local_crossorigin_sources? ? true : nil),
+        ],
+      )
     end
   end
 
   private
 
+  def local_crossorigin_sources?
+    Rails.env.development? && ENV.key?('WEBPACK_PORT')
+  end
+
   def javascript_polyfill_pack_tag
-    javascript_include_tag_without_preload(*AssetSources.get_sources('polyfill'), nomodule: '')
+    javascript_include_tag_without_preload(
+      *AssetSources.get_sources('polyfill'),
+      nomodule: '',
+      crossorigin: local_crossorigin_sources? ? true : nil,
+    )
   end
 
   def without_preload_links_header

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -51,13 +51,7 @@ RSpec.describe ScriptHelper do
       context 'local development crossorigin sources' do
         before do
           allow(Rails.env).to receive(:development?).and_return(true)
-        end
-
-        around do |example|
-          original_webpack_port = ENV['WEBPACK_PORT']
-          ENV['WEBPACK_PORT'] = '3000'
-          example.run
-          ENV['WEBPACK_PORT'] = original_webpack_port
+          stub_const('ENV', 'WEBPACK_PORT' => '3000')
         end
 
         it 'prints script sources with crossorigin attribute' do

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -49,9 +49,11 @@ RSpec.describe ScriptHelper do
       end
 
       context 'local development crossorigin sources' do
+        let(:webpack_port) { '3035' }
+
         before do
           allow(Rails.env).to receive(:development?).and_return(true)
-          stub_const('ENV', 'WEBPACK_PORT' => '3000')
+          stub_const('ENV', 'WEBPACK_PORT' => webpack_port)
         end
 
         it 'prints script sources with crossorigin attribute' do
@@ -64,6 +66,16 @@ RSpec.describe ScriptHelper do
             count: 1,
             visible: :all,
           )
+        end
+
+        context 'empty webpack port' do
+          let(:webpack_port) { '' }
+
+          it 'renders as if webpack port was unassigned' do
+            output = render_javascript_pack_once_tags
+
+            expect(output).to_not have_css('[crossorigin]', visible: :all)
+          end
         end
       end
     end

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -40,12 +40,37 @@ RSpec.describe ScriptHelper do
         output = render_javascript_pack_once_tags
 
         expect(output).to have_css(
-          "script[src^='/polyfill.js'][nomodule] ~ \
-          script[src^='/application.js'] ~ \
-          script[src^='/document-capture.js']",
+          "script:not([crossorigin])[src^='/polyfill.js'][nomodule] ~ \
+          script:not([crossorigin])[src^='/application.js'] ~ \
+          script:not([crossorigin])[src^='/document-capture.js']",
           count: 1,
           visible: :all,
         )
+      end
+
+      context 'local development crossorigin sources' do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(true)
+        end
+
+        around do |example|
+          original_webpack_port = ENV['WEBPACK_PORT']
+          ENV['WEBPACK_PORT'] = '3000'
+          example.run
+          ENV['WEBPACK_PORT'] = original_webpack_port
+        end
+
+        it 'prints script sources with crossorigin attribute' do
+          output = render_javascript_pack_once_tags
+
+          expect(output).to have_css(
+            "script[crossorigin][src^='/polyfill.js'][nomodule] ~ \
+            script[crossorigin][src^='/application.js'] ~ \
+            script[crossorigin][src^='/document-capture.js']",
+            count: 1,
+            visible: :all,
+          )
+        end
       end
     end
 


### PR DESCRIPTION
**Why**: To prevent issues where React is unable to access error details in development mode, in combination with assets served cross-origin via `webpack-dev-server`.

Steps to reproduce: Follow ["Testing identity proofing" process](https://developers.login.gov/testing/#testing-identity-proofing) to upload an error document to the document capture step. Without these changes, you would see a generic "technical difficulties" message.

Related docs: https://reactjs.org/docs/cross-origin-errors.html