### PR TITLE
Drop unused types for sp_costs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -428,16 +428,6 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def add_sp_cost(token)
-    Db::SpCost::AddSpCost.call(
-      current_sp,
-      sp_session_ial,
-      token,
-      transaction_id: nil,
-      user: current_user,
-    )
-  end
-
   def mobile?
     BrowserCache.parse(request.user_agent).mobile?
   end

--- a/app/controllers/concerns/billable_event_trackable.rb
+++ b/app/controllers/concerns/billable_event_trackable.rb
@@ -6,7 +6,6 @@ module BillableEventTrackable
       increment_sp_monthly_auths
       create_sp_return_log(billable: true)
       mark_current_session_billed
-      add_sp_cost(:authentication)
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -127,7 +127,6 @@ module Users
     def handle_valid_authentication
       sign_in(resource_name, resource)
       cache_active_profile(auth_params[:password])
-      add_sp_cost(:digest)
       create_user_event(:sign_in_before_2fa)
       EmailAddress.update_last_sign_in_at_on_user_id_and_email(
         user_id: current_user.id,

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -180,7 +180,7 @@ module Users
     end
 
     def handle_telephony_result(method:, default:)
-      track_events(method)
+      track_events
       if @telephony_result.success?
         redirect_to login_two_factor_url(
           otp_delivery_preference: method,
@@ -197,9 +197,8 @@ module Users
       end
     end
 
-    def track_events(method)
+    def track_events
       analytics.track_event(Analytics::TELEPHONY_OTP_SENT, @telephony_result.to_h)
-      add_sp_cost(method) if @telephony_result.success?
     end
 
     def exceeded_otp_send_limit?

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -9,15 +9,9 @@ module Db
         acuant_back_image
         acuant_result
         acuant_selfie
-        authentication
-        digest
         lexis_nexis_resolution
         lexis_nexis_address
         gpo_letter
-        phone_otp
-        sms
-        user_added
-        voice
       ].freeze
 
       def self.call(service_provider, ial, token, transaction_id: nil, user: nil)

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -45,7 +45,6 @@ class IdentityLinker
   def find_or_create_identity_with_costing
     identity_record = identity_relation.first
     return identity_record if identity_record
-    Db::SpCost::AddSpCost.call(service_provider, @ial, :user_added)
     user.identities.create(service_provider: service_provider.issuer)
   end
 

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -73,7 +73,6 @@ module Idv
 
     def add_cost
       Db::ProofingCost::AddUserProofingCost.call(user.id, :phone_otp)
-      Db::SpCost::AddSpCost.call(idv_session.service_provider, 2, :phone_otp)
     end
 
     def extra_analytics_attributes

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1753,8 +1753,6 @@ describe SamlIdpController do
                ial: 1)
 
         generate_saml_response(user)
-
-        expect_sp_authentication_cost
       end
     end
 
@@ -1789,8 +1787,6 @@ describe SamlIdpController do
                ial: 1)
 
         generate_saml_response(user)
-
-        expect_sp_authentication_cost
       end
     end
   end
@@ -1816,13 +1812,5 @@ describe SamlIdpController do
     it 'returns false for empty referer' do
       expect(subject.external_saml_request?).to eq false
     end
-  end
-
-  def expect_sp_authentication_cost
-    sp_cost = SpCost.where(
-      issuer: 'http://localhost:3000',
-      cost_type: 'authentication',
-    ).first
-    expect(sp_cost).to be_present
   end
 end

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -12,32 +12,21 @@ feature 'SP Costing', :email do
   let(:email) { 'test@test.com' }
   let(:password) { Features::SessionHelper::VALID_PASSWORD }
 
-  it 'logs the correct costs for an ial1 user creation from sp with oidc' do
-    create_ial1_user_from_sp(email)
-
-    expect_sp_cost_type(0, 1, 'sms')
-    expect_sp_cost_type(1, 1, 'user_added')
-    expect_sp_cost_type(2, 1, 'authentication')
-  end
-
   it 'logs the correct costs for an ial2 user creation from sp with oidc', js: true do
     create_ial2_user_from_sp(email)
 
