### PR TITLE
LG-6120 update alt text

### DIFF
--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -25,7 +25,12 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
       <PersonalKeyStep {...stepProps} />
       <Modal onRequestClose={closeModalActions}>
         <div className="pin-top pin-x display-flex flex-column flex-align-center top-neg-3">
-          <img alt="" height="60" width="60" src={getAssetPath('p-key.svg')} />
+          <img
+            alt={t('idv.titles.personal_key')}
+            height="60"
+            width="60"
+            src={getAssetPath('p-key.svg')}
+          />
         </div>
         <Modal.Heading>{t('forms.personal_key.title')}</Modal.Heading>
         <Modal.Description>{t('forms.personal_key.instructions')}</Modal.Description>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -8,7 +8,7 @@
         <div class="i18n-mobile-toggle display-flex flex-align-center flex-justify-center">
             <button class="text-primary fs-13p language-mobile-button" aria-expanded="false">
               <%= image_tag asset_url('globe-blue.svg'), width: 12,
-                                                         class: 'margin-right-1', alt: '', 'aria-hidden': 'true' %><%= t('i18n.language') %><span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
+                                                         class: 'margin-right-1', alt: t('shared.footer_lite.blue_globe'), 'aria-hidden': 'true' %><%= t('i18n.language') %><span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
             </button>
         </div>
       </div>

--- a/app/views/sign_up/registrations/_required_pii_accordion.html.erb
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.erb
@@ -1,7 +1,7 @@
 <p class="grid-row grid-gutter">
   <%= image_tag(
         asset_url('get-started/ID.svg'),
-        size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+        size: '40', alt: t('idv.index.id.state_issue'), class: 'margin-top-05 grid-col-auto',
       ) %>
   <span class="grid-col-fill padding-left-2">
     <%= t('idv.index.id.need_html') %>
@@ -13,7 +13,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/email-password.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_1_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_1_html') %>
@@ -22,7 +22,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/2FA.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_2_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_2_html') %>
@@ -31,7 +31,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/personal-details.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_3_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_3_html') %>
@@ -49,7 +49,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/financial.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_5_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_5_html') %>
@@ -58,7 +58,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('p-key.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_6_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_6_html') %>

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -50,13 +50,18 @@ en:
         it. Please follow the instructions below.
       start:
         accordion: You will also need
+        bullet_1_img: Email
         bullet_1_html: An <strong>email address</strong>.
+        bullet_2_img: Device
         bullet_2_html: Enable <strong>two-step authentication</strong>.
+        bullet_3_img: Informational profile
         bullet_3_html: To provide <strong>basic information</strong>, such as your name,
           address and phone number.
         bullet_4_html: Your <strong>Social Security number</strong>.
+        bullet_5_img: Verify your address
         bullet_5_html: To verify your address by providing a <strong>phone number or
           mailing address where you receive mail</strong>.
+        bullet_6_img: Personal key
         bullet_6_html: When you are finished with this process we’ll give you a
           <strong>personal key</strong>. Write it down and store it in a safe
           place; it’s important. You’ll be asked for the personal key every time

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -50,22 +50,22 @@ en:
         it. Please follow the instructions below.
       start:
         accordion: You will also need
-        bullet_1_img: Email
         bullet_1_html: An <strong>email address</strong>.
-        bullet_2_img: Device
+        bullet_1_img: Email
         bullet_2_html: Enable <strong>two-step authentication</strong>.
-        bullet_3_img: Informational profile
+        bullet_2_img: Device
         bullet_3_html: To provide <strong>basic information</strong>, such as your name,
           address and phone number.
+        bullet_3_img: Informational profile
         bullet_4_html: Your <strong>Social Security number</strong>.
-        bullet_5_img: Verify your address
         bullet_5_html: To verify your address by providing a <strong>phone number or
           mailing address where you receive mail</strong>.
-        bullet_6_img: Personal key
+        bullet_5_img: Verify your address
         bullet_6_html: When you are finished with this process we’ll give you a
           <strong>personal key</strong>. Write it down and store it in a safe
           place; it’s important. You’ll be asked for the personal key every time
           you make changes to your account.
+        bullet_6_img: Personal key
         learn_more: Learn more about verifying your identity
     sessions:
       signed_in: ''

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -53,22 +53,22 @@ es:
         nuevo número, seguiremos usando su número de teléfono antiguo.
       start:
         accordion: También necesitarás
-        bullet_1_img: Correo electrónico
         bullet_1_html: Una <strong>dirección de correo electrónico</strong>.
-        bullet_2_img: Dispositivo
+        bullet_1_img: Correo electrónico
         bullet_2_html: Permita <strong>la autenticación de dos factores</strong>.
-        bullet_3_img: Perfil informativo
+        bullet_2_img: Dispositivo
         bullet_3_html: Para proporcionar <strong>información básica</strong>, como su
           nombre, dirección y número de teléfono.
+        bullet_3_img: Perfil informativo
         bullet_4_html: Su <strong>número de Seguridad Social</strong>.
-        bullet_5_img: Verifique su dirección
         bullet_5_html: para verificar su dirección, proporcione un <strong>número de
           teléfono o dirección postal donde recibe el correo</strong>.
