### PR TITLE
LG-6205: Add endpoint, button to trigger password reset (IdV app)

### DIFF
--- a/app/assets/stylesheets/components/_spinner-button.scss
+++ b/app/assets/stylesheets/components/_spinner-button.scss
@@ -20,14 +20,19 @@ lg-spinner-button {
     [type='button'] {
       color: transparent;
       opacity: 1;
+    }
+  }
 
-      &:not(.usa-button--outline) {
-        background-color: color('primary-darker');
+  &:not(.spinner-button--outline) .spinner-button__content {
+    a,
+    button:not([type]),
+    [type='submit'],
+    [type='button'] {
+      background-color: color('primary-darker');
+    }
 
-        + .spinner-dots {
-          color: color('white');
-        }
-      }
+    .spinner-dots {
+      color: color('white');
     }
   }
 }

--- a/app/assets/stylesheets/components/_spinner-button.scss
+++ b/app/assets/stylesheets/components/_spinner-button.scss
@@ -18,9 +18,16 @@ lg-spinner-button {
     button:not([type]),
     [type='submit'],
     [type='button'] {
-      background-color: color('primary-darker');
       color: transparent;
       opacity: 1;
+
+      &:not(.usa-button--outline) {
+        background-color: color('primary-darker');
+
+        + .spinner-dots {
+          color: color('white');
+        }
+      }
     }
   }
 }

--- a/app/components/spinner_button_component.html.erb
+++ b/app/components/spinner_button_component.html.erb
@@ -1,4 +1,4 @@
-<lg-spinner-button>
+<%= content_tag(:'lg-spinner-button', class: css_class) do %>
   <div class="spinner-button__content">
     <%= render ButtonComponent.new(type: :button, **button_options).with_content(content) %>
     <span class="spinner-dots spinner-dots--centered" aria-hidden="true">
@@ -13,4 +13,4 @@
                 data: { message: action_message },
                 class: 'spinner-button__action-message usa-sr-only' %>
   <% end %>
-</lg-spinner-button>
+<% end %>

--- a/app/components/spinner_button_component.html.erb
+++ b/app/components/spinner_button_component.html.erb
@@ -1,7 +1,7 @@
 <lg-spinner-button>
   <div class="spinner-button__content">
     <%= render ButtonComponent.new(type: :button, **button_options).with_content(content) %>
-    <span class="spinner-dots spinner-dots--centered text-white" aria-hidden="true">
+    <span class="spinner-dots spinner-dots--centered" aria-hidden="true">
       <span class="spinner-dots__dot"></span>
       <span class="spinner-dots__dot"></span>
       <span class="spinner-dots__dot"></span>

--- a/app/components/spinner_button_component.rb
+++ b/app/components/spinner_button_component.rb
@@ -1,5 +1,5 @@
 class SpinnerButtonComponent < BaseComponent
-  attr_reader :action_message, :button_options
+  attr_reader :action_message, :button_options, :outline
 
   # @param [String] action_message Message describing the action being performed, shown visually to
   #                                users when the animation has been active for a long time, and
@@ -7,5 +7,10 @@ class SpinnerButtonComponent < BaseComponent
   def initialize(action_message: nil, **button_options)
     @action_message = action_message
     @button_options = button_options
+    @outline = button_options[:outline]
+  end
+
+  def css_class
+    'spinner-button--outline' if outline
   end
 end

--- a/app/controllers/api/verify/password_reset_controller.rb
+++ b/app/controllers/api/verify/password_reset_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module Verify
+    class PasswordResetController < Api::BaseController
+      def create
+        analytics.idv_forgot_password_confirmed
+        request_id = sp_session[:request_id]
+        email = current_user.email
+        reset_password(email, request_id)
+
+        render json: { redirect_url: forgot_password_url(request_id: request_id) },
+               status: :accepted
+      end
+
+      private
+
+      def reset_password(email, request_id)
+        sign_out
+        RequestPasswordReset.new(email: email, request_id: request_id, analytics: analytics).perform
+        session[:email] = email
+      end
+    end
+  end
+end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -10,7 +10,6 @@ class VerifyController < ApplicationController
   before_action :confirm_profile_has_been_created, if: :first_step_is_personal_key?
 
   def show
