### PR TITLE
LG-6274: Allow users to select phone as their sole second option

### DIFF
--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -50,15 +50,10 @@ class TwoFactorOptionsForm
   def phone_only_mfa_method?
     MfaContext.new(user).enabled_mfa_methods_count == 0
   end
-  
-  def phone_validations?
-    (IdentityConfig.store.select_multiple_mfa_options && phone_selected?) &&
-      !phone_alternative_enabled?
-  end
 
   def phone_alternative_enabled?
     count = MfaContext.new(user).enabled_mfa_methods_count
-    if count >= 2 || count == 1 && MfaContext.new(user).phone_configurations.none? || phone_only_mfa_method?
+    if count >= 2 || count == 1 && MfaContext.new(user).phone_configurations.none?
       return true
     else
       return false
@@ -66,7 +61,8 @@ class TwoFactorOptionsForm
   end
 
   def phone_validations?
-    (IdentityConfig.store.select_multiple_mfa_options && phone_selected?) && 
+    (IdentityConfig.store.select_multiple_mfa_options &&
+      phone_selected? && phone_only_mfa_method?) &&
       !phone_alternative_enabled?
   end
 end

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -53,16 +53,12 @@ class TwoFactorOptionsForm
 
   def phone_alternative_enabled?
     count = MfaContext.new(user).enabled_mfa_methods_count
-    if count >= 2 || count == 1 && MfaContext.new(user).phone_configurations.none?
-      return true
-    else
-      return false
-    end
+    count >= 2 || (count == 1 && MfaContext.new(user).phone_configurations.none?)
   end
 
   def phone_validations?
-    (IdentityConfig.store.select_multiple_mfa_options &&
-      phone_selected? && phone_only_mfa_method?) &&
+    IdentityConfig.store.select_multiple_mfa_options &&
+      phone_selected? && phone_only_mfa_method? &&
       !phone_alternative_enabled?
   end
 end

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -7,7 +7,7 @@ class TwoFactorOptionsForm
   validates :selection, inclusion: { in: %w[phone sms voice auth_app piv_cac
                                             webauthn webauthn_platform
                                             backup_code] }
-  validates :selection, length: { minimum: 2, message: 'phone' }, if: :phone_validations? 
+  validates :selection, length: { minimum: 2, message: 'phone' }, if: :phone_validations?
 
   def initialize(user)
     self.user = user
@@ -49,6 +49,11 @@ class TwoFactorOptionsForm
 
   def phone_only_mfa_method?
     MfaContext.new(user).enabled_mfa_methods_count == 0
+  end
+  
+  def phone_validations?
+    (IdentityConfig.store.select_multiple_mfa_options && phone_selected?) &&
+      !phone_alternative_enabled?
   end
 
   def phone_alternative_enabled?

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -63,29 +63,17 @@ describe TwoFactorOptionsForm do
       end
     end
 
-    context 'when phone is selected' do
+    context 'when phone is selected as their first authentication method' do
       it 'does not submit the phone when selected as the first single option' do
         allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
         %w[phone].each do |selection|
           result = subject.submit(selection: selection)
-  
+
           expect(result.success?).to eq false
         end
       end
 
-      it 'submits the form when phone is selected as an additional method' do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-          %w[auth_app].each do |selection|
-            result = subject.submit(selection: selection)
-    
-            expect(result.success?).to eq true
-          end
-
-          %w[phone].each do |selection|
-            result = subject.submit(selection: selection)
-    
-            expect(result.success?).to eq true
-        end
+      context 'when phone is selected as an additional authentication methd' do
       end
     end
   end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -64,16 +64,27 @@ describe TwoFactorOptionsForm do
     end
 
     context 'when phone is selected as their first authentication method' do
-      it 'does not submit the phone when selected as the first single option' do
+      before do
         allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+      end
+
+      it 'does not submit the phone when selected as the first single option' do
         %w[phone].each do |selection|
           result = subject.submit(selection: selection)
 
           expect(result.success?).to eq false
         end
       end
+    end
 
-      context 'when phone is selected as an additional authentication methd' do
+    context 'when a user wants to select phone as their second authentication method' do
+      let(:user) { build(:user, :with_personal_key) }
+      it 'submits the form' do
+        %w[phone].each do |selection|
+          result = subject.submit(selection: selection)
+  
+          expect(result.success?).to eq true
+        end
       end
     end
   end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -13,72 +13,72 @@ describe TwoFactorOptionsForm do
       end
     end
 
-    # it 'is unsuccessful if the selection is invalid for multi mfa' do
-    #   allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-    #   %w[phone sms voice !!!!].each do |selection|
-    #     result = subject.submit(selection: selection)
+    it 'is unsuccessful if the selection is invalid for multi mfa' do
+      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+      %w[phone sms voice !!!!].each do |selection|
+        result = subject.submit(selection: selection)
 
-    #     expect(result.success?).to eq false
-    #   end
-    # end
+        expect(result.success?).to eq false
+      end
+    end
 
