### PR TITLE
Remove default wrapper and margin from hidden inputs

### DIFF
--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -20,8 +20,8 @@
                        html: { autocomplete: 'off', method: :post, class: 'margin-bottom-2' },
                        url: user_password_path do |f| %>
 
-  <%= f.input :email, as: :hidden, wrapper: false %>
-  <%= f.input :resend, as: :hidden, wrapper: false %>
+  <%= f.input :email, as: :hidden %>
+  <%= f.input :resend, as: :hidden %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>
   <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled margin-left-05' %></p>

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -22,9 +22,9 @@
 <%= validated_form_for @resend_email_confirmation_form,
                        html: { class: 'margin-bottom-2' },
                        url: sign_up_register_path do |f| %>
-  <%= f.input :email, as: :hidden, wrapper: false %>
-  <%= f.input :resend, as: :hidden, wrapper: false %>
-  <%= f.input :request_id, as: :hidden, wrapper: false %>
+  <%= f.input :email, as: :hidden %>
+  <%= f.input :resend, as: :hidden %>
+  <%= f.input :request_id, as: :hidden %>
   <p><%= t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start') %>
   <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled margin-left-05' %></p>
 

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -9,6 +9,7 @@ SimpleForm.setup do |config|
   config.wrapper_mappings = {
     boolean: :uswds_checkbox,
     radio_buttons: :uswds_radio_buttons,
+    hidden: :unwrapped,
   }
 
   config.wrappers :base do |b|
@@ -29,6 +30,10 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'div', class: 'usa-hint' }
     b.use :input, class: 'display-block width-full field', error_class: 'usa-input--error'
     b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
+  end
+
+  config.wrappers :unwrapped, wrapper: false do |b|
+    b.use :input
   end
 
   config.wrappers :uswds_checkbox do |b|


### PR DESCRIPTION
**Why**: So that hidden inputs don't affect the page layout.

Notably, this removes an unexpectedly-large gap between the password field and "Sign In" button on the Sign In page which is not intended, per Figma design references (see "Authentication for Partners").

Most all SimpleForm inputs use the same "wrapper", which applies default styling for inputs, including a bottom margin of 2rem. Since hidden inputs are expected to be... well, hidden... they should not affect page layout.

This does impact a number of existing inputs using `as: :hidden`. A "safer" (lazier) option would have been to [use `input_field` instead](https://github.com/heartcombo/simple_form#stripping-away-all-wrapper-divs), or `wrapper: false` as we already do in a few places. But since it seems reasonable this should be default to all hidden inputs, and since it may not be obvious to use those options (evidenced by existing issues), I instead chose to reconfigure the form defaults.

**Screenshots:**

Before|After
---|---
![localhost_3000_](https://user-images.githubusercontent.com/1779930/168314185-87cb739f-f29d-4a93-840f-1e3e88bab5f6.png)|![localhost_3000_ (1)](https://user-images.githubusercontent.com/1779930/168314184-ae478ff9-4f3a-4d9a-9fb8-f98b84af058f.png)

FYSA @anniehirshman-gsa 