### PR TITLE
Lg 6219 prevent removing last non restricted mfa

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -9,6 +9,7 @@ module Users
     before_action :ensure_backup_codes_in_session, only: %i[continue download refreshed]
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
+    before_action :can_delete_backup_codes?, only: [:delete]
 
     def index; end
 
@@ -89,6 +90,11 @@ module Users
 
     def generator
       @generator ||= BackupCodeGenerator.new(current_user)
+    end
+
+    def can_delete_backup_codes?
+      return if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+      redirect_to account_two_factor_authentication_path
     end
   end
 end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -9,7 +9,7 @@ module Users
     before_action :ensure_backup_codes_in_session, only: %i[continue download refreshed]
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
-    before_action :can_delete_backup_codes?, only: [:delete]
+    before_action :authorize_backup_code_disable, only: [:delete]
 
     def index; end
 
@@ -92,7 +92,7 @@ module Users
       @generator ||= BackupCodeGenerator.new(current_user)
     end
 
-    def can_delete_backup_codes?
+    def authorize_backup_code_disable
       return if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
       redirect_to account_two_factor_authentication_path
     end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -122,7 +122,9 @@ module Users
     end
 
     def authorize_piv_cac_disable
-      return if piv_cac_enabled? && MfaPolicy.new(current_user).multiple_factors_enabled?
+      if piv_cac_enabled? && MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+        return
+      end
       redirect_to account_two_factor_authentication_path
     end
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -32,8 +32,9 @@ module Users
     end
 
     def disable
-      process_successful_disable if MfaPolicy.new(current_user).multiple_factors_enabled?
-
+      if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+        process_successful_disable
+      end
       redirect_to account_two_factor_authentication_path
     end
 

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -46,7 +46,7 @@ module Users
     end
 
     def delete
-      if MfaPolicy.new(current_user).multiple_factors_enabled?
+      if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
         handle_successful_delete
       else
         handle_failed_delete

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -97,6 +97,10 @@ class MfaContext
       personal_key_method_count
   end
 
+  def enabled_non_restricted_mfa_methods_count
+    enabled_mfa_methods_count - phone_configurations.to_a.count(&:mfa_enabled?)
+  end
+
   # returns a hash showing the count for each enabled 2FA configuration,
   # such as: { phone: 2, webauthn: 1 }. This is useful for analytics purposes.
   def enabled_two_factor_configuration_counts_hash

--- a/app/policies/mfa_policy.rb
+++ b/app/policies/mfa_policy.rb
@@ -17,6 +17,12 @@ class MfaPolicy
     mfa_user.enabled_mfa_methods_count > 1
   end
 
+  def multiple_non_restricted_factors_enabled?
+    IdentityConfig.store.select_multiple_mfa_options ?
+      mfa_user.enabled_non_restricted_mfa_methods_count > 1 :
+      multiple_factors_enabled?
+  end
+
   def unphishable?
     mfa_user.phishable_configuration_count.zero? &&
       mfa_user.unphishable_configuration_count.positive?

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -9,9 +9,11 @@
           <%= auth_app_configuration.name %>
         </div>
       </div>
-      <div class="grid-col-4 text-right">
-        <%= render 'accounts/actions/disable_totp', id: auth_app_configuration.id %>
-      </div>
+      <% if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled? %>
+        <div class="grid-col-4 text-right">
+          <%= render 'accounts/actions/disable_totp', id: auth_app_configuration.id %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/_backup_codes.html.erb
+++ b/app/views/accounts/_backup_codes.html.erb
@@ -8,7 +8,7 @@
       <%= render TimeComponent.new(time: @presenter.backup_codes_generated_at) %>
     </div>
     <div class="grid-col-3 text-right">
-      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+      <% if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled? %>
         <%= link_to t('forms.buttons.delete'), backup_code_delete_path %>
       <% end %>
     </div>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -10,9 +10,11 @@
           <%= piv_cac_configuration.name %>
         </div>
       </div>
-      <div class="grid-col-4 text-right">
-        <%= render 'accounts/actions/disable_piv_cac', id: piv_cac_configuration.id %>
-      </div>
+      <% if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled? %>
+        <div class="grid-col-4 text-right">
+          <%= render 'accounts/actions/disable_piv_cac', id: piv_cac_configuration.id %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -8,7 +8,7 @@
       <div class="grid-col-8 tablet:grid-col-6 truncate">
         <%= cfg.name %>
       </div>
