### PR TITLE
Partial KMS session encryption

### DIFF
--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -1,23 +1,6 @@
 module DocAuth
   module Mock
     class ResultResponseBuilder
-      DEFAULT_PII_FROM_DOC = {
-        first_name: 'FAKEY',
-        middle_name: nil,
-        last_name: 'MCFAKERSON',
-        address1: '1 FAKE RD',
-        address2: nil,
-        city: 'GREAT FALLS',
-        state: 'MT',
-        zipcode: '59010',
-        dob: '1938-10-06',
-        state_id_number: '1111111111111',
-        state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
-        state_id_expiration: '2099-12-31',
-        phone: nil,
-      }.freeze
-
       attr_reader :uploaded_file, :config, :liveness_enabled
 
       def initialize(uploaded_file, config, liveness_enabled)
@@ -117,7 +100,7 @@ module DocAuth
           raw_pii = parsed_data_from_uploaded_file['document']
           raw_pii&.symbolize_keys || {}
         else
-          DEFAULT_PII_FROM_DOC
+          Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC
         end
       end
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -38,16 +38,14 @@ module Pii
     # See SessionEncryptor#kms_encrypt_pii! for more detail.
     def fetch_string
       return unless user_session[:decrypted_pii] || user_session[:encrypted_pii]
-      if user_session[:decrypted_pii]
-        user_session[:decrypted_pii]
-      elsif user_session[:encrypted_pii]
-        decrypted = SessionEncryptor.new.kms_decrypt(
-          user_session[:encrypted_pii],
-        )
-        user_session[:decrypted_pii] = decrypted
+      return user_session[:decrypted_pii] if user_session[:decrypted_pii].present?
 
-        decrypted
-      end
+      decrypted = SessionEncryptor.new.kms_decrypt(
+        user_session[:encrypted_pii],
+      )
+      user_session[:decrypted_pii] = decrypted
+
+      decrypted
     end
 
     def exists_in_session?

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -32,15 +32,26 @@ module Pii
     end
 
     def fetch_string
-      user_session[:decrypted_pii]
+      return unless user_session[:decrypted_pii] || user_session[:encrypted_pii]
+      if user_session[:decrypted_pii]
+        user_session[:decrypted_pii]
+      elsif user_session[:encrypted_pii]
+        decrypted = SessionEncryptor.new.kms_decrypt(
+          user_session[:encrypted_pii],
+        )
+        user_session[:decrypted_pii] = decrypted
+
+        decrypted
+      end
     end
 
     def exists_in_session?
-      fetch_string.present?
+      return user_session[:decrypted_pii] || user_session[:encrypted_pii]
     end
 
     def delete
       user_session.delete(:decrypted_pii)
+      user_session.delete(:encrypted_pii)
     end
 
     private

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -31,6 +31,11 @@ module Pii
       Pii::Attributes.new_from_json(pii_string)
     end
 
+    # Between requests, the decrypted PII bundle is encrypted with KMS and moved to the
+    # 'encrypted_pii' key by the SessionEncryptor.
+    #
+    # The PII is decrypted on-demand by this method and moved into the 'decrypted_pii' key.
+    # See SessionEncryptor#kms_encrypt_pii! for more detail.
     def fetch_string
       return unless user_session[:decrypted_pii] || user_session[:encrypted_pii]
       if user_session[:decrypted_pii]

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -216,6 +216,8 @@ select_multiple_mfa_options: false
 service_provider_request_ttl_hours: 24
 session_check_delay: 30
 session_check_frequency: 30
+session_encryptor_alert_enabled: false
+session_encryptor_v2_enabled: true
 session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
@@ -362,6 +364,8 @@ production:
   password_pepper:
   piv_cac_verify_token_secret:
   platform_authentication_enabled: false
