### PR TITLE
Add and fix spec coverage for JS-enabled, IAL2 strict doc auth

### DIFF
--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -14,7 +14,7 @@ export function isLikelyMobile() {
  * @return {boolean}
  */
 export function hasMediaAccess() {
-  return 'mediaDevices' in window.navigator;
+  return !!navigator.mediaDevices;
 }
 
 /**

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -168,6 +168,14 @@ feature 'doc auth document capture step' do
       expect(page).to have_current_path(idv_doc_auth_document_capture_step)
       expect(page).to have_content(I18n.t('doc_auth.errors.general.network_error'))
     end
+
+    context 'when javascript is enabled', js: true do
+      it 'proceeds to the next step' do
+        attach_and_submit_images
+
+        expect(page).to have_current_path(next_step)
+      end
+    end
   end
 
   context 'when liveness checking is not enabled' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -92,6 +92,11 @@ module DocAuthHelper
     # JavaScript-enabled mobile devices will skip directly to document capture, so stop as complete.
     return if page.current_path == idv_doc_auth_document_capture_step
     expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
+    if javascript_enabled?
+      # By default, user would be prevented from continuing on desktop if the proofing flow requires
+      # liveness and there is no detectable camera. This forces the desktop link to be visible.
+      page.find('#upload-comp-liveness-off', visible: :all).evaluate_script('this.className = ""')
+    end
     click_on t('doc_auth.info.upload_computer_link')
   end
 

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -24,14 +24,14 @@ module DocumentCaptureStepHelper
   end
 
   def attach_images_with_js
-    attach_file 'Front of your ID', 'app/assets/images/logo.png'
-    attach_file 'Back of your ID', 'app/assets/images/logo.png'
+    attach_file t('doc_auth.headings.document_capture_front'), 'app/assets/images/logo.png'
+    attach_file t('doc_auth.headings.document_capture_back'), 'app/assets/images/logo.png'
     if selfie_required?
       # Disable `mediaDevices` support so that selfie upload does not attempt a live capture, and
       # instead falls back to image upload.
       page.execute_script('Object.defineProperty(navigator, "mediaDevices", { value: undefined });')
       click_idv_continue
-      attach_file 'Your photo', 'app/assets/images/logo.png'
+      attach_file t('doc_auth.headings.document_capture_selfie'), 'app/assets/images/logo.png'
     end
   end
 

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -2,11 +2,7 @@ module DocumentCaptureStepHelper
   def attach_and_submit_images
     attach_images
 
-    # If selfie is required, we simulate a submission with the document capture
-    # react component. As a result, the page has already been submitted so
-    # submitting is a noop
-
-    if javascript_enabled? && !selfie_required?
+    if javascript_enabled?
       click_on 'Submit'
       # Wait for the background image job to finish and success flash to appear before continuing
       expect(page).to have_content(t('doc_auth.headings.interstitial'))
@@ -28,11 +24,14 @@ module DocumentCaptureStepHelper
   end
 
   def attach_images_with_js
+    attach_file 'Front of your ID', 'app/assets/images/logo.png'
+    attach_file 'Back of your ID', 'app/assets/images/logo.png'
     if selfie_required?
-      simulate_image_upload_api_submission
-    else
-      attach_file 'Front of your ID', 'app/assets/images/logo.png'
-      attach_file 'Back of your ID', 'app/assets/images/logo.png'
+      # Disable `mediaDevices` support so that selfie upload does not attempt a live capture, and
+      # instead falls back to image upload.
+      page.execute_script('Object.defineProperty(navigator, "mediaDevices", { value: undefined });')
+      click_idv_continue
+      attach_file 'Your photo', 'app/assets/images/logo.png'
     end
   end
 
@@ -40,14 +39,6 @@ module DocumentCaptureStepHelper
     attach_file 'doc_auth_front_image', 'app/assets/images/logo.png'
     attach_file 'doc_auth_back_image', 'app/assets/images/logo.png'
     attach_file 'doc_auth_selfie_image', 'app/assets/images/logo.png' if selfie_required?
-  end
-
-  def simulate_image_upload_api_submission
-    connection = Faraday.new(url: document_capture_endpoint_host) do |conn|
-      conn.request(:multipart)
-    end
-    connection.post document_capture_endpoint_path, image_upload_api_payload
-    page.execute_script('document.querySelector(".js-document-capture-form").submit();')
   end
 
   def document_capture_form


### PR DESCRIPTION
Extracted from #6229

**Why**: Because it appears we did not have coverage for this flow previously, evidenced by the fact that the current test helpers are currently broken.
