### PR TITLE
Adjust page footer spacing to match layout design specs

### DIFF
--- a/app/components/page_footer_component.rb
+++ b/app/components/page_footer_component.rb
@@ -10,6 +10,6 @@ class PageFooterComponent < BaseComponent
   end
 
   def css_class
-    ['margin-top-4 padding-top-1 border-top border-primary-light', *tag_options[:class]]
+    ['margin-top-4 padding-top-2 border-top border-primary-light', *tag_options[:class]]
   end
 end

--- a/app/javascript/packages/verify-flow/start-over-or-cancel.tsx
+++ b/app/javascript/packages/verify-flow/start-over-or-cancel.tsx
@@ -22,7 +22,7 @@ function StartOverOrCancel({ canStartOver = true }: StartOverOrCancelProps) {
           {t('doc_auth.buttons.start_over')}
         </ButtonTo>
       )}
-      <div className="margin-top-2 padding-top-1 border-top border-primary-light">
+      <div className="margin-top-2 padding-top-2 border-top border-primary-light">
         <a href={addSearchParams(cancelURL, { step })}>{t('links.cancel')}</a>
       </div>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -53,12 +53,12 @@
 
 <%= render PageFooterComponent.new do %>
   <% if decorated_session.sp_name %>
-    <div class="margin-y-1">
+    <div class="margin-bottom-1">
       <%= render 'devise/sessions/return_to_service_provider' %>
     </div>
   <% end %>
 
-  <div class="margin-y-1">
+  <div class="margin-bottom-1">
     <%= link_to(
           t('links.passwords.forgot'),
           new_user_password_url(request_id: @request_id),

--- a/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
+++ b/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
@@ -11,7 +11,7 @@ locals:
           class: 'usa-button usa-button--unstyled',
         ) { t('doc_auth.buttons.start_over') } %>
   <% end %>
-  <div class="margin-top-2 padding-top-1 border-top border-primary-light">
+  <div class="margin-top-2 padding-top-2 border-top border-primary-light">
     <%= link_to cancel_link_text, idv_cancel_path(step: local_assigns[:step]) %>
   </div>
 </div>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -86,7 +86,7 @@
   <% if user_fully_authenticated? %>
     <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
   <% else %>
-    <div class='margin-top-2 padding-top-1 border-top border-primary-light'>
+    <div class='margin-top-2 padding-top-2 border-top border-primary-light'>
       <%= link_to(t('two_factor_authentication.choose_another_option'), two_factor_options_path) %>
     </div>
   <% end %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -56,6 +56,6 @@
       class: 'usa-button usa-button--unstyled',
     ) { t('idv.messages.clear_and_start_over') } %>
 
-<div class="margin-top-2 padding-top-1 border-top border-primary-light">
+<div class="margin-top-2 padding-top-2 border-top border-primary-light">
   <%= link_to t('idv.buttons.cancel'), account_path %>
 </div>

--- a/app/views/shared/_cancel.html.erb
+++ b/app/views/shared/_cancel.html.erb
@@ -1,7 +1,7 @@
-<div class='margin-top-4 padding-top-1 border-top border-primary-light'>
+<%= render PageFooterComponent.new do %>
   <% if user_signing_up? %>
     <%= link_to cancel_link_text, sign_up_cancel_path, method: :get, class: 'usa-button usa-button--unstyled' %>
   <% else %>
     <%= link_to cancel_link_text, link || return_to_sp_cancel_path %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/shared/_cancel_or_back_to_options.html.erb
+++ b/app/views/shared/_cancel_or_back_to_options.html.erb
@@ -1,7 +1,7 @@
-<div class="margin-top-2 padding-top-1 border-top border-primary-light">
+<%= render PageFooterComponent.new do %>
   <% if MfaPolicy.new(current_user).two_factor_enabled? %>
     <%= link_to t('links.cancel'), account_path %>
   <% else %>
     <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -31,6 +31,6 @@
       ].select(&:present?),
     ) %>
 
-<div class="margin-top-4 padding-top-1 border-top border-primary-light">
+<%= render PageFooterComponent.new do %>
   <%= link_to cancel_link_text, @cancel_url %>
-</div>
+<% end %>

--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -28,6 +28,6 @@
               @other_mfa_options_url %>
 <% end %>
 
-<div class="margin-top-4 padding-top-1 border-top border-primary-light">
+<%= render PageFooterComponent.new do %>
   <%= link_to cancel_link_text, @cancel_url %>
-</div>
+<% end %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -39,7 +39,6 @@
   <%= f.button :submit, t('forms.buttons.send_security_code'), class: 'usa-button--big usa-button--wide' %>
 <% end %>
 
-
-<div class="margin-top-4 padding-top-1 border-top border-primary-light">
+<%= render PageFooterComponent.new do %>
   <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
-</div>
+<% end %>

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -8,12 +8,10 @@
   <%= @presenter.description %>
 </p>
 
-<div class="margin-top-2 padding-top-1 border-top border-primary-light">
-  <p>
-    <% if MfaPolicy.new(current_user).two_factor_enabled? %>
-      <%= link_to t('links.cancel'), account_path %>
-    <% else %>
-      <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
-    <% end %>
-  </p>
-</div>
+<%= render PageFooterComponent.new do %>
+  <% if MfaPolicy.new(current_user).two_factor_enabled? %>
+    <%= link_to t('links.cancel'), account_path %>
+  <% else %>
+    <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
**Why**:

- Because the implemented layout should conform to design specifications
- Updating to use common page footer component ensures consistency and allows for single point of update for future revisions

General expectation is:

- 2rem top margin for footer section
- 1rem padding for contents of footer section (including top "contents", such as "Start Over")

I'd observed this imbalance when implementing "Start Over" and "Cancel" for the IdV application in #6350.

Note that identity proofing layout may be subject to more changes pending implementation of LG-5258, as well as FSMv2 refactor of LG-4159. As such, I didn't spend the time trying to refactor "Start Over or Cancel" links to use the page footer component, and instead adjusted the layout ad hoc.

**Screenshots:**

A couple examples:

Screen|Before|After
---|---|---
IdV Welcome|![localhost_3000_verify_doc_auth_welcome (1)](https://user-images.githubusercontent.com/1779930/168610983-ca483e95-a4a0-4155-a2fb-8e7049324dc5.png)|![localhost_3000_verify_doc_auth_welcome](https://user-images.githubusercontent.com/1779930/168610985-19c7b9fc-51ae-4e43-9693-4a53229557aa.png)
IdV Agreement|![localhost_3000_verify_doc_auth_agreement (1)](https://user-images.githubusercontent.com/1779930/168610979-ab606816-6e83-4bf2-8490-66e769c09096.png)|![localhost_3000_verify_doc_auth_agreement](https://user-images.githubusercontent.com/1779930/168610982-ca681ebd-b442-45db-bb3c-8255930ea861.png)

FYSA @anniehirshman-gsa 