+  session_encryptor_alert_enabled: true
+  session_encryptor_v2_enabled: false
   recurring_jobs_disabled_names: "[]"
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 require 'session_encryptor'
+require 'legacy_session_encryptor'
 require 'session_encryptor_error_handler'
 
 Rails.application.config.session_store(

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -306,6 +306,8 @@ class IdentityConfig
     config.add(:session_check_delay, type: :integer)
     config.add(:session_check_frequency, type: :integer)
     config.add(:session_encryption_key, type: :string)
+    config.add(:session_encryptor_alert_enabled, type: :boolean)
+    config.add(:session_encryptor_v2_enabled, type: :boolean)
     config.add(:session_timeout_in_minutes, type: :integer)
     config.add(:session_timeout_warning_seconds, type: :integer)
     config.add(:session_total_duration_timeout_in_minutes, type: :integer)

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -10,5 +10,22 @@ module Idp
     AAL1 = 1
     AAL2 = 2
     AAL3 = 3
+
+    DEFAULT_MOCK_PII_FROM_DOC = {
+      first_name: 'FAKEY',
+      middle_name: nil,
+      last_name: 'MCFAKERSON',
+      address1: '1 FAKE RD',
+      address2: nil,
+      city: 'GREAT FALLS',
+      state: 'MT',
+      zipcode: '59010',
+      dob: '1938-10-06',
+      state_id_number: '1111111111111',
+      state_id_jurisdiction: 'ND',
+      state_id_type: 'drivers_license',
+      state_id_expiration: '2099-12-31',
+      phone: nil,
+    }.freeze
   end
 end

--- a/lib/legacy_session_encryptor.rb
+++ b/lib/legacy_session_encryptor.rb
@@ -1,0 +1,18 @@
+class LegacySessionEncryptor
+  def load(value)
+    decrypted = encryptor.decrypt(value)
+
+    JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
+  end
+
+  def dump(value)
+    plain = JSON.generate(value, quirks_mode: true)
+    encryptor.encrypt(plain)
+  end
+
+  private
+
+  def encryptor
+    Encryption::Encryptors::SessionEncryptor.new
+  end
+end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -5,7 +5,7 @@ class SessionEncryptor
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
     'zip_code', 'dob', 'phone', 'phone_number', 'ssn', 'prev_address1', 'prev_address2',
     'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc', 'password', 'personal_key'
-  ]
+  ].to_set.freeze
 
   SENSITIVE_PATHS = [
     ['warden.user.user.session', 'idv/doc_auth'],

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -83,7 +83,13 @@ class SessionEncryptor
     sensitive_paths.each do |path|
       all_but_last_key = path[0..-2]
       last_key = path.last
-      value = session.dig(*all_but_last_key)&.delete(last_key)
+
+      if all_but_last_key.blank?
+        value = session.delete(last_key)
+      else
+        value = session.dig(*all_but_last_key)&.delete(last_key)
+      end
+
       if value
         all_but_last_key.reduce(sensitive_data) do |hash, key|
           hash[key] ||= {}

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -4,7 +4,8 @@ class SessionEncryptor
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
     'zip_code', 'dob', 'phone', 'phone_number', 'ssn', 'prev_address1', 'prev_address2',
-    'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc', 'password', 'personal_key'
+    'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc', 'password', 'personal_key',
+    'email', 'email_address'
   ].to_set.freeze
 
   # 'idv/doc_auth' and 'idv' are used during the proofing process and can contain PII
@@ -15,6 +16,8 @@ class SessionEncryptor
     ['warden.user.user.session', 'idv'],
     ['warden.user.user.session', 'personal_key'],
     ['flash', 'flashes', 'personal_key'],
+    ['flash', 'flashes', 'email'],
+    ['email'],
   ]
 
   def load(value)

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -1,18 +1,116 @@
 class SessionEncryptor
-  def load(value)
-    decrypted = encryptor.decrypt(value)
+  class SensitiveKeyError < StandardError; end
+  SENSITIVE_KEYS = [
+    'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
+    'zip_code', 'dob', 'phone', 'phone_number', 'ssn', 'prev_address1', 'prev_address2',
+    'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc', 'password', 'personal_key'
+  ]
 
