### PR TITLE
IdV app: Add step value presence validation

### DIFF
--- a/app/javascript/packages/verify-flow/higher-order/with-presence-validation.spec.tsx
+++ b/app/javascript/packages/verify-flow/higher-order/with-presence-validation.spec.tsx
@@ -1,0 +1,49 @@
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import type { FormStepComponentProps } from '@18f/identity-form-steps';
+import withPresenceValidation from './with-presence-validation';
+
+describe('withPresenceValidation', () => {
+  type FormValues = { example: string };
+  const DEFAULT_PROPS = {
+    onChange() {},
+    onError() {},
+    errors: [],
+    toPreviousStep() {},
+    registerField: () => () => {},
+    unknownFieldErrors: [],
+    value: {} as FormValues,
+  };
+  interface ComponentProps extends FormStepComponentProps<FormValues> {
+    value: Partial<FormValues> & { example: string };
+  }
+  function Component({ value }: ComponentProps) {
+    return <>{value.example.toString()}</>;
+  }
+  const EnhancedComponent = withPresenceValidation(Component, 'example');
+
+  context('if the value is not present', () => {
+    it('renders nothing', () => {
+      const { container } = render(<EnhancedComponent {...DEFAULT_PROPS} />);
+
+      expect(container.innerHTML).to.be.empty();
+    });
+
+    it('calls toPreviousStep', () => {
+      const toPreviousStep = sinon.spy();
+      render(<EnhancedComponent {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />);
+
+      expect(toPreviousStep).to.have.been.calledOnce();
+    });
+  });
+
+  context('if the value is present', () => {
+    it('renders the default component implementation result', () => {
+      const { getByText } = render(
+        <EnhancedComponent {...DEFAULT_PROPS} value={{ example: 'present' }} />,
+      );
+
+      expect(getByText('present')).to.be.ok();
+    });
+  });
+});

--- a/app/javascript/packages/verify-flow/higher-order/with-presence-validation.tsx
+++ b/app/javascript/packages/verify-flow/higher-order/with-presence-validation.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import type { ComponentType } from 'react';
+import type { FormStepComponentProps } from '@18f/identity-form-steps';
+
+/**
+ * Higher order component which confirms that the specified keys are present in the form step value,
+ * else returns the user to the previous step.
+ *
+ * @param Component Original step component implementation.
+ * @param keys Steps to validate.
+ *
+ * @return Enhanced component.
+ */
+const withPresenceValidation =
+  <P extends FormStepComponentProps<any>, K extends keyof P['value']>(
+    Component: ComponentType<P>,
+    ...keys: K[]
+  ): ComponentType<P & { value: { [key in K]?: P[key] } }> =>
+  (props: P) => {
+    const { value, toPreviousStep } = props;
+    const isValid = keys.every((key) => value[key] !== undefined);
+    useEffect(() => {
+      if (!isValid) {
+        toPreviousStep();
+      }
+    }, [isValid]);
+
+    return isValid ? <Component {...props} /> : null;
+  };
+
+export default withPresenceValidation;

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -1,9 +1,10 @@
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FormSteps } from '@18f/identity-form-steps';
+import { FormStep, FormSteps } from '@18f/identity-form-steps';
 import * as analytics from '@18f/identity-analytics';
 import PersonalKeyConfirmStep from './personal-key-confirm-step';
+import { VerifyFlowValues } from '../../verify-flow';
 
 describe('PersonalKeyConfirmStep', () => {
   const DEFAULT_PROPS = {
@@ -62,7 +63,12 @@ describe('PersonalKeyConfirmStep', () => {
     const onComplete = sinon.spy();
     const { getByLabelText, getAllByText, container } = render(
       <FormSteps
-        steps={[{ name: 'personal_key_confirm', form: PersonalKeyConfirmStep }]}
+        steps={[
+          {
+            name: 'personal_key_confirm',
+            form: PersonalKeyConfirmStep,
+          } as FormStep<VerifyFlowValues>,
+        ]}
         initialValues={{ personalKey: '0000-0000-0000-0000' }}
         onComplete={onComplete}
       />,

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -5,15 +5,18 @@ import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { Modal } from '@18f/identity-modal';
 import { getAssetPath } from '@18f/identity-assets';
 import { trackEvent } from '@18f/identity-analytics';
+import withPresenceValidation from '../../higher-order/with-presence-validation';
 import PersonalKeyStep from '../personal-key/personal-key-step';
 import PersonalKeyInput from './personal-key-input';
 import type { VerifyFlowValues } from '../../verify-flow';
 
-interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
+interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {
+  value: Partial<VerifyFlowValues> & { personalKey: string };
+}
 
 function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
   const { registerField, value, onChange, toPreviousStep } = stepProps;
-  const personalKey = value.personalKey!;
+  const { personalKey } = value;
 
   const closeModalActions = () => {
     trackEvent('IdV: hide personal key modal');
@@ -58,4 +61,4 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
   );
 }
 
-export default PersonalKeyConfirmStep;
+export default withPresenceValidation(PersonalKeyConfirmStep, 'personalKey');

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -8,12 +8,15 @@ import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { getAssetPath } from '@18f/identity-assets';
 import { trackEvent } from '@18f/identity-analytics';
 import type { VerifyFlowValues } from '../../verify-flow';
+import withPresenceValidation from '../../higher-order/with-presence-validation';
 import DownloadButton from './download-button';
 
-interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {}
+interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {
+  value: Partial<VerifyFlowValues> & { personalKey: string };
+}
 
 function PersonalKeyStep({ value }: PersonalKeyStepProps) {
-  const personalKey = value.personalKey!;
+  const { personalKey } = value;
 
   return (
     <>
@@ -81,4 +84,4 @@ function PersonalKeyStep({ value }: PersonalKeyStepProps) {
   );
 }
 
-export default PersonalKeyStep;
+export default withPresenceValidation(PersonalKeyStep, 'personalKey');


### PR DESCRIPTION
Alternative to #6316

**Why**: So that a user cannot visit a step for which they have not completed the prerequisites, and so that the implementation of a step can safely assume the presence of its dependent values.

**Testing Instructions:**

This is difficult to test before we've got the password confirmation step implemented, but you can force it with a local diff:

```
diff --git a/app/controllers/verify_controller.rb b/app/controllers/verify_controller.rb
index 68cff80cc..8f973737d 100644
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -25 +25 @@ class VerifyController < ApplicationController
-        'personalKey' => personal_key,
+        # 'personalKey' => personal_key,
```

1. Set `idv_api_steps_enabled: '["personal_key","personal_key_confirm"]'` in local `config/application.yml`
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to personal key page
5. Go to http://localhost:3000/verify/v2
6. Observe no errors in developer console (previously, errors due to trying to operate on missing `personalKey`)