### PR TITLE
Fix logging of webauthn authentications

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -100,7 +100,8 @@ module TwoFactorAuthentication
     end
 
     def analytics_properties
-      auth_method = if form&.webauthn_configuration&.platform_authenticator || params[:platform]
+      auth_method = if form&.webauthn_configuration&.platform_authenticator ||
+                       params[:platform].to_s == 'true'
                       'webauthn_platform'
                     else
                       'webauthn'

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -58,6 +58,7 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           client_data_json: verification_client_data_json,
           signature: signature,
           credential_id: credential_id,
+          platform: '',
         }
       end
       before do


### PR DESCRIPTION
Currently all webauthn authentications are logged as `webauthn_platform` due to a small bug in checking whether we are verifying a platform or roaming authenticator.  We pass in an empty `platform=` parameter, which leads `params[:platform]` to be a truthy empty string.

This PR makes the check a little stricter and adds the param to the spec to better mirror the usage in deployed environments.