### PR TITLE
Clear session values when flow is complete (IdV app)

### DIFF
--- a/app/javascript/packages/secret-session-storage/index.spec.ts
+++ b/app/javascript/packages/secret-session-storage/index.spec.ts
@@ -138,4 +138,22 @@ describe('SecretSessionStorage', () => {
       expect(storage2.getItems()).to.deep.equal({});
     });
   });
+
+  describe('#clear', () => {
+    it('removes values from in-memory storage', async () => {
+      const storage = createStorage();
+      await storage.setItem('foo', 'bar');
+      storage.clear();
+
+      expect(storage.getItems()).to.deep.equal({});
+    });
+
+    it('removes values from persisted storage', async () => {
+      const storage = createStorage();
+      await storage.setItem('foo', 'bar');
+      storage.clear();
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).be.null();
+    });
+  });
 });

--- a/app/javascript/packages/secret-session-storage/index.ts
+++ b/app/javascript/packages/secret-session-storage/index.ts
@@ -87,6 +87,14 @@ class SecretSessionStorage<S extends Record<string, JSONValue>> {
   }
 
   /**
+   * Remove all values from in-memory and persisted storage.
+   */
+  clear() {
+    sessionStorage.removeItem(this.storageKey);
+    this.storage = {} as S;
+  }
+
+  /**
    * Reads and decrypts storage object, if available.
    */
   async #readStorage() {

--- a/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-initial-step-validation.ts
@@ -25,7 +25,10 @@ const getStepIndex = (stepName: string, steps: FormStep[]) =>
  *
  * @return Tuple of the validated initial step and a setter for assigning a completed step.
  */
-function useInitialStepValidation(basePath: string, steps: FormStep[]): [string, Dispatch<string>] {
+function useInitialStepValidation(
+  basePath: string,
+  steps: FormStep[],
+): [string, Dispatch<string | null>] {
   const [completedStep, setCompletedStep] = useSessionStorage('completedStep');
   const initialStep = useMemo(() => {
     const pathStep = getStepParam(window.location.pathname.split(basePath)[1]);

--- a/app/javascript/packages/verify-flow/hooks/use-session-storage.spec.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-session-storage.spec.ts
@@ -14,6 +14,7 @@ describe('useSessionStorage', () => {
       value: {
         getItem: sinon.stub(),
         setItem: sinon.stub(),
+        removeItem: sinon.stub(),
       },
     });
   });
@@ -44,11 +45,19 @@ describe('useSessionStorage', () => {
     expect(sessionStorage.setItem).not.to.have.been.called();
   });
 
-  it('sets a value into storage', () => {
+  it('sets a string value into storage', () => {
     const { result } = renderHook(() => useSessionStorage(TEST_KEY));
     const [, setValue] = result.current;
     act(() => setValue('value'));
 
     expect(sessionStorage.setItem).to.have.been.calledWith(TEST_KEY, 'value');
+  });
+
+  it('unsets storage when given a null value', () => {
+    const { result } = renderHook(() => useSessionStorage(TEST_KEY));
+    const [, setValue] = result.current;
+    act(() => setValue(null));
+
+    expect(sessionStorage.removeItem).to.have.been.calledWith(TEST_KEY);
   });
 });

--- a/app/javascript/packages/verify-flow/hooks/use-session-storage.ts
+++ b/app/javascript/packages/verify-flow/hooks/use-session-storage.ts
@@ -9,10 +9,12 @@ import type { Dispatch } from 'react';
  *
  * @return Tuple of the current value and a setter to assign a value into storage.
  */
-function useSessionStorage(key: string): [string | null, Dispatch<string>] {
+function useSessionStorage(key: string): [string | null, Dispatch<string | null>] {
   const [value, setValue] = useState(() => sessionStorage.getItem(key));
   useDidUpdateEffect(() => {
-    if (value !== null) {
+    if (value === null) {
+      sessionStorage.removeItem(key);
+    } else {
       sessionStorage.setItem(key, value);
     }
   }, [value]);

--- a/app/javascript/packages/verify-flow/verify-flow.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.spec.tsx
@@ -33,6 +33,7 @@ describe('VerifyFlow', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: password confirm submitted');
 
     // Personal key
+    expect(sessionStorage.getItem('completedStep')).to.equal('password_confirm');
     expect(document.title).to.equal('titles.idv.personal_key - Example App');
     await findByText('idv.messages.confirm');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key visited');
@@ -41,6 +42,7 @@ describe('VerifyFlow', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key submitted');
 
     // Personal key confirm
+    expect(sessionStorage.getItem('completedStep')).to.equal('personal_key');
     expect(document.title).to.equal('titles.idv.personal_key - Example App');
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: personal key confirm visited');
     expect(window.location.pathname).to.equal('/personal_key_confirm');
@@ -49,6 +51,7 @@ describe('VerifyFlow', () => {
     await userEvent.keyboard('{Enter}');
 
     expect(onComplete).to.have.been.called();
+    expect(sessionStorage.getItem('completedStep')).to.be.null();
   });
 
   context('with specific enabled steps', () => {

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -118,6 +118,11 @@ function VerifyFlow({
     setCompletedStep(stepName);
   }
 
+  function onFormComplete() {
+    setCompletedStep(null);
+    onComplete();
+  }
+
   return (
     <FlowContext.Provider value={context}>
       <VerifyFlowStepIndicator currentStep={currentStep} />
@@ -131,7 +136,7 @@ function VerifyFlow({
         onChange={setSyncedValues}
         onStepSubmit={onStepSubmit}
         onStepChange={setCurrentStep}
-        onComplete={onComplete}
+        onComplete={onFormComplete}
       />
     </FlowContext.Provider>
   );

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -69,10 +69,6 @@ const camelCase = (string: string) =>
 const mapKeys = (object: object, mapKey: (key: string) => string) =>
   Object.entries(object).map(([key, value]) => [mapKey(key), value]);
 
-function onComplete() {
-  window.location.href = completionURL;
-}
-
 const storage = new SecretSessionStorage<SecretValues>('verify');
 
 (async () => {
@@ -91,6 +87,11 @@ const storage = new SecretSessionStorage<SecretValues>('verify');
     const jwtData = JSON.parse(atob(userBundleToken.split('.')[1]));
     const pii = Object.fromEntries(mapKeys(jwtData.pii, camelCase));
     Object.assign(initialValues, pii);
+  }
+
+  function onComplete() {
+    storage.clear();
+    window.location.href = completionURL;
   }
 
   render(


### PR DESCRIPTION
**Why**: So that lingering values don't remain beyond the completion of identity verification, even if those values would have been encrypted.
