### PR TITLE
Enable Rubocop IndentationWidth cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -188,7 +188,10 @@ Layout/IndentationConsistency:
 
 Layout/IndentationStyle:
   Enabled: true
-  IndentationWidth: null
+
+Layout/IndentationWidth:
+  Enabled: true
+
 Layout/InitialIndentation:
   Enabled: true
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -233,7 +233,7 @@ module Idv
         to_h.
         transform_values do |str|
           JSON.parse(str)
-      rescue JSON::ParserError
+        rescue JSON::ParserError
           nil
         end.
         compact.

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -50,9 +50,8 @@ class AddressProofingJob < ApplicationJob
   private
 
   def address_proofer
-    @address_proofer ||= if IdentityConfig.store.proofer_mock_fallback
-      Proofing::Mock::AddressMockClient.new
-    else
+    @address_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
+      Proofing::Mock::AddressMockClient.new :
       Proofing::LexisNexis::PhoneFinder::Proofer.new(
         phone_finder_workflow: IdentityConfig.store.lexisnexis_phone_finder_workflow,
         account_id: IdentityConfig.store.lexisnexis_account_id,
@@ -61,6 +60,5 @@ class AddressProofingJob < ApplicationJob
         password: IdentityConfig.store.lexisnexis_password,
         request_mode: IdentityConfig.store.lexisnexis_request_mode,
       )
-    end
   end
 end

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -50,15 +50,18 @@ class AddressProofingJob < ApplicationJob
   private
 
   def address_proofer
-    @address_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
-      Proofing::Mock::AddressMockClient.new :
-      Proofing::LexisNexis::PhoneFinder::Proofer.new(
-        phone_finder_workflow: IdentityConfig.store.lexisnexis_phone_finder_workflow,
-        account_id: IdentityConfig.store.lexisnexis_account_id,
-        base_url: IdentityConfig.store.lexisnexis_base_url,
-        username: IdentityConfig.store.lexisnexis_username,
-        password: IdentityConfig.store.lexisnexis_password,
-        request_mode: IdentityConfig.store.lexisnexis_request_mode,
-      )
+    @address_proofer ||=
+      if IdentityConfig.store.proofer_mock_fallback
+        Proofing::Mock::AddressMockClient.new
+      else
+        Proofing::LexisNexis::PhoneFinder::Proofer.new(
+          phone_finder_workflow: IdentityConfig.store.lexisnexis_phone_finder_workflow,
+          account_id: IdentityConfig.store.lexisnexis_account_id,
+          base_url: IdentityConfig.store.lexisnexis_base_url,
+          username: IdentityConfig.store.lexisnexis_username,
+          password: IdentityConfig.store.lexisnexis_password,
+          request_mode: IdentityConfig.store.lexisnexis_request_mode,
+        )
+      end
   end
 end

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -187,29 +187,35 @@ class ResolutionProofingJob < ApplicationJob
   end
 
   def resolution_proofer
-    @resolution_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
-      Proofing::Mock::ResolutionMockClient.new :
-      Proofing::LexisNexis::InstantVerify::Proofer.new(
-        instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
-        account_id: IdentityConfig.store.lexisnexis_account_id,
-        base_url: IdentityConfig.store.lexisnexis_base_url,
-        username: IdentityConfig.store.lexisnexis_username,
-        password: IdentityConfig.store.lexisnexis_password,
-        request_mode: IdentityConfig.store.lexisnexis_request_mode,
-      )
+    @resolution_proofer ||=
+      if IdentityConfig.store.proofer_mock_fallback
+        Proofing::Mock::ResolutionMockClient.new
+      else
+        Proofing::LexisNexis::InstantVerify::Proofer.new(
+          instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
+          account_id: IdentityConfig.store.lexisnexis_account_id,
+          base_url: IdentityConfig.store.lexisnexis_base_url,
+          username: IdentityConfig.store.lexisnexis_username,
+          password: IdentityConfig.store.lexisnexis_password,
+          request_mode: IdentityConfig.store.lexisnexis_request_mode,
+        )
+      end
   end
 
   def state_id_proofer
