### PR TITLE
Lg 6218 enforce non restricted mfa

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -266,7 +266,8 @@ class ApplicationController < ActionController::Base
   end
 
   def two_factor_kantara_enabled?
-    IdentityConfig.store.kantara_2fa_phone_restricted && MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+    IdentityConfig.store.kantara_2fa_phone_restricted &&
+      MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
   end
 
   def reauthn?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -267,7 +267,7 @@ class ApplicationController < ActionController::Base
 
   def two_factor_kantara_enabled?
     IdentityConfig.store.kantara_2fa_phone_restricted &&
-      MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+      MfaContext.new(current_user).enabled_non_restricted_mfa_methods_count < 1
   end
 
   def reauthn?
@@ -282,7 +282,7 @@ class ApplicationController < ActionController::Base
     return prompt_to_verify_mfa unless user_fully_authenticated?
     return prompt_to_setup_mfa if service_provider_mfa_policy.
                                   user_needs_sp_auth_method_setup?
-    return prompt_to_setup_non_restricted_mfa unless two_factor_kantara_enabled?
+    return prompt_to_setup_non_restricted_mfa if two_factor_kantara_enabled?
     return prompt_to_verify_sp_required_mfa if service_provider_mfa_policy.
                                                user_needs_sp_auth_method_verification?
     enforce_total_session_duration_timeout

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -265,6 +265,10 @@ class ApplicationController < ActionController::Base
       )
   end
 
+  def two_factor_kantara_enabled?
+    IdentityConfig.store.kantara_2fa_phone_restricted && MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
+  end
+
   def reauthn?
     reauthn = reauthn_param
     reauthn.present? && reauthn == 'true'
@@ -277,6 +281,7 @@ class ApplicationController < ActionController::Base
     return prompt_to_verify_mfa unless user_fully_authenticated?
     return prompt_to_setup_mfa if service_provider_mfa_policy.
                                   user_needs_sp_auth_method_setup?
+    return prompt_to_setup_non_restricted_mfa unless two_factor_kantara_enabled?
     return prompt_to_verify_sp_required_mfa if service_provider_mfa_policy.
                                                user_needs_sp_auth_method_verification?
     enforce_total_session_duration_timeout
@@ -314,6 +319,10 @@ class ApplicationController < ActionController::Base
 
   def prompt_to_setup_mfa
     redirect_to authentication_methods_setup_url
+  end
+
+  def prompt_to_setup_non_restricted_mfa
+    redirect_to auth_method_confirmation_url
   end
 
   def prompt_to_verify_mfa

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -266,6 +266,7 @@ class ApplicationController < ActionController::Base
   end
 
   def two_factor_kantara_enabled?
+    return false if controller_path == 'mfa_confirmation'
     IdentityConfig.store.kantara_2fa_phone_restricted &&
       MfaContext.new(current_user).enabled_non_restricted_mfa_methods_count < 1
   end

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -5,8 +5,8 @@ class MfaConfirmationController < ApplicationController
   helper_method :enforce_second_mfa?
 
   def show
+    @content = MfaConfirmationPresenter.new(current_user)
     @next_path = next_path
-    @content = content
   end
 
   def skip
@@ -27,23 +27,7 @@ class MfaConfirmationController < ApplicationController
     end
   end
 
-  def enforce_second_mfa?
-    IdentityConfig.store.select_multiple_mfa_options &&
-      !MfaPolicy.new(current_user).multiple_non_restricted_factors_enabled?
-    true
-  end
-
   private
-
-  def content
-    {
-      heading: enforce_second_mfa? ?
-      t('mfa.non_restricted.heading') :
-      t('titles.mfa_setup. suggest_second_mfa'),
-      info: enforce_second_mfa? ? t('mfa.non_restricted.info_html') : t('mfa.account_info'),
-      button: enforce_second_mfa? ? t('mfa.non_restricted.button') : t('mfa.add'),
-    }
-  end
 
   def next_path
     return second_mfa_setup_non_restricted_path if enforce_second_mfa?

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -1,6 +1,6 @@
 class MfaConfirmationController < ApplicationController
   include MfaSetupConcern
-  before_action :confirm_two_factor_authenticated, except: :show
+  before_action :confirm_two_factor_authenticated
 
   def show
     @content = MfaConfirmationPresenter.new(current_user)

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -2,8 +2,6 @@ class MfaConfirmationController < ApplicationController
   include MfaSetupConcern
   before_action :confirm_two_factor_authenticated, except: :show
 
-  helper_method :enforce_second_mfa?
-
   def show
     @content = MfaConfirmationPresenter.new(current_user)
     @next_path = next_path
@@ -28,6 +26,11 @@ class MfaConfirmationController < ApplicationController
   end
 
   private
+
+  def enforce_second_mfa?
+    IdentityConfig.store.select_multiple_mfa_options &&
+      MfaContext.new(current_user).enabled_non_restricted_mfa_methods_count < 1
+  end
 
   def next_path
     return second_mfa_setup_non_restricted_path if enforce_second_mfa?

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -4,7 +4,10 @@ module Users
     include MfaSetupConcern
 
     before_action :authenticate_user
