### PR TITLE
LG-6193: Enable personal key step in development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :development, :test do
   gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'brakeman', require: false
   gem 'bullet', '>= 6.0.2'
+  gem 'capybara-webmock', git: 'https://github.com/hashrocket/capybara-webmock.git', ref: '63d790a0'
   gem 'data_uri', require: false
   gem 'erb_lint', '~> 0.1.0', require: false
   gem 'i18n-tasks', '>= 0.9.31'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,19 @@ GIT
       pkcs11
       uuid
 
+GIT
+  remote: https://github.com/hashrocket/capybara-webmock.git
+  revision: 63d790a0b6c779b9700634bfc153e25ccdeb3688
+  ref: 63d790a0
+  specs:
+    capybara-webmock (0.6.0)
+      capybara (>= 2.4, < 4)
+      rack (>= 1.4)
+      rack-proxy (>= 0.6.0)
+      rexml (>= 3.2)
+      selenium-webdriver (>= 4.0)
+      webrick (>= 1.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -442,6 +455,8 @@ GEM
     rack-headers_filter (0.0.1)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
+    rack-proxy (0.7.2)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-timeout (0.6.0)
@@ -700,6 +715,7 @@ DEPENDENCIES
   bullet (>= 6.0.2)
   bundler-audit
   capybara-selenium (>= 0.0.6)
+  capybara-webmock!
   connection_pool
   cssbundling-rails
   data_uri

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -123,7 +123,7 @@ module Idv
 
     def idv_api_personal_key_step_enabled?
       return false if idv_session.address_verification_mechanism == 'gpo'
-      IdentityConfig.store.idv_api_enabled_steps.include?(:personal_key)
+      IdentityConfig.store.idv_api_enabled_steps.include?('personal_key')
     end
   end
 end

--- a/app/views/test/saml_test/decode_response.html.erb
+++ b/app/views/test/saml_test/decode_response.html.erb
@@ -26,7 +26,7 @@
         <%= link_to 'Open in New Window',
                     "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                     target: '_blank', rel: 'noopener noreferrer' %>
-        <input type="hidden" id="SAMLResponse" value="<%= xml_doc %>">
+        <%= hidden_field_tag '', xml_doc, id: 'SAMLResponse' %>
       </td>
     </tr>
     <tr>

--- a/app/views/test/saml_test/decode_response.html.erb
+++ b/app/views/test/saml_test/decode_response.html.erb
@@ -26,6 +26,7 @@
         <%= link_to 'Open in New Window',
                     "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                     target: '_blank', rel: 'noopener noreferrer' %>
+        <input type="hidden" id="SAMLResponse" value="<%= xml_doc %>">
       </td>
     </tr>
     <tr>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -281,6 +281,7 @@ development:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true
+  idv_api_enabled_steps: '["personal_key","personal_key_confirm"]'
   liveness_checking_enabled: true
   logins_per_ip_limit: 5
   logo_upload_enabled: true

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -93,7 +93,7 @@ gpo_designated_receiver_pii: '{}'
 hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
-idv_api_enabled_steps: '[]'
+idv_api_enabled_steps: '["personal_key","personal_key_confirm"]'
 idv_attempt_window_in_hours: 6
 idv_max_attempts: 5
 idv_min_age_years: 13
@@ -281,7 +281,6 @@ development:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true
-  idv_api_enabled_steps: '["personal_key","personal_key_confirm"]'
   liveness_checking_enabled: true
   logins_per_ip_limit: 5
   logo_upload_enabled: true
@@ -348,6 +347,7 @@ production:
   enable_usps_verification: false
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'
+  idv_api_enabled_steps: '[]'
   in_person_proofing_enabled: false
   logins_per_ip_limit: 20
   logins_per_ip_period: 20

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -93,7 +93,7 @@ gpo_designated_receiver_pii: '{}'
 hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
-idv_api_enabled_steps: '["personal_key","personal_key_confirm"]'
+idv_api_enabled_steps: '[]'
 idv_attempt_window_in_hours: 6
 idv_max_attempts: 5
 idv_min_age_years: 13
@@ -281,6 +281,7 @@ development:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true
+  idv_api_enabled_steps: '["personal_key","personal_key_confirm"]'
   liveness_checking_enabled: true
   logins_per_ip_limit: 5
   logo_upload_enabled: true
@@ -347,7 +348,6 @@ production:
   enable_usps_verification: false
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'
-  idv_api_enabled_steps: '[]'
   in_person_proofing_enabled: false
   logins_per_ip_limit: 20
   logins_per_ip_period: 20

--- a/spec/controllers/api/verify/complete_controller_spec.rb
+++ b/spec/controllers/api/verify/complete_controller_spec.rb
@@ -31,7 +31,7 @@ describe Api::Verify::CompleteController do
   let(:jwt) { JWT.encode({ pii: pii, metadata: {} }, key, 'RS256', sub: user.uuid) }
 
   before do
-    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([:personal_key])
+    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(['personal_key'])
   end
 
   describe 'before_actions' do

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -293,27 +293,6 @@ describe Idv::ReviewController do
         allow(@analytics).to receive(:track_event)
       end
 
-      it 'redirects to personal key path' do
-        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-
-        expect(@analytics).to have_received(:track_event).with(Analytics::IDV_REVIEW_COMPLETE)
-        expect(@analytics).to have_received(:track_event).with(
-          'IdV: final resolution',
-          success: true,
-        )
-        expect(response).to redirect_to idv_personal_key_path
-      end
-
-      it 'redirects to confirmation path after user presses the back button' do
-        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-
-        expect(subject.user_session[:need_personal_key_confirmation]).to eq(true)
-
-        allow_any_instance_of(User).to receive(:active_profile).and_return(true)
-        get :new
-        expect(response).to redirect_to idv_personal_key_path
-      end
-
       it 'creates Profile with applicant attributes' do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
@@ -324,6 +303,32 @@ describe Idv::ReviewController do
 
         expect(idv_session.applicant[:first_name]).to eq 'José'
         expect(pii.first_name).to eq 'José'
+      end
+
+      context 'with idv app personal key step disabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([])
+        end
+
+        it 'redirects to personal key path' do
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(@analytics).to have_received(:track_event).with(
+            'IdV: final resolution',
+            success: true,
+          )
+          expect(response).to redirect_to idv_personal_key_path
+        end
+
+        it 'redirects to confirmation path after user presses the back button' do
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(subject.user_session[:need_personal_key_confirmation]).to eq(true)
+
+          allow_any_instance_of(User).to receive(:active_profile).and_return(true)
+          get :new
+          expect(response).to redirect_to idv_personal_key_path
+        end
       end
 
       context 'user picked phone confirmation' do
@@ -349,17 +354,14 @@ describe Idv::ReviewController do
           expect(disavowal_event_count).to eq 1
         end
 
-        context 'with idv app personal key step enabled' do
-          before do
-            allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return(['personal_key'])
-          end
+        it 'redirects to idv app personal key path' do
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
-          it 'redirects to idv app personal key path' do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-
-            expect(response).to redirect_to idv_app_root_url
-          end
+          expect(@analytics).to have_received(:track_event).with(
+            'IdV: final resolution',
+            success: true,
+          )
+          expect(response).to redirect_to idv_app_root_url
         end
       end
 
@@ -377,17 +379,14 @@ describe Idv::ReviewController do
           expect(profile).to_not be_active
         end
 
-        context 'with idv api personal key step enabled' do
-          before do
-            allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return(['personal_key'])
-          end
+        it 'redirects to personal key path' do
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
-          it 'redirects to personal key path' do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-
-            expect(response).to redirect_to idv_personal_key_path
-          end
+          expect(@analytics).to have_received(:track_event).with(
+            'IdV: final resolution',
+            success: true,
+          )
+          expect(response).to redirect_to idv_personal_key_path
         end
       end
     end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -352,7 +352,7 @@ describe Idv::ReviewController do
         context 'with idv app personal key step enabled' do
           before do
             allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return([:personal_key])
+              and_return(['personal_key'])
           end
 
           it 'redirects to idv app personal key path' do
@@ -380,7 +380,7 @@ describe Idv::ReviewController do
         context 'with idv api personal key step enabled' do
           before do
             allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return([:personal_key])
+              and_return(['personal_key'])
           end
 
           it 'redirects to personal key path' do

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -37,7 +37,7 @@ describe VerifyController do
     context 'with step feature-enabled' do
       before do
         allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-          and_return([:personal_key, :personal_key_confirm])
+          and_return(['personal_key', 'personal_key_confirm'])
       end
 
       it 'renders view' do

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     end
 
     after(:build) do |profile, evaluator|
-      if evaluator.pii
+      if evaluator.pii && profile.user
         pii_attrs = Pii::Attributes.new_from_hash(evaluator.pii)
         profile.encrypt_pii(pii_attrs, profile.user.password)
       end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -32,8 +32,17 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pii do
+      pii do
+        DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
+          ssn: DocAuthHelper::GOOD_SSN,
+          phone: '+1 (555) 555-1234',
+        )
+      end
+    end
+
     after(:build) do |profile, evaluator|
