### PR TITLE
Fix 500 in analytics logging from missing constant

### DIFF
--- a/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
@@ -3,7 +3,7 @@ module Funnel
     class RegisterStepFromAnalyticsSubmitEvent
       ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN = {
         Analytics::IDV_GPO_ADDRESS_LETTER_REQUESTED => :usps_letter_sent,
-        Analytics::IDV_PHONE_CONFIRMATION_FORM => :verify_phone,
+        'IdV: phone confirmation form' => :verify_phone,
       }.freeze
 
       def self.call(user_id, issuer, event, result)


### PR DESCRIPTION
**Why**: So that the build passes, and so that we don't have 500 errors.

Context: https://github.com/18F/identity-idp/pull/6288/files#r864759689

There's probably a more elegant way to implement this than to repeat the event name string, but I'm most concerned with restoring the passing build.