### PR TITLE
Fix icon display for status page

### DIFF
--- a/app/components/status_page_component.rb
+++ b/app/components/status_page_component.rb
@@ -27,7 +27,7 @@ class StatusPageComponent < BaseComponent
   end
 
   def icon_src
-    image_path("status/#{[status, icon].compact.join('-')}")
+    image_path("status/#{[status, icon].compact.join('-')}.svg")
   end
 
   def icon_alt

--- a/app/components/status_page_component.rb
+++ b/app/components/status_page_component.rb
@@ -27,7 +27,7 @@ class StatusPageComponent < BaseComponent
   end
 
   def icon_src
-    image_path("status/#{[status, icon].compact.join('-')}.svg")
+    image_path("status/#{[status, icon].compact.join('-')}", extname: '.svg')
   end
 
   def icon_alt


### PR DESCRIPTION
**Why**: So that we don't show broken images.

**Implementation Notes:**

* This was previously working locally because the image could be resolved as extensionless using the asset pipeline. With the static assets CDN in deployed environments, the resolution was not happening automatically.
* I tried coming up with a test case to cover this scenario, though I wasn't successful in stubbing the Rails configuration such that it would resolve similar to how it behaves in production.

**Screenshots:**

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/166458387-8d72094c-5cfb-4c40-99dc-36d1fc03b898.png)|![after](https://user-images.githubusercontent.com/1779930/166458731-b0ea85a5-e353-47e0-bfe9-322232053bd3.png)


