### PR TITLE
Add DELETE route for session logout

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
       get '/bounced' => 'users/sp_handoff_bounced#bounced'
       post '/' => 'users/sessions#create', as: :user_session
       get '/logout' => 'users/sessions#destroy', as: :destroy_user_session
+      delete '/logout' => 'users/sessions#destroy'
       get '/active' => 'users/sessions#active'
       post '/sessions/keepalive' => 'users/sessions#keepalive'
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -129,6 +129,25 @@ describe Users::SessionsController, devise: true do
       sign_in_as_user
 
       get :destroy
+      expect(controller.current_user).to be nil
+    end
+  end
+
+  describe 'DELETE /logout' do
+    it 'tracks a logout event' do
+      stub_analytics
+      expect(@analytics).to receive(:track_event).with(
+        'Logout Initiated',
+        hash_including(
+          sp_initiated: false,
+          oidc: false,
+        ),
+      )
+
+      sign_in_as_user
+
+      delete :destroy
+      expect(controller.current_user).to be nil
     end
   end
 


### PR DESCRIPTION
Relevant [Slack thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1654010545842009) where the issue was raised that a destructive action should probably not be behind a GET route

To softly deprecate the GET route and keep backwards compatibility, this PR only adds the route.  The next set of changes can switch existing references within Login.gov.