### PR TITLE
drop unused doc_auths table

### DIFF
--- a/app/models/doc_auth_record.rb
+++ b/app/models/doc_auth_record.rb
@@ -1,6 +1,0 @@
-class DocAuthRecord < ApplicationRecord
-  self.table_name = 'doc_auths'
-
-  belongs_to :user, inverse_of: :doc_auth
-  validates :user_id, presence: true
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,6 @@ class User < ApplicationRecord
   has_many :webauthn_configurations, dependent: :destroy, inverse_of: :user
   has_many :piv_cac_configurations, dependent: :destroy, inverse_of: :user
   has_many :auth_app_configurations, dependent: :destroy, inverse_of: :user
-  has_one :doc_auth, dependent: :destroy, inverse_of: :user, class_name: 'DocAuthRecord'
   has_many :backup_code_configurations, dependent: :destroy
   has_many :document_capture_sessions, dependent: :destroy
   has_many :throttles, dependent: :destroy

--- a/db/primary_migrate/20220422190622_drop_doc_auths.rb
+++ b/db/primary_migrate/20220422190622_drop_doc_auths.rb
@@ -1,0 +1,16 @@
+class DropDocAuths < ActiveRecord::Migration[6.1]
+  def up
+    drop_table :doc_auths
+  end
+
+  def down
+    create_table :doc_auths do |t|
+      t.references :user, null: false
+      t.datetime :attempted_at
+      t.integer :attempts, default: 0
+      t.datetime :license_confirmed_at
+      t.datetime :selfie_confirmed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_183611) do
+ActiveRecord::Schema.define(version: 2022_04_22_190622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -172,17 +172,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_183611) do
     t.boolean "aamva"
     t.index ["user_id"], name: "index_doc_auth_logs_on_user_id", unique: true
     t.index ["verified_view_at"], name: "index_doc_auth_logs_on_verified_view_at"
-  end
-
-  create_table "doc_auths", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.datetime "attempted_at"
-    t.integer "attempts", default: 0
-    t.datetime "license_confirmed_at"
-    t.datetime "selfie_confirmed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_doc_auths_on_user_id"
   end
 
   create_table "document_capture_sessions", force: :cascade do |t|

--- a/spec/models/doc_auth_record_spec.rb
+++ b/spec/models/doc_auth_record_spec.rb
@@ -1,8 +1,0 @@
-require 'rails_helper'
-
-describe DocAuthRecord do
-  describe 'Associations' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to validate_presence_of(:user_id) }
-  end
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe User do
     it { is_expected.to have_one(:account_reset_request) }
     it { is_expected.to have_many(:phone_configurations) }
     it { is_expected.to have_many(:webauthn_configurations) }
-    it { is_expected.to have_one(:doc_auth) }
     it { is_expected.to have_one(:proofing_component) }
     it { is_expected.to have_many(:throttles) }
   end


### PR DESCRIPTION
Looks like the last usage was removed in https://github.com/18F/identity-idp/pull/4368