### PR TITLE
LG-6220: Split IdV app feature flags to per-step

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,13 +1,11 @@
 module Api
   class BaseController < ApplicationController
-    before_action :check_api_enabled
+    include RenderConditionConcern
+
+    check_or_render_not_found -> { FeatureManagement.idv_api_enabled? }
     before_action :confirm_two_factor_authenticated_for_api
 
     respond_to :json
-
-    def check_api_enabled
-      render_api_not_found unless IdentityConfig.store.idv_api_enabled
-    end
 
     def confirm_two_factor_authenticated_for_api
       return if user_fully_authenticated?

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -13,9 +13,5 @@ module Api
       return if user_fully_authenticated?
       render json: { error: 'user is not fully authenticated' }, status: :unauthorized
     end
-
-    def render_api_not_found
-      render json: { error: "The page you were looking for doesn't exist" }, status: :not_found
-    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -396,6 +396,10 @@ class ApplicationController < ActionController::Base
     render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
   end
 
+  def render_json_not_found
+    render json: { error: "The page you were looking for doesn't exist" }, status: :not_found
+  end
+
   def render_not_acceptable
     render template: 'pages/not_acceptable', layout: false, status: :not_acceptable, formats: :html
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -393,11 +393,14 @@ class ApplicationController < ActionController::Base
   end
 
   def render_not_found
-    render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
-  end
-
-  def render_json_not_found
-    render json: { error: "The page you were looking for doesn't exist" }, status: :not_found
+    respond_to do |format|
+      format.html do
+        render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
+      end
+      format.json do
+        render json: { error: "The page you were looking for doesn't exist" }, status: :not_found
+      end
+    end
   end
 
   def render_not_acceptable

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -394,11 +394,11 @@ class ApplicationController < ActionController::Base
 
   def render_not_found
     respond_to do |format|
-      format.html do
-        render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
-      end
       format.json do
         render json: { error: "The page you were looking for doesn't exist" }, status: :not_found
+      end
+      format.any do
+        render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
       end
     end
   end

--- a/app/controllers/concerns/render_condition_concern.rb
+++ b/app/controllers/concerns/render_condition_concern.rb
@@ -3,13 +3,7 @@ module RenderConditionConcern
 
   module ClassMethods
     def check_or_render_not_found(callable, **kwargs)
-      before_action(**kwargs) do
-        next if callable.call
-        respond_to do |format|
-          format.html { render_not_found }
-          format.json { render_json_not_found }
-        end
-      end
+      before_action(**kwargs) { render_not_found if !callable.call }
     end
   end
 end

--- a/app/controllers/concerns/render_condition_concern.rb
+++ b/app/controllers/concerns/render_condition_concern.rb
@@ -3,7 +3,13 @@ module RenderConditionConcern
 
   module ClassMethods
     def check_or_render_not_found(callable, **kwargs)
-      before_action(**kwargs) { render_not_found if !callable.call }
+      before_action(**kwargs) do
+        next if callable.call
+        respond_to do |format|
+          format.html { render_not_found }
+          format.json { render_json_not_found }
+        end
+      end
     end
   end
 end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -114,11 +114,16 @@ module Idv
     end
 
     def next_step
-      if IdentityConfig.store.idv_api_enabled && idv_session.address_verification_mechanism != 'gpo'
+      if idv_api_personal_key_step_enabled?
         idv_app_root_url
       else
         idv_personal_key_url
       end
+    end
+
+    def idv_api_personal_key_step_enabled?
+      return false if idv_session.address_verification_mechanism == 'gpo'
+      IdentityConfig.store.idv_api_enabled_steps.include?(:personal_key)
     end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -1,12 +1,12 @@
 class VerifyController < ApplicationController
+  include RenderConditionConcern
   include IdvSession
+
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_vendor_session_started
   before_action :confirm_profile_has_been_created
 
-  include RenderConditionConcern
-
-  check_or_render_not_found -> { IdentityConfig.store.idv_api_enabled }, only: [:show]
+  check_or_render_not_found -> { FeatureManagement.idv_api_enabled? }, only: [:show]
 
   def show
     @app_data = app_data
@@ -20,6 +20,7 @@ class VerifyController < ApplicationController
       app_name: APP_NAME,
       completion_url: completion_url,
       initial_values: { 'personalKey' => personal_key },
