### PR TITLE
Add tracking of billable IAL to SP Redirect events

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -123,6 +123,7 @@ module SamlIdpAuthConcern
       ial: requested_ial_authn_context,
       service_provider: saml_request_service_provider,
       authn_context_comparison: saml_request.requested_authn_context_comparison,
+      user: current_user,
     )
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -147,7 +147,17 @@ module OpenidConnect
     end
 
     def track_events
-      analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: sp_session_ial)
+      event_ial_context = IalContext.new(
+        ial: @authorize_form.ial,
+        service_provider: @authorize_form.service_provider,
+        user: current_user,
+      )
+
+      analytics.track_event(
+        Analytics::SP_REDIRECT_INITIATED,
+        ial: event_ial_context.ial,
+        billed_ial: event_ial_context.bill_for_ial_1_or_2,
+      )
       track_billing_events
     end
   end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -162,7 +162,11 @@ class SamlIdpController < ApplicationController
   end
 
   def track_events
-    analytics.track_event(Analytics::SP_REDIRECT_INITIATED, ial: ial_context.ial)
+    analytics.track_event(
+      Analytics::SP_REDIRECT_INITIATED,
+      ial: ial_context.ial,
+      billed_ial: ial_context.bill_for_ial_1_or_2,
+    )
     track_billing_events
   end
 end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -99,6 +99,10 @@ class OpenidConnectAuthorizeForm
     @ial_context ||= IalContext.new(ial: ial, service_provider: service_provider)
   end
 
+  def ial
+    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max]
+  end
+
   def_delegators :ial_context,
                  :ial2_or_greater?,
                  :ial2_requested?,
@@ -193,10 +197,6 @@ class OpenidConnectAuthorizeForm
       type: :invalid_verified_within_duration,
     )
     false
-  end
-
-  def ial
-    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max]
   end
 
   def extra_analytics_attributes

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -59,8 +59,11 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
                  scope: 'openid')
           expect(@analytics).to receive(:track_event).
-            with(Analytics::SP_REDIRECT_INITIATED,
-                 ial: 1)
+            with(
+              Analytics::SP_REDIRECT_INITIATED,
+              ial: 1,
+              billed_ial: 1,
+            )
 
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
@@ -115,8 +118,11 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
                      scope: 'openid profile')
               expect(@analytics).to receive(:track_event).
-                with(Analytics::SP_REDIRECT_INITIATED,
-                     ial: 2)
+                with(
+                  Analytics::SP_REDIRECT_INITIATED,
+                  ial: 2,
+                  billed_ial: 2,
+                )
 
               IdentityLinker.new(user, service_provider).link_identity(ial: 2)
               user.identities.last.update!(
@@ -163,6 +169,151 @@ RSpec.describe OpenidConnect::AuthorizationController do
             it 'redirects to have the user enter their personal key' do
               action
               expect(controller).to redirect_to(reactivate_account_url)
+            end
+          end
+        end
+
+        context 'with ialmax requested' do
+          before { params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
+
+          context 'account is already verified' do
+            let(:user) do
+              create(
+                :profile, :active, :verified, proofing_components: { liveness_check: true }
+              ).user
+            end
+
+            it 'redirects to the redirect_uri immediately when pii is unlocked' do
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+              action
+
+              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+            end
+
+            it 'redirects to the password capture url when pii is locked' do
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              allow(controller).to receive(:pii_requested_but_locked?).and_return(true)
+              action
+
+              expect(response).to redirect_to(capture_password_url)
+            end
+
+            it 'tracks IAL2 authentication event' do
+              stub_analytics
+              expect(@analytics).to receive(:track_event).
+                with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
+                     success: true,
+                     client_id: client_id,
+                     errors: {},
+                     unauthorized_scope: false,
+                     user_fully_authenticated: true,
+                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                     scope: 'openid profile')
+              expect(@analytics).to receive(:track_event).
+                with(
+                  Analytics::SP_REDIRECT_INITIATED,
+                  ial: 0,
+                  billed_ial: 2,
+                )
+
+              IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+              action
+
+              sp_return_log = SpReturnLog.find_by(issuer: client_id)
+              expect(sp_return_log.ial).to eq(2)
+            end
+          end
+
+          context 'account is not already verified' do
+            it 'redirects to the redirect_uri immediately without proofing' do
+              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+
+              action
+              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+            end
+
+            it 'tracks IAL1 authentication event' do
+              stub_analytics
+              expect(@analytics).to receive(:track_event).
+                with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
+                     success: true,
+                     client_id: client_id,
+                     errors: {},
+                     unauthorized_scope: false,
+                     user_fully_authenticated: true,
+                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                     scope: 'openid profile')
+              expect(@analytics).to receive(:track_event).
+                with(
+                  Analytics::SP_REDIRECT_INITIATED,
+                  ial: 0,
+                  billed_ial: 1,
+                )
+
+              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              action
+
+              sp_return_log = SpReturnLog.find_by(issuer: client_id)
+              expect(sp_return_log.ial).to eq(1)
+            end
+          end
+
+          context 'profile is reset' do
+            let(:user) { create(:profile, :password_reset).user }
+
+            it 'redirects to the redirect_uri immediately without proofing' do
+              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+
+              action
+              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+            end
+
+            it 'tracks IAL1 authentication event' do
+              stub_analytics
+              expect(@analytics).to receive(:track_event).
+                with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
+                     success: true,
+                     client_id: client_id,
+                     errors: {},
+                     unauthorized_scope: false,
+                     user_fully_authenticated: true,
+                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                     scope: 'openid profile')
+              expect(@analytics).to receive(:track_event).
+                with(
+                  Analytics::SP_REDIRECT_INITIATED,
+                  ial: 0,
+                  billed_ial: 1,
+                )
+
+              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              action
+
+              sp_return_log = SpReturnLog.find_by(issuer: client_id)
+              expect(sp_return_log.ial).to eq(1)
             end
           end
         end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -553,8 +553,11 @@ describe SamlIdpController do
                idv: false,
                finish_profile: false)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SP_REDIRECT_INITIATED,
