### PR TITLE
Changelog script: Use current branch as default source

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -71,6 +71,10 @@ def build_structured_git_log(git_log)
   end
 end
 
+def current_branch
+  Open3.capture2('git', 'branch', '--show-current')[0].chomp
+end
+
 def commit_messages_contain_skip_changelog?(base_branch, source_branch)
   log, status = Open3.capture2(
     'git', 'log', '--pretty=\'%B\'', "#{base_branch}..#{source_branch}"
@@ -180,7 +184,7 @@ def format_changelog(changelog_entries)
 end
 
 def main(args)
-  options = { base_branch: 'main' }
+  options = { base_branch: 'main', source_branch: current_branch }
   basename = File.basename($0)
 
   optparse = OptionParser.new do |opts|
@@ -197,7 +201,11 @@ def main(args)
       options[:base_branch] = val
     end
 
-    opts.on('-s', '--source_branch SOURCE_BRANCH', 'Name of source branch (required)') do |val|
+    opts.on(
+      '-s',
+      '--source_branch SOURCE_BRANCH',
+      'Name of source branch, defaults to current',
+    ) do |val|
       options[:source_branch] = val
     end
   end

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -71,10 +71,6 @@ def build_structured_git_log(git_log)
   end
 end
 
-def current_branch
-  Open3.capture2('git', 'branch', '--show-current')[0].chomp
-end
-
 def commit_messages_contain_skip_changelog?(base_branch, source_branch)
   log, status = Open3.capture2(
     'git', 'log', '--pretty=\'%B\'', "#{base_branch}..#{source_branch}"
@@ -184,7 +180,7 @@ def format_changelog(changelog_entries)
 end
 
 def main(args)
-  options = { base_branch: 'main', source_branch: current_branch }
+  options = { base_branch: 'main', source_branch: 'HEAD' }
   basename = File.basename($0)
 
   optparse = OptionParser.new do |opts|
@@ -204,7 +200,7 @@ def main(args)
     opts.on(
       '-s',
       '--source_branch SOURCE_BRANCH',
-      'Name of source branch, defaults to current',
+      'Name of source branch, defaults to HEAD',
     ) do |val|
       options[:source_branch] = val
     end

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -179,7 +179,7 @@ def format_changelog(changelog_entries)
   changelog.strip
 end
 
-def main(args)
+def parsed_options(args)
   options = { base_branch: 'main', source_branch: 'HEAD' }
   basename = File.basename($0)
 
@@ -207,6 +207,11 @@ def main(args)
   end
 
   optparse.parse!(args)
+  options
+end
+
+def main(args)
+  options = parsed_options(args)
 
   abort(optparse.help) if options[:source_branch].nil?
 

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'scripts/changelog_check' do
     context 'with base branch passed as argument' do
       let(:args) { ['-b', 'example'] }
 
-      it 'assigns source_branch option' do
+      it 'assigns base_branch option' do
         expect(options).to eq({ base_branch: 'example', source_branch: 'HEAD' })
       end
     end

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -103,4 +103,29 @@ RSpec.describe 'scripts/changelog_check' do
       expect(changelogs.first.change).to start_with('P')
     end
   end
+
+  describe '#parsed_options' do
+    let(:args) { [] }
+    subject(:options) { parsed_options(args) }
+
+    it 'populates default values' do
+      expect(options).to eq({ base_branch: 'main', source_branch: 'HEAD' })
+    end
+
+    context 'with source branch passed as argument' do
+      let(:args) { ['-s', 'example'] }
+
+      it 'assigns source_branch option' do
+        expect(options).to eq({ base_branch: 'main', source_branch: 'example' })
+      end
+    end
+
+    context 'with base branch passed as argument' do
+      let(:args) { ['-b', 'example'] }
+
+      it 'assigns source_branch option' do
+        expect(options).to eq({ base_branch: 'example', source_branch: 'HEAD' })
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Since it avoids adding an extra flag in the common use-case of generating a changelog for the current staging branch.

Related discussion: https://github.com/18F/identity-handbook/pull/267#discussion_r891334994