### PR TITLE
Ensure service provider return logs is backwards compatible with previous behavior

### DIFF
--- a/app/services/db/sp_return_log.rb
+++ b/app/services/db/sp_return_log.rb
@@ -1,5 +1,6 @@
 module Db
   class SpReturnLog
+    # rubocop:disable Rails/SkipsModelValidations
     def self.create_return(request_id:, user_id:, billable:, ial:, issuer:, requested_at:)
       ::SpReturnLog.create!(
         request_id: request_id,
@@ -11,7 +12,15 @@ module Db
         returned_at: Time.zone.now,
       )
     rescue ActiveRecord::RecordNotUnique
+      # Can be removed after deploy of RC 185
+      ::SpReturnLog.where(request_id: request_id).update_all(
+        user_id: user_id,
+        returned_at: Time.zone.now,
+        billable: billable,
+        ial: ial,
+      )
       nil
     end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/spec/services/db/sp_return_log_spec.rb
+++ b/spec/services/db/sp_return_log_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe Db::SpReturnLog do
+  describe '#create_return' do
+    # Can be removed after deploy of RC 185
+    it 'updates return log if it already exists' do
+      sp_return_log = SpReturnLog.create(
+        request_id: SecureRandom.uuid,
+        user_id: 1,
+        billable: true,
+        ial: 1,
+        issuer: 'example.com',
+        requested_at: Time.zone.now,
+      )
+      Db::SpReturnLog.create_return(
+        request_id: sp_return_log.request_id,
+        user_id: sp_return_log.user_id,
+        billable: sp_return_log.billable,
+        ial: sp_return_log.ial,
+        issuer: sp_return_log.issuer,
+        requested_at: sp_return_log.requested_at,
+      )
+      expect(sp_return_log.reload.returned_at).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Follows up #6141 to make sure that during the deploy when both versions of the code are running that we also attempt to update existing rows instead of just failing to create the row.

The potential pattern this fixes is:

1. Person arrives from a service provider and hits a server running the old version, which creates a partial sp_return_log
2. Person is getting redirected back to the service provider on a server running the new version, which attempts to create the row, and fails to create it because a row with that `request_id` already exists
3. The partial row remains and does not have `returned_at` set despite the person being returned to the service provider