### PR TITLE
LG-6192  Add alert banner for successful completion of Password Entry

### DIFF
--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -1,5 +1,7 @@
 import { FormSteps } from '@18f/identity-form-steps';
 import { StepIndicator, StepIndicatorStep, StepStatus } from '@18f/identity-step-indicator';
+import { t } from '@18f/identity-i18n';
+import { Alert } from '@18f/identity-components';
 import { STEPS } from './steps';
 
 export interface VerifyFlowValues {
@@ -35,6 +37,9 @@ export function VerifyFlow({ initialValues = {}, basePath, appName }: VerifyFlow
         <StepIndicatorStep title="Verify phone or address" status={StepStatus.COMPLETE} />
         <StepIndicatorStep title="Secure your account" status={StepStatus.CURRENT} />
       </StepIndicator>
+      <Alert type="success" className="margin-bottom-4">
+          {t('idv.messages.confirm')}
+      </Alert>
       <FormSteps
         steps={STEPS}
         initialValues={initialValues}

--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -38,7 +38,7 @@ export function VerifyFlow({ initialValues = {}, basePath, appName }: VerifyFlow
         <StepIndicatorStep title="Secure your account" status={StepStatus.CURRENT} />
       </StepIndicator>
       <Alert type="success" className="margin-bottom-4">
-          {t('idv.messages.confirm')}
+        {t('idv.messages.confirm')}
       </Alert>
       <FormSteps
         steps={STEPS}

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -1,4 +1,4 @@
-import { PageHeading, Alert } from '@18f/identity-components';
+import { PageHeading } from '@18f/identity-components';
 import { ClipboardButton } from '@18f/identity-clipboard-button';
 import { PrintButton } from '@18f/identity-print-button';
 import { t } from '@18f/identity-i18n';
@@ -16,11 +16,6 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
 
   return (
     <>
-      {customElements.get('lg-step-indicator') && (
-        <Alert type="success" className="margin-bottom-4">
-          {t('idv.messages.confirm')}
-        </Alert>
-      )}
       <PageHeading>{t('headings.personal_key')}</PageHeading>
       <p>{t('instructions.personal_key.info')}</p>
       <div className="full-width-box margin-y-5">

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -1,4 +1,4 @@
-import { PageHeading } from '@18f/identity-components';
+import { PageHeading, Alert } from '@18f/identity-components';
 import { ClipboardButton } from '@18f/identity-clipboard-button';
 import { PrintButton } from '@18f/identity-print-button';
 import { t } from '@18f/identity-i18n';
@@ -16,6 +16,11 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
 
   return (
     <>
+      {customElements.get('lg-step-indicator') && (
+        <Alert type="success" className="margin-bottom-4">
+          {t('idv.messages.confirm')}
+        </Alert>
+      )}
       <PageHeading>{t('headings.personal_key')}</PageHeading>
       <p>{t('instructions.personal_key.info')}</p>
       <div className="full-width-box margin-y-5">


### PR DESCRIPTION
[LG-6192  Add alert banner for successful completion of Password Entry](https://cm-jira.usa.gov/browse/LG-6192)

**Why:** We need to let the user know that their data has been encrypted after they enter their password

**Testing Instructions**
1. Make sure idv_api_enabled is set to true in application.yml.default
2. Go to http://localhost:3000/verify/v2/personal_key
3. Observe that the alert is present per screenshot

**Screenshot**
<img width="719" alt="Screen Shot 2022-04-21 at 7 22 01 PM" src="https://user-images.githubusercontent.com/6639858/164567979-d167d6be-a6c5-4d26-9157-65940e77c9f3.png">

**Note** 

This is a draft PR because I'm not sure about my idea for handling the fact that users can reset their personal key after they go through the steps. Since we don't want to display the alert in that scenario, I thought this maybe could be handled by simply checking if the step indicator element is present or not. Major assumption being that resetting the personal key does not involve its own multi step flow (I tried looking for it in the account dashboard to confirm but couldn't seem to find it)  

