### PR TITLE
Move more PII bundle usage to the common interface in Pii::Cacher

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -88,7 +88,7 @@ module Idv
 
     def create_gpo_entry
       move_pii_to_user_session
-      self.pii = Pii::Attributes.new_from_json(user_session[:decrypted_pii]) if pii.is_a?(String)
+      self.pii = Pii::Cacher.new(current_user, user_session).fetch if pii.is_a?(String)
       confirmation_maker = GpoConfirmationMaker.new(
         pii: pii, service_provider: service_provider,
         profile: profile
@@ -131,7 +131,8 @@ module Idv
 
     def move_pii_to_user_session
       return if session[:decrypted_pii].blank?
-      user_session[:decrypted_pii] = session.delete(:decrypted_pii)
+      decrypted_pii = session.delete(:decrypted_pii)
+      Pii::Cacher.new(current_user, user_session).save_decrypted_pii_json(decrypted_pii)
     end
 
     def session

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -12,10 +12,16 @@ module Pii
     end
 
     def save(user_password, profile = user.active_profile)
-      user_session[:decrypted_pii] = profile.decrypt_pii(user_password).to_json if profile
+      decrypted_pii = profile.decrypt_pii(user_password) if profile
+      save_decrypted_pii_json(decrypted_pii.to_json) if decrypted_pii
       rotate_fingerprints(profile) if stale_fingerprints?(profile)
       rotate_encrypted_attributes if stale_attributes?
       user_session[:decrypted_pii]
+    end
+
+    def save_decrypted_pii_json(decrypted_pii_json)
+      user_session[:decrypted_pii] = decrypted_pii_json
+      nil
     end
 
     def fetch

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -28,7 +28,10 @@ class ReactivateAccountSession
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:personal_key] = true
-    reactivate_account_session[:pii] = pii.to_json
+    pii_json = pii.to_json
+    reactivate_account_session[:pii] = pii_json
+    Pii::Cacher.new(@user, session).save_decrypted_pii_json(pii_json)
+    nil
   end
 
   def personal_key?


### PR DESCRIPTION
Follow up to #6054 to update places where we store a PII bundle to use the `Pii::Cacher`:

- Gpo Confirmation
- End of IDV where we move PII from the IDV part to the main PII bundle location
- Account reactivation