### PR TITLE
Deploy RC 184.2 to Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :development, :test do
   gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'brakeman', require: false
   gem 'bullet', '>= 6.0.2'
+  gem 'data_uri', require: false
   gem 'erb_lint', '~> 0.1.0', require: false
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'knapsack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
       addressable
     cssbundling-rails (1.0.0)
       railties (>= 6.0.0)
+    data_uri (0.1.0)
     debug_inspector (1.1.0)
     derailed_benchmarks (1.8.1)
       benchmark-ips (~> 2)
@@ -705,6 +706,7 @@ DEPENDENCIES
   capybara-selenium (>= 0.0.6)
   connection_pool
   cssbundling-rails
+  data_uri
   derailed_benchmarks (~> 1.8)
   devise (~> 4.8)
   dotiw (>= 4.0.1)

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -22,6 +22,7 @@ module Idv
       redirect_to next_step
     end
 
+    # Remove this after the next deploy
     def download
       personal_key = user_session[:personal_key]
 

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -9,6 +9,7 @@ const formEl = document.getElementById('confirm-key');
 const input = formEl.querySelector('input[type="text"]');
 const modalTrigger = document.querySelector('[data-toggle="modal"]');
 const modalDismiss = document.querySelector('[data-dismiss="personal-key-confirm"]');
+const downloadLink = document.querySelector('a[download]');
 
 let isInvalidForm = false;
 
@@ -114,6 +115,20 @@ function hide() {
   modal.hide();
 }
 
+function downloadForIE(event) {
+  event.preventDefault();
+
+  const filename = downloadLink.getAttribute('download');
+  const data = scrapePersonalKey();
+  const blob = new Blob([data], { type: 'text/plain' });
+
+  window.navigator.msSaveBlob(blob, filename);
+}
+
 modalTrigger.addEventListener('click', show);
 modalDismiss.addEventListener('click', hide);
 formEl.addEventListener('submit', handleSubmit);
+
+if (window.navigator.msSaveBlob) {
+  downloadLink.addEventListener('click', downloadForIE);
+}

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -10,7 +10,12 @@
 </div>
 <%= render ButtonComponent.new(
       action: ->(**tag_options, &block) do
-        link_to(idv_download_personal_key_path, **tag_options, &block)
+        link_to(
+          "data:text/plain;charset=utf-8,#{CGI.escape(code)}",
+          download: 'personal_key.txt',
+          **tag_options,
+          &block
+        )
       end,
       icon: :file_download,
       outline: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,6 +272,7 @@ Rails.application.routes.draw do
       get '/come_back_later' => 'come_back_later#show'
       get '/personal_key' => 'personal_key#show'
       post '/personal_key' => 'personal_key#update'
+      # Remove this after the next deploy
       get '/download_personal_key' => 'personal_key#download'
       get '/forgot_password' => 'forgot_password#new'
       post '/forgot_password' => 'forgot_password#update'

--- a/spec/views/shared/_personal_key.html.erb_spec.rb
+++ b/spec/views/shared/_personal_key.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'data_uri'
+
+RSpec.describe 'shared/_personal_key.html.erb' do
+  let(:personal_key) { RandomPhrase.new(num_words: 4).to_s }
+
+  describe 'download link' do
+    around do |ex|
+      # data_uri depends on URI.decode which was removed in Ruby 3.0 :sob:
+      module URI
+        def self.decode(value)
+          CGI.unescape(value)
+        end
+      end
+
+      ex.run
+
+      URI.singleton_class.undef_method(:decode)
+    end
+
+    it 'has the download attribute and a data: url for the personal key' do
+      render 'shared/personal_key', code: personal_key, update_path: '/test'
+
+      doc = Nokogiri::HTML(rendered)
+      download_link = doc.at_css('a[download]')
+      data_uri = URI::Data.new(download_link[:href])
+
+      expect(data_uri.content_type).to eq('text/plain')
+      expect(data_uri.data).to eq(personal_key)
+    end
+  end
+end


### PR DESCRIPTION
Fix downloading personal keys outside of IDV (LG-5882) (#6161)

* download personal key via data: URL or JS fallback for Internet Explorer
* add specs and removal notes

changelog: Bug Fixes, Personal keys, Fixes downloading personal keys outside of identity verification