### PR TITLE
LG-6159: add and place images in personal key step

### DIFF
--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -21,7 +21,7 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
       <Modal>
         <div className="pin-top pin-x"> 
           <div className="display-flex flex-column flex-align-center">
-           <img className="top-neg-3" height="60" width="60" src={getAssetPath('p-key.svg')}></img>
+           <img className="top-neg-3" alt="" height="60" width="60" src={getAssetPath('p-key.svg')}></img>
           </div>
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -20,12 +20,7 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
       </FormStepsContext.Provider>
       <Modal>
         <div className="pin-top pin-x display-flex flex-column flex-align-center top-neg-3">
-            <img
-              alt=""
-              height="60"
-              width="60"
-              src={getAssetPath('p-key.svg')}
-            />
+          <img alt="" height="60" width="60" src={getAssetPath('p-key.svg')} />
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>
         <Modal.Description>{t('forms.personal_key.instructions')}</Modal.Description>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -19,16 +19,13 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
         <PersonalKeyStep {...stepProps} />
       </FormStepsContext.Provider>
       <Modal>
-        <div className="pin-top pin-x">
-          <div className="display-flex flex-column flex-align-center">
+        <div className="pin-top pin-x display-flex flex-column flex-align-center top-neg-3">
             <img
-              className="top-neg-3"
               alt=""
               height="60"
               width="60"
               src={getAssetPath('p-key.svg')}
             />
-          </div>
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>
         <Modal.Description>{t('forms.personal_key.instructions')}</Modal.Description>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -6,6 +6,7 @@ import { Modal } from '@18f/identity-modal';
 import PersonalKeyStep from '../personal-key/personal-key-step';
 import PersonalKeyInput from './personal-key-input';
 import type { VerifyFlowValues } from '../..';
+import { getAssetPath } from '@18f/identity-assets';
 
 interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
@@ -18,6 +19,11 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
         <PersonalKeyStep {...stepProps} />
       </FormStepsContext.Provider>
       <Modal>
