### PR TITLE
Avoid handling stored result for async document capture

### DIFF
--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -111,6 +111,7 @@ module Idv
       end
 
       def request_should_use_stored_result?
+        return false if FeatureManagement.document_capture_async_uploads_enabled?
         return false if stored_result.blank?
         IMAGE_UPLOAD_PARAM_NAMES.each do |param_name|
           return false if flow_params[param_name].present?

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -111,7 +111,7 @@ module Idv
       end
 
       def request_should_use_stored_result?
-        return false if FeatureManagement.document_capture_async_uploads_enabled?
+        return true if FeatureManagement.document_capture_async_uploads_enabled?
         return false if stored_result.blank?
         IMAGE_UPLOAD_PARAM_NAMES.each do |param_name|
           return false if flow_params[param_name].present?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -429,7 +429,6 @@ test:
   database_worker_jobs_username: ''
   database_worker_jobs_host: ''
   database_worker_jobs_password: ''
-  doc_auth_enable_presigned_s3_urls: true
   doc_auth_max_attempts: 4
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false

--- a/spec/services/idv/steps/document_capture_step_spec.rb
+++ b/spec/services/idv/steps/document_capture_step_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe Idv::Steps::DocumentCaptureStep do
+  let(:user) { build(:user) }
+  let(:service_provider) { create(:service_provider) }
+  let(:controller) do
+    instance_double(
+      'controller',
+      session: { sp: { issuer: service_provider.issuer } },
+      current_sp: service_provider,
+      current_user: user,
+      params: params,
+    )
+  end
+
+  let(:document_capture_session) do
+    DocumentCaptureSession.create(user: user)
+  end
+  let(:document_capture_session_uuid) { document_capture_session.uuid }
+
+  let(:flow) do
+    Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+      flow.flow_session = { document_capture_session_uuid: document_capture_session_uuid }
+    end
+  end
+
+  subject(:step) do
+    Idv::Steps::DocumentCaptureStep.new(flow)
+  end
+
+
+  describe '#call' do
+    before do
+      allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
+        and_return(document_capture_async_uploads_enabled)
+    end
+
+    context 'in a synchronous context' do
+      let(:document_capture_async_uploads_enabled) { false }
+
+      let(:params) do
+        {
+          doc_auth: {
+            front_image: DocAuthImageFixtures.document_front_image_multipart,
+            back_image: DocAuthImageFixtures.document_back_image_multipart,
+            selfie_image: DocAuthImageFixtures.document_face_image_multipart,
+          }
+        }
+      end
+
+      it 'works' do
+        result = nil
+        expect { result = step.call }.to(change { ProofingComponent.find_by(user: user) })
+
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context 'in an async context' do
+      let(:document_capture_async_uploads_enabled) { true }
+      let(:params) { { doc_auth: {} } }
+
+      before do
+        document_capture_session.store_result_from_response(
+          DocAuth::Response.new(
+            success: true,
+            errors: {},
+            pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT,
+          ),
+        )
+      end
+
+      it 'works' do
+        result = nil
+        expect { result = step.call }.to(change { ProofingComponent.find_by(user: user) })
+
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/idv/steps/document_capture_step_spec.rb
+++ b/spec/services/idv/steps/document_capture_step_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 describe Idv::Steps::DocumentCaptureStep do
   let(:user) { build(:user) }
   let(:service_provider) { create(:service_provider) }
+  let(:params) { { doc_auth: {} } }
   let(:controller) do
     instance_double(
       'controller',
       session: { sp: { issuer: service_provider.issuer } },
       current_sp: service_provider,
       current_user: user,
-      params: params,
+      params: ActionController::Parameters.new(params),
     )
   end
 
@@ -28,38 +29,36 @@ describe Idv::Steps::DocumentCaptureStep do
     Idv::Steps::DocumentCaptureStep.new(flow)
   end
 
-
   describe '#call' do
+    let(:document_capture_async_uploads_enabled) { false }
+
     before do
       allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
         and_return(document_capture_async_uploads_enabled)
     end
 
-    context 'in a synchronous context' do
-      let(:document_capture_async_uploads_enabled) { false }
-
+    context 'with form parameters' do
       let(:params) do
         {
           doc_auth: {
             front_image: DocAuthImageFixtures.document_front_image_multipart,
             back_image: DocAuthImageFixtures.document_back_image_multipart,
             selfie_image: DocAuthImageFixtures.document_face_image_multipart,
-          }
+          },
         }
       end
 
-      it 'works' do
+      it 'extracts pii and adds proofing component using form parameters' do
         result = nil
-        expect { result = step.call }.to(change { ProofingComponent.find_by(user: user) })
+        expect(step).to receive(:post_images_and_handle_result).and_call_original
+        expect(step).to receive(:extract_pii_from_doc)
+        expect { result = step.base_call }.to(change { ProofingComponent.find_by(user: user) })
 
         expect(result.success?).to eq(true)
       end
     end
 
-    context 'in an async context' do
-      let(:document_capture_async_uploads_enabled) { true }
-      let(:params) { { doc_auth: {} } }
-
+    context 'with a stored result' do
       before do
         document_capture_session.store_result_from_response(
           DocAuth::Response.new(
@@ -70,11 +69,26 @@ describe Idv::Steps::DocumentCaptureStep do
         )
       end
 
-      it 'works' do
+      it 'extracts pii and adds proofing component using stored result' do
         result = nil
-        expect { result = step.call }.to(change { ProofingComponent.find_by(user: user) })
+        expect(step).to receive(:handle_stored_result).and_call_original
+        expect(step).to receive(:extract_pii_from_doc)
+        expect { result = step.base_call }.to(change { ProofingComponent.find_by(user: user) })
 
-        expect(result).to be_nil
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context 'in an async context' do
+      let(:document_capture_async_uploads_enabled) { true }
+
+      it 'does not handle the images or the stored result' do
+        expect(step).not_to receive(:handle_stored_result)
+        expect(step).not_to receive(:post_images_and_handle_result)
+
+        result = step.base_call
+
+        expect(result.success?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
**Why** When async uploads are enabled, we don't want to (and can't) handle the stored result here. The [handling is done in `VerifyDocumentStatusAction`](https://github.com/18F/identity-idp/blob/72fa0e270b58a097ce5efa6c3e24f75d0d757634/app/services/idv/actions/verify_document_status_action.rb#L53-L59), and the stored result is _deleted_, so `request_should_use_stored_result?` would always be false.

See: https://github.com/18F/identity-idp/pull/6423/files#r883640170

Still thinking through a strategy for if/how to test this.