-    @state_id_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
-      Proofing::Mock::StateIdMockClient.new :
-      Proofing::Aamva::Proofer.new(
-        auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
-        auth_url: IdentityConfig.store.aamva_auth_url,
-        cert_enabled: IdentityConfig.store.aamva_cert_enabled,
-        private_key: IdentityConfig.store.aamva_private_key,
-        public_key: IdentityConfig.store.aamva_public_key,
-        verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
-        verification_url: IdentityConfig.store.aamva_verification_url,
-      )
+    @state_id_proofer ||=
+      if IdentityConfig.store.proofer_mock_fallback
+        Proofing::Mock::StateIdMockClient.new
+      else
+        Proofing::Aamva::Proofer.new(
+          auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
+          auth_url: IdentityConfig.store.aamva_auth_url,
+          cert_enabled: IdentityConfig.store.aamva_cert_enabled,
+          private_key: IdentityConfig.store.aamva_private_key,
+          public_key: IdentityConfig.store.aamva_public_key,
+          verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
+          verification_url: IdentityConfig.store.aamva_verification_url,
+        )
+      end
   end
 end

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -187,9 +187,8 @@ class ResolutionProofingJob < ApplicationJob
   end
 
   def resolution_proofer
-    @resolution_proofer ||= if IdentityConfig.store.proofer_mock_fallback
-      Proofing::Mock::ResolutionMockClient.new
-    else
+    @resolution_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
+      Proofing::Mock::ResolutionMockClient.new :
       Proofing::LexisNexis::InstantVerify::Proofer.new(
         instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
         account_id: IdentityConfig.store.lexisnexis_account_id,
@@ -198,13 +197,11 @@ class ResolutionProofingJob < ApplicationJob
         password: IdentityConfig.store.lexisnexis_password,
         request_mode: IdentityConfig.store.lexisnexis_request_mode,
       )
-    end
   end
 
   def state_id_proofer
-    @state_id_proofer ||= if IdentityConfig.store.proofer_mock_fallback
-      Proofing::Mock::StateIdMockClient.new
-    else
+    @state_id_proofer ||= IdentityConfig.store.proofer_mock_fallback ?
+      Proofing::Mock::StateIdMockClient.new :
       Proofing::Aamva::Proofer.new(
         auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
         auth_url: IdentityConfig.store.aamva_auth_url,
@@ -214,6 +211,5 @@ class ResolutionProofingJob < ApplicationJob
         verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
         verification_url: IdentityConfig.store.aamva_verification_url,
       )
-    end
   end
 end

--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -70,16 +70,17 @@ class Throttle < ApplicationRecord
   # @param [User] user
   # @return [Throttle]
   def self.for(throttle_type:, user: nil, target: nil)
-    throttle = if user
-                 find_or_create_by(user: user, throttle_type: throttle_type)
-               elsif target
-                 if !target.is_a?(String)
-                   raise ArgumentError, "target must be a string, but got #{target.class}"
-                 end
-                 find_or_create_by(target: target, throttle_type: throttle_type)
-               else
-                 raise 'Throttle must have a user or a target, but neither were provided'
-               end
+    throttle =
+      if user
+        find_or_create_by(user: user, throttle_type: throttle_type)
+      elsif target
+        if !target.is_a?(String)
+          raise ArgumentError, "target must be a string, but got #{target.class}"
+        end
+        find_or_create_by(target: target, throttle_type: throttle_type)
+      else
+        raise 'Throttle must have a user or a target, but neither were provided'
+      end
 
     throttle.reset_if_expired_and_maxed
     throttle

--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -71,15 +71,15 @@ class Throttle < ApplicationRecord
   # @return [Throttle]
   def self.for(throttle_type:, user: nil, target: nil)
     throttle = if user
-      find_or_create_by(user: user, throttle_type: throttle_type)
-    elsif target
-      if !target.is_a?(String)
-        raise ArgumentError, "target must be a string, but got #{target.class}"
-      end
-      find_or_create_by(target: target, throttle_type: throttle_type)
-    else
-      raise 'Throttle must have a user or a target, but neither were provided'
-    end
+                 find_or_create_by(user: user, throttle_type: throttle_type)
+               elsif target
+                 if !target.is_a?(String)
+                   raise ArgumentError, "target must be a string, but got #{target.class}"
+                 end
+                 find_or_create_by(target: target, throttle_type: throttle_type)
+               else
+                 raise 'Throttle must have a user or a target, but neither were provided'
+               end
 
     throttle.reset_if_expired_and_maxed
     throttle

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -621,11 +621,11 @@ module AnalyticsEvents
     letter_already_sent:,
     **extra
   )
