### PR TITLE
Fix 500 in document capture step

### DIFF
--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -33,7 +33,7 @@ module Idv
       private
 
       def handle_stored_result
-        if stored_result.success?
+        if stored_result&.success?
           save_proofing_components
           extract_pii_from_doc(stored_result, store_in_session: !hybrid_flow_mobile?)
         else

--- a/spec/services/idv/steps/document_capture_step_spec.rb
+++ b/spec/services/idv/steps/document_capture_step_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Idv::Steps::DocumentCaptureStep do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { build(:user) }
+  let(:service_provider) do
+    create(
+      :service_provider,
+      issuer: 'http://sp.example.com',
+      app_id: '123',
+    )
+  end
+  let(:controller) do
+    instance_double(
+      'controller',
+      session: { sp: { issuer: service_provider.issuer } },
+      current_user: user,
+      analytics: FakeAnalytics.new,
+      url_options: {},
+      request: double(
+        'request',
+        headers: {
+          'X-Amzn-Trace-Id' => amzn_trace_id,
+        },
+      ),
+    )
+  end
+  let(:amzn_trace_id) { SecureRandom.uuid }
+
+  let(:pii_from_doc) do
+    {
+      ssn: '123-45-6789',
+    }
+  end
+
+  let(:flow) do
+    Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+      flow.flow_session = {}
+    end
+  end
+
+  subject(:step) do
+    Idv::Steps::DocumentCaptureStep.new(flow)
+  end
+
+  describe '#call' do
+    it 'does not raise an exception when stored_result is nil' do
+      allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
+        and_return(false)
+      allow(step).to receive(:stored_result).and_return(nil)
+      step.call
+    end
+  end
+end


### PR DESCRIPTION
The stored result may not exist, and we should handle that error appropriately ([NR link 1](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=604800000&state=b2736ea6-c54e-4bc8-1656-c4b4174d66a4), [NR link 2](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=604800000&state=a8c70fe5-3e3c-f656-18b7-c17d1d73c3e2))