### PR TITLE
Document additional analytics events (LG-5928)

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -7,14 +7,14 @@ module Idv
 
     def new
       properties = ParseControllerFromReferer.new(request.referer).call
-      analytics.track_event(Analytics::IDV_CANCELLATION, properties.merge(step: params[:step]))
+      analytics.idv_cancellation_visited(step: params[:step], **properties)
       self.session_go_back_path = go_back_path || idv_path
       @hybrid_session = hybrid_session?
     end
 
     def update
       if params.key?(:cancel)
-        analytics.track_event(Analytics::IDV_CANCELLATION_GO_BACK, step: params[:step])
+        analytics.idv_cancellation_go_back(step: params[:step])
         redirect_to session_go_back_path || idv_path
       else
         render :new
@@ -22,7 +22,7 @@ module Idv
     end
 
     def destroy
-      analytics.track_event(Analytics::IDV_CANCELLATION_CONFIRMED, step: params[:step])
+      analytics.idv_cancellation_confirmed(step: params[:step])
       @return_to_sp_path = return_to_sp_failure_to_proof_path(location_params)
       @hybrid_session = hybrid_session?
       if hybrid_session?

--- a/app/controllers/idv/come_back_later_controller.rb
+++ b/app/controllers/idv/come_back_later_controller.rb
@@ -4,7 +4,7 @@ module Idv
     before_action :confirm_user_needs_gpo_confirmation
 
     def show
-      analytics.track_event(Analytics::IDV_COME_BACK_LATER_VISIT)
+      analytics.idv_come_back_later_visit
     end
 
     private

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -135,9 +135,6 @@ class Analytics
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  IDV_CANCELLATION = 'IdV: cancellation visited'
-  IDV_CANCELLATION_GO_BACK = 'IdV: cancellation go back'
-  IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'
   IDV_DOC_AUTH_EXCEPTION_VISITED = 'IdV: doc auth exception visited'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -135,7 +135,6 @@ class Analytics
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'
   IDV_DOC_AUTH_EXCEPTION_VISITED = 'IdV: doc auth exception visited'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -135,7 +135,6 @@ class Analytics
   # rubocop:disable Layout/LineLength
   ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  IDV_DOC_AUTH_EXCEPTION_VISITED = 'IdV: doc auth exception visited'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'
   IDV_DOC_AUTH_SUBMITTED_PII_VALIDATION = 'IdV: doc auth image upload vendor pii validation'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -421,6 +421,12 @@ module AnalyticsEvents
     track_event('IdV: cancellation go back', step: step, **extra)
   end
 
+  # @identity.idp.event_name IdV: come back later visited
+  # The user visited the "come back later" page shown during the GPO mailing flow
+  def idv_come_back_later_visit
+    track_event('IdV: come back later visited')
+  end
+
   # @deprecated
   # A user has downloaded their personal key. This event is no longer emitted.
   # @identity.idp.event_name IdV: personal key downloaded

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -427,6 +427,19 @@ module AnalyticsEvents
     track_event('IdV: come back later visited')
   end
 
+  # @identity.idp.event_name IdV: doc auth exception visited
+  # @param [String] step_name which step the user was on
+  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
+  # The user visited an error page due to an encountering an exception talking to a proofing vendor
+  def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
+    track_event(
+      'IdV: doc auth exception visited',
+      step_name: step_name,
+      remaining_attempts: remaining_attempts,
+      **extra,
+    )
+  end
+
   # @deprecated
   # A user has downloaded their personal key. This event is no longer emitted.
   # @identity.idp.event_name IdV: personal key downloaded

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -393,6 +393,34 @@ module AnalyticsEvents
     track_event('IdV: address visited')
   end
 
