### PR TITLE
LG-6204/LG-6220: capture user pii in a signed JWT and pass to frontend

### DIFF
--- a/app/controllers/api/verify/complete_controller.rb
+++ b/app/controllers/api/verify/complete_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         result, personal_key = Api::ProfileCreationForm.new(
           password: verify_params[:password],
-          jwt: verify_params[:details],
+          jwt: verify_params[:user_bundle_token],
           user_session: user_session,
           service_provider: current_sp,
         ).submit
@@ -23,7 +23,7 @@ module Api
       private
 
       def verify_params
-        params.permit(:password, :details)
+        params.permit(:password, :user_bundle_token)
       end
 
       def add_proofing_component(user)

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -60,6 +60,6 @@ class VerifyController < ApplicationController
       user: current_user,
       idv_session: idv_session,
       service_provider: current_sp,
-    ).call
+    ).token
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -21,11 +21,12 @@ class VerifyController < ApplicationController
       base_path: idv_app_root_path,
       app_name: APP_NAME,
       completion_url: completion_url,
-      initial_values: { 'personalKey' => personal_key },
+      initial_values: {
+        'personalKey' => personal_key,
+        'userBundleToken' => user_bundle_token,
+      },
       enabled_step_names: IdentityConfig.store.idv_api_enabled_steps,
       store_key: user_session[:idv_api_store_key],
-      user_bundle_token: user_bundle_token,
-      idv_public_key: IdentityConfig.store.idv_public_key,
     }
   end
 

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -24,6 +24,8 @@ class VerifyController < ApplicationController
       initial_values: { 'personalKey' => personal_key },
       enabled_step_names: IdentityConfig.store.idv_api_enabled_steps,
       store_key: user_session[:idv_api_store_key],
+      user_bundle_token: user_bundle_token,
+      idv_public_key: IdentityConfig.store.idv_public_key,
     }
   end
 
@@ -50,5 +52,13 @@ class VerifyController < ApplicationController
     else
       after_sign_in_path_for(current_user)
     end
