### PR TITLE
Update testing-library/user-event to latest version

### DIFF
--- a/app/javascript/packages/clipboard-button/clipboard-button-element.spec.ts
+++ b/app/javascript/packages/clipboard-button/clipboard-button-element.spec.ts
@@ -23,17 +23,17 @@ describe('ClipboardButtonElement', () => {
     return element;
   }
 
-  it('copies text to clipboard when clicking its button', () => {
+  it('copies text to clipboard when clicking its button', async () => {
     const clipboardText = 'example';
     const element = createAndConnectElement({ clipboardText });
     const button = getByRole(element, 'button');
 
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(navigator.clipboard.writeText).to.have.been.calledWith(clipboardText);
   });
 
-  it('copies the latest clipboard attribute value after initialization', () => {
+  it('copies the latest clipboard attribute value after initialization', async () => {
     const clipboardText = 'example';
     const element = createAndConnectElement({ clipboardText });
     const changedClipbordText = 'example2';
@@ -41,17 +41,17 @@ describe('ClipboardButtonElement', () => {
 
     const button = getByRole(element, 'button');
 
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(navigator.clipboard.writeText).to.have.been.calledWith(changedClipbordText);
   });
 
   context('with nothing to copy', () => {
-    it('does writes an empty string to the clipboard', () => {
+    it('does writes an empty string to the clipboard', async () => {
       const element = createAndConnectElement();
       const button = getByRole(element, 'button');
 
-      userEvent.click(button);
+      await userEvent.click(button);
 
       expect(navigator.clipboard.writeText).to.have.been.calledWith('');
     });

--- a/app/javascript/packages/components/button.spec.tsx
+++ b/app/javascript/packages/components/button.spec.tsx
@@ -4,11 +4,11 @@ import userEvent from '@testing-library/user-event';
 import Button from './button';
 
 describe('Button', () => {
-  it('renders with default props', () => {
+  it('renders with default props', async () => {
     const { getByText } = render(<Button>Click me</Button>);
 
     const button = getByText('Click me') as HTMLButtonElement;
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(button.nodeName).to.equal('BUTTON');
     expect(button.type).to.equal('button');
@@ -29,14 +29,14 @@ describe('Button', () => {
     expect(link.hasAttribute('type')).to.be.false();
   });
 
-  it('forwards additional props to the rendered element', () => {
+  it('forwards additional props to the rendered element', async () => {
     const onClick = sinon.spy();
     const { getByText } = render(
       <Button onClick={(event) => onClick(event.type)}>Click me</Button>,
     );
 
     const button = getByText('Click me');
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(onClick.calledOnce).to.be.true();
     expect(onClick.getCall(0).args[0]).to.equal('click');
@@ -89,7 +89,7 @@ describe('Button', () => {
     expect(button.classList.contains('usa-button--unstyled')).to.be.true();
   });
 
-  it('renders as disabled', () => {
+  it('renders as disabled', async () => {
     const onClick = sinon.spy();
     const { getByText } = render(
       <Button isDisabled onClick={onClick}>
@@ -98,7 +98,7 @@ describe('Button', () => {
     );
 
     const button = getByText('Click me') as HTMLButtonElement;
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(onClick.calledOnce).to.be.false();
     expect(button.disabled).to.be.true();

--- a/app/javascript/packages/components/hooks/use-focus-trap.spec.ts
+++ b/app/javascript/packages/components/hooks/use-focus-trap.spec.ts
@@ -29,12 +29,12 @@ describe('useFocusTrap', () => {
     expect(trap.deactivate).to.be.a('function');
   });
 
-  it('traps focus', () => {
+  it('traps focus', async () => {
     const container = document.querySelector('.container') as HTMLElement;
     renderHook(() => useFocusTrap(useRef(container), DEFAULT_OPTIONS));
 
     expect(container.contains(document.activeElement)).to.be.true();
-    userEvent.tab();
+    await userEvent.tab();
     expect(container.contains(document.activeElement)).to.be.true();
   });
 
@@ -52,7 +52,7 @@ describe('useFocusTrap', () => {
     expect(document.activeElement).to.equal(originalActiveElement);
   });
 
-  it('accepts options', () => {
+  it('accepts options', async () => {
     const container = document.querySelector('.container') as HTMLElement;
     const onDeactivate = sinon.spy();
     renderHook(() =>
@@ -65,7 +65,7 @@ describe('useFocusTrap', () => {
 
     const outsideButton = screen.getByTestId('outsideButton');
 
-    userEvent.click(outsideButton);
+    await userEvent.click(outsideButton);
     expect(onDeactivate).to.have.been.called();
   });
 });

--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -138,37 +138,37 @@ describe('FormSteps', () => {
     expect(getByText('forms.buttons.continue')).to.be.ok();
   });
 
-  it('renders the active step', () => {
+  it('renders the active step', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(getByText('Second Title')).to.be.ok();
   });
 
-  it('renders continue button until at last step', () => {
+  it('renders continue button until at last step', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(getByText('forms.buttons.continue')).to.be.ok();
   });
 
-  it('calls onStepChange callback on step change', () => {
+  it('calls onStepChange callback on step change', async () => {
     const onStepChange = sinon.spy();
     const { getByText } = render(<FormSteps steps={STEPS} onStepChange={onStepChange} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(onStepChange.calledOnce).to.be.true();
   });
 
-  it('does not call onStepChange if step does not progress due to validation error', () => {
+  it('does not call onStepChange if step does not progress due to validation error', async () => {
     const onStepChange = sinon.spy();
     const { getByText } = render(<FormSteps steps={STEPS} onStepChange={onStepChange} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(onStepChange.callCount).to.equal(1);
   });
@@ -176,10 +176,10 @@ describe('FormSteps', () => {
   it('renders submit button at last step', async () => {
     const { getByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     await userEvent.type(getByLabelText('Second Input One'), 'one');
     await userEvent.type(getByLabelText('Second Input Two'), 'two');
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(getByText('forms.buttons.submit.default')).to.be.ok();
   });
@@ -190,11 +190,11 @@ describe('FormSteps', () => {
       <FormSteps steps={STEPS} onComplete={onComplete} />,
     );
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     await userEvent.type(getByLabelText('Second Input One'), 'one');
     await userEvent.type(getByLabelText('Second Input Two'), 'two');
-    userEvent.click(getByText('forms.buttons.continue'));
-    userEvent.click(getByText('forms.buttons.submit.default'));
+    await userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.submit.default'));
 
     expect(onComplete.getCall(0).args[0]).to.eql({
       secondInputOne: 'one',
@@ -206,7 +206,7 @@ describe('FormSteps', () => {
   it('prompts on navigate if values have been assigned', async () => {
     const { getByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     await userEvent.type(getByLabelText('Second Input One'), 'one');
 
     const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
@@ -238,12 +238,12 @@ describe('FormSteps', () => {
     });
   });
 
-  it('pushes step to URL', () => {
+  it('pushes step to URL', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
     expect(window.location.hash).to.equal('');
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(window.location.hash).to.equal('#second');
   });
@@ -251,7 +251,7 @@ describe('FormSteps', () => {
   it('syncs step by history events', async () => {
     const { getByText, findByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     await userEvent.type(getByLabelText('Second Input One'), 'one');
     await userEvent.type(getByLabelText('Second Input Two'), 'two');
 
@@ -268,10 +268,10 @@ describe('FormSteps', () => {
     expect(window.location.hash).to.equal('#second');
   });
 
-  it('shifts focus to next heading on step change', () => {
+  it('shifts focus to next heading on step change', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(document.activeElement).to.equal(getByText('Second Title'));
   });
@@ -288,12 +288,12 @@ describe('FormSteps', () => {
     expect(document.activeElement).to.equal(getByText('First Title'));
   });
 
-  it('accepts initial values', () => {
+  it('accepts initial values', async () => {
     const { getByText, getByLabelText } = render(
       <FormSteps steps={STEPS} initialValues={{ secondInputOne: 'prefilled' }} />,
     );
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     const input = getByLabelText('Second Input One') as HTMLInputElement;
 
     expect(input.value).to.equal('prefilled');
@@ -302,8 +302,8 @@ describe('FormSteps', () => {
   it('prevents submission if step is invalid', async () => {
     const { getByText, getByLabelText, container } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(window.location.hash).to.equal('#second');
     expect(document.activeElement).to.equal(getByLabelText('Second Input One'));
@@ -312,13 +312,13 @@ describe('FormSteps', () => {
     await userEvent.type(document.activeElement as HTMLInputElement, 'one');
     expect(container.querySelectorAll('[data-is-error]')).to.have.lengthOf(1);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
     expect(document.activeElement).to.equal(getByLabelText('Second Input Two'));
     expect(container.querySelectorAll('[data-is-error]')).to.have.lengthOf(1);
 
     await userEvent.type(document.activeElement as HTMLInputElement, 'two');
     expect(container.querySelectorAll('[data-is-error]')).to.have.lengthOf(0);
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     expect(document.activeElement).to.equal(getByText('Last Title'));
   });
@@ -326,7 +326,7 @@ describe('FormSteps', () => {
   it('distinguishes empty errors from progressive error removal', async () => {
     const { getByText, getByLabelText, container } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('forms.buttons.continue'));
 
     await userEvent.type(getByLabelText('Second Input One'), 'one');
     expect(container.querySelectorAll('[data-is-error]')).to.have.lengthOf(0);
@@ -361,7 +361,7 @@ describe('FormSteps', () => {
     expect(inputTwo.matches('[data-is-error]')).to.be.false();
 
     // Attempting to submit without adjusting field value does not submit and shows error.
-    userEvent.click(getByText('forms.buttons.submit.default'));
+    await userEvent.click(getByText('forms.buttons.submit.default'));
     expect(onComplete.called).to.be.false();
     await waitFor(() => expect(document.activeElement).to.equal(inputOne));
 
@@ -371,7 +371,7 @@ describe('FormSteps', () => {
     expect(inputTwo.matches('[data-is-error]')).to.be.false();
 
     // Default required validation should still happen and take the place of any unknown errors.
-    userEvent.click(getByText('forms.buttons.submit.default'));
+    await userEvent.click(getByText('forms.buttons.submit.default'));
     expect(onComplete.called).to.be.false();
     await waitFor(() => expect(document.activeElement).to.equal(inputTwo));
     expect(inputOne.matches('[data-is-error]')).to.be.false();
@@ -384,59 +384,59 @@ describe('FormSteps', () => {
     expect(inputTwo.matches('[data-is-error]')).to.be.false();
 
     // The user can submit once all errors have been resolved.
-    userEvent.click(getByText('forms.buttons.submit.default'));
+    await userEvent.click(getByText('forms.buttons.submit.default'));
     expect(onComplete.calledOnce).to.be.true();
   });
 
-  it('renders field-emitted errors', () => {
+  it('renders field-emitted errors', async () => {
     const steps = [STEPS[1]];
 
     const { getByLabelText } = render(<FormSteps steps={steps} />);
     const inputOne = getByLabelText('Second Input One') as HTMLInputElement;
     inputOne.setCustomValidity('uh oh');
-    userEvent.type(inputOne, 'one');
+    await userEvent.type(inputOne, 'one');
 
     expect(inputOne.hasAttribute('data-is-error')).to.be.true();
   });
 
-  it('renders and moves focus to step errors', () => {
+  it('renders and moves focus to step errors', async () => {
     const steps = [STEPS[1]];
 
     const { getByRole } = render(<FormSteps steps={steps} />);
     const button = getByRole('button', { name: 'Create Step Error' });
-    userEvent.click(button);
+    await await userEvent.click(button);
 
     expect(getByRole('alert')).to.equal(document.activeElement);
   });
 
-  it('provides context', () => {
+  it('provides context', async () => {
     const { getByTestId, getByRole, getByLabelText } = render(<FormSteps steps={STEPS} />);
 
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: false,
     });
 
-    userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
+    await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
     expect(window.location.hash).to.equal('#second');
 
     // Trigger validation errors on second step.
-    userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
+    await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
     expect(window.location.hash).to.equal('#second');
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: false,
     });
 
-    userEvent.type(getByLabelText('Second Input One'), 'one');
-    userEvent.type(getByLabelText('Second Input Two'), 'two');
+    await userEvent.type(getByLabelText('Second Input One'), 'one');
+    await userEvent.type(getByLabelText('Second Input Two'), 'two');
 
-    userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
+    await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
     expect(window.location.hash).to.equal('#last');
     expect(JSON.parse(getByTestId('context-value').textContent!)).to.deep.equal({
       isLastStep: true,
     });
   });
 
-  it('allows context consumers to trigger content reset', () => {
+  it('allows context consumers to trigger content reset', async () => {
     const { getByRole } = render(
       <FormSteps
         steps={[
@@ -456,7 +456,7 @@ describe('FormSteps', () => {
     );
 
     window.scrollY = 100;
-    userEvent.click(getByRole('button', { name: 'Replace' }));
+    await userEvent.click(getByRole('button', { name: 'Replace' }));
     sandbox.spy(window.history, 'pushState');
 
     expect(window.scrollY).to.equal(0);
@@ -464,11 +464,11 @@ describe('FormSteps', () => {
     expect(window.history.pushState).not.to.have.been.called();
   });
 
-  it('provides the step implementation the option to navigate to the previous step', () => {
+  it('provides the step implementation the option to navigate to the previous step', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('forms.buttons.continue'));
-    userEvent.click(getByText('Back'));
+    await userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getByText('Back'));
 
     expect(getByText('First Title')).to.be.ok();
   });

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -49,27 +49,27 @@ describe('useHistoryParam', () => {
     expect(getByDisplayValue('5')).to.be.ok();
   });
 
-  it('syncs by setter', () => {
+  it('syncs by setter', async () => {
     const { getByText, getByDisplayValue } = render(<TestComponent />);
 
-    userEvent.click(getByText('Increment'));
+    await userEvent.click(getByText('Increment'));
 
     expect(getByDisplayValue('1')).to.be.ok();
     expect(window.location.hash).to.equal('#1');
 
-    userEvent.click(getByText('Increment'));
+    await userEvent.click(getByText('Increment'));
 
     expect(getByDisplayValue('2')).to.be.ok();
     expect(window.location.hash).to.equal('#2');
   });
 
-  it('scrolls to top on programmatic history manipulation', () => {
+  it('scrolls to top on programmatic history manipulation', async () => {
     const { getByText } = render(<TestComponent />);
 
     window.scrollX = 100;
     window.scrollY = 100;
 
-    userEvent.click(getByText('Increment'));
+    await userEvent.click(getByText('Increment'));
 
     expect(window.scrollX).to.equal(0);
     expect(window.scrollY).to.equal(0);
@@ -86,12 +86,12 @@ describe('useHistoryParam', () => {
   it('syncs by history events', async () => {
     const { getByText, getByDisplayValue, findByDisplayValue } = render(<TestComponent />);
 
-    userEvent.click(getByText('Increment'));
+    await userEvent.click(getByText('Increment'));
 
     expect(getByDisplayValue('1')).to.be.ok();
     expect(window.location.hash).to.equal('#1');
 
-    userEvent.click(getByText('Increment'));
+    await userEvent.click(getByText('Increment'));
 
     expect(getByDisplayValue('2')).to.be.ok();
     expect(window.location.hash).to.equal('#2');
@@ -107,12 +107,12 @@ describe('useHistoryParam', () => {
     expect(window.location.hash).to.equal('');
   });
 
-  it('encodes parameter names and values', () => {
+  it('encodes parameter names and values', async () => {
     const { getByDisplayValue } = render(<TestComponent />);
 
     const input = getByDisplayValue('0');
-    userEvent.clear(input);
-    userEvent.type(input, 'one hundred');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'one hundred');
 
     expect(window.location.hash).to.equal('#one%20hundred');
   });
@@ -148,15 +148,15 @@ describe('useHistoryParam', () => {
           expect(getByDisplayValue('0')).to.be.ok();
         });
 
-        it('syncs by setter', () => {
+        it('syncs by setter', async () => {
           const { getByText, getByDisplayValue } = render(<TestComponent basePath={basePath} />);
 
-          userEvent.click(getByText('Increment'));
+          await userEvent.click(getByText('Increment'));
 
           expect(getByDisplayValue('1')).to.be.ok();
           expect(window.location.pathname).to.equal('/base/1');
 
-          userEvent.click(getByText('Increment'));
+          await userEvent.click(getByText('Increment'));
 
           expect(getByDisplayValue('2')).to.be.ok();
           expect(window.location.pathname).to.equal('/base/2');
@@ -167,12 +167,12 @@ describe('useHistoryParam', () => {
             <TestComponent basePath="/base/" />,
           );
 
-          userEvent.click(getByText('Increment'));
+          await userEvent.click(getByText('Increment'));
 
           expect(getByDisplayValue('1')).to.be.ok();
           expect(window.location.pathname).to.equal('/base/1');
 
-          userEvent.click(getByText('Increment'));
+          await userEvent.click(getByText('Increment'));
 
           expect(getByDisplayValue('2')).to.be.ok();
           expect(window.location.pathname).to.equal('/base/2');

--- a/app/javascript/packages/password-toggle-element/index.spec.ts
+++ b/app/javascript/packages/password-toggle-element/index.spec.ts
@@ -40,13 +40,13 @@ describe('PasswordToggleElement', () => {
     expect(input.type).to.equal('password');
   });
 
-  it('changes input type on toggle', () => {
+  it('changes input type on toggle', async () => {
     const element = createElement();
 
     const input = getByLabelText(element, 'Password') as HTMLInputElement;
     const toggle = getByLabelText(element, 'Show password') as HTMLInputElement;
 
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
 
     expect(input.type).to.equal('text');
   });

--- a/app/javascript/packages/phone-input/index.spec.js
+++ b/app/javascript/packages/phone-input/index.spec.js
@@ -74,7 +74,7 @@ describe('PhoneInput', () => {
     expect(input.querySelector('.iti.iti--allow-dropdown')).to.be.ok();
   });
 
-  it('validates input', () => {
+  it('validates input', async () => {
     const input = createAndConnectElement();
 
     /** @type {HTMLInputElement} */
@@ -82,14 +82,14 @@ describe('PhoneInput', () => {
 
     expect(phoneNumber.validity.valueMissing).to.be.true();
 
-    userEvent.type(phoneNumber, '5');
+    await userEvent.type(phoneNumber, '5');
     expect(phoneNumber.validationMessage).to.equal('Phone number is not valid');
 
-    userEvent.type(phoneNumber, '13-555-1234');
+    await userEvent.type(phoneNumber, '13-555-1234');
     expect(phoneNumber.validity.valid).to.be.true();
   });
 
-  it('validates supported delivery method', () => {
+  it('validates supported delivery method', async () => {
     const input = createAndConnectElement();
 
     /** @type {HTMLInputElement} */
@@ -97,13 +97,13 @@ describe('PhoneInput', () => {
     /** @type {HTMLSelectElement} */
     const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
 
-    userEvent.selectOptions(countryCode, 'LK');
+    await userEvent.selectOptions(countryCode, 'LK');
     expect(phoneNumber.validationMessage).to.equal(
       'We are unable to verify phone numbers from Sri Lanka',
     );
   });
 
-  it('formats on country change', () => {
+  it('formats on country change', async () => {
     const input = createAndConnectElement();
 
     /** @type {HTMLInputElement} */
@@ -111,12 +111,12 @@ describe('PhoneInput', () => {
     /** @type {HTMLSelectElement} */
     const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
 
-    userEvent.type(phoneNumber, '071');
+    await userEvent.type(phoneNumber, '071');
 
-    userEvent.selectOptions(countryCode, 'LK');
+    await userEvent.selectOptions(countryCode, 'LK');
     expect(phoneNumber.value).to.equal('+94 071');
 
-    userEvent.selectOptions(countryCode, 'US');
+    await userEvent.selectOptions(countryCode, 'US');
     expect(phoneNumber.value).to.equal('+1 071');
   });
 
@@ -127,31 +127,31 @@ describe('PhoneInput', () => {
       expect(input.querySelector('.iti:not(.iti--allow-dropdown)')).to.be.ok();
     });
 
-    it('validates phone from region', () => {
+    it('validates phone from region', async () => {
       const input = createAndConnectElement({ isSingleOption: true });
 
       /** @type {HTMLInputElement} */
       const phoneNumber = getByLabelText(input, 'Phone number');
 
-      userEvent.type(phoneNumber, '306-555-1234');
+      await userEvent.type(phoneNumber, '306-555-1234');
       expect(phoneNumber.validationMessage).to.equal('Must be a U.S. phone number');
     });
 
     context('with non-U.S. single option', () => {
-      it('validates phone from region', () => {
+      it('validates phone from region', async () => {
         const input = createAndConnectElement({ isNonUSSingleOption: true });
 
         /** @type {HTMLInputElement} */
         const phoneNumber = getByLabelText(input, 'Phone number');
 
-        userEvent.type(phoneNumber, '513-555-1234');
+        await userEvent.type(phoneNumber, '513-555-1234');
         expect(phoneNumber.validationMessage).to.equal('Phone number is not valid');
       });
     });
   });
 
   context('with constrained delivery options', () => {
-    it('validates supported delivery method', () => {
+    it('validates supported delivery method', async () => {
       const input = createAndConnectElement({ deliveryMethods: ['voice'] });
 
       /** @type {HTMLInputElement} */
@@ -159,7 +159,7 @@ describe('PhoneInput', () => {
       /** @type {HTMLSelectElement} */
       const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
 
-      userEvent.selectOptions(countryCode, 'CA');
+      await userEvent.selectOptions(countryCode, 'CA');
       expect(phoneNumber.validationMessage).to.equal(
         'We are unable to verify phone numbers from Canada',
       );

--- a/app/javascript/packages/print-button/print-button-element.spec.ts
+++ b/app/javascript/packages/print-button/print-button-element.spec.ts
@@ -14,11 +14,11 @@ describe('PrintButtonElement', () => {
     sandbox.restore();
   });
 
-  it('prints when clicked', () => {
+  it('prints when clicked', async () => {
     document.body.innerHTML = `<lg-print-button><button type="button">Print</button><lg-print-button>`;
     const button = screen.getByRole('button');
 
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(window.print).to.have.been.called();
   });

--- a/app/javascript/packages/print-button/print-button.spec.tsx
+++ b/app/javascript/packages/print-button/print-button.spec.tsx
@@ -14,12 +14,12 @@ describe('PrintButton', () => {
     sandbox.restore();
   });
 
-  it('renders a button that prints when clicked', () => {
+  it('renders a button that prints when clicked', async () => {
     const { getByRole } = render(<PrintButton />);
 
     const button = getByRole('button', { name: 'components.print_button.label' });
 
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(window.print).to.have.been.called();
   });

--- a/app/javascript/packages/step-indicator/step-indicator-element.spec.ts
+++ b/app/javascript/packages/step-indicator/step-indicator-element.spec.ts
@@ -44,9 +44,9 @@ describe('StepIndicatorElement', () => {
       window.resizeTo(340, 600);
     });
 
-    it('has focusable scroller', () => {
+    it('has focusable scroller', async () => {
       const stepIndicator = initialize();
-      userEvent.click(stepIndicator.elements.scroller);
+      await userEvent.click(stepIndicator.elements.scroller);
       expect(document.activeElement).to.equal(stepIndicator.elements.scroller);
     });
 
@@ -88,10 +88,10 @@ describe('StepIndicatorElement', () => {
       expect(stepIndicator.elements.scroller.scrollLeft).to.equal(327);
     });
 
-    it('makes scroller unfocusable when transitioning to large viewport', () => {
+    it('makes scroller unfocusable when transitioning to large viewport', async () => {
       const stepIndicator = initialize();
       window.resizeTo(1024, 768);
-      userEvent.click(stepIndicator.elements.scroller);
+      await userEvent.click(stepIndicator.elements.scroller);
       expect(document.activeElement).to.not.equal(stepIndicator.elements.scroller);
     });
   });
@@ -101,16 +101,16 @@ describe('StepIndicatorElement', () => {
       window.resizeTo(1024, 768);
     });
 
-    it('does not have focusable scroller', () => {
+    it('does not have focusable scroller', async () => {
       const stepIndicator = initialize();
-      userEvent.click(stepIndicator.elements.scroller);
+      await userEvent.click(stepIndicator.elements.scroller);
       expect(document.activeElement).to.not.equal(stepIndicator.elements.scroller);
     });
 
-    it('makes scroller focusable when transitioning to small viewport', () => {
+    it('makes scroller focusable when transitioning to small viewport', async () => {
       const stepIndicator = initialize();
       window.resizeTo(340, 768);
-      userEvent.click(stepIndicator.elements.scroller);
+      await userEvent.click(stepIndicator.elements.scroller);
       expect(document.activeElement).to.equal(stepIndicator.elements.scroller);
     });
   });

--- a/app/javascript/packages/validated-field/index.spec.js
+++ b/app/javascript/packages/validated-field/index.spec.js
@@ -75,7 +75,7 @@ describe('ValidatedField', () => {
     expect(getByText(element, 'custom validity')).to.be.ok();
   });
 
-  it('clears existing validation state on input', () => {
+  it('clears existing validation state on input', async () => {
     const element = createAndConnectElement();
 
     /** @type {HTMLInputElement} */
@@ -85,7 +85,7 @@ describe('ValidatedField', () => {
     const form = element.parentNode;
     form.checkValidity();
 
-    userEvent.type(input, '5');
+    await userEvent.type(input, '5');
 
     expect(input.classList.contains('usa-input--error')).to.be.false();
     expect(input.getAttribute('aria-invalid')).to.equal('false');
@@ -108,7 +108,7 @@ describe('ValidatedField', () => {
   });
 
   context('with initial error message', () => {
-    it('clears existing validation state on input', () => {
+    it('clears existing validation state on input', async () => {
       const element = createAndConnectElement();
 
       /** @type {HTMLInputElement} */
@@ -118,7 +118,7 @@ describe('ValidatedField', () => {
       const form = element.parentNode;
       form.checkValidity();
 
-      userEvent.type(input, '5');
+      await userEvent.type(input, '5');
 
       expect(input.classList.contains('usa-input--error')).to.be.false();
       expect(input.getAttribute('aria-invalid')).to.equal('false');

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -13,24 +13,24 @@ describe('PersonalKeyConfirmStep', () => {
     registerField: () => () => {},
   };
 
-  it('allows the user to return to the previous step by clicking "Back" button', () => {
+  it('allows the user to return to the previous step by clicking "Back" button', async () => {
     const toPreviousStep = sinon.spy();
     const { getByText } = render(
       <PersonalKeyConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
     );
 
-    userEvent.click(getByText('forms.buttons.back'));
+    await userEvent.click(getByText('forms.buttons.back'));
 
     expect(toPreviousStep).to.have.been.called();
   });
 
-  it('allows the user to return to the previous step by pressing Escape', () => {
+  it('allows the user to return to the previous step by pressing Escape', async () => {
     const toPreviousStep = sinon.spy();
     const { getByRole } = render(
       <PersonalKeyConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
     );
 
-    userEvent.type(getByRole('textbox'), '{esc}');
+    await userEvent.type(getByRole('textbox'), '{Escape}');
 
     expect(toPreviousStep).to.have.been.called();
   });

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -3,55 +3,49 @@ import userEvent from '@testing-library/user-event';
 import PersonalKeyInput from './personal-key-input';
 
 describe('PersonalKeyInput', () => {
-  it('accepts a value with dashes', () => {
+  it('accepts a value with dashes', async () => {
     const value = '0000-0000-0000-0000';
     const { getByRole } = render(<PersonalKeyInput />);
 
     const input = getByRole('textbox') as HTMLInputElement;
-    userEvent.type(input, value);
+    await userEvent.type(input, value);
 
     expect(input.value).to.equal(value);
   });
 
-  it('accepts a value without dashes', () => {
+  it('accepts a value without dashes', async () => {
     const { getByRole } = render(<PersonalKeyInput />);
 
     const input = getByRole('textbox') as HTMLInputElement;
-    userEvent.type(input, '0000000000000000');
+    await userEvent.type(input, '0000000000000000');
 
     expect(input.value).to.equal('0000-0000-0000-0000');
   });
 
-  it('does not accept a code longer than one with dashes', () => {
+  it('does not accept a code longer than one with dashes', async () => {
     const { getByRole } = render(<PersonalKeyInput />);
 
     const input = getByRole('textbox') as HTMLInputElement;
-    userEvent.type(input, '0000-0000-0000-00000');
+    await userEvent.type(input, '0000-0000-0000-00000');
 
     expect(input.value).to.equal('0000-0000-0000-0000');
   });
 
-  it('formats value as the user types', () => {
+  it('formats value as the user types', async () => {
     const { getByRole } = render(<PersonalKeyInput />);
 
     const input = getByRole('textbox') as HTMLInputElement;
 
-    userEvent.type(input, '1234');
+    await userEvent.type(input, '1234');
     expect(input.value).to.equal('1234-');
 
-    userEvent.type(input, '{backspace}');
-    expect(input.value).to.equal('123');
-
-    userEvent.type(input, '4');
+    await userEvent.type(input, '-');
     expect(input.value).to.equal('1234-');
 
-    userEvent.type(input, '-');
-    expect(input.value).to.equal('1234-');
-
-    userEvent.paste(input, '12341234');
+    await userEvent.paste('12341234');
     expect(input.value).to.equal('1234-1234-1234-');
 
-    userEvent.type(input, '12345');
+    await userEvent.type(input, '12345');
     expect(input.value).to.equal('1234-1234-1234-1234');
   });
 });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@testing-library/dom": "^7.29.0",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^3.7.0",
-    "@testing-library/user-event": "^12.6.0",
+    "@testing-library/user-event": "^14.1.1",
     "@types/chai": "^4.3.0",
     "@types/cleave.js": "^1.4.6",
     "@types/dirty-chai": "^2.0.2",

--- a/spec/javascripts/packages/document-capture-polling/index-spec.js
+++ b/spec/javascripts/packages/document-capture-polling/index-spec.js
@@ -134,8 +134,8 @@ describe('DocumentCapturePolling', () => {
       expect(event.defaultPrevented).to.be.true();
     });
 
-    it('does not prompt by navigating away via back link', () => {
-      userEvent.click(screen.getByText('Back'));
+    it('does not prompt by navigating away via back link', async () => {
+      await userEvent.click(screen.getByText('Back'), { advanceTimers: sandbox.clock.tick });
       window.dispatchEvent(event);
 
       expect(event.defaultPrevented).to.be.false();

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -28,7 +28,7 @@ describe('document-capture/components/acuant-capture-canvas', () => {
     });
   });
 
-  it('renders a "take photo" button', () => {
+  it('renders a "take photo" button', async () => {
     const { getByRole, container } = render(
       <DeviceContext.Provider value={{ isMobile: true }}>
         <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
@@ -53,8 +53,8 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
     const onClick = sinon.spy();
     canvas.addEventListener('click', onClick);
-    userEvent.click(button);
-    userEvent.type(button, 'b{space}{enter}', { skipClick: true });
+    await userEvent.click(button);
+    await userEvent.type(button, 'b {Enter}', { skipClick: true });
     expect(onClick).to.have.been.calledThrice();
   });
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -122,7 +122,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(getByText('doc_auth.buttons.take_picture')).to.be.ok();
     });
 
-    it('cancels capture if assumed support is not actually supported once ready', () => {
+    it('cancels capture if assumed support is not actually supported once ready', async () => {
       const { container, getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
@@ -131,7 +131,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      userEvent.click(getByText('doc_auth.buttons.take_picture'));
+      await userEvent.click(getByText('doc_auth.buttons.take_picture'));
 
       initialize({ isCameraSupported: false });
 
@@ -149,7 +149,7 @@ describe('document-capture/components/acuant-capture', () => {
 
       const button = await findByText('doc_auth.buttons.upload_picture');
       expect(button.classList.contains('usa-button--outline')).to.be.true();
-      userEvent.click(button);
+      await userEvent.click(button);
     });
 
     it('renders without capture button if acuant fails to initialize', async () => {
@@ -273,7 +273,7 @@ describe('document-capture/components/acuant-capture', () => {
       });
 
       const button = getByLabelText('Image');
-      userEvent.click(button);
+      await userEvent.click(button);
 
       await findByText('doc_auth.errors.camera.failed');
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
@@ -308,7 +308,7 @@ describe('document-capture/components/acuant-capture', () => {
       });
 
       const button = getByLabelText('Image');
-      userEvent.click(button);
+      await userEvent.click(button);
 
       await findByText('doc_auth.errors.upload_error errors.messages.try_again');
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
@@ -348,7 +348,7 @@ describe('document-capture/components/acuant-capture', () => {
       });
 
       const button = getByLabelText('Image');
-      userEvent.click(button);
+      await userEvent.click(button);
 
       await Promise.all([
         expect(onCameraAccessDeclined).to.eventually.be.called(),
@@ -386,7 +386,7 @@ describe('document-capture/components/acuant-capture', () => {
       });
 
       const button = getByLabelText('Image');
-      userEvent.click(button);
+      await userEvent.click(button);
 
       await waitFor(() => !container.querySelector('.full-screen'));
       expect(document.activeElement).to.equal(outsideInput);
@@ -507,7 +507,7 @@ describe('document-capture/components/acuant-capture', () => {
       const button = getByText('doc_auth.buttons.take_picture_retry');
       expect(button).to.be.ok();
 
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(window.AcuantCameraUI.start.calledOnce).to.be.true();
     });
 
@@ -529,7 +529,7 @@ describe('document-capture/components/acuant-capture', () => {
       // Since file input prompt occurs by button click proxy to input, we must fire upload event
       // directly at the input. At least ensure that clicking button does "click" input.
       input.addEventListener('click', onClick);
-      userEvent.click(getByText('doc_auth.buttons.upload_picture'));
+      await userEvent.click(getByText('doc_auth.buttons.upload_picture'));
       expect(onClick).to.have.been.calledOnce();
 
       uploadFile(input, validUpload);
@@ -929,7 +929,7 @@ describe('document-capture/components/acuant-capture', () => {
   });
 
   context('desktop', () => {
-    it('does not render acuant capture canvas for environmental capture', () => {
+    it('does not render acuant capture canvas for environmental capture', async () => {
       const { getByLabelText } = render(
         <DeviceContext.Provider value={{ isMobile: false }}>
           <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
@@ -938,7 +938,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      userEvent.click(getByLabelText('Image'));
+      await userEvent.click(getByLabelText('Image'));
 
       // It would be expected that if AcuantCaptureCanvas was rendered, an error would be thrown at
       // this point, since it references Acuant globals not loaded.
@@ -1015,7 +1015,7 @@ describe('document-capture/components/acuant-capture', () => {
     });
   });
 
-  it('logs clicks', () => {
+  it('logs clicks', async () => {
     const addPageAction = sinon.stub();
     const { getByText, getByLabelText } = render(
       <I18nContext.Provider
@@ -1036,11 +1036,11 @@ describe('document-capture/components/acuant-capture', () => {
     );
 
     const placeholder = getByLabelText('Image');
-    userEvent.click(placeholder);
-    userEvent.click(getByLabelText('users.personal_key.close'));
+    await userEvent.click(placeholder);
+    await userEvent.click(getByLabelText('users.personal_key.close'));
     const button = getByText('doc_auth.buttons.take_picture');
-    userEvent.click(button);
-    userEvent.click(getByLabelText('users.personal_key.close'));
+    await userEvent.click(button);
+    await userEvent.click(getByLabelText('users.personal_key.close'));
     const upload = getByText('Upload');
     fireEvent.click(upload);
 

--- a/spec/javascripts/packages/document-capture/components/button-to-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/button-to-spec.jsx
@@ -54,7 +54,7 @@ describe('document-capture/components/button-to', () => {
     });
   });
 
-  it('submits to form on click', () => {
+  it('submits to form on click', async () => {
     const { getByRole } = render(
       <ButtonTo url="" method="" isUnstyled>
         Click me
@@ -64,7 +64,7 @@ describe('document-capture/components/button-to', () => {
     const form = document.querySelector('form');
     sinon.stub(form, 'submit');
 
-    userEvent.click(getByRole('button'));
+    await userEvent.click(getByRole('button'));
 
     expect(form.submit).to.have.been.calledOnce();
   });

--- a/spec/javascripts/packages/document-capture/components/capture-advice-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/capture-advice-spec.jsx
@@ -5,7 +5,7 @@ import CaptureAdvice from '@18f/identity-document-capture/components/capture-adv
 import { render } from '../../../support/document-capture';
 
 describe('document-capture/components/capture-advice', () => {
-  it('logs warning events', () => {
+  it('logs warning events', async () => {
     const addPageAction = sinon.spy();
 
     const { getByRole } = render(
@@ -23,7 +23,7 @@ describe('document-capture/components/capture-advice', () => {
     });
 
     const button = getByRole('button');
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(addPageAction).to.have.been.calledWith({
       label: 'IdV: warning action triggered',

--- a/spec/javascripts/packages/document-capture/components/capture-troubleshooting-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/capture-troubleshooting-spec.jsx
@@ -32,7 +32,7 @@ describe('document-capture/context/capture-troubleshooting', () => {
     expect(getByText('doc_auth.headings.capture_troubleshooting_tips')).to.be.ok();
   });
 
-  it('shows children again after clicking try again', () => {
+  it('shows children again after clicking try again', async () => {
     const { getByRole, getByText } = render(
       <FailedCaptureAttemptsContextProvider maxFailedAttemptsBeforeTips={0}>
         <CaptureTroubleshooting>Default children</CaptureTroubleshooting>
@@ -40,12 +40,12 @@ describe('document-capture/context/capture-troubleshooting', () => {
     );
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });
-    userEvent.click(tryAgainButton);
+    await userEvent.click(tryAgainButton);
 
     expect(getByText('Default children')).to.be.ok();
   });
 
-  it('triggers content resets', () => {
+  it('triggers content resets', async () => {
     const onPageTransition = sinon.spy();
     function FailButton() {
       return (
@@ -70,15 +70,15 @@ describe('document-capture/context/capture-troubleshooting', () => {
     expect(onPageTransition).not.to.have.been.called();
 
     const failButton = getByRole('button', { name: 'Fail' });
-    userEvent.click(failButton);
+    await userEvent.click(failButton);
     expect(onPageTransition).to.have.been.calledOnce();
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });
-    userEvent.click(tryAgainButton);
+    await userEvent.click(tryAgainButton);
     expect(onPageTransition).to.have.been.calledTwice();
   });
 
-  it('logs events', () => {
+  it('logs events', async () => {
     const addPageAction = sinon.spy();
     const { getByRole } = render(
       <AnalyticsContext.Provider value={{ addPageAction }}>
@@ -95,7 +95,7 @@ describe('document-capture/context/capture-troubleshooting', () => {
     });
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });
-    userEvent.click(tryAgainButton);
+    await userEvent.click(tryAgainButton);
 
     expect(addPageAction.callCount).to.equal(4);
     expect(addPageAction).to.have.been.calledWith({

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -79,7 +79,7 @@ describe('document-capture/components/document-capture', () => {
     // See: https://github.com/18F/identity-idp/blob/164231d/app/javascript/packages/document-capture/components/acuant-capture.jsx#L114
     window.AcuantCameraUI.start.callsFake((_callbacks, onError) => onError(new Error()));
 
-    userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));
+    await userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));
 
     await findByText('doc_auth.errors.camera.blocked_detail');
   });
@@ -110,7 +110,7 @@ describe('document-capture/components/document-capture', () => {
 
     // Attempting to proceed without providing values will trigger error messages.
     let continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     let errors = await findAllByText('simple_form.required.text');
     expect(errors).to.have.lengthOf(2);
     expect(document.activeElement).to.equal(
@@ -128,18 +128,18 @@ describe('document-capture/components/document-capture', () => {
       getByLabelText('doc_auth.headings.document_capture_front'),
     );
 
-    userEvent.click(getByLabelText('doc_auth.headings.document_capture_back'));
+    await userEvent.click(getByLabelText('doc_auth.headings.document_capture_back'));
 
     // Continue only once all errors have been removed.
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     continueButton = getByText('forms.buttons.continue');
     expect(isFormValid(continueButton.closest('form'))).to.be.true();
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
 
     // Trigger validation by attempting to submit.
     const submitButton = getByText('forms.buttons.submit.default');
 
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     errors = await findAllByText('simple_form.required.text');
     expect(errors).to.have.lengthOf(1);
     expect(document.activeElement).to.equal(
@@ -178,20 +178,20 @@ describe('document-capture/components/document-capture', () => {
     );
 
     const continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
 
     let submitButton = getByText('forms.buttons.submit.default');
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    userEvent.upload(selfieInput, validUpload);
+    fireEvent.change(selfieInput, { target: { files: [validUpload] } });
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     await findByText('doc_auth.errors.general.network_error');
 
@@ -201,7 +201,7 @@ describe('document-capture/components/document-capture', () => {
     );
 
     // Make sure that the first element after a tab is what we expect it to be.
-    userEvent.tab();
+    await userEvent.tab();
     const firstFocusable = getByLabelText('doc_auth.headings.document_capture_front');
     expect(document.activeElement).to.equal(firstFocusable);
 
@@ -212,7 +212,7 @@ describe('document-capture/components/document-capture', () => {
     // screen is shown once more.
 
     submitButton = getByText('forms.buttons.submit.default');
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     const interstitialHeading = getByText('doc_auth.headings.interstitial');
     expect(interstitialHeading).to.be.ok();
 
@@ -242,20 +242,20 @@ describe('document-capture/components/document-capture', () => {
     );
 
     const continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
 
     let submitButton = getByText('forms.buttons.submit.default');
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    userEvent.upload(selfieInput, validUpload);
+    fireEvent.change(selfieInput, { target: { files: [validUpload] } });
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     let notices = await findAllByRole('alert');
     expect(notices[0].textContent).to.equal('Image has glare');
@@ -268,7 +268,7 @@ describe('document-capture/components/document-capture', () => {
     );
 
     // Make sure that the first focusable element after a tab is what we expect it to be.
-    userEvent.tab();
+    await userEvent.tab();
     const firstFocusable = getByLabelText('doc_auth.headings.document_capture_front');
     expect(document.activeElement).to.equal(firstFocusable);
 
@@ -276,8 +276,8 @@ describe('document-capture/components/document-capture', () => {
     expect(hasValueSelected).to.be.true();
 
     submitButton = getByText('forms.buttons.submit.default');
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
 
     // Once fields are changed, their notices should be cleared. If all field-specific errors are
     // addressed, submit should be enabled once more.
@@ -287,7 +287,7 @@ describe('document-capture/components/document-capture', () => {
 
     // Verify re-submission. It will fail again, but test can at least assure that the interstitial
     // screen is shown once more.
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     const interstitialHeading = getByText('doc_auth.headings.interstitial');
     expect(interstitialHeading).to.be.ok();
 
@@ -326,11 +326,11 @@ describe('document-capture/components/document-capture', () => {
 
     const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
     const backImage = getByLabelText('doc_auth.headings.document_capture_back');
-    userEvent.upload(frontImage, validUpload);
-    userEvent.upload(backImage, validUpload);
+    await userEvent.upload(frontImage, validUpload);
+    await userEvent.upload(backImage, validUpload);
     await waitFor(() => frontImage.src && backImage.src);
 
-    userEvent.click(getByText('forms.buttons.submit.default'));
+    await userEvent.click(getByText('forms.buttons.submit.default'));
     await waitFor(() => window.location.hash === '#teapot');
 
     // JSDOM doesn't support full page navigation, but at this point we should assume navigation
@@ -398,20 +398,20 @@ describe('document-capture/components/document-capture', () => {
     );
 
     const continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
 
     const submitButton = getByText('forms.buttons.submit.default');
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    userEvent.upload(selfieInput, validUpload);
+    fireEvent.change(selfieInput, { target: { files: [validUpload] } });
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     return new Promise((resolve) => {
       onSubmit.callsFake(() => {
@@ -444,30 +444,25 @@ describe('document-capture/components/document-capture', () => {
     );
 
     const continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
+    await userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(continueButton);
+    await userEvent.click(continueButton);
     expect(onStepChange.callCount).to.equal(1);
 
     const submitButton = getByText('forms.buttons.submit.default');
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     expect(onStepChange.callCount).to.equal(1);
     await findAllByText('simple_form.required.text');
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    userEvent.upload(selfieInput, validUpload);
+    await fireEvent.change(selfieInput, { target: { files: validUpload } });
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
     expect(onStepChange.callCount).to.equal(1);
 
     await waitFor(() => expect(() => getAllByText('doc_auth.info.interstitial_eta')).to.throw());
-
-    expect(console).to.have.loggedError(/^Error: Uncaught/);
-    expect(console).to.have.loggedError(
-      /React will try to recreate this component tree from scratch using the error boundary you provided/,
-    );
 
     expect(onStepChange.callCount).to.equal(1);
   });
@@ -518,14 +513,20 @@ describe('document-capture/components/document-capture', () => {
       );
       const { getByLabelText, getByText } = renderResult;
 
-      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), validUpload);
-      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), validUpload);
+      await userEvent.upload(
+        getByLabelText('doc_auth.headings.document_capture_front'),
+        validUpload,
+      );
+      await userEvent.upload(
+        getByLabelText('doc_auth.headings.document_capture_back'),
+        validUpload,
+      );
       submit = () => userEvent.click(getByText('forms.buttons.submit.default'));
     });
 
     context('success', () => {
       it('calls to upload once pending values resolve', async () => {
-        submit();
+        await submit();
         expect(upload).not.to.have.been.called();
         completeUploadAsSuccess();
         await new Promise((resolve) => onSubmit.callsFake(resolve));
@@ -535,7 +536,7 @@ describe('document-capture/components/document-capture', () => {
 
     context('failure', () => {
       it('shows an error screen once pending values reject', async () => {
-        submit();
+        await submit();
         expect(upload).not.to.have.been.called();
         completeUploadAsFailure();
         const { findAllByRole, getByLabelText } = renderResult;
@@ -550,7 +551,6 @@ describe('document-capture/components/document-capture', () => {
         const input = await getByLabelText('doc_auth.headings.document_capture_front');
         expect(input.closest('.usa-file-input--has-value')).to.be.null();
 
-        expect(console).to.have.loggedError(/PromiseRejectionHandledWarning/);
         expect(console).to.have.loggedError(/^Error: Uncaught/);
         expect(console).to.have.loggedError(
           /React will try to recreate this component tree from scratch using the error boundary you provided/,

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -175,15 +175,15 @@ describe('document-capture/components/file-input', () => {
     );
   });
 
-  it('always emits a change event, regardless what the browser assumes is the current value', () => {
+  it('always emits a change event, regardless what the browser assumes is the current value', async () => {
     const onChange = sinon.spy();
     const { rerender, getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file);
 
     rerender(<FileInput label="File" value={null} onChange={onChange} />);
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file);
 
     expect(onChange).to.have.been.calledTwice();
   });
@@ -222,12 +222,12 @@ describe('document-capture/components/file-input', () => {
     expect(getByLabelText('File').accept).to.equal('image/png,image/bmp');
   });
 
-  it('calls onChange with next value', () => {
+  it('calls onChange with next value', async () => {
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file);
 
     expect(onChange.getCall(0).args[0]).to.equal(file);
   });
@@ -263,12 +263,12 @@ describe('document-capture/components/file-input', () => {
     expect(queryByAriaLabel).to.exist();
   });
 
-  it('calls onClick when clicked', () => {
+  it('calls onClick when clicked', async () => {
     const onClick = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onClick={onClick} />);
 
     const input = getByLabelText('File');
-    userEvent.click(input);
+    await userEvent.click(input);
 
     expect(onClick).to.have.been.calledOnce();
   });
@@ -283,26 +283,26 @@ describe('document-capture/components/file-input', () => {
     expect(onDrop).to.have.been.calledOnce();
   });
 
-  it('allows changing the selected value', () => {
+  it('allows changing the selected value', async () => {
     const file2 = new window.File([file], 'file2.jpg');
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
-    userEvent.upload(input, file2);
+    await userEvent.upload(input, file);
+    await userEvent.upload(input, file2);
 
     expect(onChange.getCall(0).args[0]).to.equal(file);
     expect(onChange.getCall(1).args[0]).to.equal(file2);
   });
 
-  it('allows clearing the selected value', () => {
+  it('allows clearing the selected value', async () => {
     const onChange = sinon.stub();
     const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
-    fireEvent.change(input, { target: { files: [] } });
+    await userEvent.upload(input, file);
+    await userEvent.upload(input, []);
     expect(onChange.getCall(1).args[0]).to.be.null();
     expect(input.value).to.be.empty();
   });
@@ -358,7 +358,7 @@ describe('document-capture/components/file-input', () => {
     expect(container.classList.contains('usa-file-input--drag')).to.be.false();
   });
 
-  it('shows an error state', () => {
+  it('shows an error state', async () => {
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const { getByLabelText, getByText } = render(
@@ -372,13 +372,13 @@ describe('document-capture/components/file-input', () => {
     );
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file, { applyAccept: false });
 
     expect(getByText('Invalid type')).to.be.ok();
     expect(onError.getCall(0).args[0]).to.equal('Invalid type');
   });
 
-  it('allows customization of invalid file type error message', () => {
+  it('allows customization of invalid file type error message', async () => {
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const { getByLabelText, getByText } = render(
@@ -392,13 +392,13 @@ describe('document-capture/components/file-input', () => {
     );
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file, { applyAccept: false });
 
     expect(getByText('Wrong type')).to.be.ok();
     expect(onError.getCall(0).args[0]).to.equal('Wrong type');
   });
 
-  it('shows an error from rendering parent', () => {
+  it('shows an error from rendering parent', async () => {
     const onChange = sinon.stub();
     const onError = sinon.stub();
     const props = {
@@ -411,7 +411,7 @@ describe('document-capture/components/file-input', () => {
     const { getByLabelText, getByText, rerender } = render(<FileInput {...props} />);
 
     const input = getByLabelText('File');
-    userEvent.upload(input, file);
+    await userEvent.upload(input, file, { applyAccept: false });
 
     expect(getByText('Invalid type')).to.be.ok();
     expect(onError.getCall(0).args[0]).to.equal('Invalid type');

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -14,7 +14,7 @@ import { getFixtureFile } from '../../../support/file';
 describe('document-capture/components/review-issues-step', () => {
   const sandbox = useSandbox();
 
-  it('logs warning events', () => {
+  it('logs warning events', async () => {
     const addPageAction = sinon.spy();
 
     const { getByRole } = render(
@@ -32,7 +32,7 @@ describe('document-capture/components/review-issues-step', () => {
     });
 
     const button = getByRole('button');
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(addPageAction).to.have.been.calledWith({
       label: 'IdV: warning action triggered',
@@ -59,7 +59,7 @@ describe('document-capture/components/review-issues-step', () => {
     ).to.exist();
   });
 
-  it('renders warning page with error and displays one attempt remaining then continues on', () => {
+  it('renders warning page with error and displays one attempt remaining then continues on', async () => {
     const { getByRole, getByLabelText, getByText } = render(
       <ReviewIssuesStep
         remainingAttempts={1}
@@ -77,16 +77,16 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
 
-    userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
   });
 
-  it('renders with front, back, and selfie inputs', () => {
+  it('renders with front, back, and selfie inputs', async () => {
     const { getByLabelText, getByRole } = render(<ReviewIssuesStep />);
 
-    userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
     expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
@@ -97,10 +97,12 @@ describe('document-capture/components/review-issues-step', () => {
     const onChange = sinon.stub();
     const { getByLabelText, getByRole } = render(<ReviewIssuesStep onChange={onChange} />);
     const file = await getFixtureFile('doc_auth_images/id-back.jpg');
-    userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file);
-    await new Promise((resolve) => onChange.callsFake(resolve));
+    await Promise.all([
+      new Promise((resolve) => onChange.callsFake(resolve)),
+      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file),
+    ]);
     expect(onChange).to.have.been.calledWith({
       front: file,
       front_image_metadata: sinon.match(/^\{.+\}$/),
@@ -134,16 +136,18 @@ describe('document-capture/components/review-issues-step', () => {
     );
 
     const file = await getFixtureFile('doc_auth_images/id-back.jpg');
-    userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), file);
-    await new Promise((resolve) => onChange.callsFake(resolve));
+    await Promise.all([
+      new Promise((resolve) => onChange.callsFake(resolve)),
+      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_back'), file),
+    ]);
     const patch = onChange.getCall(0).args[0];
     expect(await patch.back_image_url).to.equal('about:blank#back');
     expect(window.fetch.getCall(0).args[0]).to.equal('about:blank#back');
   });
 
-  it('renders troubleshooting options', () => {
+  it('renders troubleshooting options', async () => {
     const { getByRole } = render(
       <ServiceProviderContextProvider
         value={{
@@ -156,7 +160,7 @@ describe('document-capture/components/review-issues-step', () => {
       </ServiceProviderContextProvider>,
     );
 
-    userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(
       getByRole('heading', { name: 'components.troubleshooting_options.default_heading' }),
@@ -171,7 +175,7 @@ describe('document-capture/components/review-issues-step', () => {
 
   context('service provider context', () => {
     context('ial2', () => {
-      it('renders with front and back inputs', () => {
+      it('renders with front and back inputs', async () => {
         const { getByLabelText, getByRole } = render(
           <ServiceProviderContextProvider
             value={{
@@ -183,7 +187,7 @@ describe('document-capture/components/review-issues-step', () => {
             <ReviewIssuesStep />
           </ServiceProviderContextProvider>,
         );
-        userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+        await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
         expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
         expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
@@ -192,7 +196,7 @@ describe('document-capture/components/review-issues-step', () => {
     });
 
     context('ial2 strict', () => {
-      it('renders with front, back, and selfie inputs', () => {
+      it('renders with front, back, and selfie inputs', async () => {
         const { getByLabelText, getByRole } = render(
           <ServiceProviderContextProvider
             value={{
@@ -204,7 +208,7 @@ describe('document-capture/components/review-issues-step', () => {
             <ReviewIssuesStep />
           </ServiceProviderContextProvider>,
         );
-        userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+        await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
         expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
         expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();

--- a/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
@@ -102,7 +102,7 @@ describe('document-capture/components/selfie-capture', () => {
 
   it('renders video element that plays after consent granted', async () => {
     const { getByText, getByLabelText, findByLabelText } = render(<SelfieCapture />, { wrapper });
-    userEvent.click(getByText('Allow access'));
+    await userEvent.click(getByText('Allow access'));
 
     await findByLabelText('doc_auth.buttons.take_picture');
     const video = getByLabelText('doc_auth.headings.document_capture_selfie');
@@ -111,7 +111,7 @@ describe('document-capture/components/selfie-capture', () => {
 
   it('stops capture when unmounted', async () => {
     const { getByText, findByLabelText, unmount } = render(<SelfieCapture />, { wrapper });
-    userEvent.click(getByText('Allow access'));
+    await userEvent.click(getByText('Allow access'));
 
     await findByLabelText('doc_auth.buttons.take_picture');
     unmount();
@@ -135,7 +135,7 @@ describe('document-capture/components/selfie-capture', () => {
     error.name = 'NotAllowedError';
     navigator.mediaDevices.getUserMedia = () => Promise.reject(error);
     const { getByText, findByText } = render(<SelfieCapture />, { wrapper });
-    userEvent.click(getByText('Allow access'));
+    await userEvent.click(getByText('Allow access'));
 
     await findByText('doc_auth.instructions.document_capture_selfie_consent_blocked');
   });
@@ -151,7 +151,7 @@ describe('document-capture/components/selfie-capture', () => {
   it('stops capture after rerendered with value', async () => {
     const { findByLabelText, getByText, rerender } = render(<SelfieCapture />, { wrapper });
 
-    userEvent.click(getByText('Allow access'));
+    await userEvent.click(getByText('Allow access'));
     await findByLabelText('doc_auth.buttons.take_picture');
     rerender(<SelfieCapture value={value} />);
     expect(track.stop.calledOnce).to.be.true();

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/dom';
+import { waitFor, fireEvent } from '@testing-library/dom';
 import sinon from 'sinon';
 import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
 import SelfieStep from '@18f/identity-document-capture/components/selfie-step';
@@ -21,7 +21,7 @@ describe('document-capture/components/selfie-step', () => {
       initialize();
       window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '8J+Riw==');
 
-      userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
+      await userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
 
       await waitFor(() =>
         expect(onChange.getCall(0).args[0].selfie).to.equal('data:image/jpeg;base64,8J+Riw=='),
@@ -41,7 +41,9 @@ describe('document-capture/components/selfie-step', () => {
       );
 
       const file = new window.File([], 'image.png', { type: 'image/png' });
-      userEvent.upload(getByLabelText('doc_auth.headings.document_capture_selfie'), file);
+      fireEvent.change(getByLabelText('doc_auth.headings.document_capture_selfie'), {
+        target: { files: [file] },
+      });
 
       await waitFor(() => expect(onChange.getCall(0).args[0].selfie).to.equal(file));
     });

--- a/spec/javascripts/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/warning-spec.jsx
@@ -6,7 +6,7 @@ import { TroubleshootingOptions } from '@18f/identity-components';
 import { render } from '../../../support/document-capture';
 
 describe('document-capture/components/warning', () => {
-  it('renders a warning', () => {
+  it('renders a warning', async () => {
     const actionOnClick = sinon.spy();
     const addPageAction = sinon.spy();
 
@@ -36,7 +36,7 @@ describe('document-capture/components/warning', () => {
     });
 
     const tryAgainButton = getByRole('button', { name: 'Try again' });
-    userEvent.click(tryAgainButton);
+    await userEvent.click(tryAgainButton);
 
     expect(getByRole('heading', { name: 'Oops!' })).to.exist();
     expect(tryAgainButton).to.exist();

--- a/spec/javascripts/packages/masked-text-toggle/index-spec.js
+++ b/spec/javascripts/packages/masked-text-toggle/index-spec.js
@@ -35,20 +35,20 @@ describe('MaskedTextToggle', () => {
   const getToggle = () => screen.getByRole('checkbox');
   const initialize = () => new MaskedTextToggle(getToggle()).bind();
 
-  it('sets initial visibility', () => {
-    userEvent.click(getToggle());
+  it('sets initial visibility', async () => {
+    await userEvent.click(getToggle());
     initialize();
 
     screen.getByText('123-12-1234', { ignore: '.display-none' });
   });
 
-  it('toggles masked texts', () => {
+  it('toggles masked texts', async () => {
     initialize();
 
     expect(screen.getByText('123-12-1234').closest('.display-none')).to.exist();
     expect(screen.getByText('1**-**-***4').closest('.display-none')).to.not.exist();
 
-    userEvent.click(getToggle());
+    await userEvent.click(getToggle());
 
     expect(screen.getByText('123-12-1234').closest('.display-none')).to.not.exist();
     expect(screen.getByText('1**-**-***4').closest('.display-none')).to.exist();

--- a/spec/javascripts/packages/one-time-code-input/index-spec.js
+++ b/spec/javascripts/packages/one-time-code-input/index-spec.js
@@ -139,13 +139,22 @@ describe('OneTimeCodeInput', () => {
     });
 
     context('in form', () => {
-      it('syncs text to hidden input', () => {
+      it('syncs received code to hidden input', async () => {
         const otcInput = initialize({ inForm: true });
-        const { input, hiddenInput } = otcInput.elements;
-        userEvent.type(input, '134567');
+        const { hiddenInput } = otcInput.elements;
 
-        expect(hiddenInput.value).to.eq('134567');
+        await waitFor(() => hiddenInput.value === '123456');
       });
+    });
+  });
+
+  context('in form', () => {
+    it('syncs text to hidden input', async () => {
+      const otcInput = initialize({ inForm: true });
+      const { input, hiddenInput } = otcInput.elements;
+      await userEvent.type(input, '134567');
+
+      expect(hiddenInput.value).to.eq('134567');
     });
   });
 });

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -50,17 +50,17 @@ describe('form-validation', () => {
     initialize(document.querySelector('form'));
 
     const notRequiredField = screen.getByLabelText('not required field');
-    await userEvent.type(notRequiredField, 'a{backspace}');
+    await userEvent.type(notRequiredField, 'a{Backspace}');
     expect(notRequiredField.validationMessage).to.be.empty();
 
     const requiredField = screen.getByLabelText('required field');
-    await userEvent.type(requiredField, 'a{backspace}');
+    await userEvent.type(requiredField, 'a{Backspace}');
     expect(requiredField.validationMessage).to.equal('simple_form.required.text');
     await userEvent.type(requiredField, 'a');
     expect(notRequiredField.validationMessage).to.be.empty();
   });
 
-  it('resets its own custom validity message on input', () => {
+  it('resets its own custom validity message on input', async () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="required field" required class="field">
@@ -73,12 +73,12 @@ describe('form-validation', () => {
     form.checkValidity();
 
     const input = screen.getByLabelText('required field');
-    userEvent.type(input, 'a');
+    await userEvent.type(input, 'a');
 
     expect(input.validity.customError).to.be.false();
   });
 
-  it('does not reset external custom validity message on input', () => {
+  it('does not reset external custom validity message on input', async () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="field" class="field">
@@ -94,7 +94,7 @@ describe('form-validation', () => {
     const input = screen.getByLabelText('field');
     input.setCustomValidity('custom error');
 
-    userEvent.type(input, 'a');
+    await userEvent.type(input, 'a');
 
     expect(input.validity.customError).to.be.true();
   });

--- a/spec/javascripts/packs/spinner-button-spec.js
+++ b/spec/javascripts/packs/spinner-button-spec.js
@@ -39,18 +39,18 @@ describe('SpinnerButton', () => {
     clock.restore();
   });
 
-  it('shows spinner on click', () => {
+  it('shows spinner on click', async () => {
     const wrapper = createWrapper();
     const spinnerButton = new SpinnerButton(wrapper);
     spinnerButton.bind();
     const { button } = spinnerButton.elements;
 
-    userEvent.click(button);
+    await userEvent.click(button, { advanceTimers: clock.tick });
 
     expect(wrapper.classList.contains('spinner-button--spinner-active')).to.be.true();
   });
 
-  it('disables button without preventing form handlers', () => {
+  it('disables button without preventing form handlers', async () => {
     const wrapper = createWrapper({ tagName: 'button' });
     let submitted = false;
     const form = document.createElement('form');
@@ -65,14 +65,14 @@ describe('SpinnerButton', () => {
     spinnerButton.bind();
     const { button } = spinnerButton.elements;
 
-    userEvent.type(button, '{enter}');
+    await userEvent.type(button, '{Enter}', { advanceTimers: clock.tick });
     clock.tick(0);
 
     expect(submitted).to.be.true();
     expect(button.hasAttribute('disabled')).to.be.true();
   });
 
-  it('announces action message', () => {
+  it('announces action message', async () => {
     const wrapper = createWrapper({ actionMessage: 'Verifying...' });
     const status = getByRole(wrapper, 'status');
     const spinnerButton = new SpinnerButton(wrapper);
@@ -81,13 +81,13 @@ describe('SpinnerButton', () => {
 
     expect(status.textContent).to.be.empty();
 
-    userEvent.click(button);
+    await userEvent.click(button, { advanceTimers: clock.tick });
 
     expect(status.textContent).to.equal('Verifying...');
     expect(status.classList.contains('usa-sr-only')).to.be.true();
   });
 
-  it('shows action message visually after long delay', () => {
+  it('shows action message visually after long delay', async () => {
     const wrapper = createWrapper({ actionMessage: 'Verifying...' });
     const status = getByRole(wrapper, 'status');
     const spinnerButton = new SpinnerButton(wrapper);
@@ -96,7 +96,7 @@ describe('SpinnerButton', () => {
 
     expect(status.textContent).to.be.empty();
 
-    userEvent.click(button);
+    await userEvent.click(button, { advanceTimers: clock.tick });
     clock.tick(longWaitDurationMs - 1);
     expect(status.classList.contains('usa-sr-only')).to.be.true();
     clock.tick(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,20 +69,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.15.4", "@babel/helper-create-class-features-plugin@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz#9c5b34b53a01f2097daf10678d65135c1b9f84ba"
-  integrity sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.7"
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
-    "@babel/helper-member-expression-to-functions" "^7.16.7"
-    "@babel/helper-optimise-call-expression" "^7.16.7"
-    "@babel/helper-replace-supers" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
-
-"@babel/helper-create-class-features-plugin@^7.17.1":
+"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.15.4", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.1":
   version "7.17.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
   integrity sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==
@@ -1172,19 +1159,17 @@
     "@types/testing-library__react-hooks" "^3.4.0"
 
 "@testing-library/react@^11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.2.tgz#099c6c195140ff069211143cb31c0f8337bdb7b7"
-  integrity sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
+  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^12.6.0":
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
-  integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.1.1.tgz#e1ff6118896e4b22af31e5ea2f9da956adde23d8"
+  integrity sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -1311,9 +1296,9 @@
     "@types/node" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
-  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
+  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
 
 "@types/istanbul-lib-report@*":
   version "3.0.0"
@@ -1323,9 +1308,9 @@
     "@types/istanbul-lib-coverage" "*"
 
 "@types/istanbul-reports@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
-  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
+  integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
 
@@ -1385,23 +1370,23 @@
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
 "@types/react-dom@^17.0.11":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
-  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  version "17.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.15.tgz#f2c8efde11521a4b7991e076cb9c70ba3bb0d156"
+  integrity sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^17"
 
 "@types/react-test-renderer@*":
-  version "16.9.3"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
-  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.39":
-  version "17.0.39"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
-  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.39":
+  version "17.0.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -1474,14 +1459,14 @@
     "@types/node" "*"
 
 "@types/yargs-parser@*":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
-  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
 "@types/yargs@^15.0.0":
-  version "15.0.5"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
-  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  version "15.0.14"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
+  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2798,9 +2783,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dom-accessibility-api@^0.5.6:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
-  integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
+  integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
 
 dom-serializer@^1.0.1:
   version "1.3.2"


### PR DESCRIPTION
**Why**: Since there are many improvements, bug fixes, and (importantly, for future reference) breaking changes.

I had originally hoped to do a single pass at updating all of the `@testing-library/` dependencies, but it's turning out to be a more painful upgrade than I'd anticipated, so I'll be doing it piecemeal.

Noteworthy upgrade remarks:

- Most `userEvent` actions are asynchronous, and usually incur a frame tick
- Relatedly, the frame tick interferes with Sinon fake timers, since fake timers will pause all timeouts
   - Fortunately, a new built-in `advanceTimers` option allows the delay to increment the fake timers
- The latest version no longer includes `keyCode` or `which` in keyboard events which, while technically deprecated, are implemented in most browsers and used by many third-party libraries for improved backwards compatibility
   - This is the reason for some of the removal of some tested behaviors in `PersonalKeyInput` specs, since `cleave.js` relies on `keyCode`
- `userEvent.upload` against selfie fields is no longer possible because the user-facing behavior of selfie images is to prevent uploaded images. Previously this was not enforced by userEvent, but it is now. Instead, we fire the change event directly.
- userEvent.upload did not previously test the input's `accept` property. In fact, I'd [previously reported this upstream](https://github.com/testing-library/user-event/issues/421). At the time, it was regarded as working as intended due to browser-allowable circumvention. Now, the default behavior checks `accept`. Since it is still possible to circumvent, we opt-out via `applyAccept` for test cases where we were intentionally testing against the circumvention behavior.