### PR TITLE
Remove classlist-polyfill from app scripts

### DIFF
--- a/app/javascript/app/components/modal.js
+++ b/app/javascript/app/components/modal.js
@@ -1,4 +1,3 @@
-import 'classlist-polyfill';
 import { createFocusTrap } from 'focus-trap';
 import Events from '../utils/events';
 

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -1,5 +1,3 @@
-import 'classlist-polyfill';
-
 document.addEventListener('DOMContentLoaded', () => {
   const mobileLink = document.querySelector('.i18n-mobile-toggle > button');
   const mobileDropdown = document.querySelector('.i18n-mobile-dropdown');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/register": "^7.15.3",
     "babel-loader": "^8.2.3",
     "babel-plugin-polyfill-corejs3": "^0.5.2",
-    "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.6.0",
     "core-js": "^3.21.1",
     "fast-glob": "^3.2.7",


### PR DESCRIPTION
**Why**:

- Because polyfills are intended to be confined to the polyfill package (#6060)
- So that it's not included in modern browsers (#6068, -0.9kb gzipped)
- To reduce surface area of dependencies shared with USWDS (related to https://github.com/18F/identity-style-guide/pull/312#issuecomment-1097156590)
- Because the polyfill is not even needed for these scripts, as they are only using simple features of `classList#add`, `classList#remove`, and `classList#toggle` supported by Internet Explorer