### PR TITLE
Try: FormSteps: Add support for step code splitting

### DIFF
--- a/app/javascript/packages/verify-flow/steps/password-confirm/index.ts
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/index.ts
@@ -1,13 +1,17 @@
+import { lazy } from 'react';
 import { t } from '@18f/identity-i18n';
 import { getConfigValue } from '@18f/identity-config';
 import type { FormStep } from '@18f/identity-form-steps';
 import type { VerifyFlowValues } from '../../verify-flow';
-import form from './password-confirm-step';
 import submit from './submit';
+
+const load = () =>
+  import(/* webpackChunkName: "verify-flow-password-confirm" */ './password-confirm-step');
 
 export default {
   name: 'password_confirm',
   title: t('idv.titles.session.review', { app_name: getConfigValue('appName') }),
-  form,
+  form: lazy(load),
   submit,
+  preload: load,
 } as FormStep<VerifyFlowValues>;


### PR DESCRIPTION
**Why**: For a lengthy flow where each step may depend on sizable dependencies (e.g. password confirm step's `libphonenumber-js`), it may provide a better user experience to load some or all steps dynamically, to avoid waiting for all steps' dependencies to be downloaded up-front.

**Draft progress:**

- [ ] Decide if it's a worthwhile endeavor
- [ ] Decide if it should be applied to all steps, or only "heavy" steps
- [ ] Decide if it should wait until "heavy" step is not the first step, to avoid possible flash of empty content for initial page load
- [ ] Add specs