### PR TITLE
Remove unnecessary or outdated i18n-tasks unused keys

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -93,27 +93,12 @@ ignore_missing:
 ## not, and if we didn't ignore them, the spec that makes sure that we don't have
 ## any unused translations would fail erroneously.
 ignore_unused:
-  - 'account.login.piv_cac_info.*'
-  - 'countries.*'
   - 'devise.failure.*'
-  - 'devise.mailer.reset_password_instructions.subject'
   - 'devise.sessions.signed_in'
-  - 'errors.messages.*'
-  - 'forms.two_factor_choice.legend'
-  - 'forms.two_factor_recovery_choice.legend'
-  - 'jobs.sms_otp_sender_job.login_message'
-  - 'jobs.sms_otp_sender_job.verify_message'
-  - 'service_providers.*'
-  - 'simple_form.*'
-  - 'step_indicator.flows.*'
-  - 'time.*'
-  - 'user_mailer.email_confirmation_instructions.subject'
-  - 'valid_email.validations.email.invalid'
   - 'errors.attributes.*'
-# - 'simple_form.{yes,no}'
-# - 'simple_form.{placeholders,hints,labels}.*'
-# - 'simple_form.{error_notification,required}.:'
-
+  - 'errors.messages.*'
+  - 'simple_form.*'
+  - 'time.*'
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -74,12 +74,6 @@ en:
       regenerate_personal_key: Reset
     login:
       piv_cac: Sign in with your government employee ID
-      piv_cac_info:
-        ial1: If you have added your PIV/CAC card to your account, you may use it
-          instead of your email and password.
-        ial2: If you have added your PIV/CAC card to your account, you may use it
-          instead of your email. You will need to provide your password to
-          unlock your profile.
     navigation:
       access_services: Access your government benefits and services from your
         %{app_name} account.

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -75,12 +75,6 @@ es:
       regenerate_personal_key: Restablecer
     login:
       piv_cac: Inicie sesión con su identificación de empleado del gobierno
-      piv_cac_info:
-        ial1: Si ha agregado su tarjeta PIV / CAC a su cuenta, puede usarla en lugar de
-          su correo electrónico y contraseña.
-        ial2: Si ha agregado su tarjeta PIV / CAC a su cuenta, puede usarla en lugar de
-          su correo electrónico. Deberá proporcionar su contraseña para
-          desbloquear su perfil.
     navigation:
       access_services: Acceda a los beneficios y servicios de su gobierno desde su
         cuenta %{app_name}.

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -80,13 +80,6 @@ fr:
       regenerate_personal_key: Réinitialiser
     login:
       piv_cac: Connectez-vous avec votre ID d’employé du gouvernement
-      piv_cac_info:
-        ial1: Si vous avez ajouté votre carte PIV / CAC à votre compte, vous pouvez
-          l’utiliser à la place de votre adresse courriel et de votre mot de
-          passe.
-        ial2: Si vous avez ajouté votre carte PIV / CAC à votre compte, vous pouvez
-          l’utiliser à la place de votre adresse courriel. Vous devrez fournir
-          votre mot de passe pour déverrouiller votre profil.
     navigation:
       access_services: Accédez à vos avantages et services gouvernementaux depuis
         votre compte %{app_name}.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -106,8 +106,6 @@ en:
       code: One-time code
       personal_key: Personal key
       try_again: Use another phone number
-    two_factor_choice:
-      legend: Select an option to secure your account
     validation:
       required_checkbox: Please check this box to continue
     verify_profile:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -113,8 +113,6 @@ es:
       code: Código de un solo uso
       personal_key: Clave personal
       try_again: Use otro número de teléfono.
-    two_factor_choice:
-      legend: Seleccione una opción para proteger su cuenta
     validation:
       required_checkbox: Marque esta casilla para continuar
     verify_profile:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -114,8 +114,6 @@ fr:
       code: Code à usage unique
       personal_key: Clé personnelle
       try_again: Utilisez un autre numéro de téléphone
