### PR TITLE
Use IdV mock PII data consistently

### DIFF
--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -100,7 +100,7 @@ module DocAuth
           raw_pii = parsed_data_from_uploaded_file['document']
           raw_pii&.symbolize_keys || {}
         else
-          Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC
+          Idp::Constants::MOCK_IDV_APPLICANT
         end
       end
 

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -11,7 +11,7 @@ module Idp
     AAL2 = 2
     AAL3 = 3
 
-    DEFAULT_MOCK_PII_FROM_DOC = {
+    MOCK_IDV_APPLICANT = {
       first_name: 'FAKEY',
       middle_name: nil,
       last_name: 'MCFAKERSON',
@@ -27,5 +27,9 @@ module Idp
       state_id_expiration: '2099-12-31',
       phone: nil,
     }.freeze
+
+    MOCK_IDV_APPLICANT_WITH_SSN = MOCK_IDV_APPLICANT.merge(ssn: '900-66-1234').freeze
+
+    MOCK_IDV_APPLICANT_WITH_PHONE = MOCK_IDV_APPLICANT_WITH_SSN.merge(phone: '14065551234').freeze
   end
 end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -23,7 +23,7 @@ class SessionEncryptor
     ['email'],
   ]
 
-  SENSITIVE_DEFAULT_FIELDS = Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.slice(
+  SENSITIVE_DEFAULT_FIELDS = Idp::Constants::MOCK_IDV_APPLICANT.slice(
     :last_name,
     :address1,
     :city,

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -10,26 +10,12 @@ describe Api::Verify::PasswordConfirmController do
 
   let(:password) { 'iambatman' }
   let(:user) { create(:user, :signed_up, password: password) }
-  let(:applicant) do
-    { first_name: 'Bruce',
-      last_name: 'Wayne',
-      address1: '123 Mansion St',
-      address2: 'Ste 456',
-      city: 'Gotham City',
-      state: 'NY',
-      zipcode: '10015' }
-  end
-
-  let(:pii) do
-    { first_name: 'Bruce',
-      last_name: 'Wayne',
-      ssn: '900-90-1234' }
-  end
+  let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
 
   let(:profile) { subject.idv_session.profile }
   let(:key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(IdentityConfig.store.idv_private_key)) }
   let(:jwt_metadata) { { vendor_phone_confirmation: true, user_phone_confirmation: true } }
-  let(:jwt) { JWT.encode({ pii: pii, metadata: jwt_metadata }, key, 'RS256', sub: user.uuid) }
+  let(:jwt) { JWT.encode({ pii: applicant, metadata: jwt_metadata }, key, 'RS256', sub: user.uuid) }
 
   before do
     allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(['password_confirm'])

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -30,21 +30,7 @@ FactoryBot.define do
     end
 
     trait :with_pii do
-      pii do
-        Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
-          ssn: DocAuthHelper::GOOD_SSN,
-          phone: '+1 (555) 555-1234',
-        )
-      end
-    end
-
-    trait :with_pii do
-      pii do
-        Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
-          ssn: DocAuthHelper::GOOD_SSN,
-          phone: '+1 (555) 555-1234',
-        )
-      end
+      pii { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
     end
 
     after(:build) do |profile, evaluator|

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -162,7 +162,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS +
-          [Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:state_id_jurisdiction]],
+          [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
       )
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
@@ -185,7 +185,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS -
-          [Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:state_id_jurisdiction]],
+          [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
       )
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe SessionEncryptor do
 
       it 'raises if sensitive value is not KMS encrypted' do
         session = {
-          'new_key' => Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC[:last_name],
+          'new_key' => Idp::Constants::MOCK_IDV_APPLICANT[:last_name],
         }
 
         expect {

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -186,7 +186,7 @@ describe Analytics do
     it 'does not alert when pii values are inside words' do
       expect(ahoy).to receive(:track)
 
-      stub_const('Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC', zipcode: '12345')
+      stub_const('Idp::Constants::MOCK_IDV_APPLICANT', zipcode: '12345')
 
       expect do
         analytics.track_event(

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).
-          to eq(Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC)
+          to eq(Idp::Constants::MOCK_IDV_APPLICANT)
       end
     end
 
@@ -178,7 +178,7 @@ RSpec.describe DocAuth::Mock::ResultResponseBuilder do
         expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).