-  track_event(
-    'IdV: USPS address visited',
-    letter_already_sent: letter_already_sent,
-    **extra,
-  )
+    track_event(
+      'IdV: USPS address visited',
+      letter_already_sent: letter_already_sent,
+      **extra,
+    )
   end
 
   # @identity.idp.previous_event_name Account verification submitted

--- a/app/services/doc_auth/error_result.rb
+++ b/app/services/doc_auth/error_result.rb
@@ -1,46 +1,46 @@
 module DocAuth
-    class ErrorResult
-      def initialize(error = nil, side = nil)
-        @error = ''
-        @error_display = nil
-        @sides = []
-        set_error(error) unless error.nil?
-        add_side(side) unless side.nil?
-      end
+  class ErrorResult
+    def initialize(error = nil, side = nil)
+      @error = ''
+      @error_display = nil
+      @sides = []
+      set_error(error) unless error.nil?
+      add_side(side) unless side.nil?
+    end
 
-      def set_error(error)
-        @error = error
-        @error_display = Errors::USER_DISPLAY[@error]
-      end
+    def set_error(error)
+      @error = error
+      @error_display = Errors::USER_DISPLAY[@error]
+    end
 
-      def error
-        @error
-      end
+    def error
+      @error
+    end
 
-      def add_side(side)
-        if side == :id
-          @sides.push(:front, :back)
-        else
-          @sides << side
-        end
-      end
-
-      def empty?
-        @error.empty?
-      end
-
-      def to_h
-        return {} if @error.empty? || @error_display.empty?
-        error_output = {}
-
-        plural_banner = @error_display[:long_msg_plural] || @error_display[:long_msg]
-
-        error_output[:general] = [@sides.length < 2 ? @error_display[:long_msg] : plural_banner]
-        @sides.each { |side| error_output[side] = [@error_display[:field_msg]] }
-
-        error_output[:hints] = @error_display[:hints] || false
-
-        error_output
+    def add_side(side)
+      if side == :id
+        @sides.push(:front, :back)
+      else
+        @sides << side
       end
     end
+
+    def empty?
+      @error.empty?
+    end
+
+    def to_h
+      return {} if @error.empty? || @error_display.empty?
+      error_output = {}
+
+      plural_banner = @error_display[:long_msg_plural] || @error_display[:long_msg]
+
+      error_output[:general] = [@sides.length < 2 ? @error_display[:long_msg] : plural_banner]
+      @sides.each { |side| error_output[side] = [@error_display[:field_msg]] }
+
+      error_output[:hints] = @error_display[:hints] || false
+
+      error_output
+    end
+  end
 end

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -31,9 +31,12 @@ module Idv
       end
 
       def enqueue_job
-        verify_document_capture_session = hybrid_flow_mobile? ?
-          document_capture_session :
-          create_document_capture_session(verify_document_capture_session_uuid_key)
+        verify_document_capture_session =
+          if hybrid_flow_mobile?
+            document_capture_session
+          else
+            create_document_capture_session(verify_document_capture_session_uuid_key)
+          end
         verify_document_capture_session.requested_at = Time.zone.now
         verify_document_capture_session.create_doc_auth_session
 

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -31,13 +31,9 @@ module Idv
       end
 
       def enqueue_job
-        verify_document_capture_session = if hybrid_flow_mobile?
-          document_capture_session
-        else
-          create_document_capture_session(
-            verify_document_capture_session_uuid_key,
-          )
-        end
+        verify_document_capture_session = hybrid_flow_mobile? ?
+          document_capture_session :
+          create_document_capture_session(verify_document_capture_session_uuid_key)
         verify_document_capture_session.requested_at = Time.zone.now
         verify_document_capture_session.create_doc_auth_session
 
@@ -80,7 +76,7 @@ module Idv
           to_h.
           transform_values do |str|
             JSON.parse(str)
