### PR TITLE
Fix missing reactivation prompt for password reset with prior cancelled profile

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -73,7 +73,7 @@ class UserDecorator
   # This user's most recently activated profile that has also been deactivated
   # due to a password reset, or nil if there is no such profile
   def password_reset_profile
-    profile = user.profiles.order(activated_at: :desc).first
+    profile = user.profiles.where.not(activated_at: nil).order(activated_at: :desc).first
     profile if profile&.password_reset?
   end
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -295,6 +295,14 @@ describe UserDecorator do
         before { active_profile.deactivate(:password_reset) }
 
         it { expect(decorated_user.password_reset_profile).to eq(active_profile) }
+
+        context 'with a previously-cancelled pending profile' do
+          before do
+            user.profiles << build(:profile, :verification_cancelled)
+          end
+
+          it { expect(decorated_user.password_reset_profile).to eq(active_profile) }
+        end
       end
     end
   end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       deactivation_reason { :password_reset }
     end
 
+    trait :verification_cancelled do
+      deactivation_reason { :verification_cancelled }
+    end
+
     trait :with_liveness do
       proofing_components { { liveness_check: 'vendor' } }
     end


### PR DESCRIPTION
**Why**: So that a user who resets their password with an active profile always has the chance to reactivate the profile.

**Steps to reproduce:**

1. Go to http://localhost:3000
2. Sign in with an unproofed account
3. Go to http://localhost:3000/verify
4. Complete proofing process, opting to verify address by receiving a letter
5. Once complete and returned to the account page, click the link to "Enter the code received by mail"
6. Click "Clear my information and start over"
7. Complete proofing process, verifying address by phone
8. Sign out
9. On Sign In screen, click "Forgot your password?"
10. Complete process to reset your password
11. Sign in

Before: You would not be prompted to reactivate your profile
After: You should be prompted to reactivate your profile

**Screenshots:**

Before|After
---|---
![Screen Shot 2022-06-02 at 8 31 28 AM](https://user-images.githubusercontent.com/1779930/171629919-4e65a42b-e684-4648-8b1f-187ce3138e26.png)|![Screen Shot 2022-06-02 at 8 31 35 AM](https://user-images.githubusercontent.com/1779930/171629922-1dbdcc74-5c99-41b8-8686-142baf413974.png)

**Implementation Notes:**

The root cause appears to be that when sorting records in descending order, a value of `nil` will be first, which is not the expected behavior when trying to find the most recently-activated profile. The resolution is to exclude `nil` activation dates from the query.