-    before_action :confirm_user_authenticated_for_2fa_setup, except: :non_restricted
+    before_action :confirm_user_authenticated_for_2fa_setup, if: proc {
+                                                                   !params[:non_restricted].
+                                                                   to_s != 'true'
+                                                                 }
     before_action :multiple_factors_enabled?
 
     def index
@@ -12,12 +15,6 @@ module Users
       @after_setup_path = after_mfa_setup_path
       @presenter = two_factor_options_presenter
       analytics.user_registration_2fa_additional_setup_visit
-    end
-
-    def non_restricted
-      @two_factor_options_form = TwoFactorOptionsForm.new(current_user)
-      @presenter = two_factor_options_presenter
-      render 'index'
     end
 
     def update

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -17,7 +17,7 @@ module Users
     def non_restricted
       @two_factor_options_form = TwoFactorOptionsForm.new(current_user)
       @presenter = two_factor_options_presenter
-      render "index"
+      render 'index'
     end
 
     def update
@@ -34,7 +34,7 @@ module Users
         flash[:error] = t('errors.two_factor_auth_setup.must_select_additional_option')
         redirect_back(fallback_location: second_mfa_setup_path, allow_other_host: false)
       end
-      rescue ActionController::ParameterMissing
+    rescue ActionController::ParameterMissing
       flash[:error] = t('errors.two_factor_auth_setup.must_select_option')
       redirect_back(fallback_location: two_factor_options_path, allow_other_host: false)
     end

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -4,7 +4,7 @@ module Users
     include MfaSetupConcern
 
     before_action :authenticate_user
-    before_action :confirm_user_authenticated_for_2fa_setup
+    before_action :confirm_user_authenticated_for_2fa_setup, except: :non_restricted
     before_action :multiple_factors_enabled?
 
     def index
@@ -14,16 +14,29 @@ module Users
       analytics.user_registration_2fa_additional_setup_visit
     end
 
+    def non_restricted
+      @two_factor_options_form = TwoFactorOptionsForm.new(current_user)
+      @presenter = two_factor_options_presenter
+      render "index"
+    end
+
     def update
       result = submit_form
       analytics.user_registration_2fa_additional_setup(**result.to_h)
 
       if result.success?
         process_valid_form
+      elsif (result.errors[:selection].include? 'phone') ||
+            IdentityConfig.store.kantara_2fa_phone_restricted
+        flash[:phone_error] = t('errors.two_factor_auth_setup.must_select_additional_option')
+        redirect_to two_factor_options_path(anchor: 'select_phone')
       else
         flash[:error] = t('errors.two_factor_auth_setup.must_select_additional_option')
         redirect_back(fallback_location: second_mfa_setup_path, allow_other_host: false)
       end
+      rescue ActionController::ParameterMissing
+      flash[:error] = t('errors.two_factor_auth_setup.must_select_option')
+      redirect_back(fallback_location: two_factor_options_path, allow_other_host: false)
     end
 
     private

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -26,7 +26,7 @@ module Users
 
       if result.success?
         process_valid_form
-      elsif (result.errors[:selection].include? 'phone') ||
+      elsif (result.errors[:selection].include? 'phone') &&
             IdentityConfig.store.kantara_2fa_phone_restricted
         flash[:phone_error] = t('errors.two_factor_auth_setup.must_select_additional_option')
         redirect_to two_factor_options_path(anchor: 'select_phone')

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -4,10 +4,7 @@ module Users
     include MfaSetupConcern
 
     before_action :authenticate_user
-    before_action :confirm_user_authenticated_for_2fa_setup, if: proc {
-                                                                   !params[:non_restricted].
-                                                                   to_s != 'true'
-                                                                 }
+    before_action :confirm_user_authenticated_for_2fa_setup, except: :non_restricted
     before_action :multiple_factors_enabled?
 
     def index
@@ -15,6 +12,12 @@ module Users
       @after_setup_path = after_mfa_setup_path
       @presenter = two_factor_options_presenter
       analytics.user_registration_2fa_additional_setup_visit
+    end
+
+    def non_restricted
+      @two_factor_options_form = TwoFactorOptionsForm.new(current_user)
+      @presenter = two_factor_options_presenter
+      render 'index'
     end
 
     def update

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -8,8 +8,11 @@ module Users
     before_action :redirect_if_blank_phone, only: [:send_code]
 
     def show
-      service_provider_mfa_requirement_redirect || non_phone_redirect || phone_redirect ||
-        backup_code_redirect || redirect_on_nothing_enabled
+      service_provider_mfa_requirement_redirect ||
+      non_phone_redirect ||
+      phone_redirect ||
+      backup_code_redirect ||
+      redirect_on_nothing_enabled
     end
 
     def send_code

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -9,10 +9,10 @@ module Users
 
     def show
       service_provider_mfa_requirement_redirect ||
-      non_phone_redirect ||
-      phone_redirect ||
-      backup_code_redirect ||
-      redirect_on_nothing_enabled
+        non_phone_redirect ||
+        phone_redirect ||
+        backup_code_redirect ||
+        redirect_on_nothing_enabled
     end
 
     def send_code

