### PR TITLE
Do not create double email addresses for user in tests

### DIFF
--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -4,12 +4,7 @@ describe SignUp::PasswordsController do
   describe '#create' do
     it 'tracks a valid password event' do
       token = 'new token'
-      email = create(
-        :email_address, :unconfirmed,
-        confirmation_token: token,
-        user: build(:user, :unconfirmed)
-      )
-      user = email.user
+      user = create(:user, :unconfirmed, confirmation_token: token)
 
       stub_analytics
 
@@ -42,15 +37,14 @@ describe SignUp::PasswordsController do
       invalid_confirmation_sent_at =
         Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
       token = 'new token'
-      email = create(
-        :email_address, :unconfirmed,
-        confirmation_sent_at: invalid_confirmation_sent_at,
+      user = create(
+        :user,
+        :unconfirmed,
         confirmation_token: token,
-        user: build(:user, :unconfirmed)
+        confirmation_sent_at: invalid_confirmation_sent_at,
       )
-      user = email.user
 
-      validator = EmailConfirmationTokenValidator.new(email)
+      validator = EmailConfirmationTokenValidator.new(user.email_addresses.first)
       result = validator.submit
       expect(result.success?).to eq false
 
@@ -67,12 +61,7 @@ describe SignUp::PasswordsController do
 
     it 'tracks an invalid password event' do
       token = 'new token'
-      email = create(
-        :email_address, :unconfirmed,
-        confirmation_token: token,
-        user: build(:user, :unconfirmed)
-      )
-      user = email.user
+      user = create(:user, :unconfirmed, confirmation_token: token)
 
       stub_analytics
 
@@ -106,11 +95,7 @@ describe SignUp::PasswordsController do
     render_views
     it 'instructs crawlers to not index this page' do
       token = 'foo token'
-      create(
-        :email_address, :unconfirmed,
-        confirmation_token: token,
-        user: build(:user, :unconfirmed)
-      )
+      create(:user, :unconfirmed, confirmation_token: token)
       get :new, params: { confirmation_token: token }
 
       expect(response.body).to match('<meta content="noindex,nofollow" name="robots" />')
@@ -121,10 +106,10 @@ describe SignUp::PasswordsController do
         Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
       token = 'new token'
       create(
-        :email_address, :unconfirmed,
-        confirmation_sent_at: invalid_confirmation_sent_at,
+        :user,
+        :unconfirmed,
         confirmation_token: token,
-        user: build(:user, :unconfirmed)
+        confirmation_sent_at: invalid_confirmation_sent_at,
       )
 
       get :new, params: { confirmation_token: token }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
       with { {} }
       email { Faker::Internet.safe_email }
       confirmed_at { Time.zone.now }
+      confirmation_token { nil }
+      confirmation_sent_at { 5.minutes.ago }
     end
 
     accepted_terms_at { Time.zone.now if email }
@@ -17,9 +19,13 @@ FactoryBot.define do
       user.email_addresses.build(
         email: evaluator.email,
         confirmed_at: evaluator.confirmed_at,
+        confirmation_sent_at: evaluator.confirmation_sent_at,
+        confirmation_token: evaluator.confirmation_token,
       )
       user.email = evaluator.email
       user.confirmed_at = evaluator.confirmed_at
+      user.confirmation_sent_at = evaluator.confirmation_sent_at
+      user.confirmation_token = evaluator.confirmation_token
     end
 
     after(:stub) do |user, evaluator|
@@ -27,9 +33,13 @@ FactoryBot.define do
       user.email_addresses.build(
         email: evaluator.email,
         confirmed_at: evaluator.confirmed_at,
+        confirmation_sent_at: evaluator.confirmation_sent_at,
+        confirmation_token: evaluator.confirmation_token,
       )
       user.email = evaluator.email
       user.confirmed_at = evaluator.confirmed_at
+      user.confirmation_sent_at = evaluator.confirmation_sent_at
+      user.confirmation_token = evaluator.confirmation_token
     end
 
     trait :with_multiple_emails do
@@ -174,6 +184,7 @@ FactoryBot.define do
     trait :unconfirmed do
       confirmed_at { nil }
       confirmation_sent_at { 5.minutes.ago }
+      confirmation_token { 'token' }
       password { nil }
     end
   end


### PR DESCRIPTION
Fixes some flakiness where the `build(:user)` function always creates an email address even if one is intended to be created for them soon after