-    JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
+  def load(value)
+    return LegacySessionEncryptor.new.load(value) if should_use_legacy_encryptor_for_read?(value)
+
+    _v2, ciphertext = value.split(':')
+    decrypted = outer_encryptor.decrypt(ciphertext)
+
+    session = JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
+    kms_decrypt_doc_auth_pii!(session)
+    kms_decrypt_idv_pii!(session)
+
+    session
   end
 
   def dump(value)
+    return LegacySessionEncryptor.new.dump(value) if should_use_legacy_encryptor_for_write?
+    value.deep_stringify_keys!
+
+    kms_encrypt_pii!(value)
+    kms_encrypt_doc_auth_pii!(value)
+    kms_encrypt_idv_pii!(value)
+    alert_or_raise_if_contains_sensitive_keys!(value)
     plain = JSON.generate(value, quirks_mode: true)
-    encryptor.encrypt(plain)
+    'v2:' + outer_encryptor.encrypt(plain)
+  end
+
+  def kms_encrypt(text)
+    Base64.encode64(Encryption::KmsClient.new.encrypt(text, 'context' => 'session-encryption'))
+  end
+
+  def kms_decrypt(text)
+    Encryption::KmsClient.new.decrypt(
+      Base64.decode64(text), 'context' => 'session-encryption'
+    )
+  end
+
+  def outer_encryptor
+    Encryption::Encryptors::AttributeEncryptor.new
   end
 
   private
 
-  def encryptor
-    Encryption::Encryptors::SessionEncryptor.new
+  def kms_encrypt_pii!(session)
+    return unless session.dig('warden.user.user.session', 'decrypted_pii')
+    decrypted_pii = session['warden.user.user.session'].delete('decrypted_pii')
+    session['warden.user.user.session']['encrypted_pii'] =
+      kms_encrypt(JSON.generate(decrypted_pii, quirks_mode: true))
+    nil
+  end
+
+  def kms_encrypt_doc_auth_pii!(session)
+    return unless session.dig('warden.user.user.session', 'idv/doc_auth')
+    doc_auth_pii = session.dig('warden.user.user.session').delete('idv/doc_auth')
+    session['warden.user.user.session']['encrypted_idv/doc_auth'] =
+      kms_encrypt(JSON.generate(doc_auth_pii, quirks_mode: true))
+    nil
+  end
+
+  def kms_decrypt_doc_auth_pii!(session)
+    return unless session.dig('warden.user.user.session', 'encrypted_idv/doc_auth')
+    doc_auth_pii = session['warden.user.user.session'].delete('encrypted_idv/doc_auth')
+    session['warden.user.user.session']['idv/doc_auth'] = JSON.parse(
+      kms_decrypt(doc_auth_pii), quirks_mode: true
+    )
+    nil
+  end
+
+  def kms_encrypt_idv_pii!(session)
+    return unless session.dig('warden.user.user.session', 'idv')
+    idv_pii = session.dig('warden.user.user.session').delete('idv')
+    session['warden.user.user.session']['encrypted_idv'] =
+      kms_encrypt(JSON.generate(idv_pii, quirks_mode: true))
+    nil
+  end
+
+  def kms_decrypt_idv_pii!(session)
+    return unless session.dig('warden.user.user.session', 'encrypted_idv')
+    idv_pii = session['warden.user.user.session'].delete('encrypted_idv')
+    session['warden.user.user.session']['idv'] = JSON.parse(kms_decrypt(idv_pii), quirks_mode: true)
+    nil
+  end
+
+  def alert_or_raise_if_contains_sensitive_keys!(hash)
+    hash.deep_transform_keys do |key|
+      if SENSITIVE_KEYS.include?(key.to_s)
+        exception = SensitiveKeyError.new("#{key} unexpectedly appeared in session")
+        if IdentityConfig.store.session_encryptor_alert_enabled
+          NewRelic::Agent.notice_error(
+            exception, custom_params: {
+              session_structure: hash.deep_transform_values { |v| nil },
+            }
+          )
+        else
+          raise exception
+        end
+      end
+    end
+  end
+
+  def should_use_legacy_encryptor_for_read?(value)
+    ## Legacy ciphertexts will not include a colon and thus will have no header
+    header = value.split(':').first
+    header != 'v2'
+  end
+
+  def should_use_legacy_encryptor_for_write?
+    !IdentityConfig.store.session_encryptor_v2_enabled
   end
 end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -23,9 +23,16 @@ class SessionEncryptor
     ['email'],
   ]
 
