### PR TITLE
Remove unused MFA security labels

### DIFF
--- a/app/presenters/two_factor_authentication/auth_app_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/auth_app_selection_presenter.rb
@@ -4,11 +4,6 @@ module TwoFactorAuthentication
       :auth_app
     end
 
-    # :reek:UtilityFunction
-    def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.secure_label')
-    end
-
     def disabled?
       user&.auth_app_configurations&.any?
     end

--- a/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
@@ -4,11 +4,6 @@ module TwoFactorAuthentication
       :backup_code
     end
 
-    # :reek:UtilityFunction
-    def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.least_secure_label')
-    end
-
     def disabled?
       user&.backup_code_configurations&.any?
     end

--- a/app/presenters/two_factor_authentication/phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/phone_selection_presenter.rb
@@ -23,10 +23,6 @@ module TwoFactorAuthentication
       user.phone_configurations.count
     end
 
-    def security_level
-      t('two_factor_authentication.two_factor_choice_options.less_secure_label')
-    end
-
     def disabled?
       VendorStatus.new.all_phone_vendor_outage? || user&.phone_configurations&.any?
     end

--- a/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
@@ -4,10 +4,6 @@ module TwoFactorAuthentication
       :piv_cac
     end
 
-    def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.more_secure_label')
-    end
-
     def disabled?
       user&.piv_cac_configurations&.any?
     end

--- a/app/presenters/two_factor_authentication/selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/selection_presenter.rb
@@ -39,8 +39,6 @@ module TwoFactorAuthentication
       )
     end
 
-    def security_level; end
-
     def html_class
       ''
     end

--- a/app/presenters/two_factor_authentication/webauthn_platform_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/webauthn_platform_selection_presenter.rb
@@ -12,10 +12,6 @@ module TwoFactorAuthentication
       user&.webauthn_configurations&.where(platform_authenticator: true)&.any?
     end
 
-    def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.more_secure_label')
-    end
-
     def mfa_configuration_count
       user.webauthn_configurations.where(platform_authenticator: true).count
     end

--- a/app/presenters/two_factor_authentication/webauthn_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/webauthn_selection_presenter.rb
@@ -8,11 +8,6 @@ module TwoFactorAuthentication
       'display-none'
     end
 
-    # :reek:UtilityFunction
-    def security_level
-      I18n.t('two_factor_authentication.two_factor_choice_options.more_secure_label')
-    end
-
     def disabled?
       user&.webauthn_configurations&.where(platform_authenticator: [false, nil])&.any?
     end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -46,10 +46,6 @@ class TwoFactorOptionsPresenter
     end
   end
 
-  def show_security_level?
-    !(piv_cac_required? || (aal3_only? && mfa_policy.two_factor_enabled?))
-  end
-
   private
 
   def piv_cac_option

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -132,9 +132,6 @@ en:
       configurations_added:
         one: '(%{count} added)'
         other: '(%{count} added)'
-      least_secure_label: Least secure
-      less_secure_label: Less secure
-      more_secure_label: More Secure
       phone: Text or voice message
       phone_info: Receive a secure code by (SMS) text or phone call.
       phone_info_html: Receive a secure code by (SMS) text or phone call. <strong>You
@@ -143,7 +140,6 @@ en:
         (toll) phone numbers.
       piv_cac: Government employee ID
       piv_cac_info: PIV/CAC cards for government and military employees. Desktop only.
-      secure_label: Secure
       sms: Text message / SMS
       sms_info: Get your security code via text message / SMS.
       unused_backup_code:

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -143,9 +143,6 @@ es:
       configurations_added:
         one: '(%{count} añadido)'
         other: '(%{count} añadido)'
-      least_secure_label: Lo menos seguro
-      less_secure_label: Menos seguro
-      more_secure_label: Más seguro
       phone: Mensaje de texto o de voz
       phone_info: Recibir un código seguro por medio de un mensaje de texto (SMS) o
         una llamada telefónica.
@@ -157,7 +154,6 @@ es:
       piv_cac: Identificación de empleado gubernamental
       piv_cac_info: Credenciales PIV/CAC para empleados gubernamentales y del
         ejército. Únicamente versión de escritorio.
-      secure_label: Seguro
       sms: Mensaje de texto / SMS
       sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS.
       unused_backup_code:

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -147,9 +147,6 @@ fr:
       configurations_added:
         one: '(%{count} ajouté)'
         other: '(%{count} ajoutés)'
-      least_secure_label: Le moins sécurisé
-      less_secure_label: Moins sécurisé
-      more_secure_label: Plus sécurisé
       phone: Message texte ou vocal
       phone_info: Recevoir un code de sécurité par texto (SMS) ou appel téléphonique.
       phone_info_html: Recevoir un code de sécurité par texto (SMS) ou appel
@@ -160,7 +157,6 @@ fr:
       piv_cac: Carte d’identification des employés du gouvernement
       piv_cac_info: Cartes PIV/CAC pour les fonctionnaires et les militaires. Bureau
         uniquement.
-      secure_label: Sécurisé
       sms: SMS
       sms_info: Obtenez votre code de sécurité par SMS.
       unused_backup_code:


### PR DESCRIPTION
**Why**: Because they're unused since #5989