### PR TITLE
LG-6499: Update missing GPO-specific content (IdV app)

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -77,12 +77,12 @@ class VerifyController < ApplicationController
   end
 
   def completion_url
-    if session[:sp]
-      sign_up_completed_url
-    elsif idv_session.address_verification_mechanism == 'gpo'
+    if idv_session.address_verification_mechanism == 'gpo'
       idv_come_back_later_url
+    elsif session[:sp]
+      sign_up_completed_url
     else
-      after_sign_in_path_for(current_user)
+      account_url
     end
   end
 
@@ -91,5 +91,9 @@ class VerifyController < ApplicationController
       user: current_user,
       idv_session: idv_session,
     ).token
+  end
+
+  def pending_profile?
+    current_user.pending_profile?
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -92,8 +92,4 @@ class VerifyController < ApplicationController
       idv_session: idv_session,
     ).token
   end
-
-  def pending_profile?
-    current_user.pending_profile?
-  end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -79,6 +79,8 @@ class VerifyController < ApplicationController
   def completion_url
     if session[:sp]
       sign_up_completed_url
+    elsif idv_session.address_verification_mechanism == 'gpo'
+      idv_come_back_later_url
     else
       after_sign_in_path_for(current_user)
     end

--- a/app/javascript/packages/verify-flow/context/address-verification-method-context.spec.tsx
+++ b/app/javascript/packages/verify-flow/context/address-verification-method-context.spec.tsx
@@ -7,7 +7,7 @@ import AddressVerificationMethodContext, {
 
 describe('AddressVerificationMethodContextProvider', () => {
   function TestComponent() {
-    const [addressVerificationMethod, setAddressVerificationMethod] = useContext(
+    const { addressVerificationMethod, setAddressVerificationMethod } = useContext(
       AddressVerificationMethodContext,
     );
     return (

--- a/app/javascript/packages/verify-flow/context/address-verification-method-context.spec.tsx
+++ b/app/javascript/packages/verify-flow/context/address-verification-method-context.spec.tsx
@@ -1,0 +1,59 @@
+import { useContext } from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddressVerificationMethodContext, {
+  AddressVerificationMethodContextProvider,
+} from './address-verification-method-context';
+
+describe('AddressVerificationMethodContextProvider', () => {
+  function TestComponent() {
+    const [addressVerificationMethod, setAddressVerificationMethod] = useContext(
+      AddressVerificationMethodContext,
+    );
+    return (
+      <>
+        <div>Current value: {addressVerificationMethod}</div>
+        <button
+          type="button"
+          onClick={() =>
+            setAddressVerificationMethod(addressVerificationMethod === 'phone' ? 'gpo' : 'phone')
+          }
+        >
+          Update
+        </button>
+      </>
+    );
+  }
+
+  it('initializes with default value', () => {
+    const { getByText } = render(
+      <AddressVerificationMethodContextProvider>
+        <TestComponent />
+      </AddressVerificationMethodContextProvider>,
+    );
+
+    expect(getByText('Current value: phone')).to.exist();
+  });
+
+  it('can be overridden with an initial method', () => {
+    const { getByText } = render(
+      <AddressVerificationMethodContextProvider initialMethod="gpo">
+        <TestComponent />
+      </AddressVerificationMethodContextProvider>,
+    );
+
+    expect(getByText('Current value: gpo')).to.exist();
+  });
+
+  it('exposes a setter to change the value', async () => {
+    const { getByText } = render(
+      <AddressVerificationMethodContextProvider initialMethod="gpo">
+        <TestComponent />
+      </AddressVerificationMethodContextProvider>,
+    );
+
+    await userEvent.click(getByText('Update'));
+
+    expect(getByText('Current value: phone')).to.exist();
+  });
+});

--- a/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
+++ b/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
@@ -1,22 +1,49 @@
 import { createContext, useState } from 'react';
 import type { ReactNode } from 'react';
 
+/**
+ * Mechanisms by which a user can verify their address.
+ */
 export type AddressVerificationMethod = 'phone' | 'gpo';
 
+/**
+ * Context provider props.
+ */
 interface AddressVerificationMethodContextProviderProps {
+  /**
+   * Optional initial context value.
+   */
   initialMethod?: AddressVerificationMethod;
 
+  /**
+   * Context children.
+   */
   children?: ReactNode;
 }
 
+/**
+ * Context value.
+ */
 type AddressVerificationMethodContextValue = [
+  /**
+   * Current address verification method.
+   */
   addressVerificationMethod: AddressVerificationMethod,
 
+  /**
+   * Setter to update to a new address verification method.
+   */
   setAddressVerificationMethod: (nextMethod: AddressVerificationMethod) => void,
 ];
 
+/**
+ * Default address verification method.
+ */
 const DEFAULT_METHOD: AddressVerificationMethod = 'phone';
 
+/**
+ * Address verification method context container.
+ */
 const AddressVerificationMethodContext = createContext<AddressVerificationMethodContextValue>([
   DEFAULT_METHOD,
   () => {},

--- a/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
+++ b/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState } from 'react';
+import { useObjectMemo } from '@18f/identity-react-hooks';
 import type { ReactNode } from 'react';
 
 /**
@@ -24,17 +25,17 @@ interface AddressVerificationMethodContextProviderProps {
 /**
  * Context value.
  */
-type AddressVerificationMethodContextValue = [
+interface AddressVerificationMethodContextValue {
   /**
    * Current address verification method.
    */
-  addressVerificationMethod: AddressVerificationMethod,
+  addressVerificationMethod: AddressVerificationMethod;
 
   /**
    * Setter to update to a new address verification method.
    */
-  setAddressVerificationMethod: (nextMethod: AddressVerificationMethod) => void,
-];
+  setAddressVerificationMethod: (nextMethod: AddressVerificationMethod) => void;
+}
 
 /**
  * Default address verification method.
@@ -44,10 +45,10 @@ const DEFAULT_METHOD: AddressVerificationMethod = 'phone';
 /**
  * Address verification method context container.
  */
-const AddressVerificationMethodContext = createContext<AddressVerificationMethodContextValue>([
-  DEFAULT_METHOD,
-  () => {},
-]);
+const AddressVerificationMethodContext = createContext<AddressVerificationMethodContextValue>({
+  addressVerificationMethod: DEFAULT_METHOD,
+  setAddressVerificationMethod: () => {},
+});
 
 AddressVerificationMethodContext.displayName = 'AddressVerificationMethodContext';
 
@@ -55,10 +56,11 @@ export function AddressVerificationMethodContextProvider({
   initialMethod = DEFAULT_METHOD,
   children,
 }: AddressVerificationMethodContextProviderProps) {
-  const state = useState(initialMethod);
+  const [addressVerificationMethod, setAddressVerificationMethod] = useState(initialMethod);
+  const value = useObjectMemo({ addressVerificationMethod, setAddressVerificationMethod });
 
   return (
-    <AddressVerificationMethodContext.Provider value={state}>
+    <AddressVerificationMethodContext.Provider value={value}>
       {children}
     </AddressVerificationMethodContext.Provider>
   );

--- a/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
+++ b/app/javascript/packages/verify-flow/context/address-verification-method-context.tsx
@@ -1,0 +1,40 @@
+import { createContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+export type AddressVerificationMethod = 'phone' | 'gpo';
+
+interface AddressVerificationMethodContextProviderProps {
+  initialMethod?: AddressVerificationMethod;
+
+  children?: ReactNode;
+}
+
+type AddressVerificationMethodContextValue = [
+  addressVerificationMethod: AddressVerificationMethod,
+
+  setAddressVerificationMethod: (nextMethod: AddressVerificationMethod) => void,
+];
+
+const DEFAULT_METHOD: AddressVerificationMethod = 'phone';
+
+const AddressVerificationMethodContext = createContext<AddressVerificationMethodContextValue>([
+  DEFAULT_METHOD,
+  () => {},
+]);
+
+AddressVerificationMethodContext.displayName = 'AddressVerificationMethodContext';
+
+export function AddressVerificationMethodContextProvider({
+  initialMethod = DEFAULT_METHOD,
+  children,
+}: AddressVerificationMethodContextProviderProps) {
+  const state = useState(initialMethod);
+
+  return (
+    <AddressVerificationMethodContext.Provider value={state}>
+      {children}
+    </AddressVerificationMethodContext.Provider>
+  );
+}
+
+export default AddressVerificationMethodContext;

--- a/app/javascript/packages/verify-flow/index.ts
+++ b/app/javascript/packages/verify-flow/index.ts
@@ -4,4 +4,5 @@ export { default as StartOverOrCancel } from './start-over-or-cancel';
 export { default as VerifyFlow } from './verify-flow';
 
 export type { SecretValues } from './context/secrets-context';
+export type { AddressVerificationMethod } from './context/address-verification-method-context';
 export type { VerifyFlowValues } from './verify-flow';

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -8,6 +8,7 @@ import { FormSteps } from '@18f/identity-form-steps';
 import { t, i18n } from '@18f/identity-i18n';
 import PasswordConfirmStep from './password-confirm-step';
 import submit, { PasswordSubmitError } from './submit';
+import { AddressVerificationMethodContextProvider } from '../../context/address-verification-method-context';
 
 describe('PasswordConfirmStep', () => {
   const sandbox = useSandbox();
@@ -118,18 +119,24 @@ describe('PasswordConfirmStep', () => {
   });
 
   describe('alert', () => {
-    context('without phone value', () => {
+    context('with gpo as address verification method', () => {
       it('does not render success alert', () => {
-        const { queryByRole } = render(<PasswordConfirmStep {...DEFAULT_PROPS} />);
+        const { queryByRole } = render(
+          <AddressVerificationMethodContextProvider initialMethod="gpo">
+            <PasswordConfirmStep {...DEFAULT_PROPS} />
+          </AddressVerificationMethodContextProvider>,
+        );
 
         expect(queryByRole('status')).to.not.exist();
       });
     });
 
-    context('with phone value', () => {
+    context('with phone as address verification method', () => {
       it('renders success alert', () => {
         const { queryByRole } = render(
-          <PasswordConfirmStep {...DEFAULT_PROPS} value={{ phone: '5135551234' }} />,
+          <AddressVerificationMethodContextProvider initialMethod="phone">
+            <PasswordConfirmStep {...DEFAULT_PROPS} />
+          </AddressVerificationMethodContextProvider>,
         );
 
         const status = queryByRole('status')!;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -28,7 +28,7 @@ const FORGOT_PASSWORD_PATH = 'forgot_password';
 function PasswordConfirmStep({ errors, registerField, onChange, value }: PasswordConfirmStepProps) {
   const { basePath } = useContext(FlowContext);
   const { onPageTransition } = useContext(FormStepsContext);
-  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
+  const { addressVerificationMethod } = useContext(AddressVerificationMethodContext);
   const stepPath = `${basePath}/password_confirm`;
   const [path] = useHistoryParam(undefined, { basePath: stepPath });
   useDidUpdateEffect(onPageTransition, [path]);

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -17,6 +17,7 @@ import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { ForgotPassword } from './forgot-password';
 import PersonalInfoSummary from './personal-info-summary';
 import StartOverOrCancel from '../../start-over-or-cancel';
+import AddressVerificationMethodContext from '../../context/address-verification-method-context';
 import type { VerifyFlowValues } from '../..';
 import { PasswordSubmitError } from './submit';
 
@@ -27,6 +28,7 @@ const FORGOT_PASSWORD_PATH = 'forgot_password';
 function PasswordConfirmStep({ errors, registerField, onChange, value }: PasswordConfirmStepProps) {
   const { basePath } = useContext(FlowContext);
   const { onPageTransition } = useContext(FormStepsContext);
+  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
   const stepPath = `${basePath}/password_confirm`;
   const [path] = useHistoryParam(undefined, { basePath: stepPath });
   useDidUpdateEffect(onPageTransition, [path]);
@@ -39,7 +41,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
 
   return (
     <>
-      {value.phone && (
+      {addressVerificationMethod === 'phone' && (
         <Alert type="success" className="margin-bottom-4">
           {formatHTML(
             t('idv.messages.review.info_verified_html', {

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.spec.tsx
@@ -3,6 +3,7 @@ import * as analytics from '@18f/identity-analytics';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PersonalKeyStep from './personal-key-step';
+import { AddressVerificationMethodContextProvider } from '../../context/address-verification-method-context';
 
 describe('PersonalKeyStep', () => {
   const sandbox = sinon.createSandbox();
@@ -49,11 +50,31 @@ describe('PersonalKeyStep', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: print personal key');
   });
 
-  it('renders success alert', () => {
-    const { getByRole } = render(<PersonalKeyStep {...DEFAULT_PROPS} />);
+  context('with gpo as address verification method', () => {
+    it('renders success alert', () => {
+      const { getByRole } = render(
+        <AddressVerificationMethodContextProvider initialMethod="gpo">
+          <PersonalKeyStep {...DEFAULT_PROPS} />
+        </AddressVerificationMethodContextProvider>,
+      );
 
-    const status = getByRole('status');
+      const status = getByRole('status');
 
-    expect(status.textContent).to.equal('idv.messages.confirm');
+      expect(status.textContent).to.equal('idv.messages.mail_sent');
+    });
+  });
+
+  context('with phone as address verification method', () => {
+    it('renders success alert', () => {
+      const { getByRole } = render(
+        <AddressVerificationMethodContextProvider initialMethod="phone">
+          <PersonalKeyStep {...DEFAULT_PROPS} />
+        </AddressVerificationMethodContextProvider>,
+      );
+
+      const status = getByRole('status');
+
+      expect(status.textContent).to.equal('idv.messages.confirm');
+    });
   });
 });

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -16,7 +16,7 @@ interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> 
 
 function PersonalKeyStep({ value }: PersonalKeyStepProps) {
   const personalKey = value.personalKey!;
-  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
+  const { addressVerificationMethod } = useContext(AddressVerificationMethodContext);
 
   return (
     <>

--- a/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key/personal-key-step.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { Alert, PageHeading } from '@18f/identity-components';
 import { ClipboardButton } from '@18f/identity-clipboard-button';
 import { PrintButton } from '@18f/identity-print-button';
@@ -8,17 +9,21 @@ import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { getAssetPath } from '@18f/identity-assets';
 import { trackEvent } from '@18f/identity-analytics';
 import type { VerifyFlowValues } from '../../verify-flow';
+import AddressVerificationMethodContext from '../../context/address-verification-method-context';
 import DownloadButton from './download-button';
 
 interface PersonalKeyStepProps extends FormStepComponentProps<VerifyFlowValues> {}
 
 function PersonalKeyStep({ value }: PersonalKeyStepProps) {
   const personalKey = value.personalKey!;
+  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
 
   return (
     <>
       <Alert type="success" className="margin-bottom-4">
-        {t('idv.messages.confirm')}
+        {addressVerificationMethod === 'phone'
+          ? t('idv.messages.confirm')
+          : t('idv.messages.mail_sent')}
       </Alert>
       <PageHeading>{t('headings.personal_key')}</PageHeading>
       <p>{t('instructions.personal_key.info')}</p>

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { StepStatus } from '@18f/identity-step-indicator';
+import { AddressVerificationMethodContextProvider } from './context/address-verification-method-context';
 import VerifyFlowStepIndicator, { getStepStatus } from './verify-flow-step-indicator';
 
 describe('getStepStatus', () => {
@@ -31,5 +32,18 @@ describe('VerifyFlowStepIndicator', () => {
 
     const previous = getByText('step_indicator.flows.idv.verify_phone_or_address');
     expect(previous.closest('.step-indicator__step--complete')).to.exist();
+  });
+
+  context('with gpo as address verification method', () => {
+    it('renders address verification as pending', () => {
+      const { getByText } = render(
+        <AddressVerificationMethodContextProvider initialMethod="gpo">
+          <VerifyFlowStepIndicator currentStep="personal_key" />
+        </AddressVerificationMethodContextProvider>,
+      );
+
+      const previous = getByText('step_indicator.flows.idv.verify_phone_or_address');
+      expect(previous.closest('.step-indicator__step--pending')).to.exist();
+    });
   });
 });

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
@@ -4,12 +4,6 @@ import { t } from '@18f/identity-i18n';
 import AddressVerificationMethodContext from './context/address-verification-method-context';
 import type { AddressVerificationMethod } from './context/address-verification-method-context';
 
-// i18n-tasks-use t('step_indicator.flows.idv.getting_started')
-// i18n-tasks-use t('step_indicator.flows.idv.verify_id')
-// i18n-tasks-use t('step_indicator.flows.idv.verify_info')
-// i18n-tasks-use t('step_indicator.flows.idv.verify_phone_or_address')
-// i18n-tasks-use t('step_indicator.flows.idv.secure_account')
-
 type VerifyFlowStepIndicatorStep =
   | 'getting_started'
   | 'verify_id'
@@ -91,6 +85,12 @@ function VerifyFlowStepIndicator({ currentStep }: VerifyFlowStepIndicatorProps) 
   const currentStepIndex = STEP_INDICATOR_STEPS.indexOf(FLOW_STEP_STEP_MAPPING[currentStep]);
   const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
   const statusOverrides = getStatusOverrides({ addressVerificationMethod });
+
+  // i18n-tasks-use t('step_indicator.flows.idv.getting_started')
+  // i18n-tasks-use t('step_indicator.flows.idv.verify_id')
+  // i18n-tasks-use t('step_indicator.flows.idv.verify_info')
+  // i18n-tasks-use t('step_indicator.flows.idv.verify_phone_or_address')
+  // i18n-tasks-use t('step_indicator.flows.idv.secure_account')
 
   return (
     <StepIndicator className="margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4">

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
@@ -83,7 +83,7 @@ function getStatusOverrides({
 
 function VerifyFlowStepIndicator({ currentStep }: VerifyFlowStepIndicatorProps) {
   const currentStepIndex = STEP_INDICATOR_STEPS.indexOf(FLOW_STEP_STEP_MAPPING[currentStep]);
-  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
+  const { addressVerificationMethod } = useContext(AddressVerificationMethodContext);
   const statusOverrides = getStatusOverrides({ addressVerificationMethod });
 
   // i18n-tasks-use t('step_indicator.flows.idv.getting_started')

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
@@ -1,5 +1,8 @@
+import { useContext } from 'react';
 import { StepIndicator, StepIndicatorStep, StepStatus } from '@18f/identity-step-indicator';
 import { t } from '@18f/identity-i18n';
+import AddressVerificationMethodContext from './context/address-verification-method-context';
+import type { AddressVerificationMethod } from './context/address-verification-method-context';
 
 // i18n-tasks-use t('step_indicator.flows.idv.getting_started')
 // i18n-tasks-use t('step_indicator.flows.idv.verify_id')
@@ -62,8 +65,32 @@ export function getStepStatus(index, currentStepIndex): StepStatus {
   return StepStatus.INCOMPLETE;
 }
 
+/**
+ * Given contextual details of the current flow path, returns explicit statuses which should be used
+ * at particular steps.
+ *
+ * @param details Flow details
+ *
+ * @return Step status overrides.
+ */
+function getStatusOverrides({
+  addressVerificationMethod,
+}: {
+  addressVerificationMethod: AddressVerificationMethod;
+}) {
+  const statuses: Partial<Record<VerifyFlowStepIndicatorStep, StepStatus>> = {};
+
+  if (addressVerificationMethod === 'gpo') {
+    statuses.verify_phone_or_address = StepStatus.PENDING;
+  }
+
+  return statuses;
+}
+
 function VerifyFlowStepIndicator({ currentStep }: VerifyFlowStepIndicatorProps) {
   const currentStepIndex = STEP_INDICATOR_STEPS.indexOf(FLOW_STEP_STEP_MAPPING[currentStep]);
+  const [addressVerificationMethod] = useContext(AddressVerificationMethodContext);
+  const statusOverrides = getStatusOverrides({ addressVerificationMethod });
 
   return (
     <StepIndicator className="margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4">
@@ -71,7 +98,7 @@ function VerifyFlowStepIndicator({ currentStep }: VerifyFlowStepIndicatorProps) 
         <StepIndicatorStep
           key={step}
           title={t(`step_indicator.flows.idv.${step}`)}
-          status={getStepStatus(index, currentStepIndex)}
+          status={statusOverrides[step] || getStepStatus(index, currentStepIndex)}
         />
       ))}
     </StepIndicator>

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -8,6 +8,10 @@ import VerifyFlowStepIndicator from './verify-flow-step-indicator';
 import { useSyncedSecretValues } from './context/secrets-context';
 import FlowContext from './context/flow-context';
 import useInitialStepValidation from './hooks/use-initial-step-validation';
+import {
+  AddressVerificationMethod,
+  AddressVerificationMethodContextProvider,
+} from './context/address-verification-method-context';
 
 export interface VerifyFlowValues {
   userBundleToken?: string;
@@ -66,6 +70,11 @@ interface VerifyFlowProps {
   cancelURL?: string;
 
   /**
+   * Initial value for address verification method.
+   */
+  initialAddressVerificationMethod?: AddressVerificationMethod;
+
+  /**
    * Callback invoked after completing the form.
    */
   onComplete: () => void;
@@ -98,6 +107,7 @@ function VerifyFlow({
   basePath,
   startOverURL = '',
   cancelURL = '',
+  initialAddressVerificationMethod,
   onComplete,
 }: VerifyFlowProps) {
   let steps = STEPS;
@@ -125,19 +135,21 @@ function VerifyFlow({
 
   return (
     <FlowContext.Provider value={context}>
-      <VerifyFlowStepIndicator currentStep={currentStep} />
-      <FormSteps
-        steps={steps}
-        initialValues={syncedValues}
-        initialStep={initialStep}
-        promptOnNavigate={false}
-        basePath={basePath}
-        titleFormat={`%{step} - ${getConfigValue('appName')}`}
-        onChange={setSyncedValues}
-        onStepSubmit={onStepSubmit}
-        onStepChange={setCurrentStep}
-        onComplete={onFormComplete}
-      />
+      <AddressVerificationMethodContextProvider initialMethod={initialAddressVerificationMethod}>
+        <VerifyFlowStepIndicator currentStep={currentStep} />
+        <FormSteps
+          steps={steps}
+          initialValues={syncedValues}
+          initialStep={initialStep}
+          promptOnNavigate={false}
+          basePath={basePath}
+          titleFormat={`%{step} - ${getConfigValue('appName')}`}
+          onChange={setSyncedValues}
+          onStepSubmit={onStepSubmit}
+          onStepChange={setCurrentStep}
+          onComplete={onFormComplete}
+        />
+      </AddressVerificationMethodContextProvider>
     </FlowContext.Provider>
   );
 }

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -18,6 +18,8 @@ describe VerifyController do
     end
     let(:profile) { subject.idv_session.profile }
     let(:step) { '' }
+    let(:sp) { build(:service_provider) }
+    let(:sp_session) { { issuer: sp.issuer } }
 
     subject(:response) { get :show, params: { step: step } }
 
@@ -26,6 +28,7 @@ describe VerifyController do
         and_return(idv_api_enabled_steps)
       stub_sign_in(user)
       stub_idv_session
+      session[:sp] = sp_session if sp_session
     end
 
     it 'renders 404' do
@@ -70,7 +73,7 @@ describe VerifyController do
             base_path: idv_app_path,
             start_over_url: idv_session_path,
             cancel_url: idv_cancel_path,
-            completion_url: idv_gpo_verify_url,
+            completion_url: sign_up_completed_url,
             enabled_step_names: idv_api_enabled_steps,
             initial_values: { 'personalKey' => kind_of(String) },
             store_key: kind_of(String),
@@ -85,15 +88,35 @@ describe VerifyController do
           end
         end
 
+        context 'without associated sp' do
+          let(:sp_session) { nil }
+
+          it 'sets completion url' do
+            response
+
+            expect(assigns[:app_data][:completion_url]).to eq(account_url)
+          end
+        end
+
         context 'with gpo as address verification method' do
           before do
             controller.idv_session.address_verification_mechanism = 'gpo'
           end
 
-          it 'sets completion url for gpo completion' do
+          it 'sets completion url' do
             response
 
             expect(assigns[:app_data][:completion_url]).to eq(idv_come_back_later_url)
+          end
+
+          context 'without associated sp' do
+            let(:sp_session) { nil }
+
+            it 'sets completion url' do
+              response
+
+              expect(assigns[:app_data][:completion_url]).to eq(idv_come_back_later_url)
+            end
           end
         end
       end
@@ -113,7 +136,7 @@ describe VerifyController do
             base_path: idv_app_path,
             start_over_url: idv_session_path,
             cancel_url: idv_cancel_path,
-            completion_url: account_url,
+            completion_url: sign_up_completed_url,
             enabled_step_names: idv_api_enabled_steps,
             initial_values: { 'userBundleToken' => kind_of(String) },
             store_key: kind_of(String),
@@ -134,7 +157,7 @@ describe VerifyController do
       idv_session = Idv::Session.new(
         user_session: controller.user_session,
         current_user: user,
-        service_provider: nil,
+        service_provider: sp,
       )
       idv_session.applicant = applicant
       idv_session.resolution_successful = true

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -84,6 +84,18 @@ describe VerifyController do
             expect(response).to render_template(:show)
           end
         end
+
+        context 'with gpo as address verification method' do
+          before do
+            controller.idv_session.address_verification_mechanism = 'gpo'
+          end
+
+          it 'sets completion url for gpo completion' do
+            response
+
+            expect(assigns[:app_data][:completion_url]).to eq(idv_come_back_later_url)
+          end
+        end
       end
 
       context 'with password confirmation step enabled' do

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -28,7 +28,7 @@ feature 'idv confirmation step', js: true do
   context 'with idv app feature enabled' do
     before do
       allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-        and_return(['personal_key', 'personal_key_confirm'])
+        and_return(['password_confirm', 'personal_key', 'personal_key_confirm'])
     end
 
     it_behaves_like 'idv confirmation step'

--- a/spec/support/idv_examples/confirmation_step.rb
+++ b/spec/support/idv_examples/confirmation_step.rb
@@ -21,7 +21,8 @@ shared_examples 'idv confirmation step' do |sp|
     end
 
     context 'user selected gpo verification' do
-      it 'shows step indicator progress with pending verify phone step' do
+      it 'shows status content for gpo verification progress' do
+        expect(page).to have_content(t('idv.messages.mail_sent'))
         expect(page).to have_css(
           '.step-indicator__step--current',
           text: t('step_indicator.flows.idv.secure_account'),
@@ -40,7 +41,8 @@ shared_examples 'idv confirmation step' do |sp|
       complete_idv_steps_with_phone_before_confirmation_step
     end
 
-    it 'shows step indicator progress with complete verify phone step' do
+    it 'shows status content for phone verification progress' do
+      expect(page).to have_content(t('idv.messages.confirm'))
       expect(page).to have_css(
         '.step-indicator__step--current',
         text: t('step_indicator.flows.idv.secure_account'),
@@ -49,6 +51,7 @@ shared_examples 'idv confirmation step' do |sp|
         '.step-indicator__step--complete',
         text: t('step_indicator.flows.idv.verify_phone_or_address'),
       )
+      expect(page).not_to have_css('.step-indicator__step--pending')
     end
 
     it 'redirects to the completions page and then to the SP', if: sp.present? do
@@ -70,16 +73,6 @@ shared_examples 'idv confirmation step' do |sp|
 
       expect(page).to have_content(t('headings.account.verified_account'))
       expect(page).to have_current_path(account_path)
-    end
-
-    context 'user selected gpo verification' do
-      it 'shows step indicator progress without pending verify step' do
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.secure_account'),
-        )
-        expect(page).not_to have_css('.step-indicator__step--pending')
-      end
     end
   end
 end


### PR DESCRIPTION
**Why**: For parity with the existing experience, users should expect to see content specific for the GPO verification method (e.g. status alerts, "Come back later" page after completion, pending step indicator status).

Also, this addresses an issue where previously, the absence of a phone value was used in determining method, but this isn't accurate, since phone may be assigned if the user already have a verified phone number ([source](https://github.com/18F/identity-idp/blob/d9da3df889d87e4b2e917a394330487346280b13/app/services/idv/steps/doc_auth_base_step.rb#L63)).

**Testing Instructions:**

1. With locally-running IdP, go to http://localhost:3000
1. Sign in
1. Go to http://localhost:3000/verify
1. Complete proofing flow up to phone address verification step
1. Choose to verify your address by receiving a letter
1. Confirm "Send a letter"
1. You should now be at "Re-enter your password" step
1. Observe there is no success alert banner
1. Observe that the "Verify your address" step indicator step is marked pending
1. Enter your password
1. Click Continue
1. Observe there is a success banner for "Your letter is on its way"
1. Confirm your personal key
1. Observe you are redirected to a "Come back later" page

**Screen recording:**

https://user-images.githubusercontent.com/1779930/171272808-b78ad0e2-9997-4a9d-a53b-b04ec2d2956f.mov