### PR TITLE
LG-5225 validation error IAL2 

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -32,6 +32,7 @@ module Idv
     def create
       result = idv_form.submit(step_params)
       analytics.track_event(Analytics::IDV_PHONE_CONFIRMATION_FORM, result.to_h)
+      flash[:error] = result.first_error_message if !result.success?
       return render :new, locals: { gpo_letter_available: gpo_letter_available } if !result.success?
       submit_proofing_attempt
       redirect_to idv_phone_path

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -141,7 +141,7 @@ describe Idv::PhoneController do
       it 'renders #new' do
         put :create, params: { idv_phone_form: { phone: '703' } }
 
-        expect(flash[:error]).to eq t('errors.messages.improbable_phone')
+        expect(flash[:error]).to eq t('errors.messages.must_have_us_country_code')
         expect(response).to render_template(:new)
       end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -149,6 +149,7 @@ describe Idv::PhoneController do
         put :create, params: { idv_phone_form: { phone: international_phone } }
 
         expect(flash[:warning]).to be_nil
+        expect(flash[:error]).not_to be_nil
         expect(response).to render_template(:new)
       end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -148,8 +148,7 @@ describe Idv::PhoneController do
       it 'disallows non-US numbers' do
         put :create, params: { idv_phone_form: { phone: international_phone } }
 
-        expect(flash[:warning]).to be_nil
-        expect(flash[:error]).not_to be_nil
+        expect(flash[:error]).to eq t('errors.messages.must_have_us_country_code')
         expect(response).to render_template(:new)
       end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -141,7 +141,7 @@ describe Idv::PhoneController do
       it 'renders #new' do
         put :create, params: { idv_phone_form: { phone: '703' } }
 
-        expect(flash[:warning]).to be_nil
+        expect(flash[:error]).to eq t('errors.messages.improbable_phone')
         expect(response).to render_template(:new)
       end
 


### PR DESCRIPTION
[LG-5225 Validation Errors not shown in IAL2](https://cm-jira.usa.gov/browse/LG-5225) 

**Why**:
- A good bug PR to get my hands dirty as a new dev on team ada 
- Possible edge cases (disabling JS?) where this bug might still occur, but adding this line of code doesn't do any harm 

**How**:
- Adding a flash[:error] in rails in the phone controller create function 

**Testing Instructions**
1. Go to http://localhost:3000/verify
2. Create account, follow steps until you get to verify phone
3. In the developer tools DOM, edit `<form> `and add `novalidate `
4. Add a phone number that is **not** US (ie: 3065551234) 
5. You should see the error as it appears in the screenshot below 

**Screenshot**

<img width="621" alt="Screen Shot 2022-04-12 at 2 38 43 PM" src="https://user-images.githubusercontent.com/6639858/163030944-e889f7ff-d469-48d5-9508-d417bea15a7e.png">
