### PR TITLE
LG-6139: Handle and display password confirm errors

### DIFF
--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -105,20 +105,20 @@ module Api
 
     def valid_jwt
       @user_bundle = Api::UserBundleDecorator.new(user_bundle: jwt, public_key: public_key)
-    rescue JWT::DecodeError => err
-      errors.add(:jwt, "decode error: #{err.message}", type: :decode_error)
-    rescue ::Api::UserBundleError => err
-      errors.add(:jwt, "malformed user bundle: #{err.message}", type: :malfored_user_bundle)
+    rescue JWT::DecodeError
+      errors.add(:jwt, I18n.t('idv.failure.exceptions.internal_error'), type: :decode_error)
+    rescue ::Api::UserBundleError
+      errors.add(:jwt, I18n.t('idv.failure.exceptions.internal_error'), type: :user_bundle_error)
     end
 
     def valid_user
       return if user
-      errors.add(:user, 'user not found', type: :invalid_user)
+      errors.add(:user, I18n.t('devise.failure.unauthenticated'), type: :invalid_user)
     end
 
     def valid_password
       return if user&.valid_password?(password)
-      errors.add(:password, 'invalid password', type: :invalid_password)
+      errors.add(:password, I18n.t('idv.errors.incorrect_password'), type: :invalid_password)
     end
 
     def form_valid?

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -29,7 +29,7 @@ module Api
 
       response = FormResponse.new(
         success: form_valid?,
-        errors: errors.to_hash,
+        errors: errors,
         extra: extra_attributes,
       )
       [response, personal_key]
@@ -106,19 +106,19 @@ module Api
     def valid_jwt
       @user_bundle = Api::UserBundleDecorator.new(user_bundle: jwt, public_key: public_key)
     rescue JWT::DecodeError => err
-      errors.add(:jwt, "decode error: #{err.message}", type: :invalid)
+      errors.add(:jwt, "decode error: #{err.message}", type: :decode_error)
     rescue ::Api::UserBundleError => err
-      errors.add(:jwt, "malformed user bundle: #{err.message}", type: :invalid)
+      errors.add(:jwt, "malformed user bundle: #{err.message}", type: :malfored_user_bundle)
     end
 
     def valid_user
       return if user
-      errors.add(:user, 'user not found', type: :invalid)
+      errors.add(:user, 'user not found', type: :invalid_user)
     end
 
     def valid_password
       return if user&.valid_password?(password)
-      errors.add(:password, 'invalid password', type: :invalid)
+      errors.add(:password, 'invalid password', type: :invalid_password)
     end
 
     def form_valid?

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx
@@ -62,7 +62,7 @@ function DocumentSideAcuantCapture({
       }
       onCameraAccessDeclined={() => {
         onError(new CameraAccessDeclinedError(), { field: side });
-        onError(new CameraAccessDeclinedError({ isDetail: true }));
+        onError(new CameraAccessDeclinedError(undefined, { isDetail: true }));
       }}
       errorMessage={error ? error.message : undefined}
       name={side}

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -7,15 +7,6 @@ import { FormError } from '@18f/identity-form-steps';
 export class UploadFormEntryError extends FormError {
   /** @type {string} */
   field = '';
-
-  /**
-   * @param {string} message
-   */
-  constructor(message) {
-    super();
-
-    this.message = message;
-  }
 }
 
 export class UploadFormEntriesError extends FormError {

--- a/app/javascript/packages/form-steps/form-error.spec.ts
+++ b/app/javascript/packages/form-steps/form-error.spec.ts
@@ -1,0 +1,27 @@
+import FormError from './form-error';
+
+describe('FormError', () => {
+  it('constructs with a message', () => {
+    const error = new FormError('message');
+
+    expect(error.message).to.equal('message');
+    expect(error.isDetail).to.be.false();
+    expect(error.field).to.be.undefined();
+  });
+
+  it('constructs as detailed error', () => {
+    const error = new FormError('message', { isDetail: true });
+
+    expect(error.message).to.equal('message');
+    expect(error.isDetail).to.be.true();
+    expect(error.field).to.be.undefined();
+  });
+
+  it('constructs as associated with a field', () => {
+    const error = new FormError('message', { field: 'field' });
+
+    expect(error.message).to.equal('message');
+    expect(error.isDetail).to.be.false();
+    expect(error.field).to.equal('field');
+  });
+});

--- a/app/javascript/packages/form-steps/form-error.spec.ts
+++ b/app/javascript/packages/form-steps/form-error.spec.ts
@@ -24,4 +24,16 @@ describe('FormError', () => {
     expect(error.isDetail).to.be.false();
     expect(error.field).to.equal('field');
   });
+
+  it('supports message on subclass property initializer', () => {
+    class ExampleFormError extends FormError {
+      message = 'message';
+    }
+
+    const error = new ExampleFormError();
+
+    expect(error.message).to.equal('message');
+    expect(error.isDetail).to.be.false();
+    expect(error.field).to.be.undefined();
+  });
 });