-        bullet_6_img: Clave personal
+        bullet_5_img: Verifique su dirección
         bullet_6_html: Cuando haya terminado con este proceso, le daremos <strong>una
           clave personal</strong>. Escríbala y guárdela en un lugar seguro; es
           importante. Se le pedirá la clave personal cada vez que realice
           cambios en su cuenta.
+        bullet_6_img: Clave personal
         learn_more: Obtenga más información sobre la verificación de su identidad.
     sessions:
       signed_in: ''

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -53,13 +53,18 @@ es:
         nuevo número, seguiremos usando su número de teléfono antiguo.
       start:
         accordion: También necesitarás
+        bullet_1_img: Correo electrónico
         bullet_1_html: Una <strong>dirección de correo electrónico</strong>.
+        bullet_2_img: Dispositivo
         bullet_2_html: Permita <strong>la autenticación de dos factores</strong>.
+        bullet_3_img: Perfil informativo
         bullet_3_html: Para proporcionar <strong>información básica</strong>, como su
           nombre, dirección y número de teléfono.
         bullet_4_html: Su <strong>número de Seguridad Social</strong>.
+        bullet_5_img: Verifique su dirección
         bullet_5_html: para verificar su dirección, proporcione un <strong>número de
           teléfono o dirección postal donde recibe el correo</strong>.
+        bullet_6_img: Clave personal
         bullet_6_html: Cuando haya terminado con este proceso, le daremos <strong>una
           clave personal</strong>. Escríbala y guárdela en un lugar seguro; es
           importante. Se le pedirá la clave personal cada vez que realice

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -61,14 +61,19 @@ fr:
         ancien numéro de téléphone.
       start:
         accordion: Vous aurez aussi besoin
+        bullet_1_img: Courriel
         bullet_1_html: Une <strong>adresse e-mail</strong>.
+        bullet_2_img: Dispositif
         bullet_2_html: Activez <strong>l’authentification à deux facteurs</strong>.
+        bullet_3_img: Profil informatif
         bullet_3_html: Pour fournir des <strong>informations de base</strong>, telles
           que votre nom, adresse et numéro de téléphone.
         bullet_4_html: Votre <strong>numéro de Sécurité Sociale</strong>.
+        bullet_5_img: Vérifiez votre adresse
         bullet_5_html: Pour vérifier votre adresse en fournissant un <strong>numéro de
           téléphone ou adresse postale où vous recevez du courrier
           électronique</strong>.
+        bullet_6_img: Clé personnelle
         bullet_6_html: Lorsque vous avez terminé ce processus, nous allons vous donner
           un <strong>clé personnelle</strong>. Ecrivez-le et rangez-le dans un
           endroit sûr. C’est important. La clé personnelle vous sera demandée

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -61,23 +61,23 @@ fr:
         ancien numéro de téléphone.
       start:
         accordion: Vous aurez aussi besoin
-        bullet_1_img: Courriel
         bullet_1_html: Une <strong>adresse e-mail</strong>.
-        bullet_2_img: Dispositif
+        bullet_1_img: Courriel
         bullet_2_html: Activez <strong>l’authentification à deux facteurs</strong>.
-        bullet_3_img: Profil informatif
+        bullet_2_img: Dispositif
         bullet_3_html: Pour fournir des <strong>informations de base</strong>, telles
           que votre nom, adresse et numéro de téléphone.
+        bullet_3_img: Profil informatif
         bullet_4_html: Votre <strong>numéro de Sécurité Sociale</strong>.
-        bullet_5_img: Vérifiez votre adresse
         bullet_5_html: Pour vérifier votre adresse en fournissant un <strong>numéro de
           téléphone ou adresse postale où vous recevez du courrier
           électronique</strong>.
-        bullet_6_img: Clé personnelle
+        bullet_5_img: Vérifiez votre adresse
         bullet_6_html: Lorsque vous avez terminé ce processus, nous allons vous donner
           un <strong>clé personnelle</strong>. Ecrivez-le et rangez-le dans un
           endroit sûr. C’est important. La clé personnelle vous sera demandée
           chaque fois que vous apportez des modifications à votre compte.
+        bullet_6_img: Clé personnelle
         learn_more: En savoir plus sur la vérification de votre identité
     sessions:
       signed_in: ''

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -83,9 +83,9 @@ en:
       zipcode: ZIP Code
     index:
       id:
-        state_issue: State-issued ID
         need_html: If you’re creating an account, you’ll need a <strong>current
           state-issued ID</strong>.
+        state_issue: State-issued ID
     messages:
       activated_html: Your identity has been verified. If you need to change your
         verified information, please %{link}.
@@ -145,11 +145,11 @@ en:
     titles:
       activated: Your identity has already been verified
       come_back_later: Come back soon
-      personal_key: Personal key
       mail:
         resend: Want another letter?
         verify: Want a letter?
       otp_delivery_method: How would you like to receive a code?
+      personal_key: Personal key
       review: Review and submit
       session:
         phone: Enter a phone number with your name on the plan

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -83,6 +83,7 @@ en:
       zipcode: ZIP Code
     index:
       id:
