### PR TITLE
LG-6293 Add more DOCUMENT_FAIL conditions to verification failures report

### DIFF
--- a/app/jobs/reports/verification_failures_report.rb
+++ b/app/jobs/reports/verification_failures_report.rb
@@ -2,7 +2,7 @@ require 'identity/hostdata'
 require 'csv'
 
 module Reports
-  class VerificationErrorsReport < BaseReport
+  class VerificationFailuresReport < BaseReport
     REPORT_NAME = 'verification-errors-report'.freeze
 
     include GoodJob::ActiveJobExtensions::Concurrency
@@ -31,7 +31,7 @@ module Reports
       csv << %w[uuid welcome_view_at error_code]
       issuers.each do |issuer|
         transaction_with_timeout do
-          rows = ::VerificationErrorsReport.call(
+          rows = ::VerificationFailuresReport.call(
             issuer,
             (date.beginning_of_day - 1).beginning_of_day,
             date.beginning_of_day,
@@ -42,7 +42,7 @@ module Reports
         end
       end
       data = csv.string
-      save_report("#{REPORT_NAME}.#{report_name}", data, extension: 'csv')
+      save_report("#{REPORT_NAME}/#{report_name}", data, extension: 'csv')
       data
     end
 
@@ -50,18 +50,26 @@ module Reports
       welcome_at = row['welcome_view_at']
       verify_at = row['verify_submit_at']
       phone_submit_at = row['verify_phone_submit_at']
-      doc_at = row['document_capture_submit_at']
       encrypt_at = row['encrypt_view_at']
       ssn_at = row['ssn_view_at']
       phone_view_at = row['verify_phone_view_at']
       return 'PHONE_FAIL' if submit_failed?(welcome_at, phone_submit_at, encrypt_at)
       return 'VERIFY_FAIL' if submit_failed?(welcome_at, verify_at, phone_view_at)
-      return 'DOCUMENT_FAIL' if submit_failed?(welcome_at, doc_at, ssn_at)
+      if submit_failed?(welcome_at, row['document_capture_submit_at'], ssn_at) ||
+         submit_failed?(welcome_at, row['back_image_submit_at'], ssn_at) ||
+         submit_failed?(welcome_at, row['capture_mobile_back_image_submit_at'], ssn_at) ||
+         submit_failed?(welcome_at, row['mobile_back_image_submit_at'], ssn_at)
+        return 'DOCUMENT_FAIL'
+      end
       'ABANDON'
     end
 
     def submit_failed?(welcome_at, submit_at, next_step_at)
-      submit_at && submit_at >= welcome_at && (!next_step_at || next_step_at < submit_at)
+      allow_recent_by_hours = 18 # this is tied to job frequency which is currently 24 hours
+      return unless submit_at # need a submit
+      return unless (submit_at + allow_recent_by_hours.hours) >= welcome_at # need to be in range
+      return true unless next_step_at # submit must have failed if we did not get to next step
+      (submit_at + allow_recent_by_hours.hours) >= next_step_at
     end
   end
 end

--- a/app/jobs/reports/verification_failures_report.rb
+++ b/app/jobs/reports/verification_failures_report.rb
@@ -3,7 +3,7 @@ require 'csv'
 
 module Reports
   class VerificationFailuresReport < BaseReport
-    REPORT_NAME = 'verification-errors-report'.freeze
+    REPORT_NAME = 'verification-failures-report'.freeze
 
     include GoodJob::ActiveJobExtensions::Concurrency
 

--- a/app/services/verification_failures_report.rb
+++ b/app/services/verification_failures_report.rb
@@ -1,9 +1,12 @@
-class VerificationErrorsReport
+class VerificationFailuresReport
   def self.call(service_provider, start_time, end_time)
     report_sql = <<~SQL
       SELECT 
         agency_identities.uuid,
         document_capture_submit_at,
+        back_image_submit_at,
+        capture_mobile_back_image_submit_at,
+        mobile_back_image_submit_at,
         encrypt_view_at,
         enter_info_view_at,
         ssn_view_at,

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -167,7 +167,7 @@ else
       },
       # Upload list of verification errors to S3
       verification_errors_report: {
-        class: 'Reports::VerificationErrorsReport',
+        class: 'Reports::VerificationFailuresReport',
         cron: cron_24h,
         args: -> { [Time.zone.today] },
       },

--- a/db/primary_migrate/20220517103312_add_back_image_submit_at_to_doc_auth_logs.rb
+++ b/db/primary_migrate/20220517103312_add_back_image_submit_at_to_doc_auth_logs.rb
@@ -1,0 +1,7 @@
+class AddBackImageSubmitAtToDocAuthLogs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :doc_auth_logs, :back_image_submit_at, :datetime
+    add_column :doc_auth_logs, :capture_mobile_back_image_submit_at, :datetime
+    add_column :doc_auth_logs, :mobile_back_image_submit_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_22_193820) do
+ActiveRecord::Schema.define(version: 2022_05_17_103312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -174,7 +174,9 @@ ActiveRecord::Schema.define(version: 2022_04_22_193820) do
     t.integer "verify_phone_submit_count", default: 0
     t.datetime "verify_phone_submit_at"
     t.datetime "document_capture_submit_at"
-    t.index ["issuer"], name: "index_doc_auth_logs_on_issuer"
+    t.datetime "back_image_submit_at"
+    t.datetime "capture_mobile_back_image_submit_at"
+    t.datetime "mobile_back_image_submit_at"
     t.index ["user_id"], name: "index_doc_auth_logs_on_user_id", unique: true
     t.index ["verified_view_at"], name: "index_doc_auth_logs_on_verified_view_at"
   end

--- a/spec/features/reports/doc_auth_funnel_report_spec.rb
+++ b/spec/features/reports/doc_auth_funnel_report_spec.rb
@@ -94,6 +94,9 @@ feature 'Doc Auth Funnel report' do
       'verify_phone_submit_percent' => 0.0,
       'document_capture_submit_percent' => 100.0,
       'verify_submit_percent' => 100.0,
+      'back_image_submit_percent' => 0.0,
+      'capture_mobile_back_image_submit_percent' => 0.0,
+      'mobile_back_image_submit_percent' => 0.0,
     }
   end
 


### PR DESCRIPTION
**Why**: Right now DOCUMENT_FAIL conditions are triggered when the entire image set is rejected by the back end vendor.   We are going to add to that users that at least attempted to submit a back image to make it behave more like the drop offs report.  Technically they will not be the same because the drop offs report just looks at counts and a welcome timestamp in range (so technically it's reporting the furthest the user ever got) and not the daily errors.  I'm also adding in a little buffer to allow for users that submit for the day but then restart the process either within the same session or within the buffer of 23 hours since the report currently runs every 24 hours. (ie welcome step will actually have a greater timestamp then the failed submit). Also renaming the report verification-failures-report and putting all the vendor reports in one directory.
**How**:  Add timestamps for last back image submits for mobile, desktop, hybrid.