### PR TITLE
In-Person-Proofing "Beta" Tag (LG-6073)

### DIFF
--- a/app/assets/stylesheets/components/_troubleshooting-options.scss
+++ b/app/assets/stylesheets/components/_troubleshooting-options.scss
@@ -5,7 +5,7 @@
     margin-bottom: 0;
   }
 
-  &::before {
+  &:not(.troubleshooting-options__no-bar)::before {
     @include u-margin-bottom(4);
     background-color: color('secondary');
     content: '';

--- a/app/components/troubleshooting_options_component.html.erb
+++ b/app/components/troubleshooting_options_component.html.erb
@@ -1,4 +1,12 @@
 <%= tag.section(**tag_options, class: css_class) do %>
+  <% if new_features? %>
+    <div class="margin-top-3">
+      <span class="usa-tag bg-accent-cool-darker text-uppercase">
+        <%= t('components.troubleshooting_options.new_feature') %>
+      </span>
+    </div>
+  <% end %>
+
   <%= header %>
   <ul class="troubleshooting-options__options">
     <% options.each do |option| %>

--- a/app/components/troubleshooting_options_component.rb
+++ b/app/components/troubleshooting_options_component.rb
@@ -5,15 +5,24 @@ class TroubleshootingOptionsComponent < BaseComponent
   attr_reader :tag_options
 
   def initialize(**tag_options)
-    @tag_options = tag_options
+    @tag_options = tag_options.dup
+    @new_features = @tag_options.delete(:new_features)
   end
 
   def render?
     options?
   end
 
+  def new_features?
+    @new_features
+  end
+
   def css_class
-    ['troubleshooting-options', *tag_options[:class]]
+    [
+      'troubleshooting-options',
+      new_features? && 'troubleshooting-options__no-bar',
+      *tag_options[:class],
+    ].select(&:present?)
   end
 
   class TroubleshootingOptionsHeadingComponent < BaseComponent

--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -37,7 +37,6 @@ function TroubleshootingOptions({ headingTag = 'h2', heading, options, isNewFeat
           <div className="margin-top-3">
             <span
               className="usa-tag bg-accent-cool-darker text-uppercase"
-              data-testid="new-features-tag"
             >
               {t('components.troubleshooting_options.new_feature')}
             </span>

--- a/app/javascript/packages/components/troubleshooting-options.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.jsx
@@ -15,18 +15,35 @@ import { useI18n } from '@18f/identity-react-i18n';
  * @prop {'h1'|'h2'|'h3'|'h4'|'h5'|'h6'=} headingTag
  * @prop {string=} heading
  * @prop {TroubleshootingOption[]} options
+ * @prop {boolean=} isNewFeatures
  */
 
 /**
  * @param {TroubleshootingOptionsProps} props
  */
-function TroubleshootingOptions({ headingTag = 'h2', heading, options }) {
+function TroubleshootingOptions({ headingTag = 'h2', heading, options, isNewFeatures }) {
   const { t } = useI18n();
 
   const HeadingTag = headingTag;
 
   return (
-    <section className="troubleshooting-options">
+    <section
+      className={['troubleshooting-options', isNewFeatures && 'troubleshooting-options__no-bar']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {isNewFeatures && (
+        <>
+          <div className="margin-top-3">
+            <span
+              className="usa-tag bg-accent-cool-darker text-uppercase"
+              data-testid="new-features-tag"
+            >
+              {t('components.troubleshooting_options.new_feature')}
+            </span>
+          </div>
+        </>
+      )}
       <HeadingTag className="troubleshooting-options__heading">
         {heading ?? t('components.troubleshooting_options.default_heading')}
       </HeadingTag>

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -49,4 +49,22 @@ describe('TroubleshootingOptions', () => {
     expect(links[1].href).to.equal('https://example.com/2');
     expect(links[1].target).to.be.empty();
   });
+
+  it('renders a new features tag with isNewFeatures', () => {
+    const { getByTestId } = render(
+      <TroubleshootingOptions
+        heading=""
+        isNewFeatures
+        options={[
+          { text: <>Option 1</>, url: 'https://example.com/1', isExternal: true },
+          { text: 'Option 2', url: 'https://example.com/2' },
+        ]}
+      />,
+    );
+
+    const tag = getByTestId('new-features-tag');
+    expect(tag).to.exist();
+    expect(tag.textContent).to.eq('components.troubleshooting_options.new_feature');
+    expect(tag.classList.contains('text-uppercase')).to.eq(true);
+  });
 });

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -51,7 +51,7 @@ describe('TroubleshootingOptions', () => {
   });
 
   it('renders a new features tag with isNewFeatures', () => {
-    const { getByText } = render(
+    const { container, getByText } = render(
       <TroubleshootingOptions
         heading=""
         isNewFeatures
@@ -61,6 +61,10 @@ describe('TroubleshootingOptions', () => {
         ]}
       />,
     );
+
+    expect(
+      container.firstElementChild?.classList.contains('troubleshooting-options__no-bar'),
+    ).to.eq(true, 'it hides the visual bar');
 
     const tag = getByText('components.troubleshooting_options.new_feature');
     expect(tag.classList.contains('text-uppercase')).to.eq(true);

--- a/app/javascript/packages/components/troubleshooting-options.spec.jsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.jsx
@@ -51,7 +51,7 @@ describe('TroubleshootingOptions', () => {
   });
 
   it('renders a new features tag with isNewFeatures', () => {
-    const { getByTestId } = render(
+    const { getByText } = render(
       <TroubleshootingOptions
         heading=""
         isNewFeatures
@@ -62,9 +62,7 @@ describe('TroubleshootingOptions', () => {
       />,
     );
 
-    const tag = getByTestId('new-features-tag');
-    expect(tag).to.exist();
-    expect(tag.textContent).to.eq('components.troubleshooting_options.new_feature');
+    const tag = getByText('components.troubleshooting_options.new_feature');
     expect(tag.classList.contains('text-uppercase')).to.eq(true);
   });
 });

--- a/app/javascript/packages/document-capture/components/capture-advice.jsx
+++ b/app/javascript/packages/document-capture/components/capture-advice.jsx
@@ -30,6 +30,7 @@ function CaptureAdvice({ onTryAgain, isAssessedAsGlare, isAssessedAsBlurry }) {
         <DocumentCaptureTroubleshootingOptions
           heading={t('idv.troubleshooting.headings.still_having_trouble')}
           location="capture_tips"
+          hasErrors
         />
       }
     >

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -15,47 +15,67 @@ interface DocumentCaptureTroubleshootingOptionsProps {
    * Location parameter to append to links.
    */
   location?: string;
+
+  /**
+   * If there are any errors (toggles whether or not to show in person proofing option)
+   */
+  hasErrors?: boolean;
 }
 
 function DocumentCaptureTroubleshootingOptions({
   heading,
   location = 'document_capture_troubleshooting_options',
+  hasErrors,
 }: DocumentCaptureTroubleshootingOptionsProps) {
   const { t } = useI18n();
-  const { getHelpCenterURL } = useContext(HelpCenterContext);
+  const { getHelpCenterURL, idvInPersonURL } = useContext(HelpCenterContext);
   const { name: spName, getFailureToProofURL } = useContext(ServiceProviderContext);
 
   return (
-    <TroubleshootingOptions
-      heading={heading}
-      options={
-        [
-          {
-            url: getHelpCenterURL({
-              category: 'verify-your-identity',
-              article: 'how-to-add-images-of-your-state-issued-id',
-              location,
-            }),
-            text: t('idv.troubleshooting.options.doc_capture_tips'),
-            isExternal: true,
-          },
-          {
-            url: getHelpCenterURL({
-              category: 'verify-your-identity',
-              article: 'accepted-state-issued-identification',
-              location,
-            }),
-            text: t('idv.troubleshooting.options.supported_documents'),
-            isExternal: true,
-          },
-          spName && {
-            url: getFailureToProofURL(location),
-            text: t('idv.troubleshooting.options.get_help_at_sp', { sp_name: spName }),
-            isExternal: true,
-          },
-        ].filter(Boolean) as TroubleshootingOption[]
-      }
-    />
+    <>
+      <TroubleshootingOptions
+        heading={heading}
+        options={
+          [
+            {
+              url: getHelpCenterURL({
+                category: 'verify-your-identity',
+                article: 'how-to-add-images-of-your-state-issued-id',
+                location,
+              }),
+              text: t('idv.troubleshooting.options.doc_capture_tips'),
+              isExternal: true,
+            },
+            {
+              url: getHelpCenterURL({
+                category: 'verify-your-identity',
+                article: 'accepted-state-issued-identification',
+                location,
+              }),
+              text: t('idv.troubleshooting.options.supported_documents'),
+              isExternal: true,
+            },
+            spName && {
+              url: getFailureToProofURL(location),
+              text: t('idv.troubleshooting.options.get_help_at_sp', { sp_name: spName }),
+              isExternal: true,
+            },
+          ].filter(Boolean) as TroubleshootingOption[]
+        }
+      />
+      {hasErrors && idvInPersonURL && (
+        <TroubleshootingOptions
+          isNewFeatures
+          heading={t('idv.troubleshooting.headings.are_you_near')}
+          options={[
+            {
+              url: idvInPersonURL,
+              text: t('idv.troubleshooting.options.verify_in_person'),
+            },
+          ]}
+        />
+      )}
+    </>
   );
 }
 

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -72,7 +72,7 @@ function DocumentsStep({
         />
       ))}
       <FormStepsContinueButton />
-      <DocumentCaptureTroubleshootingOptions />
+      <DocumentCaptureTroubleshootingOptions hasErrors={!!errors.length} />
       <StartOverOrCancel />
     </CaptureTroubleshooting>
   );

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -163,7 +163,10 @@ function ReviewIssuesStep({
       location="doc_auth_review_issues"
       remainingAttempts={remainingAttempts}
       troubleshootingOptions={
-        <DocumentCaptureTroubleshootingOptions location="post_submission_warning" />
+        <DocumentCaptureTroubleshootingOptions
+          location="post_submission_warning"
+          hasErrors={!!errors?.length}
+        />
       }
     >
       {!!unknownFieldErrors &&

--- a/app/javascript/packages/document-capture/context/help-center.jsx
+++ b/app/javascript/packages/document-capture/context/help-center.jsx
@@ -20,6 +20,7 @@ import { addSearchParams } from '@18f/identity-url';
  *
  * @prop {string} helpCenterRedirectURL
  * @prop {GetHelpCenterURL} getHelpCenterURL
+ * @prop {string} idvInPersonURL
  */
 
 const HelpCenterContext = createContext(

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -58,6 +58,7 @@ import { I18nContext } from '@18f/identity-react-i18n';
  * @prop {FlowPath} flowPath
  * @prop {string} startOverUrl
  * @prop {string} cancelUrl
+ * @prop {string=} idvInPersonUrl
  *
  * @see AppContext
  * @see HelpCenterContextProvider
@@ -163,11 +164,12 @@ const noticeError = (error) =>
     flowPath,
     startOverUrl: startOverURL,
     cancelUrl: cancelURL,
+    idvInPersonUrl: idvInPersonURL,
   } = /** @type {AppRootData} */ (appRoot.dataset);
 
   const App = composeComponents(
     [AppContext.Provider, { value: { appName } }],
-    [HelpCenterContextProvider, { value: { helpCenterRedirectURL } }],
+    [HelpCenterContextProvider, { value: { helpCenterRedirectURL, idvInPersonURL } }],
     [DeviceContext.Provider, { value: device }],
     [AnalyticsContext.Provider, { value: { addPageAction, noticeError } }],
     [

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -29,3 +29,8 @@
             ) %>
       </p>
     <% end %>
+
+<%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
+  <% c.header(heading_level: :h2).with_content(t('idv.troubleshooting.headings.are_you_near')) %>
+  <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>
+<% end %>

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -34,3 +34,8 @@
             ) %>
       </p>
     <% end %>
+
+<%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
+  <% c.header(heading_level: :h2).with_content(t('idv.troubleshooting.headings.are_you_near')) %>
+  <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>
+<% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -35,3 +35,8 @@
             ) %>
       </p>
     <% end %>
+
+<%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
+  <% c.header(heading_level: :h2).with_content(t('idv.troubleshooting.headings.are_you_near')) %>
+  <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>
+<% end %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -38,6 +38,7 @@
       back_image_upload_url: back_image_upload_url,
       selfie_image_upload_url: selfie_image_upload_url,
       keep_alive_endpoint: sessions_keepalive_url,
+      idv_in_person_url: IdentityConfig.store.in_person_proofing_enabled ? idv_in_person_url : nil,
     } %>
 <div class="no-js">
   <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -14,3 +14,4 @@ en:
         warning: Warning
     troubleshooting_options:
       default_heading: 'Having trouble? Here’s what you can do:'
+      new_feature: New Feature

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -154,6 +154,7 @@ en:
         review: Re-enter your %{app_name} password to protect your data
     troubleshooting:
       headings:
+        are_you_near: 'Are you near Washington, D.C.?'
         missing_required_items: Are you missing one of these items?
         need_assistance: 'Need immediate assistance? Here’s how to get help:'
         still_having_trouble: Still having trouble?
@@ -167,3 +168,4 @@ en:
         learn_more_verify_by_phone: Learn more about verifying your phone number
         supported_documents: See a list of accepted state-issued IDs
         verify_by_mail: Verify your address by mail instead
+        verify_in_person: Verify your ID in person at a Post Office

--- a/spec/components/troubleshooting_options_component_spec.rb
+++ b/spec/components/troubleshooting_options_component_spec.rb
@@ -30,6 +30,27 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
       end
     end
 
+    context 'with :new_features' do
+      it 'renders a new features tag' do
+        rendered = render_inline(
+          TroubleshootingOptionsComponent.new(new_features: true),
+        ) { |c| c.option(url: '/').with_content('Link Text') }
+
+        expect(rendered).to have_css(
+          '.troubleshooting-options.troubleshooting-options__no-bar',
+        ), 'it hides the visual bar'
+
+        expect(rendered).to have_css(
+          '.troubleshooting-options .usa-tag.text-uppercase',
+          text: t('components.troubleshooting_options.new_feature'),
+        )
+
+        expect(rendered).to_not have_css(
+          '.troubleshooting-options[new_features=true]',
+        ), 'it does not add a new_feature HTML attribute'
+      end
+    end
+
     context 'with header' do
       it 'renders header' do
         rendered = render_inline(TroubleshootingOptionsComponent.new) do |c|

--- a/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
@@ -7,18 +7,19 @@ import DocumentCaptureTroubleshootingOptions from '@18f/identity-document-captur
 
 describe('DocumentCaptureTroubleshootingOptions', () => {
   const helpCenterRedirectURL = 'https://example.com/redirect/';
+  const idvInPersonURL = 'https://example.com/some/idv/ipp/url';
   const serviceProviderContext = {
     name: 'Example SP',
     failureToProofURL: 'http://example.test/url/to/failure-to-proof',
   };
   const wrappers = {
     helpCenterContext: ({ children }) => (
-      <HelpCenterContextProvider value={{ helpCenterRedirectURL }}>
+      <HelpCenterContextProvider value={{ helpCenterRedirectURL, idvInPersonURL }}>
         {children}
       </HelpCenterContextProvider>
     ),
     helpCenterAndServiceProviderContext: ({ children }) => (
-      <HelpCenterContextProvider value={{ helpCenterRedirectURL }}>
+      <HelpCenterContextProvider value={{ helpCenterRedirectURL, idvInPersonURL }}>
         <ServiceProviderContextProvider value={serviceProviderContext}>
           {children}
         </ServiceProviderContextProvider>
@@ -113,6 +114,41 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
       );
 
       expect(getByRole('heading', { name: 'custom heading' })).to.exist();
+    });
+  });
+
+  context('in person proofing links', () => {
+    context('no errors and no idvInPersonURL', () => {
+      it('has no IPP information', () => {
+        const { queryByTestId } = render(<DocumentCaptureTroubleshootingOptions />);
+
+        expect(queryByTestId('new-features-tag')).to.not.exist();
+      });
+    });
+
+    context('hasErrors but no idvInPersonURL', () => {
+      it('has no IPP information', () => {
+        const { queryByTestId } = render(<DocumentCaptureTroubleshootingOptions hasErrors />);
+
+        expect(queryByTestId('new-features-tag')).to.not.exist();
+      });
+    });
+
+    context('hasErrors and idvInPersonURL', () => {
+      it('has links to IPP information', () => {
+        const { getByTestId, getAllByRole } = render(
+          <DocumentCaptureTroubleshootingOptions hasErrors />,
+          {
+            wrapper: wrappers.helpCenterContext,
+          },
+        );
+
+        expect(getByTestId('new-features-tag')).to.exist();
+
+        const links = getAllByRole('link');
+        const ippLink = links.find(({ href }) => href === idvInPersonURL);
+        expect(ippLink).to.exist();
+      });
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
@@ -120,30 +120,30 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
   context('in person proofing links', () => {
     context('no errors and no idvInPersonURL', () => {
       it('has no IPP information', () => {
-        const { queryByTestId } = render(<DocumentCaptureTroubleshootingOptions />);
+        const { queryByText } = render(<DocumentCaptureTroubleshootingOptions />);
 
-        expect(queryByTestId('new-features-tag')).to.not.exist();
+        expect(queryByText('components.troubleshooting_options.new_feature')).to.not.exist();
       });
     });
 
     context('hasErrors but no idvInPersonURL', () => {
       it('has no IPP information', () => {
-        const { queryByTestId } = render(<DocumentCaptureTroubleshootingOptions hasErrors />);
+        const { queryByText } = render(<DocumentCaptureTroubleshootingOptions hasErrors />);
 
-        expect(queryByTestId('new-features-tag')).to.not.exist();
+        expect(queryByText('components.troubleshooting_options.new_feature')).to.not.exist();
       });
     });
 
     context('hasErrors and idvInPersonURL', () => {
       it('has links to IPP information', () => {
-        const { getByTestId, getAllByRole } = render(
+        const { getByText, getAllByRole } = render(
           <DocumentCaptureTroubleshootingOptions hasErrors />,
           {
             wrapper: wrappers.helpCenterContext,
           },
         );
 
-        expect(getByTestId('new-features-tag')).to.exist();
+        expect(getByText('components.troubleshooting_options.new_feature')).to.exist();
 
         const links = getAllByRole('link');
         const ippLink = links.find(({ href }) => href === idvInPersonURL);


### PR DESCRIPTION
Adds a "new feature" tag that separates this new option, to both client (for doc auth errors) and server (for other errors)

I've deployed this to my personal env to click around on (https://idp.zmargolis.identitysandbox.gov/)

- [ ] get translations
- [ ] add release notes

| URL | screenshot |
| --- | ---- |
| doc auth after one error submission |  <img width="720" alt="Screen Shot 2022-04-12 at 1 31 49 PM" src="https://user-images.githubusercontent.com/458784/163049128-283b730d-dbc5-4408-97ec-e9af3b02aa61.png"> |
| /verify/session/errors/failure |  <img width="530" alt="Screen Shot 2022-04-12 at 1 34 33 PM" src="https://user-images.githubusercontent.com/458784/163049084-8ff1d3db-df08-4cf0-af7a-5ece00a5c478.png"> |
| /verify/session/errors/throttled | <img width="530" alt="Screen Shot 2022-04-12 at 1 35 31 PM" src="https://user-images.githubusercontent.com/458784/163049263-fb409b58-82c4-4f32-8eff-1fbb3ab462fb.png"> |
| /verify/session/errors/exception | <img width="530" alt="Screen Shot 2022-04-12 at 1 36 12 PM" src="https://user-images.githubusercontent.com/458784/163049431-4c8c5148-bd11-4337-8d42-80fc5220bcde.png"> |
| /verify/session/errors/exception (no change on purpose) | <img width="530" alt="Screen Shot 2022-04-12 at 1 36 22 PM" src="https://user-images.githubusercontent.com/458784/163049516-777cb8c7-c4e2-4457-a431-1ae93a302a85.png"> |




