### PR TITLE
Revise password confirmation "Forgot Password" as link

### DIFF
--- a/app/javascript/packages/components/index.ts
+++ b/app/javascript/packages/components/index.ts
@@ -13,4 +13,5 @@ export { default as TroubleshootingOptions } from './troubleshooting-options';
 
 export type { ButtonProps } from './button';
 export type { FullScreenRefHandle } from './full-screen';
+export type { LinkProps } from './link';
 export type { TextInputProps } from './text-input';

--- a/app/javascript/packages/components/link.spec.tsx
+++ b/app/javascript/packages/components/link.spec.tsx
@@ -38,6 +38,14 @@ describe('Link', () => {
     expect([...link.classList.values()]).to.have.all.members(['usa-link']);
   });
 
+  it('forwards extra props to underlying anchor element', () => {
+    const { getByRole } = render(<Link data-foo="bar" href="/" />);
+
+    const link = getByRole('link');
+
+    expect(link.getAttribute('data-foo')).to.equal('bar');
+  });
+
   context('with custom css class', () => {
     it('renders link with class', () => {
       const { getByRole } = render(<Link href="/" className="my-custom-class" />);

--- a/app/javascript/packages/components/link.tsx
+++ b/app/javascript/packages/components/link.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode, AnchorHTMLAttributes } from 'react';
 import { t } from '@18f/identity-i18n';
 
-export interface LinkProps {
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
    * Link destination.
    */
@@ -42,6 +42,7 @@ function Link({
   isNewTab = isExternal,
   className,
   children,
+  ...anchorProps
 }: LinkProps) {
   const classes = ['usa-link', className, isExternal && 'usa-link--external']
     .filter(Boolean)
@@ -53,7 +54,7 @@ function Link({
   }
 
   return (
-    <a href={href} {...newTabProps} className={classes}>
+    <a href={href} {...newTabProps} {...anchorProps} className={classes}>
       {children}
       {isNewTab && <span className="usa-sr-only"> {t('links.new_window')}</span>}
     </a>

--- a/app/javascript/packages/form-steps/history-link.spec.tsx
+++ b/app/javascript/packages/form-steps/history-link.spec.tsx
@@ -1,0 +1,77 @@
+import { render, fireEvent, createEvent } from '@testing-library/react';
+import HistoryLink from './history-link';
+
+describe('HistoryLink', () => {
+  it('renders a link to the intended step', () => {
+    const { getByRole } = render(<HistoryLink basePath="/base" step="step" />);
+
+    const link = getByRole('link');
+
+    expect(link.getAttribute('href')).to.equal('/base/step');
+  });
+
+  it('renders a visual button to the intended step', () => {
+    const { getByRole } = render(<HistoryLink basePath="/base" step="step" isVisualButton isBig />);
+
+    const link = getByRole('link');
+
+    expect(link.getAttribute('href')).to.equal('/base/step');
+    expect(link.classList.contains('usa-button')).to.be.true();
+    expect(link.classList.contains('usa-button--big')).to.be.true();
+  });
+
+  it('intercepts navigation to route using client-side routing', () => {
+    const { getByRole } = render(<HistoryLink step="step" />);
+
+    const beforeHash = window.location.hash;
+    const link = getByRole('link');
+
+    const didPreventDefault = !fireEvent.click(link);
+
+    expect(didPreventDefault).to.be.true();
+    expect(window.location.hash).to.not.equal(beforeHash);
+    expect(window.location.hash).to.equal('#step');
+  });
+
+  it('does not intercept navigation when holding modifier key', () => {
+    const { getByRole } = render(<HistoryLink step="step" />);
+
+    const beforeHash = window.location.hash;
+    const link = getByRole('link');
+
+    for (const mod of ['metaKey', 'shiftKey', 'ctrlKey', 'altKey']) {
+      const didPreventDefault = !fireEvent.click(link, { [mod]: true });
+
+      expect(didPreventDefault).to.be.false();
+      expect(window.location.hash).to.equal(beforeHash);
+    }
+  });
+
+  it('does not intercept navigation when clicking with other than main button', () => {
+    const { getByRole } = render(<HistoryLink step="step" />);
+
+    const beforeHash = window.location.hash;
+    const link = getByRole('link');
+
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value
+    for (const button of [1, 2, 3, 4]) {
+      const didPreventDefault = !fireEvent.click(link, { button });
+
+      expect(didPreventDefault).to.be.false();
+      expect(window.location.hash).to.equal(beforeHash);
+    }
+  });
+
+  it('does not intercept navigation if event was already default-prevented', () => {
+    const { getByRole } = render(<HistoryLink step="step" />);
+
+    const beforeHash = window.location.hash;
+    const link = getByRole('link');
+    const event = createEvent('click', link);
+    event.preventDefault();
+
+    fireEvent(link, event);
+
+    expect(window.location.hash).to.equal(beforeHash);
+  });
+});

--- a/app/javascript/packages/form-steps/history-link.tsx
+++ b/app/javascript/packages/form-steps/history-link.tsx
@@ -5,7 +5,7 @@ import type { LinkProps } from '@18f/identity-components';
 import useHistoryParam, { getParamURL } from './use-history-param';
 import type { ParamValue } from './use-history-param';
 
-type HistoryLinkProps = Partial<LinkProps> & {
+type HistoryLinkProps = Partial<Exclude<LinkProps, 'href'>> & {
   basePath?: string;
 
   step: ParamValue;

--- a/app/javascript/packages/form-steps/history-link.tsx
+++ b/app/javascript/packages/form-steps/history-link.tsx
@@ -1,30 +1,40 @@
 import { useCallback } from 'react';
 import type { MouseEventHandler } from 'react';
-import { Link } from '@18f/identity-components';
-import type { LinkProps } from '@18f/identity-components';
+import { Link, Button } from '@18f/identity-components';
+import type { LinkProps, ButtonProps } from '@18f/identity-components';
 import useHistoryParam, { getParamURL } from './use-history-param';
 import type { ParamValue } from './use-history-param';
 
-type HistoryLinkProps = Partial<Exclude<LinkProps, 'href'>> & {
+type HistoryLinkProps = (Partial<Exclude<LinkProps, 'href'>> | Partial<ButtonProps>) & {
+  /**
+   * When using path fragments for maintaining history, the base path to which the current step name
+   * is appended.
+   */
   basePath?: string;
 
+  /**
+   * The step to which the link should navigate.
+   */
   step: ParamValue;
+
+  /**
+   * Whether to render the link with the appearance of a button.
+   */
+  isVisualButton?: boolean;
 };
 
 /**
- * Renders a link to the given step. Enhances a Link to perform client-side routing using
+ * Renders a link to the given step. Enhances a Link or Button to perform client-side routing using
  * useHistoryParam hook.
  *
  * @param props Props object.
  *
  * @return Link element.
  */
-function HistoryLink({ basePath, step, ...linkProps }: HistoryLinkProps) {
+function HistoryLink({ basePath, step, isVisualButton = false, ...extraProps }: HistoryLinkProps) {
   const [, setPath] = useHistoryParam(undefined, { basePath });
-  const handleClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(
+  const handleClick = useCallback<MouseEventHandler<Element>>(
     (event) => {
-      linkProps.onClick?.(event);
-
       if (
         !event.defaultPrevented &&
         !event.metaKey &&
@@ -40,7 +50,13 @@ function HistoryLink({ basePath, step, ...linkProps }: HistoryLinkProps) {
     [basePath],
   );
 
-  return <Link {...linkProps} href={getParamURL(step, { basePath })} onClick={handleClick} />;
+  const href = getParamURL(step, { basePath });
+
+  if (isVisualButton) {
+    return <Button {...(extraProps as Partial<ButtonProps>)} href={href} onClick={handleClick} />;
+  }
+
+  return <Link {...(extraProps as Partial<LinkProps>)} href={href} onClick={handleClick} />;
 }
 
 export default HistoryLink;

--- a/app/javascript/packages/form-steps/history-link.tsx
+++ b/app/javascript/packages/form-steps/history-link.tsx
@@ -10,6 +10,14 @@ type HistoryLinkProps = Partial<LinkProps> & {
   step: string;
 };
 
+/**
+ * Renders a link to the given step. Enhances a Link to perform client-side routing using
+ * useHistoryParam hook.
+ *
+ * @param props Props object.
+ *
+ * @return Link element.
+ */
 function HistoryLink({ basePath, step, ...linkProps }: HistoryLinkProps) {
   const [, setPath] = useHistoryParam(undefined, { basePath });
   const handleClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(

--- a/app/javascript/packages/form-steps/history-link.tsx
+++ b/app/javascript/packages/form-steps/history-link.tsx
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import type { MouseEventHandler } from 'react';
+import { Link } from '@18f/identity-components';
+import type { LinkProps } from '@18f/identity-components';
+import useHistoryParam, { getParamURL } from './use-history-param';
+
+type HistoryLinkProps = Partial<LinkProps> & {
+  basePath?: string;
+
+  step: string;
+};
+
+function HistoryLink({ basePath, step, ...linkProps }: HistoryLinkProps) {
+  const [, setPath] = useHistoryParam(undefined, { basePath });
+  const handleClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(
+    (event) => {
+      linkProps.onClick?.(event);
+
+      if (
+        !event.defaultPrevented &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        event.button === 0
+      ) {
+        event.preventDefault();
+        setPath(step);
+      }
+    },
+    [basePath],
+  );
+
+  return <Link {...linkProps} href={getParamURL(step, { basePath })} onClick={handleClick} />;
+}
+
+export default HistoryLink;

--- a/app/javascript/packages/form-steps/history-link.tsx
+++ b/app/javascript/packages/form-steps/history-link.tsx
@@ -3,11 +3,12 @@ import type { MouseEventHandler } from 'react';
 import { Link } from '@18f/identity-components';
 import type { LinkProps } from '@18f/identity-components';
 import useHistoryParam, { getParamURL } from './use-history-param';
+import type { ParamValue } from './use-history-param';
 
 type HistoryLinkProps = Partial<LinkProps> & {
   basePath?: string;
 
-  step: string;
+  step: ParamValue;
 };
 
 /**

--- a/app/javascript/packages/form-steps/index.ts
+++ b/app/javascript/packages/form-steps/index.ts
@@ -3,8 +3,9 @@ export { default as FormError } from './form-error';
 export { default as RequiredValueMissingError } from './required-value-missing-error';
 export { default as FormStepsContext } from './form-steps-context';
 export { default as FormStepsButton } from './form-steps-button';
+export { default as HistoryLink } from './history-link';
 export { default as PromptOnNavigate } from './prompt-on-navigate';
-export { default as useHistoryParam, getStepParam } from './use-history-param';
+export { default as useHistoryParam, getStepParam, getParamURL } from './use-history-param';
 
 export type {
   FormStepError,

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import { useDefineProperty } from '@18f/identity-test-helpers';
 import useHistoryParam, { getStepParam } from './use-history-param';
@@ -138,10 +139,23 @@ describe('useHistoryParam', () => {
     const { getByDisplayValue } = render(<TestComponent />);
 
     const input = getByDisplayValue('0');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'one hundred');
+    await userEvent.type(input, ' 1');
 
-    expect(window.location.hash).to.equal('#one%20hundred');
+    expect(window.location.hash).to.equal('#0%201');
+  });
+
+  it('syncs across instances', () => {
+    const inst1 = renderHook(() => useHistoryParam());
+    const inst2 = renderHook(() => useHistoryParam());
+    const inst3 = renderHook(() => useHistoryParam(undefined, { basePath: '/base' }));
+
+    const [, setPath1] = inst1.result.current;
+    setPath1('root');
+
+    const [path2] = inst2.result.current;
+    const [path3] = inst3.result.current;
+    expect(path2).to.equal('root');
+    expect(path3).to.be.undefined();
   });
 
   Object.entries({

--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 
-type ParamValue = string | undefined;
+export type ParamValue = string | undefined;
 
 interface HistoryOptions {
   basePath?: string;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
@@ -1,13 +1,14 @@
-import { PageHeading, Button } from '@18f/identity-components';
+import { PageHeading } from '@18f/identity-components';
 import { t } from '@18f/identity-i18n';
 import { getAssetPath } from '@18f/identity-assets';
+import { HistoryLink } from '@18f/identity-form-steps';
 import PasswordResetButton from './password-reset-button';
 
 interface ForgotPasswordProps {
-  goBack: () => void;
+  stepPath: string;
 }
 
-export function ForgotPassword({ goBack }: ForgotPasswordProps) {
+export function ForgotPassword({ stepPath }: ForgotPasswordProps) {
   return (
     <>
       <img
@@ -24,9 +25,9 @@ export function ForgotPassword({ goBack }: ForgotPasswordProps) {
         ))}
       </ul>
       <div className="margin-top-4">
-        <Button isBig isWide onClick={goBack}>
+        <HistoryLink basePath={stepPath} step={undefined} isVisualButton isBig isWide>
           {t('idv.forgot_password.try_again')}
-        </Button>
+        </HistoryLink>
       </div>
       <div className="margin-top-2">
         <PasswordResetButton />

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -64,7 +64,7 @@ describe('PasswordConfirmStep', () => {
     it('navigates to forgot password subpage', async () => {
       const { getByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
 
-      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.link_text' }));
+      await userEvent.click(getByRole('link', { name: 'idv.forgot_password.link_text' }));
 
       expect(window.location.pathname).to.equal('/password_confirm/forgot_password');
     });
@@ -72,10 +72,10 @@ describe('PasswordConfirmStep', () => {
     it('navigates back from forgot password subpage', async () => {
       const { getByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
 
-      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.link_text' }));
+      await userEvent.click(getByRole('link', { name: 'idv.forgot_password.link_text' }));
       await userEvent.click(getByRole('button', { name: 'idv.forgot_password.try_again' }));
 
-      expect(window.location.pathname).to.equal('/password_confirm/');
+      expect(window.location.pathname).to.equal('/password_confirm');
     });
   });
 

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -73,7 +73,7 @@ describe('PasswordConfirmStep', () => {
       const { getByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
 
       await userEvent.click(getByRole('link', { name: 'idv.forgot_password.link_text' }));
-      await userEvent.click(getByRole('button', { name: 'idv.forgot_password.try_again' }));
+      await userEvent.click(getByRole('link', { name: 'idv.forgot_password.try_again' }));
 
       expect(window.location.pathname).to.equal('/password_confirm');
     });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -27,11 +27,11 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
   const { basePath } = useContext(FlowContext);
   const { onPageTransition } = useContext(FormStepsContext);
   const stepPath = `${basePath}/password_confirm`;
-  const [path, setPath] = useHistoryParam(undefined, { basePath: stepPath });
+  const [path] = useHistoryParam(undefined, { basePath: stepPath });
   useDidUpdateEffect(onPageTransition, [path]);
 
   if (path === FORGOT_PASSWORD_PATH) {
-    return <ForgotPassword goBack={() => setPath(undefined)} />;
+    return <ForgotPassword stepPath={stepPath} />;
   }
 
   const appName = getConfigValue('appName');

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -1,11 +1,16 @@
 import { useContext } from 'react';
 import { useDidUpdateEffect } from '@18f/identity-react-hooks';
 import { t } from '@18f/identity-i18n';
-import { FormStepsButton, useHistoryParam, FormStepsContext } from '@18f/identity-form-steps';
+import {
+  FormStepsButton,
+  useHistoryParam,
+  FormStepsContext,
+  HistoryLink,
+} from '@18f/identity-form-steps';
 import { PasswordToggle } from '@18f/identity-password-toggle';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { formatHTML } from '@18f/identity-react-i18n';
-import { PageHeading, Accordion, Alert, Button, Link } from '@18f/identity-components';
+import { PageHeading, Accordion, Alert, Link } from '@18f/identity-components';
 import { getConfigValue } from '@18f/identity-config';
 import type { ChangeEvent } from 'react';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
@@ -16,6 +21,8 @@ import type { VerifyFlowValues } from '../..';
 
 interface PasswordConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
+const FORGOT_PASSWORD_PATH = 'forgot_password';
+
 function PasswordConfirmStep({ errors, registerField, onChange, value }: PasswordConfirmStepProps) {
   const { basePath } = useContext(FlowContext);
   const { onPageTransition } = useContext(FormStepsContext);
@@ -23,16 +30,8 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
   const [path, setPath] = useHistoryParam(undefined, { basePath: stepPath });
   useDidUpdateEffect(onPageTransition, [path]);
 
-  function goToForgotPassword() {
-    setPath('forgot_password');
-  }
-
-  function goBack() {
-    setPath(undefined);
-  }
-
-  if (path === 'forgot_password') {
-    return <ForgotPassword goBack={goBack} />;
+  if (path === FORGOT_PASSWORD_PATH) {
+    return <ForgotPassword goBack={() => setPath(undefined)} />;
   }
 
   const appName = getConfigValue('appName');
@@ -76,9 +75,9 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
           }),
           {
             button: ({ children }) => (
-              <Button isUnstyled onClick={() => goToForgotPassword()}>
+              <HistoryLink basePath={stepPath} step={FORGOT_PASSWORD_PATH}>
                 {children}
-              </Button>
+              </HistoryLink>
             ),
           },
         )}

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -47,7 +47,7 @@ feature 'forgot password step' do
       start_idv_from_sp
       complete_idv_steps_before_review_step
 
-      click_button t('idv.forgot_password.link_text')
+      click_link t('idv.forgot_password.link_text')
 
       expect(page.current_path).to eq(idv_app_forgot_password_path)
     end
@@ -56,8 +56,8 @@ feature 'forgot password step' do
       start_idv_from_sp
       complete_idv_steps_before_review_step
 
-      click_button t('idv.forgot_password.link_text')
-      click_button t('idv.forgot_password.try_again')
+      click_link t('idv.forgot_password.link_text')
+      click_link t('idv.forgot_password.try_again')
 
       expect(page.current_path).to eq idv_app_path(step: :password_confirm)
     end
@@ -66,7 +66,7 @@ feature 'forgot password step' do
       start_idv_from_sp
       complete_idv_steps_before_review_step
 
-      click_button t('idv.forgot_password.link_text')
+      click_link t('idv.forgot_password.link_text')
       click_button t('idv.forgot_password.reset_password')
 
       expect(page).to have_current_path(forgot_password_path, ignore_query: true, wait: 10)

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -59,7 +59,7 @@ feature 'forgot password step' do
       click_button t('idv.forgot_password.link_text')
       click_button t('idv.forgot_password.try_again')
 
-      expect(page.current_path).to eq "#{idv_app_path(step: :password_confirm)}/"
+      expect(page.current_path).to eq idv_app_path(step: :password_confirm)
     end
 
     it 'allows the user to reset their password' do


### PR DESCRIPTION
**Why**: Because it looks and behaves like a link, it should carry semantics of a link, supporting native behavior such as opening in a new tab.