### PR TITLE
Revert "Do not write to users table email address columns (#6474)" except for callback

### DIFF
--- a/app/controllers/api/verify/password_reset_controller.rb
+++ b/app/controllers/api/verify/password_reset_controller.rb
@@ -6,7 +6,7 @@ module Api
       def create
         analytics.idv_forgot_password_confirmed
         request_id = sp_session[:request_id]
-        email = current_user.confirmed_email_addresses.first.email
+        email = current_user.email
         reset_password(email, request_id)
 
         render json: { redirect_url: forgot_password_url(request_id: request_id) },

--- a/app/controllers/idv/forgot_password_controller.rb
+++ b/app/controllers/idv/forgot_password_controller.rb
@@ -12,7 +12,7 @@ module Idv
     def update
       analytics.idv_forgot_password_confirmed
       request_id = sp_session[:request_id]
-      email = current_user.confirmed_email_addresses.first.email
+      email = current_user.email
       reset_password(email, request_id)
     end
 

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -45,13 +45,10 @@ module SignUp
 
     def process_successful_password_creation
       password = permitted_params[:password]
-      now = Time.zone.now
       UpdateUser.new(
         user: @user,
-        attributes: { password: password, confirmed_at: now },
+        attributes: { password: password, confirmed_at: Time.zone.now },
       ).call
-      @user.email_addresses.take.update(confirmed_at: now)
-
       Funnel::Registration::AddPassword.call(@user.id)
       sign_in_and_redirect_user
     end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -18,10 +18,29 @@ class DeleteUserEmailForm
 
   private
 
+  # When the user deletes an email address, we need to make sure we update the email columns on the
+  # user model with the values from an email address record to make sure they are not occupied by
+  # the email address the user deleted
+  #
+  # In order to do this, we need to update the columns without running the callbacks. Running the
+  # callback will cause the code that updates the email address table when there are changes to
+  # the user model to run
+  #
+  # rubocop:disable Rails/SkipsModelValidations
+  def update_user_email_column
+    new_email_address = user.confirmed_email_addresses.take
+    user.update_columns(
+      encrypted_email: new_email_address.encrypted_email,
+      email_fingerprint: new_email_address.email_fingerprint,
+    )
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
   def email_address_destroyed
     return false unless EmailPolicy.new(@user).can_delete_email?(@email_address)
     return false if email_address.destroy == false
     user.email_addresses.reload
+    update_user_email_column
     true
   end
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -73,6 +73,7 @@ class RegisterUserEmailForm
       user: user,
       email: email,
     )
+    user.email = email # Delete this when email address is retired
 
     self.email_language = email_language
     user.email_language = email_language

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -42,15 +42,7 @@ class ResetPasswordForm
 
   def update_user
     attributes = { password: password }
-
-    ActiveRecord::Base.transaction do
-      unless user.confirmed?
-        now = Time.zone.now
-        user.email_addresses.take.update(confirmed_at: now)
-        attributes[:confirmed_at] = now
-      end
-    end
-
+    attributes[:confirmed_at] = Time.zone.now unless user.confirmed?
     UpdateUser.new(user: user, attributes: attributes).call
   end
 

--- a/app/models/concerns/email_address_callback.rb
+++ b/app/models/concerns/email_address_callback.rb
@@ -1,0 +1,39 @@
+module EmailAddressCallback
+  extend ActiveSupport::Concern
+
+  EMAIL_COLUMNS = %i[
+    encrypted_email confirmed_at email_fingerprint
+  ].freeze
+
+  def update_email_address
+    if email_addresses.any?
+      update_email_address_record if email_information_changed?
+    elsif encrypted_email.present?
+      create_full_email_address_record
+    end
+  end
+
+  private
+
+  def update_email_address_record
+    email_addresses.take.update!(
+      encrypted_email: encrypted_email,
+      confirmed_at: confirmed_at,
+      email_fingerprint: email_fingerprint,
+    )
+  end
+
+  def create_full_email_address_record
+    email_addresses.create!(
+      user: self,
+      encrypted_email: encrypted_email,
+      confirmed_at: confirmed_at,
+      email_fingerprint: email_fingerprint,
+    )
+    email_addresses.reload
+  end
+
+  def email_information_changed?
+    EMAIL_COLUMNS.any? { |column| saved_change_to_attribute?(column) }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,12 @@ class User < ApplicationRecord
 
   include EncryptableAttribute
 
