### PR TITLE
Run feature specs prebuild with unset Webpack env

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,11 +69,12 @@ RSpec.configure do |config|
   if !ENV['CI']
     config.before(js: true) do
       # rubocop:disable Style/GlobalVars
-      next if defined?($ran_webpack_build)
-      $ran_webpack_build = true
+      next if defined?($ran_asset_build)
+      $ran_asset_build = true
       # rubocop:enable Style/GlobalVars
-      puts 'Bundling JavaScript...'
+      puts 'Bundling JavaScript and stylesheets...'
       system 'WEBPACK_PORT= yarn build'
+      system 'yarn build:css'
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,11 @@ RSpec.configure do |config|
   end
 
   if !ENV['CI']
-    config.before(:suite, js: true) do
+    config.before(js: true) do
+      # rubocop:disable Style/GlobalVars
+      next if defined?($ran_webpack_build)
+      $ran_webpack_build = true
+      # rubocop:enable Style/GlobalVars
       puts 'Bundling JavaScript...'
       system 'WEBPACK_PORT= yarn build'
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
   end
 
   if !ENV['CI']
-    config.before(:all, js: true) do
+    config.before(:suite, js: true) do
       puts 'Bundling JavaScript...'
       system 'WEBPACK_PORT= yarn build'
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   if !ENV['CI']
     config.before(:all, js: true) do
       puts 'Bundling JavaScript...'
-      system 'make public/packs/manifest.json'
+      system 'WEBPACK_PORT= yarn build'
     end
   end
 


### PR DESCRIPTION
**Why**: Avoid potential conflicts for...

1. Environment variables which can affect intended build output expecting Webpack dev server ([source](https://github.com/18F/identity-idp/blob/d7d303fdd55577ccc00e055674b455f19f47a7c1/webpack.config.js#L41-L42))
2. False negatives for Make "nothing to do" if environment variable would impact build artifact, by instead always running the build

Previously: #6392

Slack context: https://gsa-tts.slack.com/archives/C0NGESUN5/p1653077779604529