### PR TITLE
Add the ability for IRS service providers to start tracking events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,6 +79,21 @@ class ApplicationController < ActionController::Base
     effective_user || AnonymousUser.new
   end
 
+  def irs_attempts_api_tracker
+    @irs_attempts_api_tracker ||= IrsAttemptsApi::Tracker.new(
+      session_id: irs_attempts_api_session_id,
+      enabled_for_session: irs_attempt_api_enabled_for_session?,
+    )
+  end
+
+  def irs_attempt_api_enabled_for_session?
+    current_sp&.irs_attempts_api_enabled? && irs_attempts_api_session_id.present?
+  end
+
+  def irs_attempts_api_session_id
+    decorated_session.irs_attempts_api_session_id
+  end
+
   def user_event_creator
     @user_event_creator ||= UserEventCreator.new(request: request, current_user: current_user)
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -156,13 +156,18 @@ module Users
     def track_authentication_attempt(email)
       user = User.find_with_email(email) || AnonymousUser.new
 
+      success = user_signed_in_and_not_locked_out?(user)
       analytics.email_and_password_auth(
-        success: user_signed_in_and_not_locked_out?(user),
+        success: success,
         user_id: user.uuid,
         user_locked_out: user_locked_out?(user),
         stored_location: session['user_return_to'],
         sp_request_url_present: sp_session[:request_url].present?,
         remember_device: remember_device_cookie.present?,
+      )
+      irs_attempts_api_tracker.email_and_password_auth(
+        email: email,
+        success: success,
       )
     end
 

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -113,6 +113,10 @@ class ServiceProviderSessionDecorator
     end
   end
 
+  def irs_attempts_api_session_id
+    @irs_attempts_api_session_id ||= request_params['irs_attempts_api_session_id']
+  end
+
   private
 
   attr_reader :sp, :view_context, :sp_session, :service_provider_request

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -43,6 +43,8 @@ class SessionDecorator
     false
   end
 
+  def irs_attempts_api_session_id; end
+
   private
 
   attr_reader :view_context

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -1,25 +1,33 @@
 module IrsAttemptsApi
   class Tracker
-    attr_reader :session_id
+    attr_reader :session_id, :enabled_for_session
 
-    def initialize(session_id:)
+    def initialize(session_id:, enabled_for_session:)
       @session_id = session_id
+      @enabled_for_session = enabled_for_session
     end
 
     def track_event(event_type, metadata = {})
-      return unless IdentityConfig.store.irs_attempt_api_enabled
+      return unless enabled?
 
-      jti, jwe = IrsAttemptsApi::EncryptedEventTokenBuilder.new(
+      event = AttemptEvent.new(
         event_type: event_type,
         session_id: session_id,
         occurred_at: Time.zone.now,
         event_metadata: metadata,
-      ).build_event_token
-      redis_client.write_event(jti: jti, jwe: jwe)
-      jti
+      )
+
+      redis_client.write_event(jti: event.jti, jwe: event.to_jwe)
+      event
     end
 
+    include TrackerEvents
+
     private
+
+    def enabled?
+      IdentityConfig.store.irs_attempt_api_enabled && @enabled_for_session
+    end
 
     def redis_client
       @redis_client ||= IrsAttemptsApi::RedisClient.new

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -1,0 +1,14 @@
+module IrsAttemptsApi
+  module TrackerEvents
+    # @param [String] email The submitted email address
+    # @param [Boolean] success True if the email and password matched
+    # A user has submitted an email address and password for authentication
+    def email_and_password_auth(email:, success:)
+      track_event(
+        :email_and_password_auth,
+        email: email,
+        success: success,
+      )
+    end
+  end
+end

--- a/db/primary_migrate/20220613174442_add_irs_attempts_api_enabled_to_service_provider.rb
+++ b/db/primary_migrate/20220613174442_add_irs_attempts_api_enabled_to_service_provider.rb
@@ -1,0 +1,5 @@
+class AddIrsAttemptsApiEnabledToServiceProvider < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_providers, :irs_attempts_api_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_07_150151) do
+ActiveRecord::Schema.define(version: 2022_06_13_174442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -527,6 +527,7 @@ ActiveRecord::Schema.define(version: 2022_06_07_150151) do
     t.string "certs", array: true
     t.boolean "email_nameid_format_allowed", default: false
     t.boolean "use_legacy_name_id_behavior", default: false
+    t.boolean "irs_attempts_api_enabled"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe ServiceProviderSessionDecorator do
       sp: sp,
       view_context: view_context,
       sp_session: {},
-      service_provider_request: ServiceProviderRequest.new,
+      service_provider_request: service_provider_request,
     )
   end
   let(:sp) { build_stubbed(:service_provider) }
+  let(:service_provider_request) { ServiceProviderRequest.new }
   let(:sp_name) { subject.sp_name }
   let(:sp_create_link) { '/sign_up/enter_email' }
 
@@ -263,6 +264,27 @@ RSpec.describe ServiceProviderSessionDecorator do
         it 'is true' do
           expect(requested_more_recent_verification?).to eq(true)
         end
