### PR TITLE
Show configured 2FA on account page (LG-6366)

### DIFF
--- a/app/policies/two_factor_authentication/webauthn_policy.rb
+++ b/app/policies/two_factor_authentication/webauthn_policy.rb
@@ -21,6 +21,14 @@ module TwoFactorAuthentication
       platform_configured?
     end
 
+    def roaming_configured?
+      mfa_user.webauthn_roaming_configurations.any?
+    end
+
+    def roaming_enabled?
+      roaming_configured?
+    end
+
     def visible?
       true
     end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -62,11 +62,42 @@
   </div>
 <% end %>
 
-<div class="margin-bottom-4 card profile-info-box">
-  <% if TwoFactorAuthentication::PhonePolicy.new(current_user).visible? %>
+<% if TwoFactorAuthentication::PhonePolicy.new(current_user).configured? %>
+  <div class="margin-bottom-4 card profile-info-box">
     <%= render 'phone' %>
-  <% end %>
-</div>
+  </div>
+<% end %>
+
+<% if TwoFactorAuthentication::AuthAppPolicy.new(current_user).configured? %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/auth_apps' %>
+  </div>
+<% end %>
+
+<% if TwoFactorAuthentication::WebauthnPolicy.new(current_user).platform_configured? &&
+    IdentityConfig.store.platform_authentication_enabled %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/webauthn_platform' %>
+  </div>
+<% end %>
+
+<% if TwoFactorAuthentication::WebauthnPolicy.new(current_user).roaming_configured? %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/webauthn_roaming' %>
+  </div>
+<% end %>
+
+<% if TwoFactorAuthentication::PivCacPolicy.new(current_user).configured? %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/piv_cac' %>
+  </div>
+<% end %>
+
+<% if TwoFactorAuthentication::BackupCodePolicy.new(current_user).configured? %>
+  <div class="margin-bottom-4 card profile-info-box">
+    <%= render 'accounts/backup_codes' %>
+  </div>
+<% end %>
 
 <% if @presenter.show_pii_partial? %>
   <%= render 'accounts/pii', pii: @presenter.pii,

--- a/spec/policies/webauthn_login_option_policy_spec.rb
+++ b/spec/policies/webauthn_login_option_policy_spec.rb
@@ -28,4 +28,29 @@ describe TwoFactorAuthentication::WebauthnPolicy do
       end
     end
   end
+
+  describe '#roaming_enabled?' do
+    context 'without a webauthn configured' do
+      let(:user) { build(:user) }
+
+      it { expect(subject.roaming_enabled?).to be_falsey }
+    end
+
+    context 'with a roaming webauthn configured' do
+      let(:user) { create(:user) }
+      before do
+        create(
+          :webauthn_configuration,
+          user: user,
+          credential_id: credential_id,
+          credential_public_key: credential_public_key,
+          platform_authenticator: false,
+        )
+      end
+
+      it 'returns a truthy value' do
+        expect(subject.roaming_enabled?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -72,33 +72,70 @@ describe 'accounts/show.html.erb' do
   end
 
   context 'phone listing and adding' do
-    it 'renders the phone section' do
-      render
-
-      expect(view).to render_template(partial: '_phone')
-    end
-
     context 'user has no phone' do
       let(:user) do
         record = create(:user, :signed_up, :with_piv_or_cac)
         record.phone_configurations = []
         record
       end
+
+      it 'does not render phone' do
+        expect(view).to_not render_template(partial: '_phone')
+      end
     end
 
     context 'user has a phone' do
-      context 'phone number formatting' do
-        before do
-          user.phone_configurations.first.tap do |phone_configuration|
-            phone_configuration.phone = '+18888675309'
-            phone_configuration.save
-          end
-        end
+      it 'renders the phone section' do
+        render
 
-        it 'formats phone numbers' do
-          render
-          expect(rendered).to have_selector('.grid-col-fill', text: '+1 888-867-5309')
+        expect(view).to render_template(partial: '_phone')
+      end
+
+      it 'formats phone numbers' do
+        user.phone_configurations.first.tap do |phone_configuration|
+          phone_configuration.phone = '+18888675309'
+          phone_configuration.save
         end
+        render
+        expect(rendered).to have_selector('.grid-col-fill', text: '+1 888-867-5309')
+      end
+    end
+  end
+
+  context 'auth app listing and adding' do
+    context 'user has no auth app' do
+      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
+
+      it 'does not render auth app' do
+        expect(view).to_not render_template(partial: '_auth_apps')
+      end
+    end
+
+    context 'user has an auth app' do
+      let(:user) { create(:user, :signed_up, :with_authentication_app) }
+      it 'renders the auth app section' do
+        render
+
+        expect(view).to render_template(partial: '_auth_apps')
+      end
+    end
+  end
+
+  context 'PIV/CAC listing and adding' do
+    context 'user has no piv/cac' do
+      let(:user) { create(:user, :signed_up, :with_authentication_app) }
+
+      it 'does not render piv/cac' do
+        expect(view).to_not render_template(partial: '_piv_cac')
+      end
+    end
+
+    context 'user has a piv/cac' do
+      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
+      it 'renders the piv/cac section' do
+        render
+
+        expect(view).to render_template(partial: '_piv_cac')
       end
     end
   end


### PR DESCRIPTION
We've had a couple of reported instances ([1](https://gsa-tts.slack.com/archives/C0NGESUN5/p1647610831587719), [2](https://gsa-tts.slack.com/archives/CG64NU5C7/p1652806389709729?thread_ts=1643736538.278459&cid=CG64NU5C7)) where users with multiple different 2FA methods have not been able to find where they can manage their existing non-phone 2FA methods.  The current account home page lists a handful of account aspects, and distinctly includes only the phone management template, even if you have none configured, and does not display other methods.

This PR aims to fix this inconsistency and improve clarity by switching the account page to list all _existing_ 2FA methods.

| Old | New |
|----|------|
| ![image](https://user-images.githubusercontent.com/1430443/169170390-7fc0767e-0ae6-401d-a9c2-7399021d0be1.png) | ![image](https://user-images.githubusercontent.com/1430443/169170343-a7d28826-40c9-44bb-a6b1-83aa27980b7a.png) |

This change is pending, another option currently being considered is removing phone management from this page.