### PR TITLE
Drop unused users columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,5 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[
-    totp_timestamp
-    sign_in_count
-    current_sign_in_at
-    last_sign_in_at
-    current_sign_in_ip
-    last_sign_in_ip
-  ]
+  self.ignored_columns = %w[totp_timestamp]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/db/primary_migrate/20220406155240_drop_users_sign_in_at_sign_in_ip_sign_in_count.rb
+++ b/db/primary_migrate/20220406155240_drop_users_sign_in_at_sign_in_ip_sign_in_count.rb
@@ -1,0 +1,19 @@
+class DropUsersSignInAtSignInIpSignInCount < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      remove_column :users, :sign_in_count
+      remove_column :users, :current_sign_in_at
+      remove_column :users, :last_sign_in_at
+      remove_column :users, :current_sign_in_ip
+      remove_column :users, :last_sign_in_ip
+    end
+  end
+
+  def down
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :text
+    add_column :users, :last_sign_in_ip, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_07_214616) do
+ActiveRecord::Schema.define(version: 2022_04_06_155240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -593,11 +593,6 @@ ActiveRecord::Schema.define(version: 2022_03_07_214616) do
     t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip", limit: 255
-    t.string "last_sign_in_ip", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "confirmation_token", limit: 255


### PR DESCRIPTION
Follow up to #6148, but this should not be merged until the previous PR is deployed everywhere