--- a/app/presenters/mfa_confirmation_presenter.rb
+++ b/app/presenters/mfa_confirmation_presenter.rb
@@ -16,16 +16,13 @@ class MfaConfirmationPresenter
 
   def info
     enforce_second_mfa? ? I18n.t(
-      'mfa.non_restricted.info_html',
-      link: learn_more,
-    ) : I18n.t('mfa.account_info', link: learn_more)
+      'mfa.non_restricted.info',
+    ) : I18n.t('mfa.account_info')
   end
 
   def button
     enforce_second_mfa? ? I18n.t('mfa.non_restricted.button') : I18n.t('mfa.add')
   end
-
-  private
 
   def learn_more
     MarketingSite.help_center_article_url(

--- a/app/presenters/mfa_confirmation_presenter.rb
+++ b/app/presenters/mfa_confirmation_presenter.rb
@@ -1,0 +1,24 @@
+class MfaConfirmationPresenter
+  def initialize(user)
+    @user = user
+  end
+
+  def enforce_second_mfa?
+    IdentityConfig.store.select_multiple_mfa_options &&
+      MfaContext.new(@user).enabled_non_restricted_mfa_methods_count < 1
+  end
+
+  def heading
+    enforce_second_mfa? ?
+      I18n.t('mfa.non_restricted.heading') :
+      I18n.t('titles.mfa_setup.suggest_second_mfa')
+  end
+
+  def info
+    enforce_second_mfa? ? I18n.t('mfa.non_restricted.info_html') : I18n.t('mfa.account_info')
+  end
+
+  def button
+    enforce_second_mfa? ? I18n.t('mfa.non_restricted.button') : I18n.t('mfa.add')
+  end
+end

--- a/app/presenters/mfa_confirmation_presenter.rb
+++ b/app/presenters/mfa_confirmation_presenter.rb
@@ -15,10 +15,22 @@ class MfaConfirmationPresenter
   end
 
   def info
-    enforce_second_mfa? ? I18n.t('mfa.non_restricted.info_html') : I18n.t('mfa.account_info')
+    enforce_second_mfa? ? I18n.t(
+      'mfa.non_restricted.info_html',
+      link: learn_more,
+    ) : I18n.t('mfa.account_info', link: learn_more)
   end
 
   def button
     enforce_second_mfa? ? I18n.t('mfa.non_restricted.button') : I18n.t('mfa.add')
+  end
+
+  private
+
+  def learn_more
+    MarketingSite.help_center_article_url(
+      category: 'get-started',
+      article: 'authentication-options',
+    )
   end
 end

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -11,6 +11,7 @@ class MarketingSite
     verify-your-identity/how-to-add-images-of-your-state-issued-id
     verify-your-identity/phone-number-and-phone-plan-in-your-name
     verify-your-identity/verify-your-address-by-mail
+    get-started/authentication-options
   ].to_set.freeze
 
   def self.locale_segment

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -7,16 +7,20 @@
 <p class='margin-top-1 margin-bottom-4'><%= t('mfa.account_info') %></p>
 
 <div class="col-12">
+<%= @next_path %>
+<%= heading_content %>
   <%= link_to(
-        second_mfa_setup_path,
+        @next_path,
         class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
       ) { t('mfa.add') } %>
 </div>
 
-<%= button_to(
-      auth_method_confirmation_skip_path,
-      method: :post,
-      class: 'usa-button usa-button--unstyled',
-    ) do %>
-  <%= t('mfa.skip') %>
+<% unless enforce_second_mfa? %>
+  <%= button_to(
+        auth_method_confirmation_skip_path,
+        method: :post,
+        class: 'usa-button usa-button--unstyled',
+      ) do %>
+    <%= t('mfa.skip') %>
+  <% end %>
 <% end %>

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 
-<%= render PageHeadingComponent.new.with_content( @content.heading) %>
+<%= render PageHeadingComponent.new.with_content(@content.heading) %>
 
 <p class='margin-top-1 margin-bottom-4'><%= sanitize @content.info %></p>
 

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -2,17 +2,15 @@
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 
-<%= render PageHeadingComponent.new.with_content(t('titles.mfa_setup.suggest_second_mfa')) %>
+<%= render PageHeadingComponent.new.with_content( @content[:heading]) %>
 
-<p class='margin-top-1 margin-bottom-4'><%= t('mfa.account_info') %></p>
+<p class='margin-top-1 margin-bottom-4'><%= sanitize @content[:info] %></p>
 
 <div class="col-12">
-<%= @next_path %>
-<%= heading_content %>
   <%= link_to(
         @next_path,
         class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
-      ) { t('mfa.add') } %>
+      ) { @content[:button] } %>
 </div>
 
 <% unless enforce_second_mfa? %>

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -2,18 +2,18 @@
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 
-<%= render PageHeadingComponent.new.with_content( @content[:heading]) %>
+<%= render PageHeadingComponent.new.with_content( @content.heading) %>
 
-<p class='margin-top-1 margin-bottom-4'><%= sanitize @content[:info] %></p>
+<p class='margin-top-1 margin-bottom-4'><%= sanitize @content.info %></p>
 
 <div class="col-12">
   <%= link_to(
         @next_path,
         class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
-      ) { @content[:button] } %>
+      ) { @content.button } %>
 </div>
 
