### PR TITLE
Fix SAML auth context handling for IAL2 strict request

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -90,7 +90,7 @@ class SamlIdpController < ApplicationController
   end
 
   def profile_or_identity_needs_verification_or_decryption?
-    return false unless ial2_requested?
+    return false unless ial_context.ial2_or_greater?
     profile_needs_verification? || identity_needs_verification? || identity_needs_decryption?
   end
 

--- a/app/presenters/saml_request_presenter.rb
+++ b/app/presenters/saml_request_presenter.rb
@@ -23,7 +23,7 @@ class SamlRequestPresenter
   end
 
   def requested_attributes
-    if ial2_authn_context? || ialmax_authn_context?
+    if ial2_authn_context? || ial2_strict_authn_context? || ialmax_authn_context?
       bundle.map { |attr| ATTRIBUTE_TO_FRIENDLY_NAME_MAP[attr] }.compact.uniq
     else
       attrs = [:email]
@@ -38,6 +38,10 @@ class SamlRequestPresenter
 
   def ial2_authn_context?
     (Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS & authn_context).present?
+  end
+
+  def ial2_strict_authn_context?
+    authn_context.include? Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF
   end
 
   def ialmax_authn_context?

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -32,7 +32,11 @@ module Saml
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
       VALID_AUTHN_CONTEXTS = IdentityConfig.store.valid_authn_contexts
-      IAL2_AUTHN_CONTEXTS = [IAL2_AUTHN_CONTEXT_CLASSREF, LOA3_AUTHN_CONTEXT_CLASSREF].freeze
+      IAL2_AUTHN_CONTEXTS = [
+        IAL2_AUTHN_CONTEXT_CLASSREF,
+        IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+        LOA3_AUTHN_CONTEXT_CLASSREF,
+      ].freeze
 
       AUTHN_CONTEXT_CLASSREF_TO_IAL = {
         LOA1_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL1,

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -32,11 +32,7 @@ module Saml
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
       VALID_AUTHN_CONTEXTS = IdentityConfig.store.valid_authn_contexts
-      IAL2_AUTHN_CONTEXTS = [
-        IAL2_AUTHN_CONTEXT_CLASSREF,
-        IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
-        LOA3_AUTHN_CONTEXT_CLASSREF,
-      ].freeze
+      IAL2_AUTHN_CONTEXTS = [IAL2_AUTHN_CONTEXT_CLASSREF, LOA3_AUTHN_CONTEXT_CLASSREF].freeze
 
       AUTHN_CONTEXT_CLASSREF_TO_IAL = {
         LOA1_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL1,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -442,7 +442,15 @@ describe SamlIdpController do
       )
     end
 
-    context 'with IAL2 and the identity is already verified' do
+    shared_examples 'a verified identity' do |authn_context, ial|
+      let(:ial2_settings) do
+        saml_settings(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: authn_context,
+          },
+        )
+      end
       let(:user) { create(:profile, :active, :verified).user }
       let(:pii) do
         Pii::Attributes.new_from_hash(
@@ -457,7 +465,7 @@ describe SamlIdpController do
         ial2_authnrequest = saml_authn_request_url(
           overrides: {
             issuer: sp1_issuer,
-            authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+            authn_context: authn_context,
           },
         )
         raw_req = CGI.unescape ial2_authnrequest.split('SAMLRequest').last
@@ -476,7 +484,7 @@ describe SamlIdpController do
 
       before do
         stub_sign_in(user)
-        IdentityLinker.new(user, sp1).link_identity(ial: 2)
+        IdentityLinker.new(user, sp1).link_identity(ial: ial)
         user.identities.last.update!(
           verified_attributes: %w[given_name family_name social_security_number address],
         )
@@ -491,9 +499,9 @@ describe SamlIdpController do
         saml_get_auth(ial2_settings)
       end
 
-      it 'sets identity ial to 2' do
+      it 'sets identity ial' do
         saml_get_auth(ial2_settings)
-        expect(user.identities.last.ial).to eq(2)
+        expect(user.identities.last.ial).to eq(ial)
       end
 
       it 'does not redirect the user to the IdV URL' do
@@ -521,23 +529,23 @@ describe SamlIdpController do
         stub_analytics
         expect(@analytics).to receive(:track_event).
           with('SAML Auth Request',
-               requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+               requested_ial: authn_context,
                service_provider: sp1_issuer)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SAML_AUTH,
                success: true,
                errors: {},
                nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-               authn_context: ['http://idmanagement.gov/ns/assurance/ial/2'],
+               authn_context: [authn_context],
                authn_context_comparison: 'exact',
-               requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+               requested_ial: authn_context,
                service_provider: sp1_issuer,
                endpoint: '/api/saml/auth2022',
                idv: false,
                finish_profile: false)
         expect(@analytics).to receive(:track_event).
           with(Analytics::SP_REDIRECT_INITIATED,
-               ial: 2)
+               ial: ial)
 
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         saml_get_auth(ial2_settings)
@@ -551,6 +559,22 @@ describe SamlIdpController do
           expect(response).to redirect_to capture_password_url
         end
       end
+    end
+
+    context 'with IAL2 and the identity is already verified' do
+      it_behaves_like 'a verified identity',
+                      Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                      Idp::Constants::IAL2
+    end
+
+    context 'with IAL2 strict and the identity is already verified' do
+      before do
+        allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
+      end
+
+      it_behaves_like 'a verified identity',
+                      Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF,
+                      Idp::Constants::IAL2_STRICT
     end
 
     context 'with IAL2 and the identity is not already verified' do


### PR DESCRIPTION
**Why**: So that an IAL2 strict request behaves similar to a standard IAL2 request, particularly in how a user should be directed to enter their password to decrypt PII if encrypted.

Discovered in #6229, via failing feature specs where user would not be prompted to enter their password to decrypt profile when authenticating as IAL2 strict.