### PR TITLE
Run report for full fiscal year on October 1st for SP Active Users report

### DIFF
--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -15,9 +15,8 @@ module Reports
       end
     end
 
-    def fiscal_start_date
-      now = Time.zone.now.beginning_of_day
-      now.change(year: now.month >= 10 ? now.year : now.year - 1, month: 10, day: 1)
+    def fiscal_start_date(time = Time.zone.now.beginning_of_day)
+      time.change(year: time.month >= 10 ? time.year : time.year - 1, month: 10, day: 1)
     end
 
     def first_of_this_month

--- a/app/jobs/reports/sp_active_users_report.rb
+++ b/app/jobs/reports/sp_active_users_report.rb
@@ -11,11 +11,42 @@ module Reports
       key: -> { "#{REPORT_NAME}-#{arguments.first}" },
     )
 
-    def perform(_date)
+    # This daily job captures the total number of active users per SP from the beginning of the the
+    # current fiscal year until now.
+    #
+    # A fiscal year is from October 1st 12:00:00AM to September 30th 11:59:59PM the following year.
+    #
+    # To provide a report that captures the total number of active users for an entire fiscal year
+    # and avoids reporting partial days, October 1st is treated differently.
+    # The report will run for the entire fiscal year that ended the day before rather than for the
+    # partial day of October 1st in the current fiscal year.
+    def perform(date)
       results = transaction_with_timeout do
-        Db::Identity::SpActiveUserCounts.call(fiscal_start_date)
+        Db::Identity::SpActiveUserCounts.call(start_time(date), finish_time(date))
       end
       save_report(REPORT_NAME, results.to_json, extension: 'json')
+    end
+
+    def start_time(time)
+      if time.month == 10 && time.day == 1
+        current_fiscal_start_date = fiscal_start_date(time)
+        current_fiscal_start_date.change(year: current_fiscal_start_date.year - 1).beginning_of_day
+      else
+        fiscal_start_date(time)
+      end
+    end
+
+    def finish_time(time)
+      if time.month == 10 && time.day == 1
+        current_fiscal_end_date = fiscal_end_date(time)
+        current_fiscal_end_date.change(year: current_fiscal_end_date.year - 1).end_of_day
+      else
+        time.end_of_day
+      end
+    end
+
+    def fiscal_end_date(time)
+      time.change(year: time.month >= 10 ? time.year + 1 : time.year, month: 9, day: 30).end_of_day
     end
   end
 end

--- a/app/jobs/reports/sp_active_users_report.rb
+++ b/app/jobs/reports/sp_active_users_report.rb
@@ -32,7 +32,7 @@ module Reports
         current_fiscal_start_date = fiscal_start_date(time)
         current_fiscal_start_date.change(year: current_fiscal_start_date.year - 1).beginning_of_day
       else
-        fiscal_start_date(time)
+        fiscal_start_date(time).beginning_of_day
       end
     end
 
@@ -47,6 +47,10 @@ module Reports
 
     def fiscal_end_date(time)
       time.change(year: time.month >= 10 ? time.year + 1 : time.year, month: 9, day: 30).end_of_day
+    end
+
+    def reporting_range(time)
+      start_time(time)..finish_time(time)
     end
   end
 end

--- a/app/jobs/reports/sp_active_users_report.rb
+++ b/app/jobs/reports/sp_active_users_report.rb
@@ -22,7 +22,8 @@ module Reports
     # partial day of October 1st in the current fiscal year.
     def perform(date)
       results = transaction_with_timeout do
-        Db::Identity::SpActiveUserCounts.call(start_time(date), finish_time(date))
+        range = reporting_range(date)
+        Db::Identity::SpActiveUserCounts.call(range.begin, range.end)
       end
       save_report(REPORT_NAME, results.to_json, extension: 'json')
     end

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe Reports::SpActiveUsersReport do
   subject { described_class.new }
 
-  let(:fiscal_start_date) { 1.year.ago.to_s }
   let(:issuer) { 'foo' }
   let(:issuer2) { 'foo2' }
   let(:app_id) { 'app' }
@@ -13,28 +12,70 @@ describe Reports::SpActiveUsersReport do
   end
 
   it 'returns total active user counts per sp broken down by ial1 and ial2' do
-    now = Time.zone.now
+    job_date = Date.new(2022, 1, 1)
+    authenticated_time = job_date.noon
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app')
     ServiceProviderIdentity.create(
       user_id: 1, service_provider: issuer, uuid: 'foo1',
-      last_ial1_authenticated_at: now, last_ial2_authenticated_at: now
+      last_ial1_authenticated_at: authenticated_time, last_ial2_authenticated_at: authenticated_time
     )
     ServiceProviderIdentity.create(
       user_id: 2, service_provider: issuer, uuid: 'foo2',
-      last_ial1_authenticated_at: now
+      last_ial1_authenticated_at: authenticated_time
     )
     ServiceProviderIdentity.create(
       user_id: 3, service_provider: issuer, uuid: 'foo3',
-      last_ial2_authenticated_at: now
+      last_ial2_authenticated_at: authenticated_time
     )
     ServiceProviderIdentity.create(
       user_id: 4, service_provider: issuer, uuid: 'foo4',
-      last_ial2_authenticated_at: now
+      last_ial2_authenticated_at: authenticated_time
     )
     result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json
 
     expect(subject.perform(Time.zone.today)).to eq(result)