-<% unless enforce_second_mfa? %>
+<% unless @content.enforce_second_mfa? %>
   <%= button_to(
         auth_method_confirmation_skip_path,
         method: :post,

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -4,7 +4,12 @@
 
 <%= render PageHeadingComponent.new.with_content(@content.heading) %>
 
-<p class='margin-top-1 margin-bottom-4'><%= sanitize @content.info %></p>
+<p class='margin-top-1 margin-bottom-4'>
+  <%= @content.info %>
+  <% if @content.enforce_second_mfa? %>
+    <%= link_to(t('mfa.non_restricted.learn_more'), @content.learn_more) %>
+  <% end %>
+</p>
 
 <div class="col-12">
   <%= link_to(

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -10,11 +10,10 @@ en:
     non_restricted:
       button: Add an authentication method
       heading: Add another authentication method.
-      info_html: You opted to receive a code by SMS/text or a phone call to sign in
-        after you entered your email and password. You are now required to add
-        another authentication method as a backup in case you lose access to
-        your phone. <a href='%{link}'>Learn more about authentication
-        options</a>
+      info: You opted to receive a code by SMS/text or a phone call to sign in after
+        you entered your email and password. You are now required to add another
+        authentication method as a backup in case you lose access to your phone.
+      learn_more: Learn more about authentication options
     second_method_warning:
       link: Add a second authentication method.
       text: You will have to delete your account and start over if you lose your only

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -13,9 +13,7 @@ en:
       info_html: You opted to receive a code by SMS/text or a phone call to sign in
         after you entered your email and password. You are now required to add
         another authentication method as a backup in case you lose access to
-        your phone. <a
-        href='https://login.gov/help/get-started/authentication-options'>Learn
-        more</a>
+        your phone. <a href='%{link}'>Learn more</a>
     second_method_warning:
       link: Add a second authentication method.
       text: You will have to delete your account and start over if you lose your only

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -7,6 +7,15 @@ en:
     info: Add another layer of security by selecting a multi-factor authentication
       method. We recommend you select at least (2) two different options in case
       you lose one of your methods.
+    non_restricted:
+      button: Add an authentication method
+      heading: Add another authentication method.
+      info_html: You opted to receive a code by SMS/text or a phone call to sign in
+        after you entered your email and password. You are now required to add
+        another authentication method as a backup in case you lose access to
+        your phone. <a
+        href='https://login.gov/help/get-started/authentication-options'>Learn
+        more</a>
     second_method_warning:
       link: Add a second authentication method.
       text: You will have to delete your account and start over if you lose your only

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -13,7 +13,8 @@ en:
       info_html: You opted to receive a code by SMS/text or a phone call to sign in
         after you entered your email and password. You are now required to add
         another authentication method as a backup in case you lose access to
-        your phone. <a href='%{link}'>Learn more</a>
+        your phone. <a href='%{link}'>Learn more about authentication
+        options</a>
     second_method_warning:
       link: Add a second authentication method.
       text: You will have to delete your account and start over if you lose your only

--- a/config/locales/mfa/es.yml
+++ b/config/locales/mfa/es.yml
@@ -14,7 +14,8 @@ es:
         telefónica para iniciar sesión después de introducir su correo
         electrónico y contraseña. Ahora debe añadir otro método de autenticación
         como copia de seguridad en caso de que pierda el acceso a su teléfono.
-        <a href='%{link}'>Más información</a>
+        <a href='%{link}'>Obtenga más información sobre las opciones de
+        autenticación</a>
     second_method_warning:
       link: Agregue un segundo método de autenticación.
       text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de

--- a/config/locales/mfa/es.yml
+++ b/config/locales/mfa/es.yml
@@ -7,6 +7,16 @@ es:
     info: Agregue otro nivel de seguridad seleccionando un método de autentificación
       de varios factores. Le recomendamos seleccionar al menos dos opciones
       diferentes en caso de que pierda uno de los métodos.
+    non_restricted:
+      button: Añadir un método de autenticación
+      heading: Añadir otro método de autenticación.
+      info_html: Ha optado por recibir un código por SMS/texto o una llamada
+        telefónica para iniciar sesión después de introducir su correo
+        electrónico y contraseña. Ahora debe añadir otro método de autenticación
+        como copia de seguridad en caso de que pierda el acceso a su teléfono.
+        <a
+        href='https://login.gov/es/help/get-started/authentication-options/'>Más
+        información</a>
     second_method_warning:
       link: Agregue un segundo método de autenticación.
       text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de

--- a/config/locales/mfa/es.yml
+++ b/config/locales/mfa/es.yml
@@ -10,12 +10,11 @@ es:
     non_restricted:
       button: Añadir un método de autenticación
       heading: Añadir otro método de autenticación.
-      info_html: Ha optado por recibir un código por SMS/texto o una llamada
-        telefónica para iniciar sesión después de introducir su correo
-        electrónico y contraseña. Ahora debe añadir otro método de autenticación
-        como copia de seguridad en caso de que pierda el acceso a su teléfono.
-        <a href='%{link}'>Obtenga más información sobre las opciones de
-        autenticación</a>
+      info: Ha optado por recibir un código por SMS/texto o una llamada telefónica
+        para iniciar sesión después de introducir su correo electrónico y
+        contraseña. Ahora debe añadir otro método de autenticación como copia de
+        seguridad en caso de que pierda el acceso a su teléfono.
+      learn_more: Obtenga más información sobre las opciones de autenticación
     second_method_warning:
       link: Agregue un segundo método de autenticación.
       text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de

--- a/config/locales/mfa/es.yml
+++ b/config/locales/mfa/es.yml
@@ -14,9 +14,7 @@ es:
         telefónica para iniciar sesión después de introducir su correo
         electrónico y contraseña. Ahora debe añadir otro método de autenticación
         como copia de seguridad en caso de que pierda el acceso a su teléfono.
-        <a
-        href='https://login.gov/es/help/get-started/authentication-options/'>Más
-        información</a>
+        <a href='%{link}'>Más información</a>
     second_method_warning:
       link: Agregue un segundo método de autenticación.
       text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de

--- a/config/locales/mfa/fr.yml
+++ b/config/locales/mfa/fr.yml
@@ -11,12 +11,12 @@ fr:
     non_restricted:
       button: Ajoutez une méthode d’authentification
       heading: Ajoutez une autre méthode d’authentification.
-      info_html: Vous avez choisi de recevoir un code par SMS/texte ou par appel
+      info: Vous avez choisi de recevoir un code par SMS/texte ou par appel
         téléphonique pour vous connecter après avoir saisi votre adresse e-mail
         et votre mot de passe. Veuillez à présent ajouter une autre méthode
         d’authentification comme mesure de secours au cas où vous perdriez
-        l’accès à votre téléphone. <a href='%{link}/'>En savoir plus sur les
-        options d’authentification</a>
+        l’accès à votre téléphone.
+      learn_more: En savoir plus sur les options d’authentification
     second_method_warning:
       link: Ajoutez une deuxième méthode d’authentification.
       text: Vous devrez supprimer votre compte et recommencer si vous perdez votre

--- a/config/locales/mfa/fr.yml
+++ b/config/locales/mfa/fr.yml
@@ -15,7 +15,8 @@ fr:
         téléphonique pour vous connecter après avoir saisi votre adresse e-mail
         et votre mot de passe. Veuillez à présent ajouter une autre méthode
         d’authentification comme mesure de secours au cas où vous perdriez
-        l’accès à votre téléphone. <a href='%{link}/'>En savoir plus</a>
+        l’accès à votre téléphone. <a href='%{link}/'>En savoir plus sur les
+        options d’authentification</a>
     second_method_warning:
       link: Ajoutez une deuxième méthode d’authentification.
       text: Vous devrez supprimer votre compte et recommencer si vous perdez votre

--- a/config/locales/mfa/fr.yml
+++ b/config/locales/mfa/fr.yml
@@ -8,6 +8,16 @@ fr:
       d’authentification multi-facteurs. Nous vous recommandons de sélectionner
       au moins deux options différentes au cas où vous perdriez l’une de vos
       méthodes.
+    non_restricted:
+      button: Ajoutez une méthode d’authentification
+      heading: Ajoutez une autre méthode d’authentification.
+      info_html: Vous avez choisi de recevoir un code par SMS/texte ou par appel
+        téléphonique pour vous connecter après avoir saisi votre adresse e-mail
+        et votre mot de passe. Veuillez à présent ajouter une autre méthode
+        d’authentification comme mesure de secours au cas où vous perdriez
+        l’accès à votre téléphone. <a
+        href='https://login.gov/fr/help/get-started/authentication-options/'>En
+        savoir plus</a>
     second_method_warning:
       link: Ajoutez une deuxième méthode d’authentification.
       text: Vous devrez supprimer votre compte et recommencer si vous perdez votre

--- a/config/locales/mfa/fr.yml
+++ b/config/locales/mfa/fr.yml
@@ -15,9 +15,7 @@ fr:
         téléphonique pour vous connecter après avoir saisi votre adresse e-mail
         et votre mot de passe. Veuillez à présent ajouter une autre méthode
         d’authentification comme mesure de secours au cas où vous perdriez
-        l’accès à votre téléphone. <a
-        href='https://login.gov/fr/help/get-started/authentication-options/'>En
-        savoir plus</a>
+        l’accès à votre téléphone. <a href='%{link}/'>En savoir plus</a>
     second_method_warning:
       link: Ajoutez une deuxième méthode d’authentification.
       text: Vous devrez supprimer votre compte et recommencer si vous perdez votre

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Rails.application.routes.draw do
     get '/two_factor_options', to: redirect('/authentication_methods_setup')
     patch '/two_factor_options' => 'users/two_factor_authentication_setup#create'
     get '/second_mfa_setup' => 'users/mfa_selection#index'
+    get '/second_mfa_setup/non_restricted' => 'users/mfa_selection#non_restricted'
     patch '/second_mfa_setup' => 'users/mfa_selection#update'
     get '/phone_setup' => 'users/phone_setup#index'
     patch '/phone_setup' => 'users/phone_setup#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
     get '/two_factor_options', to: redirect('/authentication_methods_setup')
     patch '/two_factor_options' => 'users/two_factor_authentication_setup#create'
     get '/second_mfa_setup' => 'users/mfa_selection#index'
-    get '/second_mfa_setup/non_restricted' => 'users/mfa_selection#non_restricted'
+    get '/second_mfa_setup/non_restricted' => 'users/mfa_selection#index'
     patch '/second_mfa_setup' => 'users/mfa_selection#update'
     get '/phone_setup' => 'users/phone_setup#index'
     patch '/phone_setup' => 'users/phone_setup#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
     get '/two_factor_options', to: redirect('/authentication_methods_setup')
     patch '/two_factor_options' => 'users/two_factor_authentication_setup#create'
     get '/second_mfa_setup' => 'users/mfa_selection#index'
-    get '/second_mfa_setup/non_restricted' => 'users/mfa_selection#index'
+    get '/second_mfa_setup/non_restricted' => 'users/mfa_selection#non_restricted'
     patch '/second_mfa_setup' => 'users/mfa_selection#update'
     get '/phone_setup' => 'users/phone_setup#index'
     patch '/phone_setup' => 'users/phone_setup#create'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -197,6 +197,30 @@ describe ApplicationController do
         expect(response).to redirect_to user_two_factor_authentication_url
       end
     end
+
+    context 'kantara feature is on' do
+      before do
+        allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted) { true }
+      end
+
+      it 'redirects users with restricted mfa configurations to add a non-restricted mfa' do
+        user = create(:user, :with_phone)
+        sign_in_as_user(user)
+
+        get :index
+
+        expect(response).to redirect_to auth_method_confirmation_url
+      end
+
+      it 'does not redirect a user with non restricted mfa configurations' do
+        user = create(:user, :with_phone, :with_authentication_app)
+        sign_in_as_user(user)
+
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
+    end
   end
 
   describe '#analytics' do

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -23,7 +23,7 @@ describe Users::MfaSelectionController do
     end
   end
 
-  describe '#non_restricted' do
+  describe '#index/non_restricted' do
     before do
       allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
       user = build(:user, :signed_up, :with_phone)
@@ -31,7 +31,7 @@ describe Users::MfaSelectionController do
     end
 
     it 'shows the mfa setup screen' do
-      get :non_restricted
+      get :index
 
       expect(response).to render_template(:index)
     end

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -60,6 +60,29 @@ describe Users::MfaSelectionController do
       patch :update, params: voice_params
     end
 
+    context 'when the selection is only phone and multi mfa is enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+        allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
+        stub_sign_in_before_2fa
+
+        patch :update, params: {
+          two_factor_options_form: {
+            selection: 'phone',
+          },
+        }
+      end
+
+      it 'the redirect to the form page with an anchor' do
+        expect(response).to redirect_to(two_factor_options_path(anchor: 'select_phone'))
+      end
+      it 'contains a flash message' do
+        expect(flash[:phone_error]).to eq(
+          t('errors.two_factor_auth_setup.must_select_additional_option'),
+        )
+      end
+    end
+
     context 'when the selection is phone' do
       let(:user) do
         create(
@@ -163,6 +186,24 @@ describe Users::MfaSelectionController do
       end
     end
 
+    context 'when the form is empty' do
+      before do
+        stub_sign_in
+
+        patch :update, params: {
+          two_factor_options_form: {
+          },
+        }
+      end
+      it 'renders the index page' do
+        expect(response).to redirect_to two_factor_options_path
+      end
+      it 'contains a flash message' do
+        expect(flash[:error]).to eq(
+          t('errors.two_factor_auth_setup.must_select_option'),
+        )
+      end
+    end
     context 'when the selection is not valid' do
       it 'renders the index page' do
         stub_sign_in

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -164,7 +164,7 @@ describe Users::MfaSelectionController do
     end
 
     context 'when the selection is not valid' do
-      it 'returns to index page' do
+      it 'redirects to the index page' do
         stub_sign_in
 
         patch :update, params: {

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -23,7 +23,7 @@ describe Users::MfaSelectionController do
     end
   end
 
-  describe '#index/non_restricted' do
+  describe '#non_restricted' do
     before do
       allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
       user = build(:user, :signed_up, :with_phone)
@@ -31,7 +31,7 @@ describe Users::MfaSelectionController do
     end
 
     it 'shows the mfa setup screen' do
-      get :index
+      get :non_restricted
 
       expect(response).to render_template(:index)
     end

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -214,7 +214,7 @@ describe Users::MfaSelectionController do
           },
         }
 
-        expect(response).to render_template(:index)
+        expect(response).to redirect_to second_mfa_setup_path
       end
     end
   end

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -164,7 +164,7 @@ describe Users::MfaSelectionController do
     end
 
     context 'when the selection is not valid' do
-      it 'redirects to the index page' do
+      it 'renders the index page' do
         stub_sign_in
 
         patch :update, params: {
@@ -173,7 +173,7 @@ describe Users::MfaSelectionController do
           },
         }
 