-      if evaluator.pii && profile.user
+      if evaluator.pii
         pii_attrs = Pii::Attributes.new_from_hash(evaluator.pii)
         profile.encrypt_pii(pii_attrs, profile.user.password)
       end

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -57,7 +57,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path
+      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -71,7 +71,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path
+      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -85,7 +85,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path
+      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -57,7 +57,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
+      expect(current_path).to be_in([idv_personal_key_path, idv_app_root_path])
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -71,7 +71,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
+      expect(current_path).to be_in([idv_personal_key_path, idv_app_root_path])
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
@@ -85,7 +85,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path.or idv_app_root_url
+      expect(current_path).to be_in([idv_personal_key_path, idv_app_root_path])
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled

--- a/spec/features/idv/clearing_and_restarting_spec.rb
+++ b/spec/features/idv/clearing_and_restarting_spec.rb
@@ -5,7 +5,7 @@ describe 'clearing IdV and restarting' do
 
   let(:user) { user_with_2fa }
 
-  context 'during GPO otp verification' do
+  context 'during GPO otp verification', js: true do
     before do
       start_idv_from_sp
       complete_idv_steps_with_gpo_before_confirmation_step(user)

--- a/spec/features/idv/clearing_and_restarting_spec.rb
+++ b/spec/features/idv/clearing_and_restarting_spec.rb
@@ -9,7 +9,7 @@ describe 'clearing IdV and restarting' do
     before do
       start_idv_from_sp
       complete_idv_steps_with_gpo_before_confirmation_step(user)
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
     end
 
     context 'before signing out' do

--- a/spec/features/idv/gpo_disabled_spec.rb
+++ b/spec/features/idv/gpo_disabled_spec.rb
@@ -17,7 +17,7 @@ feature 'disabling GPO address verification' do
       Rails.application.reload_routes!
     end
 
-    it 'allows verification without the option to confirm address with usps' do
+    it 'allows verification without the option to confirm address with usps', js: true do
       user = user_with_2fa
       start_idv_from_sp
       complete_idv_steps_before_phone_step(user)
@@ -36,7 +36,7 @@ feature 'disabling GPO address verification' do
       click_submit_default
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(sign_up_completed_path)
     end

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe 'proofing components' do
       expect(current_path).to eq idv_doc_auth_step_path(step: :welcome)
 
       complete_all_doc_auth_steps
-      click_continue
-      expect(page).to have_current_path('/verify/review', wait: 5)
+      click_idv_continue
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
       click_continue
       acknowledge_and_confirm_personal_key

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'proofing components' do
       expect(page).to have_current_path('/verify/review', wait: 5)
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
     end
 
     context 'async proofing', js: true do

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'proofing components' do
     end
   end
 
-  it 'clears the liveness enabled proofing component when a user re-proofs without liveness' do
+  it 'clears liveness enabled proofing component when user re-proofs without liveness', js: true do
     allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
     user = user_with_2fa
     sign_in_and_2fa_user(user)

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -24,4 +24,33 @@ feature 'idv confirmation step', js: true do
 
     it_behaves_like 'personal key page'
   end
+
+  context 'with idv app feature enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+        and_return(['personal_key', 'personal_key_confirm'])
+    end
+
+    it_behaves_like 'idv confirmation step'
+    it_behaves_like 'idv confirmation step', :oidc
+    it_behaves_like 'idv confirmation step', :saml
+
+    context 'personal key information and actions' do
+      before do
+        @user = sign_in_and_2fa_user
+
+        visit idv_path
+
+        complete_idv_steps_before_confirmation_step(@user)
+      end
+
+      it 'allows the user to refresh and still displays the personal key' do
+        # Visit the current path is the same as refreshing
+        visit current_path
+        expect(page).to have_content(t('headings.personal_key'))
+      end
+
+      it_behaves_like 'personal key page'
+    end
+  end
 end

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'idv confirmation step' do
+feature 'idv confirmation step', js: true do
   include IdvStepHelper
 
   it_behaves_like 'idv confirmation step'

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -49,7 +49,7 @@ feature 'idv gpo step' do
       click_on t('idv.buttons.mail.send')
       fill_in 'Password', with: user_password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       visit root_path
       click_on t('idv.buttons.cancel')
       first(:link, t('links.sign_out')).click

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -24,7 +24,7 @@ feature 'idv gpo step' do
   context 'the user has sent a letter but not verified an OTP' do
     let(:user) { user_with_2fa }
 
-    it 'allows the user to resend a letter and redirects to the come back later step' do
+    it 'allows the user to resend a letter and redirects to the come back later step', js: true do
       complete_idv_and_return_to_gpo_step
 
       expect { click_on t('idv.buttons.mail.resend') }.
