### PR TITLE
Fix 500 error on sign up completions page

### DIFF
--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -1,6 +1,7 @@
 module VerifySpAttributesConcern
   def needs_completion_screen_reason
     return nil if sp_session[:issuer].blank?
+    return nil if sp_session&.dig(:request_url).blank?
 
     if sp_session_identity.nil?
       :new_sp

--- a/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
+++ b/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe VerifySpAttributesConcern do
         {
           issuer: issuer,
           requested_attributes: requested_attributes,
+          request_url: 'http://localhost',
         }
       end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -10,12 +10,24 @@ describe SignUp::CompletionsController do
         allow(@analytics).to receive(:track_event)
       end
 
+      it 'redirects to account page when SP request URL is not present' do
+          user = create(:user)
+          stub_sign_in(user)
+          subject.session[:sp] = {
+            issuer: current_sp.issuer,
+          }
+          get :show
+
+          expect(response).to redirect_to account_url
+      end
+
       context 'IAL1' do
         it 'tracks page visit' do
           user = create(:user)
           stub_sign_in(user)
           subject.session[:sp] = {
-            issuer: current_sp.issuer, ial2: false, requested_attributes: [:email]
+            issuer: current_sp.issuer, ial2: false, requested_attributes: [:email],
+            request_url: 'http://localhost:3000'
           }
           get :show
 
@@ -41,7 +53,8 @@ describe SignUp::CompletionsController do
         before do
           stub_sign_in(user)
           subject.session[:sp] = {
-            issuer: current_sp.issuer, ial2: true, requested_attributes: [:email]
+            issuer: current_sp.issuer, ial2: true, requested_attributes: [:email],
+            request_url: 'http://localhost:3000'
           }
           allow(controller).to receive(:user_session).and_return('decrypted_pii' => pii.to_json)
         end
@@ -101,7 +114,8 @@ describe SignUp::CompletionsController do
         user = create(:user)
         sp = create(:service_provider, issuer: 'https://awesome')
         stub_sign_in(user)
-        subject.session[:sp] = { issuer: sp.issuer, ial2: false, requested_attributes: [:email] }
+        subject.session[:sp] = { issuer: sp.issuer, ial2: false, requested_attributes: [:email],
+                                 request_url: 'http://localhost:3000' }
         get :show
 
         expect(response).to render_template(:show)


### PR DESCRIPTION
Currently, we will redirect to the sign up completions page even if we don't have a URL to redirect to, which can cause 500 errors ([NR Link](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=21600000&state=b4d1a878-b240-36ff-45fe-79ec61e4e6dd))

This is a slight follow up to (#6139)