### PR TITLE
Remove references to deprecated and renamed session keys

### DIFF
--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -27,23 +27,21 @@ class ReactivateAccountSession
   # Stores PII as a string in the session
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
-    reactivate_account_session[:personal_key] = true
     reactivate_account_session[:validated_personal_key] = true
     pii_json = pii.to_json
-    reactivate_account_session[:pii] = pii_json
     Pii::Cacher.new(@user, session).save_decrypted_pii_json(pii_json)
     nil
   end
 
   def validated_personal_key?
-    reactivate_account_session[:personal_key]
+    reactivate_account_session[:validated_personal_key]
   end
 
   # Parses string into PII struct
   # @return [Pii::Attributes, nil]
   def decrypted_pii
-    json_str = reactivate_account_session[:pii]
-    Pii::Attributes.new_from_json(json_str) if json_str
+    return unless validated_personal_key?
+    Pii::Cacher.new(@user, session).fetch
   end
 
   private
@@ -53,9 +51,7 @@ class ReactivateAccountSession
   def generate_session
     {
       active: false,
-      personal_key: false,
       validated_personal_key: false,
-      pii: nil,
       x509: nil,
     }
   end

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -63,9 +63,8 @@ describe ReactivateAccountSession do
       pii = Pii::Attributes.new(first_name: 'Test')
       @reactivate_account_session.store_decrypted_pii(pii)
       account_reactivation_obj = user_session[:reactivate_account]
-      expect(account_reactivation_obj[:personal_key]).to be(true)
       expect(account_reactivation_obj[:validated_personal_key]).to be(true)
-      expect(account_reactivation_obj[:pii]).to eq(pii.to_json)
+      expect(user_session[:decrypted_pii]).to eq(pii.to_json)
     end
   end
 


### PR DESCRIPTION
Follow up to #6273 and #6283

Drops the now deprecated fields from the session and reads the new value, but should not be merged until after the next deploy