### PR TITLE
LG-6572 update language urls to reflect correct path in JS

### DIFF
--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+export function setUp() {
   const mobileLink = document.querySelector('.i18n-mobile-toggle > button');
   const mobileDropdown = document.querySelector('.i18n-mobile-dropdown');
   const desktopLink = document.querySelector('.i18n-desktop-toggle > button');
@@ -35,4 +35,34 @@ document.addEventListener('DOMContentLoaded', () => {
   if (mobileLink) {
     languagePicker(mobileLink, mobileDropdown);
   }
-});
+
+  function syncLinkURLs() {
+    const links = document.querySelectorAll('.i18n-dropdown a[lang]');
+    links.forEach((link) => {
+      const lang = link.getAttribute('lang');
+      let prefix = '';
+      if (lang !== 'en') {
+        prefix = `/${lang}`;
+      }
+      const url = new URL(window.location.href);
+      url.pathname = prefix + url.pathname;
+      link.setAttribute('href', url.toString());
+    });
+  }
+
+  const originalPushState = History.prototype.pushState;
+  History.prototype.pushState = function (...args) {
+    const result = originalPushState.apply(this, args);
+    syncLinkURLs();
+    return result;
+  };
+  window.addEventListener('popstate', syncLinkURLs);
+
+  return () => {
+    History.prototype.pushState = originalPushState;
+  };
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  setUp();
+}

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -36,27 +36,35 @@ export function setUp() {
     languagePicker(mobileLink, mobileDropdown);
   }
 
