### PR TITLE
Log External SAML Auth Requests

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -113,13 +113,12 @@ class SamlIdpController < ApplicationController
   def log_external_saml_auth_request
     return unless external_saml_request?
 
-    analytics_payload = {
+    analytics.saml_auth_request(
       identity_needs_verification: identity_needs_verification?,
       profile_needs_verification: profile_needs_verification?,
       requested_ial: saml_request&.requested_ial_authn_context || 'none',
       service_provider: saml_request&.issuer,
-    }
-    analytics.saml_auth_request(**analytics_payload)
+    )
   end
 
   def external_saml_request?

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -114,8 +114,8 @@ class SamlIdpController < ApplicationController
     return unless external_saml_request?
 
     analytics_payload = {
-      idv: identity_needs_verification?,
-      finish_profile: profile_needs_verification?,
+      identity_needs_verification: identity_needs_verification?,
+      profile_needs_verification: profile_needs_verification?,
       requested_ial: saml_request&.requested_ial_authn_context || 'none',
       service_provider: saml_request&.issuer,
     }

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -111,7 +111,8 @@ class SamlIdpController < ApplicationController
   end
 
   def log_external_saml_auth_request
-    return unless URI(request.referer).host == request.host
+    return unless external_saml_request?
+
     analytics_payload = {
       idv: identity_needs_verification?,
       finish_profile: profile_needs_verification?,
@@ -119,6 +120,11 @@ class SamlIdpController < ApplicationController
       service_provider: saml_request&.issuer,
     }
     analytics.saml_auth_request(**analytics_payload)
+  end
+
+  def external_saml_request?
+    URI(request.referer).host != request.host ||
+      /authpost\d{4}/.match?(request.env['PATH_INFO'])
   end
 
   def handle_successful_handoff

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -123,8 +123,8 @@ class SamlIdpController < ApplicationController
   end
 
   def external_saml_request?
-    URI(request.referer).host != request.host ||
-      /authpost\d{4}/.match?(request.env['PATH_INFO'])
+    (!request.referer.nil? && URI(request.referer).host != request.host) ||
+      request.path.start_with?('/api/saml/authpost')
   end
 
   def handle_successful_handoff

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -248,4 +248,29 @@ module AnalyticsEvents
   def proofing_document_result_missing
     track_event('Proofing Document Result Missing')
   end
+
+  # @identity.idp.event_name SAML Auth Request
+  # @param [Boolean] idv indicating whether identity verification is needed
+  # @param [Boolean] finish_profile indicating if proofing is needed for a pending/reset profile
+  # @param [Integer] requested_ial
+  # @param [String] service_provider
+  # An external request for SAML Authentication was received
+  def saml_auth_request(
+    idv:,
+    finish_profile:,
+    requested_ial:,
+    service_provider:,
+    **extra
+  )
+    track_event(
+      'SAML Auth Request',
+      {
+        idv: idv,
+        finish_profile: finish_profile,
+        requested_ial: requested_ial,
+        service_provider: service_provider,
+        **extra,
+      }.compact,
+    )
+  end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -250,14 +250,15 @@ module AnalyticsEvents
   end
 
   # @identity.idp.event_name SAML Auth Request
-  # @param [Boolean] idv indicating whether identity verification is needed
-  # @param [Boolean] finish_profile indicating if proofing is needed for a pending/reset profile
+  # @param [Boolean] identity_needs_verification indicates whether identity verification is needed
+  # @param [Boolean] profile_needs_verification indicates if proofing is needed for a pending/reset
+  # profile
   # @param [Integer] requested_ial
   # @param [String] service_provider
   # An external request for SAML Authentication was received
   def saml_auth_request(
-    idv:,
-    finish_profile:,
+    identity_needs_verification:,
+    profile_needs_verification:,
     requested_ial:,
     service_provider:,
     **extra
@@ -265,8 +266,8 @@ module AnalyticsEvents
     track_event(
       'SAML Auth Request',
       {
-        idv: idv,
-        finish_profile: finish_profile,
+        identity_needs_verification: identity_needs_verification,
+        profile_needs_verification: profile_needs_verification,
         requested_ial: requested_ial,
         service_provider: service_provider,
         **extra,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -821,8 +821,6 @@ describe SamlIdpController do
 
     context 'POST to auth correctly stores SP in session' do
       before do
-        stub_analytics
-        allow(@analytics).to receive(:track_event)
         @user = create(:user, :signed_up)
         @saml_request = saml_request(saml_settings)
         @post_request = saml_post_auth(@saml_request)
@@ -852,15 +850,6 @@ describe SamlIdpController do
         session_request_url = session[:sp][:request_url]
 
         expect(session_request_url).to match(%r{/api/saml/auth\d{4}})
-      end
-
-      it 'logs SAML Auth Request event' do
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth Request',
-               requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-               service_provider: 'http://localhost:3000',
-               identity_needs_verification: false,
-               profile_needs_verification: false)
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -523,8 +523,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                service_provider: sp1_issuer,
-               idv: false,
-               finish_profile: false)
+               identity_needs_verification: false,
+               profile_needs_verification: false)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SAML_AUTH,
                success: true,
