### PR TITLE
IdV app: Add alert message for password confirmation step

### DIFF
--- a/app/javascript/packages/verify-flow/verify-flow-alert.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-alert.spec.tsx
@@ -1,17 +1,49 @@
 import { render } from '@testing-library/react';
+import { i18n } from '@18f/identity-i18n';
+import { usePropertyValue } from '@18f/identity-test-helpers';
 import VerifyFlowAlert from './verify-flow-alert';
 
 describe('VerifyFlowAlert', () => {
-  context('step with a status message', () => {
-    [
-      ['personal_key', 'idv.messages.confirm'],
-      ['personal_key_confirm', 'idv.messages.confirm'],
-    ].forEach(([step, expected]) => {
-      it('renders status message', () => {
-        const { getByRole } = render(<VerifyFlowAlert currentStep={step} />);
-
-        expect(getByRole('status').textContent).equal(expected);
+  context('password confirm step', () => {
+    context('with verified phone number', () => {
+      usePropertyValue(i18n, 'strings', {
+        'idv.messages.review.info_verified_html': 'We found records matching your %{phone_message}',
+        'idv.messages.phone.phone_of_record': 'Phone of record',
       });
+
+      it('renders status message', () => {
+        const { getByRole } = render(
+          <VerifyFlowAlert currentStep="password_confirm" values={{ phone: '5135551234' }} />,
+        );
+
+        expect(getByRole('status').querySelector('p')?.innerHTML).equal(
+          'We found records matching your <strong>Phone of record</strong>',
+        );
+      });
+    });
+
+    context('with gpo verification', () => {
+      it('renders nothing', () => {
+        const { container } = render(<VerifyFlowAlert currentStep="password_confirm" />);
+
+        expect(container.innerHTML).to.be.empty();
+      });
+    });
+  });
+
+  context('personal key step', () => {
+    it('renders status message', () => {
+      const { getByRole } = render(<VerifyFlowAlert currentStep="personal_key" />);
+
+      expect(getByRole('status').textContent).equal('idv.messages.confirm');
+    });
+  });
+
+  context('personal key confirm step', () => {
+    it('renders status message', () => {
+      const { getByRole } = render(<VerifyFlowAlert currentStep="personal_key_confirm" />);
+
+      expect(getByRole('status').textContent).equal('idv.messages.confirm');
     });
   });
 

--- a/app/javascript/packages/verify-flow/verify-flow-alert.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-alert.tsx
@@ -1,26 +1,47 @@
+import type { ReactNode } from 'react';
 import { t } from '@18f/identity-i18n';
+import { formatHTML } from '@18f/identity-react-i18n';
 import { Alert } from '@18f/identity-components';
+import type { VerifyFlowValues } from './verify-flow';
 
 interface VerifyFlowAlertProps {
   /**
    * Current step name.
    */
   currentStep: string;
+
+  /**
+   * Current flow values.
+   */
+  values?: Partial<VerifyFlowValues>;
 }
 
 /**
  * Returns the status message to show for a given step, if applicable.
  *
  * @param stepName Step name.
+ * @param values Flow values.
  */
-function getStepMessage(stepName: string): string | undefined {
+function getStepMessage(
+  stepName: string,
+  values: Partial<VerifyFlowValues>,
+): ReactNode | undefined {
+  if (stepName === 'password_confirm' && values.phone) {
+    return formatHTML(
+      t('idv.messages.review.info_verified_html', {
+        phone_message: `<strong>${t('idv.messages.phone.phone_of_record')}</strong>`,
+      }),
+      { strong: 'strong' },
+    );
+  }
+
   if (stepName === 'personal_key' || stepName === 'personal_key_confirm') {
     return t('idv.messages.confirm');
   }
 }
 
-function VerifyFlowAlert({ currentStep }: VerifyFlowAlertProps) {
-  const message = getStepMessage(currentStep);
+function VerifyFlowAlert({ currentStep, values = {} }: VerifyFlowAlertProps) {
+  const message = getStepMessage(currentStep, values);
   if (!message) {
     return null;
   }

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -92,6 +92,7 @@ function VerifyFlow({
 
   const [syncedValues, setSyncedValues] = useSyncedSecretValues(initialValues);
   const [currentStep, setCurrentStep] = useState(steps[0].name);
+  const [values, setValues] = useState(syncedValues);
   const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, steps);
   useEffect(() => {
     logStepVisited(currentStep);
@@ -102,10 +103,15 @@ function VerifyFlow({
     setCompletedStep(stepName);
   }
 
+  function onChange(nextValues: Partial<VerifyFlowValues>) {
+    setValues(nextValues);
+    setSyncedValues(nextValues);
+  }
+
   return (
     <>
       <VerifyFlowStepIndicator currentStep={currentStep} />
-      <VerifyFlowAlert currentStep={currentStep} />
+      <VerifyFlowAlert currentStep={currentStep} values={values} />
       <FormSteps
         steps={steps}
         initialValues={syncedValues}
@@ -113,7 +119,7 @@ function VerifyFlow({
         promptOnNavigate={false}
         basePath={basePath}
         titleFormat={`%{step} - ${getConfigValue('appName')}`}
-        onChange={setSyncedValues}
+        onChange={onChange}
         onStepSubmit={onStepSubmit}
         onStepChange={setCurrentStep}
         onComplete={onComplete}


### PR DESCRIPTION
**Why**: For feature parity with the existing password confirmation step, we should show a success alert message for users who have just confirmed their address by phone verification.

**Testing Instructions:**

You will need to set the step as enabled in your local `config/application.yml`:

```yml
development:
  idv_api_enabled_steps: '["password_confirm","personal_key","personal_key_confirm"]'
```

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to password confirmation step
6. Observe success alert at the top of the password confirmation step

**Screenshot:**

Before|After
---|---
![localhost_3000_verify_v2_password_confirm (1)](https://user-images.githubusercontent.com/1779930/168318986-e3a47016-3f74-4e9d-9174-873ba2c5c021.png)|![localhost_3000_verify_v2_password_confirm](https://user-images.githubusercontent.com/1779930/168318987-2ccac8e8-999e-4de5-a6b3-37e6ccd8341a.png)

