### PR TITLE
Disallow * as analytics_event param name

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -14,8 +14,12 @@ class FrontendLogController < ApplicationController
   def create
     event = log_params[:event]
     payload = log_params[:payload].to_h
-    if EVENT_MAP.key?(event)
-      EVENT_MAP[event].bind_call(analytics, **payload)
+    if (analytics_method = EVENT_MAP[event])
+      if analytics_method.parameters.empty?
+        analytics_method.bind_call(analytics)
+      else
+        analytics_method.bind_call(analytics, **payload)
+      end
     else
       analytics.track_event("Frontend: #{event}", payload)
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -505,13 +505,13 @@ module AnalyticsEvents
 
   # @identity.idp.event_name IdV: personal key visited
   # User visited IDV personal key page
-  def idv_personal_key_visited(*)
+  def idv_personal_key_visited
     track_event('IdV: personal key visited')
   end
 
   # @identity.idp.event_name IdV: personal key submitted
   # User submitted IDV personal key page
-  def idv_personal_key_submitted(*)
+  def idv_personal_key_submitted
     track_event('IdV: personal key submitted')
   end
 
@@ -526,7 +526,7 @@ module AnalyticsEvents
   # @identity.idp.event_name IdV: personal key confirm visited
   # @identity.idp.previous_event_name IdV: show personal key modal
   # User opened IDV personal key confirmation modal
-  def idv_personal_key_confirm_visited(*)
+  def idv_personal_key_confirm_visited
     track_event('IdV: personal key confirm visited')
   end
 

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -86,6 +86,10 @@ class AnalyticsEventsDocumenter
         errors << "#{error_prefix} missing **extra"
       end
 
+      if method_object.signature.end_with?('*)')
+        errors << "#{error_prefix} don't use * as an argument, remove all args or name args"
+      end
+
       errors
     end
   end

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -137,6 +137,20 @@ RSpec.describe AnalyticsEventsDocumenter do
         expect(documenter.missing_documentation.first).to include('some_event missing **extra')
       end
     end
+
+    context 'when a method has * as its only arg' do
+      let(:source_code) { <<~RUBY }
+        class AnalyticsEvents
+          # @identity.idp.event_name Some Event
+          def some_event(*)
+          end
+        end
+      RUBY
+
+      it 'errors' do
+        expect(documenter.missing_documentation.first).to include("don't use * as an argument")
+      end
+    end
   end
 
   describe '#as_json' do


### PR DESCRIPTION
**Why**: This allows any arguments, so if callers passed args,
they would go undocumented and also not make it to the logs

[skip changelog]

- It turns out `*` is invisible to YARD as parameter because it doesn't have a name, so we had to look at the signature for it