### PR TITLE
Reconcile inconsistencies with verify API implementations

### DIFF
--- a/app/controllers/api/verify/base_controller.rb
+++ b/app/controllers/api/verify/base_controller.rb
@@ -16,19 +16,18 @@ module Api
         !required_step || IdentityConfig.store.idv_api_enabled_steps.include?(required_step)
       end
 
-      def render_errors(error_or_errors, status: :bad_request)
-        errors = error_or_errors.instance_of?(Hash) ? error_or_errors : Array(error_or_errors)
-        render json: { errors: errors }, status: status
-      end
-
       before_action :confirm_two_factor_authenticated_for_api
       respond_to :json
 
       private
 
+      def render_errors(errors, status: :bad_request)
+        render json: { errors: errors }, status: status
+      end
+
       def confirm_two_factor_authenticated_for_api
         return if user_authenticated_for_api?
-        render json: { error: 'user is not fully authenticated' }, status: :unauthorized
+        render_errors({ user: 'Unauthorized' }, status: :unauthorized)
       end
 
       def user_authenticated_for_api?

--- a/app/controllers/api/verify/base_controller.rb
+++ b/app/controllers/api/verify/base_controller.rb
@@ -3,7 +3,6 @@ module Api
     class BaseController < ApplicationController
       skip_before_action :verify_authenticity_token
       include RenderConditionConcern
-      include EffectiveUser
 
       class_attribute :required_step
 
@@ -25,8 +24,12 @@ module Api
       private
 
       def confirm_two_factor_authenticated_for_api
-        return if effective_user
+        return if user_authenticated_for_api?
         render json: { error: 'user is not fully authenticated' }, status: :unauthorized
+      end
+
+      def user_authenticated_for_api?
+        user_fully_authenticated?
       end
     end
   end

--- a/app/controllers/api/verify/base_controller.rb
+++ b/app/controllers/api/verify/base_controller.rb
@@ -6,11 +6,14 @@ module Api
 
       class_attribute :required_step
 
+      def self.required_step
+        NotImplementedError.new('Controller must define required_step')
+      end
+
       check_or_render_not_found -> do
-        if self.class.required_step.blank?
-          raise NotImplementedError, 'Controller must define required_step'
-        end
-        IdentityConfig.store.idv_api_enabled_steps.include?(self.class.required_step)
+        required_step = self.class.required_step
+        raise required_step if required_step.is_a?(NotImplementedError)
+        !required_step || IdentityConfig.store.idv_api_enabled_steps.include?(required_step)
       end
 
       def render_errors(error_or_errors, status: :bad_request)

--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -75,6 +75,10 @@ module Api
           compact.
           transform_keys { |key| key.gsub(/_image_metadata$/, '') }
       end
+
+      def user_authenticated_for_api?
+        !!effective_user
+      end
     end
   end
 end

--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -19,7 +19,7 @@ module Api
             completion_url: completion_url(result),
           }
         else
-          render json: { error: result.errors }, status: :bad_request
+          render_errors(result.errors)
         end
       end
 

