### PR TITLE
Split up "Account Reset" analytics event (LG-5910)

### DIFF
--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -4,7 +4,7 @@ module AccountReset
       return render :show unless token
 
       result = AccountReset::ValidateCancelToken.new(token).call
-      track_event(result)
+      analytics.account_reset_cancel_token_validation(**result.to_h)
 
       if result.success?
         handle_valid_token
@@ -16,7 +16,7 @@ module AccountReset
     def create
       result = AccountReset::Cancel.new(session[:cancel_token]).call
 
-      track_event(result)
+      analytics.account_reset_cancel(**result.to_h)
 
       handle_success if result.success?
 
@@ -24,10 +24,6 @@ module AccountReset
     end
 
     private
-
-    def track_event(result)
-      analytics.account_reset(**result.to_h)
-    end
 
     def handle_valid_token
       session[:cancel_token] = token

--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -4,7 +4,7 @@ module AccountReset
       render :show and return unless token
 
       result = AccountReset::ValidateGrantedToken.new(token).call
-      analytics.account_reset(**result.to_h)
+      analytics.account_reset_granted_token_validation(**result.to_h)
 
       if result.success?
         handle_valid_token
@@ -16,7 +16,7 @@ module AccountReset
     def delete
       granted_token = session.delete(:granted_token)
       result = AccountReset::DeleteAccount.new(granted_token).call
-      analytics.account_reset(**result.to_h.except(:email))
+      analytics.account_reset_delete(**result.to_h.except(:email))
 
       if result.success?
         handle_successful_deletion(result)

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -18,7 +18,7 @@ module AccountReset
 
     def create_account_reset_request
       response = AccountReset::CreateRequest.new(current_user).call
-      analytics.account_reset(**response.to_h.merge(analytics_attributes))
+      analytics.account_reset_request(**response.to_h.merge(analytics_attributes))
     end
 
     def confirm_two_factor_enabled
