### PR TITLE
Reduce JavaScript size by importing custom element definitions directly

### DIFF
--- a/app/components/clipboard_button_component.ts
+++ b/app/components/clipboard_button_component.ts
@@ -1,1 +1,1 @@
-import '@18f/identity-clipboard-button';
+import '@18f/identity-clipboard-button/clipboard-button-element';

--- a/app/components/password_toggle_component.ts
+++ b/app/components/password_toggle_component.ts
@@ -1,1 +1,1 @@
-import '@18f/identity-password-toggle';
+import '@18f/identity-password-toggle/password-toggle-element';

--- a/app/components/print_button_component.ts
+++ b/app/components/print_button_component.ts
@@ -1,1 +1,1 @@
-import '@18f/identity-print-button';
+import '@18f/identity-print-button/print-button-element';

--- a/app/components/spinner_button_component.ts
+++ b/app/components/spinner_button_component.ts
@@ -1,1 +1,1 @@
-import '@18f/identity-spinner-button';
+import '@18f/identity-spinner-button/spinner-button-element';

--- a/app/components/validated_field_component.js
+++ b/app/components/validated_field_component.js
@@ -1,1 +1,1 @@
-import '@18f/identity-validated-field';
+import '@18f/identity-validated-field/validated-field-element';

--- a/app/javascript/packages/clipboard-button/README.md
+++ b/app/javascript/packages/clipboard-button/README.md
@@ -6,10 +6,10 @@ Custom element and React implementation for a clipboard button component.
 
 ### Custom Element
 
-Importing the package will register the `<lg-clipboard-button>` custom element:
+Importing the element will register the `<lg-clipboard-button>` custom element:
 
 ```ts
-import '@18f/identity-clipboard-button';
+import '@18f/identity-clipboard-button/clipboard-button-element';
 ```
 
 The custom element will implement the copying behavior, but all markup must already exist, rendered server-side or by the included React component.

--- a/app/javascript/packages/clipboard-button/index.ts
+++ b/app/javascript/packages/clipboard-button/index.ts
@@ -1,3 +1,1 @@
-import './clipboard-button-element';
-
 export { default as ClipboardButton } from './clipboard-button';

--- a/app/javascript/packages/password-toggle/index.ts
+++ b/app/javascript/packages/password-toggle/index.ts
@@ -1,3 +1,1 @@
-import './password-toggle-element';
-
 export { default as PasswordToggle } from './password-toggle';

--- a/app/javascript/packages/print-button/README.md
+++ b/app/javascript/packages/print-button/README.md
@@ -6,10 +6,10 @@ Custom element and React implementation for a print button component.
 
 ### Custom Element
 
-Importing the package will register the `<lg-print-button>` custom element:
+Importing the element will register the `<lg-print-button>` custom element:
 
 ```ts
-import '@18f/identity-print-button';
+import '@18f/identity-print-button/print-button-element';
 ```
 
 The custom element will implement the behavior to show a print dialog upon click, but all markup must already exist, rendered server-side or by the included React component.

--- a/app/javascript/packages/print-button/index.ts
+++ b/app/javascript/packages/print-button/index.ts
@@ -1,3 +1,1 @@
-import './print-button-element';
-
 export { default as PrintButton } from './print-button';

--- a/app/javascript/packages/spinner-button/index.ts
+++ b/app/javascript/packages/spinner-button/index.ts
@@ -1,4 +1,2 @@
-import './spinner-button-element';
-
 export { default as SpinnerButton } from './spinner-button';
 export type { SpinnerButtonRefHandle } from './spinner-button';

--- a/app/javascript/packages/step-indicator/README.md
+++ b/app/javascript/packages/step-indicator/README.md
@@ -6,10 +6,10 @@ Custom element and React implementation for a step indicator UI component.
 
 ### Custom Element
 
-Importing the package will register the `<lg-step-indicator>` custom element:
+Importing the element will register the `<lg-step-indicator>` custom element:
 
 ```ts
-import '@18f/identity-step-indicator';
+import '@18f/identity-step-indicator/step-indicator-element';
 ```
 
 The custom element will implement the small viewport scroll behavior, but all markup must already exist, rendered server-side or by the included React component.

--- a/app/javascript/packages/step-indicator/index.ts
+++ b/app/javascript/packages/step-indicator/index.ts
@@ -1,4 +1,2 @@
-import './step-indicator-element';
-
 export { default as StepIndicator } from './step-indicator';
 export { default as StepIndicatorStep, StepStatus } from './step-indicator-step';

--- a/app/javascript/packages/validated-field/index.ts
+++ b/app/javascript/packages/validated-field/index.ts
@@ -1,5 +1,3 @@
-import './validated-field-element';
-
 export { default as ValidatedField } from './validated-field';
 
 export type { ValidatedFieldValidator } from './validated-field';

--- a/app/javascript/packs/step-indicator.js
+++ b/app/javascript/packs/step-indicator.js
@@ -1,1 +1,1 @@
-import '@18f/identity-step-indicator';
+import '@18f/identity-step-indicator/step-indicator-element';


### PR DESCRIPTION
**Why**: So that React is not included in bundles which are expecting to use only the native custom element implementation.

There isn't expected to be a net reduction in bundle size (i.e. no celebration warranted), but instead resolves a regression in the form of inflated bundle sizes, caused by the introduction of a pattern of workspace packages which export both custom element and React component implementations of a UI component.

Ideally, this could also be addressed using [Webpack tree shaking features](https://webpack.js.org/guides/tree-shaking/). In particular, the custom element definition is expected to be the only side-effecty file of the package. Thus, it would be expected that defining something like `"sideEffects": ["./print-button-element.ts"]` in `package.json` would suffice to exclude React from the default import, but this does not work in practice. I'm still unclear how to configure it correctly (expecting built file names? full relative file paths? original import string without file extension?). In the meantime, the proposed changes should suffice as an alternative.

**Performance Impact:**

Measured against http://localhost:3000 as the full transferred size of JavaScript after running `NODE_ENV=production yarn build && rails s`. Notably, there is no compression reflected in these sizes.

Before|After|Diff%
---|---|---
182kB|41.2kB|-77.4%