@@ -34,7 +34,7 @@ feature 'idv gpo step' do
       expect(page).to have_current_path(idv_come_back_later_path)
     end
 
-    it 'allows the user to return to gpo otp confirmation' do
+    it 'allows the user to return to gpo otp confirmation', js: true do
       complete_idv_and_return_to_gpo_step
       click_doc_auth_back_link
 

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -13,6 +13,8 @@ feature 'idv review step' do
     start_idv_from_sp
     complete_idv_steps_before_review_step
 
+    click_on t('idv.messages.review.intro')
+
     expect(page).to have_content('FAKEY')
     expect(page).to have_content('MCFAKERSON')
     expect(page).to have_content('1 FAKE RD')

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -31,7 +31,7 @@ feature 'idv review step' do
     click_idv_continue
 
     expect(page).to have_content(t('headings.personal_key'))
-    expect(page).to have_current_path(idv_personal_key_path)
+    expect(current_path).to be_in([idv_personal_key_path, idv_app_root_path])
   end
 
   context 'choosing to confirm address with phone' do

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -9,7 +9,7 @@ feature 'idv review step' do
     expect(current_path).to eq(root_path)
   end
 
-  it 'requires the user to enter the correct password to redirect to confirmation step' do
+  it 'requires the user to enter the correct password to redirect to confirmation step', js: true do
     start_idv_from_sp
     complete_idv_steps_before_review_step
 

--- a/spec/features/idv/strict_ial2/upgrade_spec.rb
+++ b/spec/features/idv/strict_ial2/upgrade_spec.rb
@@ -22,7 +22,7 @@ feature 'Strict IAL2 upgrade', js: true do
     expect(page.current_path).to eq(idv_doc_auth_welcome_step)
 
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: user.password
     click_continue
     acknowledge_and_confirm_personal_key
@@ -54,7 +54,7 @@ feature 'Strict IAL2 upgrade', js: true do
       expect(page.current_path).to eq(idv_doc_auth_welcome_step)
 
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key

--- a/spec/features/idv/strict_ial2/upgrade_spec.rb
+++ b/spec/features/idv/strict_ial2/upgrade_spec.rb
@@ -25,7 +25,7 @@ feature 'Strict IAL2 upgrade', js: true do
     click_continue
     fill_in 'Password', with: user.password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_agree_and_continue
 
     expect(current_url).to start_with('http://localhost:7654/auth/result')
@@ -57,7 +57,7 @@ feature 'Strict IAL2 upgrade', js: true do
       click_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       click_agree_and_continue
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')

--- a/spec/features/idv/strict_ial2/upgrade_spec.rb
+++ b/spec/features/idv/strict_ial2/upgrade_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Strict IAL2 upgrade' do
+feature 'Strict IAL2 upgrade', js: true do
   include IdvHelper
   include OidcAuthHelper
   include SamlAuthHelper

--- a/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
+++ b/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
@@ -67,7 +67,7 @@ feature 'Strict IAL2 with usps upload disallowed' do
     click_continue
     fill_in 'Password', with: user.password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_agree_and_continue
 
     expect(current_url).to start_with('http://localhost:7654/auth/result')

--- a/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
+++ b/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
@@ -64,7 +64,7 @@ feature 'Strict IAL2 with usps upload disallowed', js: true do
     expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
 
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: user.password
     click_continue
     acknowledge_and_confirm_personal_key

--- a/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
+++ b/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Strict IAL2 with usps upload disallowed' do
+feature 'Strict IAL2 with usps upload disallowed', js: true do
   include IdvHelper
   include OidcAuthHelper
   include IdvHelper

--- a/spec/features/idv/uak_password_spec.rb
+++ b/spec/features/idv/uak_password_spec.rb
@@ -12,7 +12,7 @@ feature 'A user with a UAK passwords attempts IdV' do
     start_idv_from_sp(:oidc)
     complete_idv_steps_with_phone_before_confirmation_step(user)
 
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     expect(page).to have_current_path(sign_up_completed_path)
 

--- a/spec/features/idv/uak_password_spec.rb
+++ b/spec/features/idv/uak_password_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'A user with a UAK passwords attempts IdV' do
   include IdvStepHelper
 
-  it 'allows the user to continue to the SP' do
+  it 'allows the user to continue to the SP', js: true do
     user = user_with_2fa
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest(user.password),

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -29,7 +29,7 @@ feature 'IAL2 Single Sign On' do
     click_on t('idv.buttons.mail.send')
     fill_in t('idv.form.password'), with: user.password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_link t('idv.buttons.continue_plain')
   end
 
@@ -48,7 +48,7 @@ feature 'IAL2 Single Sign On' do
     click_on t('idv.buttons.mail.resend')
     fill_in t('idv.form.password'), with: user.password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_link t('idv.buttons.continue_plain')
   end
 
@@ -140,7 +140,7 @@ feature 'IAL2 Single Sign On' do
       end
 
       context 'provides an option to update address if undeliverable' do
-        it 'allows the user to update the address', js: true do
+        it 'allows the user to update the address' do
           user = create(:user, :signed_up)
 
           perform_id_verification_with_gpo_without_confirming_code(user)

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -90,7 +90,7 @@ feature 'IAL2 Single Sign On' do
       )
     end
 
-    context 'having previously selected USPS verification' do
+    context 'having previously selected USPS verification', js: true do
       let(:phone_confirmed) { false }
 
       context 'provides an option to send another letter' do
@@ -140,7 +140,7 @@ feature 'IAL2 Single Sign On' do
       end
 
       context 'provides an option to update address if undeliverable' do
-        it 'allows the user to update the address' do
+        it 'allows the user to update the address', js: true do
           user = create(:user, :signed_up)
 
           perform_id_verification_with_gpo_without_confirming_code(user)

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -20,7 +20,7 @@ feature 'SP Costing', :email do
     expect_sp_cost_type(2, 1, 'authentication')
   end
 
-  it 'logs the correct costs for an ial2 user creation from sp with oidc' do
+  it 'logs the correct costs for an ial2 user creation from sp with oidc', js: true do
     create_ial2_user_from_sp(email)
 
     expect_sp_cost_type(0, 2, 'sms')
@@ -40,7 +40,7 @@ feature 'SP Costing', :email do
     expect_sp_cost_type(8, 2, 'authentication')
   end
 
-  it 'logs the cost to the SP for reproofing' do
+  it 'logs the cost to the SP for reproofing', js: true do
     create_ial2_user_from_sp(email)
 
     # track costs without dealing with 'remember device'
@@ -93,7 +93,7 @@ feature 'SP Costing', :email do
     expect_sp_cost_type(2, 1, 'authentication')
   end
 
