### PR TITLE
Show IdV app alert message relevant for current step

### DIFF
--- a/app/javascript/packages/verify-flow/index.tsx
+++ b/app/javascript/packages/verify-flow/index.tsx
@@ -1,2 +1,2 @@
 export { SecretsContextProvider } from './context/secrets-context';
-export { VerifyFlow } from './verify-flow';
+export { default as VerifyFlow } from './verify-flow';

--- a/app/javascript/packages/verify-flow/verify-flow-alert.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-alert.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import VerifyFlowAlert from './verify-flow-alert';
+
+describe('VerifyFlowAlert', () => {
+  context('step with a status message', () => {
+    [
+      ['personal_key', 'idv.messages.confirm'],
+      ['personal_key_confirm', 'idv.messages.confirm'],
+    ].forEach(([step, expected]) => {
+      it('renders status message', () => {
+        const { getByRole } = render(<VerifyFlowAlert currentStep={step} />);
+
+        expect(getByRole('status').textContent).equal(expected);
+      });
+    });
+  });
+
+  context('step without a status message', () => {
+    it('renders nothing', () => {
+      const { container } = render(<VerifyFlowAlert currentStep="bad" />);
+
+      expect(container.innerHTML).to.be.empty();
+    });
+  });
+});

--- a/app/javascript/packages/verify-flow/verify-flow-alert.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-alert.tsx
@@ -1,0 +1,30 @@
+import { t } from '@18f/identity-i18n';
+import { Alert } from '@18f/identity-components';
+
+interface VerifyFlowAlertProps {
+  /**
+   * Current step name.
+   */
+  currentStep: string;
+}
+
+function VerifyFlowAlert({ currentStep }: VerifyFlowAlertProps) {
+  let message;
+  switch (currentStep) {
+    case 'personal_key':
+    case 'personal_key_confirm':
+      message = t('idv.messages.confirm');
+      break;
+
+    default:
+      return null;
+  }
+
+  return (
+    <Alert type="success" className="margin-bottom-4">
+      {message}
+    </Alert>
+  );
+}
+
+export default VerifyFlowAlert;

--- a/app/javascript/packages/verify-flow/verify-flow-alert.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-alert.tsx
@@ -8,16 +8,21 @@ interface VerifyFlowAlertProps {
   currentStep: string;
 }
 
-function VerifyFlowAlert({ currentStep }: VerifyFlowAlertProps) {
-  let message;
-  switch (currentStep) {
-    case 'personal_key':
-    case 'personal_key_confirm':
-      message = t('idv.messages.confirm');
-      break;
+/**
+ * Returns the status message to show for a given step, if applicable.
+ *
+ * @param stepName Step name.
+ */
+function getStepMessage(stepName: string): string | undefined {
+  if (stepName === 'personal_key' || stepName === 'personal_key_confirm') {
+    return t('idv.messages.confirm');
+  }
+}
 
-    default:
-      return null;
+function VerifyFlowAlert({ currentStep }: VerifyFlowAlertProps) {
+  const message = getStepMessage(currentStep);
+  if (!message) {
+    return null;
   }
 
   return (

--- a/app/javascript/packages/verify-flow/verify-flow.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.spec.tsx
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import * as analytics from '@18f/identity-analytics';
 import userEvent from '@testing-library/user-event';
-import { VerifyFlow } from './index';
+import VerifyFlow from './verify-flow';
 
 describe('VerifyFlow', () => {
   const sandbox = sinon.createSandbox();
@@ -23,7 +23,12 @@ describe('VerifyFlow', () => {
       <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={onComplete} />,
     );
 
+    // Personal key
+    expect(getByText('idv.messages.confirm')).to.be.ok();
     await userEvent.click(getByText('forms.buttons.continue'));
+
+    // Personal key confirm
+    expect(getByText('idv.messages.confirm')).to.be.ok();
     await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
     await userEvent.keyboard('{Enter}');
 

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
 import { FormSteps } from '@18f/identity-form-steps';
-import { t } from '@18f/identity-i18n';
-import { Alert } from '@18f/identity-components';
 import { trackEvent } from '@18f/identity-analytics';
-import VerifyFlowStepIndicator from './verify-flow-step-indicator';
 import { STEPS } from './steps';
+import VerifyFlowStepIndicator from './verify-flow-step-indicator';
+import VerifyFlowAlert from './verify-flow-alert';
 
 export interface VerifyFlowValues {
   personalKey?: string;
@@ -60,7 +59,7 @@ const logStepVisited = (stepName: string) =>
 const logStepSubmitted = (stepName: string) =>
   trackEvent(`IdV: ${getEventStepName(stepName)} submitted`);
 
-export function VerifyFlow({
+function VerifyFlow({
   initialValues = {},
   enabledStepNames,
   basePath,
@@ -68,7 +67,6 @@ export function VerifyFlow({
   onComplete,
 }: VerifyFlowProps) {
   const [currentStep, setCurrentStep] = useState(STEPS[0].name);
-
   useEffect(() => {
     logStepVisited(currentStep);
   }, [currentStep]);
@@ -81,9 +79,7 @@ export function VerifyFlow({
   return (
     <>
       <VerifyFlowStepIndicator currentStep={currentStep} />
-      <Alert type="success" className="margin-bottom-4">
-        {t('idv.messages.confirm')}
-      </Alert>
+      <VerifyFlowAlert currentStep={currentStep} />
       <FormSteps
         steps={steps}
         initialValues={initialValues}
@@ -97,3 +93,5 @@ export function VerifyFlow({
     </>
   );
 }
+
+export default VerifyFlow;


### PR DESCRIPTION
**Why**: So that the personal key success alert message won't be shown for all steps, as we continue to expand the flow.

This builds on #6239, where a goal was to avoid including success banner in the implementation of the step itself, since steps could possibly be reused elsewhere (e.g. account dashboard personal key reset) and the display of a success banner is more a reflection of _transition between steps_ as opposed to the step itself.

**Screenshot**

(Note: There's not expected to be any visual effect of these changes)

![image](https://user-images.githubusercontent.com/1779930/166935027-e0a77204-8114-4f45-91e8-4c8c2baecaf3.png)
