### PR TITLE
LG-6402: Add troubleshooting option to retake photos

### DIFF
--- a/app/components/block_link_component.html.erb
+++ b/app/components/block_link_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.a(**tag_options, href: url, class: css_class, target: target) do %>
+<%= wrapper do %>
   <%= content %>
   <% if new_tab %>
     <span class="usa-sr-only"><%= t('links.new_window') %></span>

--- a/app/components/block_link_component.rb
+++ b/app/components/block_link_component.rb
@@ -1,7 +1,8 @@
 class BlockLinkComponent < BaseComponent
-  attr_reader :url, :new_tab, :tag_options
+  attr_reader :url, :action, :new_tab, :tag_options
 
-  def initialize(url:, new_tab: false, **tag_options)
+  def initialize(url:, action: tag.method(:a), new_tab: false, **tag_options)
+    @action = action
     @url = url
     @new_tab = new_tab
     @tag_options = tag_options
@@ -15,5 +16,14 @@ class BlockLinkComponent < BaseComponent
 
   def target
     '_blank' if new_tab
+  end
+
+  def wrapper(&block)
+    wrapper = action.call(**tag_options, href: url, class: css_class, target: target, &block)
+    if wrapper.respond_to?(:render_in)
+      render wrapper, &block
+    else
+      wrapper
+    end
   end
 end

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,23 +1,27 @@
-<%= render(
-      'idv/shared/error',
-      type: :warning,
-      title: t('titles.failure.information_not_verified'),
-      heading: t('idv.failure.sessions.heading'),
-      action: {
-        text: t('idv.failure.button.warning'),
-        url: idv_doc_auth_path,
-      },
-      options: [
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(
-            step: 'verify_info',
-            location: request.params[:action],
-          ),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
-        },
-      ].select(&:present?),
-    ) do %>
-      <p><%= t('idv.failure.sessions.warning') %></p>
-      <p><strong><%= t('idv.failure.attempts', count: @remaining_attempts) %></strong></p>
+<% title t('titles.failure.information_not_verified') %>
+
+<%= render StatusPageComponent.new(status: :warning) do |c| %>
+  <% c.header { t('idv.failure.sessions.heading') } %>
+
+  <p><%= t('idv.failure.sessions.warning') %></p>
+  <p><strong><%= t('idv.failure.attempts', count: @remaining_attempts) %></strong></p>
+
+  <% c.action_button(
+       action: ->(**tag_options, &block) { link_to(idv_doc_auth_path, **tag_options, &block) },
+     ) { t('idv.forgot_password.try_again') } %>
+
+  <% c.troubleshooting_options do |tc| %>
+    <% tc.header { t('components.troubleshooting_options.default_heading') } %>
+    <% if decorated_session.sp_name %>
+      <% tc.option(
+           url: return_to_sp_failure_to_proof_path(
+             step: 'verify_info',
+             location: request.params[:action],
+           ),
+           new_tab: true,
+         ).with_content(
+           t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+         ) %>
     <% end %>
+  <% end %>
+<% end %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -12,6 +12,13 @@
 
   <% c.troubleshooting_options do |tc| %>
     <% tc.header { t('components.troubleshooting_options.default_heading') } %>
