### PR TITLE
Fix 500 when trying to display invalid phone numbers

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -5,6 +5,7 @@ module TwoFactorAuthentication
 
     before_action :check_sp_required_mfa_bypass
     before_action :confirm_multiple_factors_enabled
+    before_action :redirect_if_blank_phone, only: [:show]
     before_action :confirm_voice_capability, only: [:show]
 
     def show
@@ -34,6 +35,13 @@ module TwoFactorAuthentication
     end
 
     private
+
+    def redirect_if_blank_phone
+      return if phone.present?
+
+      flash[:error] = t('errors.messages.phone_required')
+      redirect_to new_user_session_path
+    end
 
     def confirm_multiple_factors_enabled
       return if UserSessionContext.confirmation_context?(context) || phone_enabled?

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -5,6 +5,7 @@ module Users
 
     before_action :check_remember_device_preference
     before_action :redirect_to_vendor_outage_if_phone_only, only: [:show]
+    before_action :redirect_if_blank_phone, only: [:send_code]
 
     def show
       service_provider_mfa_requirement_redirect || non_phone_redirect || phone_redirect ||
@@ -125,6 +126,13 @@ module Users
         otp_delivery_preference: phone_configuration.delivery_preference,
         reauthn: reauthn?,
       )
+    end
+
+    def redirect_if_blank_phone
+      return if phone_to_deliver_to.present?
+
+      flash[:error] = t('errors.messages.phone_required')
+      redirect_to login_two_factor_options_path
     end
 
     def redirect_to_vendor_outage_if_phone_only

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -64,6 +64,12 @@ describe TwoFactorAuthentication::OptionsController do
       expect(response).to redirect_to login_two_factor_webauthn_url(platform: true)
     end
 
+    it 'sets phone_id in session when selecting a phone option' do
+      post :create, params: { two_factor_options_form: { selection: 'sms_0' } }
+
+      expect(controller.user_session[:phone_id]).to eq('0')
+    end
+
     it 'rerenders the page with errors on failure' do
       post :create, params: { two_factor_options_form: { selection: 'foo' } }
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -31,6 +31,15 @@ describe TwoFactorAuthentication::OtpVerificationController do
           expect(assigns(:code_value)).to be_nil
         end
       end
+
+      context 'when the user has an invalid phone number in the session' do
+        it 'redirects to homepage' do
+          controller.user_session[:phone_id] = 0
+
+          get :show, params: { otp_delivery_preference: 'sms' }
+          expect(response).to redirect_to new_user_session_path
+        end
+      end
     end
 
     it 'tracks the page visit and context' do

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -440,6 +440,23 @@ describe Users::TwoFactorAuthenticationController do
                                          otp_make_default_number: nil },
         }
       end
+
+      context 'when selecting specific phone configuration' do
+        before do
+          user = create(:user, :signed_up)
+          sign_in_before_2fa(user)
+        end
+      end
+
+      it 'redirects to two factor options path with invalid id' do
+        controller.user_session[:phone_id] = 0
+
+        get :send_code, params: {
+          otp_delivery_selection_form: { otp_delivery_preference: 'voice' },
+        }
+
+        expect(response).to redirect_to(login_two_factor_options_path)
+      end
     end
 
     context 'phone is not confirmed' do


### PR DESCRIPTION
I suspect this is limited to people manually editing the form to specify a different (invalid) ID, but it caused some 500s ([NR](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=ea51363b-e7fe-5509-daed-6df4e93ef4be))

This PR adds validation and additional tests around this case.  I'm not overly worried about getting the redirect exactly right in case where we redirect back to the homepage.  The user in question could be signing up or authenticating, but either way something funky is going on 🙂