-        rescue JSON::ParserError
+          rescue JSON::ParserError
             nil
           end.
           compact.

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -67,11 +67,14 @@ module Idv
 
       def verify_document_capture_session
         return @verify_document_capture_session if defined?(@verify_document_capture_session)
-        @verify_document_capture_session = hybrid_flow_mobile? ?
-          document_capture_session :
-          DocumentCaptureSession.find_by(
-            uuid: flow_session[verify_document_capture_session_uuid_key],
-          )
+        @verify_document_capture_session =
+          if hybrid_flow_mobile?
+            document_capture_session
+          else
+            DocumentCaptureSession.find_by(
+              uuid: flow_session[verify_document_capture_session_uuid_key],
+            )
+        end
       end
 
       def async_state

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -67,13 +67,11 @@ module Idv
 
       def verify_document_capture_session
         return @verify_document_capture_session if defined?(@verify_document_capture_session)
-        @verify_document_capture_session = if hybrid_flow_mobile?
-          document_capture_session
-        else
+        @verify_document_capture_session = hybrid_flow_mobile? ?
+          document_capture_session :
           DocumentCaptureSession.find_by(
             uuid: flow_session[verify_document_capture_session_uuid_key],
           )
-        end
       end
 
       def async_state

--- a/app/services/secure_headers_allow_list.rb
+++ b/app/services/secure_headers_allow_list.rb
@@ -32,10 +32,10 @@ class SecureHeadersAllowList
     csp_uri_set = uris.each_with_object(Set.new) do |uri, uri_set|
       parsed_uri = URI.parse(uri)
       reduced_uri = if parsed_uri.scheme.match?(/\Ahttps?\z/)
-                         reduce_web_sp_uri(parsed_uri)
-                       else
-                         reduce_native_app_sp_uri(parsed_uri)
-                       end
+                      reduce_web_sp_uri(parsed_uri)
+                    else
+                      reduce_native_app_sp_uri(parsed_uri)
+                    end
       uri_set.add(reduced_uri)
     end
     csp_uri_set.to_a

--- a/app/services/secure_headers_allow_list.rb
+++ b/app/services/secure_headers_allow_list.rb
@@ -31,11 +31,12 @@ class SecureHeadersAllowList
   def self.reduce_sp_redirect_uris_for_csp(uris)
     csp_uri_set = uris.each_with_object(Set.new) do |uri, uri_set|
       parsed_uri = URI.parse(uri)
-      reduced_uri = if parsed_uri.scheme.match?(/\Ahttps?\z/)
-                      reduce_web_sp_uri(parsed_uri)
-                    else
-                      reduce_native_app_sp_uri(parsed_uri)
-                    end
+      reduced_uri =
+        if parsed_uri.scheme.match?(/\Ahttps?\z/)
+          reduce_web_sp_uri(parsed_uri)
+        else
+          reduce_native_app_sp_uri(parsed_uri)
+        end
       uri_set.add(reduced_uri)
     end
     csp_uri_set.to_a

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -9,15 +9,14 @@ locals:
 * options: Array of troubleshooting options.
 %>
 <% if local_assigns.fetch(:type, :error) == :error
-  image_src = 'status/error.svg'
-  troubleshooting_heading = t('idv.troubleshooting.headings.need_assistance')
-  alt = t('errors.alt.error')
-else
-  image_src = 'status/warning.svg'
-  troubleshooting_heading = t('components.troubleshooting_options.default_heading')
-  alt = t('errors.alt.warning')
-end
-%>
+     image_src = 'status/error.svg'
+     troubleshooting_heading = t('idv.troubleshooting.headings.need_assistance')
+     alt = t('errors.alt.error')
+   else
+     image_src = 'status/warning.svg'
+     troubleshooting_heading = t('components.troubleshooting_options.default_heading')
+     alt = t('errors.alt.warning')
+   end %>
 <% title local_assigns.fetch(:title, heading) %>
 <%= image_tag(image_src, width: 54, alt: alt, class: 'display-block margin-bottom-4') %>
 

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -196,7 +196,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def should_error?(job, ex)
-     job.class.warning_error_classes.none? { |warning_class| ex.is_a?(warning_class) }
+    job.class.warning_error_classes.none? { |warning_class| ex.is_a?(warning_class) }
   end
 end
 