+    <% if user_session.dig(:'idv/doc_auth', :had_barcode_read_failure) %>
+      <% tc.option(
+           url: idv_doc_auth_step_path(step: :redo_document_capture),
+           action: FormLinkComponent.method(:new),
+           method: :put,
+         ).with_content(t('idv.troubleshooting.options.add_new_photos')) %>
+    <% end %>
     <% if decorated_session.sp_name %>
       <% tc.option(
            url: return_to_sp_failure_to_proof_path(

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -161,6 +161,7 @@ en:
         need_assistance: 'Need immediate assistance? Here’s how to get help:'
         still_having_trouble: Still having trouble?
       options:
+        add_new_photos: Add new photos of your state-issued ID
         change_phone_number: Use a different phone number
         contact_support: Contact %{app_name} Support
         doc_capture_tips: More tips for adding photos of your ID

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -168,6 +168,7 @@ es:
         need_assistance: '¿Necesita ayuda inmediata? Así es como puede obtener ayuda:'
         still_having_trouble: '¿Sigue teniendo dificultades?'
       options:
+        add_new_photos: Añada nuevas fotos de su ID emitido por el estado
         change_phone_number: Utiliza un número de teléfono diferente
         contact_support: Póngase en contacto con el servicio de asistencia de %{app_name}
         doc_capture_tips: Más consejos para agregar fotos de su identificación

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -181,6 +181,8 @@ fr:
           obtenir de l’aide:'
         still_having_trouble: Vous rencontrez toujours des difficultés?
       options:
+        add_new_photos: Ajoutez de nouvelles photos de votre carte d’identité délivrée
+          par l’État.
         change_phone_number: Utiliser un autre numéro de téléphone
         contact_support: Contacter le service d’assistance de %{app_name}
         doc_capture_tips: Plus de conseils pour ajouter des photos de votre carte d’identité

--- a/spec/components/block_link_component_spec.rb
+++ b/spec/components/block_link_component_spec.rb
@@ -28,4 +28,25 @@ RSpec.describe BlockLinkComponent, type: :component do
       expect(rendered).to have_content(t('links.new_window'))
     end
   end
+
+  context 'with custom renderer' do
+    class ExampleComponent < BaseComponent
+      def initialize(href:, **)
+        @href = href
+      end
+
+      def call
+        content_tag(:button, "Example #{content.strip}", data: { href: @href })
+      end
+    end
+
+    it 'renders using the custom renderer' do
+      rendered = render_inline BlockLinkComponent.new(
+        url: '/',
+        action: ExampleComponent.method(:new),
+      ).with_content('Link Text')
+
+      expect(rendered).to have_css('button[data-href="/"]', text: 'Example Link Text')
+    end
+  end
 end

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -11,7 +11,8 @@ feature 'doc auth redo document capture action', js: true do
       mock_doc_auth_attention_with_barcode
       attach_and_submit_images
       click_idv_continue
-      complete_ssn_step
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
     end
 
     it 'shows a warning message to allow the user to return to upload new images' do
@@ -30,6 +31,19 @@ feature 'doc auth redo document capture action', js: true do
       complete_ssn_step
 
       expect(page).not_to have_css('[role="status"]')
+    end
+
+    it 'shows a troubleshooting option to allow the user to return to upload new images' do
+      click_idv_continue
+
+      expect(page).to have_link(
+        t('idv.troubleshooting.options.add_new_photos'),
+        href: idv_doc_auth_step_path(step: :redo_document_capture),
+      )
+
+      click_link t('idv.troubleshooting.options.add_new_photos')
+
+      expect(current_path).to eq(idv_doc_auth_upload_step)
     end
 
     context 'on mobile', driver: :headless_chrome_mobile do

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 describe 'idv/session_errors/warning.html.erb' do
-  let(:sp_name) { 'Example SP' }
+  let(:sp_name) { nil }
   let(:remaining_attempts) { 5 }
   let(:in_person_proofing_enabled) { false }
+  let(:user_session) { {} }
 
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
+    allow(view).to receive(:user_session).and_return(user_session)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
       and_return(in_person_proofing_enabled)
 
@@ -24,10 +26,31 @@ describe 'idv/session_errors/warning.html.erb' do
     expect(rendered).to have_text(t('idv.failure.attempts', count: remaining_attempts))
   end
 
-  it 'renders a list of troubleshooting options' do
-    expect(rendered).to have_link(
-      t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'warning'),
-    )
+  it 'does not display troubleshooting options' do
+    expect(rendered).not_to have_content(t('components.troubleshooting_options.default_heading'))
+  end
+
+  context 'with an associated service provider' do
+    let(:sp_name) { 'Example SP' }
+
+    it 'renders troubleshooting option to get help at service provider' do
+      expect(rendered).to have_content(t('components.troubleshooting_options.default_heading'))
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+        href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'warning'),
+      )
+    end
+  end
+
+  context 'with a flow session which had a barcode attention document capture result' do
+    let(:user_session) { { 'idv/doc_auth': { had_barcode_read_failure: true } } }
+
+    it 'renders troubleshooting option to retake photos' do
+      expect(rendered).to have_content(t('components.troubleshooting_options.default_heading'))
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.add_new_photos'),
+        href: idv_doc_auth_step_path(step: :redo_document_capture),
+      )
+    end
   end
 end


### PR DESCRIPTION
**Why**: When a user receives a barcode attention result, there's a higher likelihood they will fail the verify step. Allowing them to retake photos may allow them to successfully pass this step.

**Testing Instructions:**

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. As front and back image, download and use the YAML file contents at the end of this comment description
6. Press Continue when prompted "We couldn’t read the barcode on your ID."
8. As SSN, use a value which would trigger a verification failure (e.g. `111-11-1111`)
9. Press Continue
10. Press Continue
11. Observe new troubleshooting option
12. Clicking troubleshooting option should take you back to allow you to repeat document capture step
13. Repeat steps 3 to 9, but use any other image for documents, and observe there is no troubleshooting option on the warning screen

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/175570147-16c3fa44-7794-4ca0-a3ac-7ce40ccb42d6.png)

**Test YAML File**

```yaml
document:
  type: license
  first_name: Susan
  last_name: Smithwrong
  middle_name: Q
  address1: 1 Microsoft Way
  address2: Apt 3
  city: Bayside
  state: NY
  zipcode: "11364"
  dob: 10/06/1938
  phone: +1 314-555-1212
failed_alerts:
  - name: 2D Barcode Read
    result: Attention
```