### PR TITLE
Drop state_id from session SENSITIVE_REGEX

### DIFF
--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -29,7 +29,6 @@ class SessionEncryptor
     :address1,
     :city,
     :dob,
-    :state_id_number,
     :state_id_expiration,
   ).values
   SENSITIVE_REGEX = %r{#{SENSITIVE_DEFAULT_FIELDS.join('|')}}i


### PR DESCRIPTION
Follow up to #6315.  This PR drops `:state_id_number`, which is `1111111111111` because it generated a false positive match.