### PR TITLE
Rate limit phone confirmation attempts (LG-5492)

### DIFF
--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -14,6 +14,7 @@ class Throttle < ApplicationRecord
     verify_gpo_key: 8,
     proof_ssn: 9,
     proof_address: 10,
+    phone_confirmation: 11,
   }
 
   THROTTLE_CONFIG = {
@@ -56,6 +57,10 @@ class Throttle < ApplicationRecord
     proof_address: {
       max_attempts: IdentityConfig.store.proof_address_max_attempts,
       attempt_window: IdentityConfig.store.proof_address_max_attempt_window_in_minutes,
+    },
+    phone_confirmation: {
+      max_attempts: IdentityConfig.store.phone_confirmation_max_attempts,
+      attempt_window: IdentityConfig.store.phone_confirmation_max_attempt_window_in_minutes,
     },
   }.with_indifferent_access.freeze
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -153,6 +153,8 @@ participate_in_dap: false
 partner_api_bucket_prefix: ''
 password_max_attempts: 3
 personal_key_retired: true
+phone_confirmation_max_attempts: 20
+phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_setups_per_ip_limit: 25
 phone_setups_per_ip_period: 300
 phone_setups_per_ip_track_only_mode: false
@@ -428,6 +430,8 @@ test:
   otps_per_ip_period: 10
   otps_per_ip_track_only_mode: false
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
+  phone_confirmation_max_attempts: 5
+  phone_confirmation_max_attempt_window_in_minutes: 10
   phone_setups_per_ip_limit: 3
   phone_setups_per_ip_period: 10
   phone_setups_per_ip_track_only_mode: false

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -71,6 +71,7 @@ en:
       otp_failed: Your security code failed to send.
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
+      phone_confirmation_throttled: You tried too many times, please try again in %{timeout}.
       phone_country_constraint_usa: Must be a U.S. phone number
       phone_duplicate: This account is already using the phone number you entered as
         an authenticator. Please use a different phone number.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -74,6 +74,7 @@ es:
       otp_failed: Se produjo un error al enviar el código de seguridad.
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
+      phone_confirmation_throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
       phone_country_constraint_usa: Debe ser un número telefónico de los Estados Unidos
       phone_duplicate: Esta cuenta ya está utilizando el número de teléfono que
         ingresó como autenticador. Por favor, use un número de teléfono

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -81,6 +81,7 @@ fr:
       otp_failed: Échec de l’envoi de votre code de sécurité.
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
+      phone_confirmation_throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
       phone_country_constraint_usa: Dois être un numéro de téléphone américain
       phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez
         entré en tant qu’authentificateur. Veuillez utiliser un numéro de

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -235,6 +235,8 @@ class IdentityConfig
     config.add(:password_max_attempts, type: :integer)
     config.add(:password_pepper, type: :string)
     config.add(:personal_key_retired, type: :boolean)
+    config.add(:phone_confirmation_max_attempts, type: :integer)
+    config.add(:phone_confirmation_max_attempt_window_in_minutes, type: :integer)
     config.add(:phone_setups_per_ip_limit, type: :integer)
     config.add(:phone_setups_per_ip_period, type: :integer)
     config.add(:pii_lock_timeout_in_minutes, type: :integer)


### PR DESCRIPTION
This PR adds a per-account rate limit for sending new phone number confirmation OTPs to augment the existing per-phone-number rate limits.