### PR TITLE
Add form validation for present TOTP name

### DIFF
--- a/app/forms/totp_setup_form.rb
+++ b/app/forms/totp_setup_form.rb
@@ -2,15 +2,15 @@ class TotpSetupForm
   include ActiveModel::Model
 
   validate :name_is_unique
+  validates :name, presence: true
 
   attr_reader :name_taken
 
-  def initialize(user, secret, code, name = nil)
+  def initialize(user, secret, code, name)
     @user = user
     @secret = secret
     @code = code
     @name = name
-    @name = Time.zone.now.to_s if @name.blank?
     @auth_app_config = nil
   end
 
@@ -19,7 +19,7 @@ class TotpSetupForm
 
     process_valid_submission if success
 
-    FormResponse.new(success: success, extra: extra_analytics_attributes)
+    FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
 
   private

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -75,7 +75,7 @@ describe Users::TotpSetupController, devise: true do
   end
 
   describe '#confirm' do
-    let(:name) { SecureRandom.hex(4) }
+    let(:name) { SecureRandom.hex }
 
     context 'user is already signed up' do
       context 'when user presents invalid code' do

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -75,6 +75,8 @@ describe Users::TotpSetupController, devise: true do
   end
 
   describe '#confirm' do
+    let(:name) { SecureRandom.hex(4) }
+
     context 'user is already signed up' do
       context 'when user presents invalid code' do
         before do
@@ -84,7 +86,7 @@ describe Users::TotpSetupController, devise: true do
           allow(@analytics).to receive(:track_event)
           subject.user_session[:new_totp_secret] = 'abcdehij'
 
-          patch :confirm, params: { code: 123 }
+          patch :confirm, params: { name: name, code: 123 }
         end
 
         it 'redirects with an error message' do
@@ -114,7 +116,7 @@ describe Users::TotpSetupController, devise: true do
           allow(@analytics).to receive(:track_event)
           subject.user_session[:new_totp_secret] = secret
 
-          patch :confirm, params: { code: generate_totp_code(secret) }
+          patch :confirm, params: { name: name, code: generate_totp_code(secret) }
         end
 
         it 'redirects to account_path with a success message' do
@@ -143,7 +145,7 @@ describe Users::TotpSetupController, devise: true do
           allow(@analytics).to receive(:track_event)
           subject.user_session[:new_totp_secret] = secret
 
-          patch :confirm, params: {}
+          patch :confirm, params: { name: name }
         end
 
         it 'redirects with an error message' do
@@ -173,7 +175,7 @@ describe Users::TotpSetupController, devise: true do
           allow(@analytics).to receive(:track_event)
           subject.user_session[:new_totp_secret] = 'abcdehij'
 
-          patch :confirm, params: { code: 123 }
+          patch :confirm, params: { name: name, code: 123 }
         end
 
         it 'redirects with an error message' do
@@ -203,7 +205,7 @@ describe Users::TotpSetupController, devise: true do
           subject.user_session[:new_totp_secret] = secret
           subject.user_session[:selected_mfa_options] = selected_mfa_options
 
-          patch :confirm, params: { code: generate_totp_code(secret) }
+          patch :confirm, params: { name: name, code: generate_totp_code(secret) }
         end
         context 'when user selected only one method on account creation' do
           it 'redirects to account_path with a success message' do
@@ -248,7 +250,7 @@ describe Users::TotpSetupController, devise: true do
           stub_analytics
           allow(@analytics).to receive(:track_event)
 
-          patch :confirm, params: { code: 123 }
+          patch :confirm, params: { name: name, code: 123 }
         end
 
         it 'redirects with an error message' do

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -26,6 +26,7 @@ describe 'Remembering a TOTP device' do
       user.password = Features::SessionHelper::VALID_PASSWORD
 
       select_2fa_option('auth_app')
+      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default
@@ -45,6 +46,7 @@ describe 'Remembering a TOTP device' do
       click_on t('account.index.totp_confirm_delete')
       travel_to(10.seconds.from_now) # Travel past the revoked at date from disabling the device
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
+      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -26,7 +26,7 @@ describe 'Remembering a TOTP device' do
       user.password = Features::SessionHelper::VALID_PASSWORD
 
       select_2fa_option('auth_app')
-      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
+      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default
@@ -46,7 +46,7 @@ describe 'Remembering a TOTP device' do
       click_on t('account.index.totp_confirm_delete')
       travel_to(10.seconds.from_now) # Travel past the revoked at date from disabling the device
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
-      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
+      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -10,7 +10,7 @@ describe 'Unchecking remember device' do
         select_2fa_option('auth_app')
 
         secret = find('#qr-code').text
-        fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
+        fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
         fill_in 'code', with: generate_totp_code(secret)
         uncheck 'remember_device'
 

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -10,6 +10,7 @@ describe 'Unchecking remember device' do
         select_2fa_option('auth_app')
 
         secret = find('#qr-code').text
