### PR TITLE
Ensure correct encryption key is used for new session format

### DIFF
--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe SessionEncryptor do
 
         ciphertext = subject.dump(session)
 
-        partially_decrypted = subject.outer_encryptor.decrypt(ciphertext.split(':').last)
+        partially_decrypted = subject.outer_decrypt(ciphertext.split(':').last)
         partially_decrypted_json = JSON.parse(partially_decrypted)
 
         expect(partially_decrypted_json.fetch('warden.user.user.session')['idv']).to eq nil


### PR DESCRIPTION
Previously, we were referencing the attribute encryptor, which uses the `attribute_encryption_key`, but we should not use that for session encryption!

This does not affect production as this encryption format is not enabled yet