### PR TITLE
Add session duration to analytics

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -21,6 +21,7 @@ class Analytics
       new_session_success_state: first_success_state_this_session?,
       success_state: success_state_token(event),
       path: request&.path,
+      session_duration: session_duration,
       user_id: attributes[:user_id] || user.uuid,
       locale: I18n.locale,
     }
@@ -119,6 +120,10 @@ class Analytics
       browser_mobile: browser.device.mobile?,
       browser_bot: browser.bot?,
     }
+  end
+
+  def session_duration
+    @session[:session_started_at] ? Time.zone.now - @session[:session_started_at] : nil
   end
 
   # rubocop:disable Layout/LineLength

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -123,7 +123,13 @@ class Analytics
   end
 
   def session_duration
-    @session[:session_started_at] ? Time.zone.now - @session[:session_started_at] : nil
+    @session[:session_started_at].present? ? Time.zone.now - session_started_at : nil
+  end
+
+  def session_started_at
+    value = @session[:session_started_at]
+    return value unless value.is_a?(String)
+    Time.zone.parse(value)
   end
 
   # rubocop:disable Layout/LineLength

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -53,6 +53,7 @@ describe Analytics do
         success_state: success_state,
         new_event: true,
         path: path,
+        session_duration: nil,
       }
 
       expect(ahoy).to receive(:track).
@@ -73,6 +74,7 @@ describe Analytics do
         success_state: success_state,
         new_event: nil,
         path: path,
+        session_duration: nil,
       }
 
       expect(ahoy).to receive(:track).
@@ -95,6 +97,7 @@ describe Analytics do
         new_session_path: true,
         new_event: true,
         path: path,
+        session_duration: nil,
       }
 
       expect(ahoy).to receive(:track).
@@ -132,6 +135,7 @@ describe Analytics do
         path: path,
         new_session_success_state: true,
         success_state: success_state,
+        session_duration: nil,
       }
 
       expect(ahoy).to receive(:track).
@@ -190,6 +194,37 @@ describe Analytics do
           some_uuid: '12345678-1234-1234-1234-123456789012',
         )
       end.to_not raise_error
+    end
+  end
+
+  it 'tracks session duration' do
+    freeze_time do
+      analytics = Analytics.new(
+        user: current_user,
+        request: request,
+        sp: 'http://localhost:3000',
+        session: { session_started_at: 7.seconds.ago },
+        ahoy: ahoy,
+      )
+
+      analytics_hash = {
+        event_properties: {},
+        user_id: current_user.uuid,
+        locale: I18n.locale,
+        git_sha: IdentityConfig::GIT_SHA,
+        git_branch: IdentityConfig::GIT_BRANCH,
+        new_session_success_state: true,
+        success_state: success_state,
+        new_session_path: true,
+        new_event: true,
+        path: path,
+        session_duration: 7.0,
+      }
+
+      expect(ahoy).to receive(:track).
+        with('Trackable Event', analytics_hash.merge(request_attributes))
+
+      analytics.track_event('Trackable Event')
     end
   end
 end


### PR DESCRIPTION
**Why**: This will allow us to track average times to various steps in cloudwatch vs db and eventually get rid of registration_logs, funnel step times, etc.