--- a/app/javascript/packages/form-steps/form-error.ts
+++ b/app/javascript/packages/form-steps/form-error.ts
@@ -17,11 +17,7 @@ class FormError extends Error {
   isDetail: boolean;
 
   constructor(message?: string, options?: FormErrorOptions) {
-    super();
-
-    if (message) {
-      this.message = message;
-    }
+    super(message);
 
     this.isDetail = Boolean(options?.isDetail);
     this.field = options?.field;

--- a/app/javascript/packages/form-steps/form-error.ts
+++ b/app/javascript/packages/form-steps/form-error.ts
@@ -6,7 +6,7 @@ export interface FormErrorOptions {
   isDetail?: boolean;
 
   /**
-   * Field associated with the erorr.
+   * Field associated with the error.
    */
   field?: string;
 }

--- a/app/javascript/packages/form-steps/form-error.ts
+++ b/app/javascript/packages/form-steps/form-error.ts
@@ -4,15 +4,27 @@ export interface FormErrorOptions {
    * text description.
    */
   isDetail?: boolean;
+
+  /**
+   * Field associated with the erorr.
+   */
+  field?: string;
 }
 
 class FormError extends Error {
+  field?: string;
+
   isDetail: boolean;
 
-  constructor(options?: { isDetail: boolean }) {
+  constructor(message?: string, options?: FormErrorOptions) {
     super();
 
+    if (message) {
+      this.message = message;
+    }
+
     this.isDetail = Boolean(options?.isDetail);
+    this.field = options?.field;
   }
 }
 

--- a/app/javascript/packages/verify-flow/services/api.spec.ts
+++ b/app/javascript/packages/verify-flow/services/api.spec.ts
@@ -1,6 +1,6 @@
 import type { SinonStub } from 'sinon';
 import { useSandbox } from '@18f/identity-test-helpers';
-import { post } from './api';
+import { isErrorResponse, post } from './api';
 
 describe('post', () => {
   const sandbox = useSandbox();
@@ -71,5 +71,21 @@ describe('post', () => {
         }),
       );
     });
+  });
+});
+
+describe('isErrorResponse', () => {
+  it('returns false if object is not an error response', () => {
+    const response = {};
+    const result = isErrorResponse(response);
+
+    expect(result).to.be.false();
+  });
+
+  it('returns true if object is an error response', () => {
+    const response = { error: { field: ['message'] } };
+    const result = isErrorResponse(response);
+
+    expect(result).to.be.true();
   });
 });