-  # rubocop:disable Layout/LineLength
-  SENSITIVE_REGEX = %r{FAKEY|MIDDLEFAKER|MCFAKERSON|1111111111111|GREAT FALLS|1938-10-06|2099-12-31|314-555-1212}
-  # rubocop:enable Layout/LineLength
+  SENSITIVE_DEFAULT_FIELDS = Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.slice(
+    :first_name,
+    :last_name,
+    :address1,
+    :city,
+    :dob,
+    :state_id_number,
+    :state_id_expiration,
+  ).values
+  SENSITIVE_REGEX = %r{#{SENSITIVE_DEFAULT_FIELDS.join('|')}}i
 
   def load(value)
     return LegacySessionEncryptor.new.load(value) if should_use_legacy_encryptor_for_read?(value)

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -165,7 +165,7 @@ class SessionEncryptor
         if IdentityConfig.store.session_encryptor_alert_enabled
           NewRelic::Agent.notice_error(
             exception, custom_params: {
-              session_structure: hash.deep_transform_values { |v| nil },
+              session_structure: hash.deep_transform_values { |_v| '' },
             }
           )
         else

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -3,9 +3,9 @@ class SessionEncryptor
   NEW_CIPHERTEXT_HEADER = 'v2'
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
-    'zip_code', 'dob', 'phone', 'phone_number', 'ssn', 'prev_address1', 'prev_address2',
+    'zip_code', 'dob', 'phone_number', 'phone', 'ssn', 'prev_address1', 'prev_address2',
     'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc', 'password', 'personal_key',
-    'email', 'email_address'
+    'email', 'email_address', 'unconfirmed_phone'
   ].to_set.freeze
 
   # 'idv/doc_auth' and 'idv' are used during the proofing process and can contain PII
@@ -15,6 +15,7 @@ class SessionEncryptor
     ['warden.user.user.session', 'idv/doc_auth'],
     ['warden.user.user.session', 'idv'],
     ['warden.user.user.session', 'personal_key'],
+    ['warden.user.user.session', 'unconfirmed_phone'],
     ['flash', 'flashes', 'personal_key'],
     ['flash', 'flashes', 'email'],
     ['email'],

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -1,5 +1,6 @@
 class SessionEncryptor
   class SensitiveKeyError < StandardError; end
+  NEW_CIPHERTEXT_HEADER = 'v2'
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
     'zip_code', 'dob', 'phone', 'phone_number', 'ssn', 'prev_address1', 'prev_address2',
@@ -33,7 +34,7 @@ class SessionEncryptor
     kms_encrypt_sensitive_paths!(value, SENSITIVE_PATHS)
     alert_or_raise_if_contains_sensitive_keys!(value)
     plain = JSON.generate(value, quirks_mode: true)
-    'v2:' + outer_encryptor.encrypt(plain)
+    NEW_CIPHERTEXT_HEADER + ':' + outer_encryptor.encrypt(plain)
   end
 
   def kms_encrypt(text)
@@ -119,7 +120,7 @@ class SessionEncryptor
   def should_use_legacy_encryptor_for_read?(value)
     ## Legacy ciphertexts will not include a colon and thus will have no header
     header = value.split(':').first