+      enabled_step_names: IdentityConfig.store.idv_api_enabled_steps,
     }
   end
 

--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -19,6 +19,11 @@ interface VerifyFlowProps {
   initialValues?: Partial<VerifyFlowValues>;
 
   /**
+   * Names of steps to be included in the flow.
+   */
+  enabledStepNames?: string[];
+
+  /**
    * The path to which the current step is appended to create the current step URL.
    */
   basePath?: string;
@@ -55,10 +60,21 @@ const logStepVisited = (stepName: string) =>
 const logStepSubmitted = (stepName: string) =>
   trackEvent(`IdV: ${getEventStepName(stepName)} submitted`);
 
-export function VerifyFlow({ initialValues = {}, basePath, appName, onComplete }: VerifyFlowProps) {
+export function VerifyFlow({
+  initialValues = {},
+  enabledStepNames,
+  basePath,
+  appName,
+  onComplete,
+}: VerifyFlowProps) {
   useEffect(() => {
     logStepVisited(STEPS[0].name);
   }, []);
+
+  let steps = STEPS;
+  if (enabledStepNames) {
+    steps = steps.filter(({ name }) => enabledStepNames.includes(name));
+  }
 
   return (
     <>
@@ -73,7 +89,7 @@ export function VerifyFlow({ initialValues = {}, basePath, appName, onComplete }
         {t('idv.messages.confirm')}
       </Alert>
       <FormSteps
-        steps={STEPS}
+        steps={steps}
         initialValues={initialValues}
         promptOnNavigate={false}
         basePath={basePath}

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -8,6 +8,11 @@ interface AppRootValues {
   initialValues: string;
 
   /**
+   * JSON-encoded array of enabled step names.
+   */
+  enabledStepNames: string;
+
+  /**
    * The path to which the current step is appended to create the current step URL.
    */
   basePath: string;
@@ -28,12 +33,16 @@ interface AppRootElement extends HTMLElement {
 }
 
 const appRoot = document.getElementById('app-root') as AppRootElement;
-const { initialValues, basePath, appName, completionUrl: completionURL } = appRoot.dataset;
+const {
+  initialValues: initialValuesJSON,
+  enabledStepNames: enabledStepNamesJSON,
+  basePath,
+  appName,
+  completionUrl: completionURL,
+} = appRoot.dataset;
 
-let parsedInitialValues;
-try {
-  parsedInitialValues = JSON.parse(initialValues);
-} catch {}
+const initialValues = JSON.parse(initialValuesJSON);
+const enabledStepNames = JSON.parse(enabledStepNamesJSON) as string[];
 
 function onComplete() {
   window.location.href = completionURL;
@@ -41,7 +50,8 @@ function onComplete() {
 
 render(
   <VerifyFlow
-    initialValues={parsedInitialValues}
+    initialValues={initialValues}
+    enabledStepNames={enabledStepNames}
     basePath={basePath}
     appName={appName}
     onComplete={onComplete}

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -93,7 +93,7 @@ gpo_designated_receiver_pii: '{}'
 hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
-idv_api_enabled: false
+idv_api_enabled_steps: '[]'
 idv_attempt_window_in_hours: 6
 idv_max_attempts: 5
 idv_min_age_years: 13

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -112,6 +112,10 @@ class FeatureManagement
     !Rails.env.test? && IdentityConfig.store.log_to_stdout
   end
 
+  def self.idv_api_enabled?
+    IdentityConfig.store.idv_api_enabled_steps.present?
+  end
+
   # Manual allowlist for VOIPs, should only include known VOIPs that we use for smoke tests
   # @return [Set<String>] set of phone numbers normalized to e164
   def self.voip_allowed_phones

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -167,7 +167,7 @@ class IdentityConfig
     config.add(:hmac_fingerprinter_key_queue, type: :json)
     config.add(:identity_pki_disabled, type: :boolean)
     config.add(:identity_pki_local_dev, type: :boolean)
-    config.add(:idv_api_enabled, type: :boolean)
+    config.add(:idv_api_enabled_steps, type: :json, options: { symbolize_names: true })
     config.add(:idv_attempt_window_in_hours, type: :integer)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)

--- a/spec/controllers/api/verify/complete_controller_spec.rb
+++ b/spec/controllers/api/verify/complete_controller_spec.rb
@@ -31,7 +31,7 @@ describe Api::Verify::CompleteController do
   let(:jwt) { JWT.encode({ pii: pii, metadata: {} }, key, 'RS256', sub: user.uuid) }
 
   before do
-    allow(IdentityConfig.store).to receive(:idv_api_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([:personal_key])
   end
 
   describe 'before_actions' do
@@ -73,11 +73,11 @@ describe Api::Verify::CompleteController do
 
     context 'when the idv api is not enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:idv_api_enabled).and_return(false)
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([])
       end
 
       it 'responds with not found' do
-        post :create, params: { password: 'iambatman', details: jwt }
+        post :create, params: { password: 'iambatman', details: jwt }, as: :json
         expect(response.status).to eq 404
         expect(JSON.parse(response.body)['error']).
           to eq "The page you were looking for doesn't exist"

--- a/spec/controllers/concerns/render_condition_concern_spec.rb
+++ b/spec/controllers/concerns/render_condition_concern_spec.rb
@@ -76,4 +76,23 @@ RSpec.describe RenderConditionConcern, type: :controller do
       end
     end
   end
+
+  context 'with json response handling' do
+    controller ApplicationController do
+      include RenderConditionConcern
+
+      check_or_render_not_found -> { FeatureManagement.all_feature? }
+
+      def index
+        render json: {}
+      end
+    end
+
+    subject(:response) { get :index, as: :json }
+
+    it 'renders 404 api response' do
+      expect(response).to be_not_found
+      expect(JSON.parse(response.body)).to have_key('error')
+    end
+  end
 end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -293,7 +293,7 @@ describe Idv::ReviewController do
         allow(@analytics).to receive(:track_event)
       end
 
-      it 'redirects to confirmation path' do
+      it 'redirects to personal key path' do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_received(:track_event).with(Analytics::IDV_REVIEW_COMPLETE)
@@ -345,6 +345,19 @@ describe Idv::ReviewController do
             where.not(disavowal_token_fingerprint: nil).count
           expect(disavowal_event_count).to eq 1
         end
+
+        context 'with idv app personal key step enabled' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+              and_return([:personal_key])
+          end
+
+          it 'redirects to idv app personal key path' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(response).to redirect_to idv_app_root_url
+          end
+        end
       end
 
       context 'user picked GPO confirmation' do
@@ -359,6 +372,19 @@ describe Idv::ReviewController do
           profile.reload
 
           expect(profile).to_not be_active
+        end
+
+        context 'with idv api personal key step enabled' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+              and_return([:personal_key])
+          end
+
+          it 'redirects to personal key path' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(response).to redirect_to idv_personal_key_path
+          end
         end
       end
     end

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -24,9 +24,9 @@ describe VerifyController do
       stub_idv_session
     end
 
-    context 'with idv_api_enabled feature disabled' do
+    context 'with step feature-disabled' do
       before do
-        allow(IdentityConfig.store).to receive(:idv_api_enabled).and_return(false)
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([])
       end
 
       it 'renders 404' do
@@ -34,9 +34,10 @@ describe VerifyController do
       end
     end
 
-    context 'with idv_api_enabled feature enabled' do
+    context 'with step feature-enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:idv_api_enabled).and_return(true)
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+          and_return([:personal_key, :personal_key_confirm])
       end
 
       it 'renders view' do

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -353,6 +353,24 @@ describe 'FeatureManagement', type: :feature do
     end
   end
 
+  describe 'idv_api_enabled?' do
+    context 'with no steps enabled' do
+      it 'returns false' do
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([])
+
+        expect(FeatureManagement.idv_api_enabled?).to eq(false)
+      end
+    end
+
+    context 'with steps enabled' do
+      it 'returns true' do
+        allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return([:example])
+
+        expect(FeatureManagement.idv_api_enabled?).to eq(true)
+      end
+    end
+  end
+
   describe '.voip_allowed_phones' do
     before do
       # clear memoization


### PR DESCRIPTION
**Why**: So that we have the option to enable specific polished steps in deployed environments without needing to enable them all.