### PR TITLE
Rename session key and middleware to migrate existing cookies (LG-6584)

### DIFF
--- a/app/controllers/test/session_data_controller.rb
+++ b/app/controllers/test/session_data_controller.rb
@@ -1,0 +1,8 @@
+module Test
+  # Controller that echoes back session info, only for testing
+  class SessionDataController < ApplicationController
+    def index
+      render json: session.to_h
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -104,6 +104,8 @@ module Identity
     config.middleware.use Utf8Sanitizer
     require 'secure_cookies'
     config.middleware.insert_after ActionDispatch::Static, SecureCookies
+    require 'session_store_migration'
+    config.middleware.insert_after SecureCookies, SessionStoreMigration
 
     # rubocop:disable Metrics/BlockLength
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,8 +4,7 @@ require 'session_encryptor_error_handler'
 
 Rails.application.config.session_store(
   :redis_session_store,
-  # "Upaya" is a legacy code name for the project. This should be renamed. See: LG-6584
-  key: '_upaya_session',
+  key: '_identity_idp_session',
   redis: {
     driver: :hiredis,
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,8 @@ Rails.application.routes.draw do
 
         get '/s3/:key' => 'fake_s3#show', as: :fake_s3
         put '/s3/:key' => 'fake_s3#update'
+
+        get '/session_data' => 'session_data#index'
       end
     end
 

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -27,7 +27,7 @@ class SessionStoreMigration
   def process_in_headers!(env)
     cookie_str = env[Rack::HTTP_COOKIE]
 
-    if cookie_str.include?(OLD_KEY) && !cookie_str.include?(NEW_KEY)
+    if cookie_str && cookie_str.include?(OLD_KEY) && !cookie.include?(NEW_KEY)
       cookies = Rack::Utils.parse_cookies_header(cookie_str)
 
       updated_cookie_str = cookie_str + "; #{NEW_KEY}=#{cookies[OLD_KEY]}"

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -41,7 +41,8 @@ class SessionStoreMigration
   end
 
   def process_out_headers!(headers)
-    if (cookie_header = headers[Rack::SET_COOKIE]).present?
+    cookie_header = headers[Rack::SET_COOKIE]
+    if cookie_header.present?
       cookies = cookie_header.split(COOKIE_SEPARATOR)
 
       new_key_set = cookies.find { |cookie| cookie.start_with?(NEW_KEY) }

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -27,7 +27,7 @@ class SessionStoreMigration
   def process_in_headers!(env)
     cookie_str = env[Rack::HTTP_COOKIE]
 
-    if cookie_str.include?(OLD_KEY) && !cookie.include?(NEW_KEY)
+    if cookie_str.include?(OLD_KEY) && !cookie_str.include?(NEW_KEY)
       cookies = Rack::Utils.parse_cookies_header(cookie_str)
 
       updated_cookie_str = cookie_str + "; #{NEW_KEY}=#{cookies[OLD_KEY]}"

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -27,7 +27,7 @@ class SessionStoreMigration
   def process_in_headers!(env)
     cookie_str = env[Rack::HTTP_COOKIE]
 
-    if cookie_str.include?(OLD_KEY)
+    if cookie_str.include?(OLD_KEY) && !cookie.include?(NEW_KEY)
       cookies = Rack::Utils.parse_cookies_header(cookie_str)
 
       updated_cookie_str = cookie_str + "; #{NEW_KEY}=#{cookies[OLD_KEY]}"

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# A middleware that helps us migrate the name of our session_store cookie key
+# Phase 1
+# - update the session_store.rb to read from the new key
+# - this middleware copies "Cookie" headers with the old key to the new key (forward compat)
+# - this middleware copies "Set-Cookie" headers with the new key to the old key (backward compat)
+# Phase 2
+# - drop this middleware!
+class SessionStoreMigration
+  OLD_KEY = '_upaya_session'
+  NEW_KEY = '_identity_idp_session'
+  COOKIE_SEPARATOR = "\n"
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    process_in_headers!(env)
+
+    status, out_headers, body = @app.call(env)
+
+    [status, process_out_headers!(out_headers), body]
+  end
+
+  def process_in_headers!(env)
+    cookie_str = env[Rack::HTTP_COOKIE]
+
+    if cookie_str.include?(OLD_KEY)
+      cookies = Rack::Utils.parse_cookies_header(cookie_str)
+
+      updated_cookie_str = cookie_str + "; #{NEW_KEY}=#{cookies[OLD_KEY]}"
+
+      env[Rack::HTTP_COOKIE] = updated_cookie_str
+
+      Rails.logger.info({ name: 'session_store_migration', cookie: 'old' }.to_json)
+    else
+      Rails.logger.info({ name: 'session_store_migration', cookie: 'new' }.to_json)
+    end
+  end
+
+  def process_out_headers!(headers)
+    if (cookie_header = headers[Rack::SET_COOKIE]).present?
+      cookies = cookie_header.split(COOKIE_SEPARATOR)
+
+      new_key_set = cookies.find { |cookie| cookie.start_with?(NEW_KEY) }
+      cookies << new_key_set.sub(NEW_KEY, OLD_KEY) if new_key_set.present?
+
+      headers[Rack::SET_COOKIE] = cookies.join(COOKIE_SEPARATOR)
+    end
+
+    headers
+  end
+end

--- a/lib/session_store_migration.rb
+++ b/lib/session_store_migration.rb
@@ -27,7 +27,7 @@ class SessionStoreMigration
   def process_in_headers!(env)
     cookie_str = env[Rack::HTTP_COOKIE]
 
-    if cookie_str && cookie_str.include?(OLD_KEY) && !cookie.include?(NEW_KEY)
+    if cookie_str&.include?(OLD_KEY) && !cookie_str.include?(NEW_KEY)
       cookies = Rack::Utils.parse_cookies_header(cookie_str)
 
       updated_cookie_str = cookie_str + "; #{NEW_KEY}=#{cookies[OLD_KEY]}"

--- a/spec/requests/session_store_migration_spec.rb
+++ b/spec/requests/session_store_migration_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'session store cookie migration' do
+  def extract_session_uuid(response, session_key:)
+    cookie_str = response.headers['Set-Cookie'].
+      split("\n").
+      find { |cookie| cookie.starts_with?(session_key) }
+    cookie_str.split(';').first.split('=').last
+  end
+
+  it 'allows the app to read session data when the old key is present' do
+    get root_path
+
+    session_uuid = extract_session_uuid(response, session_key: '_identity_idp_session')
+
+    get test_session_data_path, headers: { 'Cookie' => "_upaya_session=#{session_uuid}" }
+
+    expect(JSON.parse(response.body)).to include(
+      'events' => { 'Sign in page visited' => true },
+      'first_event' => true,
+      'first_path_visit' => true,
+      'first_success_state' => true,
+      'paths_visited' => { '/' => true },
+      'success_states' => { 'GET|/|Sign in page visited' => true },
+    )
+  end
+
+  it 'sends both old and new keys with set-cookie' do
+    get root_path
+
+    response_cookies = response.headers['Set-Cookie'].split("\n")
+
+    old_cookie_header = response_cookies.find { |c| c.starts_with?('_upaya_session=') }
+    new_cookie_header = response_cookies.find { |c| c.starts_with?('_identity_idp_session=') }
+
+    expect(old_cookie_header).to be_present
+    expect(new_cookie_header).to be_present
+
+    expect(old_cookie_header.sub('_upaya_session', '_identity_idp_session')).
+      to eq(new_cookie_header)
+  end
+end


### PR DESCRIPTION
Feeling slightly bolder, builds on #6478 to attempt to smoothly rename the last item, the session store key
