### PR TITLE
More analytics and more sources for requested_attributes on SP handoff

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -8,11 +8,11 @@ module SignUp
     before_action :verify_needs_completions_screen
 
     def show
-      @presenter = completions_presenter
       analytics.track_event(
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
         analytics_attributes(''),
       )
+      @presenter = completions_presenter
     end
 
     def update
@@ -72,6 +72,8 @@ module SignUp
       { ial2: sp_session[:ial2],
         ialmax: sp_session[:ialmax],
         service_provider_name: decorated_session.sp_name,
+        sp_session_requested_attributes: sp_session[:requested_attributes],
+        sp_request_requested_attributes: service_provider_request.requested_attributes,
         page_occurence: page_occurence,
         needs_completion_screen_reason: needs_completion_screen_reason }
     end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -66,7 +66,7 @@ class ServiceProviderSessionDecorator
   end
 
   def requested_attributes
-    sp_session[:requested_attributes].sort
+    (sp_session[:requested_attributes] || service_provider_request.requested_attributes).sort
   end
 
   def sp_create_link

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -26,6 +26,8 @@ describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
+            sp_request_requested_attributes: nil,
+            sp_session_requested_attributes: [:email],
           )
         end
       end
@@ -54,6 +56,8 @@ describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
+            sp_request_requested_attributes: nil,
+            sp_session_requested_attributes: [:email],
           )
         end
       end
@@ -134,6 +138,8 @@ describe SignUp::CompletionsController do
           service_provider_name: subject.decorated_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
+          sp_request_requested_attributes: nil,
+          sp_session_requested_attributes: nil,
         )
       end
 
@@ -180,6 +186,8 @@ describe SignUp::CompletionsController do
           ial2: true,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
+          sp_request_requested_attributes: nil,
+          sp_session_requested_attributes: ['email'],
         }
 
         patch :update
@@ -191,6 +199,8 @@ describe SignUp::CompletionsController do
           service_provider_name: subject.decorated_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
+          sp_request_requested_attributes: nil,
+          sp_session_requested_attributes: ['email'],
         )
       end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -186,8 +186,6 @@ describe SignUp::CompletionsController do
           ial2: true,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
-          sp_request_requested_attributes: nil,
-          sp_session_requested_attributes: ['email'],
         }
 
         patch :update


### PR DESCRIPTION
We get a pretty rare 500 on the consent screen where the `requested_attributes` are `nil` ([NewRelic](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=1800000&state=969483dc-0fa5-9bbb-0b3e-4e24d7d51c7c)).

The cause is not quite clear, but this PR has a couple changes to potentially mitigate and also log some more information to help debug if it happens again:

1. The 500 was happening before the analytics call, so we weren't able to get as much information about the context, so one change is to swap the analytics call to come first.
2. We check both `sp_session` and `service_provider_request` for other SP-related information like [issuer](https://github.com/18F/identity-idp/blob/b813c8c/app/controllers/application_controller.rb#L109-L111), so this PR adds that as a second place to check for `requested_attributes`. I am skeptical that this solves the problem entirely, but it at least makes the behavior more consistent.
3. Due to the last two chances, I'd like to also "temporarily" log the `requested_attributes` from both sources as another avenue to help debug if/when the 500 happens again.