### PR TITLE
Use superclass to improve catching possible Pinpoint errors and avoid 500s

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -57,8 +57,7 @@ module Telephony
             channel: :sms,
             extra: response.extra,
           )
-        rescue Aws::Pinpoint::Errors::InternalServerErrorException,
-               Aws::Pinpoint::Errors::TooManyRequestsException,
+        rescue Aws::Pinpoint::Errors::ServiceError,
                Seahorse::Client::NetworkingError => e
           finish = Time.zone.now
           response = handle_pinpoint_error(e)


### PR DESCRIPTION
Converts the catching of Pinpoint errors to use the superclass mentioned [here](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Pinpoint/Errors.html) ([NR link](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=09226acb-42b9-dc3c-aeb8-3e98675340b9))