### PR TITLE
Remove visually-disabled effect from FormStepsContinueButton

### DIFF
--- a/app/javascript/packages/components/button.spec.tsx
+++ b/app/javascript/packages/components/button.spec.tsx
@@ -95,23 +95,6 @@ describe('document-capture/components/button', () => {
     expect(button.disabled).to.be.true();
   });
 
-  it('renders as visually disabled', () => {
-    const onClick = sinon.spy();
-    const { getByText } = render(
-      <Button isVisuallyDisabled onClick={onClick}>
-        Click me
-      </Button>,
-    );
-
-    const button = getByText('Click me') as HTMLButtonElement;
-
-    expect(button.classList.contains('usa-button--disabled'));
-    expect(button.disabled).to.be.false();
-
-    userEvent.click(button);
-    expect(onClick.calledOnce).to.be.true();
-  });
-
   it('renders with custom type', () => {
     const { getByText } = render(<Button type="submit">Click me</Button>);
 

--- a/app/javascript/packages/components/button.tsx
+++ b/app/javascript/packages/components/button.tsx
@@ -49,11 +49,6 @@ export interface ButtonProps {
   isUnstyled?: boolean;
 
   /**
-   * Whether button should appear disabled (but remain clickable).
-   */
-  isVisuallyDisabled?: boolean;
-
-  /**
    * Optional additional class names.
    */
   className?: string;
@@ -69,7 +64,6 @@ function Button({
   isOutline,
   isDisabled,
   isUnstyled,
-  isVisuallyDisabled,
   className,
 }: ButtonProps) {
   const classes = [
@@ -79,7 +73,6 @@ function Button({
     isWide && 'usa-button--wide',
     isOutline && 'usa-button--outline',
     isUnstyled && 'usa-button--unstyled',
-    isVisuallyDisabled && 'usa-button--disabled',
     className,
   ]
     .filter(Boolean)

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -3,9 +3,9 @@ import { Alert } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
 import { FormSteps, PromptOnNavigate } from '@18f/identity-form-steps';
 import { UploadFormEntriesError } from '../services/upload';
-import DocumentsStep, { documentsStepValidator } from './documents-step';
-import SelfieStep, { selfieStepValidator } from './selfie-step';
-import ReviewIssuesStep, { reviewIssuesStepValidator } from './review-issues-step';
+import DocumentsStep from './documents-step';
+import SelfieStep from './selfie-step';
+import ReviewIssuesStep from './review-issues-step';
 import ServiceProviderContext from '../context/service-provider';
 import UploadContext from '../context/upload';
 import Submission from './submission';
@@ -106,7 +106,6 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
             captureHints:
               submissionError instanceof UploadFormEntriesError ? submissionError.hints : null,
           })(ReviewIssuesStep),
-          validator: reviewIssuesStepValidator,
         },
       ]
     : /** @type {FormStep[]} */ (
@@ -114,12 +113,10 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
           {
             name: 'documents',
             form: DocumentsStep,
-            validator: documentsStepValidator,
           },
           serviceProvider.isLivenessRequired && {
             name: 'selfie',
             form: SelfieStep,
-            validator: selfieStepValidator,
           },
         ].filter(Boolean)
       );

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -30,13 +30,6 @@ import StartOverOrCancel from './start-over-or-cancel';
 const DOCUMENT_SIDES = ['front', 'back'];
 
 /**
- * @return {Boolean} whether or not the value is valid for the document step
- */
-function documentsStepValidator(value = {}) {
-  return DOCUMENT_SIDES.every((side) => !!value[side]);
-}
-
-/**
  * @param {import('@18f/identity-form-steps').FormStepComponentProps<DocumentsStepValue>} props Props object.
  */
 function DocumentsStep({
@@ -79,5 +72,3 @@ function DocumentsStep({
 }
 
 export default withBackgroundEncryptedUpload(DocumentsStep);
-
-export { documentsStepValidator };

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -38,22 +38,6 @@ const DOCUMENT_SIDES = ['front', 'back'];
 const DISPLAY_ATTEMPTS = 3;
 
 /**
- * @param {Partial<ReviewIssuesStepValue>=} value
- *
- * @return {boolean} Whether the value is valid for the review issues step.
- */
-function reviewIssuesStepValidator(value = {}) {
-  const hasDocuments = DOCUMENT_SIDES.every((side) => !!value[side]);
-
-  // Absent availability of service provider context here, this relies on the fact that:
-  // 1) The review step is only shown with an existing, complete set of values.
-  // 2) Clearing an existing value sets it as null, but doesn't remove the key from the object.
-  const hasSelfieIfApplicable = !('selfie' in value) || !!value.selfie;
-
-  return hasDocuments && hasSelfieIfApplicable;
-}
-
-/**
  * @param {import('@18f/identity-form-steps').FormStepComponentProps<ReviewIssuesStepValue> & {
  *  remainingAttempts: number,
  *  captureHints: boolean,
@@ -185,5 +169,3 @@ function ReviewIssuesStep({
 }
 
 export default withBackgroundEncryptedUpload(ReviewIssuesStep);
-
-export { reviewIssuesStepValidator };

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -16,13 +16,6 @@ import StartOverOrCancel from './start-over-or-cancel';
  */
 
 /**
- * @return {Boolean} whether or not the value is valid for the selfie step
- */
-function selfieStepValidator(value = {}) {
-  return !!value.selfie;
-}
-
-/**
  * @param {import('@18f/identity-form-steps').FormStepComponentProps<SelfieStepValue>} props Props object.
  */
 function SelfieStep({
@@ -72,5 +65,3 @@ function SelfieStep({
 }
 
 export default withBackgroundEncryptedUpload(SelfieStep);
-
-export { selfieStepValidator };

--- a/app/javascript/packages/form-steps/form-steps-context.tsx
+++ b/app/javascript/packages/form-steps/form-steps-context.tsx
@@ -7,11 +7,6 @@ interface FormStepsContextValue {
   isLastStep: boolean;
 
   /**
-   * Whether the user can proceed to the next step.
-   */
-  canContinueToNextStep: boolean;
-
-  /**
    * Callback invoked when content is reset in a page transition.
    */
   onPageTransition: () => void;
@@ -19,7 +14,6 @@ interface FormStepsContextValue {
 
 const FormStepsContext = createContext({
   isLastStep: true,
-  canContinueToNextStep: true,
   onPageTransition: () => {},
 } as FormStepsContextValue);
 

--- a/app/javascript/packages/form-steps/form-steps-continue-button.tsx
+++ b/app/javascript/packages/form-steps/form-steps-continue-button.tsx
@@ -5,16 +5,10 @@ import FormStepsContext from './form-steps-context';
 
 function FormStepsContinueButton() {
   const { t } = useI18n();
-  const { canContinueToNextStep, isLastStep } = useContext(FormStepsContext);
+  const { isLastStep } = useContext(FormStepsContext);
 
   return (
-    <Button
-      type="submit"
-      isBig
-      isWide
-      className="display-block margin-y-5"
-      isVisuallyDisabled={!canContinueToNextStep}
-    >
+    <Button type="submit" isBig isWide className="display-block margin-y-5">
       {isLastStep ? t('forms.buttons.submit.default') : t('forms.buttons.continue')}
     </Button>
   );

--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -417,7 +417,6 @@ describe('FormSteps', () => {
 
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: false,
-      canContinueToNextStep: true,
     });
 
     userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
@@ -428,7 +427,6 @@ describe('FormSteps', () => {
     expect(window.location.hash).to.equal('#step=second');
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: false,
-      canContinueToNextStep: false,
     });
 
     userEvent.type(getByLabelText('Second Input One'), 'one');
@@ -438,7 +436,6 @@ describe('FormSteps', () => {
     expect(window.location.hash).to.equal('#step=last');
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: true,
-      canContinueToNextStep: true,
     });
   });
 

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -76,11 +76,6 @@ export interface FormStep {
    * Step form component.
    */
   form: FC<FormStepComponentProps<Record<string, any>>>;
-
-  /**
-   * Optional function to validate values for the step
-   */
-  validator?: (object) => boolean;
 }
 
 interface FieldsRefEntry {
@@ -242,10 +237,8 @@ function FormSteps({
   }
 
   const unknownFieldErrors = activeErrors.filter((error) => !fields.current[error.field]?.element);
-  const isValidStep = step.validator?.(values) ?? true;
   const hasUnresolvedFieldErrors =
     activeErrors.length && activeErrors.length > unknownFieldErrors.length;
-  const canContinueToNextStep = isValidStep && !hasUnresolvedFieldErrors;
 
   /**
    * Increments state to the next step, or calls onComplete callback if the current step is the last
@@ -291,7 +284,7 @@ function FormSteps({
           {error.message}
         </Alert>
       ))}
-      <FormStepsContext.Provider value={{ isLastStep, canContinueToNextStep, onPageTransition }}>
+      <FormStepsContext.Provider value={{ isLastStep, onPageTransition }}>
         <Form
           key={name}
           value={values}

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -108,10 +108,8 @@ describe('document-capture/components/document-capture', () => {
     });
     window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, validSelfieBase64);
 
-    // Continue is enabled (but grayed out).Attempting to proceed without providing values will
-    // trigger error messages.
+    // Attempting to proceed without providing values will trigger error messages.
     let continueButton = getByText('forms.buttons.continue');
-    expect(continueButton.classList.contains('usa-button--disabled')).to.be.true();
     userEvent.click(continueButton);
     let errors = await findAllByText('simple_form.required.text');
     expect(errors).to.have.lengthOf(2);
@@ -132,16 +130,14 @@ describe('document-capture/components/document-capture', () => {
 
     userEvent.click(getByLabelText('doc_auth.headings.document_capture_back'));
 
-    // Continue only once all errors have been removed, button is no longer grayed out
+    // Continue only once all errors have been removed.
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     continueButton = getByText('forms.buttons.continue');
     expect(isFormValid(continueButton.closest('form'))).to.be.true();
-    expect(continueButton.classList.contains('usa-button--disabled')).to.be.false();
     userEvent.click(continueButton);
 
-    // Trigger validation by attempting to submit, button is grayed out
+    // Trigger validation by attempting to submit.
     const submitButton = getByText('forms.buttons.submit.default');
-    expect(submitButton.classList.contains('usa-button--disabled')).to.be.true();
 
     userEvent.click(submitButton);
     errors = await findAllByText('simple_form.required.text');
@@ -154,9 +150,8 @@ describe('document-capture/components/document-capture', () => {
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
     fireEvent.click(selfieInput);
 
-    // Continue only once all errors have been removed, button no longer grayed out
+    // Continue only once all errors have been removed.
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    expect(submitButton.classList.contains('usa-button--disabled')).to.be.false();
     expect(isFormValid(submitButton.closest('form'))).to.be.true();
 
     await new Promise((resolve) => {
@@ -280,9 +275,7 @@ describe('document-capture/components/document-capture', () => {
     const hasValueSelected = !!getByLabelText('doc_auth.headings.document_capture_front');
     expect(hasValueSelected).to.be.true();
 
-    // Submit button should be disabled until field errors are resolved.
     submitButton = getByText('forms.buttons.submit.default');
-    expect(submitButton.classList.contains('usa-button--disabled')).to.be.true();
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
 
@@ -291,7 +284,6 @@ describe('document-capture/components/document-capture', () => {
     notices = await findAllByRole('alert');
     const errorNotices = notices.filter((notice) => notice.classList.contains('usa-alert--error'));
     expect(errorNotices).to.have.lengthOf(0);
-    expect(submitButton.classList.contains('usa-button--disabled')).to.be.false();
 
     // Verify re-submission. It will fail again, but test can at least assure that the interstitial
     // screen is shown once more.

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -5,9 +5,7 @@ import {
   UploadContextProvider,
   AnalyticsContext,
 } from '@18f/identity-document-capture';
-import ReviewIssuesStep, {
-  reviewIssuesStepValidator,
-} from '@18f/identity-document-capture/components/review-issues-step';
+import ReviewIssuesStep from '@18f/identity-document-capture/components/review-issues-step';
 import { toFormEntryError } from '@18f/identity-document-capture/services/upload';
 import { render } from '../../../support/document-capture';
 import { useSandbox } from '../../../support/sinon';
@@ -15,51 +13,6 @@ import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/review-issues-step', () => {
   const sandbox = useSandbox();
-
-  describe('reviewIssuesStepValidator', () => {
-    it('returns false if given undefined value', () => {
-      const isValid = reviewIssuesStepValidator();
-
-      expect(isValid).to.be.false();
-    });
-
-    it('returns false if either of front or back are absent', () => {
-      for (const key of ['front', 'back']) {
-        const isValid = reviewIssuesStepValidator({ [key]: new window.Blob() });
-
-        expect(isValid).to.be.false();
-      }
-    });
-
-    it('returns true if front and back are given, and selfie is not applicable', () => {
-      const isValid = reviewIssuesStepValidator({
-        front: new window.Blob(),
-        back: new window.Blob(),
-      });
-
-      expect(isValid).to.be.true();
-    });
-
-    it('returns false if selfie is applicable and missing', () => {
-      const isValid = reviewIssuesStepValidator({
-        front: new window.Blob(),
-        back: new window.Blob(),
-        selfie: null,
-      });
-
-      expect(isValid).to.be.false();
-    });
-
-    it('returns true if selfie is applicable and given', () => {
-      const isValid = reviewIssuesStepValidator({
-        front: new window.Blob(),
-        back: new window.Blob(),
-        selfie: new window.Blob(),
-      });
-
-      expect(isValid).to.be.true();
-    });
-  });
 
   it('logs warning events', () => {
     const addPageAction = sinon.spy();


### PR DESCRIPTION
**Why**: For consistency with other submit buttons, which are always shown as enabled and validate upon submission. Since this button will be used as part of ongoing identity verification work (LG-4159), changing this default behavior ensures we don't exacerbate the inconsistency.

This effectively reverts #4501

**Screenshots:**

Before|After
---|---
![localhost_3000_verify_doc_auth_document_capture (1)](https://user-images.githubusercontent.com/1779930/163038907-8ad76fb8-d34f-49b9-b30e-c93476f0ef3c.png)|![localhost_3000_verify_doc_auth_document_capture](https://user-images.githubusercontent.com/1779930/163038908-de3f856c-7509-4a99-a617-7062c63a39fc.png)

FYSA @anniehirshman-gsa 