### PR TITLE
Avoid redundant recovery PII encrypt in profile spec factory

### DIFF
--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
       if evaluator.pii
         pii_attrs = Pii::Attributes.new_from_hash(evaluator.pii)
         profile.encrypt_pii(pii_attrs, profile.user.password)
-        profile.encrypt_recovery_pii(pii_attrs)
       end
     end
   end


### PR DESCRIPTION
Extracted from #6229

**Why**: Because `encrypt_recovery_pii` is already called as part of the preceding `encrypt_pii`.

https://github.com/18F/identity-idp/blob/0b56e2ed05744190357eb224dbc9b896fe6d4f5b/app/models/profile.rb#L57