-    session[:email] = 'bruce.wayne@batcave.com'
     @app_data = app_data
   end
 

--- a/app/javascript/packages/spinner-button/spinner-button.spec.tsx
+++ b/app/javascript/packages/spinner-button/spinner-button.spec.tsx
@@ -73,4 +73,13 @@ describe('SpinnerButton', () => {
 
     expect(button.classList.contains('usa-button--outline')).to.be.true();
   });
+
+  it('includes additional class for outline buttons', () => {
+    const { getByRole } = render(<SpinnerButton isOutline />);
+
+    const button = getByRole('button')!;
+    const spinner = button.closest('lg-spinner-button')!;
+
+    expect(spinner.classList.contains('spinner-button--outline')).to.be.true();
+  });
 });

--- a/app/javascript/packages/spinner-button/spinner-button.tsx
+++ b/app/javascript/packages/spinner-button/spinner-button.tsx
@@ -9,7 +9,7 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       'lg-spinner-button': HTMLAttributes<SpinnerButtonElement> &
-        RefAttributes<SpinnerButtonElement>;
+        RefAttributes<SpinnerButtonElement> & { class?: string };
     }
   }
 }
@@ -34,20 +34,29 @@ interface SpinnerButtonProps extends ButtonProps {
 export type SpinnerButtonRefHandle = SpinnerButtonElement;
 
 function SpinnerButton(
-  { spinOnClick = true, actionMessage, longWaitDurationMs, ...buttonProps }: SpinnerButtonProps,
+  {
+    spinOnClick = true,
+    actionMessage,
+    longWaitDurationMs,
+    isOutline,
+    ...buttonProps
+  }: SpinnerButtonProps,
   ref: ForwardedRef<SpinnerButtonElement | null>,
 ) {
   const elementRef = useRef<SpinnerButtonRefHandle>(null);
   useImperativeHandle(ref, () => elementRef.current!);
+
+  const classes = isOutline ? 'spinner-button--outline' : undefined;
 
   return (
     <lg-spinner-button
       spin-on-click={spinOnClick}
       long-wait-duration-ms={longWaitDurationMs}
       ref={elementRef}
+      class={classes}
     >
       <div className="spinner-button__content">
-        <Button {...buttonProps} />
+        <Button isOutline={isOutline} {...buttonProps} />
         <span className="spinner-dots spinner-dots--centered" aria-hidden="true">
           <span className="spinner-dots__dot" />
           <span className="spinner-dots__dot" />

--- a/app/javascript/packages/spinner-button/spinner-button.tsx
+++ b/app/javascript/packages/spinner-button/spinner-button.tsx
@@ -48,7 +48,7 @@ function SpinnerButton(
     >
       <div className="spinner-button__content">
         <Button {...buttonProps} />
-        <span className="spinner-dots spinner-dots--centered text-white" aria-hidden="true">
+        <span className="spinner-dots spinner-dots--centered" aria-hidden="true">
           <span className="spinner-dots__dot" />
           <span className="spinner-dots__dot" />
           <span className="spinner-dots__dot" />

--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -20,11 +20,6 @@ const FlowContext = createContext({
    * The path to which the current step is appended to create the current step URL.
    */
   basePath: '',
-
-  /**
-   * URL for reset password page in rails used for redirect
-   */
-  resetPasswordUrl: '',
 });
 
 FlowContext.displayName = 'FlowContext';

--- a/app/javascript/packages/verify-flow/services/api.ts
+++ b/app/javascript/packages/verify-flow/services/api.ts
@@ -1,4 +1,4 @@
-export interface ErrorResponse<Field extends string> {
+export interface ErrorResponse<Field extends string = string> {
   error: Record<Field, [string, ...string[]]>;
 }
 

--- a/app/javascript/packages/verify-flow/start-over-or-cancel.spec.tsx
+++ b/app/javascript/packages/verify-flow/start-over-or-cancel.spec.tsx
@@ -28,7 +28,6 @@ describe('StartOverOrCancel', () => {
             cancelURL: 'http://example.test/cancel',
             currentStep: 'one',
             basePath: '',
-            resetPasswordUrl: '',
           }}
         >
           <StartOverOrCancel />

--- a/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
@@ -1,20 +1,13 @@
-import { useContext } from 'react';
 import { PageHeading, Button } from '@18f/identity-components';
 import { t } from '@18f/identity-i18n';
 import { getAssetPath } from '@18f/identity-assets';
-import { FlowContext } from '@18f/identity-verify-flow';
+import PasswordResetButton from './password-reset-button';
 
 interface ForgotPasswordProps {
   goBack: () => void;
 }
 
 export function ForgotPassword({ goBack }: ForgotPasswordProps) {
-  const { resetPasswordUrl } = useContext(FlowContext);
-
-  function goToResetPassword() {
-    window.location.href = resetPasswordUrl!;
-  }
-
   return (
     <>
       <img
@@ -36,9 +29,7 @@ export function ForgotPassword({ goBack }: ForgotPasswordProps) {
         </Button>
       </div>
       <div className="margin-top-2">
-        <Button isBig isOutline isWide onClick={goToResetPassword}>
-          {t('idv.forgot_password.reset_password')}
-        </Button>
+        <PasswordResetButton />
       </div>
     </>
   );

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -1,11 +1,10 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useDefineProperty, useSandbox } from '@18f/identity-test-helpers';
+import { useSandbox } from '@18f/identity-test-helpers';
 import PasswordResetButton, { API_ENDPOINT } from './password-reset-button';
 
 describe('PasswordResetButton', () => {
   const sandbox = useSandbox();
-  const defineProperty = useDefineProperty();
 
   const REDIRECT_URL = '/password_reset';
 
@@ -19,21 +18,10 @@ describe('PasswordResetButton', () => {
       } as Response);
   });
 
-  it('triggers password reset API call and redirects', () => {
-    const { getByRole } = render(<PasswordResetButton />);
+  it('triggers password reset API call and redirects', (done) => {
+    const { getByRole } = render(<PasswordResetButton onNavigate={() => done()} />);
 
-    return new Promise<void>((resolve) => {
-      defineProperty(window, 'location', {
-        value: {
-          set href(nextHref) {
-            expect(nextHref).to.equal(REDIRECT_URL);
-            resolve();
-          },
-        },
-      });
-
-      const button = getByRole('button');
-      userEvent.click(button);
-    });
+    const button = getByRole('button');
+    userEvent.click(button);
   });
 });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDefineProperty, useSandbox } from '@18f/identity-test-helpers';
+import PasswordResetButton, { API_ENDPOINT } from './password-reset-button';
+
+describe('PasswordResetButton', () => {
+  const sandbox = useSandbox();
+  const defineProperty = useDefineProperty();
+
+  const REDIRECT_URL = '/password_reset';
+
+  before(() => {
+    sandbox
+      .stub(window, 'fetch')
+      .withArgs(API_ENDPOINT)
+      .resolves({
+        status: 202,
+        json: () => Promise.resolve({ redirect_url: REDIRECT_URL }),
+      } as Response);
+  });
+
+  it('triggers password reset API call and redirects', () => {
+    const { getByRole } = render(<PasswordResetButton />);
+
+    return new Promise<void>((resolve) => {
+      defineProperty(window, 'location', {
+        value: {
+          set href(nextHref) {
+            expect(nextHref).to.equal(REDIRECT_URL);
+            resolve();
+          },
+        },
+      });
+
+      const button = getByRole('button');
+      userEvent.click(button);
+    });
+  });
+});

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
@@ -1,0 +1,39 @@
+import { SpinnerButton } from '@18f/identity-spinner-button';
+import { t } from '@18f/identity-i18n';
+import { isErrorResponse, post } from '../../services/api';
+import type { ErrorResponse } from '../../services/api';
+
+/**
+ * API endpoint for password reset.
+ */
+export const API_ENDPOINT = '/api/verify/v2/password_reset';
+
+/**
+ * API response shape.
+ */
+interface PasswordResetSuccessResponse {
+  redirect_url: string;
+}
+
+/**
+ * API response shape.
+ */
+type PasswordResetResponse = PasswordResetSuccessResponse | ErrorResponse;
+
+function PasswordResetButton() {
+  async function requestReset() {
+    const json = await post<PasswordResetResponse>(API_ENDPOINT, {}, { csrf: true, json: true });
+    if (!isErrorResponse(json)) {
+      const { redirect_url: redirectURL } = json;
+      window.location.href = redirectURL;
+    }
+  }
+
+  return (
+    <SpinnerButton isBig isOutline isWide onClick={requestReset}>
+      {t('idv.forgot_password.reset_password')}
+    </SpinnerButton>
+  );
+}
+
+export default PasswordResetButton;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
@@ -20,12 +20,21 @@ interface PasswordResetSuccessResponse {
  */
 type PasswordResetResponse = PasswordResetSuccessResponse | ErrorResponse;
 
-function PasswordResetButton() {
+/**
+ * Navigates user to the given URL.
+ *
+ * @param url Destination URL.
+ */
+function navigate(url) {
+  window.location.href = url;
+}
+
+function PasswordResetButton({ onNavigate = navigate }) {
   async function requestReset() {
     const json = await post<PasswordResetResponse>(API_ENDPOINT, {}, { csrf: true, json: true });
     if (!isErrorResponse(json)) {
       const { redirect_url: redirectURL } = json;
-      window.location.href = redirectURL;
+      onNavigate(redirectURL);
     }
   }
 

--- a/app/javascript/packages/verify-flow/verify-flow.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.spec.tsx
@@ -21,12 +21,7 @@ describe('VerifyFlow', () => {
     const onComplete = sandbox.spy();
 
     const { getByText, findByText, getByLabelText } = render(
-      <VerifyFlow
-        initialValues={{ personalKey }}
-        onComplete={onComplete}
-        basePath="/"
-        resetPasswordUrl=""
-      />,
+      <VerifyFlow initialValues={{ personalKey }} onComplete={onComplete} basePath="/" />,
     );
 
     // Password confirm
@@ -64,7 +59,6 @@ describe('VerifyFlow', () => {
           onComplete={() => {}}
           enabledStepNames={[STEPS[1].name]}
           basePath="/"
-          resetPasswordUrl=""
         />,
       );
 

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -68,11 +68,6 @@ interface VerifyFlowProps {
    * Callback invoked after completing the form.
    */
   onComplete: () => void;
-
-  /**
-   * URL for reset password page in rails used for redirect
-   */
-  resetPasswordUrl: string;
 }
 
 /**
@@ -102,7 +97,6 @@ function VerifyFlow({
   basePath,
   startOverURL = '',
   cancelURL = '',
-  resetPasswordUrl,
   onComplete,
 }: VerifyFlowProps) {
   let steps = STEPS;
@@ -114,13 +108,7 @@ function VerifyFlow({
   const [currentStep, setCurrentStep] = useState(steps[0].name);
   const [values, setValues] = useState(syncedValues);
   const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, steps);
-  const context = useObjectMemo({
-    startOverURL,
-    cancelURL,
-    currentStep,
-    basePath,
-    resetPasswordUrl,
-  });
+  const context = useObjectMemo({ startOverURL, cancelURL, currentStep, basePath });
   useEffect(() => {
     logStepVisited(currentStep);
   }, [currentStep]);

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -40,11 +40,6 @@ interface AppRootValues {
   storeKey: string;
 
   /**
-   * URL for reset password page in rails used for redirect
-   */
-  resetPasswordUrl: string;
-
-  /**
    * Signed JWT containing user data.
    */
   userBundleToken: string;
@@ -62,7 +57,6 @@ const {
   startOverUrl: startOverURL,
   cancelUrl: cancelURL,
   completionUrl: completionURL,
-  resetPasswordUrl,
   storeKey: storeKeyBase64,
 } = appRoot.dataset;
 const storeKey = s2ab(atob(storeKeyBase64));
@@ -106,7 +100,6 @@ const storage = new SecretSessionStorage<SecretValues>('verify');
         enabledStepNames={enabledStepNames}
         startOverURL={startOverURL}
         cancelURL={cancelURL}
-        resetPasswordUrl={resetPasswordUrl}
         basePath={basePath}
         onComplete={onComplete}
       />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,7 @@ Rails.application.routes.draw do
 
     namespace :api do
       post '/verify/v2/password_confirm' => 'verify/password_confirm#create'
+      post '/verify/v2/password_reset' => 'verify/password_reset#create'
     end
 
     get '/account/verify' => 'idv/gpo_verify#index', as: :idv_gpo_verify

--- a/spec/components/spinner_button_component_spec.rb
+++ b/spec/components/spinner_button_component_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe SpinnerButtonComponent, type: :component do
       expect(rendered).to have_css('.spinner-button__action-message[data-message="Verifying..."]')
     end
   end
+
+  context 'with outline button' do
+    it 'renders with additional css class' do
+      rendered = render_inline SpinnerButtonComponent.new(outline: true).with_content('')
+
+      expect(rendered).to have_css('lg-spinner-button.spinner-button--outline')
+    end
+  end
 end

--- a/spec/controllers/api/verify/password_reset_controller_spec.rb
+++ b/spec/controllers/api/verify/password_reset_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Api::Verify::PasswordResetController do
+  let(:request_id) { 'request_id' }
+  let(:user) { build(:user) }
+  let(:sp_session) { { request_id: request_id } }
+
+  before do
+    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(['personal_key'])
+    allow(controller).to receive(:sp_session).and_return(sp_session)
+    stub_sign_in(user)
+  end
+
+  it 'extends behavior of base api class' do
+    expect(subject).to be_kind_of Api::BaseController
+  end
+
+  describe '#create' do
+    it 'returns redirect url' do
+      post :create
+
+      parsed_body = JSON.parse(response.body)
+
+      expect(parsed_body['redirect_url']).to eq forgot_password_url(request_id: request_id)
+      expect(response.status).to eq 202
+    end
+
+    it 'sets the user email into session in preparation for redirect' do
+      post :create
+
+      expect(session[:email]).to eq user.email
+    end
+
+    context 'with absent request id' do
+      let(:request_id) { nil }
+
+      it 'returns redirect url' do
+        post :create
+
+        parsed_body = JSON.parse(response.body)
+
+        expect(parsed_body['redirect_url']).to eq forgot_password_url
+        expect(response.status).to eq 202
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that a user will receive an email to reset their password after confirming to do password reset during identity proofing.

**Testing Instructions:**


You will need to set the step as enabled in your local `config/application.yml`:

```yml
development:
  idv_api_enabled_steps: '["password_confirm","personal_key","personal_key_confirm"]'
```

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to password confirmation step
5. Click "Follow these instructions" (adjacent "Forgot your password?")
6. Click Reset Password button
7. Observe that you're redirected to a page confirming password reset, including the correct email for the current user

**Screen recording:**

https://user-images.githubusercontent.com/1779930/168907100-345f478f-0ff6-4ab2-9734-46ad089db838.mov

FYI @anniehirshman-gsa @Kamal-Munshi : Since the (current) implementation calls to an API before redirecting, I opted to use the spinner button we use elsewhere for asynchronous page transitions. This button is an outline button, which we haven't implemented as spinner buttons until now.
