### PR TITLE
Remove support for password confirm as first step of IdV app

### DIFF
--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -120,16 +120,7 @@ module Idv
     end
 
     def next_step
-      if idv_api_personal_key_step_enabled?
-        idv_app_url
-      else
-        idv_personal_key_url
-      end
-    end
-
-    def idv_api_personal_key_step_enabled?
-      return false if idv_session.address_verification_mechanism == 'gpo'
-      IdentityConfig.store.idv_api_enabled_steps.include?('personal_key')
+      idv_personal_key_url
     end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -7,7 +7,6 @@ class VerifyController < ApplicationController
   before_action :validate_step
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_vendor_session_started
-  before_action :confirm_profile_has_been_created, if: :first_step_is_personal_key?
 
   def show
     @app_data = app_data
@@ -37,17 +36,11 @@ class VerifyController < ApplicationController
     case first_step
     when 'password_confirm'
       { 'userBundleToken' => user_bundle_token }
-    when 'personal_key'
-      { 'personalKey' => personal_key }
     end
   end
 
   def first_step
     enabled_steps.detect { |step| step_enabled?(step) }
-  end
-
-  def first_step_is_personal_key?
-    first_step == 'personal_key'
   end
 
   def enabled_steps
@@ -60,19 +53,6 @@ class VerifyController < ApplicationController
 
   def random_encryption_key
     Encryption::AesCipher.encryption_cipher.random_key
-  end
-
-  def confirm_profile_has_been_created
-    redirect_to account_url if idv_session.profile.blank?
-  end
-
-  def personal_key
-    idv_session.personal_key || generate_personal_key
-  end
-
-  def generate_personal_key
-    cacher = Pii::Cacher.new(current_user, user_session)
-    idv_session.profile.encrypt_recovery_pii(cacher.fetch)
   end
 
   def user_bundle_token

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -365,7 +365,7 @@ describe Idv::ReviewController do
         context 'with idv app personal key step enabled' do
           before do
             allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return(['personal_key'])
+              and_return(['password_confirm', 'personal_key', 'personal_key_confirm'])
           end
 
           it 'redirects to idv app personal key path' do
@@ -388,19 +388,6 @@ describe Idv::ReviewController do
           profile.reload
 
           expect(profile).to_not be_active
-        end
-
-        context 'with idv api personal key step enabled' do
-          before do
-            allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
-              and_return(['personal_key'])
-          end
-
-          it 'redirects to personal key path' do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-
-            expect(response).to redirect_to idv_personal_key_path
-          end
         end
       end
     end

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -36,7 +36,8 @@ describe VerifyController do
     end
 
     context 'with idv api enabled' do
-      let(:idv_api_enabled_steps) { ['something'] }
+      let(:idv_api_enabled_steps) { ['password_confirm', 'personal_key', 'personal_key_confirm'] }
+      let(:step) { 'password_confirm' }
 
       context 'invalid step' do
         let(:step) { 'bad' }
@@ -46,75 +47,28 @@ describe VerifyController do
         end
       end
 
-      context 'with personal key step enabled' do
-        let(:idv_api_enabled_steps) { ['personal_key', 'personal_key_confirm'] }
-        let(:step) { 'personal_key' }
-
-        before do
-          profile_maker = Idv::ProfileMaker.new(
-            applicant: applicant,
-            user: user,
-            user_password: password,
-          )
-          profile = profile_maker.save_profile
-          controller.idv_session.pii = profile_maker.pii_attributes
-          controller.idv_session.profile_id = profile.id
-          controller.idv_session.personal_key = profile.personal_key
-        end
-
-        it 'renders view' do
-          expect(response).to render_template(:show)
-        end
-
-        it 'sets app data' do
-          response
-
-          expect(assigns[:app_data]).to include(
-            base_path: idv_app_path,
-            start_over_url: idv_session_path,
-            cancel_url: idv_cancel_path,
-            enabled_step_names: idv_api_enabled_steps,
-            initial_values: { 'personalKey' => kind_of(String) },
-            store_key: kind_of(String),
-          )
-        end
-
-        context 'empty step' do
-          let(:step) { nil }
-
-          it 'renders view' do
-            expect(response).to render_template(:show)
-          end
-        end
+      it 'renders view' do
+        expect(response).to render_template(:show)
       end
 
-      context 'with password confirmation step enabled' do
-        let(:idv_api_enabled_steps) { ['password_confirm', 'personal_key', 'personal_key_confirm'] }
-        let(:step) { 'password_confirm' }
+      it 'sets app data' do
+        response
+
+        expect(assigns[:app_data]).to include(
+          base_path: idv_app_path,
+          start_over_url: idv_session_path,
+          cancel_url: idv_cancel_path,
+          enabled_step_names: idv_api_enabled_steps,
+          initial_values: { 'userBundleToken' => kind_of(String) },
+          store_key: kind_of(String),
+        )
+      end
+
+      context 'empty step' do
+        let(:step) { nil }
 
         it 'renders view' do
           expect(response).to render_template(:show)
-        end
-
-        it 'sets app data' do
-          response
-
-          expect(assigns[:app_data]).to include(
-            base_path: idv_app_path,
-            start_over_url: idv_session_path,
-            cancel_url: idv_cancel_path,
-            enabled_step_names: idv_api_enabled_steps,
-            initial_values: { 'userBundleToken' => kind_of(String) },
-            store_key: kind_of(String),
-          )
-        end
-
-        context 'empty step' do
-          let(:step) { nil }
-
-          it 'renders view' do
-            expect(response).to render_template(:show)
-          end
         end
       end
     end


### PR DESCRIPTION
**Why**: It was originally implemented with the expectation that we might ship the personal key step independently, but with stabilization of the password re-entry step, it's most likely we'd ship them together now. This allows for some simplification of the handling for initializing the IdV application.