### PR TITLE
LG 6201 audit/implement logs

### DIFF
--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import sinon from 'sinon';
 import { PageHeading } from '@18f/identity-components';
+import * as analytics from '@18f/identity-analytics';
 import FormSteps, { FormStepComponentProps, getStepIndexByName } from './form-steps';
 import FormError from './form-error';
 import FormStepsContext from './form-steps-context';
@@ -19,6 +20,10 @@ interface StepValues {
 
 describe('FormSteps', () => {
   const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    sandbox.spy(analytics, 'trackEvent');
+  });
 
   afterEach(() => {
     sandbox.restore();

--- a/app/javascript/packages/verify-flow/index.spec.tsx
+++ b/app/javascript/packages/verify-flow/index.spec.tsx
@@ -19,11 +19,11 @@ describe('VerifyFlow', () => {
   it('advances through flow to completion', async () => {
     const onComplete = sinon.spy();
 
-    const { getAllByText, getByLabelText } = render(
+    const { getByText, getByLabelText } = render(
       <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={onComplete} />,
     );
 
-    await userEvent.click(getAllByText('forms.buttons.continue')[0]);
+    await userEvent.click(getByText('forms.buttons.continue'));
     await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
     await userEvent.keyboard('{Enter}');
 
@@ -31,12 +31,12 @@ describe('VerifyFlow', () => {
   });
 
   it('calls trackEvents for personal key steps', async () => {
-    const { getByLabelText, getAllByText } = render(
+    const { getByLabelText, getByText, getAllByText } = render(
       <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={() => {}} />,
     );
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key visited');
 
-    await userEvent.click(getAllByText('forms.buttons.continue')[0]);
+    await userEvent.click(getByText('forms.buttons.continue'));
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: show personal key modal');
     await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
     await userEvent.click(getAllByText('forms.buttons.submit.default')[1]);

--- a/app/javascript/packages/verify-flow/index.spec.tsx
+++ b/app/javascript/packages/verify-flow/index.spec.tsx
@@ -1,26 +1,46 @@
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
+import * as analytics from '@18f/identity-analytics';
 import userEvent from '@testing-library/user-event';
 import { VerifyFlow } from './index';
 
 describe('VerifyFlow', () => {
+  const sandbox = sinon.createSandbox();
+  const personalKey = '0000-0000-0000-0000';
+
+  beforeEach(() => {
+    sandbox.spy(analytics, 'trackEvent');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('advances through flow to completion', async () => {
-    const personalKey = '0000-0000-0000-0000';
     const onComplete = sinon.spy();
 
-    const { getByText, getByLabelText } = render(
-      <VerifyFlow
-        appName="Example App"
-        initialValues={{ personalKey }}
-        basePath="/"
-        onComplete={onComplete}
-      />,
+    const { getAllByText, getByLabelText } = render(
+      <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={onComplete} />,
     );
 
-    await userEvent.click(getByText('forms.buttons.continue'));
+    await userEvent.click(getAllByText('forms.buttons.continue')[0]);
     await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
     await userEvent.keyboard('{Enter}');
 
     expect(onComplete).to.have.been.called();
+  });
+
+  it('calls trackEvents for personal key steps', async () => {
+    const { getByLabelText, getAllByText } = render(
+      <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={() => {}} />,
+    );
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key visited');
+
+    await userEvent.click(getAllByText('forms.buttons.continue')[0]);
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: show personal key modal');
+    await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
+    await userEvent.click(getAllByText('forms.buttons.submit.default')[1]);
+
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key submitted');
   });
 });

--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react';
 import { FormSteps } from '@18f/identity-form-steps';
 import { StepIndicator, StepIndicatorStep, StepStatus } from '@18f/identity-step-indicator';
 import { t } from '@18f/identity-i18n';
 import { Alert } from '@18f/identity-components';
+import { trackEvent } from '@18f/identity-analytics';
 import { STEPS } from './steps';
 
 export interface VerifyFlowValues {
@@ -19,7 +21,7 @@ interface VerifyFlowProps {
   /**
    * The path to which the current step is appended to create the current step URL.
    */
-  basePath: string;
+  basePath?: string;
 
   /**
    * Application name, used in generating page titles for current step.
@@ -33,6 +35,19 @@ interface VerifyFlowProps {
 }
 
 export function VerifyFlow({ initialValues = {}, basePath, appName, onComplete }: VerifyFlowProps) {
+  function trackVisitedStepEvent(stepName) {
+    if (stepName === 'personal_key') {
+      trackEvent('IdV: personal key visited');
+    }
+    if (stepName === 'personal_key_confirm') {
+      trackEvent('IdV: show personal key modal');
+    }
+  }
+
+  useEffect(() => {
+    trackVisitedStepEvent(STEPS[0].name);
+  }, []);
+
   return (
     <>
       <StepIndicator className="margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4">
@@ -51,6 +66,14 @@ export function VerifyFlow({ initialValues = {}, basePath, appName, onComplete }
         promptOnNavigate={false}
         basePath={basePath}
         titleFormat={`%{step} - ${appName}`}
+        onStepSubmit={(submittedStepName) => {
+          if (submittedStepName === 'personal_key_confirm') {
+            trackEvent('IdV: personal key submitted');
+          }
+        }}
+        onStepChange={(stepName) => {
+          trackVisitedStepEvent(stepName);
+        }}
         onComplete={onComplete}
       />
     </>

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -47,7 +47,7 @@ describe('PersonalKeyConfirmStep', () => {
     expect(toPreviousStep).to.have.been.called();
   });
 
-  it('calls trackEvent when user dismisses modal by pressing "Back" button ', async () => {
+  it('calls trackEvent when user dismisses modal by pressing "Back" button', async () => {
     const toPreviousStep = sinon.spy();
 
     const { getByText } = render(

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormSteps } from '@18f/identity-form-steps';
+import * as analytics from '@18f/identity-analytics';
 import PersonalKeyConfirmStep from './personal-key-confirm-step';
 
 describe('PersonalKeyConfirmStep', () => {
@@ -13,6 +14,16 @@ describe('PersonalKeyConfirmStep', () => {
     onError() {},
     registerField: () => () => {},
   };
+
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    sandbox.spy(analytics, 'trackEvent');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   it('allows the user to return to the previous step by clicking "Back" button', async () => {
     const toPreviousStep = sinon.spy();
@@ -34,6 +45,17 @@ describe('PersonalKeyConfirmStep', () => {
     await userEvent.type(getByRole('textbox'), '{Escape}');
 
     expect(toPreviousStep).to.have.been.called();
+  });
+
+  it('calls trackEvent when user dismisses modal by pressing "Back" button ', async () => {
+    const toPreviousStep = sinon.spy();
+
+    const { getByText } = render(
+      <PersonalKeyConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
+    );
+
+    await userEvent.click(getByText('forms.buttons.back'));
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: hide personal key modal');
   });
 
   it('allows the user to continue only with a correct value', async () => {

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -4,6 +4,7 @@ import { t } from '@18f/identity-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { Modal } from '@18f/identity-modal';
 import { getAssetPath } from '@18f/identity-assets';
+import { trackEvent } from '@18f/identity-analytics';
 import PersonalKeyStep from '../personal-key/personal-key-step';
 import PersonalKeyInput from './personal-key-input';
 import type { VerifyFlowValues } from '../..';
@@ -14,12 +15,17 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
   const { registerField, value, onChange, toPreviousStep } = stepProps;
   const personalKey = value.personalKey!;
 
+  const closeModalActions = () => {
+    trackEvent('IdV: hide personal key modal');
+    toPreviousStep();
+  };
+
   return (
     <>
       <FormStepsContext.Provider value={{ isLastStep: false, onPageTransition() {} }}>
         <PersonalKeyStep {...stepProps} />
       </FormStepsContext.Provider>
-      <Modal onRequestClose={toPreviousStep}>
+      <Modal onRequestClose={closeModalActions}>
         <div className="pin-top pin-x display-flex flex-column flex-align-center top-neg-3">
           <img alt="" height="60" width="60" src={getAssetPath('p-key.svg')} />
         </div>
@@ -40,7 +46,7 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
               <FormStepsContinueButton className="margin-y-0" />
             </div>
             <div className="grid-col-12 tablet:grid-col-6">
-              <Button isBig isWide isOutline onClick={toPreviousStep}>
+              <Button isBig isWide isOutline onClick={closeModalActions}>
                 {t('forms.buttons.back')}
               </Button>
             </div>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
@@ -24,7 +24,7 @@ describe('PersonalKeyStep', () => {
     sandbox.restore();
   });
 
-  it('calls trackEvent when user clicks on "Download" button ', async () => {
+  it('calls trackEvent when user clicks on "Download" button', async () => {
     const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
 
     const button = getByText('forms.backup_code.download');
@@ -33,14 +33,14 @@ describe('PersonalKeyStep', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: download personal key');
   });
 
-  it('calls trackEvent when user clicks on "Clipboard" button ', async () => {
+  it('calls trackEvent when user clicks on "Clipboard" button', async () => {
     const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
 
     await userEvent.click(getByText('components.clipboard_button.label'));
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: copy personal key');
   });
 
-  it('calls trackEvent when user clicks on "Print" button ', async () => {
+  it('calls trackEvent when user clicks on "Print" button', async () => {
     window.print = () => {};
 
     const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+import * as analytics from '@18f/identity-analytics';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PersonalKeyStep from './personal-key-step';
+
+describe('PersonalKeyStep', () => {
+  const sandbox = sinon.createSandbox();
+  const DEFAULT_PROPS = {
+    onChange() {},
+    onError() {},
+    errors: [],
+    toPreviousStep() {},
+    registerField: () => () => {},
+    unknownFieldErrors: [],
+    value: { personalKey: '' },
+  };
+
+  beforeEach(() => {
+    sandbox.spy(analytics, 'trackEvent');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('calls trackEvent when user clicks on "Download" button ', async () => {
+    const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
+
+    const button = getByText('forms.backup_code.download');
+    button.addEventListener('click', (event) => event.preventDefault());
+    await userEvent.click(button);
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: download personal key');
+  });
+
+  it('calls trackEvent when user clicks on "Clipboard" button ', async () => {
+    const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
+
+    await userEvent.click(getByText('components.clipboard_button.label'));
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: copy personal key');
+  });
+
+  it('calls trackEvent when user clicks on "Print" button ', async () => {
+    window.print = () => {};
+
+    const { getByText } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
+
+    await userEvent.click(getByText('components.print_button.label'));
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: print personal key');
+  });
+});

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -6,6 +6,7 @@ import { formatHTML } from '@18f/identity-react-i18n';
 import { FormStepsContinueButton } from '@18f/identity-form-steps';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { getAssetPath } from '@18f/identity-assets';
+import { trackEvent } from '@18f/identity-analytics';
 import type { VerifyFlowValues } from '../..';
 import DownloadButton from './download-button';
 
@@ -45,15 +46,21 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
       <DownloadButton
         content={personalKey}
         fileName="personal_key.txt"
+        onClick={() => trackEvent('IdV: download personal key')}
         isOutline
         className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0"
       >
         {t('forms.backup_code.download')}
       </DownloadButton>
-      <PrintButton isOutline className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0" />
+      <PrintButton
+        isOutline
+        onClick={() => trackEvent('IdV: print personal key')}
+        className="margin-right-2 margin-bottom-2 tablet:margin-bottom-0"
+      />
       <ClipboardButton
         clipboardText={personalKey}
         isOutline
+        onClick={() => trackEvent('IdV: copy personal key')}
         className="margin-bottom-2 tablet:margin-bottom-0"
       />
       <div className="margin-y-5 clearfix">


### PR DESCRIPTION
[LG-6201](https://cm-jira.usa.gov/browse/LG-6201)

**What**
Adding logs for personal_key step based on [event log documentation in Figma](https://www.figma.com/file/vtgBsP61slpBopu8ixXB0K/IAL2-Event-Logs?node-id=3357%3A16150)
Also adding test coverage for all logging events. 

**Why**
We need to add logging to the personal key step to match the existing logging in production.

**Testing Instructions**
1. In `application.yml.default`, set `idv_api_enabled` to `true `
2. Go through initial steps to create new account (set up password, click link in email) on localhost
3. Navigate to localhost:3000/verify/v2
4. Open dev tools Network tab, check that logger event from Figma doc is called  (personal key visited) 
5. Click on download button, check that logger event (download personal key) is called
6. Click on clipboard button, check that logger event (copy personal key) is called
7. Click on print button, check that logger event (print personal key) is called
8. Click continue button, check that logger event (show personal key modal) is called
9. Click back button, check that logger event (hide personal key modal) is called
10. Enter correct personal key (0000-0000-0000-0000)  into input, press submit
11. Check that logger event (personal key submitted) is called 

