### PR TITLE
Add per-issuer unique user columns to combined invoice report (LG-6333)

### DIFF
--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -79,6 +79,10 @@ module Reports
           'issuer_ial1_total_auth_count',
           'issuer_ial2_total_auth_count',
           'issuer_ial1_plus_2_total_auth_count',
+
+          'issuer_ial1_unique_users',
+          'issuer_ial2_unique_users',
+          'issuer_ial1_plus_2_unique_users',
           'issuer_ial2_new_unique_users',
         ]
 
@@ -106,14 +110,18 @@ module Reports
                 year_month,
                 year_month_start.strftime('%B %Y'),
 
-                (ial1_unique_users = extract(iaa_results, :unique_users, ial: 1)),
-                (ial2_unique_users = extract(iaa_results, :unique_users, ial: 2)),
-                ial1_unique_users + ial2_unique_users,
+                (iaa_ial1_unique_users = extract(iaa_results, :unique_users, ial: 1)),
+                (iaa_ial2_unique_users = extract(iaa_results, :unique_users, ial: 2)),
+                iaa_ial1_unique_users + iaa_ial2_unique_users,
                 extract(iaa_results, :new_unique_users, ial: 2),
 
                 (ial1_total_auth_count = extract(issuer_results, :total_auth_count, ial: 1)),
                 (ial2_total_auth_count = extract(issuer_results, :total_auth_count, ial: 2)),
                 ial1_total_auth_count + ial2_total_auth_count,
+
+                (issuer_ial1_unique_users = extract(issuer_results, :unique_users, ial: 1)),
+                (issuer_ial2_unique_users = extract(issuer_results, :unique_users, ial: 2)),
+                issuer_ial1_unique_users + issuer_ial2_unique_users,
                 extract(issuer_results, :new_unique_users, ial: 2),
               ]
             end

--- a/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
@@ -155,6 +155,10 @@ RSpec.describe Reports::CombinedInvoiceSupplementReport do
           expect(row['issuer_ial1_total_auth_count'].to_i).to eq(1)
           expect(row['issuer_ial2_total_auth_count'].to_i).to eq(0)
           expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(1)
+
+          expect(row['issuer_ial1_unique_users'].to_i).to eq(1)
+          expect(row['issuer_ial2_unique_users'].to_i).to eq(0)
+          expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(1)
           expect(row['issuer_ial2_new_unique_users'].to_i).to eq(0)
         end
 
@@ -180,6 +184,10 @@ RSpec.describe Reports::CombinedInvoiceSupplementReport do
             expect(row['issuer_ial1_total_auth_count'].to_i).to eq(0)
             expect(row['issuer_ial2_total_auth_count'].to_i).to eq(1)
             expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(1)
+
+            expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
+            expect(row['issuer_ial2_unique_users'].to_i).to eq(1)
+            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(1)
             expect(row['issuer_ial2_new_unique_users'].to_i).to eq(1)
           end
         end


### PR DESCRIPTION
**Why**: This data exists at the IAA level in the report, but
breaking it down by issuer helps with more complex agreements
