### PR TITLE
Only show reset personal key if user has an active profile

### DIFF
--- a/app/presenters/navigation_presenter.rb
+++ b/app/presenters/navigation_presenter.rb
@@ -17,7 +17,7 @@ class NavigationPresenter
           NavItem.new(I18n.t('account.navigation.add_email'), add_email_path),
           NavItem.new(I18n.t('account.navigation.edit_password'), manage_password_path),
           NavItem.new(I18n.t('account.navigation.delete_account'), account_delete_path),
-          user.encrypted_recovery_code_digest.present? ? NavItem.new(
+          user.encrypted_recovery_code_digest.present? && user.active_profile ? NavItem.new(
             I18n.t('account.navigation.reset_personal_key'), create_new_personal_key_path
           ) : nil,
         ].compact

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -191,5 +191,13 @@ FactoryBot.define do
         create(:profile, :active, :verified, :with_pii, user: user)
       end
     end
+
+    trait :deactivated_password_reset_profile do
+      signed_up
+
+      after :build do |user|
+        create(:profile, :password_reset, :with_pii, user: user)
+      end
+    end
   end
 end

--- a/spec/presenters/navigation_presenter_spec.rb
+++ b/spec/presenters/navigation_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NavigationPresenter do
   describe '#navigation_items' do
     describe 'personal key' do
       context 'for a user with a personal key' do
-        let(:user) { build(:user, personal_key: 'abcdef') }
+        let(:user) { build(:user, :proofed) }
 
         it 'has a link to reset personal key' do
           nav_item = navigation.navigation_items.first.children.last
@@ -18,6 +18,18 @@ RSpec.describe NavigationPresenter do
 
       context 'for a user that does not have a personal key' do
         it 'does not link to reset personal key' do
+          has_reset_personal_key = navigation.navigation_items.first.children.any? do |item|
+            item.title == I18n.t('account.navigation.reset_personal_key')
+          end
+
+          expect(has_reset_personal_key).to eq(false)
+        end
+      end
+
+      context 'for a proofed user with deactivated profile due to password reset' do
+        let(:user) { build(:user, :deactivated_password_reset_profile) }
+
+        it 'does not have a link to reset personal key' do
           has_reset_personal_key = navigation.navigation_items.first.children.any? do |item|
             item.title == I18n.t('account.navigation.reset_personal_key')
           end


### PR DESCRIPTION
If a user has a personal key, but does not have an active perofile (ex: has reset their password), we should not offer the option to regenerate the personal key

[Relevant slack thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1654281440310989)