### PR TITLE
Improve form validation for password confirm step

### DIFF
--- a/app/javascript/packages/password-toggle/password-toggle.spec.tsx
+++ b/app/javascript/packages/password-toggle/password-toggle.spec.tsx
@@ -1,4 +1,5 @@
 import { createRef } from 'react';
+import { computeAccessibleDescription } from 'dom-accessibility-api';
 import { render } from '@testing-library/react';
 import PasswordToggle from './password-toggle';
 
@@ -54,5 +55,15 @@ describe('PasswordToggle', () => {
     render(<PasswordToggle ref={ref} />);
 
     expect(ref.current).to.be.an.instanceOf(HTMLInputElement);
+  });
+
+  it('validates input as a ValidatedField', () => {
+    const { getByLabelText } = render(<PasswordToggle label="Input" required />);
+
+    const input = getByLabelText('Input') as HTMLInputElement;
+
+    input.reportValidity();
+    const description = computeAccessibleDescription(input);
+    expect(description).to.equal('simple_form.required.text');
   });
 });

--- a/app/javascript/packages/password-toggle/password-toggle.tsx
+++ b/app/javascript/packages/password-toggle/password-toggle.tsx
@@ -4,6 +4,7 @@ import { t } from '@18f/identity-i18n';
 import { TextInput } from '@18f/identity-components';
 import { useInstanceId } from '@18f/identity-react-hooks';
 import type { TextInputProps } from '@18f/identity-components';
+import { ValidatedField } from '@18f/identity-validated-field';
 import './password-toggle-element';
 import type PasswordToggleElement from './password-toggle-element';
 
