### PR TITLE
Test Helpers: Fix usePropertyValue for previously-undefined value

### DIFF
--- a/app/javascript/packages/test-helpers/use-property-value.spec.ts
+++ b/app/javascript/packages/test-helpers/use-property-value.spec.ts
@@ -1,15 +1,42 @@
 import usePropertyValue from './use-property-value';
 
 describe('usePropertyValue', () => {
-  (global as any).usePropertyValue = 10;
-  usePropertyValue(global as any, 'usePropertyValue', 20);
+  context('value was a key in object, with value', () => {
+    const key = `usePropertyValue1`;
+    (global as any)[key] = 10;
+    usePropertyValue(global as any, key, 20);
 
-  after(() => {
-    expect((global as any).usePropertyValue).to.equal(10);
-    delete (global as any).usePropertyValue;
+    after(() => {
+      expect((global as any)[key]).to.equal(10);
+      delete (global as any)[key];
+    });
+
+    it('has value during spec', () => {
+      expect((global as any)[key]).to.equal(20);
+    });
   });
 
-  it('has value during spec', () => {
-    expect((global as any).usePropertyValue).to.equal(20);
+  context('value was not a key in object', () => {
+    const key = `usePropertyValue2`;
+    usePropertyValue(global as any, key, true);
+
+    after(() => {
+      expect((key in global) as any).to.be.false();
+    });
+
+    it('unsets the key after the test', () => {});
+  });
+
+  context('value was a key in object, with an explicitly undefined value', () => {
+    const key = `usePropertyValue3`;
+    (global as any)[key] = 10;
+    usePropertyValue(global as any, key, true);
+
+    after(() => {
+      expect((key in global) as any).to.be.true();
+      delete (global as any).baz;
+    });
+
+    it('does not unset the key after the test', () => {});
   });
 });

--- a/app/javascript/packages/test-helpers/use-property-value.spec.ts
+++ b/app/javascript/packages/test-helpers/use-property-value.spec.ts
@@ -29,7 +29,7 @@ describe('usePropertyValue', () => {
 
   context('value was a key in object, with an explicitly undefined value', () => {
     const key = `usePropertyValue3`;
-    (global as any)[key] = 10;
+    (global as any)[key] = undefined;
     usePropertyValue(global as any, key, true);
 
     after(() => {

--- a/app/javascript/packages/test-helpers/use-property-value.ts
+++ b/app/javascript/packages/test-helpers/use-property-value.ts
@@ -7,14 +7,20 @@
  * @param value Temporary property value.
  */
 function usePropertyValue<O extends object>(object: O, property: keyof O, value: any) {
+  let wasDefined: boolean;
   let originalValue;
   before(() => {
+    wasDefined = property in object;
     originalValue = object[property];
     object[property] = value;
   });
 
   after(() => {
-    object[property] = originalValue;
+    if (wasDefined) {
+      object[property] = originalValue;
+    } else {
+      delete object[property];
+    }
   });
 }
 


### PR DESCRIPTION
**Why**: So that `key in obj` tests don't wrongly report `true` after a test has completed.

Observed in #6257 (see [example test failure](https://app.circleci.com/pipelines/github/18F/identity-idp/72541/workflows/49afb4fd-27fc-4308-a051-53b5021846c8/jobs/121923), [root cause](https://github.com/18F/identity-idp/blob/efa887fb8ad9ecf820299add99010a5044cde731/app/javascript/packages/verify-flow/steps/personal-key/download-button.spec.tsx#L57), [impacted code](https://github.com/18F/identity-idp/blob/efa887fb8ad9ecf820299add99010a5044cde731/app/javascript/packages/verify-flow/steps/personal-key/download-button.tsx#L23))