+  encrypted_attribute_without_setter(name: :email)
+
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides
   include UserEncryptedAttributeOverrides
+  include EmailAddressCallback
   include DeprecatedUserAttributes
   include UserOtpMethods
 
@@ -45,10 +48,10 @@ class User < ApplicationRecord
            source: :service_provider_record
   has_many :sign_in_restrictions, dependent: :destroy
 
-  attr_accessor :asserted_attributes, :email
+  attr_accessor :asserted_attributes
 
   def confirmed_email_addresses
-    email_addresses.where.not(confirmed_at: nil).order('last_sign_in_at DESC NULLS LAST')
+    email_addresses.where.not(confirmed_at: nil)
   end
 
   def need_two_factor_authentication?(_request)

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -45,7 +45,7 @@ module Idv
         mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
         UserMailer.doc_auth_desktop_link_to_sp(
-          current_user, current_user.confirmed_email_addresses.first.email, application, link
+          current_user, current_user.email, application, link
         ).deliver_now_or_later
         form_response(destination: :email_sent)
       end

--- a/app/services/key_rotator/hmac_fingerprinter.rb
+++ b/app/services/key_rotator/hmac_fingerprinter.rb
@@ -2,6 +2,7 @@ module KeyRotator
   class HmacFingerprinter
     def rotate(user:, pii_attributes: nil, profile: nil)
       User.transaction do
+        rotate_email_fingerprint(user)
         rotate_email_fingerprints(user)
         if pii_attributes
           profile ||= user.active_profile
@@ -13,6 +14,11 @@ module KeyRotator
     private
 
     # rubocop:disable Rails/SkipsModelValidations
+    def rotate_email_fingerprint(user)
+      ee = EncryptedAttribute.new_from_decrypted(user.email)
+      user.update_columns(email_fingerprint: ee.fingerprint)
+    end
+
     def rotate_pii_fingerprints(profile, pii_attributes)
       ssn_fingerprint = Pii::Fingerprinter.fingerprint(pii_attributes.ssn.to_s)
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -70,10 +70,7 @@ module Pii
     end
 
     def rotate_encrypted_attributes
-      user.email_addresses.each do |email_address|
-        KeyRotator::AttributeEncryption.new(email_address).rotate
-      end
-
+      KeyRotator::AttributeEncryption.new(user).rotate
       user.phone_configurations.each do |phone_configuration|
         KeyRotator::AttributeEncryption.new(phone_configuration).rotate
       end
@@ -90,8 +87,7 @@ module Pii
     end
 
     def stale_attributes?
-      user.phone_configurations.any?(&:stale_encrypted_phone?) ||
-        user.email_addresses.any?(&:stale_encrypted_email?)
+      user.phone_configurations.any?(&:stale_encrypted_phone?) || user.stale_encrypted_email?
     end
 
     def stale_ssn_signature?(profile)

--- a/app/views/idv/doc_auth/email_sent.html.erb
+++ b/app/views/idv/doc_auth/email_sent.html.erb
@@ -3,7 +3,7 @@
 <%= image_tag(asset_url('state-id-confirm@3x.png'), width: 210, class: 'margin-bottom-2') %>
 
 <%= render PageHeadingComponent.new do %>
-  <%= t('doc_auth.instructions.email_sent', email: current_user.confirmed_email_addresses.first.email) %>
+  <%= t('doc_auth.instructions.email_sent', email: current_user.email) %>
 <% end %>
 
 <%= render 'idv/doc_auth/start_over_or_cancel', step: 'email_sent' %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -18,7 +18,7 @@
       },
     ) do |f| %>
   <%= hidden_field_tag :user_id, current_user.id, id: 'user_id' %>
-  <%= hidden_field_tag :user_email, current_user.confirmed_email_addresses.first.email, id: 'user_email' %>
+  <%= hidden_field_tag :user_email, current_user.email, id: 'user_email' %>
   <%= hidden_field_tag :user_challenge, user_session[:webauthn_challenge].to_json, id: 'user_challenge' %>
   <%= hidden_field_tag :exclude_credentials, @exclude_credentials&.join(','), id: 'exclude_credentials' %>
   <%= hidden_field_tag :webauthn_id, '', id: 'webauthn_id' %>

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -11,6 +11,8 @@ namespace :rotate do
     User.find_in_batches.with_index do |users, _batch|
       User.transaction do
         users.each do |user|