-    header != 'v2'
+    header != NEW_CIPHERTEXT_HEADER
   end
 
   def should_use_legacy_encryptor_for_write?

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
 
     trait :with_pii do
       pii do
-        DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
+        Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
           ssn: DocAuthHelper::GOOD_SSN,
           phone: '+1 (555) 555-1234',
         )
@@ -34,7 +34,7 @@ FactoryBot.define do
 
     trait :with_pii do
       pii do
-        DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
+        Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
           ssn: DocAuthHelper::GOOD_SSN,
           phone: '+1 (555) 555-1234',
         )

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -165,7 +165,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS +
-          [DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
+          [Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:state_id_jurisdiction]],
       )
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
@@ -188,7 +188,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS -
-          [DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
+          [Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:state_id_jurisdiction]],
       )
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -168,6 +168,18 @@ RSpec.describe SessionEncryptor do
 
         subject.dump(session)
       end
+
+      it 'raises if sensitive value is not KMS encrypted' do
+        session = {
+          'new_key' => 'FAKEY',
+        }
+
+        expect {
+          subject.dump(session)
+        }.to raise_error(
+          SessionEncryptor::SensitiveValueError,
+        )
+      end
     end
 
     context 'without version 2 encryption enabled' do

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SessionEncryptor do
 
       it 'encrypts decrypted_pii bundle without automatically decrypting' do
         session = { 'warden.user.user.session' => {
-          'decrypted_pii' => { 'ssn' => '666-66-6666' },
+          'decrypted_pii' => { 'ssn' => '666-66-6666' }.to_json,
         } }
 
         ciphertext = subject.dump(session)
@@ -72,7 +72,7 @@ RSpec.describe SessionEncryptor do
 
       it 'can decrypt PII bundle with Pii::Cacher' do
         session = { 'warden.user.user.session' => {
-          'decrypted_pii' => { 'ssn' => '666-66-6666' },
+          'decrypted_pii' => { 'ssn' => '666-66-6666' }.to_json,
         } }
 
         ciphertext = subject.dump(session)
