### PR TITLE
Ensure backup codes exist before rendering refreshed template to fix 500

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -6,7 +6,7 @@ module Users
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
-    before_action :ensure_backup_codes_in_session, only: %i[continue download]
+    before_action :ensure_backup_codes_in_session, only: %i[continue download refreshed]
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
 

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -33,4 +33,16 @@ describe Users::BackupCodeSetupController do
     expect(response).to redirect_to(account_two_factor_authentication_path)
     expect(user.backup_code_configurations.length).to eq 0
   end
+
+  describe '#refreshed' do
+    render_views
+
+    it 'does not 500 when codes have not been generated' do
+      user = create(:user, :signed_up)
+      stub_sign_in(user)
+      get :refreshed
+
+      expect(response).to redirect_to(backup_code_setup_url)
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you navigate to https://idp.int.identitysandbox.gov/backup_code_refreshed while logged in, you can trigger a 500 (NR Link)

This PR adds the `refreshed` route to the `ensure_backup_codes_in_session` check