--- a/lib/tasks/convert_application_yml_to_proper_types.rake
+++ b/lib/tasks/convert_application_yml_to_proper_types.rake
@@ -29,31 +29,31 @@ namespace :convert_application_yml_to_proper_types do
   end
 
   def value_types
-      @value_types ||= begin
-        types = {}
-        IO.foreach("#{Rails.root}/lib/identity_config.rb") do |line|
-          if (line.strip.index('config.add') == 0)
-            line = line.split(':')
-            name = nil
-            type = nil
-            if line.length == 2
-              name = line[1].strip[0..-2]
-              type = 'string'
-            elsif line.length == 4
-              name = line[1].split(',').first
-              type = line.last.strip[0..-2]
-            elsif line.length == 5
-              name = line[1].split(',').first
-              type = line[3].split(',').first
-            elsif line.length == 6
-              name = line[1].split(',').first
-              type = line[3].split(',').first
-            end
-            types[name] = type
+    @value_types ||= begin
+      types = {}
+      IO.foreach("#{Rails.root}/lib/identity_config.rb") do |line|
+        if (line.strip.index('config.add') == 0)
+          line = line.split(':')
+          name = nil
+          type = nil
+          if line.length == 2
+            name = line[1].strip[0..-2]
+            type = 'string'
+          elsif line.length == 4
+            name = line[1].split(',').first
+            type = line.last.strip[0..-2]
+          elsif line.length == 5
+            name = line[1].split(',').first
+            type = line[3].split(',').first
+          elsif line.length == 6
+            name = line[1].split(',').first
+            type = line[3].split(',').first
           end
+          types[name] = type
         end
-        types
       end
+      types
+    end
   end
 
   def convert(value, value_type)

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -180,10 +180,10 @@ module Telephony
         delivery_status = message_response_result.delivery_status
         exception_message = "Pinpoint Error: #{delivery_status} - #{status_code}"
         exception_class = if permanent_failure_opt_out?(message_response_result)
-          OptOutError
-        else
-          ERROR_HASH[delivery_status] || TelephonyError
-        end
+                            OptOutError
+                          else
+                            ERROR_HASH[delivery_status] || TelephonyError
+                          end
         exception_class.new(exception_message)
       end
 

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -179,11 +179,12 @@ module Telephony
         status_code = message_response_result.status_code
         delivery_status = message_response_result.delivery_status
         exception_message = "Pinpoint Error: #{delivery_status} - #{status_code}"
-        exception_class = if permanent_failure_opt_out?(message_response_result)
-                            OptOutError
-                          else
-                            ERROR_HASH[delivery_status] || TelephonyError
-                          end
+        exception_class =
+          if permanent_failure_opt_out?(message_response_result)
+            OptOutError
+          else
+            ERROR_HASH[delivery_status] || TelephonyError
+          end
         exception_class.new(exception_message)
       end
 

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -60,12 +60,12 @@ def build_structured_git_log(git_log)
       commit_message_lines.split(%r{[\r\n]}).filter { |line| line != '' }
     end
   }.map do |title_and_commit_messages|
-      title = title_and_commit_messages.first.first.delete_prefix('title: ')
-      messages = title_and_commit_messages[1]
-      SquashedCommit.new(
-        title: title,
-        commit_messages: messages,
-      )
+    title = title_and_commit_messages.first.first.delete_prefix('title: ')
+    messages = title_and_commit_messages[1]
+    SquashedCommit.new(
+      title: title,
+      commit_messages: messages,
+    )
   end
 end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -11,14 +11,14 @@ describe SignUp::CompletionsController do
       end
 
       it 'redirects to account page when SP request URL is not present' do
-          user = create(:user)
-          stub_sign_in(user)
-          subject.session[:sp] = {
-            issuer: current_sp.issuer,
-          }
-          get :show
+        user = create(:user)
+        stub_sign_in(user)
+        subject.session[:sp] = {
+          issuer: current_sp.issuer,
+        }
+        get :show
 
-          expect(response).to redirect_to account_url
+        expect(response).to redirect_to account_url
       end
 
       context 'IAL1' do

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -65,14 +65,14 @@ describe Users::BackupCodeSetupController do
   end
 
   context 'with multiple MFA selection turned off' do