@@ -106,11 +106,7 @@ RSpec.describe SessionEncryptor do
         expect(partially_decrypted_json.fetch('warden.user.user.session')['idv']).to eq nil
         expect(partially_decrypted_json.fetch('warden.user.user.session')['idv/doc_auth']).to eq nil
         expect(
-          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv'],
-        ).to_not eq nil
-
-        expect(
-          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv/doc_auth'],
+          partially_decrypted_json.fetch('sensitive_data'),
         ).to_not eq nil
 
         expect(
@@ -133,11 +129,7 @@ RSpec.describe SessionEncryptor do
         expect(partially_decrypted_json.fetch('warden.user.user.session')['idv']).to eq nil
         expect(partially_decrypted_json.fetch('warden.user.user.session')['idv/doc_auth']).to eq nil
         expect(
-          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv'],
-        ).to_not eq nil
-
-        expect(
-          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv/doc_auth'],
+          partially_decrypted_json.fetch('sensitive_data'),
         ).to_not eq nil
 
         expect(

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -1,0 +1,203 @@
+require 'rails_helper'
+
+RSpec.describe SessionEncryptor do
+  subject { SessionEncryptor.new }
+  describe '#load' do
+    context 'with a legacy session ciphertext' do
+      it 'decrypts the legacy session' do
+        session = { 'foo' => 'bar' }
+
+        ciphertext = LegacySessionEncryptor.new.dump(session)
+
+        result = subject.load(ciphertext)
+
+        expect(result).to eq(session)
+      end
+    end
+
+    context 'with version 2 encryption enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:session_encryptor_v2_enabled).and_return(true)
+      end
+
+      it 'decrypts the new version of the session' do
+        session = { 'foo' => 'bar' }
+
+        ciphertext = SessionEncryptor.new.dump(session)
+
+        result = subject.load(ciphertext)
+
+        expect(result).to eq session
+      end
+    end
+  end
+
+  describe '#dump' do
+    context 'with version 2 encryption enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:session_encryptor_v2_enabled).and_return(true)
+      end
+
+      it 'transparently encrypts/decrypts doc auth elements of the session' do
+        session = { 'warden.user.user.session' => {
+          'idv' => { 'ssn' => '666-66-6666' },
+          'idv/doc_auth' => { 'ssn' => '666-66-6666' },
+          'other_value' => 42,
+        } }
+
+        ciphertext = subject.dump(session)
+
+        result = subject.load(ciphertext)
+        expect(result).to eq(
+          { 'warden.user.user.session' => {
+            'idv' => { 'ssn' => '666-66-6666' },
+            'idv/doc_auth' => { 'ssn' => '666-66-6666' },
+            'other_value' => 42,
+          } },
+        )
+      end
+
+      it 'encrypts decrypted_pii bundle without automatically decrypting' do
+        session = { 'warden.user.user.session' => {
+          'decrypted_pii' => { 'ssn' => '666-66-6666' },
+        } }
+
+        ciphertext = subject.dump(session)
+
+        result = subject.load(ciphertext)
+
+        expect(result.fetch('warden.user.user.session')['decrypted_pii']).to eq nil
+        expect(result.fetch('warden.user.user.session')['encrypted_pii']).to_not eq nil
+      end
+
+      it 'can decrypt PII bundle with Pii::Cacher' do
+        session = { 'warden.user.user.session' => {
+          'decrypted_pii' => { 'ssn' => '666-66-6666' },
+        } }
+
+        ciphertext = subject.dump(session)
+
+        result = subject.load(ciphertext)
+        pii_cacher = Pii::Cacher.new(nil, result.fetch('warden.user.user.session'))
+
+        expect(result.fetch('warden.user.user.session')['decrypted_pii']).to eq nil
+        expect(result.fetch('warden.user.user.session')['encrypted_pii']).to_not eq nil
+
+        pii_cacher.fetch
+        expect(JSON.parse(result.fetch('warden.user.user.session')['decrypted_pii'])).to eq(
+          {
+            'ssn' => '666-66-6666',
+          },
+        )
+      end
+
+      it 'KMS encrypts/decrypts doc auth elements of the session' do
+        session = { 'warden.user.user.session' => {
+          'idv' => { 'ssn' => '666-66-6666' },
+          'idv/doc_auth' => { 'ssn' => '666-66-6666' },
+          'other_value' => 42,
+        } }
+
+        ciphertext = subject.dump(session)
+
+        partially_decrypted = subject.outer_encryptor.decrypt(ciphertext.split(':').last)
+        partially_decrypted_json = JSON.parse(partially_decrypted)
+
+        expect(partially_decrypted_json.fetch('warden.user.user.session')['idv']).to eq nil
+        expect(partially_decrypted_json.fetch('warden.user.user.session')['idv/doc_auth']).to eq nil
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv'],
+        ).to_not eq nil
+
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv/doc_auth'],
+        ).to_not eq nil
+
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['other_value'],
+        ).to eq 42
+      end
+
+      it 'KMS encrypts/decrypts doc auth elements of the session' do
+        session = { 'warden.user.user.session' => {
+          'idv' => { 'ssn' => '666-66-6666' },
+          'idv/doc_auth' => { 'ssn' => '666-66-6666' },
+          'other_value' => 42,
+        } }
+
+        ciphertext = subject.dump(session)
+
+        partially_decrypted = subject.outer_encryptor.decrypt(ciphertext.split(':').last)
+        partially_decrypted_json = JSON.parse(partially_decrypted)
+
+        expect(partially_decrypted_json.fetch('warden.user.user.session')['idv']).to eq nil
+        expect(partially_decrypted_json.fetch('warden.user.user.session')['idv/doc_auth']).to eq nil
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv'],
+        ).to_not eq nil
+
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['encrypted_idv/doc_auth'],
+        ).to_not eq nil
+
+        expect(
+          partially_decrypted_json.fetch('warden.user.user.session')['other_value'],
+        ).to eq 42
+      end
+
+      it 'raises if PII key appears outside of expected areas when alerting is disabled' do
+        nested_session = { 'warden.user.user.session' => {
+          'idv_new' => { 'nested' => { 'ssn' => '666-66-6666' } },
+        } }
+
+        nested_array_session = { 'warden.user.user.session' => {
+          'idv_new' => [{ 'nested' => { 'ssn' => '666-66-6666' } }],
+        } }
+
+        expect {
+          subject.dump(nested_session)
+        }.to raise_error(
+          SessionEncryptor::SensitiveKeyError, 'ssn unexpectedly appeared in session'
+        )
+
+        expect {
+          subject.dump(nested_array_session)
+        }.to raise_error(
+          SessionEncryptor::SensitiveKeyError, 'ssn unexpectedly appeared in session'
+        )
+      end
+
+      it 'sends alert if PII key appears outside of expected areas if alerting is enabled' do
+        allow(IdentityConfig.store).to receive(:session_encryptor_alert_enabled).and_return(true)
+        session = { 'warden.user.user.session' => {
+          'idv_new' => { 'nested' => { 'ssn' => '666-66-6666' } },
+        } }
+
+        expect(NewRelic::Agent).to receive(:notice_error).with(
+          SessionEncryptor::SensitiveKeyError.new('ssn unexpectedly appeared in session'),
+          custom_params: {
+            session_structure: { 'warden.user.user.session' => {
+              'idv_new' => { 'nested' => { 'ssn' => nil } },
+            } },
+          },
+        )
+
+        subject.dump(session)
+      end
+    end
+
+    context 'without version 2 encryption enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:session_encryptor_v2_enabled).and_return(false)
+      end
+
+      it 'encrypts the session with the legacy encryptor' do
+        session = { 'foo' => 'bar' }
+        ciphertext = subject.dump(session)
+        decrypted_session = LegacySessionEncryptor.new.load(ciphertext)
+
+        expect(decrypted_session).to eq(session)
+      end
+    end
+  end
+end

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -184,4 +184,34 @@ RSpec.describe SessionEncryptor do
       end
     end
   end
