### PR TITLE
Skip querying unused user columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp]
+  self.ignored_columns = %w[totp_timestamp idv_attempted_at idv_attempts attribute_cost
+                            failed_attempts locked_at]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer


### PR DESCRIPTION
Then we can drop them