### PR TITLE
Clear the verified attributes when a user disconnects from an app (LG-5981)

### DIFF
--- a/app/services/revoke_service_provider_consent.rb
+++ b/app/services/revoke_service_provider_consent.rb
@@ -7,6 +7,6 @@ class RevokeServiceProviderConsent
   end
 
   def call
-    identity.update!(deleted_at: now)
+    identity.update!(deleted_at: now, verified_attributes: nil)
   end
 end

--- a/spec/services/revoke_service_provider_consent_spec.rb
+++ b/spec/services/revoke_service_provider_consent_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe RevokeServiceProviderConsent do
   subject(:service) { RevokeServiceProviderConsent.new(identity, now: now) }
 
   describe '#call' do
-    let!(:identity) { create(:service_provider_identity, deleted_at: nil, verified_attributes: ['email']) }
+    let!(:identity) do
+      create(:service_provider_identity, deleted_at: nil, verified_attributes: ['email'])
+    end
 
     it 'sets the deleted_at' do
       expect { service.call }.

--- a/spec/services/revoke_service_provider_consent_spec.rb
+++ b/spec/services/revoke_service_provider_consent_spec.rb
@@ -6,12 +6,18 @@ RSpec.describe RevokeServiceProviderConsent do
   subject(:service) { RevokeServiceProviderConsent.new(identity, now: now) }
 
   describe '#call' do
-    let!(:identity) { create(:service_provider_identity, deleted_at: nil) }
+    let!(:identity) { create(:service_provider_identity, deleted_at: nil, verified_attributes: ['email']) }
 
     it 'sets the deleted_at' do
       expect { service.call }.
         to change { identity.reload.deleted_at&.to_i }.
         from(nil).to(now.to_i)
+    end
+
+    it 'clears the verified attributes' do
+      expect { service.call }.
+        to change { identity.reload.verified_attributes }.
+        from(['email']).to(nil)
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where a verified user who revokes consent from an SP, then re-consents to IAL1 has their full original list of consented fields marked as consented.

**Steps to replicate**:
1. Set up verified Login.gov account and sign in to an SP at IAL2 (including consent for attributes like name, SSN, etc)
2. Visit account page on Login.gov and "Disconnect" from that SP
3. Sign in to that SP at IAL1, consent to share email during authentication
4. Sign in to that SP at IAL2 (with additional attributes requested)

**Expected**: User is prompted to consent to share additional verified attributes with the SP

**Actual**: No consent prompt for IAL2 attributes but they are sent anyway

Note: can also test using the new `Step-up` IAL option in the sample apps.