--- a/app/javascript/packages/verify-flow/services/api.spec.ts
+++ b/app/javascript/packages/verify-flow/services/api.spec.ts
@@ -83,7 +83,7 @@ describe('isErrorResponse', () => {
   });
 
   it('returns true if object is an error response', () => {
-    const response = { error: { field: ['message'] } };
+    const response = { errors: { field: ['message'] } };
     const result = isErrorResponse(response);
 
     expect(result).to.be.true();

--- a/app/javascript/packages/verify-flow/services/api.ts
+++ b/app/javascript/packages/verify-flow/services/api.ts
@@ -1,5 +1,5 @@
 export interface ErrorResponse<Field extends string = string> {
-  error: Record<Field, [string, ...string[]]>;
+  errors: Record<Field, [string, ...string[]]>;
 }
 
 interface PostOptions {
@@ -48,4 +48,4 @@ export async function post<Response = any>(
 
 export const isErrorResponse = <F extends string>(
   response: object | ErrorResponse<F>,
-): response is ErrorResponse<F> => 'error' in response;
+): response is ErrorResponse<F> => 'errors' in response;

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -77,7 +77,7 @@ describe('PasswordConfirmStep', () => {
   it('validates incorrect password', async () => {
     sandbox.stub(window, 'fetch').resolves({
       status: 400,
-      json: () => Promise.resolve({ error: { password: ['Incorrect password'] } }),
+      json: () => Promise.resolve({ errors: { password: ['Incorrect password'] } }),
     } as Response);
 
     const { getByRole, findByRole, getByLabelText } = render(

--- a/app/javascript/packages/verify-flow/steps/password-confirm/submit.spec.ts
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/submit.spec.ts
@@ -41,7 +41,7 @@ describe('submit', () => {
           sandbox.match({ body: JSON.stringify({ user_bundle_token: '..', password: 'hunter2' }) }),
         )
         .resolves({
-          json: () => Promise.resolve({ error: { password: ['incorrect password'] } }),
+          json: () => Promise.resolve({ errors: { password: ['incorrect password'] } }),
         } as Response);
     });
 

--- a/app/javascript/packages/verify-flow/steps/password-confirm/submit.ts
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/submit.ts
@@ -45,7 +45,7 @@ async function submit({
   });
 
   if (isErrorResponse(json)) {
-    const [field, [error]] = Object.entries(json.error)[0];
+    const [field, [error]] = Object.entries(json.errors)[0];
     throw new PasswordSubmitError(error, { field });
   }
 

--- a/spec/controllers/api/verify/base_controller_spec.rb
+++ b/spec/controllers/api/verify/base_controller_spec.rb
@@ -49,5 +49,29 @@ describe Api::Verify::BaseController do
         end
       end
     end
+
+    context 'with an explicitly nil required_step' do
+      controller Api::Verify::BaseController do
+        self.required_step = nil
+
+        def show
+          render json: {}
+        end
+      end
+
+      before { routes.draw { get '/' => 'api/verify/base#show' } }
+
+      it 'renders as unauthorized (401)' do
+        expect(response.status).to eq(401)
+      end
+
+      context 'with authenticated user' do
+        before { stub_sign_in }
+
+        it 'renders as ok (200)' do
+          expect(response.status).to eq(200)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/api/verify/base_controller_spec.rb
+++ b/spec/controllers/api/verify/base_controller_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 describe Api::Verify::BaseController do
-  describe '#show' do
-    subject(:response) { get :show }
+  describe '#create' do
+    subject(:response) { post :create }
 
     context 'without required_step defined' do
       controller Api::Verify::BaseController do
-        def show; end
+        def create; end
       end
 
-      before { routes.draw { get '/' => 'api/verify/base#show' } }
+      before { routes.draw { post '/' => 'api/verify/base#create' } }
 
       it 'raises an exception' do
         expect { response }.to raise_error(NotImplementedError)
@@ -20,12 +20,12 @@ describe Api::Verify::BaseController do
       controller Api::Verify::BaseController do
         self.required_step = 'example'
 
-        def show
+        def create
           render json: {}
         end
       end
 
-      before { routes.draw { get '/' => 'api/verify/base#show' } }
+      before { routes.draw { get '/' => 'api/verify/base#create' } }
 
       it 'renders as not found (404)' do
         expect(response.status).to eq(404)
@@ -46,6 +46,18 @@ describe Api::Verify::BaseController do
           it 'renders as ok (200)' do
             expect(response.status).to eq(200)
           end
+
+          context 'with request forgery protection enabled' do
+            around do |ex|
+              ActionController::Base.allow_forgery_protection = true
+              ex.run
+              ActionController::Base.allow_forgery_protection = false
+            end
+
+            it 'renders as ok (200)' do
+              expect(response.status).to eq(200)
+            end
+          end
         end
       end
     end
@@ -54,12 +66,12 @@ describe Api::Verify::BaseController do
       controller Api::Verify::BaseController do
         self.required_step = nil
 
-        def show
+        def create
           render json: {}
         end
       end
 
-      before { routes.draw { get '/' => 'api/verify/base#show' } }
+      before { routes.draw { get '/' => 'api/verify/base#create' } }
 
       it 'renders as unauthorized (401)' do
         expect(response.status).to eq(401)

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -29,9 +29,10 @@ describe Api::Verify::PasswordConfirmController do
     context 'when the user is not signed in and submits the password' do
       it 'does not create a profile or return a key' do
         post :create, params: { password: 'iambatman', user_bundle_token: jwt }
-        expect(JSON.parse(response.body)['personal_key']).to be_nil
+        parsed_body = JSON.parse(response.body, symbolize_names: true)
+
         expect(response.status).to eq 401
-        expect(JSON.parse(response.body)['error']).to eq 'user is not fully authenticated'
+        expect(parsed_body).to eq(errors: { user: 'Unauthorized' })
       end
     end
 
@@ -54,7 +55,7 @@ describe Api::Verify::PasswordConfirmController do
         post :create, params: { password: 'iamnotbatman', user_bundle_token: jwt }
         response_json = JSON.parse(response.body)
         expect(response_json['personal_key']).to be_nil
-        expect(response_json['error']['password']).to eq([I18n.t('idv.errors.incorrect_password')])
+        expect(response_json['errors']['password']).to eq([I18n.t('idv.errors.incorrect_password')])
         expect(response.status).to eq 400
       end
 


### PR DESCRIPTION
Partially extracted from #6483

**Why:** So that usage is more predictable.

This does a few things:

- Consistently renders errors using `render_errors` base controller helper
   - In doing so, updates all references to consistently use "errors" (plural) response property
- Allows `required_step` to be explicitly `nil` to avoid requiring feature flag step enabled (alternative to issue described in #6492)
- Only allow "effective user" (hybrid document capture session) in document capture endpoints by splitting overridable `user_authenticated_for_api?` base controller method