-  it 'logs the correct costs for an ial2 authentication' do
+  it 'logs the correct costs for an ial2 authentication', js: true do
     create_ial2_user_from_sp(email)
     SpCost.delete_all
 

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -54,7 +54,7 @@ feature 'SP Costing', :email do
     fill_in_code_with_last_phone_otp
     click_submit_default
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: password
     click_continue
     acknowledge_and_confirm_personal_key

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -57,7 +57,7 @@ feature 'SP Costing', :email do
     click_continue
     fill_in 'Password', with: password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_agree_and_continue
 
     %w[

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -53,7 +53,7 @@ feature 'View personal key' do
         click_continue
 
         expect(page).to have_content(t('headings.personal_key'))
-        click_acknowledge_personal_key
+        acknowledge_and_confirm_personal_key
 
         expect(user.reload.encrypted_recovery_code_digest).to_not eq old_digest
       end

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -157,14 +157,14 @@ def expect_to_be_back_on_manage_personal_key_page_with_continue_button_in_focus
 end
 
 def submit_form_without_entering_the_code
-  click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
-  expect(page).to have_selector('.validation-message')
-  expect(page).not_to have_selector('#personal-key-alert')
+  within('[role=dialog]') { click_continue }
+  expect(page).to have_content(t('simple_form.required.text'))
+  expect(page).not_to have_content(t('users.personal_key.confirmation_error'))
 end
 
 def submit_form_with_the_wrong_code
   fill_in 'personal_key', with: 'hellohellohello'
-  click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
+  within('[role=dialog]') { click_continue }
   expect(page).to have_content(t('users.personal_key.confirmation_error'))
-  expect(page).not_to have_selector('.validation-message')
+  expect(page).not_to have_content(t('simple_form.required.text'))
 end

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -31,7 +31,7 @@ feature 'View personal key' do
     end
 
     context 'regenerating new code after canceling edit password action' do
-      scenario 'displays new code' do
+      scenario 'displays new code', js: true do
         sign_in_and_2fa_user(user)
         old_digest = user.encrypted_recovery_code_digest
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -140,8 +140,7 @@ def sign_up_and_view_personal_key
 end
 
 def expect_confirmation_modal_to_appear_with_first_code_field_in_focus
-  expect(page).not_to have_xpath("//div[@id='personal-key-confirm'][@class='display-none']")
-  expect(page.evaluate_script('document.activeElement.name')).to eq 'personal_key'
+  expect(page.find(':focus')).to eq page.find_field(t('forms.personal_key.confirmation_label'))
 end
 
 def click_back_button

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -144,7 +144,7 @@ feature 'User profile' do
         expect(page).to have_content(t('idv.messages.personal_key'))
       end
 
-      it 'allows the user reactivate their profile by reverifying' do
+      it 'allows the user reactivate their profile by reverifying', js: true do
         profile = create(:profile, :active, :verified, pii: { ssn: '1234', dob: '1920-01-01' })
         user = profile.user
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -158,7 +158,7 @@ feature 'User profile' do
         click_idv_continue
         fill_in 'Password', with: user_password
         click_idv_continue
-        click_acknowledge_personal_key
+        acknowledge_and_confirm_personal_key
 
         expect(current_path).to eq(sign_up_completed_path)
 

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -364,7 +364,7 @@ describe 'FeatureManagement', type: :feature do
 
     context 'with steps enabled' do
       it 'returns true' do
-        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([:example])
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(['example'])
 
         expect(FeatureManagement.idv_api_enabled?).to eq(true)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ require 'email_spec'
 require 'factory_bot'
 require 'view_component/test_helpers'
 require 'capybara/rspec'
+require 'capybara/webmock'
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -102,7 +103,9 @@ RSpec.configure do |config|
 
   config.around(:each, type: :feature) do |example|
     Bullet.enable = true
+    Capybara::Webmock.start
     example.run
+    Capybara::Webmock.stop
     Bullet.enable = false
   end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -10,6 +10,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument('--window-size=1200x700')
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-dev-shm-usage')
+  options.add_argument("--proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}")
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
@@ -31,6 +32,7 @@ Capybara.register_driver(:headless_chrome_mobile) do |app|
   options.add_argument('--window-size=414,736')
   options.add_argument("--user-agent='#{user_agent_string}'")
   options.add_argument('--use-fake-device-for-media-stream')
+  options.add_argument("--proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}")
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -152,6 +152,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_proofing_steps
     complete_all_doc_auth_steps
     click_continue
+    expect(page).to have_current_path(idv_review_path, wait: 10)
     fill_in 'Password', with: RequestHelper::VALID_PASSWORD
     click_continue
     acknowledge_and_confirm_personal_key

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -154,7 +154,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     click_continue
     fill_in 'Password', with: RequestHelper::VALID_PASSWORD
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_agree_and_continue
   end
 

--- a/spec/support/features/idv_from_sp_helper.rb
+++ b/spec/support/features/idv_from_sp_helper.rb
@@ -14,7 +14,7 @@ module IdvFromSpHelper
     click_continue
     fill_in 'Password', with: password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     click_agree_and_continue
   end
 
@@ -23,7 +23,7 @@ module IdvFromSpHelper
     click_continue
     fill_in 'Password', with: password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
   end
 
   def create_ial1_user_from_sp(email)

--- a/spec/support/features/idv_from_sp_helper.rb
+++ b/spec/support/features/idv_from_sp_helper.rb
@@ -11,7 +11,7 @@ module IdvFromSpHelper
     visit_idp_from_sp_with_ial2(:oidc, **options)
     register_user(email)
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: password
     click_continue
     acknowledge_and_confirm_personal_key
@@ -20,7 +20,7 @@ module IdvFromSpHelper
 
   def reproof_for_ial2_strict
     complete_all_doc_auth_steps
-    click_continue
+    click_idv_continue
     fill_in 'Password', with: password
     click_continue
     acknowledge_and_confirm_personal_key

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -60,11 +60,13 @@ module IdvHelper
           embed_sign: false,
         },
       }
-      sp = ServiceProvider.find_by(issuer: sp1_issuer)
-      acs_url = URI.parse(sp.acs_url)
-      acs_url.host = page.server.host
-      acs_url.port = page.server.port
-      sp.update(acs_url: acs_url.to_s)
+      if javascript_enabled?
+        service_provider = ServiceProvider.find_by(issuer: sp1_issuer)
+        acs_url = URI.parse(service_provider.acs_url)
+        acs_url.host = page.server.host
+        acs_url.port = page.server.port
+        service_provider.update(acs_url: acs_url.to_s)
+      end
       visit_saml_authn_request_url(overrides: saml_overrides)
     elsif sp == :oidc
       @state = SecureRandom.hex

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -60,6 +60,11 @@ module IdvHelper
           embed_sign: false,
         },
       }
