### PR TITLE
LG-6199: Show current IdV app step as page title

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -12,6 +12,7 @@ class VerifyController < ApplicationController
   def app_data
     {
       base_path: idv_app_root_path,
+      app_name: APP_NAME,
       initial_values: { 'personalKey' => '0000-0000-0000-0000' },
     }
   end

--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -27,6 +27,7 @@ describe('FormSteps', () => {
   const STEPS = [
     {
       name: 'first',
+      title: 'First Title',
       form: () => (
         <>
           <PageHeading>First Title</PageHeading>
@@ -130,6 +131,12 @@ describe('FormSteps', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
     expect(getByText('First')).to.be.ok();
+  });
+
+  it('sets the browser page title using titleFormat', () => {
+    render(<FormSteps steps={STEPS} titleFormat="%{step} - Example" />);
+
+    expect(document.title).to.equal('First Title - Example');
   });
 
   it('renders continue button at first step', () => {

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -150,7 +150,7 @@ interface FormStepsProps {
   basePath?: string;
 
   /**
-   * Formatted string for page title, interpolated with step title as `step`.
+   * Format string for page title, interpolated with step title as `%{step}` parameter.
    */
   titleFormat?: string;
 }
@@ -159,7 +159,7 @@ interface FormStepsProps {
  * React hook which sets page title for the current step.
  *
  * @param step Current step.
- * @param titleFormat Formatted string for page title, interpolated with step title as `step`.
+ * @param titleFormat Format string for page title.
  */
 function useStepTitle(step: FormStep, titleFormat?: string) {
   useEffect(() => {

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { RefCallback, FormEventHandler, FC } from 'react';
 import { Alert } from '@18f/identity-components';
+import { replaceVariables } from '@18f/identity-i18n';
 import { useDidUpdateEffect, useIfStillMounted } from '@18f/identity-react-hooks';
 import RequiredValueMissingError from './required-value-missing-error';
 import FormStepsContext from './form-steps-context';
@@ -81,6 +82,11 @@ export interface FormStep {
    * Step form component.
    */
   form: FC<FormStepComponentProps<Record<string, any>>>;
+
+  /**
+   * Human-readable step label.
+   */
+  title?: string;
 }
 
 interface FieldsRefEntry {
@@ -142,6 +148,25 @@ interface FormStepsProps {
    * is appended.
    */
   basePath?: string;
+
+  /**
+   * Formatted string for page title, interpolated with step title as `step`.
+   */
+  titleFormat?: string;
+}
+
+/**
+ * React hook which sets page title for the current step.
+ *
+ * @param step Current step.
+ * @param titleFormat Formatted string for page title, interpolated with step title as `step`.
+ */
+function useStepTitle(step: FormStep, titleFormat?: string) {
+  useEffect(() => {
+    if (titleFormat && step.title) {
+      document.title = replaceVariables(titleFormat, { step: step.title });
+    }
+  }, [step]);
 }
 
 /**
@@ -183,6 +208,7 @@ function FormSteps({
   autoFocus,
   promptOnNavigate = true,
   basePath,
+  titleFormat,
 }: FormStepsProps) {
   const [values, setValues] = useState(initialValues);
   const [activeErrors, setActiveErrors] = useState(initialActiveErrors);
@@ -231,6 +257,7 @@ function FormSteps({
     }
   }, [stepErrors]);
 
+  useStepTitle(step, titleFormat);
   useDidUpdateEffect(onStepChange, [step]);
   useDidUpdateEffect(onPageTransition, [step]);
 

--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -16,9 +16,14 @@ interface VerifyFlowProps {
    * The path to which the current step is appended to create the current step URL.
    */
   basePath: string;
+
+  /**
+   * Application name, used in generating page titles for current step.
+   */
+  appName: string;
 }
 
-export function VerifyFlow({ initialValues = {}, basePath }: VerifyFlowProps) {
+export function VerifyFlow({ initialValues = {}, basePath, appName }: VerifyFlowProps) {
   return (
     <>
       <StepIndicator className="margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4">
@@ -33,6 +38,7 @@ export function VerifyFlow({ initialValues = {}, basePath }: VerifyFlowProps) {
         initialValues={initialValues}
         promptOnNavigate={false}
         basePath={basePath}
+        titleFormat={`%{step} - ${appName}`}
       />
     </>
   );

--- a/app/javascript/packages/verify-flow/steps/index.ts
+++ b/app/javascript/packages/verify-flow/steps/index.ts
@@ -1,4 +1,5 @@
 import type { FormStep } from '@18f/identity-form-steps';
+import { t } from '@18f/identity-i18n';
 import PersonalKeyStep from './personal-key/personal-key-step';
 import PersonalKeyConfirmStep from './personal-key-confirm/personal-key-confirm-step';
 
@@ -6,9 +7,11 @@ export const STEPS: FormStep[] = [
   {
     name: 'personal_key',
     form: PersonalKeyStep,
+    title: t('titles.idv.personal_key'),
   },
   {
     name: 'personal_key_confirm',
     form: PersonalKeyConfirmStep,
+    title: t('titles.idv.personal_key'),
   },
 ];

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -11,6 +11,11 @@ interface AppRootValues {
    * The path to which the current step is appended to create the current step URL.
    */
   basePath: string;
+
+  /**
+   * Application name.
+   */
+  appName: string;
 }
 
 interface AppRootElement extends HTMLElement {
@@ -18,11 +23,14 @@ interface AppRootElement extends HTMLElement {
 }
 
 const appRoot = document.getElementById('app-root') as AppRootElement;
-const { initialValues, basePath } = appRoot.dataset;
+const { initialValues, basePath, appName } = appRoot.dataset;
 
 let parsedInitialValues;
 try {
   parsedInitialValues = JSON.parse(initialValues);
 } catch {}
 
-render(<VerifyFlow initialValues={parsedInitialValues} basePath={basePath} />, appRoot);
+render(
+  <VerifyFlow initialValues={parsedInitialValues} basePath={basePath} appName={appName} />,
+  appRoot,
+);


### PR DESCRIPTION
**Why**:

- As a user, I expect that each page is uniquely titled, so that I can understand its purpose.
- Feature parity with existing step implementation.

**Testing Instructions:**

1. Set `idv_api_enabled: "true"` in local `config/application.yml`
2. Go to: http://localhost:3000/verify/v2
3. Observe browser tab title is "Save your personal key - Login.gov"

**Implementation Notes:**

Based on current implementation:

https://github.com/18F/identity-idp/blob/e8555810d4a18870f233d3330e5ae6b3931c2bcd/app/views/layouts/base.html.erb#L20-L23

https://github.com/18F/identity-idp/blob/e8555810d4a18870f233d3330e5ae6b3931c2bcd/app/views/idv/personal_key/show.html.erb#L10

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/164470820-8e8ebcc0-5bb5-4698-8ddf-c65f20c14fc0.png)
