### PR TITLE
Rename reactivate account session :personal_key key to be more descriptive

### DIFF
--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -25,7 +25,7 @@ module Users
     private
 
     def confirm_personal_key
-      return if reactivate_account_session.personal_key?
+      return if reactivate_account_session.validated_personal_key?
       redirect_to root_url
     end
 

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -28,13 +28,14 @@ class ReactivateAccountSession
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:personal_key] = true
+    reactivate_account_session[:validated_personal_key] = true
     pii_json = pii.to_json
     reactivate_account_session[:pii] = pii_json
     Pii::Cacher.new(@user, session).save_decrypted_pii_json(pii_json)
     nil
   end
 
-  def personal_key?
+  def validated_personal_key?
     reactivate_account_session[:personal_key]
   end
 
@@ -53,6 +54,7 @@ class ReactivateAccountSession
     {
       active: false,
       personal_key: false,
+      validated_personal_key: false,
       pii: nil,
       x509: nil,
     }

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -44,7 +44,7 @@ describe Users::VerifyPasswordController do
 
     context 'with personal key flag set' do
       before do
-        allow(subject.reactivate_account_session).to receive(:personal_key?).
+        allow(subject.reactivate_account_session).to receive(:validated_personal_key?).
           and_return(personal_key)
       end
 

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -106,7 +106,7 @@ describe Users::VerifyPersonalKeyController do
 
         post :create, params: { personal_key: profiles.first.personal_key }
 
-        expect(subject.reactivate_account_session.personal_key?).to eq(true)
+        expect(subject.reactivate_account_session.validated_personal_key?).to eq(true)
       end
     end
 

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -47,35 +47,36 @@ describe ReactivateAccountSession do
       @reactivate_account_session.store_decrypted_pii(pii)
 
       expect(@reactivate_account_session.started?).to be(true)
-      expect(@reactivate_account_session.personal_key?).to be(true)
+      expect(@reactivate_account_session.validated_personal_key?).to be(true)
       expect(@reactivate_account_session.decrypted_pii).to eq(pii)
 
       @reactivate_account_session.suspend
 
       expect(@reactivate_account_session.started?).to be(false)
-      expect(@reactivate_account_session.personal_key?).to be(false)
+      expect(@reactivate_account_session.validated_personal_key?).to be(false)
       expect(@reactivate_account_session.decrypted_pii).to eq(nil)
     end
   end
 
   describe '#store_decrypted_pii' do
-    it 'stores the supplied object in the session and toggles `personal_key` flag' do
+    it 'stores the supplied object in the session and toggles `validated_personal_key` flag' do
       pii = Pii::Attributes.new(first_name: 'Test')
       @reactivate_account_session.store_decrypted_pii(pii)
       account_reactivation_obj = user_session[:reactivate_account]
       expect(account_reactivation_obj[:personal_key]).to be(true)
+      expect(account_reactivation_obj[:validated_personal_key]).to be(true)
       expect(account_reactivation_obj[:pii]).to eq(pii.to_json)
     end
   end
 
-  describe '#personal_key?' do
+  describe '#validated_personal_key?' do
     it 'defaults to false' do
-      expect(@reactivate_account_session.personal_key?).to be(false)
+      expect(@reactivate_account_session.validated_personal_key?).to be(false)
     end
 
     it 'returns a boolean indicating if the user hsa validated their personal key' do
       @reactivate_account_session.store_decrypted_pii({})
-      expect(@reactivate_account_session.personal_key?).to be(true)
+      expect(@reactivate_account_session.validated_personal_key?).to be(true)
     end
   end
 


### PR DESCRIPTION
A slight followup to #6273. The primary motivation is to rename the key so it doesn't give the appearance of holding a personal key, and it's also an opportunity to rename to something slightly more descriptive.

This will also be a two-part change where we write to both keys on the next deploy, and then start reading the new location and stop writing the old one in the deploy after.