### PR TITLE
Lg 6428 sentence case for mfa labels

### DIFF
--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -62,10 +62,10 @@ en:
       webauthn_add: Add security key
       webauthn_confirm_delete: Yes, remove key
       webauthn_delete: Remove key
-      webauthn_platform: Face or Touch Unlock
-      webauthn_platform_add: Add Face or Touch Unlock
-      webauthn_platform_confirm_delete: Yes, remove Face or Touch Unlock
-      webauthn_platform_delete: Remove Face or Touch Unlock
+      webauthn_platform: Face or touch unlock
+      webauthn_platform_add: Add face or touch unlock
+      webauthn_platform_confirm_delete: Yes, remove face or touch unlock
+      webauthn_platform_delete: Remove face or touch unlock
     items:
       delete_your_account: Delete your account
       personal_key: Personal key

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -79,7 +79,7 @@ en:
         %{app_name} account.
       add_authentication_apps: Add authentication apps
       add_email: Add email address
-      add_federal_id: Add Federal Employee ID
+      add_federal_id: Add federal employee ID
       add_phone_number: Add phone number
       add_platform_authenticator: Add Face or Touch Unlock
       add_security_key: Add security key

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -117,14 +117,14 @@ en:
         your %{app_name} account.
       confirm: Are you sure you want to remove your security key?
     webauthn_platform_delete:
-      caution: If you remove Face or Touch Unlock you won’t be able to use it to
+      caution: If you remove face or touch unlock you won’t be able to use it to
         access your %{app_name} account.
-      confirm: Are you sure you want to remove Face or Touch Unlock?
+      confirm: Are you sure you want to remove face or touch unlock?
     webauthn_platform_setup:
       continue: Continue
       instructions_text: Use Touch or Face Unlock to access your account with %{app_name}
       instructions_title: Use Touch or Face Unlock to access your account.
-      intro: Enable Face or Touch Unlock as an authentication method on this device.
+      intro: Enable face or touch unlock as an authentication method on this device.
         You’ll need this device to use this method in the future. Start by
         giving your device a nickname.
       login_text: 'When you are ready, press the button:'

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -7,7 +7,7 @@ en:
       connected_accounts: Your connected accounts
       devices: Devices
       events: Events
-      federal_employee_id: Federal Employee ID
+      federal_employee_id: Federal employee ID
       login_info: Your account
       profile_info: Profile information
       reactivate: Reactivate your account

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -81,7 +81,7 @@ en:
           need to verify your identity using a physical device such as a
           security key or government employee ID (PIV or CAC) to access your
           information.
-        confirm_webauthn_platform_html: You have Face or Touch Unlock enabled for your %{app_name} account.
+        confirm_webauthn_platform_html: You have face or touch unlock enabled for your %{app_name} account.
       wrong_number: Entered the wrong phone number?
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -65,5 +65,5 @@ en:
       text_html: Or, %{link}
     webauthn_configured: A security key was added to your account.
     webauthn_deleted: Your security key was deleted from your account.
-    webauthn_platform_configured: Face or Touch Unlock was added to your account.
-    webauthn_platform_deleted: Face or Touch Unlock was deleted from your account.
+    webauthn_platform_configured: Face or touch unlock was added to your account.
+    webauthn_platform_deleted: Face or touch unlock was deleted from your account.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -135,7 +135,7 @@ en:
       least_secure_label: Least secure
       less_secure_label: Less secure
       more_secure_label: More Secure
-      phone: Text or Voice Message
+      phone: Text or voice message
       phone_info: Receive a secure code by (SMS) text or phone call.
       phone_info_html: Receive a secure code by (SMS) text or phone call. <strong>You
         need to select another method in addition to this one.</strong>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -125,7 +125,7 @@ en:
       auth_app: Authentication application
       auth_app_info: Download or use an authentication app of your choice to generate
         secure codes.
-      backup_code: Backup Codes
+      backup_code: Backup codes
       backup_code_info: A list of 10 codes you can print or save to your device. When
         you use the last code, we will generate a new list. Keep in mind backup
         codes are easy to lose.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -141,7 +141,7 @@ en:
         need to select another method in addition to this one.</strong>
       phone_info_no_voip: Do not use web-based (VOIP) phone services or premium rate
         (toll) phone numbers.
-      piv_cac: Government Employee ID
+      piv_cac: Government employee ID
       piv_cac_info: PIV/CAC cards for government and military employees. Desktop only.
       secure_label: Secure
       sms: Text message / SMS

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -44,7 +44,7 @@ en:
         (North America phone numbers only).
       webauthn: Security key
       webauthn_info: Use your security key to access your account.
-      webauthn_platform: Face or Touch Unlock
+      webauthn_platform: Face or touch unlock
       webauthn_platform_info: Use your device to verify your identity. We do not store
         your fingerprints or images. Recommended since it prevents phishing.
     login_options_link_text: Choose another authentication method
@@ -154,7 +154,7 @@ en:
       webauthn: Security key
       webauthn_info: A physical device, often shaped like a USB drive, that you plug
         in to your device.
-      webauthn_platform: Face or Touch Unlock
+      webauthn_platform: Face or touch unlock
       webauthn_platform_info: Use your device to verify your identity. We do not store
         your fingerprints or images. Recommended since it prevents phishing.
     two_factor_hspd12_choice: Additional authentication required
@@ -173,8 +173,8 @@ en:
     webauthn_piv_available: Use your PIV or CAC
     webauthn_platform_fallback:
       question: Don’t have your device available?
-    webauthn_platform_header_text: Use Face or Touch Unlock
-    webauthn_platform_use_key: Use Face or Touch Unlock
+    webauthn_platform_header_text: Use face or touch unlock
+    webauthn_platform_use_key: Use face or touch unlock
     webauthn_platform_verified:
       header: Device verified
       info: We have verified your device. Click continue to sign in.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -122,7 +122,7 @@ en:
     two_factor_choice_intro: Add another layer of security by using one of the
       multi-factor authentication options below.
     two_factor_choice_options:
-      auth_app: Authentication Application
+      auth_app: Authentication application
       auth_app_info: Download or use an authentication app of your choice to generate
         secure codes.
       backup_code: Backup Codes


### PR DESCRIPTION
## Why 
We're moving mfa labels from title case to sentence case throughout the application. 

## What

1. Face or Touch Unlock becomes Face or touch unlock
2. Security Key becomes Security key
3. Government Employee ID becomes Government employee ID
4. Federal Employee ID becomes Federal employee ID
5. Authentication Application becomes Authentication application
6. Text or Voice Message becomes Text or voice message
7. Backup Codes becomes Backup codes