+      end
+    end
+  end
+
+  describe '#irs_attempts_api_session_id' do
+    context 'with a irs_attempts_api_session_id on the request url' do
+      let(:service_provider_request) do
+        url = 'https://example.com/auth?irs_attempts_api_session_id=123abc'
+        ServiceProviderRequest.new(url: url)
+      end
+
+      it 'returns the value of irs_attempts_api_session_id' do
+        expect(subject.irs_attempts_api_session_id).to eq('123abc')
+      end
+    end
+
+    context 'without a irs_attempts_api_session_id on the request url' do
+      let(:service_provider_request) { ServiceProviderRequest.new }
+
+      it 'returns nil' do
+        expect(subject.irs_attempts_api_session_id).to be_nil
       end
     end
   end

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+feature 'IRS Attempts API Event Tracking' do
+  include OidcAuthHelper
+  include IrsAttemptsApiTrackingHelper
+
+  before do
+    allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)
+    mock_irs_attempts_api_encryption_key
+  end
+
+  let(:service_provider) do
+    create(
+      :service_provider,
+      active: true,
+      redirect_uris: ['http://localhost:7654/auth/result'],
+      ial: 2,
+      irs_attempts_api_enabled: true,
+    )
+  end
+
+  scenario 'signing in from an IRS SP with an attempts api session id tracks events' do
+    user = create(:user, :signed_up)
+
+    visit_idp_from_ial1_oidc_sp(
+      client_id: service_provider.issuer,
+      irs_attempts_api_session_id: 'test-session-id',
+    )
+
+    sign_in_user(user)
+
+    events = irs_attempts_api_tracked_events
+
+    expect(events.count).to eq(1)
+    event = events.first
+    expect(event.event_metadata[:email]).to eq(user.email)
+    expect(event.event_metadata[:success]).to eq(true)
+    expect(event.session_id).to eq('test-session-id')
+  end
+
+  scenario 'signing in from an IRS SP without an attempts api session id does not track events' do
+    user = create(:user, :signed_up)
+
+    visit_idp_from_ial1_oidc_sp(
+      client_id: service_provider.issuer,
+    )
+
+    sign_in_user(user)
+
+    events = irs_attempts_api_tracked_events
+
+    expect(events.count).to eq(0)
+  end
+
+  scenario 'signing in from a non-IRS SP with an attempts api session id does not track events' do
+    service_provider.update!(irs_attempts_api_enabled: false)
+
+    user = create(:user, :signed_up)
+
+    visit_idp_from_ial1_oidc_sp(
+      client_id: service_provider.issuer,
+      irs_attempts_api_session_id: 'test-session_id',
+    )
+
+    sign_in_user(user)
+
+    events = irs_attempts_api_tracked_events
+
+    expect(events.count).to eq(0)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -115,6 +115,10 @@ RSpec.configure do |config|
     descendants.each(&:disable_test_adapter)
   end
 
+  config.before(:each) do
+    IrsAttemptsApi::RedisClient.clear_attempts!
+  end
+
   config.around(:each, type: :feature) do |example|
     Bullet.enable = true
     Capybara::Webmock.start

--- a/spec/requests/irs_attempts_api_spec.rb
+++ b/spec/requests/irs_attempts_api_spec.rb
@@ -3,31 +3,34 @@ require 'rails_helper'
 RSpec.describe 'IRS attempts API' do
   before do
     allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)
-    IrsAttemptsApi::RedisClient.clear_attempts!
     events_to_acknowledge
     events_to_render
   end
 
   let(:events_to_acknowledge) do
     3.times.map do
-      jti, jwe = IrsAttemptsApi::EncryptedEventTokenBuilder.new(
+      event = IrsAttemptsApi::AttemptEvent.new(
         event_type: :test_event,
         session_id: 'test-session-id',
         occurred_at: Time.zone.now,
         event_metadata: {},
-      ).build_event_token
+      )
+      jti = event.jti
+      jwe = event.to_jwe
       IrsAttemptsApi::RedisClient.new.write_event(jti: jti, jwe: jwe)
       [jti, jwe]
     end
   end
   let(:events_to_render) do
     3.times.map do
-      jti, jwe = IrsAttemptsApi::EncryptedEventTokenBuilder.new(
+      event = IrsAttemptsApi::AttemptEvent.new(
         event_type: :test_event,
         session_id: 'test-session-id',
         occurred_at: Time.zone.now,
         event_metadata: {},
-      ).build_event_token
+      )
+      jti = event.jti
+      jwe = event.to_jwe
       IrsAttemptsApi::RedisClient.new.write_event(jti: jti, jwe: jwe)
       [jti, jwe]
     end

--- a/spec/services/irs_attempts_api/redis_client_spec.rb
+++ b/spec/services/irs_attempts_api/redis_client_spec.rb
@@ -56,7 +56,6 @@ describe IrsAttemptsApi::RedisClient do
           event_metadata: { 'foo' => 'bar' },
         )
         jti = event.jti
