### PR TITLE
Remove Devise :trackable module

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp]
+  self.ignored_columns = %w[totp_timestamp sign_in_count current_sign_in_at last_sign_in_at
+                            current_sign_in_ip last_sign_in_ip]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer
@@ -9,7 +10,6 @@ class User < ApplicationRecord
     :recoverable,
     :registerable,
     :timeoutable,
-    :trackable,
     authentication_keys: [:email],
   )
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp sign_in_count current_sign_in_at last_sign_in_at
-                            current_sign_in_ip last_sign_in_ip]
+  self.ignored_columns = %w[
+    totp_timestamp
+    sign_in_count
+    current_sign_in_at
+    last_sign_in_at
+    current_sign_in_ip
+    last_sign_in_ip
+  ]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer


### PR DESCRIPTION
We have 5 columns created for Devise's `:trackable` module:

1. `sign_in_count`
1. `current_sign_in_at`
1. `last_sign_in_at`
1. `current_sign_in_ip`
1. `last_sign_in_ip`

We currently update these columns, but do not reference them in code or use them for any reports, so we can safely stop writing them and then later drop them.

This goes wayyyyyyyyy back to @jgrevich's #2 (which will be celebrating it's 6th birthday next week!), but I'm not sure when we may have stopped using these columns.