### PR TITLE
Create warning banner CTA to add a second authentication method

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -12,6 +12,7 @@ module SignUp
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
         analytics_attributes(''),
       )
+      @multiple_factors_enabled = MfaPolicy.new(current_user).multiple_factors_enabled?
       @presenter = completions_presenter
     end
 

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -56,6 +56,7 @@ module Users
 
     def confirm_user_needs_2fa_setup
       return unless mfa_policy.two_factor_enabled?
+      return if params.has_key?(:multiple_mfa_setup)
       return if service_provider_mfa_policy.user_needs_sp_auth_method_setup?
       redirect_to after_mfa_setup_path
     end

--- a/app/views/mfa_confirmation/index.html.erb
+++ b/app/views/mfa_confirmation/index.html.erb
@@ -4,18 +4,18 @@
 <% title t('titles.mfa_setup.first_authentication_method') %>
 
 <%= render AlertComponent.new(type: :success, class: 'margin-bottom-4') do %>
-  <%= t('multi_factor_authentication.method_confirmation.face_id') %>
+  <%= t('mfa.method_confirmation.face_id') %>
 <% end %>
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.mfa_setup.first_authentication_method')) %>
 
-<p class='margin-top-1 margin-bottom-4'><%= t('multi_factor_authentication.cta') %></p>
+<p class='margin-top-1 margin-bottom-4'><%= t('mfa.cta') %></p>
 
 <%= button_to(
       account_reset_pending_cancel_path,
       class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
-    ) { t('multi_factor_authentication.add') } %>
+    ) { t('mfa.add') } %>
 
-<%= link_to t('multi_factor_authentication.skip'), root_url %>
+<%= link_to t('mfa.skip'), root_url %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -24,6 +24,15 @@
         sp: content_tag(:strong, decorated_session.sp_name),
       ) %>
 </p>
+<% if !@multiple_factors_enabled && IdentityConfig.store.select_multiple_mfa_options %>
+  <%= render(AlertComponent.new(type: :warning, class: 'margin-bottom-4')) do %>
+    <%= link_to(
+          t('mfa.second_method_warning.link'),
+          two_factor_options_url(multiple_mfa_setup: ''),
+        ) %>
+    <%= t('mfa.second_method_warning.text') %>
+  <% end %>
+<% end %>
 <p>
   <%= validated_form_for(:idv_form, url: sign_up_completed_path) do %>
     <%= submit_tag t('sign_up.agree_and_continue'), class: 'usa-button usa-button--big usa-button--wide' %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -18,7 +18,7 @@
 
 <% if IdentityConfig.store.select_multiple_mfa_options %>
   <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4') do %>
-    <%= t('multi_factor_authentication.info') %>
+    <%= t('mfa.info') %>
   <% end %>
 <% end %>
 

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  multi_factor_authentication:
+  mfa:
     add: Add another method
     cta: Adding another authentication method prevents you from getting locked out
       of your account if you lose one of your methods.
@@ -8,4 +8,8 @@ en:
       backup if you lose one of your chosen authentication devices.
     method_confirmation:
       face_id: Face ID has been added to your account
+    second_method_warning:
+      link: Add a second authentication method.
+      text: You will have to delete your account and start over if you lose your only
+        authentication method.
     skip: Skip for now

--- a/config/locales/mfa/es.yml
+++ b/config/locales/mfa/es.yml
@@ -1,6 +1,6 @@
 ---
 es:
-  multi_factor_authentication:
+  mfa:
     add: Agregar otro método
     cta: Agregar otro método de autenticación evita que se le bloquee el acceso a su
       cuenta si pierde uno de sus métodos.
@@ -9,4 +9,8 @@ es:
       autenticación elegidos.
     method_confirmation:
       face_id: Se ha agregado Face ID a su cuenta
+    second_method_warning:
+      link: Agregue un segundo método de autenticación.
+      text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de
+        autenticación.
     skip: Saltar por ahora

--- a/config/locales/mfa/fr.yml
+++ b/config/locales/mfa/fr.yml
@@ -1,6 +1,6 @@
 ---
 fr:
-  multi_factor_authentication:
+  mfa:
     add: Agregar otro método
     cta: L’ajout d’une autre méthode d’authentification vous empêche d’être bloqué
       sur votre compte si vous perdez l’une de vos méthodes.
@@ -9,4 +9,8 @@ fr:
       dispositifs d’authentification choisis.
     method_confirmation:
       face_id: Face ID a été ajouté à votre compte
+    second_method_warning:
+      link: Ajoutez une deuxième méthode d’authentification.
+      text: Vous devrez supprimer votre compte et recommencer si vous perdez votre
+        seule méthode d’authentification.
     skip: Ignorer pour l’instant

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -507,6 +507,18 @@ module Features
       click_submit_default
     end
 
+    def set_up_mfa_with_valid_phone
+      fill_in 'new_phone_form[phone]', with: '202-555-1212'
+      click_send_security_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+    end
+
+    def set_up_mfa_with_backup_codes
+      click_on t('forms.buttons.continue')
+      click_on t('forms.buttons.continue')
+    end
+
     def register_user(email = 'test@test.com')
       confirm_email_and_password(email)
       set_up_2fa_with_valid_phone

--- a/spec/views/mfa_confirmation/index.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/index.html.erb_spec.rb
@@ -16,12 +16,12 @@ describe 'mfa_confirmation/index.html.erb' do
   it 'provides a call to action to add another MFA method' do
     render
 
-    expect(rendered).to have_selector('p', text: t('multi_factor_authentication.cta'))
+    expect(rendered).to have_selector('p', text: t('mfa.cta'))
   end
 
   it 'has a button with the next step' do
     render
 
-    expect(rendered).to have_selector('button', text: t('multi_factor_authentication.add'))
+    expect(rendered).to have_selector('button', text: t('mfa.add'))
   end
 end

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -90,4 +90,59 @@ describe 'sign_up/completions/show.html.erb' do
       expect(rendered).to include('9**-**-***6')
     end
   end
+
+  describe 'MFA CTA banner' do
+    let(:multiple_factors_enabled) { nil }
+    let(:select_multiple_mfa_options) { nil }
+
+    before do
+      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).
+        and_return(select_multiple_mfa_options)
+      @multiple_factors_enabled = multiple_factors_enabled
+    end
+
+    context 'with multiple factors disabled' do
+      let(:multiple_factors_enabled) { false }
+
+      context 'with multiple MFA feature flag disabled' do
+        let(:select_multiple_mfa_options) { false }
+
+        it 'does not show a banner' do
+          render
+          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
+        end
+      end
+
+      context 'with multiple MFA feature flag enabled' do
+        let(:select_multiple_mfa_options) { true }
+
+        it 'shows a banner if the user selects one MFA option' do
+          render
+          expect(rendered).to have_content(t('mfa.second_method_warning.text'))
+        end
+      end
+    end
+
+    context 'with multiple factors enabled' do
+      let(:multiple_factors_enabled) { true }
+
+      context 'with multiple MFA feature flag disabled' do
+        let(:select_multiple_mfa_options) { false }
+
+        it 'does not show a banner' do
+          render
+          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
+        end
+      end
+
+      context 'with multiple MFA feature flag enabled' do
+        let(:select_multiple_mfa_options) { true }
+
+        it 'does not show a banner' do
+          render
+          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a CTA for users to add a second authentication banner in order to best secure their account. This is part of the "sad path" when a user does not select more than one method.

Note:
- This will not render in production at this time;
- The banner should only be displayed if multiple factors are enabled