### PR TITLE
Add missing costs tracking for async doc auth

### DIFF
--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -63,7 +63,7 @@ module Idv
       end
 
       def process_result(async_state)
-        add_cost(:acuant_result) if async_state.result.to_h[:billed]
+        add_costs(async_state.result)
       end
 
       def verify_document_capture_session

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -25,7 +25,8 @@ describe Idv::Actions::VerifyDocumentStatusAction do
   end
   let(:done) { true }
   let(:async_state) { OpenStruct.new(result: result, pii: pii, pii_from_doc: pii, 'done?' => done) }
-  let(:sp) { create(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:test_cookie') }
+  let(:issuer) { 'urn:gov:gsa:openidconnect:sp:test_cookie' }
+  let(:sp) { create(:service_provider, issuer: issuer) }
 
   subject { described_class.new(flow) }
 
@@ -50,7 +51,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
       it 'adds costs' do
         subject.call
 
-        expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+        expect(SpCost.where(issuer: issuer).map(&:cost_type)).to contain_exactly(
           'acuant_front_image',
           'acuant_back_image',
           'acuant_result',
@@ -63,7 +64,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
         it 'adds costs' do
           subject.call
 
-          expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+          expect(SpCost.where(issuer: issuer).map(&:cost_type)).to contain_exactly(
             'acuant_front_image',
             'acuant_back_image',
           )
@@ -80,7 +81,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
         it 'adds costs' do
           subject.call
 
-          expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+          expect(SpCost.where(issuer: issuer).map(&:cost_type)).to contain_exactly(
             'acuant_front_image',
             'acuant_back_image',
             'acuant_selfie',

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -4,14 +4,16 @@ describe Idv::Actions::VerifyDocumentStatusAction do
   include IdvHelper
 
   let(:user) { create(:user) }
-  let(:session) { { 'idv/doc_auth' => {} } }
+  let(:sp_session) { {} }
+  let(:session) { { 'idv/doc_auth' => {}, sp: sp_session } }
   let(:controller) do
     instance_double(Idv::DocAuthController, url_options: {}, session: session, analytics: analytics)
   end
   let(:flow) { Idv::Flows::DocAuthFlow.new(controller, session, 'idv/doc_auth') }
   let(:analytics) { FakeAnalytics.new }
+  let(:billed) { true }
   let(:result) do
-    { doc_auth_result: 'Passed', success: true, errors: {}, exception: nil, billed: true }
+    { doc_auth_result: 'Passed', success: true, errors: {}, exception: nil, billed: billed }
   end
   let(:pii) do
     {
@@ -23,6 +25,7 @@ describe Idv::Actions::VerifyDocumentStatusAction do
   end
   let(:done) { true }
   let(:async_state) { OpenStruct.new(result: result, pii: pii, pii_from_doc: pii, 'done?' => done) }
+  let(:sp) { create(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:test_cookie') }
 
   subject { described_class.new(flow) }
 
@@ -30,8 +33,8 @@ describe Idv::Actions::VerifyDocumentStatusAction do
     context 'successful async result' do
       before do
         allow(subject).to receive(:async_state).and_return(async_state)
-        allow(subject).to receive(:add_cost).and_return(true)
         allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:current_sp).and_return(sp)
       end
 
       it 'calls analytics to log the successful event' do
@@ -42,6 +45,48 @@ describe Idv::Actions::VerifyDocumentStatusAction do
           success: true,
           errors: {},
         )
+      end
+
+      it 'adds costs' do
+        subject.call
+
+        expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+          'acuant_front_image',
+          'acuant_back_image',
+          'acuant_result',
+        )
+      end
+
+      context 'unbilled' do
+        let(:billed) { false }
+
+        it 'adds costs' do
+          subject.call
+
+          expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+            'acuant_front_image',
+            'acuant_back_image',
+          )
+        end
+      end
+
+      context 'ial2 strict' do
+        let(:sp_session) { { ial2_strict: true } }
+
+        before do
+          allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
+        end
+
+        it 'adds costs' do
+          subject.call
+
+          expect(SpCost.all.map(&:cost_type)).to contain_exactly(
+            'acuant_front_image',
+            'acuant_back_image',
+            'acuant_selfie',
+            'acuant_result',
+          )
+        end
       end
     end
 


### PR DESCRIPTION
**Why**: So that we are consistently tracking costs between sync and async implementations.

Discovered in #6229, via failing "SP Costing" feature spec when run against identity verification with JavaScript enabled.

https://github.com/18F/identity-idp/blob/a013cede5d029ea4edb38a92223cca1ae19280c1/spec/features/sp_cost_tracking_spec.rb#L23-L29

