### PR TITLE
LG-6351: Fix support links for Edge, Firefox

### DIFF
--- a/app/components/javascript_required_component.rb
+++ b/app/components/javascript_required_component.rb
@@ -5,8 +5,8 @@ class JavascriptRequiredComponent < BaseComponent
 
   BROWSER_RESOURCES = [
     { name: 'Google Chrome', url: 'https://support.google.com' },
-    { name: 'Mozilla Firefox', url: 'https://support.microsoft.com/en-us/microsoft-edge' },
-    { name: 'Microsoft Edge', url: 'https://support.mozilla.org/en-US' },
+    { name: 'Mozilla Firefox', url: 'https://support.mozilla.org/en-US' },
+    { name: 'Microsoft Edge', url: 'https://support.microsoft.com/en-us/microsoft-edge' },
     { name: 'Apple Safari', url: 'https://support.apple.com/safari' },
   ].to_set.freeze
 


### PR DESCRIPTION
**Why**: Because a user would expect those support links to go to the correct destination.

The two links were accidentally switched places 🙃 (h/t @Kamal-Munshi for spotting)