### PR TITLE
Remove an extra puts statement in specs

### DIFF
--- a/spec/services/funnel/doc_auth/log_document_error_spec.rb
+++ b/spec/services/funnel/doc_auth/log_document_error_spec.rb
@@ -4,7 +4,7 @@ describe Funnel::DocAuth::LogDocumentError do
   describe '::call' do
     it 'sets last error when doc auth log exists' do
       doc_auth_log = create(:doc_auth_log, user_id: 1)
-      puts Funnel::DocAuth::LogDocumentError.call(1, 'test')
+      Funnel::DocAuth::LogDocumentError.call(1, 'test')
       expect(doc_auth_log.reload.last_document_error).to eq 'test'
     end
 


### PR DESCRIPTION
I spotted something fishy in some CI output, tracked it down and cleaned it up

```
.......................................................................................................................................................................................................................................................................................................................................................................................................................true
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................***...............................................................
```
<img width="792" alt="Screen Shot 2022-06-07 at 7 58 24 AM" src="https://user-images.githubusercontent.com/458784/172413165-5e41d791-a296-4471-a6b8-a850ebd278ef.png">

