### PR TITLE
Fix 500 when resending GPO letter

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -32,7 +32,9 @@ module Idv
       update_tracking
       idv_session.address_verification_mechanism = :gpo
 
-      if current_user.decorate.pending_profile_requires_verification?
+      if current_user.decorate.pending_profile_requires_verification? && pii_locked?
+        redirect_to capture_password_url
+      elsif current_user.decorate.pending_profile_requires_verification?
         resend_letter
         redirect_to idv_come_back_later_url
       else
@@ -255,6 +257,10 @@ module Idv
       flash[:info] = I18n.t('idv.failure.timeout')
       delete_async
       ProofingSessionAsyncResult.missing
+    end
+
+    def pii_locked?
+      !Pii::Cacher.new(current_user, user_session).exists_in_session?
     end
   end
 end

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -123,6 +123,17 @@ describe Idv::GpoController do
         allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
         expect_resend_letter_to_send_letter_and_redirect(otp: true)
       end
+
+      it 'redirects to capture password if pii is locked' do
+        pii_cacher = instance_double(Pii::Cacher)
+        allow(pii_cacher).to receive(:fetch).and_return(nil)
+        allow(pii_cacher).to receive(:exists_in_session?).and_return(false)
+        allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
+
+        put :create
+
+        expect(response).to redirect_to capture_password_path
+      end
     end
   end
 

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -141,6 +141,7 @@ describe Idv::GpoController do
     pii = { first_name: 'Samuel', last_name: 'Sampson' }
     pii_cacher = instance_double(Pii::Cacher)
     allow(pii_cacher).to receive(:fetch).and_return(pii)
+    allow(pii_cacher).to receive(:exists_in_session?).and_return(true)
     allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
 
     service_provider = create(:service_provider, issuer: '123abc')


### PR DESCRIPTION
Similar 500 to the one in https://github.com/18F/identity-idp/pull/6121 where we should request password to unlock PII before trying to access the PII bundle when people log in with PIV ([New Relic](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=43200000&state=0742e810-3099-3fc9-6993-0a4b3e1d474b))