@@ -63,13 +64,15 @@ function PasswordToggle(
 
   return (
     <lg-password-toggle class={classes}>
-      <TextInput
-        ref={ref}
-        {...textInputProps}
-        label={label}
-        id={inputId}
-        className="password-toggle__input"
-      />
+      <ValidatedField>
+        <TextInput
+          ref={ref}
+          {...textInputProps}
+          label={label}
+          id={inputId}
+          className="password-toggle__input"
+        />
+      </ValidatedField>
       <div className="password-toggle__toggle-wrapper">
         <input
           id={toggleId}

--- a/app/javascript/packages/validated-field/validated-field.spec.tsx
+++ b/app/javascript/packages/validated-field/validated-field.spec.tsx
@@ -1,6 +1,49 @@
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
-import ValidatedField from './validated-field';
+import ValidatedField, { getErrorMessages } from './validated-field';
+
+describe('getErrorMessages', () => {
+  context('undefined type', () => {
+    it('returns the expected messages', () => {
+      const messages = getErrorMessages();
+
+      expect(messages).to.deep.equal({
+        valueMissing: 'simple_form.required.text',
+      });
+    });
+  });
+
+  context('text type', () => {
+    it('returns the expected messages', () => {
+      const messages = getErrorMessages('text');
+
+      expect(messages).to.deep.equal({
+        valueMissing: 'simple_form.required.text',
+      });
+    });
+  });
+
+  context('checkbox type', () => {
+    it('returns the expected messages', () => {
+      const messages = getErrorMessages('checkbox');
+
+      expect(messages).to.deep.equal({
+        valueMissing: 'forms.validation.required_checkbox',
+      });
+    });
+  });
+
+  context('email type', () => {
+    it('returns the expected messages', () => {
+      const messages = getErrorMessages('email');
+
+      expect(messages).to.deep.equal({
+        valueMissing: 'simple_form.required.text',
+        typeMismatch: 'valid_email.validations.email.invalid',
+      });
+    });
+  });
+});
 
 describe('ValidatedField', () => {
   it('renders a validated input', () => {
@@ -34,7 +77,7 @@ describe('ValidatedField', () => {
 
   it('is described by associated error message', () => {
     const validate = sinon.stub().throws(new Error('oops'));
-    const { getByRole, baseElement } = render(<ValidatedField validate={validate} />);
+    const { getByRole, baseElement, rerender } = render(<ValidatedField validate={validate} />);
 
     const input = getByRole('textbox') as HTMLInputElement;
     input.reportValidity();
@@ -42,6 +85,12 @@ describe('ValidatedField', () => {
     const errorMessage = baseElement.querySelector(`#${input.getAttribute('aria-describedby')}`)!;
     expect(errorMessage.classList.contains('usa-error-message')).to.be.true();
     expect(errorMessage.textContent).to.equal('oops');
+
+    validate.resetBehavior();
+    rerender(<ValidatedField validate={validate} required />);
+    input.reportValidity();
+
+    expect(errorMessage.textContent).to.equal('simple_form.required.text');
   });
 
   it('merges classNames', () => {

--- a/app/javascript/packages/validated-field/validated-field.tsx
+++ b/app/javascript/packages/validated-field/validated-field.tsx
@@ -7,6 +7,7 @@ import type {
   ReactHTMLElement,
 } from 'react';
 import { useInstanceId } from '@18f/identity-react-hooks';
+import { t } from '@18f/identity-i18n';
 import './validated-field-element';
 import type ValidatedFieldElement from './validated-field-element';
 
@@ -35,6 +36,24 @@ declare global {
       };
     }
   }
+}
+
+/**
+ * Returns validity string error messages according to the given input type.
+ */
+export function getErrorMessages(inputType?: string) {
+  const messages: Partial<Record<keyof ValidityState, string>> = {
+    valueMissing:
+      inputType === 'checkbox'
+        ? t('forms.validation.required_checkbox')
+        : t('simple_form.required.text'),
+  };
+
+  if (inputType === 'email') {
+    messages.typeMismatch = t('valid_email.validations.email.invalid');
+  }
+
+  return messages;
 }
 
 function ValidatedField({
@@ -78,6 +97,9 @@ function ValidatedField({
 
   return (
     <lg-validated-field ref={fieldRef}>
+      <script type="application/json" className="validated-field__error-strings">
+        {JSON.stringify(getErrorMessages(inputProps.type))}
+      </script>
       <div className="validated-field__input-wrapper">
         {cloneElement(input, {
           ...inputProps,

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -18,6 +18,7 @@ import { ForgotPassword } from './forgot-password';
 import PersonalInfoSummary from './personal-info-summary';
 import StartOverOrCancel from '../../start-over-or-cancel';
 import type { VerifyFlowValues } from '../..';
+import { PasswordSubmitError } from './submit';
 
 interface PasswordConfirmStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
@@ -38,7 +39,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
 
   return (
     <>
-      {value.phone && !errors.length && (
+      {value.phone && (
         <Alert type="success" className="margin-bottom-4">
           {formatHTML(
             t('idv.messages.review.info_verified_html', {
@@ -48,11 +49,13 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
           )}
         </Alert>
       )}
-      {errors.map(({ error }) => (
-        <Alert key={error.message} type="error" className="margin-bottom-4">
-          {error.message}
-        </Alert>
-      ))}
+      {errors
+        .filter(({ error }) => error instanceof PasswordSubmitError)
+        .map(({ error }) => (
+          <Alert key={error.message} type="error" className="margin-bottom-4">
+            {error.message}
+          </Alert>
+        ))}
       <PageHeading>{t('idv.titles.session.review', { app_name: appName })}</PageHeading>
       <p>{t('idv.messages.sessions.review_message', { app_name: appName })}</p>
       <p>
@@ -67,6 +70,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
           onChange({ password: event.target.value });
         }}
         className="margin-top-6"
+        required
       />
       <div className="text-right margin-top-2 margin-bottom-4">
         {formatHTML(

--- a/app/javascript/packages/verify-flow/steps/password-confirm/submit.ts
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/submit.ts
@@ -7,6 +7,8 @@ import type { VerifyFlowValues } from '../../verify-flow';
  */
 export const API_ENDPOINT = '/api/verify/v2/password_confirm';
 
+export class PasswordSubmitError extends FormError {}
+
 /**
  * Successful API response shape.
  */
@@ -33,7 +35,7 @@ async function submit({ userBundleToken, password }: VerifyFlowValues) {
 
   if (isErrorResponse(json)) {
     const [field, [error]] = Object.entries(json.error)[0];
-    throw new FormError(error, { field });
+    throw new PasswordSubmitError(error, { field });
   }
 
   return { personalKey: json.personal_key };

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chai-as-promised": "^7.1.1",
     "clipboard-polyfill": "^3.0.3",
     "dirty-chai": "^2.0.1",
+    "dom-accessibility-api": "^0.5.14",
     "eslint": "^8.9.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,10 +2787,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
-  integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
+dom-accessibility-api@^0.5.14, dom-accessibility-api@^0.5.6:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-serializer@^1.0.1:
   version "1.3.2"


### PR DESCRIPTION
**Why**: For improved consistency with the existing screen, to avoid flashing content and perform validation client-side when possible (e.g. don't send empty password).

**Specifics:**

- Use `required` on the password field in combination with `ValidatedField` to prevent submission for empty field
- Always show the phone success alert (will confirm, but I believe this is how it works in production today, since otherwise it can be awkward and jarring to juggle when/if to show success, error, or no alert messaging)
- Allow display of errors at field-level when not associated with form submission (i.e. required validation)

**Screen recording:**

https://user-images.githubusercontent.com/1779930/170705300-62beb626-0084-4533-9e03-8e0657d6a357.mov