+  # @identity.idp.event_name IdV: cancellation visited
+  # @param [String] step the step that the user was on when they clicked cancel
+  # @param [String] request_came_from the controller and action from the
+  #   source such as "users/sessions#new"
+  # The user clicked cancel during IDV (presented with an option to go back or confirm)
+  def idv_cancellation_visited(step:, request_came_from:, **extra)
+    track_event(
+      'IdV: cancellation visited',
+      step: step,
+      request_came_from: request_came_from,
+      **extra,
+    )
+  end
+
+  # @identity.idp.event_name IdV: cancellation confirmed
+  # @param [String] step the step that the user was on when they clicked cancel
+  # The user confirmed their choice to cancel going through IDV
+  def idv_cancellation_confirmed(step:, **extra)
+    track_event('IdV: cancellation confirmed', step: step, **extra)
+  end
+
+  # @identity.idp.event_name IdV: cancellation go back
+  # @param [String] step the step that the user was on when they clicked cancel
+  # The user chose to go back instead of cancel IDV
+  def idv_cancellation_go_back(step:, **extra)
+    track_event('IdV: cancellation go back', step: step, **extra)
+  end
+
   # @deprecated
   # A user has downloaded their personal key. This event is no longer emitted.
   # @identity.idp.event_name IdV: personal key downloaded

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -24,8 +24,7 @@ module Idv
           )
           redirect_to idv_session_errors_failure_url
         elsif result.extra.dig(:proofing_results, :exception).present?
-          @flow.analytics.track_event(
-            Analytics::IDV_DOC_AUTH_EXCEPTION_VISITED,
+          @flow.analytics.idv_doc_auth_exception_visited(
             step_name: self.class.name,
             remaining_attempts: throttle.remaining_count,
           )

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -19,7 +19,7 @@ describe Idv::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer', step: nil }
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
+      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
 
       get :new
     end
@@ -30,7 +30,7 @@ describe Idv::CancellationsController do
       request.env['HTTP_REFERER'] = 'http://example.com/'
       properties = { request_came_from: 'users/sessions#new', step: nil }
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
+      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
 
       get :new
     end
@@ -40,7 +40,7 @@ describe Idv::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer', step: 'first' }
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
+      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
 
       get :new, params: { step: 'first' }
     end
@@ -107,7 +107,7 @@ describe Idv::CancellationsController do
     context 'with cancel param' do
       it 'logs cancellation go back' do
         expect(@analytics).to receive(:track_event).with(
-          Analytics::IDV_CANCELLATION_GO_BACK,
+          'IdV: cancellation go back',
           step: 'first',
         )
 
@@ -144,7 +144,7 @@ describe Idv::CancellationsController do
       stub_analytics
 
       expect(@analytics).to receive(:track_event).with(
-        Analytics::IDV_CANCELLATION_CONFIRMED,
+        'IdV: cancellation confirmed',
         step: 'first',
       )
 

--- a/spec/controllers/idv/come_back_later_controller_spec.rb
+++ b/spec/controllers/idv/come_back_later_controller_spec.rb
@@ -16,7 +16,7 @@ describe Idv::ComeBackLaterController do
     it 'renders the show template' do
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_COME_BACK_LATER_VISIT)
+      expect(@analytics).to receive(:track_event).with('IdV: come back later visited')
 
       get :show
 

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -80,11 +80,11 @@ feature 'doc auth welcome step' do
 
     it 'logs events when returning to sp' do
       click_on t('links.cancel')
-      expect(fake_analytics).to have_logged_event(Analytics::IDV_CANCELLATION, step: 'welcome')
+      expect(fake_analytics).to have_logged_event('IdV: cancellation visited', step: 'welcome')
 
       click_on t('forms.buttons.cancel')
       expect(fake_analytics).to have_logged_event(
-        Analytics::IDV_CANCELLATION_CONFIRMED,
+        'IdV: cancellation confirmed',
         step: 'welcome',
       )
 

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -33,7 +33,7 @@ feature 'doc capture document capture step' do
 
     expect(page).to have_text(t('idv.cancel.headings.prompt.hybrid'))
     expect(fake_analytics).to have_logged_event(
-      Analytics::IDV_CANCELLATION,
+      'IdV: cancellation visited',
       step: 'document_capture',
     )
 