+  end
+
+  def user_bundle_token
+    Idv::UserBundleTokenizer.new(
+      user: current_user,
+      idv_session: idv_session,
+      service_provider: current_sp,
+    ).call
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -59,7 +59,6 @@ class VerifyController < ApplicationController
     Idv::UserBundleTokenizer.new(
       user: current_user,
       idv_session: idv_session,
-      service_provider: current_sp,
     ).token
   end
 end

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -10,6 +10,24 @@ export interface VerifyFlowValues {
   personalKey?: string;
 
   personalKeyConfirm?: string;
+
+  firstName?: string;
+
+  lastName?: string;
+
+  address1?: string;
+
+  address2?: string;
+
+  city?: string;
+
+  state?: string;
+
+  zipcode?: string;
+
+  phone?: string;
+
+  ssn?: string;
 }
 
 interface VerifyFlowProps {

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -59,11 +59,11 @@ const enabledStepNames = JSON.parse(enabledStepNamesJSON) as string[];
 const camelCase = (string: string) =>
   string.replace(/[^a-z]([a-z])/gi, (_match, nextLetter) => nextLetter.toUpperCase());
 
-const jwtData = JSON.parse(atob(userBundleToken));
+const jwtData = JSON.parse(atob(initialValues.userBundleToken));
 const pii = Object.fromEntries(
   Object.entries(jwtData.pii).map(([key, value]) => [camelCase(key), value]),
 );
-Object.assign(parsedInitialValues, pii);
+Object.assign(initialValues, pii);
 
 function onComplete() {
   window.location.href = completionURL;

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -32,6 +32,11 @@ interface AppRootValues {
    * Base64-encoded encryption key for secret session store.
    */
   storeKey: string;
+
+  /**
+   * Signed JWT containing user data.
+   */
+  userBundleToken: string;
 }
 
 interface AppRootElement extends HTMLElement {
@@ -50,6 +55,15 @@ const {
 const storeKey = s2ab(atob(storeKeyBase64));
 const initialValues = JSON.parse(initialValuesJSON);
 const enabledStepNames = JSON.parse(enabledStepNamesJSON) as string[];
+
+const camelCase = (string: string) =>
+  string.replace(/[^a-z]([a-z])/gi, (_match, nextLetter) => nextLetter.toUpperCase());
+
+const jwtData = JSON.parse(atob(userBundleToken));
+const pii = Object.fromEntries(
+  Object.entries(jwtData.pii).map(([key, value]) => [camelCase(key), value]),
+);
+Object.assign(parsedInitialValues, pii);
 
 function onComplete() {
   window.location.href = completionURL;

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -59,7 +59,7 @@ const enabledStepNames = JSON.parse(enabledStepNamesJSON) as string[];
 const camelCase = (string: string) =>
   string.replace(/[^a-z]([a-z])/gi, (_match, nextLetter) => nextLetter.toUpperCase());
 
-const jwtData = JSON.parse(atob(initialValues.userBundleToken));
+const jwtData = JSON.parse(atob(initialValues.userBundleToken.split('.')[1]));
 const pii = Object.fromEntries(
   Object.entries(jwtData.pii).map(([key, value]) => [camelCase(key), value]),
 );

--- a/app/services/idv/user_bundle_tokenizer.rb
+++ b/app/services/idv/user_bundle_tokenizer.rb
@@ -1,9 +1,8 @@
 module Idv
   class UserBundleTokenizer
-    def initialize(user:, idv_session:, service_provider: nil)
+    def initialize(user:, idv_session:)
       @user = user
       @idv_session = idv_session
-      @service_provider = service_provider
     end
 
     def token
@@ -21,7 +20,7 @@ module Idv
 
     private
 
-    attr_reader :user, :idv_session, :service_provider
+    attr_reader :user, :idv_session
 
     def private_key
       OpenSSL::PKey::RSA.new(Base64.strict_decode64(IdentityConfig.store.idv_private_key))
@@ -34,8 +33,6 @@ module Idv
       data[:address_verification_mechanism] = idv_session.address_verification_mechanism
       data[:user_phone_confirmation] = idv_session.user_phone_confirmation
       data[:vendor_phone_confirmation] = idv_session.vendor_phone_confirmation
-
-      data[:issuer] = service_provider.issuer if service_provider
 
       data
     end

--- a/app/services/idv/user_bundle_tokenizer.rb
+++ b/app/services/idv/user_bundle_tokenizer.rb
@@ -1,0 +1,43 @@
+module Idv
+  class UserBundleTokenizer
+    def initialize(user:, idv_session:, service_provider: nil)
+      @user = user
+      @idv_session = idv_session
+      @service_provider = service_provider
+    end
+
+    def call
+      JWT.encode(
+        {
+          # for now, load whatever pii is saved in the session
+          pii: idv_session.applicant,
+          metadata: metadata,
+        },
+        private_key,
+        'RS256',
+        sub: user.uuid,
+      )
+    end
+
+    private
+
+    attr_reader :user, :idv_session, :service_provider
+
+    def private_key
+      OpenSSL::PKey::RSA.new(Base64.strict_decode64(IdentityConfig.store.idv_private_key))
+    end
+
+    def metadata
+      # populate with anything from the session we'll need later on
+      data = {}
+
+      data[:address_verification_mechanism] = idv_session.address_verification_mechanism
+      data[:user_phone_confirmation] = idv_session.user_phone_confirmation
+      data[:vendor_phone_confirmation] = idv_session.vendor_phone_confirmation
+
+      data[:issuer] = service_provider.issuer if service_provider
+
+      data
+    end
+  end
+end

--- a/app/services/idv/user_bundle_tokenizer.rb
+++ b/app/services/idv/user_bundle_tokenizer.rb
@@ -6,7 +6,7 @@ module Idv
       @service_provider = service_provider
     end
 
-    def call
+    def token
       JWT.encode(
         {
           # for now, load whatever pii is saved in the session

--- a/spec/controllers/api/verify/complete_controller_spec.rb
+++ b/spec/controllers/api/verify/complete_controller_spec.rb
@@ -46,7 +46,7 @@ describe Api::Verify::CompleteController do
   describe '#create' do
     context 'when the user is not signed in and submits the password' do
       it 'does not create a profile or return a key' do
-        post :create, params: { password: 'iambatman', details: jwt }
+        post :create, params: { password: 'iambatman', user_bundle_token: jwt }
         expect(JSON.parse(response.body)['personal_key']).to be_nil
         expect(response.status).to eq 401
         expect(JSON.parse(response.body)['error']).to eq 'user is not fully authenticated'
@@ -59,13 +59,13 @@ describe Api::Verify::CompleteController do
       end
 
       it 'creates a profile and returns a key' do
-        post :create, params: { password: 'iambatman', details: jwt }
+        post :create, params: { password: 'iambatman', user_bundle_token: jwt }
         expect(JSON.parse(response.body)['personal_key']).not_to be_nil
         expect(response.status).to eq 200
       end
 
       it 'does not create a profile and return a key when it has the wrong password' do
-        post :create, params: { password: 'iamnotbatman', details: jwt }
+        post :create, params: { password: 'iamnotbatman', user_bundle_token: jwt }
         expect(JSON.parse(response.body)['personal_key']).to be_nil
         expect(response.status).to eq 400
       end
@@ -77,7 +77,7 @@ describe Api::Verify::CompleteController do
       end
 
       it 'responds with not found' do
-        post :create, params: { password: 'iambatman', details: jwt }, as: :json
+        post :create, params: { password: 'iambatman', user_bundle_token: jwt }, as: :json
         expect(response.status).to eq 404
         expect(JSON.parse(response.body)['error']).
           to eq "The page you were looking for doesn't exist"

--- a/spec/services/idv/user_bundle_tokenizer_spec.rb
+++ b/spec/services/idv/user_bundle_tokenizer_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Idv::UserBundleTokenizer do
+  let(:public_key) do
+    OpenSSL::PKey::RSA.new(Base64.strict_decode64(IdentityConfig.store.idv_public_key))
+  end
+  let(:user) { create(:user) }
+  let(:sp) { create(:service_provider) }
+  let(:user_session) do
+    {
+      idv: {
+        applicant: {
+          'first_name' => 'Ada',
+          'last_name' => 'Lovelace',
+          'ssn' => '900900900',
+          'phone' => '+1 410-555-1212',
+        },
+        address_verification_mechanism: 'phone',
+        user_phone_confirmation: true,
+        vendor_phone_confirmation: true,
+      },
+    }
+  end
+  let(:idv_session) do
+    Idv::Session.new(user_session: user_session, current_user: user, service_provider: sp)
+  end
+  subject do
+    Idv::UserBundleTokenizer.new(user: user, idv_session: idv_session, service_provider: sp)
+  end
+
+  context 'when initialized with data' do
+    it 'encodes a signed JWT' do
+      token = subject.call
+      decorator = Api::UserBundleDecorator.new(user_bundle: token, public_key: public_key)
+
+      expect(decorator.pii).to eq user_session[:idv][:applicant]
+    end
+  end
+end

--- a/spec/services/idv/user_bundle_tokenizer_spec.rb
+++ b/spec/services/idv/user_bundle_tokenizer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Idv::UserBundleTokenizer do
     Idv::Session.new(user_session: user_session, current_user: user, service_provider: sp)
   end
   subject do
-    Idv::UserBundleTokenizer.new(user: user, idv_session: idv_session, service_provider: sp)
+    Idv::UserBundleTokenizer.new(user: user, idv_session: idv_session)
   end
 
   context 'when initialized with data' do

--- a/spec/services/idv/user_bundle_tokenizer_spec.rb
+++ b/spec/services/idv/user_bundle_tokenizer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Idv::UserBundleTokenizer do
 
   context 'when initialized with data' do
     it 'encodes a signed JWT' do
-      token = subject.call
+      token = subject.token
       decorator = Api::UserBundleDecorator.new(user_bundle: token, public_key: public_key)
 
       expect(decorator.pii).to eq user_session[:idv][:applicant]


### PR DESCRIPTION
Captures the current state of the user's pii (and a few other session state variables) and packs them in a JWT that is used to initialize the React app for the new IdV flow.

As we work our way back in the flow from the end, we will eventually be managing the user PII in the client, though we will be passing the JWT back and forth since it will contain the verified data and will be signed by the server.

The pii in the JWT is added to the initial values that are given to the React app.