### PR TITLE
LG-6066: Add personal key confirmation modal to IDV v2 app

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -9,10 +9,10 @@ import {
 } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
 import { SpinnerDots } from '@18f/identity-components';
+import { useInstanceId } from '@18f/identity-react-hooks';
 import FileImage from './file-image';
 import StatusMessage, { Status } from './status-message';
 import DeviceContext from '../context/device';
-import useInstanceId from '../hooks/use-instance-id';
 import usePrevious from '../hooks/use-previous';
 
 /** @typedef {import('react').MouseEvent} ReactMouseEvent */

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -10,9 +10,8 @@ import {
 } from 'react';
 import { Icon } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
-import { useIfStillMounted } from '@18f/identity-react-hooks';
+import { useIfStillMounted, useInstanceId } from '@18f/identity-react-hooks';
 import FileImage from './file-image';
-import useInstanceId from '../hooks/use-instance-id';
 import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
 import AppContext from '../context/app';
 

--- a/app/javascript/packages/form-steps/form-steps-continue-button.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps-continue-button.spec.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import FormStepsContinueButton from './form-steps-continue-button';
+
+describe('FormStepsContinueButton', () => {
+  it('renders button with class names', () => {
+    const { getByRole } = render(<FormStepsContinueButton />);
+
+    const button = getByRole('button');
+
+    expect(Array.from(button.classList.values())).to.include.members([
+      'display-block',
+      'margin-y-5',
+    ]);
+  });
+
+  context('with className prop', () => {
+    it('applies additional class names', () => {
+      const { getByRole } = render(<FormStepsContinueButton className="my-custom-class" />);
+
+      const button = getByRole('button');
+
+      expect(Array.from(button.classList.values())).to.include.members([
+        'display-block',
+        'margin-y-5',
+        'my-custom-class',
+      ]);
+    });
+  });
+});

--- a/app/javascript/packages/form-steps/form-steps-continue-button.tsx
+++ b/app/javascript/packages/form-steps/form-steps-continue-button.tsx
@@ -3,12 +3,21 @@ import { Button } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
 import FormStepsContext from './form-steps-context';
 
