### PR TITLE
LG-6202: Collapse excess line break for single-line address

### DIFF
--- a/app/javascript/packages/verify-flow/steps/password-confirm/personal-info-summary.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/personal-info-summary.spec.tsx
@@ -18,4 +18,18 @@ describe('PersonalInfoSummary', () => {
 
     expect(getByText('October 6, 1938')).to.exist();
   });
+
+  it('renders address', () => {
+    const { getByText, rerender } = render(<PersonalInfoSummary pii={DEFAULT_PII} />);
+
+    let address = getByText('1 FAKE RDGREAT FALLS, MT 59010');
+
+    expect([...address.childNodes].filter((node) => node.nodeName === 'BR')).to.have.lengthOf(1);
+
+    rerender(<PersonalInfoSummary pii={{ ...DEFAULT_PII, address2: 'PO BOX 1' }} />);
+
+    address = getByText('1 FAKE RDPO BOX 1GREAT FALLS, MT 59010');
+
+    expect([...address.childNodes].filter((node) => node.nodeName === 'BR')).to.have.lengthOf(2);
+  });
 });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/personal-info-summary.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/personal-info-summary.tsx
@@ -28,9 +28,14 @@ function PersonalInfoSummary({ pii }: PersonalInfoSummaryProps) {
       </div>
       <div className="margin-top-4 h6">{t('idv.review.mailing_address')}</div>
       <div className="h4 text-bold ico-absolute ico-absolute-success">
-        {address1} <br />
-        {address2 || ''}
+        {address1}
         <br />
+        {address2 && (
+          <>
+            {address2}
+            <br />
+          </>
+        )}
         {city && state ? `${city}, ${state} ${zipcode}` : ''}
       </div>
       {dob && (


### PR DESCRIPTION
**Why**: To match the existing screen.

Before|After
---|---
![localhost_3000_verify_v2_password_confirm (1)](https://user-images.githubusercontent.com/1779930/169387354-8b9909ec-cc68-45d7-a60d-60b5d170dfd0.png)|![localhost_3000_verify_v2_password_confirm](https://user-images.githubusercontent.com/1779930/169387360-131c57b9-eb86-48ca-b03d-e30476b053bc.png)

