### PR TITLE
Include "personal_key" as alertable key in analytics PiiDetector

### DIFF
--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -26,7 +26,11 @@ module Users
       else
         result = personal_key_form.submit
 
-        analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED, result.to_h)
+        analytics.track_event(
+          Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED,
+          **result.to_h,
+          pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
+        )
         if result.success?
           handle_success(decrypted_pii: personal_key_form.decrypted_pii)
         else

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -80,7 +80,11 @@ class Analytics
   end
 
   def track_mfa_submit_event(attributes)
-    track_event(MULTI_FACTOR_AUTH, attributes)
+    track_event(
+      MULTI_FACTOR_AUTH,
+      **attributes,
+      pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
+    )
     attributes[:success] ? 'success' : 'fail'
   end
 

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -95,7 +95,9 @@ describe Users::VerifyPersonalKeyController do
         stub_analytics
         expect(@analytics).to receive(:track_event).with(
           Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED,
-          { errors: {}, success: true },
+          errors: {},
+          success: true,
+          pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
         ).once
 
         expect(@analytics).to receive(:track_event).with(
@@ -134,6 +136,7 @@ describe Users::VerifyPersonalKeyController do
           errors: { personal_key: ['Please fill in this field.', 'Incorrect personal key'] },
           error_details: { personal_key: [:blank, :personal_key_incorrect] },
           success: false,
+          pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
         ).once
         expect(@analytics).to receive(:track_event).with(
           Analytics::THROTTLER_RATE_LIMIT_TRIGGERED,

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -37,7 +37,7 @@ class FakeAnalytics
         end
       end
 
-      pii_attr_names = Pii::Attributes.members - [
+      pii_attr_names = Pii::Attributes.members + [:personal_key] - [
         :state, # state on its own is not enough to be a pii leak
       ]
 


### PR DESCRIPTION
Prompted by: https://github.com/18F/identity-idp/pull/6237#discussion_r856185655

**Why**: Since we don't want to be including this detail in any logs, as it is password-like.