-function FormStepsContinueButton() {
+interface FormStepsContinueButtonProps {
+  /**
+   * Optional additional class names to apply to button.
+   */
+  className?: string;
+}
+
+function FormStepsContinueButton({ className }: FormStepsContinueButtonProps) {
   const { t } = useI18n();
   const { isLastStep } = useContext(FormStepsContext);
 
+  const classes = ['display-block', 'margin-y-5', className].filter(Boolean).join(' ');
+
   return (
-    <Button type="submit" isBig isWide className="display-block margin-y-5">
+    <Button type="submit" isBig isWide className={classes}>
       {isLastStep ? t('forms.buttons.submit.default') : t('forms.buttons.continue')}
     </Button>
   );

--- a/app/javascript/packages/modal/README.md
+++ b/app/javascript/packages/modal/README.md
@@ -1,0 +1,33 @@
+# `@18f/identity-modal`
+
+Custom element and React implementation for a print button component.
+
+## Usage
+
+### Custom Element
+
+_The modal custom element is not currently implemented._
+
+### React
+
+The package exports a named `Modal` component, which includes several helper components available as properties of the top-level component:
+
+- `Modal`: The top-level wrapper component.
+- `Modal.Heading`: Modal heading.
+- `Modal.Description`: Optional modal description.
+
+```tsx
+import { Button } from '@18f/identity-components';
+import { Modal } from '@18f/identity-modal';
+
+export function Example() {
+  return (
+    <Modal onSubmit={() => {}} onClose={() => {}}>
+      <Modal.Heading>Are you sure you want to continue?</Modal.Heading>
+      <Modal.Description>You have unsaved changes that will be lost.</Modal.Description>
+      <Button>Continue</Button>
+      <Button isOutline>Go Back</Button>
+    </Modal>
+  );
+}
+```

--- a/app/javascript/packages/modal/index.ts
+++ b/app/javascript/packages/modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from './modal';

--- a/app/javascript/packages/modal/modal.tsx
+++ b/app/javascript/packages/modal/modal.tsx
@@ -1,0 +1,66 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { useInstanceId } from '@18f/identity-react-hooks';
+
+const ModalContext = createContext('');
+
+interface ModalProps {
+  children: ReactNode;
+}
+
+interface ModalHeadingProps {
+  children: ReactNode;
+}
+
+interface ModalDescriptionProps {
+  children: ReactNode;
+}
+
+function Modal({ children }: ModalProps) {
+  const instanceId = useInstanceId();
+
+  return (
+    <ModalContext.Provider value={instanceId}>
+      <div className="usa-modal-wrapper is-visible">
+        <div className="usa-modal-overlay">
+          <div
+            role="dialog"
+            className="padding-x-2 padding-y-6 modal"
+            aria-labelledby={`modal-heading-${instanceId}`}
+            aria-describedby={`modal-description-${instanceId}`}
+          >
+            <div className="modal-center">
+              <div className="modal-content">
+                <div className="padding-y-8 padding-x-2 tablet:padding-x-8 cntnr-skinny bg-white radius-lg">
+                  {children}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalContext.Provider>
+  );
+}
+
+Modal.Heading = ({ children }: ModalHeadingProps) => {
+  const instanceId = useContext(ModalContext);
+
+  return (
+    <h2 id={`modal-heading-${instanceId}`} className="margin-top-0 margin-bottom-2">
+      {children}
+    </h2>
+  );
+};
+
+Modal.Description = ({ children }: ModalDescriptionProps) => {
+  const instanceId = useContext(ModalContext);
+
+  return (
+    <p id={`modal-description-${instanceId}`} className="margin-bottom-4">
+      {children}
+    </p>
+  );
+};
+
+export default Modal;

--- a/app/javascript/packages/modal/package.json
+++ b/app/javascript/packages/modal/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@18f/identity-modal",
+  "version": "1.0.0",
+  "private": true,
+  "peerDependencies": {
+    "react": "*"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  }
+}

--- a/app/javascript/packages/react-hooks/index.ts
+++ b/app/javascript/packages/react-hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useDidUpdateEffect } from './use-did-update-effect';
 export { default as useIfStillMounted } from './use-if-still-mounted';
+export { default as useInstanceId } from './use-instance-id';

--- a/app/javascript/packages/react-hooks/use-instance-id.spec.ts
+++ b/app/javascript/packages/react-hooks/use-instance-id.spec.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
-import useInstanceId from '@18f/identity-document-capture/hooks/use-instance-id';
+import useInstanceId from './use-instance-id';
 