@@ -29,7 +29,6 @@ module AccountReset
 
     def analytics_attributes
       {
-        event: 'request',
         sms_phone: TwoFactorAuthentication::PhonePolicy.new(current_user).configured?,
         totp: TwoFactorAuthentication::AuthAppPolicy.new(current_user).configured?,
         piv_cac: TwoFactorAuthentication::PivCacPolicy.new(current_user).configured?,

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -18,7 +18,7 @@ module AccountReset
 
     def create_account_reset_request
       response = AccountReset::CreateRequest.new(current_user).call
-      analytics.account_reset_request(**response.to_h.merge(analytics_attributes))
+      analytics.account_reset_request(**response.to_h, **analytics_attributes)
     end
 
     def confirm_two_factor_enabled

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -5,7 +5,7 @@ module AccountReset
     before_action :confirm_two_factor_enabled
 
     def show
-      analytics.track_event(Analytics::ACCOUNT_RESET_VISIT)
+      analytics.account_reset_visit
     end
 
     def create

--- a/app/services/account_reset/cancel.rb
+++ b/app/services/account_reset/cancel.rb
@@ -54,7 +54,6 @@ module AccountReset
 
     def extra_analytics_attributes
       @telephony_response.to_h.merge(
-        event: 'cancel',
         user_id: user.uuid,
       )
     end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -59,7 +59,6 @@ module AccountReset
     def extra_analytics_attributes
       {
         user_id: user.uuid,
-        event: 'delete',
         email: user.email_addresses.take&.email,
         account_age_in_days: account_age,
         mfa_method_counts: mfa_method_counts,

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -23,10 +23,7 @@ module AccountReset
         notifications_sent += 1 if grant_request_and_send_email(arr)
       end
 
-      analytics.account_reset(
-        event: :notifications,
-        count: notifications_sent,
-      )
+      analytics.account_reset_notifications(count: notifications_sent)
 
       notifications_sent
     end

--- a/app/services/account_reset/validate_cancel_token.rb
+++ b/app/services/account_reset/validate_cancel_token.rb
@@ -23,7 +23,6 @@ module AccountReset
 
     def extra_analytics_attributes
       {
-        event: 'cancel token validation',
         user_id: user.uuid,
       }
     end

--- a/app/services/account_reset/validate_granted_token.rb
+++ b/app/services/account_reset/validate_granted_token.rb
@@ -20,7 +20,6 @@ module AccountReset
     def extra_analytics_attributes
       {
         user_id: user.uuid,
-        event: 'granted token validation',
       }
     end
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -133,7 +133,6 @@ class Analytics
   end
 
   # rubocop:disable Layout/LineLength
-  ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'
   IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -117,7 +117,6 @@ module AnalyticsEvents
   end
 
   # @identity.idp.event_name Account deletion and reset visited
-  # @identity.idp.previous_event_name Account Reset
   # User visited the account deletion and reset page
   def account_reset_visit
     track_event('Account deletion and reset visited')

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5,6 +5,7 @@ module AnalyticsEvents
   # @param [String] user_id
   # @param [String, nil] message_id from AWS Pinpoint API
   # @param [String, nil] request_id from AWS Pinpoint API
+  # An account reset was cancelled
   def account_reset_cancel(user_id:, message_id: nil, request_id: nil, **extra)
     track_event(
       'Account Reset: cancel',

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1,62 +1,118 @@
 # rubocop:disable Metrics/ModuleLength
 module AnalyticsEvents
-  # @identity.idp.event_name Account Reset
-  # @param [Boolean] success
-  # @param ["cancel", "delete", "cancel token validation", "granted token validation",
-  #  "notifications"] event
-  # @param [String] message_id from AWS Pinpoint API
-  # @param [String] request_id from AWS Pinpoint API
-  # @param [Boolean] sms_phone
-  # @param [Boolean] totp does the user have an authentication app as a 2FA option?
-  # @param [Boolean] piv_cac does the user have PIV/CAC as a 2FA option?
-  # @param [Integer] count number of notifications sent
-  # @param [Hash] errors
-  # @param [Hash] error_details
+  # @identity.idp.event_name Account Reset: cancel
+  # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
-  # @param [Integer] account_age_in_days
-  # @param [Hash] mfa_method_counts
-  # @param [Integer] email_addresses number of email addresses the user has
-  # Tracks events related to a user requesting to delete their account during the sign in process
-  # (because they have no other means to sign in).
-  def account_reset(
-    success: nil,
-    event: nil,
-    message_id: nil,
-    piv_cac: nil,
-    request_id: nil,
-    sms_phone: nil,
-    totp: nil,
-    count: nil,
-    errors: nil,
-    user_id: nil,
-    account_age_in_days: nil,
-    mfa_method_counts: nil,
-    pii_like_keypaths: nil,
-    error_details: nil,
-    email_addresses: nil,
-    **extra
-  )
+  # @param [String, nil] message_id from AWS Pinpoint API
+  # @param [String, nil] request_id from AWS Pinpoint API
+  def account_reset_cancel(user_id:, message_id: nil, request_id: nil, **extra)
     track_event(
-      'Account Reset',
+      'Account Reset: cancel',
       {
-        success: success,
-        event: event,
-        message_id: message_id,
-        piv_cac: piv_cac,
-        request_id: request_id,
-        sms_phone: sms_phone,
-        totp: totp,
-        count: count,
-        errors: errors,
         user_id: user_id,
-        account_age_in_days: account_age_in_days,
-        mfa_method_counts: mfa_method_counts,
-        pii_like_keypaths: pii_like_keypaths,
-        error_details: error_details,
-        email_addresses: email_addresses,
+        message_id: message_id,
+        request_id: request_id,
         **extra,
       }.compact,
     )
+  end
+
+  # @identity.idp.event_name Account Reset: delete
+  # @identity.idp.previous_event_name Account Reset
+  # @param [Boolean] success
+  # @param [String] user_id
+  # @param [Integer] account_age_in_days
+  # @param [Hash] mfa_method_counts
+  # @param [Hash] errors
+  # An account has been deleted through the account reset flow
+  def account_reset_delete(
+    success:,
+    user_id:,
+    account_age_in_days:,
+    mfa_method_counts:,
+    errors: nil,
+    **extra
+  )
+    track_event(
+      'Account Reset: delete',
+      success: success,
+      user_id: user_id,
+      account_age_in_days: account_age_in_days,
+      mfa_method_counts: mfa_method_counts,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @identity.idp.event_name Account Reset: request
+  # @identity.idp.previous_event_name Account Reset
+  # @param [Boolean] success
+  # @param [Boolean] sms_phone does the user have a phone factor configured?
+  # @param [Boolean] totp does the user have an authentication app as a 2FA option?
+  # @param [Boolean] piv_cac does the user have PIV/CAC as a 2FA option?
+  # @param [Integer] email_addresses number of email addresses the user has
+  # @param [String, nil] message_id from AWS Pinpoint API
+  # @param [String, nil] request_id from AWS Pinpoint API
+  # An account reset has been requested
+  def account_reset_request(
+    success:,
+    sms_phone:,
+    totp:,
+    piv_cac:,
+    email_addresses:,
+    request_id: nil,
+    message_id: nil,
+    **extra
+  )
+    track_event(
+      'Account Reset: request',
+      {
+        success: success,
+        sms_phone: sms_phone,
+        totp: totp,
+        piv_cac: piv_cac,
+        email_addresses: email_addresses,
+        request_id: request_id,
+        message_id: message_id,
+        **extra,
+      }.compact,
+    )
+  end
+
+  # @identity.idp.event_name Account Reset: cancel token validation
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the token used for cancelling an account reset
+  def account_reset_cancel_token_validation(user_id:, errors: nil, **extra)
+    track_event(
+      'Account Reset: cancel token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @identity.idp.event_name Account Reset: granted token validation
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the granted token for account reset
+  def account_reset_granted_token_validation(user_id: nil, errors: nil, **extra)
+    track_event(
+      'Account Reset: granted token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @identity.idp.event_name Account Reset: notifications
+  # @identity.idp.previous_event_name Account Reset
+  # @param [Integer] count number of email notifications sent
+  # Account reset was performed, logs the number of email notifications sent
+  def account_reset_notifications(count:, **extra)
+    track_event('Account Reset: notifications', count: count, **extra)
   end
 
   # @identity.idp.event_name Account Delete submitted

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -115,6 +115,13 @@ module AnalyticsEvents
     track_event('Account Reset: notifications', count: count, **extra)
   end
 
+  # @identity.idp.event_name Account deletion and reset visited
+  # @identity.idp.previous_event_name Account Reset
+  # User visited the account deletion and reset page
+  def account_reset_visit
+    track_event('Account deletion and reset visited')
+  end
+
   # @identity.idp.event_name Account Delete submitted
   # @param [Boolean] success
   # When a user submits a form to delete their account

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -14,13 +14,12 @@ describe AccountReset::CancelController do
       analytics_hash = {
         success: true,
         errors: {},
-        event: 'cancel',
         user_id: user.uuid,
         message_id: 'fake-message-id',
         request_id: 'fake-message-request-id',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset', analytics_hash)
+      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
 
       post :create
     end
@@ -33,11 +32,10 @@ describe AccountReset::CancelController do
         error_details: {
           token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
         },
-        event: 'cancel',
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset', analytics_hash)
+      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
       session[:cancel_token] = 'FOO'
 
       post :create
@@ -49,11 +47,10 @@ describe AccountReset::CancelController do
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_missing', app_name: APP_NAME)] },
         error_details: { token: [:blank] },
-        event: 'cancel',
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset', analytics_hash)
+      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
 
       post :create
     end
@@ -91,14 +88,14 @@ describe AccountReset::CancelController do
       stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
-        event: 'cancel token validation',
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)] },
         error_details: {
           token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
         },
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).
+        with('Account Reset: cancel token validation', properties)
 
       get :show, params: { token: 'FOO' }
 

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -15,7 +15,6 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: user.uuid,
-        event: 'delete',
         success: true,
         errors: {},
         mfa_method_counts: { backup_codes: 10, webauthn: 2, phone: 2 },
@@ -23,7 +22,7 @@ describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
       }
       expect(@analytics).
-        to receive(:track_event).with('Account Reset', properties)
+        to receive(:track_event).with('Account Reset: delete', properties)
 
       delete :delete
 
@@ -35,7 +34,6 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
-        event: 'delete',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_invalid', app_name: APP_NAME)] },
         error_details: {
@@ -45,7 +43,7 @@ describe AccountReset::DeleteAccountController do
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
 
       delete :delete
 
@@ -59,7 +57,6 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
-        event: 'delete',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_missing', app_name: APP_NAME)] },
         error_details: { token: [:blank] },
@@ -67,7 +64,7 @@ describe AccountReset::DeleteAccountController do
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
 
       delete :delete
 
@@ -86,7 +83,6 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: user.uuid,
-        event: 'delete',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
         error_details: {
@@ -96,7 +92,7 @@ describe AccountReset::DeleteAccountController do
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 2,
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
 
       travel_to(Time.zone.now + 2.days) do
         session[:granted_token] = AccountResetRequest.all[0].granted_token
@@ -115,14 +111,14 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
-        event: 'granted token validation',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_invalid', app_name: APP_NAME)] },
         error_details: {
           token: [t('errors.account_reset.granted_token_invalid', app_name: APP_NAME)],
         },
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).
+        with('Account Reset: granted token validation', properties)
 
       get :show, params: { token: 'FOO' }
 
@@ -140,14 +136,14 @@ describe AccountReset::DeleteAccountController do
       stub_analytics
       properties = {
         user_id: user.uuid,
-        event: 'granted token validation',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
         error_details: {
           token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)],
         },
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', properties)
+      expect(@analytics).to receive(:track_event).
+        with('Account Reset: granted token validation', properties)
 
       travel_to(Time.zone.now + 2.days) do
         get :show, params: { token: AccountResetRequest.all[0].granted_token }

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -41,14 +41,13 @@ describe AccountReset::RequestController do
       stub_analytics
       attributes = {
         success: true,
-        event: 'request',
         sms_phone: false,
         totp: true,
         piv_cac: false,
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', attributes)
+      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
 
       post :create
     end
@@ -60,7 +59,6 @@ describe AccountReset::RequestController do
       stub_analytics
       attributes = {
         success: true,
-        event: 'request',
         sms_phone: true,
         totp: false,
         piv_cac: false,
@@ -69,7 +67,7 @@ describe AccountReset::RequestController do
         message_id: 'fake-message-id',
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', attributes)
+      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
 
       post :create
     end
@@ -81,14 +79,13 @@ describe AccountReset::RequestController do
       stub_analytics
       attributes = {
         success: true,
-        event: 'request',
         sms_phone: false,
         totp: false,
         piv_cac: true,
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset', attributes)
+      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
 
       post :create
     end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -28,7 +28,7 @@ describe AccountReset::RequestController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(Analytics::ACCOUNT_RESET_VISIT)
+      expect(@analytics).to receive(:track_event).with('Account deletion and reset visited')
 
       get :show
     end


### PR DESCRIPTION
The  "Account Reset" event was wearing a lot of hats... it had an `event` key and was basically combining a bunch of different separate events. There were some fields in common across these, but I think it's easier to reason about if we separate them. 
- cancel
- delete
- request
- cancel token validation
- granted token valdiation
- notifications

Bonus: migrated `ACCOUNT_RESET_VISIT` while I was here