+          rotator = KeyRotator::AttributeEncryption.new(user)
+          rotator.rotate
           user.phone_configurations.each do |phone_configuration|
             rotator = KeyRotator::AttributeEncryption.new(phone_configuration)
             rotator.rotate

--- a/spec/controllers/api/verify/password_reset_controller_spec.rb
+++ b/spec/controllers/api/verify/password_reset_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Api::Verify::PasswordResetController do
   let(:request_id) { 'request_id' }
-  let(:user) { create(:user) }
+  let(:user) { build(:user) }
   let(:sp_session) { { request_id: request_id } }
 
   before do

--- a/spec/controllers/idv/forgot_password_controller_spec.rb
+++ b/spec/controllers/idv/forgot_password_controller_spec.rb
@@ -20,8 +20,7 @@ describe Idv::ForgotPasswordController do
 
   describe '#update' do
     it 'tracks an analytics event' do
-      user = create(:user)
-      stub_sign_in(user)
+      stub_sign_in
       stub_analytics
 
       expect(@analytics).to receive(:track_event).with('IdV: forgot password confirmed')

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -12,9 +12,7 @@ feature 'doc auth email sent step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_email_sent_step)
     user = User.first
-    expect(page).to have_content(
-      t('doc_auth.instructions.email_sent', email: user.confirmed_email_addresses.first.email),
-    )
+    expect(page).to have_content(t('doc_auth.instructions.email_sent', email: user.email))
     expect(page).to have_css(
       '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.verify_id'),

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -39,7 +39,7 @@ feature 'SP Costing', :email do
     user.active_profile.update!(verified_at: 60.days.ago)
 
     visit_idp_from_sp_with_ial2(:oidc, verified_within: '45d')
-    fill_in_credentials_and_submit(user.confirmed_email_addresses.first.email, password)
+    fill_in_credentials_and_submit(user.email, password)
     fill_in_code_with_last_phone_otp
     click_submit_default
     complete_all_doc_auth_steps

--- a/spec/lib/tasks/rotate_rake_spec.rb
+++ b/spec/lib/tasks/rotate_rake_spec.rb
@@ -14,8 +14,9 @@ describe 'rotate' do
 
   describe 'attribute_encryption_key' do
     it 'runs successfully' do
-      old_email = user.email_addresses.first.email
+      old_email = user.email
       old_phone = user.phone_configurations.first.phone
+      old_encrypted_email = user.encrypted_email
       old_encrypted_email_address_email = user.email_addresses.first.encrypted_email
       old_encrypted_phone = user.phone_configurations.first.encrypted_phone
 
@@ -26,7 +27,9 @@ describe 'rotate' do
       user.reload
       user.phone_configurations.reload
       expect(user.phone_configurations.first.phone).to eq old_phone
+      expect(user.email).to eq old_email
       expect(user.email_addresses.first.email).to eq old_email
+      expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(user.email_addresses.first.encrypted_email).to_not eq old_encrypted_email_address_email
       expect(user.phone_configurations.first.encrypted_phone).to_not eq old_encrypted_phone
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,6 +19,32 @@ RSpec.describe User do
     end.to change(ActionMailer::Base.deliveries, :count).by(0)
   end
 
+  describe 'email_address' do
+    it 'creates an entry for the user when created' do
+      expect do
+        User.create(email: 'nobody@nobody.com')
+      end.to change(EmailAddress, :count).by(1)
+    end
+
+    it 'mirrors the info from the user object on creation' do
+      user = create(:user)
+      email_address = user.email_addresses.first
+      expect(email_address).to be_present
+      expect(email_address.encrypted_email).to eq user.encrypted_email
+      expect(email_address.email).to eq user.email
+      expect(email_address.confirmed_at.to_i).to eq user.confirmed_at.to_i
+    end
+
+    it 'mirrors the info from an unconfirmed user object' do
+      user = create(:user, :unconfirmed)
+      email_address = user.email_addresses.first
+      expect(email_address).to be_present
+      expect(email_address.encrypted_email).to eq user.encrypted_email
+      expect(email_address.email).to eq user.email
+      expect(email_address.confirmed_at).to be_nil
+    end
+  end
+
   describe 'password validations' do
     it 'allows long phrases that contain common words' do
       user = create(:user)
@@ -222,7 +248,7 @@ RSpec.describe User do
       it 'normalizes email' do
         user = create(:user, email: 'FoO@example.org    ')
 
