### PR TITLE
Retire the liveness_checking_required flag on service providers

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -107,7 +107,7 @@ module SamlIdpAuthConcern
     IdentityLinker.
       new(current_user, saml_request_service_provider).
       link_identity(
-        ial: ial_context.ial_for_identity_record,
+        ial: ial_context.ial,
         rails_session_id: session.id,
       )
   end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -74,7 +74,7 @@ class OpenidConnectAuthorizeForm
     @identity = identity_linker.link_identity(
       nonce: nonce,
       rails_session_id: rails_session_id,
-      ial: ial_context.ial_for_identity_record,
+      ial: ial_context.ial,
       scope: scope.join(' '),
       code_challenge: code_challenge,
     )

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -15,6 +15,8 @@ class ServiceProvider < ApplicationRecord
   # See https://github.com/18F/identity_validations
   include IdentityValidations::ServiceProviderValidation
 
+  self.ignored_columns = %w[liveness_checking_required]
+
   scope(:active, -> { where(active: true) })
   scope(
     :with_push_notification_urls,

--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -40,20 +40,10 @@ class IalContext
   end
 
   def ial2_strict_requested?
-    ial == ::Idp::Constants::IAL2_STRICT ||
-      (ial == ::Idp::Constants::IAL2 && service_provider_requires_liveness?)
-  end
-
-  def ial_for_identity_record
-    return ial unless ial == ::Idp::Constants::IAL2 && service_provider_requires_liveness?
-    ::Idp::Constants::IAL2_STRICT
+    ial == ::Idp::Constants::IAL2_STRICT
   end
 
   private
-
-  def service_provider_requires_liveness?
-    !!service_provider && service_provider.liveness_checking_required
-  end
 
   def int_ial(input)
     Integer(input)

--- a/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
+++ b/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
@@ -6,69 +6,6 @@ describe 'Strong IAL2' do
   include SamlAuthHelper
   include DocAuthHelper
 
-  context 'with an sp that requires livess and a new account' do
-    before do
-      ServiceProvider.find_by(issuer: sp1_issuer).
-        update!(liveness_checking_required: true)
-    end
-
-    it 'starts the proofing process if liveness is enabled' do
-      allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
-
-      visit_idp_from_sp_with_ial2(:saml)
-      sign_up_and_2fa_ial1_user
-
-      click_agree_and_continue_optional
-
-      expect(page.current_path).to eq(idv_doc_auth_welcome_step)
-    end
-  end
-
-  context 'with an sp that requires liveness and a current verified profile with no liveness' do
-    before do
-      ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:sp:server').update!(
-        liveness_checking_required: true,
-      )
-    end
-
-    it 'upgrades user to IAL2 strict if liveness checking is enabled' do
-      allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
-
-      user ||= create(
-        :profile, :active, :verified,
-        pii: { first_name: 'John', ssn: '111223333' }
-      ).user
-      visit_idp_from_sp_with_ial2(:oidc)
-      sign_in_user(user)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-      click_agree_and_continue_optional
-
-      expect(page.current_path).to eq(idv_doc_auth_welcome_step)
-
-      complete_all_doc_auth_steps
-      click_continue
-      fill_in 'Password', with: user.password
-      click_continue
-      click_acknowledge_personal_key
-      click_agree_and_continue
-
-      expect(current_url).to start_with('http://localhost:7654/auth/result')
-      expect(user.active_profile.includes_liveness_check?).to be_truthy
-    end
-
-    it 'returns an error if liveness checking is disabled' do
-      allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(false)
-
-      visit_idp_from_sp_with_ial2(:oidc)
-
-      expect(current_url).to start_with(
-        'http://localhost:7654/auth/result?error=invalid_request'\
-        '&error_description=Acr+values+Liveness+checking+is+disabled',
-      )
-    end
-  end
-
   context 'with SP that sends an IAL2 strict request and a verified profile with no liveness' do
     it 'upgrades user to IAL2 strict if liveness checking is enabled' do
       allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -22,7 +22,6 @@ describe AttributeAsserter do
       issuer: 'http://localhost:3000',
       ial: service_provider_ial,
       default_aal: service_provider_aal,
