### PR TITLE
Remove custom camera icon implementation

### DIFF
--- a/app/javascript/packages/components/icon.tsx
+++ b/app/javascript/packages/components/icon.tsx
@@ -1,4 +1,3 @@
-import type { ComponentType } from 'react';
 import { getAssetPath } from '@18f/identity-assets';
 
 const SPRITE_URL = getAssetPath('identity-style-guide/dist/assets/img/sprite.svg');
@@ -246,37 +245,16 @@ export type DesignSystemIcon =
   | 'zoom_out'
   | 'zoom_out_map';
 
-interface BaseIconProps {
+interface IconProps {
   /**
    * Optional class name to apply to SVG element.
    */
   className?: string;
-}
 
-interface IconProps extends BaseIconProps {
+  /**
+   * Name of design system icon to show.
+   */
   icon: DesignSystemIcon;
-}
-
-interface CustomIconProps extends BaseIconProps {}
-
-/**
- * Creates a new icon component, accepting common props, and applying common wrapping elements.
- *
- * @param path SVG icon path definition.
- */
-function createIconComponent(path: string): ComponentType<CustomIconProps> {
-  return ({ className }) => (
-    <svg
-      aria-hidden
-      focusable={false}
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 512 512"
-      className={className}
-    >
-      <path fill="currentColor" d={path} />
-    </svg>
-  );
 }
 
 function Icon({ icon, className }: IconProps) {
@@ -288,9 +266,5 @@ function Icon({ icon, className }: IconProps) {
     </svg>
   );
 }
-
-Icon.Camera = createIconComponent(
-  'M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z',
-);
 
 export default Icon;

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -225,7 +225,7 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
                   aria-label={t('doc_auth.buttons.take_picture')}
                   onClick={onCapture}
                 >
-                  <Icon.Camera className="selfie-capture__capture-icon" />
+                  <Icon icon="photo_camera" className="selfie-capture__capture-icon" />
                 </button>
               </>
             ) : (

--- a/app/javascript/packages/document-capture/components/selfie-capture.scss
+++ b/app/javascript/packages/document-capture/components/selfie-capture.scss
@@ -157,6 +157,12 @@ div.selfie-capture__label[tabindex='-1']:focus {
 .selfie-capture__capture-icon {
   height: 2rem;
   width: 2rem;
+
+  .usa-button:not(.usa-button--unstyled) > &.usa-icon:first-child {
+    // Unset icon placement where assumed to be adjacent to text, since the selfie capture button
+    // uses a standalone icon.
+    margin: 0;
+  }
 }
 
 .selfie-capture__preview-heading.usa-file-input__preview-heading {


### PR DESCRIPTION
Refactoring follow-up to https://github.com/18F/identity-idp/pull/6212#discussion_r852983720

**Why**: As a simplification, since we can use it directly from the design system.

**Testing Instructions:**

1. Have both the IdP and an instance of a local [sample app](https://github.com/18F/identity-oidc-sinatra) running
2. Start at http://localhost:9292
3. Under "Options" in the top-right, select "IAL 2 (strict)"
4. Click "Sign in"
5. Complete proofing flow up to document capture
6. Upload photos of document
7. Click "Continue"
8. Grant access to your camera
9. Observe camera icon appears same as before

![image](https://user-images.githubusercontent.com/1779930/164005354-4b657011-cf30-4441-a227-20d01a42404a.png)