-        expect(response).to redirect_to second_mfa_setup_path
+        expect(response).to render_template(:index)
       end
     end
   end

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -23,6 +23,20 @@ describe Users::MfaSelectionController do
     end
   end
 
+  describe '#non_restricted' do
+    before do
+      allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
+      user = build(:user, :signed_up, :with_phone)
+      stub_sign_in(user)
+    end
+
+    it 'shows the mfa setup screen' do
+      get :non_restricted
+
+      expect(response).to render_template(:index)
+    end
+  end
+
   describe '#update' do
     it 'submits the TwoFactorOptionsForm' do
       user = build(:user)

--- a/spec/presenters/mfa_confirmation_presenter_spec.rb
+++ b/spec/presenters/mfa_confirmation_presenter_spec.rb
@@ -31,21 +31,11 @@ describe MfaConfirmationPresenter do
       expect(presenter.info).
         to eq(
           t(
-            'mfa.non_restricted.info_html', link: MarketingSite.help_center_article_url(
-              category: 'get-started',
-              article: 'authentication-options',
-            )
+            'mfa.non_restricted.info',
           ),
         )
       expect(non_restriced_presenter.info).
-        to eq(
-          t(
-            'mfa.account_info', link: MarketingSite.help_center_article_url(
-              category: 'get-started',
-              article: 'authentication-options',
-            )
-          ),
-        )
+        to eq(t('mfa.account_info'))
     end
   end
 
