### PR TITLE
Add a `includes_phone_check?` method to Profile

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -81,8 +81,13 @@ class Profile < ApplicationRecord
   end
 
   def includes_liveness_check?
-    return if proofing_components.blank?
-    proofing_components['liveness_check']
+    return false if proofing_components.blank?
+    proofing_components['liveness_check'].present?
+  end
+
+  def includes_phone_check?
+    return false if proofing_components.blank?
+    proofing_components['address_check'] == 'lexis_nexis_address'
   end
 
   private

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -35,10 +35,6 @@ describe Profile do
       it 'is the empty string' do
         expect(profile.proofing_components).to eq('')
       end
-
-      it 'does not blow up in #includes_liveness_check?' do
-        expect(profile.includes_liveness_check?).to be_falsey
-      end
     end
 
     context 'when the value is a JSON object' do
@@ -46,6 +42,46 @@ describe Profile do
       it 'is the object' do
         expect(profile.proofing_components).to eq('foo' => true)
       end
+    end
+  end
+
+  describe '#includes_liveness_check?' do
+    it 'returns true if a component for liveness is present' do
+      profile = create(:profile, proofing_components: { liveness_check: 'acuant' })
+
+      expect(profile.includes_liveness_check?).to eq(true)
+    end
+
+    it 'returns false if a component for liveness is not present' do
+      profile = create(:profile, proofing_components: { liveness_check: nil })
+
+      expect(profile.includes_liveness_check?).to eq(false)
+    end
+
+    it 'returns false if proofing_components is blank' do
+      profile = create(:profile, proofing_components: '')
+
+      expect(profile.includes_liveness_check?).to eq(false)
+    end
+  end
+
+  describe '#includes_phone_check?' do
+    it 'returns true if the address_check component is lexis_nexis_address' do
+      profile = create(:profile, proofing_components: { address_check: 'lexis_nexis_address' })
+
+      expect(profile.includes_phone_check?).to eq(true)
+    end
+
+    it 'returns false if the address_check componet is gpo_letter' do
+      profile = create(:profile, proofing_components: { address_check: 'gpo_letter' })
+
+      expect(profile.includes_phone_check?).to eq(false)
+    end
+
+    it 'returns false if proofing_components is blank' do
+      profile = create(:profile, proofing_components: '')
+
+      expect(profile.includes_phone_check?).to eq(false)
     end
   end
 


### PR DESCRIPTION
The letter flow as it is implemented may not meet the bar for strict IAL2. This commit adds a method for checking whether a letter was used to verify a user to enable building conditionals around that in a future change.