### PR TITLE
Override default_url_options to set correct host, port in JS specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,10 +71,11 @@ RSpec.configure do |config|
 
   config.before(:each, js: true) do
     server = Capybara.current_session.server
-    allow(IdentityConfig.store).to receive(:domain_name).and_return("#{server.host}:#{server.port}")
-    allow(Rails.application.routes).to receive(:default_url_options).and_return(
-      Rails.application.routes.default_url_options.merge(host: "#{server.host}:#{server.port}"),
-    )
+    server_domain = "#{server.host}:#{server.port}"
+    allow(IdentityConfig.store).to receive(:domain_name).and_return(server_domain)
+    default_url_options = ApplicationController.default_url_options.merge(host: server_domain)
+    self.default_url_options = default_url_options
+    allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
   end
 
   config.before(:each, type: :controller) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,8 +70,8 @@ RSpec.configure do |config|
   end
 
   config.before(:each, js: true) do
-    allow(IdentityConfig.store).to receive(:domain_name).and_return('127.0.0.1')
     server = Capybara.current_session.server
+    allow(IdentityConfig.store).to receive(:domain_name).and_return("#{server.host}:#{server.port}")
     allow(Rails.application.routes).to receive(:default_url_options).and_return(
       Rails.application.routes.default_url_options.merge(host: "#{server.host}:#{server.port}"),
     )


### PR DESCRIPTION
Extracted from #6229

**Why**: So that URL helpers use the correct, expected host name for the running server, rather than "example.com".

Reference: https://github.com/rspec/rspec-rails/issues/1275

I had originally planned to leave this in #6229, but coincidentally, @SammySteiner had run into the same issue for specs for #6278.