### PR TITLE
IdV app: Remove first step logic for initial values

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -33,14 +33,7 @@ class VerifyController < ApplicationController
   end
 
   def initial_values
-    case first_step
-    when 'password_confirm'
-      { 'userBundleToken' => user_bundle_token }
-    end
-  end
-
-  def first_step
-    enabled_steps.detect { |step| step_enabled?(step) }
+    { 'userBundleToken' => user_bundle_token }
   end
 
   def enabled_steps


### PR DESCRIPTION
**Why**:

- It was needed primarily to affect different initial values when personal key was supported independent from password re-entry, no longer the case after #6434
- As part of LG-5918, we may need to allow "document_capture" to be an enabled step (see #6469), which is not compatible with this logic, as first_step would no longer be "password_confirm"
