### PR TITLE
LG-5911: Fix detailed camera access error alert display

### DIFF
--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, createContext, useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
+import { Alert } from '@18f/identity-components';
 import Button from './button';
-import { RequiredValueMissingError } from './form-error-message';
+import FormErrorMessage, { RequiredValueMissingError } from './form-error-message';
 import PromptOnNavigate from './prompt-on-navigate';
 import useHistoryParam from '../hooks/use-history-param';
 import useForceRender from '../hooks/use-force-render';
@@ -251,6 +252,11 @@ function FormSteps({
   return (
     <form ref={formRef} className="read-after-submit" onSubmit={toNextStep}>
       {Object.keys(values).length > 0 && <PromptOnNavigate />}
+      {stepErrors.map((error) => (
+        <Alert key={error.message} type="error" className="margin-bottom-4">
+          <FormErrorMessage error={error} isDetail />
+        </Alert>
+      ))}
       <FormStepsContext.Provider value={{ isLastStep, canContinueToNextStep, onPageTransition }}>
         <Form
           key={name}

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -64,6 +64,26 @@ describe('document-capture/components/document-capture', () => {
     expect(step).to.be.ok();
   });
 
+  it('shows top-level step errors', async () => {
+    const { getByLabelText, findByText } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+          <DocumentCapture />
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    initialize();
+    // `onError` called with an Error instance is indication of camera access declined, which is
+    // expected to show both field-level and step error.
+    // See: https://github.com/18F/identity-idp/blob/164231d/app/javascript/packages/document-capture/components/acuant-capture.jsx#L114
+    window.AcuantCameraUI.start.callsFake((_callbacks, onError) => onError(new Error()));
+
+    userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));
+
+    await findByText('doc_auth.errors.camera.blocked_detail');
+  });
+
   it('progresses through steps to completion', async () => {
     const { getByLabelText, getByText, getAllByText, findAllByText } = render(
       <DeviceContext.Provider value={{ isMobile: true }}>

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -56,6 +56,9 @@ describe('document-capture/components/form-steps', () => {
               onChange({ secondInputTwo: event.target.value });
             }}
           />
+          <button type="button" onClick={() => onError(new Error())}>
+            Create Step Error
+          </button>
           <FormStepsContinueButton />
           <span data-testid="context-value">{JSON.stringify(useContext(FormStepsContext))}</span>
         </>
@@ -386,6 +389,16 @@ describe('document-capture/components/form-steps', () => {
     userEvent.type(inputOne, 'one');
 
     expect(inputOne.hasAttribute('data-is-error')).to.be.true();
+  });
+
+  it('renders and moves focus to step errors', () => {
+    const steps = [STEPS[1]];
+
+    const { getByRole } = render(<FormSteps steps={steps} />);
+    const button = getByRole('button', { name: 'Create Step Error' });
+    userEvent.click(button);
+
+    expect(getByRole('alert')).to.equal(document.activeElement);
   });
 
   it('provides context', () => {

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -107,7 +107,7 @@ describe('document-capture/components/review-issues-step', () => {
   });
 
   it('renders warning page with error and displays one attempt remaining then continues on', () => {
-    const { getByRole, getByLabelText, getByText } = render(
+    const { getByRole, getByLabelText, getByText, queryByRole } = render(
       <ReviewIssuesStep
         remainingAttempts={1}
         unknownFieldErrors={[
@@ -127,6 +127,7 @@ describe('document-capture/components/review-issues-step', () => {
     userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(getByText('An unknown error occurred')).to.be.ok();
+    expect(queryByRole('alert')).to.not.be.ok();
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
   });
 

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -107,7 +107,7 @@ describe('document-capture/components/review-issues-step', () => {
   });
 
   it('renders warning page with error and displays one attempt remaining then continues on', () => {
-    const { getByRole, getByLabelText, getByText, queryByRole } = render(
+    const { getByRole, getByLabelText, getByText } = render(
       <ReviewIssuesStep
         remainingAttempts={1}
         unknownFieldErrors={[
@@ -127,7 +127,6 @@ describe('document-capture/components/review-issues-step', () => {
     userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(getByText('An unknown error occurred')).to.be.ok();
-    expect(queryByRole('alert')).to.not.be.ok();
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
   });
 


### PR DESCRIPTION
**Why**: So that the user is shown a detailed alert message describing steps to take to resolve permissions issues preventing us from being able to capture a photo.

This appears to have been a regression of #5593. As part of those changes, the "unknown field errors" we receive from the server were [adapted to be shown as plain text](https://github.com/18F/identity-idp/pull/5593/files#diff-1a8fab239c87a31f300dd5508931b29bc06e5c65735f8211d1e19d72290b843bR96-R97), [in place of the alert banner](https://github.com/18F/identity-idp/pull/5593/files#diff-5fca9a27b2b1401b5c7fe26cdb6834d01c26a259a8281e81e27e550c12b5a870L255-L259) that had existed previously. However, this should have only applied for the "unknown field errors" received from the server, _not_ also to the step errors which we use for behaviors like responding to camera access declined. The changes here effectively restore this behavior for rendering step errors as alert banners, while maintaining the intended effect of #5593 to show unknown field errors as plain text.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/1779930/161083619-40f64de5-0404-4766-9aad-72d1292737d9.jpg" alt="screenshot" width="300">