@@ -41,7 +41,7 @@ feature 'doc capture document capture step' do
 
     expect(page).to have_text(t('idv.cancel.headings.confirmation.hybrid'))
     expect(fake_analytics).to have_logged_event(
-      Analytics::IDV_CANCELLATION_CONFIRMED,
+      'IdV: cancellation confirmed',
       step: 'document_capture',
     )
   end
@@ -54,7 +54,7 @@ feature 'doc capture document capture step' do
 
     expect(page).to have_current_path(idv_capture_doc_document_capture_step)
     expect(fake_analytics).to have_logged_event(
-      Analytics::IDV_CANCELLATION_GO_BACK,
+      'IdV: cancellation go back',
       step: 'document_capture',
     )
   end

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -69,7 +69,7 @@ shared_examples 'cancel at idv step' do |step, sp|
 
       expect(page).to have_content(t('headings.cancellations.prompt'))
       expect(current_path).to eq(idv_cancel_path)
-      expect(fake_analytics).to have_logged_event('IdV: cancellation go back', step: step.to_s)
+      expect(fake_analytics).to have_logged_event('IdV: cancellation visited', step: step.to_s)
 
       click_on t('forms.buttons.cancel')
 

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -17,7 +17,7 @@ shared_examples 'cancel at idv step' do |step, sp|
     expect(page).to have_content(t('headings.cancellations.prompt'))
     expect(current_path).to eq(idv_cancel_path)
     expect(fake_analytics).to have_logged_event(
-      Analytics::IDV_CANCELLATION,
+      'IdV: cancellation visited',
       step: step.to_s,
     )
 
@@ -25,7 +25,7 @@ shared_examples 'cancel at idv step' do |step, sp|
 
     expect(current_path).to eq(original_path)
     expect(fake_analytics).to have_logged_event(
-      Analytics::IDV_CANCELLATION_GO_BACK,
+      'IdV: cancellation go back',
       step: step.to_s,
     )
   end
@@ -40,14 +40,14 @@ shared_examples 'cancel at idv step' do |step, sp|
 
       expect(page).to have_content(t('headings.cancellations.prompt'))
       expect(current_path).to eq(idv_cancel_path)
-      expect(fake_analytics).to have_logged_event(Analytics::IDV_CANCELLATION, step: step.to_s)
+      expect(fake_analytics).to have_logged_event('IdV: cancellation visited', step: step.to_s)
 
       click_on t('forms.buttons.cancel')
 
       expect(page).to have_content(t('headings.cancellations.confirmation', app_name: APP_NAME))
       expect(current_path).to eq(idv_cancel_path)
       expect(fake_analytics).to have_logged_event(
-        Analytics::IDV_CANCELLATION_CONFIRMED,
+        'IdV: cancellation confirmed',
         step: step.to_s,
       )
 
@@ -69,7 +69,7 @@ shared_examples 'cancel at idv step' do |step, sp|
 
       expect(page).to have_content(t('headings.cancellations.prompt'))
       expect(current_path).to eq(idv_cancel_path)
-      expect(fake_analytics).to have_logged_event(Analytics::IDV_CANCELLATION, step: step.to_s)
+      expect(fake_analytics).to have_logged_event('IdV: cancellation go back', step: step.to_s)
 
       click_on t('forms.buttons.cancel')
 
@@ -80,7 +80,7 @@ shared_examples 'cancel at idv step' do |step, sp|
         href: account_url,
       )
       expect(fake_analytics).to have_logged_event(
-        Analytics::IDV_CANCELLATION_CONFIRMED,
+        'IdV: cancellation confirmed',
         step: step.to_s,
       )
 


### PR DESCRIPTION
- IDV_CANCELLATION (renamed to idv_cancellation_visit)
- IDV_CANCELLATION_GO_BACK
- IDV_CANCELLATION_CONFIRMED
- IDV_COME_BACK_LATER_VISIT
- IDV_DOC_AUTH_EXCEPTION_VISITED