### PR TITLE
Drop unused account_recovery_requests_table

### DIFF
--- a/db/primary_migrate/20220421183611_drop_account_recovery_requests.rb
+++ b/db/primary_migrate/20220421183611_drop_account_recovery_requests.rb
@@ -1,0 +1,16 @@
+class DropAccountRecoveryRequests < ActiveRecord::Migration[6.1]
+  def up
+    drop_table :account_recovery_requests
+  end
+
+  def down
+    create_table :account_recovery_requests do |t|
+      t.integer :user_id, null: false
+      t.string :request_token, null: false
+      t.datetime :requested_at, null: false
+      t.timestamps
+    end
+    add_index :account_recovery_requests, %i[user_id], unique: true, using: :btree
+    add_index :account_recovery_requests, %i[request_token], unique: true, using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_06_155240) do
+ActiveRecord::Schema.define(version: 2022_04_21_183611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-
-  create_table "account_recovery_requests", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "request_token", null: false
-    t.datetime "requested_at", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["request_token"], name: "index_account_recovery_requests_on_request_token", unique: true
-    t.index ["user_id"], name: "index_account_recovery_requests_on_user_id", unique: true
-  end
 
   create_table "account_reset_requests", force: :cascade do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
It looks like we intended to drop it after https://github.com/18F/identity-idp/pull/4980, so it should be ok to drop it now