@@ -55,6 +45,17 @@ describe MfaConfirmationPresenter do
         to eq(t('mfa.non_restricted.button'))
       expect(non_restriced_presenter.button).
         to eq(t('mfa.add'))
+    end
+  end
+
+  describe '#learn_more' do
+    it 'supplies href for a link' do
+      expect(presenter.learn_more).to eq(
+        MarketingSite.help_center_article_url(
+          category: 'get-started',
+          article: 'authentication-options',
+        ),
+      )
     end
   end
 end

--- a/spec/presenters/mfa_confirmation_presenter_spec.rb
+++ b/spec/presenters/mfa_confirmation_presenter_spec.rb
@@ -29,9 +29,23 @@ describe MfaConfirmationPresenter do
   describe '#info?' do
     it 'supplies a message depending on #enforce_second_mfa?' do
       expect(presenter.info).
-        to eq(t('mfa.non_restricted.info_html'))
+        to eq(
+          t(
+            'mfa.non_restricted.info_html', link: MarketingSite.help_center_article_url(
+              category: 'get-started',
+              article: 'authentication-options',
+            )
+          ),
+        )
       expect(non_restriced_presenter.info).
-        to eq(t('mfa.account_info'))
+        to eq(
+          t(
+            'mfa.account_info', link: MarketingSite.help_center_article_url(
+              category: 'get-started',
+              article: 'authentication-options',
+            )
+          ),
+        )
     end
   end
 

