### PR TITLE
Fix 500 error when parsing malformed referer header

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -69,6 +69,16 @@ class SamlIdpController < ApplicationController
     handle_valid_sp_remote_logout_request(user_id)
   end
 
+  def external_saml_request?
+    return true if request.path.start_with?('/api/saml/authpost')
+
+    begin
+      URI(request.referer).host != request.host
+    rescue ArgumentError, URI::Error
+      false
+    end
+  end
+
   private
 
   def confirm_user_is_authenticated_with_fresh_mfa
@@ -116,11 +126,6 @@ class SamlIdpController < ApplicationController
       requested_ial: saml_request&.requested_ial_authn_context || 'none',
       service_provider: saml_request&.issuer,
     )
-  end
-
-  def external_saml_request?
-    (!request.referer.nil? && URI(request.referer).host != request.host) ||
-      request.path.start_with?('/api/saml/authpost')
   end
 
   def handle_successful_handoff

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1802,4 +1802,15 @@ describe SamlIdpController do
       )
     end
   end
+
+  describe '#external_saml_request' do
+    it 'returns false for malformed referer' do
+      request.env['HTTP_REFERER'] = '{{<script>console.log()</script>'
+      expect(subject.external_saml_request?).to eq false
+    end
+
+    it 'returns false for empty referer' do
+      expect(subject.external_saml_request?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
We got a couple 500s in [NewRelic](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=a9990bf8-b008-34ff-88f1-2b7c69ac157a) in the form of `URI::InvalidURIError: bad URI(is not URI?):` on SAML authentication

This patch uses https://github.com/rails/rails/blob/3520cc77df1b52a6c808083214b583c769e9a4b2/actionpack/lib/action_controller/metal/redirecting.rb#L197-L201 as a reference