### PR TITLE
Fix flakey OTP lockout spec

### DIFF
--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -337,14 +337,18 @@ describe Users::TwoFactorAuthenticationController do
       it 'marks the user as locked out after too many attempts' do
         expect(@user.second_factor_locked_at).to be_nil
 
-        (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
-          get :send_code, params: {
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms',
-                                           otp_make_default_number: nil },
-          }
-        end
+        freeze_time do
+          (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
+            get :send_code, params: {
+              otp_delivery_selection_form: {
+                otp_delivery_preference: 'sms',
+                otp_make_default_number: nil,
+              },
+            }
+          end
 
-        expect(@user.reload.second_factor_locked_at.to_f).to be_within(0.1).of(Time.zone.now.to_f)
+          expect(@user.reload.second_factor_locked_at).to eq Time.zone.now
+        end
       end
 
       context 'when the phone has been marked as opted out in the DB' do


### PR DESCRIPTION
**Why**: Assertions which rely on precise timing are likely to fail due to slow processing. Instead, freeze time to avoid bounding timeframes.

Example: https://app.circleci.com/pipelines/github/18F/identity-idp/73937/workflows/ed474cae-09a5-4fed-b055-b1664e0365e3/jobs/128324/parallel-runs/1

I was tempted to fix more of these, since there are quite a few `be_within` assertions which are testing in much the same way this was. But for the sake of pragmatism and effort, I limited it to the one I encountered for now.