+
+  describe '#kms_encrypt_sensitive_paths!' do
+    it 'encrypts/decrypts transparently' do
+      sensitive_paths = [
+        ['a'],
+        ['1', '2', '3'],
+      ]
+
+      original_session = {
+        'unencrypted' => 0,
+        'a' => 414,
+        '1' => {
+          '2' => {
+            '3' => 34,
+          },
+        },
+      }
+
+      session = original_session.deep_dup
+      SessionEncryptor.new.send(:kms_encrypt_sensitive_paths!, session, sensitive_paths)
+
+      expect(session['unencrypted']).to eq 0
+      expect(session.key?('a')).to eq false
+      expect(session.dig('1', '2').key?('3')).to eq false
+
+      SessionEncryptor.new.send(:kms_decrypt_sensitive_paths!, session)
+
+      expect(session).to eq original_session
+    end
+  end
 end

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe SessionEncryptor do
 
       it 'raises if sensitive value is not KMS encrypted' do
         session = {
-          'new_key' => 'FAKEY',
+          'new_key' => Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:first_name],
         }
 
         expect {

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe SessionEncryptor do
           SessionEncryptor::SensitiveKeyError.new('ssn unexpectedly appeared in session'),
           custom_params: {
             session_structure: { 'warden.user.user.session' => {
-              'idv_new' => { 'nested' => { 'ssn' => nil } },
+              'idv_new' => { 'nested' => { 'ssn' => '' } },
             } },
           },
         )

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -186,7 +186,7 @@ describe Analytics do
     it 'does not alert when pii values are inside words' do
       expect(ahoy).to receive(:track)
 
