### PR TITLE
LG-6271: Validate IdV app values to push user to the correct first step

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -4,7 +4,6 @@ class VerifyController < ApplicationController
 
   check_or_render_not_found -> { FeatureManagement.idv_api_enabled? }, only: [:show]
 
-  before_action :redirect_root_path_to_first_step
   before_action :validate_step
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_vendor_session_started
@@ -16,12 +15,8 @@ class VerifyController < ApplicationController
 
   private
 
-  def redirect_root_path_to_first_step
-    redirect_to idv_app_path(step: first_step) if params[:step].blank?
-  end
-
   def validate_step
-    render_not_found if !enabled_steps.include?(params[:step])
+    render_not_found if params[:step].present? && !enabled_steps.include?(params[:step])
   end
 
   def app_data

--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -586,4 +586,10 @@ describe('FormSteps', () => {
 
     expect(getByText('First Title')).to.be.ok();
   });
+
+  it('supports starting at a specific step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} initialStep="second" />);
+
+    expect(getByText('Second Title')).to.be.ok();
+  });
 });

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -120,6 +120,11 @@ interface FormStepsProps {
   steps?: FormStep<any>[];
 
   /**
+   * Step at which to start form.
+   */
+  initialStep?: string;
+
+  /**
    * Form values to populate initial state.
    */
   initialValues?: Record<string, any>;
@@ -222,6 +227,7 @@ function FormSteps({
   onComplete = () => {},
   onStepChange = () => {},
   onStepSubmit = () => {},
+  initialStep,
   initialValues = {},
   initialActiveErrors = [],
   autoFocus,
@@ -232,7 +238,7 @@ function FormSteps({
   const [values, setValues] = useState(initialValues);
   const [activeErrors, setActiveErrors] = useState(initialActiveErrors);
   const formRef = useRef(null as HTMLFormElement | null);
-  const [stepName, setStepName] = useHistoryParam({ basePath });
+  const [stepName, setStepName] = useHistoryParam(initialStep, { basePath });
   const [stepErrors, setStepErrors] = useState([] as Error[]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fields = useRef({} as Record<string, FieldsRefEntry>);

--- a/app/javascript/packages/form-steps/index.ts
+++ b/app/javascript/packages/form-steps/index.ts
@@ -4,6 +4,7 @@ export { default as RequiredValueMissingError } from './required-value-missing-e
 export { default as FormStepsContext } from './form-steps-context';
 export { default as FormStepsButton } from './form-steps-button';
 export { default as PromptOnNavigate } from './prompt-on-navigate';
+export { default as useHistoryParam, getStepParam } from './use-history-param';
 
 export type {
   FormStepError,

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -2,7 +2,34 @@ import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDefineProperty } from '@18f/identity-test-helpers';
-import useHistoryParam from './use-history-param';
+import useHistoryParam, { getStepParam } from './use-history-param';
+
+describe('getStepParam', () => {
+  it('returns step', () => {
+    const path = 'step';
+    const result = getStepParam(path);
+
+    expect(result).to.equal('step');
+  });
+
+  context('with subpath', () => {
+    it('returns step', () => {
+      const path = 'step/subpath';
+      const result = getStepParam(path);
+
+      expect(result).to.equal('step');
+    });
+  });
+
+  context('with trailing or leading slashes', () => {
+    it('returns step', () => {
+      const path = '/step/';
+      const result = getStepParam(path);
+
+      expect(result).to.equal('step');
+    });
+  });
+});
 
 describe('useHistoryParam', () => {
   const sandbox = sinon.createSandbox();

--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -16,16 +16,16 @@ interface HistoryOptions {
  *
  * @return Tuple of current state, state setter.
  */
-function useHistoryParam({ basePath }: HistoryOptions = {}): [
-  string | undefined,
-  (nextParamValue?: string) => void,
-] {
+function useHistoryParam(
+  initialValue?: string,
+  { basePath }: HistoryOptions = {},
+): [string | undefined, (nextParamValue?: string) => void] {
   const getCurrentValue = () =>
     (typeof basePath === 'string'
       ? window.location.pathname.split(basePath)[1]?.replace(/^\/|\/$/g, '')
       : window.location.hash.slice(1)) || undefined;
 
-  const [value, setValue] = useState(getCurrentValue);
+  const [value, setValue] = useState(initialValue ?? getCurrentValue);
 
   function getValueURL(nextValue) {
     const prefix = typeof basePath === 'string' ? `${basePath.replace(/\/$/, '')}/` : '#';
@@ -46,6 +46,10 @@ function useHistoryParam({ basePath }: HistoryOptions = {}): [
   }
 
   useEffect(() => {
+    if (initialValue && initialValue !== getCurrentValue()) {
+      window.history.replaceState(null, '', getValueURL(initialValue));
+    }
+
     const syncValue = () => setValue(getCurrentValue());
     window.addEventListener('popstate', syncValue);
     return () => window.removeEventListener('popstate', syncValue);

--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -5,6 +5,15 @@ interface HistoryOptions {
 }
 
 /**
+ * Returns the step name from a given path, ignoring any subpaths or leading or trailing slashes.
+ *
+ * @param path Path from which to extract step.
+ *
+ * @return Step name.
+ */
+export const getStepParam = (path: string): string => path.split('/').filter(Boolean)[0];
+
+/**
  * Returns a hook which syncs a querystring parameter by the given name using History pushState.
  * Returns a `useState`-like tuple of the current value and a setter to assign the next parameter
  * value.
@@ -20,10 +29,16 @@ function useHistoryParam(
   initialValue?: string,
   { basePath }: HistoryOptions = {},
 ): [string | undefined, (nextParamValue?: string) => void] {
-  const getCurrentValue = () =>
-    (typeof basePath === 'string'
-      ? window.location.pathname.split(basePath)[1]?.replace(/^\/|\/$/g, '')
-      : window.location.hash.slice(1)) || undefined;
+  function getCurrentValue(): string | undefined {
+    const path =
+      typeof basePath === 'string'
+        ? window.location.pathname.split(basePath)[1]
+        : window.location.hash.slice(1);
+
+    if (path) {
+      return getStepParam(path);
+    }
+  }
 
   const [value, setValue] = useState(initialValue ?? getCurrentValue);
 

--- a/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.spec.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.spec.ts
@@ -1,0 +1,69 @@
+import sinon from 'sinon';
+import { renderHook } from '@testing-library/react-hooks';
+import { useDefineProperty } from '@18f/identity-test-helpers';
+import { FormStep } from '@18f/identity-form-steps';
+import useInitialStepValidation from './use-initial-step-validation';
+
+const TEST_BASE_PATH = '/step/';
+const STEPS = [{ name: 'one' }, { name: 'two' }, { name: 'three' }] as FormStep[];
+
+describe('useInitialStepValidation', () => {
+  const defineProperty = useDefineProperty();
+
+  context('with no path param', () => {
+    beforeEach(() => {
+      defineProperty(window, 'location', {
+        value: {
+          pathname: TEST_BASE_PATH,
+        },
+      });
+    });
+
+    it('returns the first step', () => {
+      const { result } = renderHook(() => useInitialStepValidation(TEST_BASE_PATH, STEPS));
+      const [initialStep] = result.current;
+
+      expect(initialStep).to.equal(STEPS[0].name);
+    });
+  });
+
+  context('with path param exceeding progress', () => {
+    beforeEach(() => {
+      defineProperty(window, 'location', {
+        value: {
+          pathname: TEST_BASE_PATH + STEPS[1].name,
+        },
+      });
+    });
+
+    it('returns furthest step progress', () => {
+      const { result } = renderHook(() => useInitialStepValidation(TEST_BASE_PATH, STEPS));
+      const [initialStep] = result.current;
+
+      expect(initialStep).to.equal(STEPS[0].name);
+    });
+  });
+
+  context('with path param not exceeding progress', () => {
+    beforeEach(() => {
+      defineProperty(window, 'location', {
+        value: {
+          pathname: TEST_BASE_PATH + STEPS[1].name,
+        },
+      });
+
+      defineProperty(global, 'sessionStorage', {
+        value: {
+          getItem: sinon.stub().withArgs('completedStep').returns(STEPS[0].name),
+        },
+      });
+    });
+
+    it('returns path param', () => {
+      const { result } = renderHook(() => useInitialStepValidation(TEST_BASE_PATH, STEPS));
+      const [initialStep] = result.current;
+
+      expect(initialStep).to.equal(STEPS[1].name);
+    });
+  });
+});

--- a/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import type { Dispatch } from 'react';
+import { FormStep } from '@18f/identity-form-steps';
+import useSessionStorage from './use-session-storage';
+
+/**
+ * Returns the index of the given step name in the form steps order.
+ *
+ * @param stepName Step name.
+ * @param steps Steps order.
+ *
+ * @return Step index.
+ */
+const getStepIndex = (stepName: string, steps: FormStep[]) =>
+  steps.findIndex((step) => step.name === stepName);
+
+/**
+ * React hook which validates the expected initial step to present the user, based on past
+ * completion and presence of a URL path fragment. Behaves similar to a useState hook, where the
+ * return value is a tuple of the validated initial step, and a setter for assigning a completed
+ * step.
+ *
+ * @param basePath Path to which the current step is appended to create the current step URL.
+ * @param steps Steps order.
+ *
+ * @return Tuple of the validated initial step and a setter for assigning a completed step.
+ */
+function useInitialStepValidation(basePath: string, steps: FormStep[]): [string, Dispatch<string>] {
+  const [completedStep, setCompletedStep] = useSessionStorage('completedStep');
+  const initialStep = useMemo(() => {
+    const pathStep = window.location.pathname.split(basePath)[1]?.replace(/\W/g, '');
+    const completedStepIndex = completedStep ? getStepIndex(completedStep, steps) : -1;
+    const pathStepIndex = getStepIndex(pathStep, steps);
+    const firstStepIndex = 0;
+    const stepIndex = Math.max(Math.min(completedStepIndex + 1, pathStepIndex), firstStepIndex);
+    return steps[stepIndex].name;
+  }, []);
+
+  return [initialStep, setCompletedStep];
+}
+
+export default useInitialStepValidation;

--- a/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Dispatch } from 'react';
-import { FormStep } from '@18f/identity-form-steps';
+import { FormStep, getStepParam } from '@18f/identity-form-steps';
 import useSessionStorage from './use-session-storage';
 
 /**
@@ -28,7 +28,7 @@ const getStepIndex = (stepName: string, steps: FormStep[]) =>
 function useInitialStepValidation(basePath: string, steps: FormStep[]): [string, Dispatch<string>] {
   const [completedStep, setCompletedStep] = useSessionStorage('completedStep');
   const initialStep = useMemo(() => {
-    const pathStep = window.location.pathname.split(basePath)[1]?.replace(/\W/g, '');
+    const pathStep = getStepParam(window.location.pathname.split(basePath)[1]);
     const completedStepIndex = completedStep ? getStepIndex(completedStep, steps) : -1;
     const pathStepIndex = getStepIndex(pathStep, steps);
     const firstStepIndex = 0;

--- a/app/javascript/packages/verify-flow/hooks/use-session-storage.spec.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-session-storage.spec.ts
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+import type { SinonStub } from 'sinon';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useDefineProperty } from '@18f/identity-test-helpers';
+import useSessionStorage from './use-session-storage';
+
+const TEST_KEY = 'key';
+
+describe('useSessionStorage', () => {
+  const defineProperty = useDefineProperty();
+
+  beforeEach(() => {
+    defineProperty(global, 'sessionStorage', {
+      value: {
+        getItem: sinon.stub(),
+        setItem: sinon.stub(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(TEST_KEY);
+  });
+
+  it('returns null for a value not in storage', () => {
+    (sessionStorage.getItem as SinonStub).withArgs(TEST_KEY).returns(null);
+
+    const { result } = renderHook(() => useSessionStorage(TEST_KEY));
+    const [value, setValue] = result.current;
+
+    expect(value).to.be.null();
+    expect(setValue).to.be.a('function');
+    expect(sessionStorage.setItem).not.to.have.been.called();
+  });
+
+  it('returns a value from storage', () => {
+    (sessionStorage.getItem as SinonStub).withArgs(TEST_KEY).returns('value');
+
+    const { result } = renderHook(() => useSessionStorage(TEST_KEY));
+    const [value, setValue] = result.current;
+
+    expect(value).to.equal('value');
+    expect(setValue).to.be.a('function');
+    expect(sessionStorage.setItem).not.to.have.been.called();
+  });
+
+  it('sets a value into storage', () => {
+    const { result } = renderHook(() => useSessionStorage(TEST_KEY));
+    const [, setValue] = result.current;
+    act(() => setValue('value'));
+
+    expect(sessionStorage.setItem).to.have.been.calledWith(TEST_KEY, 'value');
+  });
+});

--- a/app/javascript/packages/verify-flow/hooks/use-session-storage.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-session-storage.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useDidUpdateEffect } from '@18f/identity-react-hooks';
+import type { Dispatch } from 'react';
+
+/**
+ * React hook for maintaining a value in sessionStorage.
+ *
+ * @param key Session storage key.
+ *
+ * @return Tuple of the current value and a setter to assign a value into storage.
+ */
+function useSessionStorage(key: string): [string | null, Dispatch<string>] {
+  const [value, setValue] = useState(() => sessionStorage.getItem(key));
+  useDidUpdateEffect(() => {
+    if (value !== null) {
+      sessionStorage.setItem(key, value);
+    }
+  }, [value]);
+
+  return [value, setValue];
+}
+
+export default useSessionStorage;

--- a/app/javascript/packages/verify-flow/verify-flow.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as analytics from '@18f/identity-analytics';
 import { useSandbox } from '@18f/identity-test-helpers';
+import { STEPS } from './steps';
 import VerifyFlow from './verify-flow';
 
 describe('VerifyFlow', () => {
@@ -28,12 +29,15 @@ describe('VerifyFlow', () => {
     );
 
     // Password confirm
+    expect(document.title).to.equal('idv.titles.session.review - Example App');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: password confirm visited');
+    expect(window.location.pathname).to.equal('/password_confirm');
     await userEvent.type(getByLabelText('idv.form.password'), 'password');
     await userEvent.click(getByText('forms.buttons.continue'));
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: password confirm submitted');
 
     // Personal key
+    expect(document.title).to.equal('titles.idv.personal_key - Example App');
     await findByText('idv.messages.confirm');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key visited');
     expect(window.location.pathname).to.equal('/personal_key');
@@ -41,6 +45,7 @@ describe('VerifyFlow', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key submitted');
 
     // Personal key confirm
+    expect(document.title).to.equal('titles.idv.personal_key - Example App');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key confirm visited');
     expect(window.location.pathname).to.equal('/personal_key_confirm');
     expect(getByText('idv.messages.confirm')).to.be.ok();
@@ -48,5 +53,22 @@ describe('VerifyFlow', () => {
     await userEvent.keyboard('{Enter}');
 
     expect(onComplete).to.have.been.called();
+  });
+
+  context('with specific enabled steps', () => {
+    it('sets details according to the first enabled steps', () => {
+      render(
+        <VerifyFlow
+          appName="Example App"
+          initialValues={{ personalKey }}
+          onComplete={() => {}}
+          enabledStepNames={[STEPS[1].name]}
+          basePath="/"
+        />,
+      );
+
+      expect(document.title).to.equal(`${STEPS[1].title} - Example App`);
+      expect(window.location.pathname).to.equal(`/${STEPS[1].name}`);
+    });
   });
 });

--- a/app/javascript/packages/verify-flow/verify-flow.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.spec.tsx
@@ -1,11 +1,11 @@
-import sinon from 'sinon';
 import { render } from '@testing-library/react';
-import * as analytics from '@18f/identity-analytics';
 import userEvent from '@testing-library/user-event';
+import * as analytics from '@18f/identity-analytics';
+import { useSandbox } from '@18f/identity-test-helpers';
 import VerifyFlow from './verify-flow';
 
 describe('VerifyFlow', () => {
-  const sandbox = sinon.createSandbox();
+  const sandbox = useSandbox();
   const personalKey = '0000-0000-0000-0000';
 
   beforeEach(() => {
@@ -15,15 +15,16 @@ describe('VerifyFlow', () => {
     } as Response);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('advances through flow to completion', async () => {
-    const onComplete = sinon.spy();
+    const onComplete = sandbox.spy();
 
     const { getByText, findByText, getByLabelText } = render(
-      <VerifyFlow appName="Example App" initialValues={{ personalKey }} onComplete={onComplete} />,
+      <VerifyFlow
+        appName="Example App"
+        initialValues={{ personalKey }}
+        onComplete={onComplete}
+        basePath="/"
+      />,
     );
 
     // Password confirm
@@ -35,11 +36,13 @@ describe('VerifyFlow', () => {
     // Personal key
     await findByText('idv.messages.confirm');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key visited');
+    expect(window.location.pathname).to.equal('/personal_key');
     await userEvent.click(getByText('forms.buttons.continue'));
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key submitted');
 
     // Personal key confirm
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key confirm visited');
+    expect(window.location.pathname).to.equal('/personal_key_confirm');
     expect(getByText('idv.messages.confirm')).to.be.ok();
     await userEvent.type(getByLabelText('forms.personal_key.confirmation_label'), personalKey);
     await userEvent.keyboard('{Enter}');

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -5,6 +5,7 @@ import { STEPS } from './steps';
 import VerifyFlowStepIndicator from './verify-flow-step-indicator';
 import VerifyFlowAlert from './verify-flow-alert';
 import { useSyncedSecretValues } from './context/secrets-context';
+import useInitialStepValidation from './hooks/use-initial-step-validation';
 
 export interface VerifyFlowValues {
   userBundleToken?: string;
@@ -48,7 +49,7 @@ interface VerifyFlowProps {
   /**
    * The path to which the current step is appended to create the current step URL.
    */
-  basePath?: string;
+  basePath: string;
 
   /**
    * Application name, used in generating page titles for current step.
@@ -91,6 +92,7 @@ function VerifyFlow({
 }: VerifyFlowProps) {
   const [syncedValues, setSyncedValues] = useSyncedSecretValues(initialValues);
   const [currentStep, setCurrentStep] = useState(STEPS[0].name);
+  const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, STEPS);
   useEffect(() => {
     logStepVisited(currentStep);
   }, [currentStep]);
@@ -100,6 +102,11 @@ function VerifyFlow({
     steps = steps.filter(({ name }) => enabledStepNames.includes(name));
   }
 
+  function onStepSubmit(stepName: string) {
+    logStepSubmitted(stepName);
+    setCompletedStep(stepName);
+  }
+
   return (
     <>
       <VerifyFlowStepIndicator currentStep={currentStep} />
@@ -107,11 +114,12 @@ function VerifyFlow({
       <FormSteps
         steps={steps}
         initialValues={syncedValues}
+        initialStep={initialStep}
         promptOnNavigate={false}
         basePath={basePath}
         titleFormat={`%{step} - ${appName}`}
         onChange={setSyncedValues}
-        onStepSubmit={logStepSubmitted}
+        onStepSubmit={onStepSubmit}
         onStepChange={setCurrentStep}
         onComplete={onComplete}
       />

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -90,17 +90,17 @@ function VerifyFlow({
   appName,
   onComplete,
 }: VerifyFlowProps) {
-  const [syncedValues, setSyncedValues] = useSyncedSecretValues(initialValues);
-  const [currentStep, setCurrentStep] = useState(STEPS[0].name);
-  const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, STEPS);
-  useEffect(() => {
-    logStepVisited(currentStep);
-  }, [currentStep]);
-
   let steps = STEPS;
   if (enabledStepNames) {
     steps = steps.filter(({ name }) => enabledStepNames.includes(name));
   }
+
+  const [syncedValues, setSyncedValues] = useSyncedSecretValues(initialValues);
+  const [currentStep, setCurrentStep] = useState(steps[0].name);
+  const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, steps);
+  useEffect(() => {
+    logStepVisited(currentStep);
+  }, [currentStep]);
 
   function onStepSubmit(stepName: string) {
     logStepSubmitted(stepName);

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -79,8 +79,8 @@ describe VerifyController do
         context 'empty step' do
           let(:step) { nil }
 
-          it 'redirects to first step' do
-            expect(response).to redirect_to idv_app_path(step: 'personal_key')
+          it 'renders view' do
+            expect(response).to render_template(:show)
           end
         end
       end
@@ -109,8 +109,8 @@ describe VerifyController do
         context 'empty step' do
           let(:step) { nil }
 
-          it 'redirects to first step' do
-            expect(response).to redirect_to idv_app_path(step: 'password_confirm')
+          it 'renders view' do
+            expect(response).to render_template(:show)
           end
         end
       end

--- a/spec/javascripts/support/dom.js
+++ b/spec/javascripts/support/dom.js
@@ -2,6 +2,8 @@ import sinon from 'sinon';
 import { JSDOM, ResourceLoader } from 'jsdom';
 import matchMediaPolyfill from 'mq-polyfill';
 
+const TEST_URL = 'http://example.test';
+
 /**
  * Returns an instance of a JSDOM DOM instance configured for the test environment.
  *
@@ -9,7 +11,7 @@ import matchMediaPolyfill from 'mq-polyfill';
  */
 export function createDOM() {
   const dom = new JSDOM('<!doctype html><html lang="en"><head><title>JSDOM</title></head></html>', {
-    url: 'http://example.test',
+    url: TEST_URL,
     resources: new (class extends ResourceLoader {
       /**
        * @param {string} url
@@ -91,6 +93,8 @@ export function useCleanDOM(dom) {
     while (document.body.firstChild) {
       document.body.removeChild(document.body.firstChild);
     }
+    window.history.replaceState(null, '', TEST_URL);
+    window.location.pathname = '';
     window.location.hash = '';
     dom.cookieJar.removeAllCookiesSync();
   });


### PR DESCRIPTION
**Why**:

* So that we can push user to the correct step in the flow if the user enters at the root path
* So that we can prevent a user from reaching steps which they don't yet have the prerequisites
* So that the URL always reflects the current step (`/verify/v2` vs. `/verify/v2/personal_key`)

**Testing Instructions:**

Kinda difficult to test before we've got the password confirmation step implemented, but you can at least verify that the URL updates itself to reflect the current step:

1. Set `idv_api_steps_enabled: '["personal_key","personal_key_confirm"]'` in local `config/application.yml`
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to personal key page
5. Observe URL is `/verify/v2/personal_key` (previously `/verify/v2`)