### PR TITLE
Stop querying unused user email columns

### DIFF
--- a/app/models/concerns/deprecated_user_attributes.rb
+++ b/app/models/concerns/deprecated_user_attributes.rb
@@ -2,7 +2,7 @@ module DeprecatedUserAttributes
   extend ActiveSupport::Concern
 
   DEPRECATED_ATTRIBUTES = %i[
-    email_fingerprint encrypted_email email confirmed_at
+    email confirmed_at
   ].freeze
 
   def []=(attribute, value)

--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -21,24 +21,4 @@ module UserEncryptedAttributeOverrides
       email_address&.user
     end
   end
-
-  # Override ActiveModel::Dirty methods in order to
-  # use email_fingerprint_changed? instead of email_changed?
-  # This is necessary because email is no longer an ActiveRecord
-  # attribute and all the *_changed and *_was magic no longer works.
-  def will_save_change_to_email?
-    email_fingerprint_changed?
-  end
-
-  def email_in_database
-    EncryptedAttribute.new(encrypted_email_was).decrypted if encrypted_email_was.present?
-  end
-
-  # Override usual setter method in order to also set fingerprint
-  def email=(email)
-    set_encrypted_attribute(name: :email, value: email)
-    self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''
-    return if email_addresses.empty?
-    email_addresses.take.email = email
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp]
+  self.ignored_columns = %w[totp_timestamp email_fingerprint encrypted_email]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -432,7 +432,7 @@ feature 'Sign in' do
         create(:user, :signed_up, email: email, password: password)
 
         user = User.find_with_email(email)
-        encrypted_email = user.encrypted_email
+        encrypted_email = user.confirmed_email_addresses.first.encrypted_email
 
         rotate_attribute_encryption_key_with_invalid_queue
 
@@ -440,7 +440,7 @@ feature 'Sign in' do
           to raise_error Encryption::EncryptionError, 'unable to decrypt attribute with any key'
 
         user = user.reload
-        expect(user.encrypted_email).to eq encrypted_email
+        expect(user.confirmed_email_addresses.first.encrypted_email).to eq encrypted_email
       end
     end
 
@@ -452,14 +452,14 @@ feature 'Sign in' do
         create(:user, :signed_up, email: email, password: password)
 
         user = User.find_with_email(email)
-        encrypted_email = user.encrypted_email
+        encrypted_email = user.confirmed_email_addresses.first.encrypted_email
 
         rotate_attribute_encryption_key_with_invalid_queue
 
         sign_in_user_with_piv(user)
 
         user = user.reload
-        expect(user.encrypted_email).to eq encrypted_email
+        expect(user.confirmed_email_addresses.first.encrypted_email).to eq encrypted_email
       end
     end
   end


### PR DESCRIPTION
Following up to #6474 to skip reading the `email_fingerprint` and `encrypted_email` columns