### PR TITLE
fix redirect in phone confirmation throttle

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -301,7 +301,7 @@ module Users
       if user_fully_authenticated?
         redirect_to account_url
       else
-        redirect_to login_two_factor_options_url
+        redirect_to two_factor_options_url
       end
     end
   end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -489,7 +489,7 @@ describe Users::TwoFactorAuthenticationController do
               timeout: timeout,
             ),
           )
-          expect(response).to redirect_to login_two_factor_options_url
+          expect(response).to redirect_to two_factor_options_url
         end
       end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -124,7 +124,7 @@ feature 'Sign Up' do
         Throttle.attempt_window_in_minutes(:phone_confirmation).minutes,
       )
 
-      expect(current_path).to eq(login_two_factor_options_path)
+      expect(current_path).to eq(two_factor_options_path)
       expect(page).to have_content(
         I18n.t(
           'errors.messages.phone_confirmation_throttled',


### PR DESCRIPTION
follow up to #6216

`login_two_factor_options_url` is for choosing an existing 2FA when the intention was to redirect to setting up 2FA for _new_ accounts
