### PR TITLE
Revert tab placement change for password toggle checkbox

### DIFF
--- a/app/components/password_toggle_component.html.erb
+++ b/app/components/password_toggle_component.html.erb
@@ -1,5 +1,15 @@
 <%= content_tag(:'lg-password-toggle', class: css_class) do %>
-  <%= render field if toggle_position == :bottom %>
+  <%= render ValidatedFieldComponent.new(
+        form: form,
+        name: :password,
+        type: :password,
+        label: label,
+        **field_options,
+        input_html: field_options[:input_html].to_h.merge(
+          id: input_id,
+          class: ['password-toggle__input', *field_options.dig(:input_html, :class)],
+        ),
+      ) %>
   <div class="password-toggle__toggle-wrapper js">
     <input
       id="<%= toggle_id %>"
@@ -14,5 +24,4 @@
       <%= toggle_label %>
     </label>
   </div>
-  <%= render field if toggle_position == :top %>
 <% end %>

--- a/app/components/password_toggle_component.rb
+++ b/app/components/password_toggle_component.rb
@@ -29,18 +29,4 @@ class PasswordToggleComponent < BaseComponent
   def input_id
     "password-toggle-input-#{unique_id}"
   end
-
-  def field
-    ValidatedFieldComponent.new(
-      form: form,
-      name: :password,
-      type: :password,
-      label: label,
-      **field_options,
-      input_html: field_options[:input_html].to_h.merge(
-        id: input_id,
-        class: ['password-toggle__input', *field_options.dig(:input_html, :class)],
-      ),
-    )
-  end
 end

--- a/spec/components/password_toggle_component_spec.rb
+++ b/spec/components/password_toggle_component_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe PasswordToggleComponent, type: :component do
       it 'renders modifier class' do
         expect(rendered).to have_css('lg-password-toggle.password-toggle--toggle-top')
       end
-
-      it 'renders toggle before input' do
-        expect(rendered).to have_css('.password-toggle__toggle-wrapper + lg-validated-field')
-      end
     end
 
     context 'with bottom toggle position' do
@@ -63,10 +59,6 @@ RSpec.describe PasswordToggleComponent, type: :component do
 
       it 'renders modifier class' do
         expect(rendered).to have_css('lg-password-toggle.password-toggle--toggle-bottom')
-      end
-
-      it 'renders toggle after input' do
-        expect(rendered).to have_css('lg-validated-field + .password-toggle__toggle-wrapper')
       end
     end
   end


### PR DESCRIPTION
Related: #6081

**Why**: Since it may have a negative impact on form usability, revert until we have a chance to think about this more holistically.