-      stub_const('DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC', zipcode: '12345')
+      stub_const('Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC', zipcode: '12345')
 
       expect do
         analytics.track_event(

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).
-          to eq(DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC)
+          to eq(Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC)
       end
     end
 
@@ -178,7 +178,7 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).
-          to eq(DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC)
+          to eq(Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC)
       end
     end
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -20,7 +20,7 @@ class FakeAnalytics
         ERROR
       end
 
-      DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.slice(
+      Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.slice(
         :first_name,
         :last_name,
         :address1,

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -160,7 +160,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   end
 
   def mock_doc_auth_no_name_pii(method)
-    pii_with_no_name = DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.dup
+    pii_with_no_name = Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.dup
     pii_with_no_name[:last_name] = nil
     DocAuth::Mock::DocAuthMockClient.mock_response!(
       method: method,

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -6,7 +6,7 @@ shared_examples 'sp requesting attributes' do |sp|
   let(:good_ssn) { DocAuthHelper::GOOD_SSN }
   let(:profile) { create(:profile, :active, :verified, user: user, pii: saved_pii) }
   let(:saved_pii) do
-    DocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
+    Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
       ssn: good_ssn,
       phone: '+1 (555) 555-1234',
     )


### PR DESCRIPTION
Currently, we double encrypt the entire web session for a user.  When saving a session, first it is converted to JSON, then encrypted with AES, then with KMS, and then put into Redis.  The reverse process happens when the session is loaded.

This safe-by-default method is straightforward conceptually and in implementation, but imposes costs and friction in other ways.  We have added more and more to session storage, and KMS can only encrypt 4kB per API call, which leads to us [chunking the string](https://github.com/18F/identity-idp/blob/7c1ecde/app/services/encryption/kms_client.rb#L44-L50) and having to make multiple calls to KMS.  Certain values we store can be quite large, which inflates the session size significantly in some contexts.  The KMS API calls now take up a sizeable portion of our network and server time.

This method also places KMS in the critical path since it is used on most requests, including the home page.

From a security perspective, it means we decrypt sensitive data even when it won't be used.  The most relevant part in this regard is the PII bundle, which we only need to KMS decrypt when we are displaying it to the user or passing it to the service provider.

To meet our security requirements and ensure that sensitive data continues to be KMS encrypted while vastly reducing our KMS usage otherwise, this PR attempts to split the session into sensitive and less sensitive data.  The entire session is still AES encrypted, but the sensitive parts are KMS encrypted still.  These changes aim to handle PII in two ways:

1. For the PII bundle, it is decrypted with the user's password when we receive it and then it is stored in the session.  Subsequent requests encrypt it with KMS inside the AES encrypted session.  It is now KMS decrypted on-demand via the `Pii::Cacher` interface that we've moved our PII bundle handling towards using (#6054, #6072, #6273, #6283).
2. For personal keys and IDV-related PII where the usage is a bit more dynamic and harder to standardize, the KMS encryption/decryption happens transparently similar to how it is today.

Alerting has been added if we detect a potentially sensitive key not being KMS encrypted as it should be, and sends the session structure without values to help troubleshoot if it does.  In tests and development, it will raise exceptions if a sensitive key is not encrypted properly.

This change is not backwards compatible on its own, and will require deploying the code that contains the ability to parse  both formats (without writing the new format immediately).  Writing the new format to Redis is currently behind a configuration flag that we can switch on if and when we feel comfortable.  If the new format is problematic after being enabled, the switch can be turned off with full backwards compatibility.

[Document](https://docs.google.com/document/d/1TZBJUX0NRl5yTlRtEiLsWHehnELW4TTriByMzVfm4EY/edit#)
[Discussion Thread](https://gsa-tts.slack.com/archives/CA7NE63SB/p1651870127822979)