### PR TITLE
Refactor one_time_code_input partial to use ValidatedFieldComponent

### DIFF
--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -15,13 +15,14 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= validated_form_for(:idv_otp_verification, method: :put) do %>
+<%= simple_form_for('', method: :put) do |f| %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
       <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block text-bold' %>
       <div class="margin-bottom-5">
         <%= render(
               'shared/one_time_code_input',
+              form: f,
               name: :code,
               value: @code,
               required: true,

--- a/app/views/shared/_one_time_code_input.html.erb
+++ b/app/views/shared/_one_time_code_input.html.erb
@@ -3,35 +3,36 @@ Renders an OTP code input field. In addition to the locals described below, all 
 local assigns will be applied directly to the text input as a hash of HTML attributes.
 
 locals:
+* form: Form builder instance.
 * name: Field name. Defaults to `:code`.
+* required: Whether field is required. Defaults to `false`.
 * transport: WebOTP transport method. Defaults to 'sms'.
 * value: Field value. Defaults to `''`.
 * class: CSS classes to add (optional)
 * numeric: if the field should only accept digits. Defualts to true
 %>
-<% name = local_assigns.delete(:name) { :code }
+<% form = local_assigns.delete(:form)
+   name = local_assigns.delete(:name) { :code }
+   required = local_assigns.delete(:required) { false }
    numeric = local_assigns.delete(:numeric) { true }
    transport = local_assigns.delete(:transport) { 'sms' }
    classes = ['field font-family-mono usa-input one-time-code-input']
    classes << local_assigns.delete(:class) if local_assigns[:class] %>
 
-<div>
-  <%= text_field_tag(
-        name,
-        nil,
-        'aria-invalid': 'false',
+<%= render ValidatedFieldComponent.new(
+      form: form,
+      name: name,
+      required: required,
+      label: false,
+      input_html: {
         'data-transport': transport,
         pattern: numeric ? '[0-9]*' : '[a-zA-Z0-9]*',
         maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
         autocomplete: 'one-time-code',
         inputmode: numeric ? 'numeric' : 'text',
-        type: 'text',
         **local_assigns,
         class: classes,
-      ) %>
-  <span class='usa-error-message display-if-invalid display-if-invalid--value-missing margin-top-1' role='alert'>
-    <%= t('simple_form.required.text') %>
-  </span>
-</div>
+      },
+    ) %>
 
 <%= javascript_packs_tag_once 'one-time-code-input' %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -6,7 +6,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= validated_form_for('', method: :post) do |f| %>
+<%= simple_form_for('', method: :post) do |f| %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>
@@ -14,6 +14,7 @@
     <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block text-bold' %>
     <%= render(
           'shared/one_time_code_input',
+          form: f,
           name: :code,
           value: @presenter.code_value,
           required: true,

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -2,13 +2,14 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
-<%= validated_form_for('', method: :post, html: { class: 'margin-bottom-5' }) do |f| %>
+<%= simple_form_for('', method: :post, html: { class: 'margin-bottom-5' }) do |f| %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>
   <%= label_tag :code, t('forms.two_factor.code'), class: 'display-block text-bold' %>
   <%= render(
         'shared/one_time_code_input',
+        form: f,
         transport: nil,
         name: :code,
         value: @code,

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -9,7 +9,7 @@
       ) %>
 </p>
 
-<%= validated_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
+<%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
     <%= c.item(heading: t('forms.totp_setup.totp_step_1')) do %>
       <p><%= t('forms.totp_setup.totp_step_1a') %></p>
@@ -39,6 +39,7 @@
     <%= c.item(heading: t('forms.totp_setup.totp_step_4')) do %>
       <%= render(
             'shared/one_time_code_input',
+            form: f,
             transport: nil,
             name: :code,
             required: true,

--- a/spec/views/shared/_one_time_code_input.html.erb_spec.rb
+++ b/spec/views/shared/_one_time_code_input.html.erb_spec.rb
@@ -1,10 +1,14 @@
 require 'rails_helper'
 
 describe 'shared/_one_time_code_input.html.erb' do
+  include SimpleForm::ActionViewExtensions::FormHelper
+
   let(:params) { {} }
 
   before do
-    render('shared/one_time_code_input', **params)
+    simple_form_for('', url: '/') do |f|
+      render('shared/one_time_code_input', form: f, **params)
+    end
   end
 
   describe 'name' do


### PR DESCRIPTION
**Why**:

- Standardize on `ValidatedFieldComponent` as canonical validation approach in effort to move away from `display-if-invalid` and toward the eventual removal of the `form-validation.js` pack.
- Improve accessibility by leveraging advanced features of `ValidatedFieldComponent`
   - Relationship between field and error message via `aria-describedby`

**Testing Instructions:**

Verify no regressions in the behavior of OTP code entry, including OTP and TOTP (and setup processes for each).

**Next steps:**

The only two remaining usages of `display-if-invalid` after these changes are:

- IdV address form
- IdV GPO address form (disabled in production)