--- a/spec/presenters/mfa_confirmation_presenter_spec.rb
+++ b/spec/presenters/mfa_confirmation_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe MfaConfirmationPresenter do
+  let(:user) { create(:user, :with_phone) }
+  let(:presenter) { described_class.new(user) }
+
+  before do
+    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+  end
+
+  describe '#enforce_second_mfa?' do
+    it 'checks the multi mfa feature flag and whether the user has a non restriced mfa' do
+      expect(presenter.enforce_second_mfa?).to be true
+    end
+  end
+
+  describe '#heading?' do
+    it 'supplies a message depending on #enforce_second_mfa?' do
+      expect(presenter.heading).
+        to eq(t('mfa.non_restricted.heading'))
+    end
+  end
+
+  # describe '#info?' do
+  #   it 'supplies a message depending on #enforce_second_mfa?' do
+  #     expect(presenter.confirm_delete_message).
+  #       to eq(t('email_addresses.delete.confirm', email: email_address.email))
+  #   end
+  # end
+
+  # describe '#button?' do
+  #   it 'supplies a message depending on #enforce_second_mfa?' do
+  #     expect(presenter.confirm_delete_message).
+  #       to eq(t('email_addresses.delete.confirm', email: email_address.email))
+  #   end
+  # end
+end

--- a/spec/presenters/mfa_confirmation_presenter_spec.rb
+++ b/spec/presenters/mfa_confirmation_presenter_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe MfaConfirmationPresenter do
   let(:user) { create(:user, :with_phone) }
   let(:presenter) { described_class.new(user) }
+  let(:non_restriced_user) { create(:user, :with_authentication_app) }
+  let(:non_restriced_presenter) { described_class.new(non_restriced_user) }
 
   before do
     allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
@@ -11,6 +13,7 @@ describe MfaConfirmationPresenter do
   describe '#enforce_second_mfa?' do
     it 'checks the multi mfa feature flag and whether the user has a non restriced mfa' do
       expect(presenter.enforce_second_mfa?).to be true
+      expect(non_restriced_presenter.enforce_second_mfa?).to be false
     end
   end
 
@@ -18,20 +21,26 @@ describe MfaConfirmationPresenter do
     it 'supplies a message depending on #enforce_second_mfa?' do
       expect(presenter.heading).
         to eq(t('mfa.non_restricted.heading'))
+      expect(non_restriced_presenter.heading).
+        to eq(t('titles.mfa_setup.suggest_second_mfa'))
     end
   end
 
