### PR TITLE
Do not 500 when verifying webauthn key

### DIFF
--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -65,10 +65,15 @@ class WebauthnVerificationForm
     return false unless @webauthn_configuration
 
     public_key = @webauthn_configuration.credential_public_key
-    assertion_response.valid?(
-      @challenge.pack('c*'), original_origin,
-      public_key: Base64.decode64(public_key), sign_count: 0
-    )
+
+    begin
+      assertion_response.valid?(
+        @challenge.pack('c*'), original_origin,
+        public_key: Base64.decode64(public_key), sign_count: 0
+      )
+    rescue OpenSSL::PKey::PKeyError
+      false
+    end
   end
 
   def extra_analytics_attributes

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -68,6 +68,23 @@ describe WebauthnVerificationForm do
         expect(result.success?).to eq(false)
         expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
       end
+
+      it 'returns FormResponses with success: false when verification raises OpenSSL exception' do
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
+        allow_any_instance_of(WebAuthn::AuthenticatorAssertionResponse).to receive(:verify).
+          and_raise(OpenSSL::PKey::PKeyError)
+
+        result = subject.submit(
+          protocol,
+          authenticator_data: authenticator_data,
+          client_data_json: verification_client_data_json,
+          signature: signature,
+          credential_id: credential_id,
+        )
+
+        expect(result.success?).to eq(false)
+        expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
+      end
     end
   end
 end


### PR DESCRIPTION
When verifying a WebAuthn signature, we sometimes get an exception from within OpenSSL, which causes a 500 ([NR Link](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=604800000&state=9045272a-f3d2-50b6-5acd-4db11e83246a))