### PR TITLE
update changelog_check error message

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -215,6 +215,8 @@ def main(args)
         #{CATEGORIES.map { |category| "- #{category}" }.join("\n")}
 
         Include "[skip changelog]" in a commit message to bypass this check.
+
+        Note: the changelog message must be separated from any other commit message by a blank line.
       ERROR
     )
 


### PR DESCRIPTION
**Why**: to make it clear to developers that they need to separate the changelog message from the rest of the commit message.