-          to eq(Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC)
+          to eq(Idp::Constants::MOCK_IDV_APPLICANT)
       end
     end
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -20,7 +20,7 @@ class FakeAnalytics
         ERROR
       end
 
-      Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.slice(
+      Idp::Constants::MOCK_IDV_APPLICANT.slice(
         :first_name,
         :last_name,
         :address1,

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -3,7 +3,7 @@ require_relative 'document_capture_step_helper'
 module DocAuthHelper
   include DocumentCaptureStepHelper
 
-  GOOD_SSN = '900-66-1234'
+  GOOD_SSN = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
 
   def session_from_completed_flow_steps(finished_step)
     session = { doc_auth: {} }
@@ -185,7 +185,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   end
 
   def mock_doc_auth_no_name_pii(method)
-    pii_with_no_name = Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.dup
+    pii_with_no_name = Idp::Constants::MOCK_IDV_APPLICANT.dup
     pii_with_no_name[:last_name] = nil
     DocAuth::Mock::DocAuthMockClient.mock_response!(
       method: method,

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -3,14 +3,8 @@ shared_examples 'sp requesting attributes' do |sp|
   include IdvStepHelper
 
   let(:user) { user_with_2fa }
-  let(:good_ssn) { DocAuthHelper::GOOD_SSN }
   let(:profile) { create(:profile, :active, :verified, user: user, pii: saved_pii) }
-  let(:saved_pii) do
-    Idp::Constants::DEFAULT_MOCK_PII_FROM_DOC.merge(
-      ssn: good_ssn,
-      phone: '+1 (555) 555-1234',
-    )
-  end
+  let(:saved_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
 
   context 'visiting an SP for the first time' do
     it 'requires the user to verify the attributes submitted to the SP', js: true do
@@ -41,7 +35,11 @@ shared_examples 'sp requesting attributes' do |sp|
         expect(page).to have_content t('help_text.requested_attributes.phone')
         expect(page).to have_content '+1 202-555-1212'
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
-        expect(page).to have_css '.masked-text__text', text: good_ssn, visible: :hidden
+        expect(page).to have_css(
+          '.masked-text__text',
+          text: DocAuthHelper::GOOD_SSN,
+          visible: :hidden,
+        )
       end
     end
   end
@@ -103,7 +101,7 @@ shared_examples 'sp requesting attributes' do |sp|
         expect(page).to have_content t('help_text.requested_attributes.full_name')
         expect(page).to have_content 'FAKEY MCFAKERSON'
         expect(page).to have_content t('help_text.requested_attributes.phone')
-        expect(page).to have_content '+15555551234'
+        expect(page).to have_content '+14065551234'
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
         expect(page).to have_content DocAuthHelper::GOOD_SSN
       end

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -101,7 +101,7 @@ shared_examples 'sp requesting attributes' do |sp|
         expect(page).to have_content t('help_text.requested_attributes.full_name')
         expect(page).to have_content 'FAKEY MCFAKERSON'
         expect(page).to have_content t('help_text.requested_attributes.phone')
-        expect(page).to have_content '+14065551234'
+        expect(page).to have_content '+1 406-555-1234'
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
         expect(page).to have_content DocAuthHelper::GOOD_SSN
       end


### PR DESCRIPTION
**Why**:

- We have automated tests which [attempt to detect PII leaks in event logging](https://github.com/18F/identity-idp/blob/92e2fe738c21d3cb2571ad44276db84e3977dacd/spec/support/fake_analytics.rb#L6-L69), and it's only effective if we use the same PII consistently
- Convenient single source of truth for applicant data at various stages of the proofing process
- Less error-prone
   - Real-world example fixed here: The phone number associated with an applicant is expected to follow [a specific normalized format](https://github.com/18F/identity-idp/blob/92e2fe738c21d3cb2571ad44276db84e3977dacd/app/services/idv/phone_step.rb#L80-L85) which wasn't being used correctly in stubbing