+      sp = ServiceProvider.find_by(issuer: sp1_issuer)
+      acs_url = URI.parse(sp.acs_url)
+      acs_url.host = page.server.host
+      acs_url.port = page.server.port
+      sp.update(acs_url: acs_url.to_s)
       visit_saml_authn_request_url(overrides: saml_overrides)
     elsif sp == :oidc
       @state = SecureRandom.hex

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -60,11 +60,6 @@ module IdvHelper
           embed_sign: false,
         },
       }
-      if javascript_enabled?
-        idp_domain_name = "#{page.server.host}:#{page.server.port}"
-        saml_overrides[:idp_sso_target_url] = "http://#{idp_domain_name}/api/saml/auth"
-        saml_overrides[:idp_slo_target_url] = "http://#{idp_domain_name}/api/saml/logout"
-      end
       visit_saml_authn_request_url(overrides: saml_overrides)
     elsif sp == :oidc
       @state = SecureRandom.hex

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -28,6 +28,6 @@ module PersonalKeyHelper
   end
 
   def scrape_personal_key
-    page.all(:css, '.separator-text__code').map(&:text).join('-')
+    page.all('.separator-text__code').map(&:text).join('-')
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -308,16 +308,14 @@ module Features
       click_submit_default
     end
 
-    def acknowledge_and_confirm_personal_key(js: true)
+    def acknowledge_and_confirm_personal_key
       click_acknowledge_personal_key
 
-      if js
-        page.find(':focus').fill_in with: scrape_personal_key
-        if page.current_path == idv_personal_key_url
-          click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
-        else
-          click_submit_default
-        end
+      page.find(':focus').fill_in with: scrape_personal_key
+      if page.current_path == idv_personal_key_url
+        click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
+      else
+        click_submit_default
       end
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -3,7 +3,6 @@ require 'cgi'
 module Features
   module SessionHelper
     include PersonalKeyHelper
-    include JavascriptDriverHelper
 
     VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
 
@@ -320,11 +319,7 @@ module Features
     end
 
     def click_acknowledge_personal_key
-      if javascript_enabled?
-        acknowledge_and_confirm_personal_key
-      else
-        click_on t('forms.buttons.continue'), class: 'personal-key-continue'
-      end
+      click_continue
     end
 
     def enter_personal_key(personal_key:, selector: 'input[type="text"]')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -309,17 +309,24 @@ module Features
     end
 
     def acknowledge_and_confirm_personal_key(js: true)
-      button_text = t('forms.buttons.continue')
+      click_acknowledge_personal_key
 
-      click_on button_text, class: 'personal-key-continue' if js
-
-      fill_in 'personal_key', with: scrape_personal_key
-
-      find_all('.personal-key-confirm', text: button_text).first.click
+      if js
+        page.find(':focus').fill_in with: scrape_personal_key
+        if page.current_path == idv_personal_key_url
+          click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
+        else
+          click_submit_default
+        end
+      end
     end
 
     def click_acknowledge_personal_key
-      click_continue
+      if page.current_path == idv_personal_key_url
+        click_on t('forms.buttons.continue'), class: 'personal-key-continue'
+      else
+        click_continue
+      end
     end
 
     def enter_personal_key(personal_key:, selector: 'input[type="text"]')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -312,19 +312,11 @@ module Features
       click_acknowledge_personal_key
 
       page.find(':focus').fill_in with: scrape_personal_key
-      if page.current_path == idv_personal_key_url
-        click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
-      else
-        click_submit_default
-      end
+      within('[role=dialog]') { click_continue }
     end
 
     def click_acknowledge_personal_key
-      if page.current_path == idv_personal_key_url
-        click_on t('forms.buttons.continue'), class: 'personal-key-continue'
-      else
-        click_continue
-      end
+      click_continue
     end
 
     def enter_personal_key(personal_key:, selector: 'input[type="text"]')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -3,6 +3,7 @@ require 'cgi'
 module Features
   module SessionHelper
     include PersonalKeyHelper
+    include JavascriptDriverHelper
 
     VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
 
@@ -319,7 +320,11 @@ module Features
     end
 
     def click_acknowledge_personal_key
-      click_on t('forms.buttons.continue'), class: 'personal-key-continue'
+      if javascript_enabled?
+        acknowledge_and_confirm_personal_key
+      else
+        click_on t('forms.buttons.continue'), class: 'personal-key-continue'
+      end
     end
 
     def enter_personal_key(personal_key:, selector: 'input[type="text"]')

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -1,4 +1,6 @@
 module WebAuthnHelper
