### PR TITLE
Bundle JavaScript on-demand for JS feature specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ public/packs/manifest.json: yarn.lock $(shell find app/javascript -type f) ## Bu
 	yarn build
 
 test: export RAILS_ENV := test
-test: $(CONFIG) public/packs/manifest.json ## Runs RSpec and yarn tests
+test: $(CONFIG) ## Runs RSpec and yarn tests
 	bundle exec rake parallel:spec && yarn test
 
 fast_test: export RAILS_ENV := test
-fast_test: public/packs/manifest.json ## Abbreviated test run, runs RSpec tests without accessibility specs
+fast_test: ## Abbreviated test run, runs RSpec tests without accessibility specs
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 
 tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt: ## Self-signed cert for local HTTPS development

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,13 @@ RSpec.configure do |config|
     end
   end
 
+  if !ENV['CI']
+    config.before(:all, js: true) do
+      puts 'Bundling JavaScript...'
+      system 'make public/packs/manifest.json'
+    end
+  end
+
   config.before(:each) do
     I18n.locale = :en
   end


### PR DESCRIPTION
**Why**: So that developers don't need to be aware of and expend the effort to run `yarn build` every time before running a JavaScript-enabled feature spec, in order to avoid CSP errors related to the external Webpack dev server host.

**Testing Instructions:**

1. Run `rspec spec/features/visitors/i18n_spec.rb:68`
2. Observe in output...

```
Bundling JavaScript...
yarn build
...
```