### PR TITLE
Fix 500 when creating new identity

### DIFF
--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -43,13 +43,7 @@ class IdentityLinker
   end
 
   def find_or_create_identity_with_costing
-    identity_record = identity_relation.first
-    return identity_record if identity_record
-    user.identities.create(service_provider: service_provider.issuer)
-  end
-
-  def identity_relation
-    user.identities.where(service_provider: service_provider.issuer)
+    user.identities.create_or_find_by(service_provider: service_provider.issuer)
   end
 
   def merged_attributes(extra_attrs)


### PR DESCRIPTION
The find and then create sequence has the potential to 500 from a race condition ([NR link](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=604800000&state=21e53e46-e7fb-dea8-6c6f-26d2388c1e9d))