### PR TITLE
Reduce limit for RemoveOldThrottlesJob

### DIFF
--- a/app/jobs/remove_old_throttles_job.rb
+++ b/app/jobs/remove_old_throttles_job.rb
@@ -15,18 +15,16 @@ class RemoveOldThrottlesJob < ApplicationJob
 
   discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
-  def perform(now, limit: 1000, total_limit: 100_000)
+  def perform(now, limit: 500, total_limit: 50_000)
     max_window = Throttle::THROTTLE_CONFIG.map { |_, config| config[:attempt_window] }.max
     total_removed = 0
 
     loop do
-      removed_count = write_transaction_with_timeout do
-        Throttle.
-          where('updated_at < ?', now - (WINDOW + max_window.minutes)).
-          or(Throttle.where(updated_at: nil)).
-          limit(limit).
-          delete_all
-      end
+      removed_count = Throttle.
+        where('updated_at < ?', now - (WINDOW + max_window.minutes)).
+        or(Throttle.where(updated_at: nil)).
+        limit(limit).
+        delete_all
 
       total_removed += removed_count
 
@@ -41,19 +39,6 @@ class RemoveOldThrottlesJob < ApplicationJob
 
       break if removed_count.zero?
       break if total_removed >= total_limit
-    end
-  end
-
-  def write_transaction_with_timeout(rails_env = Rails.env)
-    # rspec-rails's use_transactional_tests does not seem to act as expected when switching
-    # connections mid-test, so we just skip for now :[
-    return yield if rails_env.test?
-
-    ActiveRecord::Base.transaction do
-      # 30 seconds
-      quoted_timeout = ActiveRecord::Base.connection.quote(30_000)
-      ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")
-      yield
     end
   end
 end


### PR DESCRIPTION
We get some failures every so often because the statement timeout is reached, this increases it to 30 seconds