### PR TITLE
Remove unused feature flag for Select Account screen

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -22,8 +22,7 @@ module OpenidConnect
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
       link_identity_to_service_provider
-      if auth_count == 1 &&
-         (first_visit_for_sp? || IdentityConfig.store.show_select_account_on_repeat_sp_visits)
+      if auth_count == 1 && first_visit_for_sp?
         return redirect_to(user_authorization_confirmation_url)
       end
       handle_successful_handoff

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -25,8 +25,7 @@ class SamlIdpController < ApplicationController
     capture_analytics
     return redirect_to_verification_url if profile_or_identity_needs_verification_or_decryption?
     return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
-    if auth_count == 1 &&
-       (first_visit_for_sp? || IdentityConfig.store.show_select_account_on_repeat_sp_visits)
+    if auth_count == 1 && first_visit_for_sp?
       return redirect_to(user_authorization_confirmation_url)
     end
     link_identity_from_session_data

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -214,7 +214,6 @@ session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
 set_remember_device_session_expiration: false
-show_select_account_on_repeat_sp_visits: false
 sp_context_needed_environment: 'prod'
 sp_handoff_bounce_max_seconds: 2
 show_user_attribute_deprecation_warnings: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -306,7 +306,6 @@ class IdentityConfig
     config.add(:set_remember_device_session_expiration, type: :boolean)
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:skip_encryption_allowed_list, type: :json)
-    config.add(:show_select_account_on_repeat_sp_visits, type: :boolean)
     config.add(:sms_resubscribe_enabled, type: :boolean)
     config.add(:sp_context_needed_environment, type: :string)
     config.add(:sp_handoff_bounce_max_seconds, type: :integer)

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -69,21 +69,6 @@ feature 'OIDC Authorization Confirmation' do
       expect(current_url).to match('http://localhost:7654/auth/result')
     end
 
-    it 'does render the confirmation screen on a return visit to the SP if configured' do
-      allow(IdentityConfig.store).to receive(:show_select_account_on_repeat_sp_visits).
-        and_return(true)
-      second_email = create(:email_address, user: user1)
-      sign_in_user(user1, second_email.email)
-
-      # first visit
-      visit_idp_from_ial1_oidc_sp
-      continue_as(second_email.email)
-
-      # second visit
-      visit_idp_from_ial1_oidc_sp
-      expect(current_path).to eq(user_authorization_confirmation_path)
-    end
-
     it 'does not render an error if a user goes back after opting to switch accounts' do
       sign_in_user(user1)
       visit_idp_from_ial1_oidc_sp

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -84,21 +84,6 @@ feature 'SAML Authorization Confirmation' do
       expect(current_url).to eq(request_url)
     end
 
-    it 'does render the confirmation screen on a return visit to the SP if configured' do
-      allow(IdentityConfig.store).to receive(:show_select_account_on_repeat_sp_visits).
-        and_return(true)
-      second_email = create(:email_address, user: user1)
-      sign_in_user(user1, second_email.email)
-
-      # first visit
-      visit request_url
-      continue_as(second_email.email)
-
-      # second visit
-      visit request_url
-      expect(current_path).to eq(user_authorization_confirmation_path)
-    end
-
     it 'redirects to the account page with no sp in session' do
       sign_in_user(user1)
       visit user_authorization_confirmation_path


### PR DESCRIPTION
[skip changelog]

Was reminded about this by some Slack chatter, hoping to pay down some technical debt now that this feature has been turned on in all environments.