### PR TITLE
LG-6576: Fix JWT parse for base64url characters, unicode encoding

### DIFF
--- a/app/javascript/packages/verify-flow/index.ts
+++ b/app/javascript/packages/verify-flow/index.ts
@@ -1,3 +1,4 @@
+export { decodeUserBundle } from './user-bundle';
 export { default as FlowContext } from './context/flow-context';
 export { SecretsContextProvider } from './context/secrets-context';
 export { default as StartOverOrCancel } from './start-over-or-cancel';

--- a/app/javascript/packages/verify-flow/user-bundle.spec.ts
+++ b/app/javascript/packages/verify-flow/user-bundle.spec.ts
@@ -1,0 +1,33 @@
+import { decodeUserBundle } from './user-bundle';
+
+describe('decodeUserBundle', () => {
+  it('decodes as base64url', () => {
+    const token =
+      'eyJzdWIiOiI0ODlhMDQxNS0zZDQ4LTRhM2UtYjhmNi05MzYyMzNmZmI0NDUiLCJhbGciOiJSUzI1NiJ9.' +
+      'eyJwaWkiOnsiZmlyc3RfbmFtZSI6IkhhZsO-w7NyIiwibGFzdF9uYW1lIjoiQmrDtnJuc3NvbiIsInNzbiI6IjkwMDkwMDkwMCIsInBob25lIjoiKzEgNTEzLTU1NS0xMjEyIn0sIm1ldGFkYXRhIjp7ImFkZHJlc3NfdmVyaWZpY2F0aW9uX21lY2hhbmlzbSI6InBob25lIiwidXNlcl9waG9uZV9jb25maXJtYXRpb24iOnRydWUsInZlbmRvcl9waG9uZV9jb25maXJtYXRpb24iOnRydWV9fQ.' +
+      'TEflx3z6BmqCqcIIvO_jlbQX6HZ1eAZPu7vhNZJjD7XWHbu973bALNolqwcOxrPFU2aOpxTyaLBDKpGzwAPQJg';
+
+    const result = decodeUserBundle(token);
+
+    expect(result).to.deep.equal({
+      metadata: {
+        address_verification_mechanism: 'phone',
+        user_phone_confirmation: true,
+        vendor_phone_confirmation: true,
+      },
+      pii: {
+        first_name: 'Hafþór',
+        last_name: 'Björnsson',
+        phone: '+1 513-555-1212',
+        ssn: '900900900',
+      },
+    });
+  });
+
+  it('returns null if token is not decodable', () => {
+    const token = '';
+    const result = decodeUserBundle(token);
+
+    expect(result).to.be.null();
+  });
+});

--- a/app/javascript/packages/verify-flow/user-bundle.ts
+++ b/app/javascript/packages/verify-flow/user-bundle.ts
@@ -1,0 +1,46 @@
+import type { AddressVerificationMethod } from './context/address-verification-method-context';
+
+interface UserBundleMetadata {
+  address_verification_mechanism: AddressVerificationMethod;
+}
+
+interface UserBundle {
+  pii: Record<string, any>;
+
+  metadata: UserBundleMetadata;
+}
+
+/**
+ * Decodes a base64URL-encoded string.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc4648#section-5
+ *
+ * @param base64URL Base64URL-encoded string.
+ *
+ * @return Decoded string.
+ */
+function decodeBase64URL(base64URL: string): string {
+  const base64 = base64URL.replace(/-/g, '+').replace(/_/g, '/');
+
+  // Fix the "Unicode Problem"
+  // See: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+  return new TextDecoder().decode(Uint8Array.from(atob(base64), (c) => c.charCodeAt(0)));
+}
+
+/**
+ * Decodes and parses a JWT token payload as the user bundle.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7519#section-7.2
+ *
+ * @param jwt JWT token.
+ *
+ * @return Decoded and parsed user bundle.
+ */
+export function decodeUserBundle(jwt: string): UserBundle | null {
+  try {
+    const [, payload] = jwt.split('.');
+    return JSON.parse(decodeBase64URL(payload)) as UserBundle;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
**Why**: To avoid crashes when loading the verify flow.

- Problem 1: JWTs are encoded using base64url, not base64, which uses a modified alphabet and crashes when naively trying to parse with `atob` (see [RFC 7519, Section 7.2](https://datatracker.ietf.org/doc/html/rfc7519#section-7.2) and [RFC 4648, Section 5](https://datatracker.ietf.org/doc/html/rfc4648#section-5))
- Problem 2: Decoded values could display incorrect characters for some unicode character values

**Open Questions:**

- Maybe we should use a library instead of rolling our own? 🙃

**Testing Instructions:**

Repeat "Steps to reproduce" as outlined in LG-6576 and verify expected outcome.