### PR TITLE
LG-6201: Add personal confirm step submitted as frontend unprefixed event

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -7,8 +7,9 @@ class FrontendLogController < ApplicationController
 
   EVENT_MAP = {
     'IdV: personal key visited' => :idv_personal_key_visited,
-    'IdV: personal key confirm visited' => :idv_personal_key_confirm_visited,
     'IdV: personal key submitted' => :idv_personal_key_submitted,
+    'IdV: personal key confirm visited' => :idv_personal_key_confirm_visited,
+    'IdV: personal key confirm submitted' => :idv_personal_key_confirm_submitted,
   }.transform_values { |method| AnalyticsEvents.instance_method(method) }.freeze
 
   def create

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -530,6 +530,12 @@ module AnalyticsEvents
     track_event('IdV: personal key confirm visited')
   end
 
+  # @identity.idp.event_name IdV: personal key confirm submitted
+  # User submitted IDV personal key confirmation modal
+  def idv_personal_key_confirm_submitted
+    track_event('IdV: personal key confirm submitted')
+  end
+
   # @identity.idp.event_name IdV: phone confirmation form
   # @param [Boolean] success
   # @param [Hash] errors


### PR DESCRIPTION
Follow-up to #6285

**Why**: Toward the objective that all "visited" and "submitted" events associated with step progress in the IDV API application should be unprefixed (no "Frontend:" prefix for events).

**Testing Instructions:**

1. Set `idv_api_enabled: true` in local `config/application.yml`
2. Sign in with an un-proofed user, or create a new account
3. Go to http://localhost:3000/verify
4. Complete the entire proofing process, including submitted personal key confirmation
5. In your terminal, run `tail -2 log/events.log`
6. Observe the first of two events is `"name":"IdV: personal key confirm submitted"` (previously, `"name":"Frontend: IdV: personal key confirm submitted"`)

**Implementation Notes:**

As an alternative, I considered collapsing "Personal Key" and "Personal Key Confirm" to a single step, which has the advantage of mapping more seamlessly to existing events. Also, one of the original reasons for splitting steps was to interoperate better with the implicit behavior of the Continue/Submit buttons, but this was changed in #6280. The primary challenge remaining with flattening the steps is that the "Continue" button to open the modal should not advance to the next step or trigger flow completion, which requires a bit of intervention. I'm still open to the idea, however.