### PR TITLE
Fix account sign up cancellation

### DIFF
--- a/app/controllers/sign_up/cancellations_controller.rb
+++ b/app/controllers/sign_up/cancellations_controller.rb
@@ -1,6 +1,8 @@
 module SignUp
   class CancellationsController < ApplicationController
+    before_action :find_user
     before_action :ensure_in_setup
+    before_action :ensure_valid_confirmation_token
 
     def new
       properties = ParseControllerFromReferer.new(request.referer).call
@@ -8,14 +10,58 @@ module SignUp
       @presenter = CancellationPresenter.new(referer: request.referer, url_options: url_options)
     end
 
-    private
-
-    def ensure_in_setup
-      redirect_to root_url if !session[:user_confirmation_token] && two_factor_enabled
+    def destroy
+      track_account_deletion_event
+      url_after_cancellation = decorated_session.cancel_link_url
+      destroy_user
+      flash[:success] = t('sign_up.cancel.success')
+      redirect_to url_after_cancellation
     end
 
-    def two_factor_enabled
-      current_user && MfaPolicy.new(current_user).two_factor_enabled?
+    private
+
+    def track_account_deletion_event
+      properties = ParseControllerFromReferer.new(request.referer).call
+      analytics.account_deletion(**properties)
+    end
+
+    def destroy_user
+      @user&.destroy!
+      sign_out if @user
+    end
+
+    def find_user
+      @user = current_user
+      return if current_user
+
+      confirmation_token = session[:user_confirmation_token]
+      email_address = EmailAddress.find_with_confirmation_token(confirmation_token)
+      @token_validator = EmailConfirmationTokenValidator.new(email_address, current_user)
+      result = @token_validator.submit
+
+      if result.success?
+        @user = email_address.user
+      else
+        @user = nil
+      end
+    end
+
+    def ensure_in_setup
+      redirect_to root_url if @user && MfaPolicy.new(@user).two_factor_enabled?
+    end
+
+    def ensure_valid_confirmation_token
+      return if @user
+      flash[:error] = error_message(@token_validator)
+      redirect_to sign_up_email_resend_url(request_id: params[:_request_id])
+    end
+
+    def error_message(token_validator)
+      if token_validator.confirmation_period_expired?
+        t('errors.messages.confirmation_period_expired')
+      else
+        t('errors.messages.confirmation_invalid_token')
+      end
     end
   end
 end

--- a/app/models/concerns/email_address_callback.rb
+++ b/app/models/concerns/email_address_callback.rb
@@ -2,7 +2,7 @@ module EmailAddressCallback
   extend ActiveSupport::Concern
 
   EMAIL_COLUMNS = %i[
-    encrypted_email confirmation_token confirmed_at confirmation_sent_at email_fingerprint
+    encrypted_email confirmed_at email_fingerprint
   ].freeze
 
   def self.included(base)
@@ -22,9 +22,7 @@ module EmailAddressCallback
   def update_email_address_record
     email_addresses.take.update!(
       encrypted_email: encrypted_email,
-      confirmation_token: confirmation_token,
       confirmed_at: confirmed_at,
-      confirmation_sent_at: confirmation_sent_at,
       email_fingerprint: email_fingerprint,
     )
   end
@@ -33,9 +31,7 @@ module EmailAddressCallback
     email_addresses.create!(
       user: self,
       encrypted_email: encrypted_email,
-      confirmation_token: confirmation_token,
       confirmed_at: confirmed_at,
-      confirmation_sent_at: confirmation_sent_at,
       email_fingerprint: email_fingerprint,
     )
     email_addresses.reload

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp]
+  self.ignored_columns = %w[totp_timestamp confirmation_token confirmation_sent_at]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -8,7 +8,6 @@ class SendSignUpEmailConfirmation
   end
 
   def call(request_id: nil, instructions: nil, password_reset_requested: false)
-    remove_legacy_confirmation_info_on_user
     update_email_address_record
 
     if password_reset_requested && !user.confirmed?
@@ -49,13 +48,6 @@ class SendSignUpEmailConfirmation
     email_address.update!(
       confirmation_token: confirmation_token,
       confirmation_sent_at: confirmation_sent_at,
-    )
-  end
-
-  def remove_legacy_confirmation_info_on_user
-    email_address.user.update!(
-      confirmation_token: nil,
-      confirmation_sent_at: nil,
     )
   end
 

--- a/app/views/sign_up/cancellations/new.html.erb
+++ b/app/views/sign_up/cancellations/new.html.erb
@@ -14,11 +14,19 @@
     <li><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
   </ul>
 