-    expect_sp_cost_type(0, 2, 'sms')
-    expect_sp_cost_type(1, 2, 'acuant_front_image')
-    expect_sp_cost_type(2, 2, 'acuant_back_image')
-    expect_sp_cost_type(3, 2, 'acuant_result')
+    expect_sp_cost_type(0, 2, 'acuant_front_image')
+    expect_sp_cost_type(1, 2, 'acuant_back_image')
+    expect_sp_cost_type(2, 2, 'acuant_result')
     expect_sp_cost_type(
-      4, 2, 'lexis_nexis_resolution',
+      3, 2, 'lexis_nexis_resolution',
       transaction_id: Proofing::Mock::ResolutionMockClient::TRANSACTION_ID
     )
     expect_sp_cost_type(
-      5, 2, 'aamva',
+      4, 2, 'aamva',
       transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID
     )
-    expect_sp_cost_type(6, 2, 'lexis_nexis_address')
-    expect_sp_cost_type(7, 2, 'user_added')
-    expect_sp_cost_type(8, 2, 'authentication')
+    expect_sp_cost_type(5, 2, 'lexis_nexis_address')
   end
 
   it 'logs the cost to the SP for reproofing', js: true do
@@ -76,56 +65,6 @@ feature 'SP Costing', :email do
     end
   end
 
-  it 'logs the correct costs for an ial1 authentication' do
-    create_ial1_user_from_sp(email)
-    SpCost.delete_all
-
-    # track costs without dealing with 'remember device'
-    Capybara.reset_session!
-
-    visit_idp_from_sp_with_ial1(:oidc)
-    fill_in_credentials_and_submit(email, password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-
-    expect_sp_cost_type(0, 1, 'digest')
-    expect_sp_cost_type(1, 1, 'sms')
-    expect_sp_cost_type(2, 1, 'authentication')
-  end
-
-  it 'logs the correct costs for an ial2 authentication', js: true do
-    create_ial2_user_from_sp(email)
-    SpCost.delete_all
-
-    # track costs without dealing with 'remember device'
-    Capybara.reset_session!
-
-    visit_idp_from_sp_with_ial2(:oidc)
-    fill_in_credentials_and_submit(email, password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-
-    expect_sp_cost_type(0, 2, 'digest')
-    expect_sp_cost_type(1, 2, 'sms')
-    expect_sp_cost_type(2, 2, 'authentication')
-  end
-
-  it 'logs the correct costs for a direct authentication' do
-    visit root_path
-    create_ial1_user_directly(email)
-    SpCost.delete_all
-
-    # track costs without dealing with 'remember device'
-    Capybara.reset_session!
-
-    visit root_path
-    fill_in_credentials_and_submit(email, password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-
-    expect_direct_cost_type(0, 'digest')
-  end
-
   def expect_sp_cost_type(sp_cost_index, ial, token, transaction_id: nil)
     sp_cost = sp_costs(sp_cost_index)
     expect(sp_cost.ial).to eq(ial)
@@ -133,13 +72,6 @@ feature 'SP Costing', :email do
     expect(sp_cost.agency_id).to eq(agency_id)
     expect(sp_cost.cost_type).to eq(token)
     expect(sp_cost.transaction_id).to(eq(transaction_id)) if transaction_id
-  end
-
-  def expect_direct_cost_type(sp_cost_index, token)
-    sp_cost = sp_costs(sp_cost_index)
-    expect(sp_cost.issuer).to eq('')
-    expect(sp_cost.agency_id).to eq(0)
-    expect(sp_cost.cost_type).to eq(token)
   end
 
   def sp_costs(index)


### PR DESCRIPTION
Re-implements #6264 and #6266 (effectively reverting #6313)

Changes were discussed [here](https://gsa-tts.slack.com/archives/C5E7EJWF7/p1651087597980499)