### PR TITLE
LG-6697: Sync completion URL to session storage

### DIFF
--- a/app/javascript/packages/verify-flow/context/secrets-context.tsx
+++ b/app/javascript/packages/verify-flow/context/secrets-context.tsx
@@ -3,7 +3,9 @@ import type { ReactNode, Dispatch } from 'react';
 import SecretSessionStorage from '@18f/identity-secret-session-storage';
 import type { VerifyFlowValues } from '../verify-flow';
 
-export type SecretValues = Pick<VerifyFlowValues, 'userBundleToken' | 'personalKey'>;
+type SecretKeys = 'userBundleToken' | 'personalKey' | 'completionURL';
+
+export type SecretValues = Pick<VerifyFlowValues, SecretKeys>;
 
 type SetItems = typeof SecretSessionStorage.prototype.setItems;
 
@@ -22,7 +24,7 @@ interface SecretsContextProviderProps {
 /**
  * Minimal set of flow values to be synced to secret session storage.
  */
-const SYNCED_SECRET_VALUES = ['userBundleToken', 'personalKey', 'completionURL'];
+const SYNCED_SECRET_VALUES: SecretKeys[] = ['userBundleToken', 'personalKey', 'completionURL'];
 
 const SecretsContext = createContext({
   storage: new SecretSessionStorage<SecretValues>(''),

--- a/app/javascript/packages/verify-flow/context/secrets-context.tsx
+++ b/app/javascript/packages/verify-flow/context/secrets-context.tsx
@@ -22,7 +22,7 @@ interface SecretsContextProviderProps {
 /**
  * Minimal set of flow values to be synced to secret session storage.
  */
-const SYNCED_SECRET_VALUES = ['userBundleToken', 'personalKey'];
+const SYNCED_SECRET_VALUES = ['userBundleToken', 'personalKey', 'completionURL'];
 
 const SecretsContext = createContext({
   storage: new SecretSessionStorage<SecretValues>(''),

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -43,6 +43,9 @@ feature 'idv confirmation step', js: true do
       # Visit the current path is the same as refreshing
       visit current_path
       expect(page).to have_content(t('headings.personal_key'))
+
+      acknowledge_and_confirm_personal_key
+      expect(page).to have_current_path(account_path)
     end
   end
 


### PR DESCRIPTION
**Why**: So that the user can finish the flow after refreshing once receiving the completion URL.

**Testing instructions:**

1. Go to http://localhost:3000/
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to personal key step
5. Refresh page
6. Finish proofing flow

_Before_: Clicking "Continue" on the confirmation modal does nothing
_After_: User can continue to next screen