-        expect(user.email_addresses.first.email).to eq 'foo@example.org'
+        expect(user.email).to eq 'foo@example.org'
       end
     end
 

--- a/spec/services/key_rotator/attribute_encryption_spec.rb
+++ b/spec/services/key_rotator/attribute_encryption_spec.rb
@@ -2,25 +2,25 @@ require 'rails_helper'
 
 describe KeyRotator::AttributeEncryption do
   describe '#rotate' do
-    let(:rotator) { described_class.new(email_address) }
-    let(:email_address) { create(:email_address) }
+    let(:rotator) { described_class.new(user) }
+    let(:user) { create(:user) }
 
     it 're-encrypts email and phone' do
-      old_encrypted_email = email_address.encrypted_email
+      old_encrypted_email = user.encrypted_email
 
       rotate_attribute_encryption_key
       rotator.rotate
 
-      expect(email_address.encrypted_email).to_not eq old_encrypted_email
+      expect(user.encrypted_email).to_not eq old_encrypted_email
     end
 
     it 'does not change the `updated_at` timestamp' do
-      old_updated_timestamp = email_address.updated_at
+      old_updated_timestamp = user.updated_at
 
       rotate_attribute_encryption_key
       rotator.rotate
 
-      expect(email_address.updated_at).to eq old_updated_timestamp
+      expect(user.updated_at).to eq old_updated_timestamp
     end
   end
 end

--- a/spec/services/key_rotator/hmac_fingerprinter_spec.rb
+++ b/spec/services/key_rotator/hmac_fingerprinter_spec.rb
@@ -19,7 +19,7 @@ describe KeyRotator::HmacFingerprinter do
 
       old_ssn_signature = profile.ssn_signature
       old_compound_signature = profile.name_zip_birth_year_signature
-      old_email_fingerprint = user.email_addresses.first.email_fingerprint
+      old_email_fingerprint = user.email_fingerprint
 
       rotate_hmac_key
 
@@ -27,7 +27,7 @@ describe KeyRotator::HmacFingerprinter do
 
       expect(user.active_profile.ssn_signature).to_not eq old_ssn_signature
       expect(user.active_profile.name_zip_birth_year_signature).to_not eq old_compound_signature
-      expect(user.email_addresses.first.email_fingerprint).to_not eq old_email_fingerprint
+      expect(user.email_fingerprint).to_not eq old_email_fingerprint
     end
 
     it 'does not change the `updated_at` timestamp' do
@@ -46,14 +46,14 @@ describe KeyRotator::HmacFingerprinter do
 
     it 'changes email fingerprint if no active profile' do
       rotator = described_class.new
-      user = create(:email_address).user
-      old_email_fingerprint = user.email_addresses.first.email_fingerprint
+      user = create(:user)
+      old_email_fingerprint = user.email_fingerprint
 
       rotate_hmac_key
 
       rotator.rotate(user: user)
 
-      expect(user.email_addresses.first.email_fingerprint).to_not eq old_email_fingerprint
+      expect(user.email_fingerprint).to_not eq old_email_fingerprint
     end
   end
 end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -48,8 +48,8 @@ describe Pii::Cacher do
     it 'updates fingerprints when keys are rotated' do
       old_ssn_signature = profile.ssn_signature
       old_compound_pii_fingerprint = profile.name_zip_birth_year_signature
-      old_email_fingerprint = user.email_addresses.first.email_fingerprint
-      old_encrypted_email = user.email_addresses.first.encrypted_email
+      old_email_fingerprint = user.email_fingerprint
+      old_encrypted_email = user.encrypted_email
       old_encrypted_phone = user.phone_configurations.first.encrypted_phone
 
       rotate_all_keys
@@ -63,8 +63,8 @@ describe Pii::Cacher do
       user.reload
       profile.reload
 
-      expect(user.email_addresses.first.email_fingerprint).to_not eq old_email_fingerprint
-      expect(user.email_addresses.first.encrypted_email).to_not eq old_encrypted_email
+      expect(user.email_fingerprint).to_not eq old_email_fingerprint
+      expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(profile.ssn_signature).to_not eq old_ssn_signature
       expect(profile.name_zip_birth_year_signature).to_not eq old_compound_pii_fingerprint
       expect(user.phone_configurations.first.encrypted_phone).to_not eq old_encrypted_phone

