### PR TITLE
Add feature flag for including SLO in SAML metadata

### DIFF
--- a/app/services/saml_endpoint.rb
+++ b/app/services/saml_endpoint.rb
@@ -35,8 +35,13 @@ class SamlEndpoint
   def saml_metadata
     config = SamlIdp.config.dup
     config.single_service_post_location += suffix
-    config.single_logout_service_post_location += suffix
-    config.remote_logout_service_post_location += suffix
+    if IdentityConfig.store.include_slo_in_saml_metadata
+      config.single_logout_service_post_location += suffix
+      config.remote_logout_service_post_location += suffix
+    else
+      config.single_logout_service_post_location = nil
+      config.remote_logout_service_post_location = nil
+    end
 
     SamlIdp::MetadataBuilder.new(
       config,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -102,6 +102,7 @@ idv_private_key: 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCT2dJQkFBSkJBS3
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 in_person_proofing_enabled: true
+include_slo_in_saml_metadata: false
 liveness_checking_enabled: false
 logins_per_ip_track_only_mode: false
 # LexisNexis #####################################################

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -176,6 +176,7 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:in_person_proofing_enabled, type: :boolean)
+    config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:lexisnexis_base_url, type: :string)
     config.add(:lexisnexis_request_mode, type: :string)
     config.add(:lexisnexis_account_id, type: :string)

--- a/spec/services/saml_endpoint_spec.rb
+++ b/spec/services/saml_endpoint_spec.rb
@@ -76,6 +76,22 @@ describe SamlEndpoint do
       result = subject.saml_metadata
 
       expect(result.configurator.single_service_post_location).to match(%r{api/saml/auth2022\Z})
+    end
+
+    it 'does not include the SingLogoutService endpoints when configured' do
+      allow(IdentityConfig.store).to receive(:include_slo_in_saml_metadata).
+        and_return(false)
+      result = subject.saml_metadata
+
+      expect(result.configurator.single_logout_service_post_location).to be_nil
+      expect(result.configurator.remote_logout_service_post_location).to be_nil
+    end
+
+    it 'includes the SingLogoutService endpoints when configured' do
+      allow(IdentityConfig.store).to receive(:include_slo_in_saml_metadata).
+        and_return(true)
+      result = subject.saml_metadata
+
       expect(result.configurator.single_logout_service_post_location).to match(
         %r{api/saml/logout2022\Z},
       )


### PR DESCRIPTION
**Why:** We require logout requests to be signed but not all SAML
clients send signed logout requests by default. Turning this on caused
certain SAML clients that weren't previously sending SLO requests to us
to start sending SLO requests, so this allows us to ease into this.

[skip changelog]