### PR TITLE
Scroll alert into view on password confirm error (IdV app)

### DIFF
--- a/app/javascript/packages/components/index.ts
+++ b/app/javascript/packages/components/index.ts
@@ -7,6 +7,7 @@ export { default as Icon } from './icon';
 export { default as FullScreen } from './full-screen';
 export { default as Link } from './link';
 export { default as PageHeading } from './page-heading';
+export { default as ScrollIntoView } from './scroll-into-view';
 export { default as SpinnerDots } from './spinner-dots';
 export { default as TextInput } from './text-input';
 export { default as TroubleshootingOptions } from './troubleshooting-options';

--- a/app/javascript/packages/components/scroll-into-view.spec.tsx
+++ b/app/javascript/packages/components/scroll-into-view.spec.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import type { SinonSpy } from 'sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
+import ScrollIntoView from './scroll-into-view';
+
+describe('ScrollIntoView', () => {
+  const sandbox = useSandbox();
+
+  it('scrolls content into view', () => {
+    sandbox.spy(Element.prototype, 'scrollIntoView');
+
+    const { getByText } = render(<ScrollIntoView>Content</ScrollIntoView>);
+
+    const text = getByText('Content');
+    const call = (Element.prototype.scrollIntoView as SinonSpy).getCall(0);
+
+    expect((call.thisValue as Element).contains(text)).to.be.true();
+  });
+
+  it('only scrolls into view on initial render', () => {
+    sandbox.spy(Element.prototype, 'scrollIntoView');
+
+    const { rerender } = render(<ScrollIntoView>Content1</ScrollIntoView>);
+    rerender(<ScrollIntoView>Content2</ScrollIntoView>);
+
+    expect(Element.prototype.scrollIntoView).to.have.been.calledOnce();
+  });
+});

--- a/app/javascript/packages/components/scroll-into-view.tsx
+++ b/app/javascript/packages/components/scroll-into-view.tsx
@@ -1,0 +1,18 @@
+import { useRef, useEffect } from 'react';
+import type { ReactNode } from 'react';
+
+interface ScrollIntoViewProps {
+  children: ReactNode;
+}
+
+/**
+ * Scrolls content into the user's viewport when mounted.
+ */
+function ScrollIntoView({ children }: ScrollIntoViewProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => ref.current?.scrollIntoView(), []);
+
+  return <div ref={ref}>{children}</div>;
+}
+
+export default ScrollIntoView;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -84,18 +84,24 @@ describe('PasswordConfirmStep', () => {
       <FormSteps steps={[{ name: 'password_confirm', form: PasswordConfirmStep, submit }]} />,
     );
 
-    await userEvent.type(getByLabelText('components.password_toggle.label'), 'password');
     sandbox.spy(Element.prototype, 'scrollIntoView');
-    await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
+    const continueButton = getByRole('button', { name: 'forms.buttons.continue' });
+
+    await userEvent.type(getByLabelText('components.password_toggle.label'), 'password');
+    await userEvent.click(continueButton);
 
     // There should not be a field-specific error, only a top-level alert.
     const alert = await findByRole('alert');
+    expect(Element.prototype.scrollIntoView).to.have.been.calledOnce();
     const { thisValue: scrollElement } = (Element.prototype.scrollIntoView as SinonSpy).getCall(0);
     expect((scrollElement as Element).contains(alert)).to.be.true();
     expect(alert.textContent).to.equal('Incorrect password');
     const input = getByLabelText('components.password_toggle.label');
     const description = computeAccessibleDescription(input);
     expect(description).to.be.empty();
+
+    await userEvent.click(continueButton);
+    expect(Element.prototype.scrollIntoView).to.have.been.calledTwice();
   });
 
   describe('forgot password', () => {

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { computeAccessibleDescription } from 'dom-accessibility-api';
 import { accordion } from 'identity-style-guide';
+import type { SinonSpy } from 'sinon';
 import * as analytics from '@18f/identity-analytics';
 import { useSandbox, usePropertyValue } from '@18f/identity-test-helpers';
 import { FormSteps } from '@18f/identity-form-steps';
@@ -84,10 +85,13 @@ describe('PasswordConfirmStep', () => {
     );
 
     await userEvent.type(getByLabelText('components.password_toggle.label'), 'password');
+    sandbox.spy(Element.prototype, 'scrollIntoView');
     await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
 
     // There should not be a field-specific error, only a top-level alert.
     const alert = await findByRole('alert');
+    const { thisValue: scrollElement } = (Element.prototype.scrollIntoView as SinonSpy).getCall(0);
+    expect((scrollElement as Element).contains(alert)).to.be.true();
     expect(alert.textContent).to.equal('Incorrect password');
     const input = getByLabelText('components.password_toggle.label');
     const description = computeAccessibleDescription(input);

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -10,7 +10,7 @@ import {
 import { PasswordToggle } from '@18f/identity-password-toggle';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { formatHTML } from '@18f/identity-react-i18n';
-import { PageHeading, Accordion, Alert, Link } from '@18f/identity-components';
+import { PageHeading, Accordion, Alert, Link, ScrollIntoView } from '@18f/identity-components';
 import { getConfigValue } from '@18f/identity-config';
 import type { ChangeEvent } from 'react';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
@@ -38,6 +38,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
   }
 
   const appName = getConfigValue('appName');
+  const stepErrors = errors.filter(({ error }) => error instanceof PasswordSubmitError);
 
   return (
     <>
@@ -51,13 +52,15 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
           )}
         </Alert>
       )}
-      {errors
-        .filter(({ error }) => error instanceof PasswordSubmitError)
-        .map(({ error }) => (
-          <Alert key={error.message} type="error" className="margin-bottom-4">
-            {error.message}
-          </Alert>
-        ))}
+      {stepErrors.length > 0 && (
+        <ScrollIntoView>
+          {stepErrors.map(({ error }) => (
+            <Alert key={error.message} type="error" className="margin-bottom-4">
+              {error.message}
+            </Alert>
+          ))}
+        </ScrollIntoView>
+      )}
       <PageHeading>{t('idv.titles.session.review', { app_name: appName })}</PageHeading>
       <p>{t('idv.messages.sessions.review_message', { app_name: appName })}</p>
       <p>


### PR DESCRIPTION
**Why**: So that the user isn't left confused about why the page hasn't changed when submitting the password confirmation step with an incorrect password.

This was discovered in a recent bug bash, and regresses the current production behavior, where the server-side form submission would reset the scroll position of the page.

**Screen recording:**

_Before:_

https://user-images.githubusercontent.com/1779930/171874590-94045d0d-342c-48c0-8e1a-2aa6e20f178d.mov 

_After:_

https://user-images.githubusercontent.com/1779930/171874597-c74d6faf-7134-4e1d-87f1-54b7cd13333e.mov