-  <% c.action_button(
-       action: ->(**tag_options, &block) do
-         button_to(destroy_user_path, method: :delete, **tag_options, &block)
-       end,
-     ) { t('forms.buttons.cancel') } %>
+  <% if IdentityConfig.store.new_sign_up_cancellation_url_enabled %>
+    <% c.action_button(
+         action: ->(**tag_options, &block) do
+           button_to(sign_up_destroy_path, method: :delete, **tag_options, &block)
+         end,
+       ) { t('forms.buttons.cancel') } %>
+   <% else %>
+    <% c.action_button(
+         action: ->(**tag_options, &block) do
+           button_to(destroy_user_path, method: :delete, **tag_options, &block)
+         end,
+       ) { t('forms.buttons.cancel') } %>
+   <% end %>
 
   <% c.action_button(
        action: ->(**tag_options, &block) do

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -151,6 +151,7 @@ max_phone_numbers_per_account: 5
 max_piv_cac_per_account: 2
 min_password_score: 3
 mx_timeout: 3
+new_sign_up_cancellation_url_enabled: true
 otp_delivery_blocklist_maxretry: 10
 otp_valid_for: 10
 otps_per_ip_limit: 25
@@ -371,6 +372,7 @@ production:
   newrelic_browser_app_id: ''
   newrelic_browser_key: ''
   newrelic_license_key: ''
+  new_sign_up_cancellation_url_enabled: false
   nonessential_email_banlist: '[]'
   otp_delivery_blocklist_findtime: 5
   participate_in_dap: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -263,6 +263,7 @@ Rails.application.routes.draw do
     post '/user_authorization_confirmation' => 'users/authorization_confirmation#create'
     match '/user_authorization_confirmation/reset' => 'users/authorization_confirmation#destroy', as: :reset_user_authorization, via: %i[put delete]
     get '/sign_up/cancel/' => 'sign_up/cancellations#new', as: :sign_up_cancel
+    delete '/sign_up/cancel' => 'sign_up/cancellations#destroy', as: :sign_up_destroy
 
     get '/redirect/return_to_sp/cancel' => 'redirect/return_to_sp#cancel', as: :return_to_sp_cancel
     get '/redirect/return_to_sp/failure_to_proof' => 'redirect/return_to_sp#failure_to_proof', as: :return_to_sp_failure_to_proof
@@ -270,6 +271,7 @@ Rails.application.routes.draw do
 
     match '/sign_out' => 'sign_out#destroy', via: %i[get post delete]
 
+    # Deprecated
     delete '/users' => 'users#destroy', as: :destroy_user
 
     get '/restricted' => 'banned_user#show', as: :banned_user

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -215,6 +215,7 @@ class IdentityConfig
     config.add(:newrelic_browser_app_id, type: :string)
     config.add(:newrelic_browser_key, type: :string)
     config.add(:newrelic_license_key, type: :string)
+    config.add(:new_sign_up_cancellation_url_enabled, type: :boolean)
     config.add(:mailer_domain_name)
     config.add(:max_auth_apps_per_account, type: :integer)
     config.add(:max_bad_passwords, type: :integer)

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -27,4 +27,112 @@ describe SignUp::CancellationsController do
       get :new
     end
   end
+
+  describe '#destroy' do
+    it 'redirects if no user is present' do
+      delete :destroy
+
+      expect(response).to redirect_to(sign_up_email_resend_url)
+    end
+
+    it 'redirects if user has completed sign up' do
+      stub_sign_in
+
+      delete :destroy
+
+      expect(response).to redirect_to(root_url)
+    end
+
+    it 'destroys the current_user if user has set password but not added 2FA' do
+      user = create(:user)
+      stub_sign_in_before_2fa(user)
+
+      expect { delete :destroy }.to change(User, :count).by(-1)
+      expect(response).to redirect_to(root_url)
+      expect(flash.now[:success]).to eq t('sign_up.cancel.success')
+    end
+
+    it 'redirects if confirmation_token is invalid' do
+      confirmation_token = '1'
+
+      create(
+        :user, email_addresses: [
+          build(
+            :email_address,
+            confirmed_at: nil,
+            confirmation_token: '2',
+          ),
+        ]
+      )
+      subject.session[:user_confirmation_token] = confirmation_token
+      delete :destroy
+
+      expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
+      expect(response).to redirect_to(sign_up_email_resend_url)
+    end
+
+    it 'redirects if confirmation_token is expired' do
+      confirmation_token = '1'
+      invalid_confirmation_sent_at =
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+
+      create(
+        :user, email_addresses: [
+          build(
+            :email_address,
+            confirmed_at: nil,
+            confirmation_sent_at: invalid_confirmation_sent_at,
+            confirmation_token: confirmation_token,
+          ),
+        ]
+      )
+      subject.session[:user_confirmation_token] = confirmation_token
+
+      delete :destroy
+      expect(response).to redirect_to(sign_up_email_resend_url)
+      expect(flash[:error]).to eq t('errors.messages.confirmation_period_expired')
+    end
+
+    it 'redirects to the branded start page if the user came from an SP' do
+      user = create(:user)
+      stub_sign_in_before_2fa(user)
+      session[:sp] = { issuer: 'http://localhost:3000', request_id: 'foo' }
+
+      delete :destroy
+
+      expect(response).
+        to redirect_to new_user_session_path(request_id: 'foo')
+    end
+
+    it 'tracks the event in analytics when referer is nil' do
+      user = create(:user)
+      stub_sign_in_before_2fa(user)
+      stub_analytics
+      properties = { request_came_from: 'no referer' }
+
+      expect(@analytics).to receive(:track_event).with('Account Deletion Requested', properties)
+
+      delete :destroy
+    end
+
+    it 'tracks the event in analytics when referer is present' do
+      user = create(:user)
+      stub_sign_in_before_2fa(user)
+      stub_analytics
+      request.env['HTTP_REFERER'] = 'http://example.com/'
+      properties = { request_came_from: 'users/sessions#new' }
+
+      expect(@analytics).to receive(:track_event).with('Account Deletion Requested', properties)
+
+      delete :destroy
+    end
+
+    it 'calls ParseControllerFromReferer' do
+      user = create(:user)
+      stub_sign_in_before_2fa(user)
+      expect_any_instance_of(ParseControllerFromReferer).to receive(:call).and_call_original
+
+      delete :destroy
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -30,15 +30,6 @@ describe UsersController do
       expect { delete :destroy }.to change(User, :count).by(0)
     end
 
-    it 'finds the proper user and removes their record without `current_user`' do
-      confirmation_token = '1'
-
-      create(:user, confirmation_token: confirmation_token)
-      subject.session[:user_confirmation_token] = confirmation_token
-
-      expect { delete :destroy }.to change(User, :count).by(-1)
-    end
-
     it 'redirects to the branded start page if the user came from an SP' do
       session[:sp] = { issuer: 'http://localhost:3000', request_id: 'foo' }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     accepted_terms_at { Time.zone.now if email }
 
     after(:build) do |user, evaluator|
+      next if !evaluator.email.present?
       next unless user.email_addresses.empty?
       user.email_addresses.build(
         email: evaluator.email,
@@ -24,11 +25,10 @@ FactoryBot.define do
       )
       user.email = evaluator.email
       user.confirmed_at = evaluator.confirmed_at
-      user.confirmation_sent_at = evaluator.confirmation_sent_at
-      user.confirmation_token = evaluator.confirmation_token
     end
 
     after(:stub) do |user, evaluator|
+      next if !evaluator.email.present?
       next unless user.email_addresses.empty?
       user.email_addresses.build(
         email: evaluator.email,
@@ -38,8 +38,6 @@ FactoryBot.define do
       )
       user.email = evaluator.email
       user.confirmed_at = evaluator.confirmed_at
-      user.confirmation_sent_at = evaluator.confirmation_sent_at
-      user.confirmation_token = evaluator.confirmation_token
     end
 
     trait :with_multiple_emails do
@@ -183,8 +181,6 @@ FactoryBot.define do
 
     trait :unconfirmed do
       confirmed_at { nil }
-      confirmation_sent_at { 5.minutes.ago }
-      confirmation_token { 'token' }
       password { nil }
     end
 

--- a/spec/features/saml/ial1/account_creation_spec.rb
+++ b/spec/features/saml/ial1/account_creation_spec.rb
@@ -24,7 +24,9 @@ feature 'Canceling Account Creation' do
 
       expect(current_url).to eq sign_up_cancel_url
 
-      click_button t('forms.buttons.cancel')
+      expect {
+        click_button t('forms.buttons.cancel')
+      }.to change(User, :count).by(-1)
       expect(current_url).to eq \
         new_user_session_url(request_id: ServiceProviderRequestProxy.last.uuid)
     end
@@ -38,8 +40,10 @@ feature 'Canceling Account Creation' do
       click_link t('links.cancel_account_creation')
 
       expect(current_url).to eq sign_up_cancel_url
+      expect {
+        click_link t('links.go_back')
+      }.to change(User, :count).by(0)
 
-      click_link t('links.go_back')
       expect(current_url).to eq previous_url
     end
   end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -294,9 +294,9 @@ feature 'Sign Up' do
     it 'does not return an error and redirect to root after confirming and entering password' do
       email = 'test2@test.com'
       User.create!(
-        confirmation_token: 'foo', uuid: 'foo', email: email,
-        confirmation_sent_at: Time.zone.now
+        uuid: 'foo', email: email,
       )
+      EmailAddress.delete_all
       travel_to(1.year.from_now) do
         visit sign_up_email_path
         submit_form_with_valid_email(email)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -229,7 +229,7 @@ module Features
     def confirm_last_user
       @raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
 
-      User.last.update(
+      User.last.email_addresses.first.update(
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.zone.now,
       )
 


### PR DESCRIPTION
This PR is the intersection of a couple things.  Initially, the goal was to continue reducing the number of `DeprecatedUserAttributes` and I noticed the only place the `confirmation_token` on the `users` table was being directly queried was when cancelling account sign up.  The column is already unused and null, meaning the account cancellation was not working as intended.  There is also a bit of crossover with #6247 (where we were not properly validating the email confirmation token).

The combination of problems resulted in a few changes:

1. Fixing the account cancellation to read the confirmation token from `EmailAddress` instead of `User`
2. Adding proper validation to ensure we don't delete accounts based on on invalid token
3. Moving the deletion route into the same controller as the route that renders the deletion form (with backwards compatibility)
4. Removing all uses of `confirmation_token` and `confirmation_sent_at` on the `users` table.  The tests were a bit tricky in this regard since they depended on the `EmailAddressCallback` functionality to copy those attributes from the User model to EmailAddress.