-  # describe '#info?' do
-  #   it 'supplies a message depending on #enforce_second_mfa?' do
-  #     expect(presenter.confirm_delete_message).
-  #       to eq(t('email_addresses.delete.confirm', email: email_address.email))
-  #   end
-  # end
+  describe '#info?' do
+    it 'supplies a message depending on #enforce_second_mfa?' do
+      expect(presenter.info).
+        to eq(t('mfa.non_restricted.info_html'))
+      expect(non_restriced_presenter.info).
+        to eq(t('mfa.account_info'))
+    end
+  end
 
-  # describe '#button?' do
-  #   it 'supplies a message depending on #enforce_second_mfa?' do
-  #     expect(presenter.confirm_delete_message).
-  #       to eq(t('email_addresses.delete.confirm', email: email_address.email))
-  #   end
-  # end
+  describe '#button?' do
+    it 'supplies a message depending on #enforce_second_mfa?' do
+      expect(presenter.button).
+        to eq(t('mfa.non_restricted.button'))
+      expect(non_restriced_presenter.button).
+        to eq(t('mfa.add'))
+    end
+  end
 end

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -47,6 +47,12 @@ describe 'mfa_confirmation/show.html.erb' do
     expect(rendered).to_not have_selector('button', text: t('mfa.skip'))
   end
 
+  it 'does have a learn more link' do
+    render
+
+    expect(rendered).to have_selector('a', text: t('mfa.non_restricted.learn_more'))
+  end
+
   context 'users with non restriced mfa' do
     let(:user) { create(:user, :signed_up, :with_authentication_app) }
 
@@ -54,6 +60,12 @@ describe 'mfa_confirmation/show.html.erb' do
       render
 
       expect(rendered).to have_selector('button', text: t('mfa.skip'))
+    end
+
+    it 'does not have a learn more link' do
+      render
+
+      expect(rendered).to_not have_selector('a', text: t('mfa.non_restricted.learn_more'))
     end
   end
 end

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -6,6 +6,8 @@ describe 'mfa_confirmation/show.html.erb' do
 
   before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:enforce_second_mfa?).and_return(true)
+    @content = MfaConfirmationPresenter.new(user)
   end
 
   it 'has a localized title' do
@@ -16,8 +18,8 @@ describe 'mfa_confirmation/show.html.erb' do
 
   it 'has a localized header' do
     render
-
-    expect(rendered).to have_content(t('titles.mfa_setup.suggest_second_mfa'))
+    puts rendered
+    expect(rendered).to have_content(@content.heading)
   end
 
   it 'provides a call to action to add another MFA method' do
@@ -25,13 +27,13 @@ describe 'mfa_confirmation/show.html.erb' do
 
     expect(rendered).to have_selector(
       'p',
-      text: t('mfa.account_info'),
+      text: @content.info,
     )
   end
 
-  it 'has a button with the ability to skip step' do
-    render
+  # it 'has a button with the ability to skip step' do
+  #   render
 
-    expect(rendered).to have_selector('button', text: t('mfa.skip'))
-  end
+  #   expect(rendered).to have_selector('button', text: t('mfa.skip'))
+  # end
 end

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe 'mfa_confirmation/show.html.erb' do
   let(:decorated_user) { user.decorate }
 
   before do
+    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:enforce_second_mfa?).and_return(true)
     @content = MfaConfirmationPresenter.new(user)
@@ -16,24 +17,43 @@ describe 'mfa_confirmation/show.html.erb' do
     render
   end
 
-  it 'has a localized header' do
+  it 'has a heading' do
     render
-    puts rendered
+
     expect(rendered).to have_content(@content.heading)
+  end
+
+  it 'provides a context for adding another MFA method' do
+    render
+
+    expect(rendered).to have_selector(
+      'p',
+      class: 'margin-top-1 margin-bottom-4',
+    )
   end
 
   it 'provides a call to action to add another MFA method' do
     render
 
     expect(rendered).to have_selector(
-      'p',
-      text: @content.info,
+      'a',
+      text: @content.button,
     )
   end
 
-  # it 'has a button with the ability to skip step' do
-  #   render
+  it 'does not have a button with the ability to skip step' do
+    render
 
-  #   expect(rendered).to have_selector('button', text: t('mfa.skip'))
-  # end
+    expect(rendered).to_not have_selector('button', text: t('mfa.skip'))
+  end
+
+  context 'users with non restriced mfa' do
+    let(:user) { create(:user, :signed_up, :with_authentication_app) }
+
+    it 'does have a button with the ability to skip step' do
+      render
+
+      expect(rendered).to have_selector('button', text: t('mfa.skip'))
+    end
+  end
 end


### PR DESCRIPTION
## Why
When we turn on the kantara non restricted feature flag, we want to prevent anyone from signing into their account page with just a phone configured. They will be forced to set up an mfa configuration with something other than phone before they can log in to their account page.

Figma with user flow: https://www.figma.com/file/S1VeH2rR8Xas4aPB9XtSn9/LG-6166-Design-interaction-for-required-second-MFA-(Kantara)?node-id=103%3A4937

Sandbox: https://idp.ssteiner.identitysandbox.gov/