### PR TITLE
LG-6160: Implement personal key confirmation modal "Back" button

### DIFF
--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -44,6 +44,7 @@ describe('FormSteps', () => {
         onChange,
         onError,
         registerField,
+        toPreviousStep,
       }: FormStepComponentProps<StepValues>) => (
         <>
           <PageHeading>Second Title</PageHeading>
@@ -71,6 +72,9 @@ describe('FormSteps', () => {
               onChange({ secondInputTwo: event.target.value });
             }}
           />
+          <button type="button" onClick={toPreviousStep}>
+            Back
+          </button>
           <button type="button" onClick={() => onError(new Error())}>
             Create Step Error
           </button>
@@ -458,5 +462,14 @@ describe('FormSteps', () => {
     expect(window.scrollY).to.equal(0);
     expect(document.activeElement).to.equal(getByRole('heading', { name: 'Content Title' }));
     expect(window.history.pushState).not.to.have.been.called();
+  });
+
+  it('provides the step implementation the option to navigate to the previous step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('Back'));
+
+    expect(getByText('First Title')).to.be.ok();
   });
 });

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -64,6 +64,11 @@ export interface FormStepComponentProps<V> {
    * Registers field by given name, returning ref assignment function.
    */
   registerField: RegisterFieldCallback;
+
+  /**
+   * Callback to navigate to the previous step.
+   */
+  toPreviousStep: () => void;
 }
 
 export interface FormStep {
@@ -285,6 +290,12 @@ function FormSteps({
     }
   };
 
+  const toPreviousStep = () => {
+    const previousStepIndex = Math.max(stepIndex - 1, 0);
+    const { name: nextStepName } = steps[previousStepIndex];
+    setStepName(nextStepName);
+  };
+
   const { form: Form, name } = step;
   const isLastStep = stepIndex + 1 === steps.length;
 
@@ -332,6 +343,7 @@ function FormSteps({
 
             return fields.current[field].refCallback;
           }}
+          toPreviousStep={toPreviousStep}
         />
       </FormStepsContext.Provider>
     </form>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -1,0 +1,26 @@
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PersonalKeyConfirmStep from './personal-key-confirm-step';
+
+describe('PersonalKeyConfirmStep', () => {
+  const DEFAULT_PROPS = {
+    onChange() {},
+    value: { personalKey: '' },
+    errors: [],
+    unknownFieldErrors: [],
+    onError() {},
+    registerField: () => () => {},
+  };
+
+  it('allows the user to return to the previous step', () => {
+    const toPreviousStep = sinon.spy();
+    const { getByText } = render(
+      <PersonalKeyConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
+    );
+
+    userEvent.click(getByText('forms.buttons.back'));
+
+    expect(toPreviousStep).to.have.been.called();
+  });
+});

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@18f/identity-components';
+import { Alert, Button } from '@18f/identity-components';
 import { FormStepsContext, FormStepsContinueButton } from '@18f/identity-form-steps';
 import { t } from '@18f/identity-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
@@ -10,7 +10,7 @@ import type { VerifyFlowValues } from '../..';
 interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
 function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
-  const { registerField, errors } = stepProps;
+  const { registerField, errors, toPreviousStep } = stepProps;
 
   return (
     <>
@@ -31,13 +31,9 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
             <FormStepsContinueButton className="margin-y-0" />
           </div>
           <div className="grid-col-12 tablet:grid-col-6">
-            <button
-              className="usa-button usa-button--big usa-button--full-width usa-button--outline"
-              type="button"
-              data-dismiss="personal-key-confirm"
-            >
+            <Button isBig isWide isOutline onClick={toPreviousStep}>
               {t('forms.buttons.back')}
-            </button>
+            </Button>
           </div>
           <div className="grid-col-12 tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0 display-none tablet:display-block">
             <FormStepsContinueButton className="margin-y-0" />


### PR DESCRIPTION
**Why**: To allow the user to return to the personal key step to record their personal key, since they need it to be able to complete the confirmation step.

**Testing Instructions:**

1. Set `idv_api_enabled: "true"` in local `config/application.yml`
2. Go to: http://localhost:3000/verify/v2/personal_key_confirm
3. Press "Back"
4. Observe that you are returned to the previous step ("personal key"), reflected both in page content and URL