### PR TITLE
LG-6276 async doc auth decrypt base64

### DIFF
--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -349,5 +349,18 @@ RSpec.describe DocumentProofingJob, type: :job do
         perform
       end
     end
+
+    context 'with jpg file body' do
+      let(:body) { DocAuthImageFixtures.document_front_image }
+
+      it 'decrypts the image correctly' do
+        expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
+          to receive(:post_images).
+          with(hash_including(front_image: DocAuthImageFixtures.document_front_image.b)).
+          and_call_original
+
+        perform
+      end
+    end
   end
 end

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe DocumentProofingJob, type: :job do
     }
   end
 
+  let(:body) { { document: applicant_pii }.to_json }
+
   before do
-    body = { document: applicant_pii }.to_json
     encrypt_and_stub_s3(body: body, url: front_image_url, iv: front_image_iv, key: encryption_key)
     encrypt_and_stub_s3(body: body, url: back_image_url, iv: back_image_iv, key: encryption_key)
     encrypt_and_stub_s3(body: body, url: selfie_image_url, iv: selfie_image_iv, key: encryption_key)
@@ -333,6 +334,19 @@ RSpec.describe DocumentProofingJob, type: :job do
         expect(DocAuthRouter).to_not receive(:doc_auth_vendor)
 
         expect { perform }.to raise_error(JobHelpers::StaleJobHelper::StaleJobError)
+      end
+    end
+
+    context 'with data url body' do
+      let(:body) { DocAuthImageFixtures.document_front_image_data_uri }
+
+      it 'decrypts the image correctly' do
+        expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
+          to receive(:post_images).
+          with(hash_including(front_image: DocAuthImageFixtures.document_front_image.b)).
+          and_call_original
+
+        perform
       end
     end
   end

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -7,6 +7,10 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(fixture_path('id-front.jpg'), 'image/jpeg')
   end
 
+  def self.document_front_image_data_uri
+    "data:image/jpeg;base64,#{Base64.strict_encode64(document_front_image)}"
+  end
+
   def self.document_back_image
     load_image_data('id-back.jpg')
   end


### PR DESCRIPTION
[LG-6276](https://cm-jira.usa.gov/browse/LG-6276)

**What**
Enabling async document upload with acuant sdk caused an error in staging where acuant returned an error that "file type is unrecognized" . We (me and @aduth ) believe that the error was caused because we were sending a data url instead of a binary file to acuant, and the code had not been updated to account for data urls (so acuant was receiving a data url and expecting a file binary, hence the error) 

**How**
We added a function in document_proofing_job.rb which checks if the body is a data url and in that case to parse it appropriately and return the file binary. We also added tests to document_proofing_job spec to confirm that a data url which is passed to the job will return a file binary. 

**Testing Instructions**
In order to be sure that this fixes our bug, we need to get this fix into staging so we can actually test with the acuant SDK (to confirm that the acuant sdk no longer returns the error of unrecognized file type 