### PR TITLE
Fix flaky test

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -116,6 +116,10 @@ describe 'throttling requests' do
     end
 
     context 'when the user is signed in' do
+      around do |ex|
+        freeze_time { ex.run }
+      end
+
       it 'logs the user UUID' do
         analytics = instance_double(Analytics)
         allow(Analytics).to receive(:new).and_return(analytics)


### PR DESCRIPTION
We sometimes get a failure along the lines of ([CircleCI example](https://app.circleci.com/pipelines/github/18F/identity-idp/71299/workflows/ecf3bceb-3af5-441c-b661-97074682bf95/jobs/116230/parallel-runs/1?filterBy=FAILED)):

```
Failures:

  1) throttling requests high requests per ip when the user is signed in logs the user UUID
     Failure/Error:
       expect(Analytics).to have_received(:new).twice do |arguments|
         expect(arguments[:user]).to eq user
       end

       (Analytics (class)).new(*(any args))
           expected: 2 times with any arguments
           received: 1 time with any arguments
     # ./spec/requests/rack_attack_spec.rb:139:in `block (4 levels) in <top (required)>'
     # ./.gem/ruby/3.0.3/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'
     # ./.gem/ruby/3.0.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./.gem/ruby/3.0.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./.gem/ruby/3.0.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./.gem/ruby/3.0.3/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./.gem/ruby/3.0.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
```

This PR applies a change that we've made in this file in the past to fix similar problems (#5909, #5971)