-      liveness_checking_required: false,
       metadata: {},
     )
   end

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -2,12 +2,10 @@ require 'rails_helper'
 
 RSpec.describe IalContext do
   let(:ial) { nil }
-  let(:sp_liveness_checking_required) { false }
   let(:sp_ial) { nil }
   let(:service_provider) do
     build(
       :service_provider,
-      liveness_checking_required: sp_liveness_checking_required,
       ial: sp_ial,
     )
   end
@@ -263,12 +261,6 @@ RSpec.describe IalContext do
       it { expect(ial_context.ial2_or_greater?).to eq(true) }
     end
 
-    context 'when ial 2 is requested and the sp requires liveness checking' do
-      let(:ial) { Idp::Constants::IAL2 }
-      let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial2_or_greater?).to eq(true) }
-    end
-
     context 'when ial 2 strict is requested' do
       let(:ial) { Idp::Constants::IAL2_STRICT }
       it { expect(ial_context.ial2_or_greater?).to eq(true) }
@@ -288,12 +280,6 @@ RSpec.describe IalContext do
 
     context 'when ial 2 is requested' do
       let(:ial) { Idp::Constants::IAL2 }
-      it { expect(ial_context.ial2_requested?).to eq(true) }
-    end
-
-    context 'when ial 2 is requested and the sp requires liveness checking' do
-      let(:ial) { Idp::Constants::IAL2 }
-      let(:sp_liveness_checking_required) { true }
       it { expect(ial_context.ial2_requested?).to eq(true) }
     end
 
@@ -327,51 +313,10 @@ RSpec.describe IalContext do
       it { expect(ial_context.ial2_strict_requested?).to eq(true) }
     end
 
-    context 'with ial2 passed in and liveness checking required on the sp' do
-      let(:ial) { Idp::Constants::IAL2 }
-      let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial2_strict_requested?).to eq(true) }
-    end
-
-    context 'with ial1 passed in but liveness checking required on the sp' do
-      let(:ial) { Idp::Constants::IAL1 }
-      let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial2_strict_requested?).to eq(false) }
-    end
-
     context 'when the SP is nil' do
       let(:service_provider) { nil }
       let(:ial) { Idp::Constants::IAL2 }
       it { expect(ial_context.ial2_strict_requested?).to eq(false) }
-    end
-  end
-
-  describe '#ial_for_identity_record' do
-    context 'with ial1' do
-      let(:ial) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
-      it { expect(ial_context.ial_for_identity_record).to eq(Idp::Constants::IAL1) }
-    end
-
-    context 'with ial2' do
-      let(:ial) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
-      it { expect(ial_context.ial_for_identity_record).to eq(Idp::Constants::IAL2) }
-    end
-
-    context 'with ial2 and liveness checking required on the sp' do
-      let(:ial) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
-      let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial_for_identity_record).to eq(Idp::Constants::IAL2_STRICT) }
-    end
-
-    context 'with ial 2 strict' do
-      let(:ial) { Saml::Idp::Constants::IAL2_STRICT_AUTHN_CONTEXT_CLASSREF }
-      it { expect(ial_context.ial_for_identity_record).to eq(Idp::Constants::IAL2_STRICT) }
-    end
-
-    context 'when the SP is nil' do
-      let(:service_provider) { nil }
-      let(:ial) { Idp::Constants::IAL2 }
-      it { expect(ial_context.ial_for_identity_record).to eq(Idp::Constants::IAL2) }
     end
   end
 end


### PR DESCRIPTION
Liveness checking specific functionality is being discarded in favor of a full IAL2 compliant flow which may include additional deltas. That makes this flag confusing and hopefully unnecessary so this commit removes it.

A follow on commit will be required to drop the column.