### PR TITLE
LG-6205: Fix forgot password "Try Again" URL

### DIFF
--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 
+type ParamValue = string | undefined;
+
 interface HistoryOptions {
   basePath?: string;
 }
@@ -28,8 +30,8 @@ export const getStepParam = (path: string): string => path.split('/').filter(Boo
 function useHistoryParam(
   initialValue?: string,
   { basePath }: HistoryOptions = {},
-): [string | undefined, (nextParamValue?: string) => void] {
-  function getCurrentValue(): string | undefined {
+): [string | undefined, (nextParamValue: ParamValue) => void] {
+  function getCurrentValue(): ParamValue {
     const path =
       typeof basePath === 'string'
         ? window.location.pathname.split(basePath)[1]
@@ -42,12 +44,12 @@ function useHistoryParam(
 
   const [value, setValue] = useState(initialValue ?? getCurrentValue);
 
-  function getValueURL(nextValue) {
+  function getValueURL(nextValue: ParamValue) {
     const prefix = typeof basePath === 'string' ? `${basePath.replace(/\/$/, '')}/` : '#';
-    return nextValue ? `${prefix}${nextValue}` : window.location.pathname + window.location.search;
+    return [prefix, nextValue].filter(Boolean).join('');
   }
 
-  function setParamValue(nextValue) {
+  function setParamValue(nextValue: ParamValue) {
     // Push the next value to history, both to update the URL, and to allow the user to return to
     // an earlier value (see `popstate` sync behavior).
     if (nextValue !== value) {

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -1,21 +1,13 @@
-import sinon from 'sinon';
-import * as analytics from '@18f/identity-analytics';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { t } from '@18f/identity-i18n';
 import { accordion } from 'identity-style-guide';
+import * as analytics from '@18f/identity-analytics';
+import { useSandbox, usePropertyValue } from '@18f/identity-test-helpers';
+import { t, i18n } from '@18f/identity-i18n';
 import PasswordConfirmStep from './password-confirm-step';
 
 describe('PasswordConfirmStep', () => {
-  before(() => {
-    accordion.on();
-  });
-
-  after(() => {
-    accordion.off();
-  });
-
-  const sandbox = sinon.createSandbox();
+  const sandbox = useSandbox();
   const DEFAULT_PROPS = {
     onChange() {},
     onError() {},
@@ -26,12 +18,16 @@ describe('PasswordConfirmStep', () => {
     value: {},
   };
 
+  before(() => {
+    accordion.on();
+  });
+
   beforeEach(() => {
     sandbox.spy(analytics, 'trackEvent');
   });
 
-  afterEach(() => {
-    sandbox.restore();
+  after(() => {
+    accordion.off();
   });
 
   it('has a collapsed accordion by default', () => {
@@ -42,10 +38,7 @@ describe('PasswordConfirmStep', () => {
   });
 
   it('expands accordion when the accordion is clicked on', async () => {
-    const toPreviousStep = sinon.spy();
-    const { getByText } = render(
-      <PasswordConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
-    );
+    const { getByText } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
 
     const button = getByText(t('idv.messages.review.intro'));
     await userEvent.click(button);
@@ -53,15 +46,36 @@ describe('PasswordConfirmStep', () => {
   });
 
   it('displays user information when the accordion is clicked on', async () => {
-    const toPreviousStep = sinon.spy();
-    const { getByText } = render(
-      <PasswordConfirmStep {...DEFAULT_PROPS} toPreviousStep={toPreviousStep} />,
-    );
+    const { getByText } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
 
     const button = getByText(t('idv.messages.review.intro'));
     await userEvent.click(button);
 
     expect(getByText('idv.review.full_name')).to.exist();
     expect(getByText('idv.review.mailing_address')).to.exist();
+  });
+
+  describe('forgot password', () => {
+    usePropertyValue(i18n, 'strings', {
+      'idv.forgot_password.link_html': 'Forgot password? %{link}',
+      'idv.forgot_password.warnings': [],
+    });
+
+    it('navigates to forgot password subpage', async () => {
+      const { getByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
+
+      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.link_text' }));
+
+      expect(window.location.pathname).to.equal('/password_confirm/forgot_password');
+    });
+
+    it('navigates back from forgot password subpage', async () => {
+      const { getByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
+
+      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.link_text' }));
+      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.try_again' }));
+
+      expect(window.location.pathname).to.equal('/password_confirm/');
+    });
   });
 });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -28,7 +28,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
   }
 
   function goBack() {
-    setPath('password_confirm');
+    setPath(undefined);
   }
 
   if (path === 'forgot_password') {


### PR DESCRIPTION
**Why**: So that a user can refresh the page after returning from "Forgot Password" to "Confirm Password" step.

**Testing Instructions:**

You will need to set the step as enabled in your local `config/application.yml`:

```yml
development:
  idv_api_enabled_steps: '["password_confirm","personal_key","personal_key_confirm"]'
```

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to password confirmation step
5. Click "Follow these instructions" (adjacent "Forgot your password?")
6. Click "Try again"
7. Reload the page

Before: You see a 404 error
After: You see the same page as before Step 7