### PR TITLE
Run integration specs for feature-flagged password confirm step

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -330,7 +330,7 @@ Rails.application.routes.draw do
     end
 
     get '/verify/v2(/:step)' => 'verify#show', as: :idv_app
-    get '/verify/v2/password_confirm/forgot_password' => 'verify#show'
+    get '/verify/v2/password_confirm/forgot_password' => 'verify#show', as: :idv_app_forgot_password
 
     namespace :api do
       post '/verify/v2/password_confirm' => 'verify/password_confirm#create'

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -36,4 +36,45 @@ feature 'forgot password step' do
 
     expect(current_path).to eq edit_user_password_path
   end
+
+  context 'with idv app feature enabled', js: true do
+    before do
+      allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+        and_return(['password_confirm', 'personal_key', 'personal_key_confirm'])
+    end
+
+    it 'goes to the forgot password page from the review page' do
+      start_idv_from_sp
+      complete_idv_steps_before_review_step
+
+      click_button t('idv.forgot_password.link_text')
+
+      expect(page.current_path).to eq(idv_app_forgot_password_path)
+    end
+
+    it 'goes back to the review page from the forgot password page' do
+      start_idv_from_sp
+      complete_idv_steps_before_review_step
+
+      click_button t('idv.forgot_password.link_text')
+      click_button t('idv.forgot_password.try_again')
+
+      expect(page.current_path).to eq(idv_app_path(step: :password_confirm))
+    end
+
+    it 'allows the user to reset their password' do
+      start_idv_from_sp
+      complete_idv_steps_before_review_step
+
+      click_button t('idv.forgot_password.link_text')
+      click_button t('idv.forgot_password.reset_password')
+
+      expect(page).to have_current_path(forgot_password_path, ignore_query: true, wait: 10)
+
+      open_last_email
+      click_email_link_matching(/reset_password_token/)
+
+      expect(current_path).to eq edit_user_password_path
+    end
+  end
 end

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -59,7 +59,7 @@ feature 'forgot password step' do
       click_button t('idv.forgot_password.link_text')
       click_button t('idv.forgot_password.try_again')
 
-      expect(page.current_path).to eq(idv_app_path(step: :password_confirm))
+      expect(page.current_path).to eq "#{idv_app_path(step: :password_confirm)}/"
     end
 
     it 'allows the user to reset their password' do

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -112,6 +112,40 @@ feature 'idv review step' do
     end
   end
 
+  context 'with idv app feature enabled', js: true do
+    before do
+      allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
+        and_return(['password_confirm', 'personal_key', 'personal_key_confirm'])
+    end
+
+    it 'redirects to personal key step after user enters their password', allow_browser_log: true do
+      start_idv_from_sp
+      complete_idv_steps_before_review_step
+
+      click_on t('idv.messages.review.intro')
+
+      expect(page).to have_content('FAKEY')
+      expect(page).to have_content('MCFAKERSON')
+      expect(page).to have_content('1 FAKE RD')
+      expect(page).to have_content('GREAT FALLS, MT 59010')
+      expect(page).to have_content('October 6, 1938')
+      expect(page).to have_content(DocAuthHelper::GOOD_SSN)
+      expect(page).to have_content('(202) 555-1212')
+
+      fill_in t('components.password_toggle.label'), with: 'this is not the right password'
+      click_idv_continue
+
+      expect(page).to have_content(t('idv.errors.incorrect_password'))
+      expect(page).to have_current_path(idv_app_path(step: :password_confirm))
+
+      fill_in t('components.password_toggle.label'), with: user_password
+      click_idv_continue
+
+      expect(page).to have_content(t('headings.personal_key'))
+      expect(page).to have_current_path(idv_app_path(step: :personal_key))
+    end
+  end
+
   context 'cancelling IdV' do
     it_behaves_like 'cancel at idv step', :review
     it_behaves_like 'cancel at idv step', :review, :oidc


### PR DESCRIPTION
**Why**: So that we can be aware of potential issues sooner than later, we should re-run existing feature specs for IdV screens on the feature-flagged implementations.

These specs caught two issues already, addressed separately in #6374 and #6381.