+        fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
         fill_in 'code', with: generate_totp_code(secret)
         uncheck 'remember_device'
 

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -44,6 +44,7 @@ describe 'totp management' do
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
 
       secret = find('#qr-code').text
+      fill_in 'name', with: 'foo'
       fill_in 'code', with: generate_totp_code(secret)
       click_button 'Submit'
 

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -4,11 +4,12 @@ describe TotpSetupForm do
   let(:user) { create(:user) }
   let(:secret) { user.generate_totp_secret }
   let(:code) { generate_totp_code(secret) }
+  let(:name) { SecureRandom.hex(4) }
 
   describe '#submit' do
     context 'when TOTP code is valid' do
       it 'returns FormResponse with success: true' do
-        form = TotpSetupForm.new(user, secret, code)
+        form = TotpSetupForm.new(user, secret, code, name)
         extra = {
           totp_secret_present: true,
           multi_factor_auth_method: 'totp',
@@ -26,7 +27,7 @@ describe TotpSetupForm do
       it 'sends a recovery information changed event' do
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
-        form = TotpSetupForm.new(user, secret, code)
+        form = TotpSetupForm.new(user, secret, code, name)
 
         form.submit
       end
@@ -34,7 +35,7 @@ describe TotpSetupForm do
 
     context 'when TOTP code is invalid' do
       it 'returns FormResponse with success: false' do
-        form = TotpSetupForm.new(user, secret, 'kode')
+        form = TotpSetupForm.new(user, secret, 'kode', name)
         extra = {
           totp_secret_present: true,
           multi_factor_auth_method: 'totp',
@@ -54,7 +55,7 @@ describe TotpSetupForm do
     # setup page was submitted without a secret_key in the user_session
     context 'when the secret key is not present' do
       it 'returns FormResponse with success: false' do
-        form = TotpSetupForm.new(user, nil, 'kode')
+        form = TotpSetupForm.new(user, nil, 'kode', name)
         extra = {
           totp_secret_present: false,
           multi_factor_auth_method: 'totp',
@@ -67,6 +68,35 @@ describe TotpSetupForm do
           **extra,
         )
         expect(user.auth_app_configurations.any?).to eq false
+      end
+    end
+
+    context 'when name is empty' do
+      let(:name) { '' }
+
+      it 'returns an unsuccessful form response' do
+        form = TotpSetupForm.new(user, secret, code, name)
+
+        expect(form.submit.to_h).to include(
+          success: false,
+          error_details: { name: [:blank] },
+          errors: { name: [t('errors.messages.blank')] },
+        )
+        expect(user.auth_app_configurations.any?).to eq false
+      end
+    end
+
+    context 'when name is not unique' do
+      it 'returns an unsuccessful form response' do
+        form1 = TotpSetupForm.new(user, secret, code, name)
+        form1.submit
+        form2 = TotpSetupForm.new(user, secret, code, name)
+
+        expect(form2.submit.to_h).to include(
+          success: false,
+          error_details: { name: [t('errors.piv_cac_setup.unique_name')] },
+          errors: { name: [t('errors.piv_cac_setup.unique_name')] },
+        )
       end
     end
   end

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -4,7 +4,7 @@ describe TotpSetupForm do
   let(:user) { create(:user) }
   let(:secret) { user.generate_totp_secret }
   let(:code) { generate_totp_code(secret) }
-  let(:name) { SecureRandom.hex(4) }
+  let(:name) { SecureRandom.hex }
 
   describe '#submit' do
     context 'when TOTP code is valid' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -543,6 +543,8 @@ module Features
 
       expect(page).to have_current_path authenticator_setup_path
 
+      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex(4)}"
+
       secret = find('#qr-code').text
       fill_in 'code', with: generate_totp_code(secret)
       click_button 'Submit'

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -543,7 +543,7 @@ module Features
 
       expect(page).to have_current_path authenticator_setup_path
 
-      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
+      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
 
       secret = find('#qr-code').text
       fill_in 'code', with: generate_totp_code(secret)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -543,7 +543,7 @@ module Features
 
       expect(page).to have_current_path authenticator_setup_path
 
-      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex(4)}"
+      fill_in t('forms.totp_setup.totp_step_1'), with: "App #{SecureRandom.hex}"
 
       secret = find('#qr-code').text
       fill_in 'code', with: generate_totp_code(secret)


### PR DESCRIPTION
Extracted from #6229

**Why**: For consistency with other MFA setup, and for consistency with the JS-enabled user experience, where the input is rendered as required.

This was discovered in #6229, where the `set_up_2fa_with_authenticator_app` spec helper would not work as expected in a JavaScript-enabled browser, since the browser validation would prevent submission without a valid name.

The previous implementation seemed to be intentionally allowing an absent name. While this may be reasonable if applied consistently, the revisions bring alignment to client-side and server-side validation, and across different MFA types (e.g. [PIV/CAC](https://github.com/18F/identity-idp/blob/1181c82ea441439a01c12fb572636ff1a7eb4c09/app/forms/user_piv_cac_setup_form.rb#L12)).