-  function syncLinkURLs() {
+  function syncLanguageLinkURLs() {
     const links = document.querySelectorAll('.i18n-dropdown a[lang]');
+    // const langArray = ['es', 'fr'];
     links.forEach((link) => {
+      //1. url is /foo , lang is es   //2 url is /es/foo, lang is fr
       const lang = link.getAttribute('lang');
       let prefix = '';
       if (lang !== 'en') {
-        prefix = `/${lang}`;
+        prefix = `/${lang}`; //1. es is not en so we make prefix /es/foo   //2 lang is not en so prefix is fr
       }
       const url = new URL(window.location.href);
-      url.pathname = prefix + url.pathname;
-      link.setAttribute('href', url.toString());
+      // langArray.forEach((oldLang) => {
+      //   url.pathname = prefix + url.pathname.replace(oldLang, '');
+      // })
+      link.setAttribute('href', url.toString()); //1. pathname becomes /es/foo    //2. pathname becomes /es/fr/foo because current url has /es
+      if (window.location.pathname.includes(`/${lang}/`)) {
+        //1. current url (/foo) does NOT include es so we skip  //2. current url does NOT have fr so we skip
+        link.setAttribute('href', window.location.href);
+      }
     });
   }
 
   const originalPushState = History.prototype.pushState;
   History.prototype.pushState = function (...args) {
     const result = originalPushState.apply(this, args);
-    syncLinkURLs();
+    syncLanguageLinkURLs();
     return result;
   };
-  window.addEventListener('popstate', syncLinkURLs);
+  window.addEventListener('popstate', syncLanguageLinkURLs);
 
   return () => {
     History.prototype.pushState = originalPushState;

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -55,7 +55,7 @@ export function setUp() {
 
   /**
    * Recursive function which monkey patches the behavior of window.history.pushState and window.history.replaceState
-   * that is used in the react app to manage url routing.
+   * which are used in the react app to manage url routing.
    *
    * @return {function}  Tear-down function
    */

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -17,7 +17,7 @@
       <ul class='usa-list--unstyled margin-bottom-0 text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
-            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-no-underline fs-13p', lang: locale == I18n.locale ? nil : locale %>
+            <%= link_to t("i18n.locale.#{locale}"), sanitized_requested_url.merge(locale: locale), class: 'display-block padding-y-105 padding-x-2 text-no-underline fs-13p', lang: locale %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -13,7 +13,7 @@
         </div>
       </div>
     </div>
-    <div class='i18n-mobile-dropdown tablet:display-none display-none'>
+    <div class='i18n-dropdown i18n-mobile-dropdown tablet:display-none display-none'>
       <ul class='usa-list--unstyled margin-bottom-0 text-center'>
         <% I18n.available_locales.each do |locale| %>
           <li class='border-bottom border-primary-light'>
@@ -53,13 +53,13 @@
                                                           class: 'margin-right-1', alt: '' %><%= t('i18n.language') %>
               <span class="caret display-inline-block margin-left-05" aria-hidden="true">&#9662;</span>
             </button>
-            <ul class="i18n-desktop-dropdown usa-dark-background bg-primary usa-list--unstyled margin-bottom-0 display-none">
+            <ul class="i18n-dropdown i18n-desktop-dropdown usa-dark-background bg-primary usa-list--unstyled margin-bottom-0 display-none">
               <% I18n.available_locales.each do |locale| %>
                 <li class='border-bottom border-primary-darker'>
                   <%= link_to t("i18n.locale.#{locale}"),
                               sanitized_requested_url.merge(locale: locale),
                               class: 'display-block padding-left-3 padding-y-2 text-no-underline',
-                              lang: locale == I18n.locale ? nil : locale %>
+                              lang: locale %>
                 </li>
               <% end %>
             </ul>

--- a/spec/javascripts/app/i18n-dropdown-spec.js
+++ b/spec/javascripts/app/i18n-dropdown-spec.js
@@ -1,0 +1,28 @@
+import { setUp } from '../../../app/javascript/app/i18n-dropdown';
+
+describe('i18n-dropdown', () => {
+  let tearDown;
+
+  before(() => {
+    document.body.innerHTML = `
+      <div class="i18n-dropdown">
+        <a href="/" href="en">English</a>
+        <a href="/" lang="fr">Français</a>
+      </div>
+    `; // TODO
+
+    tearDown = setUp();
+  });
+
+  after(() => {
+    tearDown();
+  });
+
+  it('updates links on History#pushState', () => {
+    // TODO
+  });
+
+  it('updates links on popstate event', () => {
+    // TODO
+  });
+});

--- a/spec/javascripts/app/i18n-dropdown-spec.js
+++ b/spec/javascripts/app/i18n-dropdown-spec.js
@@ -1,80 +1,126 @@
-import { setUp } from '../../../app/javascript/app/i18n-dropdown';
 import sinon from 'sinon';
+import { useDefineProperty } from '@18f/identity-test-helpers';
+import { setUp } from '../../../app/javascript/app/i18n-dropdown';
 
 describe('i18n-dropdown', () => {
+  const sandbox = sinon.createSandbox();
+  const defineProperty = useDefineProperty();
+
   let tearDown;
 
-  before(() => {
-    const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="i18n-dropdown">
+        <a href="/" lang="en">English</a>
+        <a href="/" lang="fr">Français</a>
+        <a href="/" lang="es">Español</a>
+      </div>
+    `;
 
-    // const history = ['example.com'];
-
-    // sandbox.stub(window, 'history').value(
-    //   Object.assign(history, {
-    //     pushState(_data, _unused, url) {
-    //       history.push(url);
-    //     },
-    //     replaceState(_data, _unused, url) {
-    //       history[history.length - 1] = url;
-    //     },
-    //     back() {
-    //       history.pop();
-    //       window.dispatchEvent(new CustomEvent('popstate'));
-    //     },
-    //   }),
-    // );
+    const history = [window.location.href];
+    defineProperty(window, 'location', {
+      value: {
+        get href() {
+          return history[history.length - 1];
+        },
+      },
+    });
+    sandbox.stub(History.prototype, 'pushState').callsFake((_data, _unused, url) => {
+      history.push(new URL(url, window.location.href).toString());
+    });
+    sandbox.stub(History.prototype, 'replaceState').callsFake((_data, _unused, url) => {
+      history.push(new URL(url, window.location.href).toString());
+    });
+    sandbox.stub(History.prototype, 'back').callsFake(() => {
+      history.pop();
+      window.dispatchEvent(new CustomEvent('popstate'));
+    });
 
     tearDown = setUp();
   });
 
-  after(() => {
+  afterEach(() => {
     tearDown();
+    sandbox.restore();
   });
 
-  beforeEach(() => {
-    document.body.innerHTML = `
-    <div class="i18n-dropdown">
-      <a href="/" lang="en">English</a>
-      <a href="/" lang="fr">Français</a>
-      <a href="/" lang="es">Español</a>
-    </div>
-  `;
+  describe('using history.pushState', () => {
+    context('with default language', () => {
+      it('updates links', () => {
+        window.history.pushState(null, '', '/foo');
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/foo');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/foo');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/foo');
+      });
+    });
+
+    context('with non default language', () => {
+      beforeEach(() => {
+        document.documentElement.lang = 'fr';
+      });
+
+      it('updates links', () => {
+        window.history.pushState(null, '', '/fr/bar');
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/bar');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/bar');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/bar');
+      });
+    });
   });
 
-  context('using history.pushState ', () => {
-    it('updates links with default language', () => {
-      window.history.pushState(null, '', '/foo');
-      console.log('pathname', document.querySelectorAll('a[lang="en"]')[0].href);
-      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/foo');
-      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es/foo');
-      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr/foo');
+  describe('using history.replaceState', () => {
+    context('with default language', () => {
+      it('updates links', () => {
+        window.history.replaceState(null, '', '/foo');
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/foo');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/foo');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/foo');
+      });
     });
-    it('updates links with non default language', () => {
-      window.history.pushState(null, '', '/fr/bar');
-      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/bar');
-      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es/bar');
-      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr/bar');
+
+    context('with non default language', () => {
+      beforeEach(() => {
+        document.documentElement.lang = 'fr';
+      });
+
+      it('updates links', () => {
+        window.history.replaceState(null, '', '/fr/bar');
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/bar');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/bar');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/bar');
+      });
     });
   });
 
-  context('updates links on popstate event', () => {
-    it('updates links with default language', () => {
-      window.history.pushState(null, '', '/foo');
-      console.log('window url', window.location.href);
-      history.back();
-      console.log('window url', window.location.href);
-      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es');
-      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/');
-      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr');
+  describe('updates links on popstate event', () => {
+    context('with default language', () => {
+      it('updates links', () => {
+        window.history.pushState(null, '', '/foo');
+        window.history.back();
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
+      });
     });
-    it('updates links with non default language', () => {
-      window.history.pushState(null, '', '/es/foo');
-      console.log('window url', window.location.href);
-      history.back();
-      console.log('window url', window.location.href);
-      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es');
-      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/');
-      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr');
+
+    context('with non default language', () => {
+      beforeEach(() => {
+        document.documentElement.lang = 'fr';
+      });
+
+      it('updates links', () => {
+        window.history.pushState(null, '', '/fr/foo');
+        window.history.back();
+
+        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
+        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
+        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
+      });
     });
   });
 });

--- a/spec/javascripts/app/i18n-dropdown-spec.js
+++ b/spec/javascripts/app/i18n-dropdown-spec.js
@@ -1,15 +1,28 @@
 import { setUp } from '../../../app/javascript/app/i18n-dropdown';
+import sinon from 'sinon';
 
 describe('i18n-dropdown', () => {
   let tearDown;
 
   before(() => {
-    document.body.innerHTML = `
-      <div class="i18n-dropdown">
-        <a href="/" href="en">English</a>
-        <a href="/" lang="fr">Français</a>
-      </div>
-    `; // TODO
+    const sandbox = sinon.createSandbox();
+
+    // const history = ['example.com'];
+
+    // sandbox.stub(window, 'history').value(
+    //   Object.assign(history, {
+    //     pushState(_data, _unused, url) {
+    //       history.push(url);
+    //     },
+    //     replaceState(_data, _unused, url) {
+    //       history[history.length - 1] = url;
+    //     },
+    //     back() {
+    //       history.pop();
+    //       window.dispatchEvent(new CustomEvent('popstate'));
+    //     },
+    //   }),
+    // );
 
     tearDown = setUp();
   });
@@ -18,11 +31,50 @@ describe('i18n-dropdown', () => {
     tearDown();
   });
 
-  it('updates links on History#pushState', () => {
-    // TODO
+  beforeEach(() => {
+    document.body.innerHTML = `
+    <div class="i18n-dropdown">
+      <a href="/" lang="en">English</a>
+      <a href="/" lang="fr">Français</a>
+      <a href="/" lang="es">Español</a>
+    </div>
+  `;
   });
 
-  it('updates links on popstate event', () => {
-    // TODO
+  context('using history.pushState ', () => {
+    it('updates links with default language', () => {
+      window.history.pushState(null, '', '/foo');
+      console.log('pathname', document.querySelectorAll('a[lang="en"]')[0].href);
+      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/foo');
+      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es/foo');
+      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr/foo');
+    });
+    it('updates links with non default language', () => {
+      window.history.pushState(null, '', '/fr/bar');
+      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/bar');
+      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es/bar');
+      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr/bar');
+    });
+  });
+
+  context('updates links on popstate event', () => {
+    it('updates links with default language', () => {
+      window.history.pushState(null, '', '/foo');
+      console.log('window url', window.location.href);
+      history.back();
+      console.log('window url', window.location.href);
+      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es');
+      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/');
+      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr');
+    });
+    it('updates links with non default language', () => {
+      window.history.pushState(null, '', '/es/foo');
+      console.log('window url', window.location.href);
+      history.back();
+      console.log('window url', window.location.href);
+      expect(document.querySelectorAll('a[lang="es"]')[0].pathname).to.equal('/es');
+      expect(document.querySelectorAll('a[lang="en"]')[0].pathname).to.equal('/');
+      expect(document.querySelectorAll('a[lang="fr"]')[0].pathname).to.equal('/fr');
+    });
   });
 });

--- a/spec/javascripts/support/dom.js
+++ b/spec/javascripts/support/dom.js
@@ -96,6 +96,7 @@ export function useCleanDOM(dom) {
     while (document.body.firstChild) {
       document.body.removeChild(document.body.firstChild);
     }
+    document.documentElement.lang = 'en';
     window.history.replaceState(null, '', TEST_URL);
     window.location.pathname = '';
     window.location.hash = '';


### PR DESCRIPTION
[LG-6572](https://cm-jira.usa.gov/browse/LG-6572)

**Why**
When a user clicked on a different language in the language dropdown from the FSMv2 flow, they would get redirected back to the first step in FSMv2 because the language dropdown lives in rails and wasn't updated 

As mentioned in [associated Google Doc comment](https://docs.google.com/document/d/1X0V_Tjr97jMNQXAnLU4yyAeQjnVTWDn5z35lOaleWOU/edit?disco=AAAAZ5NRh20), "the problem is that the language picker is static content, so it's already determined where the user should be redirected on the initial page load, which will always be the first step in the React-based flow. We're not updating this as the user progresses through the flow"

**How**
Because we are managing routes using window.history in FSMv2, we monkey patched the window.history.pushState and replaceState functions to fetch the current url and update the language dropdown links accordingly. We modify the href property itself to avoid accessibility issues (user expects to see the url they will be navigated to when they hover over a link). 