--- a/app/javascript/packages/verify-flow/services/api.ts
+++ b/app/javascript/packages/verify-flow/services/api.ts
@@ -1,3 +1,7 @@
+export interface ErrorResponse<Field extends string> {
+  error: Record<Field, [string, ...string[]]>;
+}
+
 interface PostOptions {
   /**
    * Whether to send the request as a JSON request.
@@ -41,3 +45,7 @@ export async function post<Response = any>(
 
   return options.json ? response.json() : response.text();
 }
+
+export const isErrorResponse = <F extends string>(
+  response: object | ErrorResponse<F>,
+): response is ErrorResponse<F> => 'error' in response;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -1,14 +1,20 @@
 import type { ChangeEvent } from 'react';
 import { t } from '@18f/identity-i18n';
 import { FormStepsButton } from '@18f/identity-form-steps';
+import { Alert } from '@18f/identity-components';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import type { VerifyFlowValues } from '../../verify-flow';
 
 interface PasswordConfirmStepStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
-function PasswordConfirmStep({ registerField, onChange }: PasswordConfirmStepStepProps) {
+function PasswordConfirmStep({ errors, registerField, onChange }: PasswordConfirmStepStepProps) {
   return (
     <>
+      {errors.map(({ error }) => (
+        <Alert key={error.message} type="error" className="margin-bottom-4">
+          {error.message}
+        </Alert>
+      ))}
       <input
         ref={registerField('password')}
         aria-label={t('idv.form.password')}

--- a/app/javascript/packages/verify-flow/steps/password-confirm/submit.spec.ts
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/submit.spec.ts
@@ -1,24 +1,53 @@
+import { FormError } from '@18f/identity-form-steps';
 import { useSandbox } from '@18f/identity-test-helpers';
 import submit, { API_ENDPOINT } from './submit';
 
 describe('submit', () => {
   const sandbox = useSandbox();
 
-  beforeEach(() => {
-    sandbox
-      .stub(window, 'fetch')
-      .withArgs(
-        API_ENDPOINT,
-        sandbox.match({ body: JSON.stringify({ user_bundle_token: '..', password: 'hunter2' }) }),
-      )
-      .resolves({
-        json: () => Promise.resolve({ personal_key: '0000-0000-0000-0000' }),
-      } as Response);
+  context('with successful submission', () => {
+    beforeEach(() => {
+      sandbox
+        .stub(window, 'fetch')
+        .withArgs(
+          API_ENDPOINT,
+          sandbox.match({ body: JSON.stringify({ user_bundle_token: '..', password: 'hunter2' }) }),
+        )
+        .resolves({
+          json: () => Promise.resolve({ personal_key: '0000-0000-0000-0000' }),
+        } as Response);
+    });
+
+    it('sends with password confirmation values', async () => {
+      const patch = await submit({ userBundleToken: '..', password: 'hunter2' });
+
+      expect(patch).to.deep.equal({ personalKey: '0000-0000-0000-0000' });
+    });
   });
 
-  it('sends with password confirmation values', async () => {
-    const patch = await submit({ userBundleToken: '..', password: 'hunter2' });
+  context('error submission', () => {
+    beforeEach(() => {
+      sandbox
+        .stub(window, 'fetch')
+        .withArgs(
+          API_ENDPOINT,
+          sandbox.match({ body: JSON.stringify({ user_bundle_token: '..', password: 'hunter2' }) }),
+        )
+        .resolves({
+          json: () => Promise.resolve({ error: { password: ['incorrect password'] } }),
+        } as Response);
+    });
 
-    expect(patch).to.deep.equal({ personalKey: '0000-0000-0000-0000' });
+    it('throws error for the offending field', async () => {
+      const didError = await submit({ userBundleToken: '..', password: 'hunter2' }).catch(
+        (error: FormError) => {
+          expect(error.field).to.equal('password');
+          expect(error.message).to.equal('incorrect password');
+          return true;
+        },
+      );
+
+      expect(didError).to.be.true();
+    });
   });
 });

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::Verify::PasswordConfirmController do
         post :create, params: { password: 'iamnotbatman', user_bundle_token: jwt }
         response_json = JSON.parse(response.body)
         expect(response_json['personal_key']).to be_nil
-        expect(response_json['error']['password']).to eq(['invalid password'])
+        expect(response_json['error']['password']).to eq([I18n.t('idv.errors.incorrect_password')])
         expect(response.status).to eq 400
       end
     end

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -66,7 +66,9 @@ describe Api::Verify::PasswordConfirmController do
 
       it 'does not create a profile and return a key when it has the wrong password' do
         post :create, params: { password: 'iamnotbatman', user_bundle_token: jwt }
-        expect(JSON.parse(response.body)['personal_key']).to be_nil
+        response_json = JSON.parse(response.body)
+        expect(response_json['personal_key']).to be_nil
+        expect(response_json['error']['password']).to eq(['invalid password'])
         expect(response.status).to eq 400
       end
     end

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Api::ProfileCreationForm do
 
         expect(response.success?).to be false
         expect(personal_key).to be_nil
-        expect(response.errors[:password]).to eq ['invalid password']
+        expect(response.errors[:password]).to eq [I18n.t('idv.errors.incorrect_password')]
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Api::ProfileCreationForm do
 
         expect(response.success?).to be false
         expect(personal_key).to be_nil
-        expect(response.errors[:user]).to eq ['user not found']
+        expect(response.errors[:user]).to eq [I18n.t('devise.failure.unauthenticated')]
       end
     end
 
@@ -143,7 +143,7 @@ RSpec.describe Api::ProfileCreationForm do
 
         expect(response.success?).to be false
         expect(personal_key).to be_nil
-        expect(response.errors[:jwt]).to eq ['decode error: Signature has expired']
+        expect(response.errors[:jwt]).to eq [I18n.t('idv.failure.exceptions.internal_error')]
       end
     end
   end
@@ -183,7 +183,8 @@ RSpec.describe Api::ProfileCreationForm do
 
       it 'is an invalid form' do
         expect(subject.valid?).to be false
-        expect(subject.errors.to_a.join(' ')).to match(%r{decode error})
+        expect(subject.errors[:jwt]).to eq [I18n.t('idv.failure.exceptions.internal_error')]
+        expect(subject.errors).to include { |error| error.options[:type] == :decode_error }
       end
     end
 
@@ -199,7 +200,8 @@ RSpec.describe Api::ProfileCreationForm do
 
       it 'is an invalid form' do
         expect(subject.valid?).to be false
-        expect(subject.errors.to_a.join(' ')).to match(%r{pii is missing})
+        expect(subject.errors[:jwt]).to eq [I18n.t('idv.failure.exceptions.internal_error')]
+        expect(subject.errors).to include { |error| error.options[:type] == :user_bundle_error }
       end
     end
 
@@ -215,7 +217,8 @@ RSpec.describe Api::ProfileCreationForm do
 
       it 'is an invalid form' do
         expect(subject.valid?).to be false
-        expect(subject.errors.to_a.join(' ')).to match(%r{metadata is missing})
+        expect(subject.errors[:jwt]).to eq [I18n.t('idv.failure.exceptions.internal_error')]
+        expect(subject.errors).to include { |error| error.options[:type] == :user_bundle_error }
       end
     end
   end


### PR DESCRIPTION
**Why**: So that the user only proceeds to the next step with a valid submission, and so that they know what they need to do to correct the issue.

**Testing Instructions:**

1. Set `idv_api_enabled_steps: '["password_confirm","personal_key","personal_key_confirm"]'` in local `config/application.yml`
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to password confirmation page
5. Submit the page with an empty field, or an incorrect password
6. Observe that an error alert message is shown

**Screenshot:**

In the screenshot below, note that "Before" shows that the application would previously crash, due to assumptions that the API request would have been successful.

Before|After
---|---
![Screen Shot 2022-05-11 at 11 31 58 AM](https://user-images.githubusercontent.com/1779930/167891212-c5a88f92-8d5e-4e10-a20d-a68e7d6c3375.png)|![Screen Shot 2022-05-11 at 11 31 35 AM](https://user-images.githubusercontent.com/1779930/167891221-9e721c15-0fbc-43ec-8c34-c0f5621f02e8.png)

