### PR TITLE
Update Frontend documentation overview

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -46,7 +46,7 @@ identify issues in your code as you write.
 
 - All new code is expected to be written using [TypeScript](https://www.typescriptlang.org/) (`.ts` or `.tsx` file extension)
 - The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
-- Follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
+- The code follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
 - Code styling is formatted automatically using [Prettier](https://prettier.io/)
 - Packages are managed with [Yarn](https://yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
 - JavaScript is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -47,11 +47,9 @@ identify issues in your code as you write.
 - All new code is expected to be written using [TypeScript](https://www.typescriptlang.org/) (`.ts` or `.tsx` file extension)
 - The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
 - Follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
-- Code styling is formatted automatically using [Prettier](https://prettier.io/).
-- JS modules are installed & managed via `yarn` (see `package.json`).
-- JS is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/).
-- Reusable code is organized using
-  [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
+- Code styling is formatted automatically using [Prettier](https://prettier.io/)
+- Packages are managed with [Yarn](https://yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
+- JS is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
 
 ### Prettier
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -48,7 +48,7 @@ identify issues in your code as you write.
 - The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
 - The code follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
 - Code styling is formatted automatically using [Prettier](https://prettier.io/)
-- Packages are managed with [Yarn](https://yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
+- Packages are managed with [Yarn](https://classic.yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
 - JavaScript is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
 
 ### Prettier

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -45,7 +45,8 @@ identify issues in your code as you write.
 ### At a Glance
 
 - The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
-- Uses AirBnB's ESLint config, alongside [Prettier](https://prettier.io/).
+- Follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
+- Code styling is formatted automatically using [Prettier](https://prettier.io/).
 - JS modules are installed & managed via `yarn` (see `package.json`).
 - JS is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/).
 - Reusable code is organized using

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -44,6 +44,7 @@ identify issues in your code as you write.
 
 ### At a Glance
 
+- All new code is expected to be written using [TypeScript](https://www.typescriptlang.org/) (`.ts` or `.tsx` file extension)
 - The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
 - Follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
 - Code styling is formatted automatically using [Prettier](https://prettier.io/).

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -49,7 +49,7 @@ identify issues in your code as you write.
 - Follows [TTS JavaScript standards](https://engineering.18f.gov/javascript/), using a [custom ESLint configuration](https://github.com/18F/identity-idp/tree/main/app/javascript/packages/eslint-plugin)
 - Code styling is formatted automatically using [Prettier](https://prettier.io/)
 - Packages are managed with [Yarn](https://yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
-- JS is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
+- JavaScript is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
 
 ### Prettier
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -44,7 +44,7 @@ identify issues in your code as you write.
 
 ### At a Glance
 
-- Site should work if JS is off (and have enhanced features if JS is on).
+- The site should be functional even when JavaScript is disabled, with a few specific exceptions (identity proofing)
 - Uses AirBnB's ESLint config, alongside [Prettier](https://prettier.io/).
 - JS modules are installed & managed via `yarn` (see `package.json`).
 - JS is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/).


### PR DESCRIPTION
**Why**: So that it's accurate and useful for onboarding.

As I discovered when recently sharing this, the document has fallen slightly out-of-date.

Refer to commit history for specific updates, as well as rationale in extended commit description.