+  include JavascriptDriverHelper
+
   def mock_webauthn_setup_challenge
     allow(WebAuthn::Credential).to receive(:options_for_create).and_return(
       instance_double(
@@ -35,7 +37,12 @@ module WebAuthnHelper
     set_hidden_field('attestation_object', attestation_object)
     set_hidden_field('client_data_json', setup_client_data_json)
 
-    first('#submit-button', visible: false).click
+    button = first('#submit-button', visible: false)
+    if javascript_enabled?
+      button.execute_script('this.click()')
+    else
+      button.click
+    end
   end
 
   def mock_press_button_on_hardware_key_on_verification
@@ -50,7 +57,12 @@ module WebAuthnHelper
   end
 
   def set_hidden_field(id, value)
-    first("input##{id}", visible: false).set(value)
+    input = first("input##{id}", visible: false)
+    if javascript_enabled?
+      input.execute_script("this.value = #{value.to_json}")
+    else
+      input.set(value)
+    end
   end
 
   def protocol

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -1,5 +1,5 @@
 shared_examples 'clearing and restarting idv' do
-  it 'allows the user to retry verification with phone' do
+  it 'allows the user to retry verification with phone', js: true do
     click_on t('idv.messages.clear_and_start_over')
 
     expect(user.reload.pending_profile?).to eq(false)
@@ -14,7 +14,7 @@ shared_examples 'clearing and restarting idv' do
     expect(user.reload.decorate.identity_verified?).to eq(true)
   end
 
-  it 'allows the user to retry verification with gpo' do
+  it 'allows the user to retry verification with gpo', js: true do
     click_on t('idv.messages.clear_and_start_over')
 
     expect(user.reload.pending_profile?).to eq(false)

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -8,7 +8,7 @@ shared_examples 'clearing and restarting idv' do
     click_idv_continue
     fill_in 'Password', with: user.password
     click_idv_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     expect(page).to have_current_path(sign_up_completed_path)
     expect(user.reload.decorate.identity_verified?).to eq(true)
@@ -28,7 +28,7 @@ shared_examples 'clearing and restarting idv' do
     end
     fill_in 'Password', with: user.password
     click_idv_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     gpo_confirmation = GpoConfirmation.order(created_at: :desc).first
 

--- a/spec/support/idv_examples/confirmation_step.rb
+++ b/spec/support/idv_examples/confirmation_step.rb
@@ -6,7 +6,7 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     it 'redirects to the come back later url then to the sp or account' do
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(idv_come_back_later_path)
       click_on t('forms.buttons.continue')
@@ -52,7 +52,7 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     it 'redirects to the completions page and then to the SP', if: sp.present? do
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(sign_up_completed_path)
 
@@ -66,7 +66,7 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     it 'redirects to the account page', if: sp.nil? do
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_content(t('headings.account.verified_account'))
       expect(page).to have_current_path(account_path)

--- a/spec/support/idv_examples/confirmation_step.rb
+++ b/spec/support/idv_examples/confirmation_step.rb
@@ -61,7 +61,7 @@ shared_examples 'idv confirmation step' do |sp|
       if sp == :oidc
         expect(current_url).to start_with('http://localhost:7654/auth/result')
       else
-        expect(current_path).to eq(api_saml_auth2022_path)
+        expect(current_path).to eq(test_saml_decode_assertion_path)
       end
     end
 

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -42,16 +42,13 @@ shared_examples 'verification step max attempts' do |step, sp|
       sign_in_live_with_2fa(user)
 
       expect(page).to_not have_content(t("idv.failure.#{step_locale_key}.heading"))
-      expect(current_url).to eq(idv_doc_auth_step_url(step: :welcome))
+      expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
 
       complete_all_doc_auth_steps
       click_idv_continue
       fill_in 'Password', with: user.password
       click_idv_continue
       acknowledge_and_confirm_personal_key
-      click_agree_and_continue
-
-      expect(current_url).to start_with('http://localhost:7654/auth/result')
     end
 
     scenario 'user sees the failure screen' do

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -32,7 +32,7 @@ shared_examples 'verification step max attempts' do |step, sp|
       expect_user_to_fail_at_phone_step
     end
 
-    scenario 'after 24 hours the user can retry and complete idv' do
+    scenario 'after 24 hours the user can retry and complete idv', js: true do
       visit account_path
       first(:link, t('links.sign_out')).click
       reattempt_interval = (IdentityConfig.store.idv_attempt_window_in_hours + 1).hours

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -48,7 +48,7 @@ shared_examples 'verification step max attempts' do |step, sp|
       click_idv_continue
       fill_in 'Password', with: user.password
       click_idv_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       click_agree_and_continue
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -42,13 +42,16 @@ shared_examples 'verification step max attempts' do |step, sp|
       sign_in_live_with_2fa(user)
 
       expect(page).to_not have_content(t("idv.failure.#{step_locale_key}.heading"))
-      expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
+      expect(current_url).to eq(idv_doc_auth_step_url(step: :welcome))
 
       complete_all_doc_auth_steps
       click_idv_continue
       fill_in 'Password', with: user.password
       click_idv_continue
       acknowledge_and_confirm_personal_key
+      click_agree_and_continue
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
     end
 
     scenario 'user sees the failure screen' do

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -203,7 +203,6 @@ shared_examples 'sp handoff after identity verification' do |sp|
     xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)
-    expect(current_url).to eq @saml_authn_request
     expect(xmldoc.phone_number.children.children.to_s).to eq(Phonelib.parse(profile_phone).e164)
   end
 

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -7,7 +7,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
   context 'sign up' do
     let(:user) { User.find_with_email(email) }
 
-    it 'requires idv and hands off correctly' do
+    it 'requires idv and hands off correctly', js: true do
       visit_idp_from_sp_with_ial2(sp)
       register_user(email)
 
@@ -36,7 +36,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
   context 'unverified user sign in' do
     let(:user) { user_with_2fa }
 
-    it 'requires idv and hands off successfully' do
+    it 'requires idv and hands off successfully', js: true do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
       fill_in_code_with_last_phone_otp
@@ -64,7 +64,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     end
   end
 
-  context 'verified user sign in' do
+  context 'verified user sign in', js: true do
     let(:user) { user_with_2fa }
 
     before do
@@ -92,7 +92,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     end
   end
 
-  context 'second time a user signs in to an SP' do
+  context 'second time a user signs in to an SP', js: true do
     let(:user) { user_with_2fa }
 
     before do

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -15,7 +15,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       expect(current_path).to eq idv_doc_auth_step_path(step: :welcome)
 
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
       click_continue
       acknowledge_and_confirm_personal_key
@@ -46,7 +46,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       expect(current_path).to eq idv_doc_auth_step_path(step: :welcome)
 
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key
@@ -71,7 +71,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     before do
       sign_in_and_2fa_user(user)
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key
@@ -104,7 +104,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       fill_in_code_with_last_phone_otp
       click_submit_default
       complete_all_doc_auth_steps
-      click_continue
+      click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -17,7 +17,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       click_continue
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
         'titles.sign_up.completion_ial2',
@@ -48,7 +48,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       click_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
         'titles.sign_up.completion_ial2',
@@ -73,7 +73,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       click_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       first(:link, t('links.sign_out')).click
     end
 
@@ -106,7 +106,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       click_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       click_agree_and_continue
       visit account_path
       first(:link, t('links.sign_out')).click

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -205,6 +205,11 @@ shared_examples 'sp handoff after identity verification' do |sp|
     xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)
+    if javascript_enabled?
+      expect(current_path).to eq test_saml_decode_assertion_path
+    else
+      expect(current_url).to eq @saml_authn_request
+    end
     expect(xmldoc.phone_number.children.children.to_s).to eq(Phonelib.parse(profile_phone).e164)
   end
 

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -1,6 +1,7 @@
 shared_examples 'sp handoff after identity verification' do |sp|
   include SamlAuthHelper
   include IdvHelper
+  include JavascriptDriverHelper
 
   let(:email) { 'test@test.com' }
 
@@ -128,6 +129,9 @@ shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_csp_headers_to_be_present
+    # Selenium driver does not support response header inspection, but we should be able to expect
+    # that the browser itself would respect CSP and refuse invalid form targets.
+    return if javascript_enabled?
     expect(page.response_headers['Content-Security-Policy']).
       to(include('form-action \'self\' http://localhost:7654'))
   end

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -27,7 +27,7 @@ shared_examples 'sp requesting attributes' do |sp|
       click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(current_path).to eq(sign_up_completed_path)
 
@@ -59,7 +59,7 @@ shared_examples 'sp requesting attributes' do |sp|
       click_idv_continue
       fill_in 'Password', with: user.password
       click_continue
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
       click_agree_and_continue
       visit account_path
       first(:link, t('links.sign_out')).click

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -76,7 +76,7 @@ shared_examples 'sp requesting attributes' do |sp|
         expect(current_url).to include('http://localhost:7654/auth/result')
       elsif sp == :saml
         if javascript_enabled?
-          expect(current_path).to eq('/test/saml/decode_assertion')
+          expect(current_path).to eq(test_saml_decode_assertion_path)
         else
           expect(current_url).to include(api_saml_auth2022_url)
         end

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -75,7 +75,11 @@ shared_examples 'sp requesting attributes' do |sp|
       if sp == :oidc
         expect(current_url).to include('http://localhost:7654/auth/result')
       elsif sp == :saml
