### PR TITLE
Stop updating sp return logs for backwards compatibility

### DIFF
--- a/app/services/db/sp_return_log.rb
+++ b/app/services/db/sp_return_log.rb
@@ -1,6 +1,5 @@
 module Db
   class SpReturnLog
-    # rubocop:disable Rails/SkipsModelValidations
     def self.create_return(request_id:, user_id:, billable:, ial:, issuer:, requested_at:)
       ::SpReturnLog.create!(
         request_id: request_id,
@@ -12,15 +11,7 @@ module Db
         returned_at: Time.zone.now,
       )
     rescue ActiveRecord::RecordNotUnique
-      # Can be removed after deploy of RC 185
-      ::SpReturnLog.where(request_id: request_id).update_all(
-        user_id: user_id,
-        returned_at: Time.zone.now,
-        billable: billable,
-        ial: ial,
-      )
       nil
     end
-    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -69,7 +69,6 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.today] },
       },
-      # Send Sp Success Rate Report to S3
       # Proofing Costs Report to S3
       proofing_costs: {
         class: 'Reports::ProofingCostsReport',

--- a/spec/services/db/sp_return_log_spec.rb
+++ b/spec/services/db/sp_return_log_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe Db::SpReturnLog do
   describe '#create_return' do
-    # Can be removed after deploy of RC 185
-    it 'updates return log if it already exists' do
+    it 'does not fail if row already exists' do
       sp_return_log = SpReturnLog.create(
         request_id: SecureRandom.uuid,
         user_id: 1,
@@ -12,6 +11,7 @@ describe Db::SpReturnLog do
         issuer: 'example.com',
         requested_at: Time.zone.now,
       )
+
       Db::SpReturnLog.create_return(
         request_id: sp_return_log.request_id,
         user_id: sp_return_log.user_id,
@@ -20,7 +20,8 @@ describe Db::SpReturnLog do
         issuer: sp_return_log.issuer,
         requested_at: sp_return_log.requested_at,
       )
-      expect(sp_return_log.reload.returned_at).to_not be_nil
+
+      expect(SpReturnLog.count).to eq 1
     end
   end
 end


### PR DESCRIPTION
Follow up to #6141 and #6147 to drop the code that enables backwards compatibility since it won't be needed any longer