### PR TITLE
LG-6120 SSN alt image

### DIFF
--- a/app/views/sign_up/registrations/_required_pii_accordion.html.erb
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.erb
@@ -40,7 +40,7 @@
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/personal-details.svg'),
-          size: '40', alt: '', class: 'margin-top-05 grid-col-auto',
+          size: '40', alt: t('devise.registrations.start.bullet_3_img'), class: 'margin-top-05 grid-col-auto',
         ) %>
     <span class="grid-col-fill padding-left-2">
       <%= t('devise.registrations.start.bullet_4_html') %>


### PR DESCRIPTION
One tweak for LG-6120 found during acceptance, we were missing an alt tag for ssn key image even though alt tags were added for all images next to it. Since image is the same as one above, I used the same yaml translation reference [See slack thread here](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1653057149438159?thread_ts=1652897560.434099&cid=CNCGEHG1G). 