### PR TITLE
Use URL-safe base64 encoding of SHA256 digest in examples

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -112,7 +112,7 @@ class OpenidConnectTokenForm
 
   def validate_code_verifier
     expected_code_challenge = remove_base64_padding(identity.try(:code_challenge))
-    given_code_challenge = remove_base64_padding(Digest::SHA256.base64digest(code_verifier.to_s))
+    given_code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier.to_s)
     return if expected_code_challenge == given_code_challenge
     errors.add :code_verifier,
                t('openid_connect.token.errors.invalid_code_verifier'),

--- a/config/initializers/ext_digest.rb
+++ b/config/initializers/ext_digest.rb
@@ -1,0 +1,10 @@
+require 'base64'
+
+module Digest
+  # ideally we could patch onto one of the mixins like Instance but that didn't seem to work
+  class SHA256
+    def self.urlsafe_base64digest(str = nil)
+      Base64.urlsafe_encode64(digest(str), padding: false)
+    end
+  end
+end

--- a/spec/config/initializers/ext_digest_spec.rb
+++ b/spec/config/initializers/ext_digest_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Digest::Instance do
+  describe '#urlsafe_base64digest' do
+    it 'is the URL-safe version of a base64 digest' do
+      base64 = Digest::SHA256.base64digest('aaa')
+
+      urlsafe = Digest::SHA256.urlsafe_base64digest('aaa')
+
+      expect(urlsafe).to eq(base64.tr('+/', '-_').tr('=', ''))
+    end
+  end
+end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -219,7 +219,7 @@ describe 'OpenID Connect' do
     state = SecureRandom.hex
     nonce = SecureRandom.hex
     code_verifier = SecureRandom.hex
-    code_challenge = Digest::SHA256.base64digest(code_verifier)
+    code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier)
 
     _user = user_with_2fa
 
@@ -342,7 +342,7 @@ describe 'OpenID Connect' do
       state = SecureRandom.hex
       nonce = SecureRandom.hex
       code_verifier = SecureRandom.hex
-      code_challenge = Digest::SHA256.base64digest(code_verifier)
+      code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier)
       user = user_with_2fa
 
       link_identity(user, build(:service_provider, issuer: client_id))
@@ -394,7 +394,7 @@ describe 'OpenID Connect' do
       state1 = SecureRandom.hex
       nonce1 = SecureRandom.hex
       code_verifier1 = SecureRandom.hex
-      code_challenge1 = Digest::SHA256.base64digest(code_verifier1)
+      code_challenge1 = Digest::SHA256.urlsafe_base64digest(code_verifier1)
 
       visit openid_connect_authorize_path(
         client_id: client_id,
@@ -412,7 +412,7 @@ describe 'OpenID Connect' do
       state2 = SecureRandom.hex
       nonce2 = SecureRandom.hex
       code_verifier2 = SecureRandom.hex
-      code_challenge2 = Digest::SHA256.base64digest(code_verifier2)
+      code_challenge2 = Digest::SHA256.urlsafe_base64digest(code_verifier2)
 
       visit openid_connect_authorize_path(
         client_id: client_id,
@@ -476,7 +476,7 @@ describe 'OpenID Connect' do
           state: SecureRandom.hex,
           nonce: SecureRandom.hex,
           prompt: 'select_account',
-          code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
+          code_challenge: Digest::SHA256.urlsafe_base64digest(SecureRandom.hex),
           code_challenge_method: 'S256',
         )
 
@@ -658,7 +658,7 @@ describe 'OpenID Connect' do
     state = SecureRandom.hex
     nonce = SecureRandom.hex
     code_verifier = SecureRandom.hex
-    code_challenge = Digest::SHA256.base64digest(code_verifier)
+    code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier)
 
     link_identity(user, build(:service_provider, issuer: client_id))
     user.identities.last.update!(verified_attributes: ['email'])

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe OpenidConnectTokenForm do
       let(:client_assertion) { nil }
       let(:client_assertion_type) { nil }
 
-      let(:code_challenge) { Digest::SHA256.base64digest(code_verifier) }
+      let(:code_challenge) { Digest::SHA256.urlsafe_base64digest(code_verifier) }
       let(:code_verifier) { SecureRandom.hex }
 
       context 'with valid params' do
@@ -352,10 +352,7 @@ RSpec.describe OpenidConnectTokenForm do
 
       context 'with a code_challenge does not have base64 padding' do
         let(:code_verifier) { SecureRandom.uuid }
-        let(:code_challenge) do
-          padded_base64 = Digest::SHA256.base64digest(code_verifier)
-          Base64.urlsafe_encode64(Base64.decode64(padded_base64), padding: false)
-        end
+        let(:code_challenge) { Digest::SHA256.urlsafe_base64digest(code_verifier) }
 
         it 'is valid' do
           expect(Digest::SHA256.base64digest(code_verifier)).to end_with('=')


### PR DESCRIPTION
**Why**: adheres to OIDC spec better

Fixes #5991