+  end
+
+  it 'when Oct 1, returns total active user counts per sp by ial1 and ial2 for last fiscal year' do
+    # run date is from 2019-10-01 to 2020-09-30
+    job_date = Date.new(2020, 10, 1)
+    beginning_of_last_fiscal_year = job_date.change(year: 2019, month: 10, day: 1).beginning_of_day
+    end_of_last_fiscal_year = job_date.change(year: 2020, month: 9, day: 30).end_of_day
+    middle_of_last_fiscal_year = job_date.change(year: 2020, month: 1, day: 31).end_of_day
+
+    beginning_of_current_fiscal_year = job_date.beginning_of_day
+    current_fiscal_year = job_date.change(hour: 12, minute: 30)
+
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: 'app')
+    ServiceProviderIdentity.create(
+      user_id: 1, service_provider: issuer, uuid: 'foo1',
+      last_ial1_authenticated_at: beginning_of_last_fiscal_year,
+      last_ial2_authenticated_at: beginning_of_last_fiscal_year
+    )
+    ServiceProviderIdentity.create(
+      user_id: 2, service_provider: issuer, uuid: 'foo2',
+      last_ial1_authenticated_at: end_of_last_fiscal_year,
+      last_ial2_authenticated_at: end_of_last_fiscal_year
+    )
+    ServiceProviderIdentity.create(
+      user_id: 3, service_provider: issuer, uuid: 'foo3',
+      last_ial2_authenticated_at: middle_of_last_fiscal_year
+    )
+    ServiceProviderIdentity.create(
+      user_id: 4, service_provider: issuer, uuid: 'foo4',
+      last_ial2_authenticated_at: beginning_of_current_fiscal_year
+    )
+
+    ServiceProviderIdentity.create(
+      user_id: 5, service_provider: issuer, uuid: 'foo5',
+      last_ial2_authenticated_at: current_fiscal_year
+    )
+
+    result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
+                total_ial2_active: 3 }].to_json
+
+    expect(subject.perform(job_date)).to eq(result)
   end
 
   describe '#good_job_concurrency_key' do

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -40,8 +40,9 @@ describe Reports::SpActiveUsersReport do
   it 'when Oct 1, returns total active user counts per sp by ial1 and ial2 for last fiscal year' do
     # run date is from 2019-10-01 to 2020-09-30
     job_date = Date.new(2020, 10, 1)
-    beginning_of_last_fiscal_year = job_date.change(year: 2019, month: 10, day: 1).beginning_of_day
-    end_of_last_fiscal_year = job_date.change(year: 2020, month: 9, day: 30).end_of_day
+    job_date_range = subject.reporting_range(job_date)
+    beginning_of_last_fiscal_year = job_date_range.first
+    end_of_last_fiscal_year = job_date_range.last
     middle_of_last_fiscal_year = job_date.change(year: 2020, month: 1, day: 31).end_of_day
 
     beginning_of_current_fiscal_year = job_date.beginning_of_day
@@ -85,6 +86,29 @@ describe Reports::SpActiveUsersReport do
       job = described_class.new(date)
       expect(job.good_job_concurrency_key).
         to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+
+  describe '#reporting_range' do
+    it 'returns entire last fiscal year when it is October 1st' do
+      job_date = Date.new(2022, 10, 1)
+      beginning = Date.new(2021, 10, 1).beginning_of_day
+      ending = Date.new(2022, 9, 30).end_of_day
+      expect(subject.reporting_range(job_date)).to eq(beginning..ending)
+    end
+
+    it 'returns current fiscal year until end of day when prior to Oct 1st' do
+      job_date = Date.new(2022, 5, 1)
+      beginning = Date.new(2021, 10, 1).beginning_of_day
+      ending = job_date.end_of_day
+      expect(subject.reporting_range(job_date)).to eq(beginning..ending)
+    end
+
+    it 'returns current fiscal year until end of day when after to Oct 1st' do
+      job_date = Date.new(2022, 11, 1)
+      beginning = Date.new(2022, 10, 1).beginning_of_day
+      ending = job_date.end_of_day
+      expect(subject.reporting_range(job_date)).to eq(beginning..ending)
     end
   end
 end


### PR DESCRIPTION
After speaking with folks in billing, they said it would be easier if the first day in the new fiscal year ran the report for all of the previous fiscal year, rather than for the partial day of the first day in the current fiscal year