### PR TITLE
Use a depth instead of recursion in the lookup shared device users tooling

### DIFF
--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -9,66 +9,26 @@ module DataRequests
   # network are found.
   #
   class LookupSharedDeviceUsers
-    attr_reader :initial_users
+    attr_reader :initial_users, :depth
 
-    def initialize(initial_users)
+    def initialize(initial_users, depth = 3)
       @initial_users = initial_users
+      @depth = depth
+      @user_ids = initial_users.map(&:id)
+      @device_cookie_uuids = []
     end
 
     def call
-      lookup_users(initial_users)
-      loop do
-        break if user_uuids_to_lookup.empty?
-        lookup_users(users_to_lookup)
+      depth.times do |i|
+        warn "Searching at depth #{i}"
+        self.device_cookie_uuids = Device.where(user_id: user_ids).map(&:cookie_uuid).uniq
+        self.user_ids = Device.where(cookie_uuid: device_cookie_uuids).map(&:user_id).uniq
       end
-      user_uuids_by_device
+      User.where(id: user_ids).all
     end
 
     private
 
-    def lookup_device(device)
-      cookie_uuid = device.cookie_uuid
-      return if user_uuids_by_device.key?(cookie_uuid)
-
-      warn "Searching for new devices matching #{cookie_uuid}"
-      user_ids = Device.where(cookie_uuid: cookie_uuid).pluck(:user_id)
-      user_uuids = User.where(id: user_ids).pluck(:uuid)
-      user_uuids_by_device[cookie_uuid] = user_uuids
-    end
-
-    def lookup_users(users)
-      users.each do |user|
-        lookup_user(user)
-      end
-    end
-
-    def lookup_user(user)
-      warn "Looking up devices for user: #{user.uuid}"
-      devices = user.devices
-      devices.each { |device| lookup_device(device) }
-      looked_up_user_uuids.add(user.uuid)
-    end
-
-    def looked_up_user_uuids
-      @looked_up_user_uuids ||= Set.new
-    end
-
-    def users_to_lookup
-      user_uuids_to_lookup.map do |uuid|
-        User.find_by(uuid: uuid)
-      end
-    end
-
-    ##
-    # A hash where the key is a cookie UUID and the values are the UUIDs for the
-    # users associated with that device
-    #
-    def user_uuids_by_device
-      @user_uuids_by_device ||= {}
-    end
-
-    def user_uuids_to_lookup
-      Set.new(user_uuids_by_device.values.flatten) - looked_up_user_uuids
-    end
+    attr_accessor :user_ids, :device_cookie_uuids
   end
 end

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -14,15 +14,15 @@ module DataRequests
     def initialize(initial_users, depth = 3)
       @initial_users = initial_users
       @depth = depth
-      @user_ids = initial_users.map(&:id)
-      @device_cookie_uuids = []
+      @user_ids = initial_users.map(&:id).to_set
+      @device_cookie_uuids = Set.new
     end
 
     def call
       depth.times do |i|
         warn "Searching at depth #{i}"
-        self.device_cookie_uuids = Device.where(user_id: user_ids).map(&:cookie_uuid).uniq
-        self.user_ids = Device.where(cookie_uuid: device_cookie_uuids).map(&:user_id).uniq
+        self.device_cookie_uuids += Device.where(user_id: user_ids).pluck(:cookie_uuid)
+        self.user_ids += Device.where(cookie_uuid: device_cookie_uuids).pluck(:user_id)
       end
       User.where(id: user_ids).all
     end

--- a/lib/tasks/data_requests.rake
+++ b/lib/tasks/data_requests.rake
@@ -7,9 +7,8 @@ namespace :data_requests do
     uuids = ENV.fetch('UUIDS', '').split(',')
     users = uuids.map { |uuid| DataRequests::LookupUserByUuid.new(uuid).call }.compact
 
-    result = DataRequests::LookupSharedDeviceUsers.new(users).call
-    puts JSON.pretty_generate(result)
-    puts "UUIDS: #{result.values.flatten.uniq.join(',')}"
+    users = DataRequests::LookupSharedDeviceUsers.new(users).call
+    puts "UUIDS: #{users.map(&:uuid).join(',')}"
   end
 
   # UUIDS=123abc,456def REQUESTING_ISSUER=sample:app:issuer rake data_requests:create_users_report

--- a/spec/services/data_requests/lookup_shared_device_users_spec.rb
+++ b/spec/services/data_requests/lookup_shared_device_users_spec.rb
@@ -21,9 +21,7 @@ describe DataRequests::LookupSharedDeviceUsers do
 
       result = subject.call
 
-      expect(result.keys.length).to eq(2)
-      expect(result[cookie_uuid1]).to match_array([user1, user2].map(&:uuid))
-      expect(result[cookie_uuid2]).to match_array([user2, user3].map(&:uuid))
+      expect(result).to match_array([user1, user2, user3])
     end
   end
 end


### PR DESCRIPTION
**Why**: We've had issues with this script running into infinite recursion or large groups of related users. This commit prevents that by stopping at a certain depth instead of building a full map of shared devices.

When we wrote this script, we did not have an index on the cookie_uuid column which mean that querying against cookie_uuids was slow and expensive. We now have that index so we can afford to take a more simple approach here.

changelog: Internal, Data requests, The script for looking up users who share devices was changed to avoid infinite recursion.