### PR TITLE
Fix Webpack asset manifest generation for production exports

### DIFF
--- a/app/javascript/packages/assets/spec/fixtures/assets.js
+++ b/app/javascript/packages/assets/spec/fixtures/assets.js
@@ -1,0 +1,1 @@
+export function getAssetPath() {}

--- a/app/javascript/packages/assets/spec/fixtures/in.js
+++ b/app/javascript/packages/assets/spec/fixtures/in.js
@@ -1,3 +1,3 @@
-const getAssetPath = () => {};
+import { getAssetPath } from './assets';
 
 globalThis.path = getAssetPath('foo.svg');

--- a/app/javascript/packages/assets/webpack-plugin.js
+++ b/app/javascript/packages/assets/webpack-plugin.js
@@ -11,7 +11,7 @@ const PLUGIN = 'AssetsWebpackPlugin';
 /**
  * Regular expression matching calls to retrieve asset path.
  */
-const GET_ASSET_CALL = /getAssetPath\)?\(\s*['"](.+?)['"]/g;
+const GET_ASSET_CALL = /getAssetPath(?: \*\/ ?\.[A-Za-z_$])?\)?\(\s*['"](.+?)['"]/g;
 
 /**
  * Given a file name, returns true if the file is a JavaScript file, or false otherwise.
@@ -70,3 +70,4 @@ class AssetsWebpackPlugin {
 }
 
 module.exports = AssetsWebpackPlugin;
+module.exports.getAssetPaths = getAssetPaths;

--- a/app/javascript/packages/assets/webpack-plugin.js
+++ b/app/javascript/packages/assets/webpack-plugin.js
@@ -11,7 +11,7 @@ const PLUGIN = 'AssetsWebpackPlugin';
 /**
  * Regular expression matching calls to retrieve asset path.
  */
-const GET_ASSET_CALL = /getAssetPath(?: \*\/ ?\.[A-Za-z_$])?\)?\(\s*['"](.+?)['"]/g;
+const GET_ASSET_CALL = /getAssetPath(?: \*\/ ?\.[A-Za-z_$]+)?\)?\(\s*['"](.+?)['"]/g;
 
 /**
  * Given a file name, returns true if the file is a JavaScript file, or false otherwise.

--- a/app/javascript/packages/assets/webpack-plugin.spec.ts
+++ b/app/javascript/packages/assets/webpack-plugin.spec.ts
@@ -72,6 +72,14 @@ describe('AssetsWebpackPlugin', () => {
       });
     });
 
+    context('mangled export name, multiple letters', () => {
+      const source = "(0,_assets__WEBPACK_IMPORTED_MODULE_0__/* .getAssetPath */ .Aa)('foo.svg');";
+
+      it('returns asset paths', () => {
+        expect(getAssetPaths(source)).to.have.all.members(['foo.svg']);
+      });
+    });
+
     context('manged export name, no whitespace', () => {
       const source = "(0,assets/* getAssetPath */.K)('foo.svg'),";
 

--- a/app/javascript/packages/assets/webpack-plugin.spec.ts
+++ b/app/javascript/packages/assets/webpack-plugin.spec.ts
@@ -4,45 +4,80 @@ const webpack = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const AssetsWebpackPlugin = require('./webpack-plugin');
 
+const { getAssetPaths } = AssetsWebpackPlugin;
+
 describe('AssetsWebpackPlugin', () => {
-  it('generates expected output', (done) => {
-    webpack(
-      {
-        mode: 'development',
-        devtool: false,
-        entry: path.resolve(__dirname, 'spec/fixtures/in.js'),
-        plugins: [
-          new AssetsWebpackPlugin(),
-          new WebpackAssetsManifest({
-            entrypoints: true,
-            publicPath: true,
-            writeToDisk: true,
-            output: 'actualmanifest.json',
-          }),
-        ],
-        output: {
-          path: path.resolve(__dirname, 'spec/fixtures'),
-          filename: 'actual[name].js',
-        },
-      },
-      async (webpackError) => {
-        try {
-          expect(webpackError).to.be.null();
+  ['development', 'production'].forEach((mode) => {
+    context(mode, () => {
+      it('generates expected output', (done) => {
+        webpack(
+          {
+            mode,
+            devtool: false,
+            entry: path.resolve(__dirname, 'spec/fixtures/in.js'),
+            plugins: [
+              new AssetsWebpackPlugin(),
+              new WebpackAssetsManifest({
+                entrypoints: true,
+                publicPath: true,
+                writeToDisk: true,
+                output: `actual${mode}manifest.json`,
+              }),
+            ],
+            output: {
+              path: path.resolve(__dirname, 'spec/fixtures'),
+              filename: `actual${mode}[name].js`,
+            },
+            optimization: {
+              concatenateModules: false,
+            },
+          },
+          async (webpackError) => {
+            try {
+              expect(webpackError).to.be.null();
 
-          const manifest = JSON.parse(
-            await fs.readFile(
-              path.resolve(__dirname, 'spec/fixtures/actualmanifest.json'),
-              'utf-8',
-            ),
-          );
+              const manifest = JSON.parse(
+                await fs.readFile(
+                  path.resolve(__dirname, `spec/fixtures/actual${mode}manifest.json`),
+                  'utf-8',
+                ),
+              );
 
-          expect(manifest.entrypoints.main.assets.svg).to.include.all.members(['foo.svg']);
+              expect(manifest.entrypoints.main.assets.svg).to.include.all.members(['foo.svg']);
 
-          done();
-        } catch (error) {
-          done(error);
-        }
-      },
-    );
+              done();
+            } catch (error) {
+              done(error);
+            }
+          },
+        );
+      });
+    });
+  });
+
+  describe('.getAssetPaths()', () => {
+    context('webpack unbound call', () => {
+      const source = "(0,_assets__WEBPACK_IMPORTED_MODULE_0__.getAssetPath)('foo.svg')";
+
+      it('returns asset paths', () => {
+        expect(getAssetPaths(source)).to.have.all.members(['foo.svg']);
+      });
+    });
+
+    context('mangled export name', () => {
+      const source = "(0,_assets__WEBPACK_IMPORTED_MODULE_0__/* .getAssetPath */ .K)('foo.svg');";
+
+      it('returns asset paths', () => {
+        expect(getAssetPaths(source)).to.have.all.members(['foo.svg']);
+      });
+    });
+
+    context('manged export name, no whitespace', () => {
+      const source = "(0,assets/* getAssetPath */.K)('foo.svg'),";
+
+      it('returns asset paths', () => {
+        expect(getAssetPaths(source)).to.have.all.members(['foo.svg']);
+      });
+    });
   });
 });

--- a/app/javascript/packages/assets/webpack-plugin.spec.ts
+++ b/app/javascript/packages/assets/webpack-plugin.spec.ts
@@ -80,7 +80,7 @@ describe('AssetsWebpackPlugin', () => {
       });
     });
 
-    context('manged export name, no whitespace', () => {
+    context('mangled export name, no whitespace', () => {
       const source = "(0,assets/* getAssetPath */.K)('foo.svg'),";
 
       it('returns asset paths', () => {


### PR DESCRIPTION
**Why**: So that the asset manifest plugin correctly identifies all assets.

This improves the plugin introduced in #6198, and addresses a similar peculiarity of Webpack code generation as in #6001. Similar to #6001, the regular expression should match the Webpack output pattern of `(0,getAssetPath)('path.svg'))`. Unlike #6001, we must account for [the "comment" fragment](https://github.com/webpack/webpack/blob/4abf353fbc6e702cf1768e8bbbeafe38ced33df7/lib/RuntimeTemplate.js#L892-L895) which may be output as part of the code generation (`(0,assets/* getAssetPath */.K)('id-card.svg'),`). The reason this happens here and not in the translation plugin is because the translation export `t` is already one character, and as such [the Webpack mangling logic will not rename it](https://github.com/webpack/webpack/blob/a72548f97037c941db3320397392a329f52db66a/lib/optimize/MangleExportsPlugin.js#L70-L71), and the comment fragment is [omitted if the export is not renamed](https://github.com/webpack/webpack/blob/4abf353fbc6e702cf1768e8bbbeafe38ced33df7/lib/RuntimeTemplate.js#L892-L893). Based on the logic of the mangling plugin, we should expect that the renamed export would be [one or more alphabetical characters, or `_`, or `$`](https://github.com/webpack/webpack/blob/a72548f97037c941db3320397392a329f52db66a/lib/Template.js#L142-L171).

~I'm hopeful this will also address the issue I observed at https://github.com/18F/identity-idp/pull/6212#issuecomment-1100360478 (will test to confirm).~ **Edit:** Confirmed.