### PR TITLE
Remove duplicative tests

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -665,8 +665,6 @@ feature 'Sign in' do
   it_behaves_like 'signing in with wrong credentials', :oidc
 
   it_behaves_like 'signing in as proofed account with broken personal key', :saml, sp_ial: 1
-  it_behaves_like 'signing in as proofed account with broken personal key', :oidc, sp_ial: 1
-  it_behaves_like 'signing in as proofed account with broken personal key', :saml, sp_ial: 2
   it_behaves_like 'signing in as proofed account with broken personal key', :oidc, sp_ial: 2
 
   context 'user signs in and chooses another authentication method' do


### PR DESCRIPTION
**Why**: These take a long time, instead of the full
matrix of { IAL1, IAL2 } x { OIDC, SAML }, we cover
one of each which should catch major regressions