-    two_factor_choice:
-      legend: Sélectionnez une option pour sécuriser votre compte
     validation:
       required_checkbox: Veuillez cocher cette case pour continuer
     verify_profile:

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -11,15 +11,3 @@ en:
           still active and can be used to access other participating government
           websites.'
         instructions2: Please visit the agency’s website to contact them for more information.
-    help_text:
-      default:
-        forgot_password: Your old %{sp_name} username and password won’t work. Please <a
-          href=%{sp_create_link}>create a %{app_name} account</a> using the same
-          email address you use for %{sp_name}. <p><a
-          href="https://login.gov/help/">Learn more</a>
-        sign_in: <b>First time here from %{sp_name}?</b><p>Your old %{sp_name} username
-          and password won’t work. Please <a href=%{sp_create_link}>create a
-          %{app_name} account</a> using the same email address you use for
-          %{sp_name}. <p><a href="https://login.gov/help/">Learn more</a>
-        sign_up: Please create a %{app_name} account using the same email address you
-          use for %{sp_name} <p><a href="https://login.gov/help/">Learn more</a>

--- a/config/locales/service_providers/es.yml
+++ b/config/locales/service_providers/es.yml
@@ -12,18 +12,3 @@ es:
           participante.'
         instructions2: Por favor, visite la agencia para contactarlos y obtener más
           información.
-    help_text:
-      default:
-        forgot_password: Si tiene un perfil de %{sp_name} existente, favor de usar la
-          dirección de correo electrónico primaria o secundaria que usó para
-          %{sp_name} para <a href=%{sp_create_link}>crear su nueva cuenta de
-          %{app_name}</a>. <p><a href="https://login.gov/help/">Obtenga más
-          información.</a>
-        sign_in: <b>¿Ha venido de %{sp_name}?</b><p>Si tiene un perfil de %{sp_name}
-          existente, favor de usar la dirección de correo electrónico primaria o
-          secundaria que usó para %{sp_name} para <a
-          href=%{sp_create_link}>crear un nueva cuenta de %{app_name}</a> <p><a
-          href="https://login.gov/help/">Obtenga más información.</a>
-        sign_up: Por favor crea un %{app_name} cuenta usando la misma dirección de
-          correo electrónico que utiliza para %{sp_name}. <p><a
-          href="https://login.gov/help/">Obtenga más información.</a>

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -12,18 +12,3 @@ fr:
           autres sites Web gouvernementaux participants.'
         instructions2: Veuillez vous rendre sur le site de l’agence afin de les
           contacter pour plus d’informations.
-    help_text:
-      default:
-        forgot_password: Si vous avez déjà un profil %{sp_name}, veuillez utiliser
-          l’adresse e-mail principale ou secondaire que vous avez utilisée pour
-          %{sp_name} pour <a href=%{sp_create_link}> créer votre nouveau compte
-          %{app_name}</a> <p><a href="https://login.gov/help/">En savoir
-          plus.</a>
-        sign_in: <b>Êtes-vous venu(e) de %{sp_name}?</b><p> Si vous avez déjà un profil
-          %{sp_name}, veuillez utiliser l’adresse e-mail principale ou
-          secondaire que vous avez utilisée pour %{sp_name} pour <a
-          href=%{sp_create_link}> créer votre nouveau compte %{app_name}</a>
-          <p><a href="https://login.gov/help/">En savoir plus.</a>
-        sign_up: Veuillez créer un compte %{app_name} avec la même adresse e-mail que
-          vous avez utilisée pour %{sp_name}. <p><a
-          href="https://login.gov/help/">En savoir plus.</a>


### PR DESCRIPTION
**Why**:

- So that the list is an accurate reflection of used keys
- So that all translation data is expected to be used in the application
- To minimize and discourage use of this override in favor of inline configuration

The general approach here was to comment out the configuration, running `i18n-tasks` and adding back only the keys confirmed to be in use.

Since some translations are referenced dynamically (typically why one would use this configuration), I'd appreciate a second set of eyes that the removed translation strings are actually unused.