### PR TITLE
Remove unused string interpolation for personal key text

### DIFF
--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -1,9 +1,6 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.personal_key')) %>
 <p>
-  <%= t(
-        'instructions.personal_key.info_html',
-        accent: content_tag(:strong, t('instructions.personal_key.accent')),
-      ) %>
+  <%= t('instructions.personal_key.info_html') %>
 </p>
 <div class="full-width-box margin-y-5">
   <%= render 'partials/personal_key/key', code: code %>

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -100,7 +100,6 @@ en:
         iv: Good
         v: Great!
     personal_key:
-      accent: Write it down or print it out.
       email_body: Don’t lose your personal key or share it with others.  We’ll ask for
         it if you reset your password.
       email_title: Save it.  Keep it safe.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -106,7 +106,6 @@ es:
         iv: Buena
         v: '¡Muy buena!'
     personal_key:
-      accent: Anótala o imprímela.
       email_body: No pierdas tu clave personal ni la compartas con otros. La pediremos
         si restableces tu contraseña.
       email_title: Guárdala. Manténla segura.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -116,7 +116,6 @@ fr:
         iv: Bonne
         v: Excellente!
     personal_key:
-      accent: Notez-la ou imprimez-la.
       email_body: Ne perdez pas votre clé personnelle et ne la partagez pas avec
         d’autres. Nous vous le demanderons si vous réinitialisez votre mot de
         passe.


### PR DESCRIPTION
**Why**: Since there is no `accent` interpolation key in the `instructions.personal_key.info_html` string:

https://github.com/18F/identity-idp/blob/402f116b6673d344dd126c2ce3f267c27bd11dee/config/locales/instructions/en.yml#L107-L109