### PR TITLE
Only include "billable" events in billing reports (LG-6539)

### DIFF
--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -128,6 +128,7 @@ module Db
                   sp_return_logs.requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer = %{issuer}
+              AND sp_return_logs.billable = true
             GROUP BY
               sp_return_logs.user_id
             , sp_return_logs.ial

--- a/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
+++ b/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
@@ -119,6 +119,7 @@ module Db
                   sp_return_logs.requested_at::date BETWEEN %{range_start} AND %{range_end}
               AND sp_return_logs.returned_at IS NOT NULL
               AND sp_return_logs.issuer IN %{issuers}
+              AND sp_return_logs.billable = true
             GROUP BY
               sp_return_logs.user_id
             , sp_return_logs.ial

--- a/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReport do
           ial: 1,
           requested_at: inside_iaa1,
           returned_at: inside_iaa1,
+          billable: true,
         )
 
         # 1 unique user in month 1 at IAA 2 sp 1 @ IAL 2

--- a/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
+++ b/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
@@ -49,8 +49,20 @@ RSpec.describe Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow do
             service_provider: service_provider,
             requested_at: partial_month_date,
             returned_at: partial_month_date,
+            billable: true,
           )
         end
+
+        # non-billable event during partial month, should be ignored
+        create(
+          :sp_return_log,
+          user: user,
+          ial: 1,
+          service_provider: service_provider,
+          requested_at: partial_month_date,
+          returned_at: partial_month_date,
+          billable: false,
+        )
 
         # 11 IAL 1 auths during full month
         create(

--- a/spec/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa_spec.rb
+++ b/spec/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa do
           ial: 1,
           requested_at: inside_partial_month,
           returned_at: inside_partial_month,
+          billable: true,
+        )
+
+        # non-billable event in partial month, should be ignored
+        create(
+          :sp_return_log,
+          user_id: user1.id,
+          issuer: issuer1,
+          ial: 1,
+          requested_at: inside_partial_month,
+          returned_at: inside_partial_month,
+          billable: false,
         )
 
         # 2 unique user in partial month @ IAL2
@@ -72,6 +84,7 @@ RSpec.describe Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa do
             ial: 2,
             requested_at: inside_partial_month,
             returned_at: inside_partial_month,
+            billable: true,
           )
         end
 


### PR DESCRIPTION
A bug report highlighted an inconsistency in our reports, digging in, I found
that we create both "billable: true" and "billable: false" rows in sp_return_logs
so the reports that added up sp_return_logs for billing were counting some extra.

For some context on the source data:
https://github.com/18F/identity-idp/blob/c5c8fe6cf2546392d90b9f7a4c2065848bb7868f/app/controllers/concerns/billable_event_trackable.rb#L2-L9

- "billable: false" don't make it into the monthly aggregate table