+        <div className="pin-top pin-x"> 
+          <div className="display-flex flex-column flex-align-center">
+           <img className="top-neg-3" height="60" width="60" src={getAssetPath('p-key.svg')}></img>
+          </div>
+        </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>
         <Modal.Description>{t('forms.personal_key.instructions')}</Modal.Description>
         {errors.length > 0 && (

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -3,10 +3,11 @@ import { FormStepsContext, FormStepsContinueButton } from '@18f/identity-form-st
 import { t } from '@18f/identity-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { Modal } from '@18f/identity-modal';
+import { getAssetPath } from '@18f/identity-assets';
 import PersonalKeyStep from '../personal-key/personal-key-step';
 import PersonalKeyInput from './personal-key-input';
 import type { VerifyFlowValues } from '../..';
-import { getAssetPath } from '@18f/identity-assets';
+
 
 interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -21,7 +21,13 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
       <Modal>
         <div className="pin-top pin-x">
           <div className="display-flex flex-column flex-align-center">
-           <img className="top-neg-3" alt="" height="60" width="60" src={getAssetPath('p-key.svg')} />
+            <img
+              className="top-neg-3"
+              alt=""
+              height="60"
+              width="60"
+              src={getAssetPath('p-key.svg')}
+            />
           </div>
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -8,7 +8,6 @@ import PersonalKeyStep from '../personal-key/personal-key-step';
 import PersonalKeyInput from './personal-key-input';
 import type { VerifyFlowValues } from '../..';
 
-
 interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
 function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
@@ -20,9 +19,9 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
         <PersonalKeyStep {...stepProps} />
       </FormStepsContext.Provider>
       <Modal>
-        <div className="pin-top pin-x"> 
+        <div className="pin-top pin-x">
           <div className="display-flex flex-column flex-align-center">
-           <img className="top-neg-3" alt="" height="60" width="60" src={getAssetPath('p-key.svg')}></img>
+           <img className="top-neg-3" alt="" height="60" width="60" src={getAssetPath('p-key.svg')} />
           </div>
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -57,7 +57,7 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">
-        <img className="float-left margin-right-2" alt="" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80"></img>
+        <img className="float-left margin-right-2" alt="" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80" />
         <p className="margin-bottom-0">
           <strong>{t('instructions.personal_key.email_title')}</strong>
         </p>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -5,8 +5,8 @@ import { t } from '@18f/identity-i18n';
 import { formatHTML } from '@18f/identity-react-i18n';
 import { FormStepsContinueButton } from '@18f/identity-form-steps';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
-import type { VerifyFlowValues } from '../..';
 import { getAssetPath } from '@18f/identity-assets';
+import type { VerifyFlowValues } from '../..';
 import DownloadButton from './download-button';
 
 interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {}
@@ -57,7 +57,7 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">
-        <img className="float-left margin-right-2" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80"></img>
+        <img className="float-left margin-right-2" alt="" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80"></img>
         <p className="margin-bottom-0">
           <strong>{t('instructions.personal_key.email_title')}</strong>
         </p>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -57,11 +57,13 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">
-        <img className="float-left margin-right-2"
+        <img
+          className="float-left margin-right-2"
           alt=""
           src={getAssetPath('icon-lock-alert-important.svg')}
           width="80"
-          height="80" />
+          height="80"
+        />
         <p className="margin-bottom-0">
           <strong>{t('instructions.personal_key.email_title')}</strong>
         </p>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -57,7 +57,11 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">
-        <img className="float-left margin-right-2" alt="" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80" />
+        <img className="float-left margin-right-2"
+          alt=""
+          src={getAssetPath('icon-lock-alert-important.svg')}
+          width="80"
+          height="80" />
         <p className="margin-bottom-0">
           <strong>{t('instructions.personal_key.email_title')}</strong>
         </p>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -6,6 +6,7 @@ import { formatHTML } from '@18f/identity-react-i18n';
 import { FormStepsContinueButton } from '@18f/identity-form-steps';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import type { VerifyFlowValues } from '../..';
+import { getAssetPath } from '@18f/identity-assets';
 import DownloadButton from './download-button';
 
 interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {}
@@ -56,6 +57,7 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">
+        <img className="float-left margin-right-2" src={getAssetPath('icon-lock-alert-important.svg')} width="80" height="80"></img>
         <p className="margin-bottom-0">
           <strong>{t('instructions.personal_key.email_title')}</strong>
         </p>


### PR DESCRIPTION
[LG-6159: Add and place images in Personal Key step](https://cm-jira.usa.gov/browse/LG-6159)

**Why:** Image assets need to be incorporated into personal key step in order for that step to have the same look/feel as the original 

**Testing Instructions** 
1.  Set `idv_api_enabled: "true"` in `local config/application.yml`
2. Go to: http://localhost:3000/verify/v2/personal_key
3. Observe that lock image is present at the bottom (see screenshot) 
4.  Click "continue"
5. Observe that red logo image is present at the top of the modal (see screenshot) 

**Note:**  One thing that differs from the [original implementation](https://github.com/18F/identity-idp/blob/a682e958fce7cbb60f90a7a12a95927e861a6de0/app/assets/stylesheets/components/_modal.scss#L37), the image at the top of the modal was a background image included in the SCSS. Because we have to use getAssetPath to fetch the correct URL, the new implementation is accomplished by adding the image in the HTML 

**Screenshots**
<img width="627" alt="Screen Shot 2022-04-18 at 4 07 28 PM" src="https://user-images.githubusercontent.com/6639858/164046463-8800e2cd-c9ad-463e-83c1-cfab4004547d.png">
![Modal icon](https://user-images.githubusercontent.com/6639858/164046599-8bb8101e-4de7-4c1d-81e1-f9de2fec987c.png)

