### PR TITLE
Merge "shows the step indicator" and "is on correct page" IdV spec cases

### DIFF
--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -12,6 +12,10 @@ feature 'doc auth verify step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_address_path)
     expect(page).to have_content(t('doc_auth.headings.address'))
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_info'),
+    )
   end
 
   it 'allows the user to enter in a new address' do
@@ -40,12 +44,5 @@ feature 'doc auth verify step' do
     visit idv_address_path
 
     expect(page).to have_current_path(idv_doc_auth_welcome_step)
-  end
-
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_info'),
-    )
   end
 end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -26,13 +26,6 @@ feature 'doc auth document capture step' do
     complete_doc_auth_steps_before_document_capture_step
   end
 
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
-  end
-
   context 'when javascript is enabled', js: true do
     it 'logs return to sp link click' do
       new_window = window_opened_by do
@@ -52,10 +45,14 @@ feature 'doc auth document capture step' do
   context 'when liveness checking is enabled' do
     let(:liveness_enabled) { true }
 
-    it 'is on the correct_page and shows the document upload options' do
+    it 'is on the correct page and shows the document upload options' do
       expect(current_path).to eq(idv_doc_auth_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     it 'shows the selfie upload option' do
@@ -173,10 +170,14 @@ feature 'doc auth document capture step' do
   context 'when liveness checking is not enabled' do
     let(:liveness_enabled) { false }
 
-    it 'is on the correct_page and shows the document upload options' do
+    it 'is on the correct page and shows the document upload options' do
       expect(current_path).to eq(idv_doc_auth_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     it 'does not show the selfie upload option' do

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -13,9 +13,6 @@ feature 'doc auth email sent step' do
     expect(page).to have_current_path(idv_doc_auth_email_sent_step)
     user = User.first
     expect(page).to have_content(t('doc_auth.instructions.email_sent', email: user.email))
-  end
-
-  it 'shows the step indicator' do
     expect(page).to have_css(
       '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.verify_id'),

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -18,6 +18,10 @@ feature 'doc auth link sent step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
     expect(page).to have_content(t('doc_auth.headings.text_message'))
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 
   it 'proceeds to the next page with valid info' do
@@ -49,13 +53,6 @@ feature 'doc auth link sent step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
-  end
-
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
   end
 
   context 'cancelled' do

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -20,6 +20,10 @@ feature 'doc auth send link step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_send_link_step)
     expect(page).to have_content(t('doc_auth.headings.take_picture'))
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_id'),
+    )
   end
 
   it 'proceeds to the next page with valid info' do
@@ -145,12 +149,5 @@ feature 'doc auth send link step' do
 
     document_capture_session.reload
     expect(document_capture_session).to have_attributes(requested_at: a_kind_of(Time))
-  end
-
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
   end
 end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -15,6 +15,10 @@ feature 'doc auth ssn step' do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
       expect(page).to have_content(t('doc_auth.headings.ssn'))
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_info'),
+      )
     end
 
     it 'proceeds to the next page with valid info', js: true do
@@ -33,13 +37,6 @@ feature 'doc auth ssn step' do
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
-
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
-    end
   end
 
   context 'doc capture hand-off' do
@@ -54,6 +51,10 @@ feature 'doc auth ssn step' do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
       expect(page).to have_content(t('doc_auth.headings.ssn'))
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_info'),
+      )
     end
 
     it 'proceeds to the next page with valid info' do
@@ -75,13 +76,6 @@ feature 'doc auth ssn step' do
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
-    end
-
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
     end
   end
 end

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -19,6 +19,10 @@ feature 'doc auth upload step' do
 
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     it 'proceeds to send link via email page when user chooses to upload from computer' do
@@ -43,6 +47,10 @@ feature 'doc auth upload step' do
   context 'on a desktop device' do
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     it 'proceeds to document capture when user chooses to upload from computer' do
@@ -62,12 +70,5 @@ feature 'doc auth upload step' do
         hash_including(step: 'upload', destination: :send_link),
       )
     end
-  end
-
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
   end
 end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -18,6 +18,10 @@ feature 'doc auth verify step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_verify_step)
     expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_css(
+      '.step-indicator__step--current',
+      text: t('step_indicator.flows.idv.verify_info'),
+    )
   end
 
   it 'masks the ssn' do
@@ -145,13 +149,6 @@ feature 'doc auth verify step' do
 
       expect(page).to have_current_path(idv_phone_path)
     end
-  end
-
-  it 'shows the step indicator' do
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_info'),
-    )
   end
 
   context 'when the user lives in an AAMVA supported state' do

--- a/spec/features/idv/doc_capture/capture_complete_step_spec.rb
+++ b/spec/features/idv/doc_capture/capture_complete_step_spec.rb
@@ -13,9 +13,6 @@ feature 'capture complete step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_capture_doc_capture_complete_step)
     expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-  end
-
-  it 'shows the step indicator' do
     expect(page).to have_css(
       '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.verify_id'),

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -170,13 +170,6 @@ feature 'doc capture document capture step' do
       complete_doc_capture_steps_before_first_step(user)
     end
 
-    it 'shows the step indicator' do
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
-    end
-
     context 'when the SP does not request strict IAL2' do
       let(:sp_requests_ial2_strict) { false }
 
@@ -189,10 +182,14 @@ feature 'doc capture document capture step' do
         expect(DocAuth::Mock::DocAuthMockClient.last_uploaded_selfie_image).to be_nil
       end
 
-      it 'is on the correct_page and shows the document upload options' do
+      it 'is on the correct page and shows the document upload options' do
         expect(current_path).to eq(idv_capture_doc_document_capture_step)
         expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
         expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).to have_css(
+          '.step-indicator__step--current',
+          text: t('step_indicator.flows.idv.verify_id'),
+        )
       end
 
       it 'does not show the selfie upload option' do
@@ -215,7 +212,7 @@ feature 'doc capture document capture step' do
       end
     end
 
-    it 'is on the correct_page and shows the document upload options' do
+    it 'is on the correct page and shows the document upload options' do
       expect(current_path).to eq(idv_capture_doc_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
@@ -324,10 +321,14 @@ feature 'doc capture document capture step' do
       complete_doc_capture_steps_before_first_step(user)
     end
 
-    it 'is on the correct_page and shows the document upload options' do
+    it 'is on the correct page and shows the document upload options' do
       expect(current_path).to eq(idv_capture_doc_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+      expect(page).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.verify_id'),
+      )
     end
 
     it 'does not show the selfie upload option' do


### PR DESCRIPTION
**Why**: To improve build performance as more feature specs require a full headless browser, avoid spinning up a browser instance for the sole purpose of verifying the presence of a step indicator, when there is already a test case for verifying common step content.
