### PR TITLE
Remove server side controller for backup code download, LG-6173

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -6,7 +6,7 @@ module Users
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
-    before_action :ensure_backup_codes_in_session, only: %i[continue download refreshed]
+    before_action :ensure_backup_codes_in_session, only: %i[continue refreshed]
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
     before_action :authorize_backup_code_disable, only: [:delete]
@@ -29,12 +29,6 @@ module Users
     def continue
       flash[:success] = t('notices.backup_codes_configured')
       redirect_to next_setup_path || after_mfa_setup_path
-    end
-
-    # Remove after next deployment
-    def download
-      data = user_session[:backup_codes].join("\r\n") + "\r\n"
-      send_data data, filename: 'backup_codes.txt'
     end
 
     def confirm_delete; end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,8 +242,6 @@ Rails.application.routes.draw do
     patch '/backup_code_setup' => 'users/backup_code_setup#create', as: :backup_code_create
     patch '/backup_code_continue' => 'users/backup_code_setup#continue'
     get '/backup_code_regenerate' => 'users/backup_code_setup#edit'
-    # Remove backup_code_download after next deployment
-    get '/backup_code_download' => 'users/backup_code_setup#download'
     get '/backup_code_delete' => 'users/backup_code_setup#confirm_delete'
     get '/backup_code_create' => 'users/backup_code_setup#confirm_create'
     delete '/backup_code_delete' => 'users/backup_code_setup#delete'

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -1,18 +1,6 @@
 require 'rails_helper'
 
 describe Users::BackupCodeSetupController do
-  # remove after next deployment
-  it 'has backup codes available for download' do
-    user = build(:user, :signed_up)
-    stub_sign_in(user)
-    codes = BackupCodeGenerator.new(user).create
-    controller.user_session[:backup_codes] = codes
-    get :download
-
-    expect(response.body).to eq(codes.join("\r\n") + "\r\n")
-    expect(response.header['Content-Type']).to eq('text/plain')
-  end
-
   it 'creates backup codes' do
     user = build(:user, :signed_up)
     stub_sign_in(user)


### PR DESCRIPTION
Related to LG-6112, https://github.com/18F/identity-idp/pull/6498
Wait for that to be deployed before merging.

This PR removes related controller method and tests for server side backup code downloads.