-        jwe = event.to_jwe
         events[jti] = event.to_jwe
       end
       events.each do |jti, jwe|

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe IrsAttemptsApi::Tracker do
   before do
-    allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(irs_attempt_api_enabled)
+    allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(
+      irs_attempt_api_enabled,
+    )
   end
 
   let(:irs_attempt_api_enabled) { true }

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 RSpec.describe IrsAttemptsApi::Tracker do
   before do
-    allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)
-    IrsAttemptsApi::RedisClient.clear_attempts!
+    allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(irs_attempt_api_enabled)
   end
 
+  let(:irs_attempt_api_enabled) { true }
   let(:session_id) { 'test-session-id' }
+  let(:enabled_for_session) { true }
 
-  subject { described_class.new(session_id: session_id) }
+  subject { described_class.new(session_id: session_id, enabled_for_session: enabled_for_session) }
 
   describe '#track_event' do
     it 'records the event in redis' do
@@ -17,6 +18,30 @@ RSpec.describe IrsAttemptsApi::Tracker do
       events = IrsAttemptsApi::RedisClient.new.read_events
 
       expect(events.values.length).to eq(1)
+    end
+
+    context 'the current session is not an IRS attempt API session' do
+      let(:enabled_for_session) { false }
+
+      it 'does not record any events in redis' do
+        subject.track_event(:test_event, foo: :bar)
+
+        events = IrsAttemptsApi::RedisClient.new.read_events
+
+        expect(events.values.length).to eq(0)
+      end
+    end
+
+    context 'the IRS attempts API is not enabled' do
+      let(:irs_attempt_api_enabled) { false }
+
+      it 'does not record any events in redis' do
+        subject.track_event(:test_event, foo: :bar)
+
+        events = IrsAttemptsApi::RedisClient.new.read_events
+
+        expect(events.values.length).to eq(0)
+      end
     end
   end
 end

--- a/spec/support/features/irs_attempts_api_tracking_helper.rb
+++ b/spec/support/features/irs_attempts_api_tracking_helper.rb
@@ -1,0 +1,28 @@
+module IrsAttemptsApiTrackingHelper
+  class IrsAttemptsApiEventDecryptor
+    def self.public_key
+      private_key.public_key
+    end
+
+    def self.private_key
+      @private_key ||= OpenSSL::PKey::RSA.new(4096)
+    end
+
+    def decrypted_events_from_store
+      jwes = IrsAttemptsApi::RedisClient.new.read_events
+      jwes.transform_values do |jwe|
+        IrsAttemptsApi::AttemptEvent.from_jwe(jwe, self.class.private_key)
+      end
+    end
+  end
+
+  def mock_irs_attempts_api_encryption_key
+    encoded_key = Base64.strict_encode64(IrsAttemptsApiEventDecryptor.public_key.to_der)
+    allow(IdentityConfig.store).to receive(:irs_attempt_api_public_key).
+      and_return(encoded_key)
+  end
+
+  def irs_attempts_api_tracked_events
+    IrsAttemptsApiEventDecryptor.new.decrypted_events_from_store.values
+  end
+end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -57,7 +57,8 @@ module OidcAuthHelper
   def ial1_params(prompt: nil,
                   state: SecureRandom.hex,
                   nonce: SecureRandom.hex,
-                  client_id: OIDC_ISSUER)
+                  client_id: OIDC_ISSUER,
+                  irs_attempts_api_session_id: nil)
     ial1_params = {
       client_id: client_id,
       response_type: 'code',
@@ -67,6 +68,9 @@ module OidcAuthHelper
       state: state,
       nonce: nonce,
     }
+    if irs_attempts_api_session_id
+      ial1_params[:irs_attempts_api_session_id] = irs_attempts_api_session_id
+    end
     ial1_params[:prompt] = prompt if prompt
     ial1_params
   end
@@ -75,7 +79,8 @@ module OidcAuthHelper
                   state: SecureRandom.hex,
                   nonce: SecureRandom.hex,
                   client_id: OIDC_ISSUER,
-                  acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+                  acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                  irs_attempts_api_session_id: nil)
     ial2_params = {
       client_id: client_id,
       response_type: 'code',
@@ -85,6 +90,9 @@ module OidcAuthHelper
       state: state,
       nonce: nonce,
     }
+    if irs_attempts_api_session_id
+      ial2_params[:irs_attempts_api_session_id] = irs_attempts_api_session_id
+    end
     ial2_params[:prompt] = prompt if prompt
     ial2_params
   end


### PR DESCRIPTION
This commit includes a number of changes to implement features of the attempts API:

1.) A boolean is added to Service Providers to indicate whether they can use the Attempts API
2.) A param is supported on the OIDC auth endpoint to specify an Attempts API session ID
3.) Logic is added to track events if the SP is Attempts API enabled and a session ID was included in the auth request
4.) Code was added to track email/password attempts in the Attempts API so we can make sure it all works