-      it 'redirects to account page' do
-        user = build(:user, :signed_up)
-        stub_sign_in(user)
-        codes = BackupCodeGenerator.new(user).create
-        controller.user_session[:backup_codes] = codes
-        post :continue
-        expect(response).to redirect_to(account_url)
-      end
+    it 'redirects to account page' do
+      user = build(:user, :signed_up)
+      stub_sign_in(user)
+      codes = BackupCodeGenerator.new(user).create
+      controller.user_session[:backup_codes] = codes
+      post :continue
+      expect(response).to redirect_to(account_url)
+    end
   end
 
   describe '#refreshed' do

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -92,15 +92,15 @@ feature 'Multi Two Factor Authentication' do
     end
 
     scenario 'clears the error when another mfa method is selected' do
-     click_2fa_option('backup_code')
-     expect(page).
-        to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+      click_2fa_option('backup_code')
+      expect(page).
+         to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
     end
 
     scenario 'clears the error when phone mfa method is unselected' do
-     click_2fa_option('phone')
-     expect(page).
-       to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+      click_2fa_option('phone')
+      expect(page).
+        to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
     end
   end
 

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -82,9 +82,9 @@ describe TwoFactorOptionsForm do
       end
 
       it 'submits the form' do
-          result = subject.submit(selection: ['phone'])
+        result = subject.submit(selection: ['phone'])
 
-          expect(result.success?).to eq true
+        expect(result.success?).to eq true
       end
     end
   end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -69,9 +69,9 @@ describe TwoFactorOptionsForm do
       end
 
       it 'does not submit the phone when selected as the first single option' do
-          result = subject.submit(selection: ['phone'])
+        result = subject.submit(selection: ['phone'])
 
-          expect(result.success?).to eq false
+        expect(result.success?).to eq false
       end
     end
 

--- a/spec/presenters/two_factor_authentication/piv_cac_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/piv_cac_selection_presenter_spec.rb
@@ -5,10 +5,10 @@ describe TwoFactorAuthentication::PivCacSelectionPresenter do
   let(:user_with_mfa) { create(:user, :with_piv_or_cac) }
   let(:configuration) {}
   let(:presenter_without_mfa) {
- described_class.new(configuration: configuration, user: user_without_mfa)
+    described_class.new(configuration: configuration, user: user_without_mfa)
   }
   let(:presenter_with_mfa) {
- described_class.new(configuration: configuration, user: user_with_mfa)
+    described_class.new(configuration: configuration, user: user_with_mfa)
   }
 
   describe '#type' do

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -140,12 +140,12 @@ describe 'accounts/show.html.erb' do
     end
 
     it 'renders the link to continue to the SP' do
-        render
+      render
 
-        expect(rendered).to have_link(
-          t('account.index.continue_to_service_provider', service_provider: sp.friendly_name),
-          href: sp.return_to_sp_url,
-        )
+      expect(rendered).to have_link(
+        t('account.index.continue_to_service_provider', service_provider: sp.friendly_name),
+        href: sp.return_to_sp_url,
+      )
     end
   end
 end

--- a/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
+++ b/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
@@ -48,11 +48,11 @@ describe 'partials/multi_factor_authentication/_mfa_selection.html.erb' do
     end
 
     it 'shows a checked checkbox for the configuration already created' do
-       expect(rendered).to have_field(
-         'two_factor_options_form[selection][]',
-         disabled: true,
-         checked: true,
-       )
+      expect(rendered).to have_field(
+        'two_factor_options_form[selection][]',
+        disabled: true,
+        checked: true,
+      )
     end
 
     it 'the checkbox for the configuration created communicates it is already created' do


### PR DESCRIPTION
**Why**: So that we can more easily ensure consistent indentation, improving readability.

Most of this is pretty straight-forward. The one notable exception is conditional assignment, which expects indentation of the next line to match the assignment operator, leading to some tight column width constraints. For a few of these, I refactored them to ternaries, which don't have the same expectation of alignment to the assignment operator.

Certainly easiest to review with whitespace changes hidden: https://github.com/18F/identity-idp/pull/6395/files?w=1