### PR TITLE
Include more context when logging telephony sent events

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -204,7 +204,7 @@ module Users
         phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
         context: context,
         otp_delivery_preference: otp_delivery_preference,
-        resend: delivery_params[:resend],
+        resend: params.dig(:otp_delivery_selection_form, :resend),
         telephony_response: @telephony_result.to_h,
         success: @telephony_result.success?,
       )

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -198,7 +198,7 @@ module Users
     end
 
     def track_events(otp_delivery_preference:)
-      extra = {
+      analytics.telephony_otp_sent(
         area_code: parsed_phone.area_code,
         country_code: parsed_phone.country_code,
         phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
@@ -207,8 +207,7 @@ module Users
         resend: delivery_params[:resend],
         telephony_response: @telephony_result.to_h,
         success: @telephony_result.success?,
-      }
-      analytics.telephony_otp_sent(**extra)
+      )
     end
 
     def exceeded_otp_send_limit?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -777,6 +777,7 @@ module AnalyticsEvents
   # @param [String] country_code country code of phone number
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
+  # @param [String] phone_fingerprint
   # @param [Hash] telephony_response response from Telephony gem
   # The user requested an OTP to confirm their phone during the IDV phone step
   def idv_phone_confirmation_otp_sent(
@@ -786,6 +787,7 @@ module AnalyticsEvents
     country_code:,
     area_code:,
     rate_limit_exceeded:,
+    phone_fingerprint:,
     telephony_response:,
     **extra
   )
@@ -797,6 +799,7 @@ module AnalyticsEvents
       country_code: country_code,
       area_code: area_code,
       rate_limit_exceeded: rate_limit_exceeded,
+      phone_fingerprint: phone_fingerprint,
       telephony_response: telephony_response,
       **extra,
     )
@@ -1538,6 +1541,44 @@ module AnalyticsEvents
         service_provider: service_provider,
         **extra,
       }.compact,
+    )
+  end
+
+  # @param [String] area_code
+  # @param [String] country_code
+  # @param [String] phone_fingerprint
+  # @param [String] context the context of the OTP, either "authentication" for confirmed phones
+  # or "confirmation" for unconfirmed
+  # @param [String] otp_delivery_preference the channel used to send the message,
+  # either "sms" or "voice"
+  # @param [Boolean] resend
+  # @param [Hash] telephony_response
+  # @param [Boolean] success
+  # A phone one-time password send was attempted
+  def telephony_otp_sent(
+    area_code:,
+    country_code:,
+    phone_fingerprint:,
+    context:,
+    otp_delivery_preference:,
+    resend:,
+    telephony_response:,
+    success:,
+    **extra
+  )
+    track_event(
+      'Telephony: OTP sent',
+      {
+        area_code: area_code,
+        country_code: country_code,
+        phone_fingerprint: phone_fingerprint,
+        context: context,
+        otp_delivery_preference: otp_delivery_preference,
+        resend: resend,
+        telephony_response: telephony_response,
+        success: success,
+        **extra,
+      },
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1549,8 +1549,7 @@ module AnalyticsEvents
   # @param [String] phone_fingerprint
   # @param [String] context the context of the OTP, either "authentication" for confirmed phones
   # or "confirmation" for unconfirmed
-  # @param [String] otp_delivery_preference the channel used to send the message,
-  # either "sms" or "voice"
+  # @param ["sms","voice"] otp_delivery_preference the channel used to send the message
   # @param [Boolean] resend
   # @param [Hash] telephony_response
   # @param [Boolean] success

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -777,7 +777,7 @@ module AnalyticsEvents
   # @param [String] country_code country code of phone number
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
-  # @param [String] phone_fingerprint
+  # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # @param [Hash] telephony_response response from Telephony gem
   # The user requested an OTP to confirm their phone during the IDV phone step
   def idv_phone_confirmation_otp_sent(
@@ -1546,7 +1546,7 @@ module AnalyticsEvents
 
   # @param [String] area_code
   # @param [String] country_code
-  # @param [String] phone_fingerprint
+  # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # @param [String] context the context of the OTP, either "authentication" for confirmed phones
   # or "confirmation" for unconfirmed
   # @param ["sms","voice"] otp_delivery_preference the channel used to send the message

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -80,6 +80,7 @@ module Idv
         otp_delivery_preference: delivery_method,
         country_code: parsed_phone.country,
         area_code: parsed_phone.area_code,
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
         rate_limit_exceeded: rate_limit_exceeded?,
         telephony_response: @telephony_response,
       }

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -54,6 +54,7 @@ describe Idv::ResendOtpController do
 
       expected_result = {
         success: true,
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(Phonelib.parse(phone).e164),
         errors: {},
         otp_delivery_preference: :sms,
         country_code: 'US',

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -316,7 +316,7 @@ describe Users::TwoFactorAuthenticationController do
           with('OTP: Delivery Selection', analytics_hash)
         expect(@analytics).to receive(:track_event).
           ordered.
-          with(Analytics::TELEPHONY_OTP_SENT, hash_including(success: true))
+          with('Telephony: OTP sent', hash_including(success: true, otp_delivery_preference: 'sms'))
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end
@@ -437,7 +437,10 @@ describe Users::TwoFactorAuthenticationController do
           with('OTP: Delivery Selection', analytics_hash)
         expect(@analytics).to receive(:track_event).
           ordered.
-          with(Analytics::TELEPHONY_OTP_SENT, hash_including(success: true))
+          with('Telephony: OTP sent', hash_including(
+            success: true,
+            otp_delivery_preference: 'voice',
+          ))
 
         get :send_code, params: {
           otp_delivery_selection_form: { otp_delivery_preference: 'voice',

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -304,7 +304,7 @@ describe Users::TwoFactorAuthenticationController do
           success: true,
           errors: {},
           otp_delivery_preference: 'sms',
-          resend: nil,
+          resend: 'true',
           context: 'authentication',
           country_code: 'US',
           area_code: '202',
@@ -316,9 +316,12 @@ describe Users::TwoFactorAuthenticationController do
           with('OTP: Delivery Selection', analytics_hash)
         expect(@analytics).to receive(:track_event).
           ordered.
-          with('Telephony: OTP sent', hash_including(success: true, otp_delivery_preference: 'sms'))
+          with('Telephony: OTP sent', hash_including(
+            resend: 'true', success: true, otp_delivery_preference: 'sms',
+          ))
 
-        get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
+        get :send_code, params: { otp_delivery_selection_form:
+                                  { otp_delivery_preference: 'sms', resend: 'true' } }
       end
 
       it 'calls OtpRateLimiter#exceeded_otp_send_limit? and #increment' do


### PR DESCRIPTION
We currently depend on a bit of the surrounding events to analyze telephony like `OTP: Delivery Selection`, but those events are a bit removed from the actual API call to send the OTP.  This PR adds the attributes that appear in other events to `Telephony: OTP sent` so that important context is logged alongside the result of the call to send an OTP via telephony.  It should be very helpful in improving our troubleshooting and understanding of telephony usage patterns.

These changes make `Telephony: OTP sent` and `IdV: phone confirmation otp sent` more similar, and we could eventually consider merging them (with the `context` attribute to distinguish IDV).  This also documents the OTP sent event in the new format.