@@ -859,8 +859,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000',
-               idv: false,
-               finish_profile: false)
+               identity_needs_verification: false,
+               profile_needs_verification: false)
       end
     end
 
@@ -1246,8 +1246,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000',
-               idv: false,
-               finish_profile: false)
+               identity_needs_verification: false,
+               profile_needs_verification: false)
 
         saml_get_auth(saml_settings)
       end
@@ -1696,8 +1696,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000',
-               idv: true,
-               finish_profile: false)
+               identity_needs_verification: true,
+               profile_needs_verification: false)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SAML_AUTH, analytics_hash)
 
@@ -1740,8 +1740,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000',
-               idv: false,
-               finish_profile: false)
+               identity_needs_verification: false,
+               profile_needs_verification: false)
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SP_REDIRECT_INITIATED,
@@ -1778,8 +1778,8 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000',
-               idv: false,
-               finish_profile: true)
+               identity_needs_verification: false,
+               profile_needs_verification: true)
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SP_REDIRECT_INITIATED,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -3,13 +3,6 @@ require 'rails_helper'
 describe SamlIdpController do
   include SamlAuthHelper
 
-  before do
-    # All the tests here were written prior to the interstitial
-    # authorization confirmation page so let's force the system
-    # to skip past that page
-    allow(controller).to receive(:auth_count).and_return(2)
-  end
-
   render_views
 
   describe '/api/saml/logout' do
@@ -431,6 +424,13 @@ describe SamlIdpController do
   end
 
   describe 'GET /api/saml/auth' do
+    before do
+      # All the tests here were written prior to the interstitial
+      # authorization confirmation page so let's force the system
+      # to skip past that page
+      allow(controller).to receive(:auth_count).and_return(2)
+    end
+
     let(:xmldoc) { SamlResponseDoc.new('controller', 'response_assertion', response) }
     let(:aal_level) { 2 }
     let(:ial2_settings) do
@@ -519,6 +519,12 @@ describe SamlIdpController do
 
       it 'tracks IAL2 authentication events' do
         stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+               service_provider: sp1_issuer,
+               idv: false,
+               finish_profile: false)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SAML_AUTH,
                success: true,
@@ -1217,13 +1223,22 @@ describe SamlIdpController do
     end
 
     context 'when user is not logged in' do
-      before do
-        saml_get_auth(saml_settings)
-      end
-
       it 'redirects the user to the SP landing page with the request_id in the params' do
+        saml_get_auth(saml_settings)
         sp_request_id = ServiceProviderRequestProxy.last.uuid
         expect(response).to redirect_to new_user_session_path(request_id: sp_request_id)
+      end
+
+      it 'logs SAML Auth Request but does not log SAML Auth' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+               service_provider: 'http://localhost:3000',
+               idv: false,
+               finish_profile: false)
+
+        saml_get_auth(saml_settings)
       end
     end
 
@@ -1667,6 +1682,12 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+               service_provider: 'http://localhost:3000',
+               idv: true,
+               finish_profile: false)
+        expect(@analytics).to receive(:track_event).
           with(Analytics::SAML_AUTH, analytics_hash)
 
         get :auth
@@ -1704,6 +1725,12 @@ describe SamlIdpController do
           finish_profile: false,
         }
 
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+               service_provider: 'http://localhost:3000',
+               idv: false,
+               finish_profile: false)
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SP_REDIRECT_INITIATED,
@@ -1736,6 +1763,12 @@ describe SamlIdpController do
           finish_profile: true,
         }
 
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+               service_provider: 'http://localhost:3000',
+               idv: false,
+               finish_profile: true)
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SP_REDIRECT_INITIATED,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -821,6 +821,8 @@ describe SamlIdpController do
 
     context 'POST to auth correctly stores SP in session' do
       before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
         @user = create(:user, :signed_up)
         @saml_request = saml_request(saml_settings)
         @post_request = saml_post_auth(@saml_request)