-    # it 'is unsuccessful if the selection is invalid' do
-    #   %w[!!!!].each do |selection|
-    #     result = subject.submit(selection: selection)
+    it 'is unsuccessful if the selection is invalid' do
+      %w[!!!!].each do |selection|
+        result = subject.submit(selection: selection)
 
-    #     expect(result.success?).to eq false
-    #     expect(result.errors).to include :selection
-    #   end
-    # end
+        expect(result.success?).to eq false
+        expect(result.errors).to include :selection
+      end
+    end
 
-    # context "when the selection is different from the user's otp_delivery_preference" do
-    #   it "updates the user's otp_delivery_preference if they have an alternate method selected" do
-    #     user_updater = instance_double(UpdateUser)
-    #     allow(UpdateUser).
-    #       to receive(:new).
-    #       with(
-    #         user: user,
-    #         attributes: { otp_delivery_preference: 'voice' },
-    #       ).
-    #       and_return(user_updater)
-    #     expect(user_updater).to receive(:call)
+    context "when the selection is different from the user's otp_delivery_preference" do
+      it "updates the user's otp_delivery_preference if they have an alternate method selected" do
+        user_updater = instance_double(UpdateUser)
+        allow(UpdateUser).
+          to receive(:new).
+          with(
+            user: user,
+            attributes: { otp_delivery_preference: 'voice' },
+          ).
+          and_return(user_updater)
+        expect(user_updater).to receive(:call)
 
-    #     subject.submit(selection: ['voice', 'backup_code'])
-    #   end
-    # end
+        subject.submit(selection: ['voice', 'backup_code'])
+      end
+    end
 
-    # context "when the selection is the same as the user's otp_delivery_preference" do
-    #   it "does not update the user's otp_delivery_preference" do
-    #     expect(UpdateUser).to_not receive(:new)
+    context "when the selection is the same as the user's otp_delivery_preference" do
+      it "does not update the user's otp_delivery_preference" do
+        expect(UpdateUser).to_not receive(:new)
 
-    #     subject.submit(selection: 'sms')
-    #   end
-    # end
+        subject.submit(selection: 'sms')
+      end
+    end
 
-    # context 'when the selection is not voice or sms' do
-    #   it "does not update the user's otp_delivery_preference" do
-    #     expect(UpdateUser).to_not receive(:new)
+    context 'when the selection is not voice or sms' do
+      it "does not update the user's otp_delivery_preference" do
+        expect(UpdateUser).to_not receive(:new)
 
-    #     subject.submit(selection: 'auth_app')
-    #   end
-    # end
+        subject.submit(selection: 'auth_app')
+      end
+    end
 
-    # context 'when phone is selected as their first authentication method' do
-    #   before do
-    #     allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-    #   end
+    context 'when phone is selected as their first authentication method' do
+      before do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+      end
 
-    #   it 'does not submit the phone when selected as the first single option' do
-    #     %w[phone].each do |selection|
-    #       result = subject.submit(selection: selection)
+      it 'does not submit the phone when selected as the first single option' do
+        %w[phone].each do |selection|
+          result = subject.submit(selection: selection)
 
-    #       expect(result.success?).to eq false
-    #     end
-    #   end
-    # end
+          expect(result.success?).to eq false
+        end
+      end
+    end
 
     context 'when a user wants to select phone as their second authentication method' do
-      let(:user) { create(:user, :with_authentication_app) }   
+      let(:user) { create(:user, :with_authentication_app) }
       before do
         allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
       end
@@ -90,6 +90,6 @@ describe TwoFactorOptionsForm do
           expect(result.success?).to eq true
         end
       end
-    end      
+    end
   end
 end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -13,79 +13,83 @@ describe TwoFactorOptionsForm do
       end
     end
 
-    it 'is unsuccessful if the selection is invalid for multi mfa' do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-      %w[phone sms voice !!!!].each do |selection|
-        result = subject.submit(selection: selection)
+    # it 'is unsuccessful if the selection is invalid for multi mfa' do
+    #   allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+    #   %w[phone sms voice !!!!].each do |selection|
+    #     result = subject.submit(selection: selection)
 
-        expect(result.success?).to eq false
-      end
-    end
+    #     expect(result.success?).to eq false
+    #   end
+    # end
 
-    it 'is unsuccessful if the selection is invalid' do
-      %w[!!!!].each do |selection|
-        result = subject.submit(selection: selection)
+    # it 'is unsuccessful if the selection is invalid' do
+    #   %w[!!!!].each do |selection|
+    #     result = subject.submit(selection: selection)
 
-        expect(result.success?).to eq false
-        expect(result.errors).to include :selection
-      end
-    end
+    #     expect(result.success?).to eq false
+    #     expect(result.errors).to include :selection
+    #   end
+    # end
 