--- a/spec/services/user_seeder_spec.rb
+++ b/spec/services/user_seeder_spec.rb
@@ -70,9 +70,13 @@ RSpec.describe UserSeeder do
       end
 
       def create_user_with_email(email)
-        user = User.create!
-        EmailAddress.create!(user: user, email: email, confirmed_at: Time.zone.now)
+        ee = EncryptedAttribute.new_from_decrypted(email)
+        user = User.create!(email_fingerprint: ee.fingerprint)
+        user.encrypted_email = ee.encrypted
         user.reset_password('S00per Seekret', 'S00per Seekret')
+        # rubocop:disable Rails/SkipsModelValidations
+        user.email_addresses.update_all(confirmed_at: Time.zone.now)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -573,7 +573,7 @@ module Features
     end
 
     def sign_in_via_branded_page(user)
-      fill_in_credentials_and_submit(user.confirmed_email_addresses.first.email, user.password)
+      fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
     end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -180,7 +180,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       expect(decoded_id_token[:aud]).to eq(@client_id)
       expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
       expect(decoded_id_token[:iss]).to eq(root_url)
-      expect(decoded_id_token[:email]).to eq(user.confirmed_email_addresses.first.email)
+      expect(decoded_id_token[:email]).to eq(user.email)
       expect(decoded_id_token[:given_name]).to eq('FAKEY')
       expect(decoded_id_token[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
 
@@ -194,7 +194,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
       userinfo_response = JSON.parse(page.body).with_indifferent_access
       expect(userinfo_response[:sub]).to eq(sub)
       expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(sub)
-      expect(userinfo_response[:email]).to eq(user.confirmed_email_addresses.first.email)
+      expect(userinfo_response[:email]).to eq(user.email)
       expect(userinfo_response[:given_name]).to eq('FAKEY')
       expect(userinfo_response[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
     end

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -52,10 +52,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
     expect(page).to have_current_path(new_user_session_path)
 
     visit root_path
-    signin(
-      user.confirmed_email_addresses.first.email,
-      user.password || Features::SessionHelper::VALID_PASSWORD,
-    )
+    signin(user.email, user.password || Features::SessionHelper::VALID_PASSWORD)
 
     expect(page).to have_content(t('two_factor_authentication.max_generic_login_attempts_reached'))
   end
@@ -64,10 +61,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
     travel_to(6.minutes.from_now) do
       visit root_path
 
-      signin(
-        user.confirmed_email_addresses.first.email,
-        user.password || Features::SessionHelper::VALID_PASSWORD,
-      )
+      signin(user.email, user.password || Features::SessionHelper::VALID_PASSWORD)
 
       expect(page).to_not have_content(
         t('two_factor_authentication.max_generic_login_attempts_reached'),

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -100,10 +100,10 @@ shared_examples 'signing in as IAL1 with personal key after resetting password' 
 
     old_personal_key = PersonalKeyGenerator.new(user).create
     visit_idp_from_sp_with_ial1(sp)
-    trigger_reset_password_and_click_email_link(user.confirmed_email_addresses.first.email)
+    trigger_reset_password_and_click_email_link(user.email)
     fill_in t('forms.passwords.edit.labels.password'), with: new_password
     click_button t('forms.passwords.edit.buttons.submit')
-    fill_in_credentials_and_submit(user.confirmed_email_addresses.first.email, new_password)
+    fill_in_credentials_and_submit(user.email, new_password)
     choose_another_security_option('personal_key')
     enter_personal_key(personal_key: old_personal_key)
     click_submit_default
@@ -292,7 +292,7 @@ def ial1_sign_in_with_personal_key_goes_to_sp(sp)
   Capybara.reset_sessions!
 
   visit_idp_from_sp_with_ial1(sp)
-  fill_in_credentials_and_submit(user.confirmed_email_addresses.first.email, 'Val!d Pass w0rd')
+  fill_in_credentials_and_submit(user.email, 'Val!d Pass w0rd')
   choose_another_security_option('personal_key')
   enter_personal_key(personal_key: old_personal_key)
   click_submit_default


### PR DESCRIPTION
This commit reverts a commit that stops writing to the email address table, but still removes the callback. This is necessary for us to be able to deploy in a 50/50 state. We need to stop running the callback then we can drop the email address columns.

This reverts commit fdb359a8af1185b32225ede25a1f66b243186db3.