-describe('document-capture/hooks/use-instance-id', () => {
+describe('useInstanceId', () => {
   it('returns a unique string id', () => {
     const { result: result1 } = renderHook(() => useInstanceId());
     const { result: result2 } = renderHook(() => useInstanceId());

--- a/app/javascript/packages/react-hooks/use-instance-id.ts
+++ b/app/javascript/packages/react-hooks/use-instance-id.ts
@@ -5,8 +5,6 @@ let instances = 0;
 /**
  * Returns a string value guaranteed to be unique to all element instances in the application. This
  * can be used in generic unique IDs when needed in, for example, form input label association.
- *
- * @return {string}
  */
 function useInstanceId() {
   return useMemo(() => {

--- a/app/javascript/packages/verify-flow/package.json
+++ b/app/javascript/packages/verify-flow/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-verify-flow",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "peerDependencies": {
+    "react": "*"
+  }
 }

--- a/app/javascript/packages/verify-flow/steps/index.ts
+++ b/app/javascript/packages/verify-flow/steps/index.ts
@@ -1,9 +1,14 @@
 import type { FormStep } from '@18f/identity-form-steps';
 import PersonalKeyStep from './personal-key/personal-key-step';
+import PersonalKeyConfirmStep from './personal-key-confirm/personal-key-confirm-step';
 
 export const STEPS: FormStep[] = [
   {
     name: 'personal-key',
     form: PersonalKeyStep,
+  },
+  {
+    name: 'personal-key-confirm',
+    form: PersonalKeyConfirmStep,
   },
 ];

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -1,0 +1,51 @@
+import { Alert } from '@18f/identity-components';
+import { FormStepsContext, FormStepsContinueButton } from '@18f/identity-form-steps';
+import { t } from '@18f/identity-i18n';
+import type { FormStepComponentProps } from '@18f/identity-form-steps';
+import { Modal } from '@18f/identity-modal';
+import PersonalKeyStep from '../personal-key/personal-key-step';
+import PersonalKeyInput from './personal-key-input';
+import type { VerifyFlowValues } from '../..';
+
+interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
+
+function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
+  const { registerField, errors } = stepProps;
+
+  return (
+    <>
+      <FormStepsContext.Provider value={{ isLastStep: false, onPageTransition() {} }}>
+        <PersonalKeyStep {...stepProps} />
+      </FormStepsContext.Provider>
+      <Modal>
+        <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>
+        <Modal.Description>{t('forms.personal_key.instructions')}</Modal.Description>
+        {errors.length > 0 && (
+          <Alert type="error" className="margin-bottom-4">
+            {t('users.personal_key.confirmation_error')}
+          </Alert>
+        )}
+        <PersonalKeyInput ref={registerField('personalKeyConfirmation', { isRequired: true })} />
+        <div className="grid-row grid-gap">
+          <div className="grid-col-12 tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0 tablet:display-none">
+            <FormStepsContinueButton className="margin-y-0" />
+          </div>
+          <div className="grid-col-12 tablet:grid-col-6">
+            <button
+              className="usa-button usa-button--big usa-button--full-width usa-button--outline"
+              type="button"
+              data-dismiss="personal-key-confirm"
+            >
+              {t('forms.buttons.back')}
+            </button>
+          </div>
+          <div className="grid-col-12 tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0 display-none tablet:display-block">
+            <FormStepsContinueButton className="margin-y-0" />
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+export default PersonalKeyConfirmStep;

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PersonalKeyInput from './personal-key-input';
+
+describe('PersonalKeyInput', () => {
+  it('accepts a value with dashes', () => {
+    const value = '0000-0000-0000-0000';
+    const { getByRole } = render(<PersonalKeyInput />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+    userEvent.type(input, value);
+
+    expect(input.value).to.equal(value);
+  });
+
+  it('accepts a value without dashes', () => {
+    const value = '0000000000000000';
+    const { getByRole } = render(<PersonalKeyInput />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+    userEvent.type(input, value);
+
+    expect(input.value).to.equal(value);
+  });
+
+  it('does not accept a code longer than one with dashes', () => {
+    const { getByRole } = render(<PersonalKeyInput />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+    userEvent.type(input, '0000-0000-0000-00000');
+
+    expect(input.value).to.equal('0000-0000-0000-0000');
+  });
+});

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -1,0 +1,19 @@
+import { forwardRef } from 'react';
+import { t } from '@18f/identity-i18n';
+
+function PersonalKeyInput(_props, ref) {
+  return (
+    <input
+      ref={ref}
+      aria-label={t('forms.personal_key.confirmation_label')}
+      autoComplete="off"
+      className="width-full margin-bottom-6 border-dashed field font-family-mono personal-key text-uppercase"
+      maxLength={16}
+      pattern="[a-zA-Z0-9-]"
+      spellCheck={false}
+      type="text"
+    />
+  );
+}
+
+export default forwardRef(PersonalKeyInput);

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -8,7 +8,7 @@ function PersonalKeyInput(_props, ref) {
       aria-label={t('forms.personal_key.confirmation_label')}
       autoComplete="off"
       className="width-full margin-bottom-6 border-dashed field font-family-mono personal-key text-uppercase"
-      maxLength={16}
+      maxLength={19}
       pattern="[a-zA-Z0-9-]"
       spellCheck={false}
       type="text"

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -53,7 +53,7 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         </p>
         <p>{t('instructions.personal_key.email_body')}</p>
       </div>
-      <FormStepsContinueButton />
+      <FormStepsContinueButton className="margin-bottom-0" />
     </>
   );
 }


### PR DESCRIPTION
**Why**: So that a user can proceed from the personal key step to confirm their personal key and complete the proofing process.

This is an incomplete but functional implementation. I will add inline review comments where additional follow-up tasks are expected.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/163586041-5d14409b-13fb-497c-8725-342ec3594581.png)