-    context "when the selection is different from the user's otp_delivery_preference" do
-      it "updates the user's otp_delivery_preference if they have an alternate method selected" do
-        user_updater = instance_double(UpdateUser)
-        allow(UpdateUser).
-          to receive(:new).
-          with(
-            user: user,
-            attributes: { otp_delivery_preference: 'voice' },
-          ).
-          and_return(user_updater)
-        expect(user_updater).to receive(:call)
+    # context "when the selection is different from the user's otp_delivery_preference" do
+    #   it "updates the user's otp_delivery_preference if they have an alternate method selected" do
+    #     user_updater = instance_double(UpdateUser)
+    #     allow(UpdateUser).
+    #       to receive(:new).
+    #       with(
+    #         user: user,
+    #         attributes: { otp_delivery_preference: 'voice' },
+    #       ).
+    #       and_return(user_updater)
+    #     expect(user_updater).to receive(:call)
 
-        subject.submit(selection: ['voice', 'backup_code'])
-      end
-    end
+    #     subject.submit(selection: ['voice', 'backup_code'])
+    #   end
+    # end
 
-    context "when the selection is the same as the user's otp_delivery_preference" do
-      it "does not update the user's otp_delivery_preference" do
-        expect(UpdateUser).to_not receive(:new)
+    # context "when the selection is the same as the user's otp_delivery_preference" do
+    #   it "does not update the user's otp_delivery_preference" do
+    #     expect(UpdateUser).to_not receive(:new)
 
-        subject.submit(selection: 'sms')
-      end
-    end
+    #     subject.submit(selection: 'sms')
+    #   end
+    # end
 
-    context 'when the selection is not voice or sms' do
-      it "does not update the user's otp_delivery_preference" do
-        expect(UpdateUser).to_not receive(:new)
+    # context 'when the selection is not voice or sms' do
+    #   it "does not update the user's otp_delivery_preference" do
+    #     expect(UpdateUser).to_not receive(:new)
 
-        subject.submit(selection: 'auth_app')
-      end
-    end
+    #     subject.submit(selection: 'auth_app')
+    #   end
+    # end
 
-    context 'when phone is selected as their first authentication method' do
+    # context 'when phone is selected as their first authentication method' do
+    #   before do
+    #     allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+    #   end
+
+    #   it 'does not submit the phone when selected as the first single option' do
+    #     %w[phone].each do |selection|
+    #       result = subject.submit(selection: selection)
+
+    #       expect(result.success?).to eq false
+    #     end
+    #   end
+    # end
+
+    context 'when a user wants to select phone as their second authentication method' do
+      let(:user) { create(:user, :with_authentication_app) }   
       before do
         allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
       end
 
-      it 'does not submit the phone when selected as the first single option' do
-        %w[phone].each do |selection|
-          result = subject.submit(selection: selection)
-
-          expect(result.success?).to eq false
-        end
-      end
-    end
-
-    context 'when a user wants to select phone as their second authentication method' do
-      let(:user) { build(:user, :with_personal_key) }
       it 'submits the form' do
         %w[phone].each do |selection|
-          result = subject.submit(selection: selection)
-  
+          result = subject.submit(selection: ['phone'])
+
           expect(result.success?).to eq true
         end
       end
-    end
+    end      
   end
 end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -62,5 +62,31 @@ describe TwoFactorOptionsForm do
         subject.submit(selection: 'auth_app')
       end
     end
+
+    context 'when phone is selected' do
+      it 'does not submit the phone when selected as the first single option' do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+        %w[phone].each do |selection|
+          result = subject.submit(selection: selection)
+  
+          expect(result.success?).to eq false
+        end
+      end
+
+      it 'submits the form when phone is selected as an additional method' do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+          %w[auth_app].each do |selection|
+            result = subject.submit(selection: selection)
+    
+            expect(result.success?).to eq true
+          end
+
+          %w[phone].each do |selection|
+            result = subject.submit(selection: selection)
+    
+            expect(result.success?).to eq true
+        end
+      end
+    end
   end
 end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -69,11 +69,9 @@ describe TwoFactorOptionsForm do
       end
 
       it 'does not submit the phone when selected as the first single option' do
-        %w[phone].each do |selection|
-          result = subject.submit(selection: selection)
+          result = subject.submit(selection: ['phone'])
 
           expect(result.success?).to eq false
-        end
       end
     end
 
@@ -84,11 +82,9 @@ describe TwoFactorOptionsForm do
       end
 
       it 'submits the form' do
-        %w[phone].each do |selection|
           result = subject.submit(selection: ['phone'])
 
           expect(result.success?).to eq true
-        end
       end
     end
   end


### PR DESCRIPTION
This ticket fixes a bug that emerged after #6278 and #6276 were completed

Current state: In setting up an account, the user would select one 2FA method (except for phone due to Kantara requirements). Once setup is complete, if the user selects the option to add a second MFA method, they will not be proceed with phone setup due to the validation added for 

Future state: If the user selects phone as their sole additional authentication method, the user will be able to select the phone option and proceed with setup.

After
![Screen Recording 2022-05-18 at 1 35 34 PM](https://user-images.githubusercontent.com/17969963/169107028-b2074932-a707-4763-9507-25f8b267f1a2.gif)

