### PR TITLE
Fix margins for "Forgot Password" form

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -19,9 +19,13 @@
               input_html: { autocorrect: 'off',
                             aria: { invalid: false, describedby: 'email-description' } } %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
-  <%= f.button :submit, t('forms.buttons.continue'), class: 'usa-button--big usa-button--wide margin-top-2' %>
+  <%= f.button(
+        :submit,
+        t('forms.buttons.continue'),
+        class: 'display-block usa-button--big usa-button--wide margin-y-5',
+      ) %>
 <% end %>
 
-<div class="margin-top-2 padding-top-1 border-top border-primary-light">
+<%= render(PageFooterComponent.new) do %>
   <%= link_to t('links.cancel'), decorated_session.cancel_link_url %>
-</div>
+<% end %>


### PR DESCRIPTION
**Why**: So that it matches the expected layout via Figma flow designs, and is consistent with other "Submit" (2.5rem vertical margin) + "Page Footer" (2rem top margin) combinations.

Refer to "Authentication for Partners" Figma document for reference design.

I've been resetting my password a lot as part of ongoing identity verification work, and it's been bothering me to look at it 😉 

**Screenshot:**

Before|After
---|---
![localhost_3000_users_password_new (1)](https://user-images.githubusercontent.com/1779930/167873564-8269bd30-06f0-423e-af00-c6ecee99e960.png)|![localhost_3000_users_password_new](https://user-images.githubusercontent.com/1779930/167873572-1ed21b43-ec52-4300-94c2-a3d3c28f671d.png)

