### PR TITLE
Remove NewRelic frontend event logging

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -342,10 +342,7 @@ function AcuantCapture(
         size: nextValue.size,
       });
 
-      addPageAction({
-        label: `IdV: ${name} image added`,
-        payload: analyticsPayload,
-      });
+      addPageAction(`IdV: ${name} image added`, analyticsPayload);
     }
 
     onChangeAndResetError(nextValue, analyticsPayload);
@@ -366,10 +363,7 @@ function AcuantCapture(
     return (fn) =>
       (...args) => {
         if (!isSuppressingClickLogging.current) {
-          addPageAction({
-            label: `IdV: ${name} image clicked`,
-            payload: { source, ...metadata },
-          });
+          addPageAction(`IdV: ${name} image clicked`, { source, ...metadata });
         }
 
         return fn(...args);
@@ -488,10 +482,7 @@ function AcuantCapture(
       size: getDecodedBase64ByteSize(nextCapture.image.data),
     });
 
-    addPageAction({
-      label: `IdV: ${name} image added`,
-      payload: analyticsPayload,
-    });
+    addPageAction(`IdV: ${name} image added`, analyticsPayload);
 
     if (assessment === 'success') {
       onChangeAndResetError(data, analyticsPayload);
@@ -537,12 +528,9 @@ function AcuantCapture(
             }
 
             setIsCapturingEnvironment(false);
-            addPageAction({
-              label: 'IdV: Image capture failed',
-              payload: {
-                field: name,
-                error: getNormalizedAcuantCaptureFailureMessage(error, code),
-              },
+            addPageAction('IdV: Image capture failed', {
+              field: name,
+              error: getNormalizedAcuantCaptureFailureMessage(error, code),
             });
           }}
         >

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -489,7 +489,6 @@ function AcuantCapture(
     });
 
     addPageAction({
-      key: 'documentCapture.acuantWebSDKResult',
       label: `IdV: ${name} image added`,
       payload: analyticsPayload,
     });

--- a/app/javascript/packages/document-capture/components/capture-troubleshooting.jsx
+++ b/app/javascript/packages/document-capture/components/capture-troubleshooting.jsx
@@ -28,16 +28,13 @@ function CaptureTroubleshooting({ children }) {
   const { isAssessedAsGlare, isAssessedAsBlurry } = lastAttemptMetadata;
 
   function onCaptureTipsShown() {
-    addPageAction({
-      label: 'IdV: Capture troubleshooting shown',
-      payload: lastAttemptMetadata,
-    });
+    addPageAction('IdV: Capture troubleshooting shown', lastAttemptMetadata);
 
     onPageTransition();
   }
 
   function onCaptureTipsDismissed() {
-    addPageAction({ label: 'IdV: Capture troubleshooting dismissed' });
+    addPageAction('IdV: Capture troubleshooting dismissed');
 
     setDidShowTroubleshooting(true);
   }

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -77,7 +77,7 @@ function ReviewIssuesStep({
   useDidUpdateEffect(onPageTransition, [hasDismissed]);
 
   function onWarningPageDismissed() {
-    addPageAction({ label: 'IdV: Capture troubleshooting dismissed' });
+    addPageAction('IdV: Capture troubleshooting dismissed');
 
     setHasDismissed(true);
   }

--- a/app/javascript/packages/document-capture/components/warning.jsx
+++ b/app/javascript/packages/document-capture/components/warning.jsx
@@ -33,10 +33,7 @@ function Warning({
   const { addPageAction } = useContext(AnalyticsContext);
   const { t } = useI18n();
   useEffect(() => {
-    addPageAction({
-      label: 'IdV: warning shown',
-      payload: { location, remaining_attempts: remainingAttempts },
-    });
+    addPageAction('IdV: warning shown', { location, remaining_attempts: remainingAttempts });
   }, []);
 
   return (
@@ -56,7 +53,7 @@ function Warning({
             type="button"
             className="usa-button usa-button--big usa-button--wide"
             onClick={() => {
-              addPageAction({ label: 'IdV: warning action triggered', payload: { location } });
+              addPageAction('IdV: warning action triggered', { location });
               actionOnClick();
             }}
           >

--- a/app/javascript/packages/document-capture/context/acuant.jsx
+++ b/app/javascript/packages/document-capture/context/acuant.jsx
@@ -205,9 +205,9 @@ function AcuantContextProvider({
                 window
               ).AcuantCamera;
 
-              addPageAction({
-                label: 'IdV: Acuant SDK loaded',
-                payload: { success: true, isCameraSupported: nextIsCameraSupported },
+              addPageAction('IdV: Acuant SDK loaded', {
+                success: true,
+                isCameraSupported: nextIsCameraSupported,
               });
 
               setIsCameraSupported(nextIsCameraSupported);
@@ -216,13 +216,10 @@ function AcuantContextProvider({
             });
           },
           onFail(code, description) {
-            addPageAction({
-              label: 'IdV: Acuant SDK loaded',
-              payload: {
-                success: false,
-                code,
-                description,
-              },
+            addPageAction('IdV: Acuant SDK loaded', {
+              success: false,
+              code,
+              description,
             });
 
             setIsError(true);

--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 
+/** @typedef {import('@18f/identity-analytics').trackEvent} TrackEvent */
 /** @typedef {Record<string,string|number|boolean|null|undefined>} Payload */
 
 /**
@@ -11,23 +12,19 @@ import { createContext } from 'react';
  */
 
 /**
- * @typedef {(action: PageAction)=>void} AddPageAction
- */
-
-/**
  * @typedef {(error: Error)=>void} NoticeError
  */
 
 /**
  * @typedef AnalyticsContext
  *
- * @prop {AddPageAction} addPageAction Log an action with optional payload.
+ * @prop {TrackEvent} addPageAction Log an action with optional payload.
  * @prop {NoticeError} noticeError Log an error without affecting application behavior.
  */
 
 const AnalyticsContext = createContext(
   /** @type {AnalyticsContext} */ ({
-    addPageAction: () => {},
+    addPageAction: () => Promise.resolve(),
     noticeError: () => {},
   }),
 );

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -130,7 +130,6 @@ const withBackgroundEncryptedUpload = (Component) => {
             .then((response) => {
               const traceId = response.headers.get('X-Amzn-Trace-Id');
               addPageAction({
-                key: 'documentCapture.asyncUpload',
                 label: 'IdV: document capture async upload submitted',
                 payload: {
                   success: response.ok,

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -102,24 +102,14 @@ const withBackgroundEncryptedUpload = (Component) => {
             value,
           )
             .catch((error) => {
-              addPageAction({
-                label: 'IdV: document capture async upload encryption',
-                payload: {
-                  success: false,
-                },
-              });
+              addPageAction('IdV: document capture async upload encryption', { success: false });
               noticeError(error);
 
               // Rethrow error to skip upload and proceed from next `catch` block.
               throw error;
             })
             .then((encryptedValue) => {
-              addPageAction({
-                label: 'IdV: document capture async upload encryption',
-                payload: {
-                  success: true,
-                },
-              });
+              addPageAction('IdV: document capture async upload encryption', { success: true });
 
               return window.fetch(url, {
                 method: 'PUT',
@@ -129,13 +119,10 @@ const withBackgroundEncryptedUpload = (Component) => {
             })
             .then((response) => {
               const traceId = response.headers.get('X-Amzn-Trace-Id');
-              addPageAction({
-                label: 'IdV: document capture async upload submitted',
-                payload: {
-                  success: response.ok,
-                  trace_id: traceId,
-                  status_code: response.status,
-                },
+              addPageAction('IdV: document capture async upload submitted', {
+                success: response.ok,
+                trace_id: traceId,
+                status_code: response.status,
               });
 
               if (!response.ok) {

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -103,11 +103,9 @@ const device = {
 };
 
 /** @type {import('@18f/identity-document-capture/context/analytics').AddPageAction} */
-function addPageAction(action) {
+function addPageAction(event, payload) {
   const { flowPath } = appRoot.dataset;
-  const payload = { ...action.payload, flow_path: flowPath };
-
-  trackEvent(action.label, payload);
+  return trackEvent(event, { ...payload, flow_path: flowPath });
 }
 
 /** @type {import('@18f/identity-document-capture/context/analytics').NoticeError} */

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -102,7 +102,7 @@ const device = {
   isMobile: isCameraCapableMobile(),
 };
 
-/** @type {import('@18f/identity-document-capture/context/analytics').AddPageAction} */
+/** @type {import('@18f/identity-analytics').trackEvent} */
 function addPageAction(event, payload) {
   const { flowPath } = appRoot.dataset;
   return trackEvent(event, { ...payload, flow_path: flowPath });

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -20,7 +20,6 @@ import { trackEvent } from '@18f/identity-analytics';
 /**
  * @typedef NewRelicAgent
  *
- * @prop {(name:string,attributes:object)=>void} addPageAction Log page action to New Relic.
  * @prop {(error:Error)=>void} noticeError Log an error without affecting application behavior.
  */
 
@@ -107,11 +106,6 @@ const device = {
 function addPageAction(action) {
   const { flowPath } = appRoot.dataset;
   const payload = { ...action.payload, flow_path: flowPath };
-
-  const { newrelic } = /** @type {DocumentCaptureGlobal} */ (window);
-  if (action.key && newrelic) {
-    newrelic.addPageAction(action.key, payload);
-  }
 
   trackEvent(action.label, payload);
 }

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -278,9 +278,9 @@ describe('document-capture/components/acuant-capture', () => {
       await findByText('doc_auth.errors.camera.failed');
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
       expect(container.querySelector('.full-screen')).to.be.null();
-      expect(addPageAction).to.have.been.calledWith({
-        label: 'IdV: Image capture failed',
-        payload: { field: 'test', error: 'Camera not supported' },
+      expect(addPageAction).to.have.been.calledWith('IdV: Image capture failed', {
+        field: 'test',
+        error: 'Camera not supported',
       });
       expect(document.activeElement).to.equal(button);
     });
@@ -313,9 +313,9 @@ describe('document-capture/components/acuant-capture', () => {
       await findByText('doc_auth.errors.upload_error errors.messages.try_again');
       expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
       expect(container.querySelector('.full-screen')).to.be.null();
-      expect(addPageAction).to.have.been.calledWith({
-        label: 'IdV: Image capture failed',
-        payload: { field: 'test', error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)' },
+      expect(addPageAction).to.have.been.calledWith('IdV: Image capture failed', {
+        field: 'test',
+        error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)',
       });
       await waitFor(() => document.activeElement === button);
 
@@ -355,9 +355,9 @@ describe('document-capture/components/acuant-capture', () => {
         expect(window.AcuantCameraUI.end).to.eventually.be.called(),
       ]);
       expect(container.querySelector('.full-screen')).to.be.null();
-      expect(addPageAction).to.have.been.calledWith({
-        label: 'IdV: Image capture failed',
-        payload: { field: 'test', error: 'User or system denied camera access' },
+      expect(addPageAction).to.have.been.calledWith('IdV: Image capture failed', {
+        field: 'test',
+        error: 'User or system denied camera access',
       });
       expect(document.activeElement).to.equal(button);
     });
@@ -573,27 +573,23 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
 
       const error = await findByText('doc_auth.errors.glare.failed_short');
-      expect(addPageAction).to.have.been.calledWith({
-        key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: test image added',
-        payload: {
-          documentType: 'id',
-          mimeType: 'image/jpeg',
-          source: 'acuant',
-          dpi: 519,
-          moire: 99,
-          glare: 49,
-          height: 1104,
-          sharpnessScoreThreshold: sinon.match.number,
-          glareScoreThreshold: 50,
-          isAssessedAsBlurry: false,
-          isAssessedAsGlare: true,
-          assessment: 'glare',
-          sharpness: 100,
-          width: 1748,
-          attempt: sinon.match.number,
-          size: sinon.match.number,
-        },
+      expect(addPageAction).to.have.been.calledWith('IdV: test image added', {
+        documentType: 'id',
+        mimeType: 'image/jpeg',
+        source: 'acuant',
+        dpi: 519,
+        moire: 99,
+        glare: 49,
+        height: 1104,
+        sharpnessScoreThreshold: sinon.match.number,
+        glareScoreThreshold: 50,
+        isAssessedAsBlurry: false,
+        isAssessedAsGlare: true,
+        assessment: 'glare',
+        sharpness: 100,
+        width: 1748,
+        attempt: sinon.match.number,
+        size: sinon.match.number,
       });
 
       expect(error).to.be.ok();
@@ -631,27 +627,23 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
 
       const error = await findByText('doc_auth.errors.sharpness.failed_short');
-      expect(addPageAction).to.have.been.calledWith({
-        key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: test image added',
-        payload: {
-          documentType: 'id',
-          mimeType: 'image/jpeg',
-          source: 'acuant',
-          dpi: 519,
-          moire: 99,
-          glare: 100,
-          height: 1104,
-          sharpnessScoreThreshold: 50,
-          glareScoreThreshold: sinon.match.number,
-          isAssessedAsBlurry: true,
-          isAssessedAsGlare: false,
-          assessment: 'blurry',
-          sharpness: 49,
-          width: 1748,
-          attempt: sinon.match.number,
-          size: sinon.match.number,
-        },
+      expect(addPageAction).to.have.been.calledWith('IdV: test image added', {
+        documentType: 'id',
+        mimeType: 'image/jpeg',
+        source: 'acuant',
+        dpi: 519,
+        moire: 99,
+        glare: 100,
+        height: 1104,
+        sharpnessScoreThreshold: 50,
+        glareScoreThreshold: sinon.match.number,
+        isAssessedAsBlurry: true,
+        isAssessedAsGlare: false,
+        assessment: 'blurry',
+        sharpness: 49,
+        width: 1748,
+        attempt: sinon.match.number,
+        size: sinon.match.number,
       });
 
       expect(error).to.be.ok();
@@ -742,27 +734,23 @@ describe('document-capture/components/acuant-capture', () => {
 
       fireEvent.click(button);
       await waitFor(() => !error.textContent);
-      expect(addPageAction).to.have.been.calledWith({
-        key: 'documentCapture.acuantWebSDKResult',
-        label: 'IdV: test image added',
-        payload: {
-          documentType: 'id',
-          mimeType: 'image/jpeg',
-          source: 'acuant',
-          dpi: 519,
-          moire: 99,
-          glare: 100,
-          height: 1104,
-          sharpnessScoreThreshold: 50,
-          glareScoreThreshold: sinon.match.number,
-          isAssessedAsBlurry: true,
-          isAssessedAsGlare: false,
-          assessment: 'blurry',
-          sharpness: 49,
-          width: 1748,
-          attempt: sinon.match.number,
-          size: sinon.match.number,
-        },
+      expect(addPageAction).to.have.been.calledWith('IdV: test image added', {
+        documentType: 'id',
+        mimeType: 'image/jpeg',
+        source: 'acuant',
+        dpi: 519,
+        moire: 99,
+        glare: 100,
+        height: 1104,
+        sharpnessScoreThreshold: 50,
+        glareScoreThreshold: sinon.match.number,
+        isAssessedAsBlurry: true,
+        isAssessedAsGlare: false,
+        assessment: 'blurry',
+        sharpness: 49,
+        width: 1748,
+        attempt: sinon.match.number,
+        size: sinon.match.number,
       });
     });
 
@@ -1002,16 +990,13 @@ describe('document-capture/components/acuant-capture', () => {
     const input = getByLabelText('Image');
     uploadFile(input, validUpload);
 
-    await expect(addPageAction).to.eventually.be.calledWith({
-      label: 'IdV: test image added',
-      payload: {
-        height: sinon.match.number,
-        mimeType: 'image/jpeg',
-        source: 'upload',
-        width: sinon.match.number,
-        attempt: sinon.match.number,
-        size: sinon.match.number,
-      },
+    await expect(addPageAction).to.eventually.be.calledWith('IdV: test image added', {
+      height: sinon.match.number,
+      mimeType: 'image/jpeg',
+      source: 'upload',
+      width: sinon.match.number,
+      attempt: sinon.match.number,
+      size: sinon.match.number,
     });
   });
 
@@ -1045,26 +1030,17 @@ describe('document-capture/components/acuant-capture', () => {
     fireEvent.click(upload);
 
     expect(addPageAction).to.have.been.calledThrice();
-    expect(addPageAction.getCall(0)).to.have.been.calledWith({
-      label: 'IdV: test image clicked',
-      payload: {
-        source: 'placeholder',
-        isDrop: false,
-      },
+    expect(addPageAction.getCall(0)).to.have.been.calledWith('IdV: test image clicked', {
+      source: 'placeholder',
+      isDrop: false,
     });
-    expect(addPageAction.getCall(1)).to.have.been.calledWith({
-      label: 'IdV: test image clicked',
-      payload: {
-        source: 'button',
-        isDrop: false,
-      },
+    expect(addPageAction.getCall(1)).to.have.been.calledWith('IdV: test image clicked', {
+      source: 'button',
+      isDrop: false,
     });
-    expect(addPageAction.getCall(2)).to.have.been.calledWith({
-      label: 'IdV: test image clicked',
-      payload: {
-        source: 'upload',
-        isDrop: false,
-      },
+    expect(addPageAction.getCall(2)).to.have.been.calledWith('IdV: test image clicked', {
+      source: 'upload',
+      isDrop: false,
     });
   });
 
@@ -1081,12 +1057,9 @@ describe('document-capture/components/acuant-capture', () => {
     const input = getByLabelText('Image');
     fireEvent.drop(input);
 
-    expect(addPageAction.getCall(0)).to.have.been.calledWith({
-      label: 'IdV: test image clicked',
-      payload: {
-        source: 'placeholder',
-        isDrop: true,
-      },
+    expect(addPageAction.getCall(0)).to.have.been.calledWith('IdV: test image clicked', {
+      source: 'placeholder',
+      isDrop: true,
     });
   });
 
@@ -1103,16 +1076,16 @@ describe('document-capture/components/acuant-capture', () => {
     const input = getByLabelText('Image');
     uploadFile(input, validUpload);
 
-    await expect(addPageAction).to.eventually.be.calledWith({
-      label: 'IdV: test image added',
-      payload: sinon.match({ attempt: 1 }),
-    });
+    await expect(addPageAction).to.eventually.be.calledWith(
+      'IdV: test image added',
+      sinon.match({ attempt: 1 }),
+    );
 
     uploadFile(input, validUpload);
 
-    await expect(addPageAction).to.eventually.be.calledWith({
-      label: 'IdV: test image added',
-      payload: sinon.match({ attempt: 2 }),
-    });
+    await expect(addPageAction).to.eventually.be.calledWith(
+      'IdV: test image added',
+      sinon.match({ attempt: 2 }),
+    );
   });
 });

--- a/spec/javascripts/packages/document-capture/components/capture-advice-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/capture-advice-spec.jsx
@@ -14,22 +14,16 @@ describe('document-capture/components/capture-advice', () => {
       </AnalyticsContext.Provider>,
     );
 
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning shown',
-      payload: {
-        location: 'doc_auth_capture_advice',
-        remaining_attempts: undefined,
-      },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning shown', {
+      location: 'doc_auth_capture_advice',
+      remaining_attempts: undefined,
     });
 
     const button = getByRole('button');
     await userEvent.click(button);
 
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning action triggered',
-      payload: {
-        location: 'doc_auth_capture_advice',
-      },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning action triggered', {
+      location: 'doc_auth_capture_advice',
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/components/capture-troubleshooting-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/capture-troubleshooting-spec.jsx
@@ -89,17 +89,15 @@ describe('document-capture/context/capture-troubleshooting', () => {
     );
 
     expect(addPageAction).to.have.been.calledTwice();
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: Capture troubleshooting shown',
-      payload: { isAssessedAsGlare: false, isAssessedAsBlurry: false },
+    expect(addPageAction).to.have.been.calledWith('IdV: Capture troubleshooting shown', {
+      isAssessedAsGlare: false,
+      isAssessedAsBlurry: false,
     });
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });
     await userEvent.click(tryAgainButton);
 
     expect(addPageAction.callCount).to.equal(4);
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: Capture troubleshooting dismissed',
-    });
+    expect(addPageAction).to.have.been.calledWith('IdV: Capture troubleshooting dismissed');
   });
 });

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -23,22 +23,16 @@ describe('document-capture/components/review-issues-step', () => {
       </AnalyticsContext.Provider>,
     );
 
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning shown',
-      payload: {
-        location: 'doc_auth_review_issues',
-        remaining_attempts: 3,
-      },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning shown', {
+      location: 'doc_auth_review_issues',
+      remaining_attempts: 3,
     });
 
     const button = getByRole('button');
     await userEvent.click(button);
 
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning action triggered',
-      payload: {
-        location: 'doc_auth_review_issues',
-      },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning action triggered', {
+      location: 'doc_auth_review_issues',
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/warning-spec.jsx
@@ -30,9 +30,9 @@ describe('document-capture/components/warning', () => {
       </AnalyticsContext.Provider>,
     );
 
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning shown',
-      payload: { location: 'example', remaining_attempts: undefined },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning shown', {
+      location: 'example',
+      remaining_attempts: undefined,
     });
 
     const tryAgainButton = getByRole('button', { name: 'Try again' });
@@ -41,11 +41,8 @@ describe('document-capture/components/warning', () => {
     expect(getByRole('heading', { name: 'Oops!' })).to.exist();
     expect(tryAgainButton).to.exist();
     expect(actionOnClick).to.have.been.calledOnce();
-    expect(addPageAction).to.have.been.calledWith({
-      label: 'IdV: warning action triggered',
-      payload: {
-        location: 'example',
-      },
+    expect(addPageAction).to.have.been.calledWith('IdV: warning action triggered', {
+      location: 'example',
     });
     expect(getByText('Something went wrong')).to.exist();
     expect(getByRole('heading', { name: 'Having trouble?' })).to.exist();

--- a/spec/javascripts/packages/document-capture/context/acuant-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/acuant-spec.jsx
@@ -156,12 +156,9 @@ describe('document-capture/context/acuant', () => {
         });
 
         it('logs', () => {
-          expect(addPageAction).to.have.been.calledWith({
-            label: 'IdV: Acuant SDK loaded',
-            payload: {
-              success: true,
-              isCameraSupported: true,
-            },
+          expect(addPageAction).to.have.been.calledWith('IdV: Acuant SDK loaded', {
+            success: true,
+            isCameraSupported: true,
           });
         });
       });
@@ -179,12 +176,9 @@ describe('document-capture/context/acuant', () => {
         });
 
         it('logs', () => {
-          expect(addPageAction).to.have.been.calledWith({
-            label: 'IdV: Acuant SDK loaded',
-            payload: {
-              success: true,
-              isCameraSupported: false,
-            },
+          expect(addPageAction).to.have.been.calledWith('IdV: Acuant SDK loaded', {
+            success: true,
+            isCameraSupported: false,
           });
         });
       });
@@ -219,13 +213,10 @@ describe('document-capture/context/acuant', () => {
       });
 
       it('logs', () => {
-        expect(addPageAction).to.have.been.calledWith({
-          label: 'IdV: Acuant SDK loaded',
-          payload: {
-            success: false,
-            code: sinon.match.number,
-            description: sinon.match.string,
-          },
+        expect(addPageAction).to.have.been.calledWith('IdV: Acuant SDK loaded', {
+          success: false,
+          code: sinon.match.number,
+          description: sinon.match.string,
         });
       });
     });

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -189,15 +189,14 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
 
           await onChange.getCall(0).args[0].foo_image_url;
           expect(addPageAction).to.have.been.calledTwice();
-          expect(addPageAction).to.have.been.calledWith({
-            label: 'IdV: document capture async upload encryption',
-            payload: { success: true },
-          });
-          expect(addPageAction).to.have.been.calledWith({
-            key: 'documentCapture.asyncUpload',
-            label: 'IdV: document capture async upload submitted',
-            payload: { success: true, trace_id: null, status_code: 200 },
-          });
+          expect(addPageAction).to.have.been.calledWith(
+            'IdV: document capture async upload encryption',
+            { success: true },
+          );
+          expect(addPageAction).to.have.been.calledWith(
+            'IdV: document capture async upload submitted',
+            { success: true, trace_id: null, status_code: 200 },
+          );
         });
       });
 
@@ -248,10 +247,10 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
             sinon.match.instanceOf(BackgroundEncryptedUploadError),
             { field: 'foo' },
           );
-          expect(addPageAction).to.have.been.calledWith({
-            label: 'IdV: document capture async upload encryption',
-            payload: { success: false },
-          });
+          expect(addPageAction).to.have.been.calledWith(
+            'IdV: document capture async upload encryption',
+            { success: false },
+          );
           expect(noticeError).to.have.been.calledWith(error);
           expect(window.fetch).not.to.have.been.called();
         });
@@ -272,19 +271,18 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
 
           await onChange.getCall(0).args[0].foo_image_url.catch(() => {});
           expect(addPageAction).to.have.been.calledTwice();
-          expect(addPageAction).to.have.been.calledWith({
-            label: 'IdV: document capture async upload encryption',
-            payload: { success: true },
-          });
-          expect(addPageAction).to.have.been.calledWith({
-            key: 'documentCapture.asyncUpload',
-            label: 'IdV: document capture async upload submitted',
-            payload: {
+          expect(addPageAction).to.have.been.calledWith(
+            'IdV: document capture async upload encryption',
+            { success: true },
+          );
+          expect(addPageAction).to.have.been.calledWith(
+            'IdV: document capture async upload submitted',
+            {
               success: false,
               trace_id: '1-67891233-abcdef012345678912345678',
               status_code: 403,
             },
-          });
+          );
         });
       });
     });


### PR DESCRIPTION
**Why**:

- Because it's redundant with logging via FrontendLogController and presumably runs up our bill
- For improved developer ergonomics, and for alignment with other event tracking methods

**For follow-up:**

- [ ] Rename `addPageAction` to `trackEvent`
- [ ] ... or remove `addPageAction` React context altogether, in favor of direct calls to `trackEvent`