### PR TITLE
test-helpers: Add useSandbox test helper

### DIFF
--- a/app/javascript/packages/countdown-element/index.spec.ts
+++ b/app/javascript/packages/countdown-element/index.spec.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { i18n } from '@18f/identity-i18n';
-import { usePropertyValue } from '@18f/identity-test-helpers';
+import { usePropertyValue, useSandbox } from '@18f/identity-test-helpers';
 import { CountdownElement } from './index';
 
 const DEFAULT_DATASET = {
@@ -10,7 +10,7 @@ const DEFAULT_DATASET = {
 };
 
 describe('CountdownElement', () => {
-  let clock: sinon.SinonFakeTimers;
+  const { clock } = useSandbox({ useFakeTimers: true });
 
   usePropertyValue(i18n, 'strings', {
     'datetime.dotiw.seconds': { one: 'one second', other: '%{count} seconds' },
@@ -22,12 +22,6 @@ describe('CountdownElement', () => {
     if (!customElements.get('lg-countdown')) {
       customElements.define('lg-countdown', CountdownElement);
     }
-
-    clock = sinon.useFakeTimers();
-  });
-
-  after(() => {
-    clock.restore();
   });
 
   function createElement(dataset = {}) {

--- a/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
@@ -1,12 +1,12 @@
-import sinon from 'sinon';
 import baseUserEvent from '@testing-library/user-event';
 import { getByRole, fireEvent, screen } from '@testing-library/dom';
+import { useSandbox } from '@18f/identity-test-helpers';
 import './spinner-button-element';
 import type { SpinnerButtonElement } from './spinner-button-element';
 
 describe('SpinnerButtonElement', () => {
-  let clock: sinon.SinonFakeTimers;
-  const userEvent = baseUserEvent.setup({ advanceTimers: (ms: number) => clock.tick(ms) });
+  const { clock } = useSandbox({ useFakeTimers: true });
+  const userEvent = baseUserEvent.setup({ advanceTimers: clock.tick });
 
   const longWaitDurationMs = 1000;
 
@@ -44,14 +44,6 @@ describe('SpinnerButtonElement', () => {
 
     return document.body.firstElementChild as SpinnerButtonElement;
   }
-
-  beforeEach(() => {
-    clock = sinon.useFakeTimers();
-  });
-
-  afterEach(() => {
-    clock.restore();
-  });
 
   it('shows spinner on click', async () => {
     const wrapper = createWrapper();

--- a/app/javascript/packages/spinner-button/spinner-button.spec.tsx
+++ b/app/javascript/packages/spinner-button/spinner-button.spec.tsx
@@ -1,21 +1,13 @@
-import sinon from 'sinon';
 import baseUserEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import { createRef } from 'react';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { SpinnerButtonElement } from './spinner-button-element';
 import SpinnerButton from './spinner-button';
 
 describe('SpinnerButton', () => {
-  const sandbox = sinon.createSandbox();
-  const userEvent = baseUserEvent.setup({ advanceTimers: (ms: number) => sandbox.clock.tick(ms) });
-
-  beforeEach(() => {
-    sandbox.useFakeTimers();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
+  const { clock } = useSandbox({ useFakeTimers: true });
+  const userEvent = baseUserEvent.setup({ advanceTimers: clock.tick });
 
   it('renders a SpinnerButton', async () => {
     const { getByRole } = render(<SpinnerButton>Spin!</SpinnerButton>);
@@ -50,7 +42,7 @@ describe('SpinnerButton', () => {
     expect(status.textContent).not.to.be.empty();
     expect(status.classList.contains('usa-sr-only')).to.be.true();
 
-    sandbox.clock.tick(1);
+    clock.tick(1);
 
     expect(status.textContent).not.to.be.empty();
     expect(status.classList.contains('usa-sr-only')).to.be.false();
@@ -70,7 +62,7 @@ describe('SpinnerButton', () => {
     expect(spinner.classList.contains('spinner-button--spinner-active')).to.be.false();
 
     spinner.toggleSpinner(true);
-    sandbox.clock.tick(1);
+    clock.tick(1);
     expect(status.classList.contains('usa-sr-only')).to.be.false();
   });
 

--- a/app/javascript/packages/test-helpers/index.ts
+++ b/app/javascript/packages/test-helpers/index.ts
@@ -1,2 +1,3 @@
 export { default as useDefineProperty } from './use-define-property';
 export { default as usePropertyValue } from './use-property-value';
+export { default as useSandbox } from './use-sandbox';

--- a/app/javascript/packages/test-helpers/package.json
+++ b/app/javascript/packages/test-helpers/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-test-helpers",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "peerDependencies": {
+    "sinon": "^9.2.2"
+  }
 }

--- a/app/javascript/packages/test-helpers/use-sandbox.spec.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.spec.ts
@@ -1,0 +1,11 @@
+import useSandbox from './use-sandbox';
+
+describe('useSandbox', () => {
+  context('with fake timers', () => {
+    const { clock } = useSandbox({ useFakeTimers: true });
+
+    it('supports invoking against a destructured clock', () => {
+      clock.tick(0);
+    });
+  });
+});

--- a/app/javascript/packages/test-helpers/use-sandbox.spec.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.spec.ts
@@ -4,8 +4,18 @@ describe('useSandbox', () => {
   context('with fake timers', () => {
     const { clock } = useSandbox({ useFakeTimers: true });
 
+    expect(clock.tick).to.be.a('function');
+
     it('supports invoking against a destructured clock', () => {
       clock.tick(0);
+    });
+
+    it('advances the clock', () => {
+      const MAX_SAFE_32_BIT_INT = 2147483647;
+      return new Promise((resolve) => {
+        setTimeout(resolve, MAX_SAFE_32_BIT_INT);
+        clock.tick(MAX_SAFE_32_BIT_INT);
+      });
     });
   });
 });

--- a/app/javascript/packages/test-helpers/use-sandbox.spec.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.spec.ts
@@ -1,6 +1,21 @@
 import useSandbox from './use-sandbox';
 
 describe('useSandbox', () => {
+  const sandbox = useSandbox();
+
+  const object = { fn: () => 0 };
+
+  afterEach(() => {
+    expect(object.fn()).to.equal(0);
+  });
+
+  it('cleans up after itself', () => {
+    sandbox.stub(object, 'fn').callsFake(() => 1);
+
+    expect(object.fn()).to.equal(1);
+    // See `afterEach` for clean-up assertions
+  });
+
   context('with fake timers', () => {
     const { clock } = useSandbox({ useFakeTimers: true });
 

--- a/app/javascript/packages/test-helpers/use-sandbox.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.ts
@@ -1,19 +1,20 @@
 import sinon from 'sinon';
-import type { SinonSandboxConfig } from 'sinon';
+import type { SinonSandboxConfig, SinonFakeTimers } from 'sinon';
 
 /**
  * Returns an instance of a Sinon sandbox, and automatically restores all stubbed methods after each
  * test case.
  */
-function useSandbox(config?: SinonSandboxConfig) {
+function useSandbox(config?: Partial<SinonSandboxConfig>) {
   const { useFakeTimers = false, ...remainingConfig } = config ?? {};
   const sandbox = sinon.createSandbox(remainingConfig);
+  const clock = {} as SinonFakeTimers;
 
   beforeEach(() => {
     // useFakeTimers overrides global timer functions as soon as sandbox is created, thus leaking
     // across tests. Instead, wait until tests start to initialize.
     if (useFakeTimers) {
-      sandbox.useFakeTimers();
+      Object.assign(clock, sandbox.useFakeTimers());
     }
   });
 
@@ -26,7 +27,7 @@ function useSandbox(config?: SinonSandboxConfig) {
     }
   });
 
-  return sandbox;
+  return { ...sandbox, clock };
 }
 
 export default useSandbox;

--- a/app/javascript/packages/test-helpers/use-sandbox.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.ts
@@ -8,13 +8,16 @@ import type { SinonSandboxConfig, SinonFakeTimers } from 'sinon';
 function useSandbox(config?: Partial<SinonSandboxConfig>) {
   const { useFakeTimers = false, ...remainingConfig } = config ?? {};
   const sandbox = sinon.createSandbox(remainingConfig);
-  const clock = {} as SinonFakeTimers;
+
+  let tick = (_ms: number) => {};
+  const clock = { tick: (ms: number) => tick(ms) } as unknown as SinonFakeTimers;
 
   beforeEach(() => {
     // useFakeTimers overrides global timer functions as soon as sandbox is created, thus leaking
     // across tests. Instead, wait until tests start to initialize.
     if (useFakeTimers) {
       Object.assign(clock, sandbox.useFakeTimers());
+      tick = clock.tick;
     }
   });
 

--- a/app/javascript/packages/test-helpers/use-sandbox.ts
+++ b/app/javascript/packages/test-helpers/use-sandbox.ts
@@ -1,0 +1,32 @@
+import sinon from 'sinon';
+import type { SinonSandboxConfig } from 'sinon';
+
+/**
+ * Returns an instance of a Sinon sandbox, and automatically restores all stubbed methods after each
+ * test case.
+ */
+function useSandbox(config?: SinonSandboxConfig) {
+  const { useFakeTimers = false, ...remainingConfig } = config ?? {};
+  const sandbox = sinon.createSandbox(remainingConfig);
+
+  beforeEach(() => {
+    // useFakeTimers overrides global timer functions as soon as sandbox is created, thus leaking
+    // across tests. Instead, wait until tests start to initialize.
+    if (useFakeTimers) {
+      sandbox.useFakeTimers();
+    }
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+    sandbox.restore();
+
+    if (useFakeTimers) {
+      sandbox.clock.restore();
+    }
+  });
+
+  return sandbox;
+}
+
+export default useSandbox;

--- a/spec/javascripts/app/components/modal-spec.js
+++ b/spec/javascripts/app/components/modal-spec.js
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/dom';
+import { useSandbox } from '@18f/identity-test-helpers';
 import BaseModal from '../../../../app/javascript/app/components/modal';
-import { useSandbox } from '../../support/sinon';
 
 describe('components/modal', () => {
   const sandbox = useSandbox();

--- a/spec/javascripts/app/webauthn_spec.js
+++ b/spec/javascripts/app/webauthn_spec.js
@@ -1,5 +1,5 @@
 import { TextEncoder } from 'util';
-import { useSandbox } from '../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 import * as WebAuthn from '../../../app/javascript/app/webauthn';
 
 describe('WebAuthn', () => {

--- a/spec/javascripts/packages/analytics/index-spec.js
+++ b/spec/javascripts/packages/analytics/index-spec.js
@@ -1,5 +1,5 @@
 import { trackEvent } from '@18f/identity-analytics';
-import { useSandbox } from '../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 
 describe('trackEvent', () => {
   const sandbox = useSandbox();

--- a/spec/javascripts/packages/document-capture-polling/index-spec.js
+++ b/spec/javascripts/packages/document-capture-polling/index-spec.js
@@ -5,7 +5,7 @@ import {
   MAX_DOC_CAPTURE_POLL_ATTEMPTS,
   DOC_CAPTURE_POLL_INTERVAL,
 } from '@18f/identity-document-capture-polling';
-import { useSandbox } from '../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 
 describe('DocumentCapturePolling', () => {
   const sandbox = useSandbox({ useFakeTimers: true });

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -16,8 +16,8 @@ import DocumentCapture, {
   except,
 } from '@18f/identity-document-capture/components/document-capture';
 import { expect } from 'chai';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
-import { useSandbox } from '../../../support/sinon';
 import { getFixture, getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/document-capture', () => {

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -7,8 +7,8 @@ import {
 } from '@18f/identity-document-capture';
 import ReviewIssuesStep from '@18f/identity-document-capture/components/review-issues-step';
 import { toFormEntryError } from '@18f/identity-document-capture/services/upload';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { render } from '../../../support/document-capture';
-import { useSandbox } from '../../../support/sinon';
 import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/review-issues-step', () => {

--- a/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
@@ -4,8 +4,8 @@ import { cleanup } from '@testing-library/react';
 import { I18nContext } from '@18f/identity-react-i18n';
 import { I18n } from '@18f/identity-i18n';
 import SelfieCapture from '@18f/identity-document-capture/components/selfie-capture';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { render } from '../../../support/document-capture';
-import { useSandbox } from '../../../support/sinon';
 import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/selfie-capture', () => {

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -5,8 +5,8 @@ import SubmissionComplete, {
   RetrySubmissionError,
 } from '@18f/identity-document-capture/components/submission-complete';
 import SuspenseErrorBoundary from '@18f/identity-document-capture/components/suspense-error-boundary';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { render, useDocumentCaptureForm } from '../../../support/document-capture';
-import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/submission-complete-step', () => {
   const onSubmit = useDocumentCaptureForm();

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -4,7 +4,7 @@ import UploadContext, {
   Provider as UploadContextProvider,
 } from '@18f/identity-document-capture/context/upload';
 import defaultUpload from '@18f/identity-document-capture/services/upload';
-import { useSandbox } from '../../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 
 describe('document-capture/context/upload', () => {
   const sandbox = useSandbox();

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -6,7 +6,7 @@ import withBackgroundEncryptedUpload, {
   blobToArrayBuffer,
   encrypt,
 } from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
-import { useSandbox } from '../../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 import { render } from '../../../support/document-capture';
 
 /**

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -4,7 +4,7 @@ import upload, {
   toFormData,
   toFormEntryError,
 } from '@18f/identity-document-capture/services/upload';
-import { useSandbox } from '../../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 
 describe('document-capture/services/upload', () => {
   const sandbox = useSandbox();

--- a/spec/javascripts/packages/one-time-code-input/index-spec.js
+++ b/spec/javascripts/packages/one-time-code-input/index-spec.js
@@ -2,7 +2,7 @@ import OneTimeCodeInput from '@18f/identity-one-time-code-input';
 import { waitFor, screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
-import { useSandbox } from '../../support/sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
 
 describe('OneTimeCodeInput', () => {
   const sandbox = useSandbox();

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -1,6 +1,5 @@
 import { fireEvent, findByRole } from '@testing-library/dom';
-import { useDefineProperty } from '@18f/identity-test-helpers';
-import { useSandbox } from '../support/sinon';
+import { useDefineProperty, useSandbox } from '@18f/identity-test-helpers';
 import {
   FormStepsWait,
   getDOMFromHTML,

--- a/spec/javascripts/packs/webauthn-setup-spec.js
+++ b/spec/javascripts/packs/webauthn-setup-spec.js
@@ -1,5 +1,4 @@
-import { useDefineProperty } from '@18f/identity-test-helpers';
-import { useSandbox } from '../support/sinon';
+import { useDefineProperty, useSandbox } from '@18f/identity-test-helpers';
 import { reloadWithError } from '../../../app/javascript/packs/webauthn-setup';
 
 describe('webauthn-setup', () => {

--- a/spec/javascripts/packs/webauthn-unhide-spec.js
+++ b/spec/javascripts/packs/webauthn-unhide-spec.js
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/dom';
-import { useDefineProperty } from '@18f/identity-test-helpers';
-import { useSandbox } from '../support/sinon';
+import { useDefineProperty, useSandbox } from '@18f/identity-test-helpers';
 import { unhideWebauthn } from '../../../app/javascript/packs/webauthn-unhide';
 
 describe('webauthn-unhide', () => {

--- a/spec/javascripts/support/sinon.js
+++ b/spec/javascripts/support/sinon.js
@@ -1,35 +1,3 @@
-import sinon from 'sinon';
-
-/**
- * Returns an instance of a Sinon sandbox, and automatically restores all stubbed methods after each
- * test case.
- *
- * @param {sinon.SinonSandboxConfig=} config
- */
-export function useSandbox(config) {
-  const { useFakeTimers = false, ...remainingConfig } = config ?? {};
-  const sandbox = sinon.createSandbox(remainingConfig);
-
-  beforeEach(() => {
-    // useFakeTimers overrides global timer functions as soon as sandbox is created, thus leaking
-    // across tests. Instead, wait until tests start to initialize.
-    if (useFakeTimers) {
-      sandbox.useFakeTimers();
-    }
-  });
-
-  afterEach(() => {
-    sandbox.reset();
-    sandbox.restore();
-
-    if (useFakeTimers) {
-      sandbox.clock.restore();
-    }
-  });
-
-  return sandbox;
-}
-
 /**
  * Chai plugin which allows a combination of `calledWith` and `eventually` to expect an eventual
  * spy (stub) call.


### PR DESCRIPTION
**Why**:

- It already exists in `spec`, but isn't currently accessible to package specs
- For convenience:
   - Automatic clean-up after spec
   - Delayed initialization of fake timers
   - Support sustained reference to destructured functions
      - Useful for `userEvent.setup({ advanceTimers: clock.tick })`
- Improved testability for the behavior of the helper itself