+        state_issue: State-issued ID
         need_html: If you’re creating an account, you’ll need a <strong>current
           state-issued ID</strong>.
     messages:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -144,6 +144,7 @@ en:
     titles:
       activated: Your identity has already been verified
       come_back_later: Come back soon
+      personal_key: Personal key
       mail:
         resend: Want another letter?
         verify: Want a letter?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -89,6 +89,7 @@ es:
       zipcode: Código postal
     index:
       id:
+        state_issue: Documento de identidad emitido por el Estado
         need_html: Si está creando una cuenta, necesitará una <strong>identificación
           emitida por el estado actual</strong>.
     messages:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -89,9 +89,9 @@ es:
       zipcode: Código postal
     index:
       id:
-        state_issue: Documento de identidad emitido por el Estado
         need_html: Si está creando una cuenta, necesitará una <strong>identificación
           emitida por el estado actual</strong>.
+        state_issue: Documento de identidad emitido por el Estado
     messages:
       activated_html: Su identidad ha sido verificada. Si necesita cambiar la
         información verificada, por favor, %{link}.
@@ -152,11 +152,11 @@ es:
     titles:
       activated: Ya se verificó tu identidad.
       come_back_later: Vuelve pronto
-      personal_key: Clave personal
       mail:
         resend: '¿Desea otra carta?'
         verify: '¿Desea una carta?'
       otp_delivery_method: '¿Cómo te gustaría recibir el código?'
+      personal_key: Clave personal
       review: Revise y envíe
       session:
         phone: Ingresa un número de teléfono para ayudar a verificar tu identidad

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -151,6 +151,7 @@ es:
     titles:
       activated: Ya se verificó tu identidad.
       come_back_later: Vuelve pronto
+      personal_key: Clave personal
       mail:
         resend: '¿Desea otra carta?'
         verify: '¿Desea una carta?'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -163,6 +163,7 @@ fr:
     titles:
       activated: Votre identité a déjà été vérifiée
       come_back_later: Revenez vite
+      personal_key: Clé personnelle
       mail:
         resend: Vous voulez une autre lettre?
         verify: Vous voulez une lettre?

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -93,9 +93,9 @@ fr:
       zipcode: Code ZIP
     index:
       id:
-        state_issue: Carte d'identité délivrée par l'État
         need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant
           actuel émis par l’état</strong>.
+        state_issue: Carte d’identité délivrée par l’État
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier votre
         information vérifiée, veuillez %{link}.
@@ -164,11 +164,11 @@ fr:
     titles:
       activated: Votre identité a déjà été vérifiée
       come_back_later: Revenez vite
-      personal_key: Clé personnelle
       mail:
         resend: Vous voulez une autre lettre?
         verify: Vous voulez une lettre?
       otp_delivery_method: Comment souhaitez-vous recevoir le code ?
+      personal_key: Clé personnelle
       review: Réviser et soumettre
       session:
         phone: Entrez un numéro de téléphone pour vous aider à vérifier votre identité

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -93,6 +93,7 @@ fr:
       zipcode: Code ZIP
     index:
       id:
+        state_issue: Carte d'identité délivrée par l'État
         need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant
           actuel émis par l’état</strong>.
     messages:

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -16,5 +16,6 @@ en:
         website. Share sensitive information only on official, secure websites.
       secure_heading: Secure .gov websites use HTTPS
     footer_lite:
+      blue_globe: Blue globe
       gsa: US General Services Administration
     skip_link: Skip to main content

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -17,5 +17,6 @@ es:
         oficiales y seguros.
       secure_heading: Los sitios web seguros .gov usan HTTPS
     footer_lite:
+      blue_globe: Globo azul
       gsa: Administración General de Servicios de EE. UU.
     skip_link: Salte al contenido principal

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -17,5 +17,6 @@ fr:
         uniquement sur des sites Web officiels et sécurisés.
       secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     footer_lite:
+      blue_globe: Globe bleu
       gsa: Administration des services généraux des États-Unis
     skip_link: Passer au contenu principal


### PR DESCRIPTION
[LG-6120](https://cm-jira.usa.gov/browse/LG-6120)

**What**
This is the last and final subtask of[ LG-5774](https://cm-jira.usa.gov/browse/LG-5774), reviewing images with empty alt tags to check if they are decorative or informative. This [Figma link](https://www.figma.com/file/uIfsIZTFPPQSbe0hMpo6oL/Confirm-whether-images-are-decorative-or-informative-(LG-6118)?node-id=0%3A1) includes the images which were reviewed, and this [translation doc](https://docs.google.com/document/d/1iwIwxLeMoOo_VSI7bhxm8cGO6HIq5rKVNURIpiuZynM/edit) includes which words were added to the yml locale files.

**Testing Instructions**
1. Go to localhost:3000/verify and create an account
2. While following through the steps, look out for the images in the Figma file listed as Informative 
3. For those listed as informative (as you come across them), you can inspect the image with developer tools to see if the expected value  shows up in the alt tag. 


Copying @Danielle-Lee for content and @Kamal-Munshi  for design on this PR for visibility and/or questions. 
