### PR TITLE
Use secure_compare for OIDC code_challenge

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -113,7 +113,9 @@ class OpenidConnectTokenForm
   def validate_code_verifier
     expected_code_challenge = remove_base64_padding(identity.try(:code_challenge))
     given_code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier.to_s)
-    if ActiveSupport::SecurityUtils.secure_compare(expected_code_challenge, given_code_challenge)
+    if expected_code_challenge &&
+       given_code_challenge &&
+       ActiveSupport::SecurityUtils.secure_compare(expected_code_challenge, given_code_challenge)
       return
     end
     errors.add :code_verifier,

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -113,7 +113,9 @@ class OpenidConnectTokenForm
   def validate_code_verifier
     expected_code_challenge = remove_base64_padding(identity.try(:code_challenge))
     given_code_challenge = Digest::SHA256.urlsafe_base64digest(code_verifier.to_s)
-    return if expected_code_challenge == given_code_challenge
+    if ActiveSupport::SecurityUtils.secure_compare(expected_code_challenge, given_code_challenge)
+      return
+    end
     errors.add :code_verifier,
                t('openid_connect.token.errors.invalid_code_verifier'),
                type: :invalid_code_verifier


### PR DESCRIPTION
**Why**: Good security practice to avoid timing attacks

[skip changelog]