-        expect(current_url).to include(api_saml_auth2022_url)
+        if javascript_enabled?
+          expect(current_path).to eq('/test/saml/decode_assertion')
+        else
+          expect(current_url).to include(api_saml_auth2022_url)
+        end
       end
     end
   end

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -13,7 +13,7 @@ shared_examples 'sp requesting attributes' do |sp|
   end
 
   context 'visiting an SP for the first time' do
-    it 'requires the user to verify the attributes submitted to the SP' do
+    it 'requires the user to verify the attributes submitted to the SP', js: true do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
       fill_in_code_with_last_phone_otp
@@ -46,7 +46,7 @@ shared_examples 'sp requesting attributes' do |sp|
     end
   end
 
-  context 'visiting an SP the user has already signed into' do
+  context 'visiting an SP the user has already signed into', js: true do
     before do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -41,7 +41,7 @@ shared_examples 'sp requesting attributes' do |sp|
         expect(page).to have_content t('help_text.requested_attributes.phone')
         expect(page).to have_content '+1 202-555-1212'
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
-        expect(page).to have_content good_ssn
+        expect(page).to have_css '.masked-text__text', text: good_ssn, visible: :hidden
       end
     end
   end

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -17,11 +17,7 @@ class SamlResponseDoc
   end
 
   def xml_response
-    Base64.decode64(
-      Capybara.current_session.find(
-        "//input[@id='#{input_id}']", visible: false
-      ).value,
-    )
+    Base64.decode64(Capybara.current_session.find("##{input_id}", visible: false).value)
   end
 
   def html_response

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -54,7 +54,7 @@ shared_examples 'creating an IAL2 account using authenticator app for 2FA' do |s
     click_submit_default
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     if sp == :oidc
       expect(page.response_headers['Content-Security-Policy']).
@@ -110,7 +110,7 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     click_submit_default
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     if sp == :oidc
       expect(page.response_headers['Content-Security-Policy']).

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -56,11 +56,6 @@ shared_examples 'creating an IAL2 account using authenticator app for 2FA' do |s
     click_continue
     acknowledge_and_confirm_personal_key
 
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\' http://localhost:7654'))
-    end
-
     click_agree_and_continue
     expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml
 
@@ -111,11 +106,6 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_continue
     acknowledge_and_confirm_personal_key
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\' http://localhost:7654'))
-    end
 
     click_agree_and_continue
     expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -42,7 +42,7 @@ shared_examples 'creating an account using authenticator app for 2FA' do |sp|
 end
 
 shared_examples 'creating an IAL2 account using authenticator app for 2FA' do |sp|
-  it 'does not prompt for recovery code before IdV flow', email: true, idv_job: true do
+  it 'does not prompt for recovery code before IdV flow', email: true, idv_job: true, js: true do
     visit_idp_from_sp_with_ial2(sp)
     register_user_with_authenticator_app
     expect(page).to have_current_path(idv_doc_auth_step_path(step: :welcome))
@@ -94,7 +94,7 @@ shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
 end
 
 shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
-  it 'does not prompt for recovery code before IdV flow', email: true do
+  it 'does not prompt for recovery code before IdV flow', email: true, js: true do
     mock_webauthn_setup_challenge
     visit_idp_from_sp_with_ial2(sp)
     confirm_email_and_password('test@test.com')

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -62,7 +62,7 @@ shared_examples 'creating an IAL2 account using authenticator app for 2FA' do |s
     end
 
     click_agree_and_continue
-    expect(current_url).to eq @saml_authn_request if sp == :saml
+    expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml
 
     if sp == :oidc
       redirect_uri = URI(current_url)
@@ -118,7 +118,7 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     end
 
     click_agree_and_continue
-    expect(current_url).to eq @saml_authn_request if sp == :saml
+    expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml
 
     if sp == :oidc
       redirect_uri = URI(current_url)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -133,7 +133,7 @@ shared_examples 'signing in as IAL2 with personal key after resetting password' 
     expect(current_path).to eq manage_personal_key_path
 
     new_personal_key = scrape_personal_key
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     expect(current_path).to eq reactivate_account_path
 
@@ -141,7 +141,7 @@ shared_examples 'signing in as IAL2 with personal key after resetting password' 
 
     expect(current_path).to eq manage_personal_key_path
 
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
 
     expect(current_url).to eq @saml_authn_request if sp == :saml
     if sp == :oidc
@@ -221,7 +221,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
 
       expect(page).to have_content(t('account.personal_key.needs_new'))
       code = page.all('.separator-text__code').map(&:text).join(' ')
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(user.reload.valid_personal_key?(code)).to eq(true)
       expect(user.active_profile.reload.recover_pii(code)).to be_present
@@ -244,7 +244,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
 
       expect(page).to have_content(t('account.personal_key.needs_new'))
       code = page.all('.separator-text__code').map(&:text).join(' ')
-      click_acknowledge_personal_key
+      acknowledge_and_confirm_personal_key
 
       expect(user.reload.valid_personal_key?(code)).to eq(true)
       expect(user.active_profile.reload.recover_pii(code)).to be_present

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -310,11 +310,6 @@ def ial2_sign_in_with_piv_cac_goes_to_sp(sp)
   # capture password before redirecting to SP
   expect(current_url).to eq capture_password_url
 
-  if sp == :oidc && !javascript_enabled?
-    expect(page.response_headers['Content-Security-Policy']).
-      to(include('form-action \'self\' http://localhost:7654'))
-  end
-
   fill_in_password_and_submit(user.password)
 
   if sp == :saml

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -319,7 +319,7 @@ def ial2_sign_in_with_piv_cac_goes_to_sp(sp)
 
   if sp == :saml
     if javascript_enabled?
-      expect(current_path).to eq('/test/saml/decode_assertion')
+      expect(current_path).to eq(test_saml_decode_assertion_path)
     else
       expect(current_url).to include(@saml_authn_request)
     end
@@ -352,7 +352,7 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
   fill_in_password_and_submit(user.password)
 
   if javascript_enabled?
-    expect(current_path).to eq('/test/saml/decode_assertion')
+    expect(current_path).to eq(test_saml_decode_assertion_path)
   else
     expect(current_url).to eq @saml_authn_request
   end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -318,7 +318,11 @@ def ial2_sign_in_with_piv_cac_goes_to_sp(sp)
   fill_in_password_and_submit(user.password)
 
   if sp == :saml
-    expect(current_url).to eq @saml_authn_request
+    if javascript_enabled?
+      expect(current_path).to eq('/test/saml/decode_assertion')
+    else
+      expect(current_url).to include(@saml_authn_request)
+    end
   elsif sp == :oidc
     redirect_uri = URI(current_url)
 
@@ -347,7 +351,11 @@ def no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
 
   fill_in_password_and_submit(user.password)
 
