### PR TITLE
LG-6066: Implement download button for personal key step (IdV app)

### DIFF
--- a/app/javascript/packages/components/button.spec.tsx
+++ b/app/javascript/packages/components/button.spec.tsx
@@ -12,6 +12,7 @@ describe('document-capture/components/button', () => {
 
     expect(button.nodeName).to.equal('BUTTON');
     expect(button.type).to.equal('button');
+    expect(button.hasAttribute('href')).to.be.false();
     expect(button.classList.contains('usa-button')).to.be.true();
     expect(button.classList.contains('usa-button--big')).to.be.false();
     expect(button.classList.contains('usa-button--flexible-width')).to.be.false();
@@ -20,7 +21,15 @@ describe('document-capture/components/button', () => {
     expect(button.classList.contains('usa-button--unstyled')).to.be.false();
   });
 
-  it('calls click callback with the event argument', () => {
+  it('renders styled as a link', () => {
+    const { getByRole } = render(<Button href="about:blank">Click me</Button>);
+
+    const link = getByRole('link') as HTMLAnchorElement;
+    expect(link.href).to.equal('about:blank');
+    expect(link.hasAttribute('type')).to.be.false();
+  });
+
+  it('forwards additional props to the rendered element', () => {
     const onClick = sinon.spy();
     const { getByText } = render(
       <Button onClick={(event) => onClick(event.type)}>Click me</Button>,

--- a/app/javascript/packages/components/button.tsx
+++ b/app/javascript/packages/components/button.tsx
@@ -1,4 +1,5 @@
-import type { MouseEvent, ReactNode } from 'react';
+import { createElement, MouseEvent, ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
 type ButtonType = 'button' | 'reset' | 'submit';
 
@@ -7,6 +8,11 @@ export interface ButtonProps {
    * Button type, defaulting to "button".
    */
   type?: ButtonType;
+
+  /**
+   * For a link styled as a button, the destination of the link.
+   */
+  href?: string;
 
   /**
    * Click handler.
@@ -55,8 +61,8 @@ export interface ButtonProps {
 }
 
 function Button({
-  type = 'button',
-  onClick,
+  href,
+  type = href ? undefined : 'button',
   children,
   isBig,
   isFlexibleWidth,
@@ -65,7 +71,10 @@ function Button({
   isDisabled,
   isUnstyled,
   className,
-}: ButtonProps) {
+  ...htmlAttributes
+}: ButtonProps &
+  AnchorHTMLAttributes<HTMLAnchorElement> &
+  ButtonHTMLAttributes<HTMLButtonElement>) {
   const classes = [
     'usa-button',
     isBig && 'usa-button--big',
@@ -78,12 +87,12 @@ function Button({
     .filter(Boolean)
     .join(' ');
 
-  return (
-    // Disable reason: We can assume `type` is provided as valid, or the default `button`.
-    // eslint-disable-next-line react/button-has-type
-    <button type={type} onClick={onClick} disabled={isDisabled} className={classes}>
-      {children}
-    </button>
+  const tagName = href ? 'a' : 'button';
+
+  return createElement(
+    tagName,
+    { type, href, disabled: isDisabled, className: classes, ...htmlAttributes },
+    children,
   );
 }
 

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
@@ -1,7 +1,8 @@
 import sinon from 'sinon';
 import { render, fireEvent, createEvent } from '@testing-library/react';
 import { usePropertyValue } from '@18f/identity-test-helpers';
-import DownloadButton from './download-button';
+import DownloadButton, { hasProprietarySaveBlob } from './download-button';
+import type { NavigatorWithSaveBlob } from './download-button';
 
 describe('DownloadButton', () => {
   it('renders a link to download the given content as file', () => {
@@ -37,8 +38,14 @@ describe('DownloadButton', () => {
     expect(onClick.getCall(0).args[0].nativeEvent).to.equal(clickEvent);
   });
 
+  describe('hasProprietarySaveBlob()', () => {
+    it('returns false', () => {
+      expect(hasProprietarySaveBlob(window.navigator)).to.be.false();
+    });
+  });
+
   context('in internet explorer', () => {
-    usePropertyValue(window.navigator as any, 'msSaveBlob', sinon.stub());
+    usePropertyValue(window.navigator as NavigatorWithSaveBlob, 'msSaveBlob', sinon.stub());
 
     it('intercepts click to download file using proprietary API', () => {
       const onClick = sinon.stub();
@@ -53,7 +60,13 @@ describe('DownloadButton', () => {
       expect(onClick).to.have.been.called();
       expect(onClick.getCall(0).args[0].nativeEvent).to.equal(clickEvent);
       expect(clickEvent.defaultPrevented).to.be.true();
-      expect((window.navigator as any).msSaveBlob).to.have.been.called();
+      expect((window.navigator as NavigatorWithSaveBlob).msSaveBlob).to.have.been.called();
+    });
+
+    describe('hasProprietarySaveBlob()', () => {
+      it('returns true', () => {
+        expect(hasProprietarySaveBlob(window.navigator)).to.be.true();
+      });
     });
   });
 });

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
@@ -1,0 +1,59 @@
+import sinon from 'sinon';
+import { render, fireEvent, createEvent } from '@testing-library/react';
+import { usePropertyValue } from '@18f/identity-test-helpers';
+import DownloadButton from './download-button';
+
+describe('DownloadButton', () => {
+  it('renders a link to download the given content as file', () => {
+    const { getByRole } = render(<DownloadButton fileName="example.txt" content="example" />);
+
+    const link = getByRole('link');
+
+    expect(link.getAttribute('download')).to.equal('example.txt');
+    expect(link.getAttribute('href')).to.equal('data:text/plain;base64,ZXhhbXBsZQ==');
+  });
+
+  it('does not prevent default when clicked', () => {
+    const { getByRole } = render(<DownloadButton fileName="example.txt" content="example" />);
+
+    const link = getByRole('link');
+    const clickEvent = createEvent('click', link, { bubbles: true, cancelable: true });
+    fireEvent(link, clickEvent);
+
+    expect(clickEvent.defaultPrevented).to.be.false();
+  });
+
+  it('calls onClick prop if given', () => {
+    const onClick = sinon.stub();
+    const { getByRole } = render(
+      <DownloadButton fileName="example.txt" content="example" onClick={onClick} />,
+    );
+
+    const link = getByRole('link');
+    const clickEvent = createEvent('click', link, { bubbles: true, cancelable: true });
+    fireEvent(link, clickEvent);
+
+    expect(onClick).to.have.been.called();
+    expect(onClick.getCall(0).args[0].nativeEvent).to.equal(clickEvent);
+  });
+
+  context('in internet explorer', () => {
+    usePropertyValue(window.navigator as any, 'msSaveBlob', sinon.stub());
+
+    it('intercepts click to download file using proprietary API', () => {
+      const onClick = sinon.stub();
+      const { getByRole } = render(
+        <DownloadButton fileName="example.txt" content="example" onClick={onClick} />,
+      );
+
+      const link = getByRole('link');
+      const clickEvent = createEvent('click', link, { bubbles: true, cancelable: true });
+      fireEvent(link, clickEvent);
+
+      expect(onClick).to.have.been.called();
+      expect(onClick.getCall(0).args[0].nativeEvent).to.equal(clickEvent);
+      expect(clickEvent.defaultPrevented).to.be.true();
+      expect((window.navigator as any).msSaveBlob).to.have.been.called();
+    });
+  });
+});

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx
@@ -5,12 +5,12 @@ import DownloadButton from './download-button';
 
 describe('DownloadButton', () => {
   it('renders a link to download the given content as file', () => {
-    const { getByRole } = render(<DownloadButton fileName="example.txt" content="example" />);
+    const { getByRole } = render(<DownloadButton fileName="example.txt" content="Hello, world!" />);
 
     const link = getByRole('link');
 
     expect(link.getAttribute('download')).to.equal('example.txt');
-    expect(link.getAttribute('href')).to.equal('data:text/plain;base64,ZXhhbXBsZQ==');
+    expect(link.getAttribute('href')).to.equal('data:,Hello%2C%20world!');
   });
 
   it('does not prevent default when clicked', () => {

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
@@ -36,7 +36,7 @@ function DownloadButton({ content, fileName, ...buttonProps }: DownloadButtonPro
   return (
     <Button
       {...buttonProps}
-      href={`data:text/plain;base64,${btoa(content)}`}
+      href={`data:,${encodeURIComponent(content)}`}
       download={fileName}
       onClick={download}
     />

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
@@ -1,0 +1,41 @@
+import type { MouseEventHandler } from 'react';
+import { Button } from '@18f/identity-components';
+import type { ButtonProps } from '@18f/identity-components';
+
+interface DownloadButtonProps {
+  /**
+   * Content of the downloaded file.
+   */
+  content: string;
+
+  /**
+   * File name to use for downloaded file.
+   */
+  fileName: string;
+}
+
+function DownloadButton({ content, fileName, ...buttonProps }: DownloadButtonProps & ButtonProps) {
+  const download: MouseEventHandler = (event) => {
+    buttonProps.onClick?.(event);
+
+    if ('msSaveBlob' in window.navigator) {
+      event.preventDefault();
+
+      const filename = (event.target as HTMLButtonElement).getAttribute('download');
+      const blob = new Blob([content], { type: 'text/plain' });
+
+      (window.navigator as any).msSaveBlob(blob, filename);
+    }
+  };
+
+  return (
+    <Button
+      {...buttonProps}
+      href={`data:text/plain;base64,${btoa(content)}`}
+      download={fileName}
+      onClick={download}
+    />
+  );
+}
+
+export default DownloadButton;

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
@@ -20,11 +20,8 @@ function DownloadButton({ content, fileName, ...buttonProps }: DownloadButtonPro
 
     if ('msSaveBlob' in window.navigator) {
       event.preventDefault();
-
-      const filename = (event.target as HTMLButtonElement).getAttribute('download');
       const blob = new Blob([content], { type: 'text/plain' });
-
-      (window.navigator as any).msSaveBlob(blob, filename);
+      (window.navigator as any).msSaveBlob(blob, fileName);
     }
   };
 

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
@@ -14,14 +14,22 @@ interface DownloadButtonProps {
   fileName: string;
 }
 
+interface NavigatorWithSaveBlob extends Navigator {
+  msSaveBlob: (blob: Blob, filename: string) => void;
+}
+
+const hasProprietarySaveBlob = (
+  navigator: Navigator | NavigatorWithSaveBlob,
+): navigator is NavigatorWithSaveBlob => 'msSaveBlob' in navigator;
+
 function DownloadButton({ content, fileName, ...buttonProps }: DownloadButtonProps & ButtonProps) {
   const download: MouseEventHandler = (event) => {
     buttonProps.onClick?.(event);
 
-    if ('msSaveBlob' in window.navigator) {
+    if (hasProprietarySaveBlob(window.navigator)) {
       event.preventDefault();
       const blob = new Blob([content], { type: 'text/plain' });
-      (window.navigator as any).msSaveBlob(blob, fileName);
+      window.navigator.msSaveBlob(blob, fileName);
     }
   };
 

--- a/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx
@@ -14,11 +14,11 @@ interface DownloadButtonProps {
   fileName: string;
 }
 
-interface NavigatorWithSaveBlob extends Navigator {
+export interface NavigatorWithSaveBlob extends Navigator {
   msSaveBlob: (blob: Blob, filename: string) => void;
 }
 
-const hasProprietarySaveBlob = (
+export const hasProprietarySaveBlob = (
   navigator: Navigator | NavigatorWithSaveBlob,
 ): navigator is NavigatorWithSaveBlob => 'msSaveBlob' in navigator;
 

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -6,6 +6,7 @@ import { formatHTML } from '@18f/identity-react-i18n';
 import { FormStepsContinueButton } from '@18f/identity-form-steps';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import type { VerifyFlowValues } from '../..';
+import DownloadButton from './download-button';
 
 interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
@@ -40,9 +41,14 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
           </p>
         </div>
       </div>
-      <Button isOutline className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0">
+      <DownloadButton
+        content={personalKey}
+        fileName="personal_key.txt"
+        isOutline
+        className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0"
+      >
         {t('forms.backup_code.download')}
-      </Button>
+      </DownloadButton>
       <PrintButton isOutline className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0" />
       <ClipboardButton
         clipboardText={personalKey}

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -1,4 +1,4 @@
-import { PageHeading, Button } from '@18f/identity-components';
+import { PageHeading } from '@18f/identity-components';
 import { ClipboardButton } from '@18f/identity-clipboard-button';
 import { PrintButton } from '@18f/identity-print-button';
 import { t } from '@18f/identity-i18n';


### PR DESCRIPTION
**Why**: So that a user can download their personal key to their computer.

Reuses and reimplements logic from #6161.