-               ial: ial)
+          with(
+            Analytics::SP_REDIRECT_INITIATED,
+            ial: ial,
+            billed_ial: [ial, 2].min,
+          )
 
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         saml_get_auth(ial2_settings)
@@ -707,8 +710,11 @@ describe SamlIdpController do
                idv: false,
                finish_profile: false)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SP_REDIRECT_INITIATED,
-               ial: 0)
+          with(
+            Analytics::SP_REDIRECT_INITIATED,
+            ial: 0,
+            billed_ial: 2,
+          )
 
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         saml_get_auth(ialmax_settings)
@@ -1869,8 +1875,11 @@ describe SamlIdpController do
                service_provider: 'http://localhost:3000')
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SP_REDIRECT_INITIATED,
-               ial: 1)
+          with(
+            Analytics::SP_REDIRECT_INITIATED,
+            ial: 1,
+            billed_ial: 1,
+          )
 
         generate_saml_response(user)
       end
@@ -1903,8 +1912,11 @@ describe SamlIdpController do
                service_provider: 'http://localhost:3000')
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SP_REDIRECT_INITIATED,
-               ial: 1)
+          with(
+            Analytics::SP_REDIRECT_INITIATED,
+            ial: 1,
+            billed_ial: 1,
+          )
 
         generate_saml_response(user)
       end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -312,6 +312,48 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
+  describe '#ial' do
+    context 'when IAL1 passed' do
+      let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns 1' do
+        expect(form.ial).to eq(1)
+      end
+    end
+
+    context 'when IAL2 passed' do
+      let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns 2' do
+        expect(form.ial).to eq(2)
+      end
+    end
+
+    context 'when IALMAX passed' do
+      let(:acr_values) { Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns 0' do
+        expect(form.ial).to eq(0)
+      end
+    end
+
+    context 'when LOA1 passed' do
+      let(:acr_values) { Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns 1' do
+        expect(form.ial).to eq(1)
+      end
+    end
+
+    context 'when LOA3 passed' do
+      let(:acr_values) { Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns 2' do
+        expect(form.ial).to eq(2)
+      end
+    end
+  end
+
   describe '#verified_within' do
     context 'without a verified_within' do
       let(:verified_within) { nil }


### PR DESCRIPTION
**Why:** With the introduction of IALMAX to SAML using the Comparison
attribute, it is now impossible to filter "SP Redirect Initiated" log
events by the actual IAL that was sent back, since the IALContext
returns an IAL of zero by default. This change adds an additional
attribute to SP Redirect Initiated events for SAML and OIDC requests to
track the actual billable IAL (based on whether or not the user has
proofed). This also adds some more comprehensive controller specs for
IALMAX behavior for OIDC.

changelog: Improvements, Authentication, Track billable "IAL" in the event log for successful requests