-  expect(current_url).to eq @saml_authn_request
+  if javascript_enabled?
+    expect(current_path).to eq('/test/saml/decode_assertion')
+  else
+    expect(current_url).to eq @saml_authn_request
+  end
 end
 
 def ial2_sign_in_with_piv_cac_gets_bad_password_error(sp)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -60,7 +60,7 @@ shared_examples 'visiting 2fa when fully authenticated' do |sp|
 end
 
 shared_examples 'signing in as IAL2 with personal key' do |sp|
-  it 'does not present personal key as an MFA option', :email do
+  it 'does not present personal key as an MFA option', :email, js: true do
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
 
     Capybara.reset_sessions!
@@ -75,19 +75,19 @@ shared_examples 'signing in as IAL2 with personal key' do |sp|
 end
 
 shared_examples 'signing in as IAL2 with piv/cac' do |sp|
-  it 'redirects to the SP after authenticating and getting the password', :email do
+  it 'redirects to the SP after authenticating and getting the password', :email, js: true do
     ial2_sign_in_with_piv_cac_goes_to_sp(sp)
   end
 
   if sp == :saml
     context 'no authn_context specified' do
-      it 'redirects to the SP after authenticating and getting the password', :email do
+      it 'redirects to the SP after authenticating and getting the password', :email, js: true do
         no_authn_context_sign_in_with_piv_cac_goes_to_sp(sp)
       end
     end
   end
 
-  it 'gets bad password error', :email do
+  it 'gets bad password error', :email, js: true do
     ial2_sign_in_with_piv_cac_gets_bad_password_error(sp)
   end
 end
@@ -119,7 +119,7 @@ shared_examples 'signing in as IAL1 with personal key after resetting password' 
 end
 
 shared_examples 'signing in as IAL2 with personal key after resetting password' do |sp|
-  xit 'redirects to SP after reactivating account', :email do
+  xit 'redirects to SP after reactivating account', :email, js: true do
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
     visit_idp_from_sp_with_ial2(sp)
     trigger_reset_password_and_click_email_link(user.email)
@@ -205,7 +205,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
   end
 
   context "protocol: #{protocol}, ial: #{sp_ial}" do
-    it 'prompts the user to get a new personal key when signing in with email/password' do
+    it 'prompts the user to get a new personal key when signing in with email/password', js: true do
       user = user_with_broken_personal_key(protocol)
 
       case sp_ial
@@ -220,14 +220,14 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
       fill_in_credentials_and_submit(user.email, user.password)
 
       expect(page).to have_content(t('account.personal_key.needs_new'))
-      code = page.all('[data-personal-key]').map(&:text).join(' ')
+      code = page.all('.separator-text__code').map(&:text).join(' ')
       click_acknowledge_personal_key
 
       expect(user.reload.valid_personal_key?(code)).to eq(true)
       expect(user.active_profile.reload.recover_pii(code)).to be_present
     end
 
-    it 'prompts for password when signing in via PIV/CAC' do
+    it 'prompts for password when signing in via PIV/CAC', js: true do
       user = user_with_broken_personal_key(protocol)
 
       create(:piv_cac_configuration, user: user)
@@ -243,7 +243,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
       click_button t('forms.buttons.submit.default')
 
       expect(page).to have_content(t('account.personal_key.needs_new'))
-      code = page.all('[data-personal-key]').map(&:text).join(' ')
+      code = page.all('.separator-text__code').map(&:text).join(' ')
       click_acknowledge_personal_key
 
       expect(user.reload.valid_personal_key?(code)).to eq(true)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -310,7 +310,7 @@ def ial2_sign_in_with_piv_cac_goes_to_sp(sp)
   # capture password before redirecting to SP
   expect(current_url).to eq capture_password_url
 
-  if sp == :oidc
+  if sp == :oidc && !javascript_enabled?
     expect(page.response_headers['Content-Security-Policy']).
       to(include('form-action \'self\' http://localhost:7654'))
   end

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -1,7 +1,12 @@
 shared_examples_for 'personal key page' do
   include PersonalKeyHelper
+  include JavascriptDriverHelper
 
   context 'informational text' do
+    before do
+      click_continue if javascript_enabled?
+    end
+
     context 'modal content' do
       it 'displays the modal title' do
         expect(page).to have_content t('forms.personal_key.title')

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -30,8 +30,7 @@ shared_examples_for 'personal key page' do
       click_on t('components.clipboard_button.label')
       copied_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
 
-      code = page.all('[data-personal-key]').map(&:text).join('-')
-      expect(copied_text).to eq(code)
+      expect(copied_text).to eq(scrape_personal_key)
     end
 
     it 'validates as case-insensitive, crockford-normalized, length-limited, dash-flexible' do

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -22,7 +22,7 @@ module SpAuthHelper
     click_idv_continue
     fill_in t('idv.form.password'), with: user.password
     click_continue
-    click_acknowledge_personal_key
+    acknowledge_and_confirm_personal_key
     expect(page).to have_current_path(sign_up_completed_path)
     click_agree_and_continue
     visit sign_out_url

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -7,7 +7,7 @@ module SpAuthHelper
     click_confirmation_link_in_email(email)
     submit_form_with_valid_password
     set_up_2fa_with_valid_phone
-    visit sign_out_path
+    visit sign_out_url
     User.find_with_email(email)
   end
 
@@ -25,7 +25,7 @@ module SpAuthHelper
     acknowledge_and_confirm_personal_key
     expect(page).to have_current_path(sign_up_completed_path)
     click_agree_and_continue
-    visit sign_out_path
+    visit sign_out_url
     user.reload
   end
 end

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -7,7 +7,7 @@ module SpAuthHelper
     click_confirmation_link_in_email(email)
     submit_form_with_valid_password
     set_up_2fa_with_valid_phone
-    visit sign_out_url
+    visit sign_out_path
     User.find_with_email(email)
   end
 
@@ -25,7 +25,7 @@ module SpAuthHelper
     acknowledge_and_confirm_personal_key
     expect(page).to have_current_path(sign_up_completed_path)
     click_agree_and_continue
-    visit sign_out_url
+    visit sign_out_path
     user.reload
   end
 end


### PR DESCRIPTION
**Why**: So that a user can functionally complete the proofing process using the new IdV app.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing process up to and including the password entry step
5. After "Continue"-ing from password entry step, observe...
   - Real personal key is shown on page
   - You can enter personal key and continue to post-proofing flow step (account page if session associated with SP, otherwise confirmation screen)

**Implementation Notes:**

- We are excluding users who've opted for GPO verification until LG-6082.
- This is still disabled in all deployed environments, but will now be enabled by default in local development

**Screenshot:**

![localhost_3000_verify_v2_personal_key_confirm_](https://user-images.githubusercontent.com/1779930/164291587-20a759ab-6cc1-4f4c-b40a-abb22f10c73f.png)
