### PR TITLE
Remove IPP links from "failures" page

### DIFF
--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -29,5 +29,3 @@
             ) %>
       </p>
     <% end %>
-
-<%= render partial: 'idv/session_errors/in_person_proofing_options' %>

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -42,23 +42,4 @@ describe 'idv/session_errors/failure.html.erb' do
       ),
     )
   end
-
-  context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled) { false }
-
-    it 'does not render an in person proofing link' do
-      expect(rendered).not_to have_link(href: idv_in_person_url)
-    end
-  end
-
-  context 'with in person proofing enabled' do
-    let(:in_person_proofing_enabled) { true }
-
-    it 'renders an in person proofing link' do
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.verify_in_person'),
-        href: idv_in_person_url,
-      )
-    end
-  end
 end


### PR DESCRIPTION
**Why**: We think this error page is shown when identity
resolution fails, which means IPP is not a viable option
to get verified

Small follow-up to #6192