### PR TITLE
Look up emails by previous key fingerprints

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -47,9 +47,9 @@ class EmailAddress < ApplicationRecord
       return nil if email.to_s.empty?
 
       email = email.downcase.strip
-      email_fingerprint = create_fingerprint(email)
+      email_fingerprints = create_fingerprints(email)
       # rubocop:disable Rails/SkipsModelValidations
-      EmailAddress.where(user_id: user_id, email_fingerprint: email_fingerprint).update_all(
+      EmailAddress.where(user_id: user_id, email_fingerprint: email_fingerprints).update_all(
         last_sign_in_at: Time.zone.now,
         updated_at: Time.zone.now,
       )

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -34,8 +34,8 @@ class EmailAddress < ApplicationRecord
       return nil if !email.is_a?(String) || email.empty?
 
       email = email.downcase.strip
-      email_fingerprint = create_fingerprint(email)
-      find_by(email_fingerprint: email_fingerprint)
+      email_fingerprints = create_fingerprints(email)
+      find_by(email_fingerprint: email_fingerprints)
     end
 
     def find_with_confirmation_token(token)
@@ -58,8 +58,8 @@ class EmailAddress < ApplicationRecord
 
     private
 
-    def create_fingerprint(email)
-      Pii::Fingerprinter.fingerprint(email)
+    def create_fingerprints(email)
+      [Pii::Fingerprinter.fingerprint(email), *Pii::Fingerprinter.previous_fingerprints(email)]
     end
   end
 end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -33,6 +33,22 @@ describe EmailAddress do
         expect(EmailAddress.find_with_email(email)).to be
       end
     end
+
+    describe '.update_last_sign_in_at_on_user_id_and_email' do
+      let(:user) { create(:user) }
+      it 'updates attributes and can look up by previous fingerprints' do
+        record = create(
+          :email_address,
+          email: email,
+          user_id: user.id,
+          email_fingerprint: Pii::Fingerprinter.previous_fingerprints(email).first,
+        )
+
+        expect do
+          EmailAddress.update_last_sign_in_at_on_user_id_and_email(user_id: user.id, email: email)
+        end.to(change { record.reload.last_sign_in_at })
+      end
+    end
   end
 
   describe 'creation' do


### PR DESCRIPTION
(discovered during our wargames exercise today)

**Why**: To ensure smoother key rotations

changelog: Bug Fixes, Attribute encryption, Update behavior for rotated keys for email