### PR TITLE
Fix paste for personal key confirmation (IdV app)

### DIFF
--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -49,6 +49,17 @@ describe('PersonalKeyInput', () => {
     expect(input.value).to.equal('1234-1234-1234-1234');
   });
 
+  it('allows the user to paste the personal key from their clipboard', async () => {
+    const { getByRole } = render(<PersonalKeyInput />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    input.focus();
+    await userEvent.paste('1234-1234-1234-1234');
+
+    expect(input.value).to.equal('1234-1234-1234-1234');
+  });
+
   it('validates the input value against the expected value (case-insensitive, crockford)', async () => {
     const { getByRole } = render(<PersonalKeyInput expectedValue="abcd-0011-DEFG-1111" />);
 

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -1,9 +1,17 @@
 import { forwardRef, useCallback } from 'react';
 import type { ForwardedRef } from 'react';
 import Cleave from 'cleave.js/react';
+import type { ReactInstanceWithCleave } from 'cleave.js/react/props';
 import { t } from '@18f/identity-i18n';
 import { ValidatedField } from '@18f/identity-validated-field';
 import type { ValidatedFieldValidator } from '@18f/identity-validated-field';
+
+/**
+ * Internal Cleave.js React instance API methods.
+ */
+interface CleaveInstanceInternalAPI {
+  updateValueState: () => void;
+}
 
 interface PersonalKeyInputProps {
   /**
@@ -42,6 +50,9 @@ function PersonalKeyInput(
   return (
     <ValidatedField validate={validate}>
       <Cleave
+        onInit={(owner) => {
+          (owner as ReactInstanceWithCleave & CleaveInstanceInternalAPI).updateValueState();
+        }}
         options={{
           blocks: [4, 4, 4, 4],
           delimiter: '-',

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 shared_examples_for 'personal key page' do
   include PersonalKeyHelper
   include JavascriptDriverHelper
@@ -36,6 +38,13 @@ shared_examples_for 'personal key page' do
       copied_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
 
       expect(copied_text).to eq(scrape_personal_key)
+
+      click_continue
+      page.find(':focus').send_keys [mac? ? :meta : :control, 'v']
+
+      path_before_submit = current_path
+      within('[role=dialog]') { click_on t('forms.buttons.continue') }
+      expect(current_path).not_to eq path_before_submit
     end
 
     it 'validates as case-insensitive, crockford-normalized, length-limited, dash-flexible' do
@@ -60,5 +69,9 @@ shared_examples_for 'personal key page' do
       within('[role=dialog]') { click_on t('forms.buttons.continue') }
       expect(current_path).not_to eq path_before_submit
     end
+  end
+
+  def mac?
+    RbConfig::CONFIG['host_os'].match? 'darwin'
   end
 end

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -40,7 +40,8 @@ shared_examples_for 'personal key page' do
       expect(copied_text).to eq(scrape_personal_key)
 
       click_continue
-      page.find(':focus').send_keys [mac? ? :meta : :control, 'v']
+      mod = mac? ? :meta : :control
+      page.find(':focus').send_keys [mod, 'v']
 
       path_before_submit = current_path
       within('[role=dialog]') { click_on t('forms.buttons.continue') }


### PR DESCRIPTION
**Why**: Because the primary user interaction we expect here is for the user to paste the personal key after clicking the "Copy" button on the personal key display page.

**Testing Instructions:**

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to personal key screen
5. Copy personal key
6. Click Continue
7. Paste personal key **by some other means than <kbd>Cmd + V</kbd>**, e.g. right-click or Mac "Edit" dropdown

Before: Content is not pasted
After: Content is pasted

**Implementation Notes:**

This may be a bug in Cleave.js, where after the input value is changed, it tries to format the value, and expects to use the _last_ input value ([[1]](https://github.com/nosir/cleave.js/blob/e3fa6f3637fa6d8ea97ef66ac1957950632b72ab/src/Cleave.react.js#L281)[[2]](https://github.com/nosir/cleave.js/blob/e3fa6f3637fa6d8ea97ef66ac1957950632b72ab/dist/cleave-angular.js#L1365)). This value is initially `undefined` and only set in response to keydown events, so if the user were to type regularly in the field, or use key combinations like <kbd>Cmd + V</kbd>, the value would be set ([[3]](https://github.com/nosir/cleave.js/blob/e3fa6f3637fa6d8ea97ef66ac1957950632b72ab/dist/cleave-angular.js#L229)). When directly pasting, it would be `undefined`, resulting in an error trying to slice an undefined value.

The resolution proposed here is to force Cleave.js to assign a string value for `lastInputValue` when initialized, via its internal `updateValueState` method ([[4]](https://github.com/nosir/cleave.js/blob/e3fa6f3637fa6d8ea97ef66ac1957950632b72ab/dist/cleave-react-node.js#L490)).

**Edit:** Upstream report: https://github.com/nosir/cleave.js/issues/691