-      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+      <% if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled? %>
         <div class="grid-col-4 tablet:grid-col-6 text-right">
           <%= link_to(
                 t('account.index.webauthn_platform_delete'),

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -8,7 +8,7 @@
       <div class="grid-col-8 tablet:grid-col-6 truncate">
         <%= cfg.name %>
       </div>
-      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+      <% if MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled? %>
         <div class="grid-col-4 tablet:grid-col-6 text-right">
           <%= link_to(
                 t('account.index.webauthn_delete'),

--- a/app/views/users/edit_phone/_remove_phone.html.erb
+++ b/app/views/users/edit_phone/_remove_phone.html.erb
@@ -1,4 +1,4 @@
-<% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
+<% if MfaPolicy.new(current_user).multiple_factors_enabled? || IdentityConfig.store.select_multiple_mfa_options %>
   <%= button_to t('forms.phone.buttons.delete'), manage_phone_path(id: @phone_configuration.id),
                 class: 'usa-button usa-button--big usa-button--danger usa-button--wide margin-top-2',
                 method: :delete %>

--- a/app/views/users/edit_phone/_remove_phone.html.erb
+++ b/app/views/users/edit_phone/_remove_phone.html.erb
@@ -1,4 +1,4 @@
-<% if MfaPolicy.new(current_user).multiple_factors_enabled? || IdentityConfig.store.select_multiple_mfa_options %>
+<% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
   <%= button_to t('forms.phone.buttons.delete'), manage_phone_path(id: @phone_configuration.id),
                 class: 'usa-button usa-button--big usa-button--danger usa-button--wide margin-top-2',
                 method: :delete %>

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -24,14 +24,24 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'deletes backup codes' do
-    user = build(:user, :signed_up, :with_authentication_app)
+    user = build(:user, :signed_up, :with_authentication_app, :with_backup_code)
     stub_sign_in(user)
-    expect(PushNotification::HttpPush).to receive(:deliver).
-      with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
+    expect(user.backup_code_configurations.length).to eq 10
+
     post :delete
 
     expect(response).to redirect_to(account_two_factor_authentication_path)
     expect(user.backup_code_configurations.length).to eq 0
+  end
+
+  it 'does not deletes backup codes if they are the only mfa' do
+    user = build(:user, :with_backup_code)
+    stub_sign_in(user)
+
+    post :delete
+
+    expect(response).to redirect_to(account_two_factor_authentication_path)
+    expect(user.backup_code_configurations.length).to eq 10
   end
 
   context 'with multiple MFA selection on' do

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -24,7 +24,7 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'deletes backup codes' do
-    user = build(:user, :signed_up)
+    user = build(:user, :signed_up, :with_authentication_app)
     stub_sign_in(user)
     expect(PushNotification::HttpPush).to receive(:deliver).
       with(PushNotification::RecoveryInformationChangedEvent.new(user: user))

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -294,12 +294,113 @@ describe MfaContext do
     end
 
     context 'with a phone and a personal key and personal key retired' do
-      it 'returns 1' do
+      it 'returns 0' do
         allow(IdentityConfig.store).to receive(:personal_key_retired).and_return(true)
         user = create(:user, :with_phone, :with_personal_key)
         subject = described_class.new(user.reload)
 
-        expect(subject.enabled_mfa_methods_count).to eq(1)
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(0)
+      end
+    end
+  end
+
+  describe '#enabled_non_restricted_mfa_methods_count' do
+    context 'with 2 phones' do
+      it 'returns 0' do
+        user = create(:user, :with_phone)
+        create(:phone_configuration, user: user, phone: '+1 703-555-1213')
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(0)
+      end
+    end
+
+    context 'with 2 webauthn tokens' do
+      it 'returns 2' do
+        user = create(:user)
+        create_list(:webauthn_configuration, 2, user: user)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(2)
+      end
+    end
+
+    context 'with 1 webauthn roaming authenticator and one platform authenticator' do
+      it 'returns 2' do
+        user = create(:user)
+        create(:webauthn_configuration, user: user)
+        create(:webauthn_configuration, platform_authenticator: true, user: user)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(2)
+      end
+    end
+
+    context 'with a phone and a webauthn token' do
+      it 'returns 1' do
+        user = create(:user, :with_phone)
+        create(:webauthn_configuration, user: user)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(1)
+      end
+    end
+
+    context 'with a phone and 10 backup codes' do
+      it 'returns 1' do
+        user = create(:user, :with_phone)
+        create_list(:backup_code_configuration, 10, user: user)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(1)
+      end
+    end
+
+    context 'with a phone and 10 used backup codes' do
+      it 'returns 0' do
+        user = create(:user, :with_phone)
+        create_list(:backup_code_configuration, 10, user: user, used_at: 1.day.ago)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(0)
+      end
+    end
+
+    context 'with a phone and a PIV/CAC' do
+      it 'returns 1' do
+        user = create(:user, :with_phone, :with_piv_or_cac)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(1)
+      end
+    end
+
+    context 'with a phone and an auth app' do
+      it 'returns 1' do
+        user = create(:user, :with_phone, :with_authentication_app)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(1)
+      end
+    end
+
+    context 'with a phone and a personal key' do
+      it 'returns 1' do
+         allow(IdentityConfig.store).to receive(:personal_key_retired).and_return(false)
+         user = create(:user, :with_phone, :with_personal_key)
+         subject = described_class.new(user.reload)
+
+         expect(subject.enabled_non_restricted_mfa_methods_count).to eq(1)
+      end
+    end
+
+    context 'with a phone and a personal key and personal key retired' do
+      it 'returns 0' do
+        allow(IdentityConfig.store).to receive(:personal_key_retired).and_return(true)
+        user = create(:user, :with_phone, :with_personal_key)
+        subject = described_class.new(user.reload)
+
+        expect(subject.enabled_non_restricted_mfa_methods_count).to eq(0)
       end
     end
   end

--- a/spec/policies/user_mfa_policy_spec.rb
+++ b/spec/policies/user_mfa_policy_spec.rb
@@ -37,4 +37,28 @@ describe MfaPolicy do
       it { expect(subject.unphishable?).to eq false }
     end
   end
+
+  describe '#multiple_non_restricted_factors_enabled?' do
+    context 'with multi mfa disabled returns true ' do
+      before do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return false
+      end
+
+      let(:user) { create(:user, :with_phone, :with_piv_or_cac) }
+
+      it { expect(subject.multiple_non_restricted_factors_enabled?).to eq true }
+    end
+  end
+
+  describe '#multiple_non_restricted_factors_enabled?' do
+    context 'with multi mfa enabled returns false ' do
+      before do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
+      end
+
+      let(:user) { create(:user, :with_phone, :with_piv_or_cac) }
+
+      it { expect(subject.multiple_non_restricted_factors_enabled?).to eq false }
+    end
+  end
 end

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -77,4 +77,25 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
       )
     end
   end
+
+  context 'when multiple mfa is enabled' do
+    let(:user) { create(:user, :with_phone, :with_authentication_app) }
+    before do
+      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
+      assign(
+        :presenter,
+        AccountShowPresenter.new(
+          decrypted_pii: nil, personal_key: nil, decorated_user: decorated_user,
+          sp_session_request_url: nil, sp_name: nil,
+          locked_for_session: false
+        ),
+      )
+    end
+
+    it 'disables delete buttons for the last non restricted mfa method with phone configured' do
+      render
+
+      expect(rendered).to_not have_link(t('forms.buttons.disable', href: auth_app_delete_path))
+    end
+  end
 end

--- a/spec/views/users/edit_phone/remove_phone.html.erb_spec.rb
+++ b/spec/views/users/edit_phone/remove_phone.html.erb_spec.rb
@@ -4,25 +4,40 @@ describe 'users/edit_phone/_remove_phone.html.erb' do
   include Devise::Test::ControllerHelpers
 
   let(:user) { create(:user, :with_phone) }
-  let(:phone_configuration) { create(:phone_configuration, user: user, phone: '+1 703-555-1214') }
 
-  context 'with multi mfa disabled' do
+  context 'when there are only 2 phone configurations' do
+    let(:phone_configuration) { create(:phone_configuration, user: user, phone: '+1 703-555-1214') }
     before do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return false
+      allow(view).to receive(:current_user).and_return(user)
       assign(:phone_configuration, phone_configuration)
     end
 
-    it 'does not render a delete phone button' do
+    it 'renders a delete phone button' do
+      render
+
+      expect(rendered).to have_button('Remove phone')
+    end
+  end
+
+  context 'when there is only 1 phone configuration' do
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+      assign(:phone_configuration, user.phone_configurations.first)
+    end
+
+    it 'renders a delete phone button' do
       render
 
       expect(rendered).to eq('')
     end
   end
 
-  context 'with multi mfa enabled' do
+  context 'when there is 1 phone configuration and 1 other configuration' do
+    let(:user) { create(:user, :with_phone, :with_authentication_app) }
+
     before do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
-      assign(:phone_configuration, phone_configuration)
+      allow(view).to receive(:current_user).and_return(user)
+      assign(:phone_configuration, user.phone_configurations.first)
     end
 
     it 'renders a delete phone button' do

--- a/spec/views/users/edit_phone/remove_phone.html.erb_spec.rb
+++ b/spec/views/users/edit_phone/remove_phone.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'users/edit_phone/_remove_phone.html.erb' do
+  include Devise::Test::ControllerHelpers
+
+  let(:user) { create(:user, :with_phone) }
+  let(:phone_configuration) { create(:phone_configuration, user: user, phone: '+1 703-555-1214') }
+
+  context 'with multi mfa disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return false
+      assign(:phone_configuration, phone_configuration)
+    end
+
+    it 'does not render a delete phone button' do
+      render
+
+      expect(rendered).to eq('')
+    end
+  end
+
+  context 'with multi mfa enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
+      assign(:phone_configuration, phone_configuration)
+    end
+
+    it 'renders a delete phone button' do
+      render
+
+      expect(rendered).to have_button('Remove phone')
+    end
+  end
+end


### PR DESCRIPTION
## Why
When the multi-mfa-selection feature is turned on we will want to prevent a user's ability to remove their last unrestricted mfa method.

## How
We currently do not display the option to remove an mfa method if it is their last one. I added a method that checks the multi-mfa feature flag, and if it is set to true, does not include phone configurations when determining how many mfa methods they have configured.