### PR TITLE
Disable production optimizations for i18n Webpack plugin spec

### DIFF
--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
@@ -14,6 +14,8 @@ describe('RailsI18nWebpackPlugin', () => {
 
     webpack(
       {
+        mode: 'development',
+        devtool: false,
         entry: {
           1: path.resolve(__dirname, 'spec/fixtures/in1.js'),
           2: path.resolve(__dirname, 'spec/fixtures/in2.js'),

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.en.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.en.js
@@ -1,1 +1,1 @@
-!function(){var e,t={"forms.button.submit":"Submit","forms.messages":{one:"One message",other:"%{count} messages"},"item.1":"First","item.2":"Second","item.3":"","forms.button.reset":"Reset"},o=window._locale_data=window._locale_data||{};for(e in t)o[e]=t[e]}();
+!function(){var k,o={"forms.button.submit":"Submit","forms.messages":{"one":"One message","other":"%{count} messages"},"item.1":"First","item.2":"Second","item.3":"","forms.button.reset":"Reset"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.es.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.es.js
@@ -1,1 +1,1 @@
-!function(){var e,n={"forms.button.submit":"Enviar","forms.messages":{one:"Un mensaje",other:"%{count} mensajes"},"item.1":"First","item.2":"Second","item.3":"","forms.button.reset":"Reiniciar"},o=window._locale_data=window._locale_data||{};for(e in n)o[e]=n[e]}();
+!function(){var k,o={"forms.button.submit":"Enviar","forms.messages":{"one":"Un mensaje","other":"%{count} mensajes"},"item.1":"First","item.2":"Second","item.3":"","forms.button.reset":"Reiniciar"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.fr.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected1.fr.js
@@ -1,1 +1,1 @@
-!function(){var e,t={"forms.button.submit":"Submit","forms.messages":{one:"Un message",other:"%{count} messages"},"item.1":"Premier","item.2":"Second","item.3":"","forms.button.reset":"Réinitialiser"},o=window._locale_data=window._locale_data||{};for(e in t)o[e]=t[e]}();
+!function(){var k,o={"forms.button.submit":"Submit","forms.messages":{"one":"Un message","other":"%{count} messages"},"item.1":"Premier","item.2":"Second","item.3":"","forms.button.reset":"Réinitialiser"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.en.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.en.js
@@ -1,1 +1,1 @@
-!function(){var a,n={"forms.dynamic":"Dynamic"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();
+!function(){var k,o={"forms.dynamic":"Dynamic"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.es.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.es.js
@@ -1,1 +1,1 @@
-!function(){var a,o={"forms.dynamic":"Dinámico"},i=window._locale_data=window._locale_data||{};for(a in o)i[a]=o[a]}();
+!function(){var k,o={"forms.dynamic":"Dinámico"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.fr.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected452.fr.js
@@ -1,1 +1,1 @@
-!function(){var a,n={"forms.dynamic":"Dynamique"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();
+!function(){var k,o={"forms.dynamic":"Dynamique"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.en.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.en.js
@@ -1,1 +1,1 @@
-!function(){var a,n={"forms.button.cancel":"Cancel"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();
+!function(){var k,o={"forms.button.cancel":"Cancel"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.es.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.es.js
@@ -1,1 +1,1 @@
-!function(){var a,n={"forms.button.cancel":"Cancelar"},o=window._locale_data=window._locale_data||{};for(a in n)o[a]=n[a]}();
+!function(){var k,o={"forms.button.cancel":"Cancelar"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.fr.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.fr.js
@@ -1,1 +1,1 @@
-!function(){var n,a={"forms.button.cancel":"Annuler"},o=window._locale_data=window._locale_data||{};for(n in a)o[n]=a[n]}();
+!function(){var k,o={"forms.button.cancel":"Annuler"},l=window._locale_data=window._locale_data||{};for(k in o)l[k]=o[k]}()

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/expected946.js
@@ -1,1 +1,22 @@
-(window.webpackJsonp=window.webpackJsonp||[]).push([[0],[function(n,o){t("forms.button.cancel")}]]);
+"use strict";
+(self["webpackChunkupaya"] = self["webpackChunkupaya"] || []).push([[946],{
+
+/***/ "./app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js":
+/*!***********************************************************************************!*\
+  !*** ./app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/common.js ***!
+  \***********************************************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _18f_identity_i18n__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @18f/identity-i18n */ "@18f/identity-i18n");
+/* harmony import */ var _18f_identity_i18n__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_18f_identity_i18n__WEBPACK_IMPORTED_MODULE_0__);
+
+
+__webpack_require__.e(/*! import() */ 452).then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/dynamic.js", 23));
+
+const text = (0,_18f_identity_i18n__WEBPACK_IMPORTED_MODULE_0__.t)('forms.button.cancel');
+
+
+/***/ })
+
+}]);


### PR DESCRIPTION
**Why**: Ideally so that we don't have flaky build failures related to the spec taking longer than 2 seconds to complete, since production optimizations (e.g. minification) are expected to take some extra time.