@@ -850,6 +852,15 @@ describe SamlIdpController do
         session_request_url = session[:sp][:request_url]
 
         expect(session_request_url).to match(%r{/api/saml/auth\d{4}})
+      end
+
+      it 'logs SAML Auth Request event' do
+        expect(@analytics).to have_received(:track_event).
+          with('SAML Auth Request',
+               requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+               service_provider: 'http://localhost:3000',
+               idv: false,
+               finish_profile: false)
       end
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -231,7 +231,35 @@ feature 'saml api' do
     end
   end
 
-  context 'when referer is external' do
+  context 'when sending POST request to /api/saml/authpost/' do
+    it 'logs one SAML Auth Requested event and multiple SAML Auth events for' do
+      fake_analytics = FakeAnalytics.new
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+
+      saml_post_url = saml_authn_request_url(
+        overrides: {
+          idp_sso_target_url: "http://#{IdentityConfig.store.domain_name}/api/saml/authpost2022",
+        },
+      )
+      page.driver.post saml_post_url
+      visit page.driver.response.location
+
+      sign_in_via_branded_page(user)
+      click_agree_and_continue
+      click_submit_default
+
+      expect(fake_analytics.events['SAML Auth Request']).to eq(
+        [{ identity_needs_verification: false, profile_needs_verification: false,
+           requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
+           service_provider: 'http://localhost:3000' }],
+      )
+      expect(fake_analytics.events['SAML Auth'].count).to eq 2
+
+      expect(current_url).to eq sp.acs_url
+    end
+  end
+
+  context 'when referer is external and sending a GET request' do
     # SAML auth receives one external request and an internal redirect
     # This test helps ensure we can disambiguate the different events
     it 'logs one SAML Auth Requested event and multiple SAML Auth events' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -231,19 +231,14 @@ feature 'saml api' do
     end
   end
 
-  context 'when sending POST request to /api/saml/authpost/' do
+  context 'when sending POST request to /api/saml/auth/' do
     it 'logs one SAML Auth Requested event and multiple SAML Auth events for' do
       fake_analytics = FakeAnalytics.new
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
 
-      saml_post_url = saml_authn_request_url(
-        overrides: {
-          idp_sso_target_url: "http://#{IdentityConfig.store.domain_name}/api/saml/authpost2022",
-        },
-      )
-      page.driver.post saml_post_url
-      visit page.driver.response.location
+      page.driver.post saml_authn_request_url
 
+      click_submit_default
       sign_in_via_branded_page(user)
       click_agree_and_continue
       click_submit_default

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -230,4 +230,28 @@ feature 'saml api' do
       end
     end
   end
+
+  context 'when referer is external' do
+    # SAML auth receives one external request and an internal redirect
+    # This test helps ensure we can disambiguate the different events
+    it 'logs one SAML Auth Requested event and multiple SAML Auth events' do
+      fake_analytics = FakeAnalytics.new
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      Capybara.current_session.driver.header 'Referer', 'http://example.com'
+
+      visit_saml_authn_request_url
+      sign_in_via_branded_page(user)
+      click_agree_and_continue
+      click_submit_default
+
+      expect(fake_analytics.events['SAML Auth Request']).to eq(
+        [{ idv: false, finish_profile: false,
+           requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
+           service_provider: 'http://localhost:3000' }],
+      )
+      expect(fake_analytics.events['SAML Auth'].count).to eq 2
+
+      expect(current_url).to eq sp.acs_url
+    end
+  end
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -245,7 +245,7 @@ feature 'saml api' do
       click_submit_default
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
-        [{ idv: false, finish_profile: false,
+        [{ identity_needs_verification: false, profile_needs_verification: false,
            requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
            service_provider: 'http://localhost:3000' }],
       )

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -7,6 +7,10 @@ class FakeSamlRequest
     'http://localhost:3000'
   end
 
+  def issuer
+    'http://localhost:3000'
+  end
+
   def requested_authn_context
     Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
   end


### PR DESCRIPTION
Currently, we log OIDC auth requests with the `OPENID_CONNECT_REQUEST_AUTHORIZATION` event. SAML has a similar event in `SAML_AUTH`, but it's not quite the same. SAML will redirect internally and this event is only logged when a user is completely authenticated. This means we capture the event later in the process, and also potentially multiple times for one authentication request.

This PR creates a `'SAML Auth Request'` event which aims to be a closer match to the behavior on the OIDC side of logging where we log the external request only and before user authentication is required. The authentication gate on the original event is what prevented from adding `external` as an attribute rather than creating a new event.