### PR TITLE
Merge content-only JavaScript-enabled feature spec cases

### DIFF
--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -55,20 +55,19 @@ feature 'doc auth document capture step' do
       )
     end
 
-    it 'shows the selfie upload option' do
+    it 'shows expected content' do
+      # Selfie upload option
       expect(page).to have_content(t('doc_auth.headings.document_capture_selfie'))
-    end
 
-    it 'displays doc capture tips' do
+      # Document capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-    end
 
-    it 'displays selfie tips' do
+      # Selfie tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -196,16 +196,16 @@ feature 'doc capture document capture step' do
         expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
       end
 
-      it 'displays doc capture tips' do
+      it 'displays expected content' do
+        # Doc capture tips
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-      end
 
-      it 'does not display selfie tips' do
+        # No selfie tips
         expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
         expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
         expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
@@ -218,20 +218,19 @@ feature 'doc capture document capture step' do
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
     end
 
-    it 'shows the selfie upload option' do
+    it 'displays expected content' do
+      # Selfie upload option
       expect(page).to have_content(t('doc_auth.headings.document_capture_selfie'))
-    end
 
-    it 'displays doc capture tips' do
+      # Doc capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-    end
 
-    it 'displays selfie tips' do
+      # Selfie tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
@@ -331,20 +330,19 @@ feature 'doc capture document capture step' do
       )
     end
 
-    it 'does not show the selfie upload option' do
+    it 'displays expected content' do
+      # No selfie upload option
       expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
-    end
 
-    it 'displays document capture tips' do
+      # Document capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-    end
 
-    it 'does not display selfie tips' do
+      # No selfie tips
       expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
       expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
       expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -37,25 +37,17 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
-    it 'is visible on page (not have "display-none" class)' do
-      expect(page).to_not have_css('#pw-strength-cntnr.display-none')
-    end
-
-    it 'updates as password changes' do
+    it 'updates strength feedback as password changes' do
       expect(page).to have_content '...'
 
       fill_in t('forms.password'), with: 'password'
       expect(page).to have_content 'Very weak'
 
-      fill_in t('forms.password'), with: 'this is a great sentence'
-      expect(page).to have_content 'Great!'
-    end
-
-    it 'has dynamic password strength feedback' do
-      expect(page).to have_content '...'
-
       fill_in t('forms.password'), with: '123456789'
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
+
+      fill_in t('forms.password'), with: 'this is a great sentence'
+      expect(page).to have_content 'Great!'
     end
   end
 

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -4,19 +4,14 @@ shared_examples_for 'personal key page' do
   include PersonalKeyHelper
   include JavascriptDriverHelper
 
-  context 'informational text' do
+  describe 'confirmation modal' do
     before do
       click_continue if javascript_enabled?
     end
 
-    context 'modal content' do
-      it 'displays the modal title' do
-        expect(page).to have_content t('forms.personal_key.title')
-      end
-
-      it 'displays the modal instructions' do
-        expect(page).to have_content t('forms.personal_key.instructions')
-      end
+    it 'displays modal content' do
+      expect(page).to have_content t('forms.personal_key.title')
+      expect(page).to have_content t('forms.personal_key.instructions')
     end
   end
 


### PR DESCRIPTION
**Why**: Since the concern of these assertions is common, and to reduce the runtime of the specs, since each test case will spin up a fresh browser tab and complete all the pre-steps required to get to these screens.

Discovered with some regex searching in `spec/support` and `spec/features` directories: `do[\s\n]+expect\(page\).to have_content`