### PR TITLE
Consolidate JavaScript error tracking

### DIFF
--- a/app/javascript/packages/document-capture/context/analytics.jsx
+++ b/app/javascript/packages/document-capture/context/analytics.jsx
@@ -12,20 +12,14 @@ import { createContext } from 'react';
  */
 
 /**
- * @typedef {(error: Error)=>void} NoticeError
- */
-
-/**
  * @typedef AnalyticsContext
  *
  * @prop {TrackEvent} addPageAction Log an action with optional payload.
- * @prop {NoticeError} noticeError Log an error without affecting application behavior.
  */
 
 const AnalyticsContext = createContext(
   /** @type {AnalyticsContext} */ ({
     addPageAction: () => Promise.resolve(),
-    noticeError: () => {},
   }),
 );
 

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
 import { t } from '@18f/identity-i18n';
 import { FormError } from '@18f/identity-form-steps';
+import { trackError } from '@18f/identity-analytics';
 import UploadContext from '../context/upload';
 import AnalyticsContext from '../context/analytics';
 
@@ -83,7 +84,7 @@ const withBackgroundEncryptedUpload = (Component) => {
    */
   function ComposedComponent({ onChange, onError, ...props }) {
     const { backgroundUploadURLs, backgroundUploadEncryptKey } = useContext(UploadContext);
-    const { addPageAction, noticeError } = useContext(AnalyticsContext);
+    const { addPageAction } = useContext(AnalyticsContext);
 
     /**
      * @param {Record<string, string|Blob|null|undefined>} nextValues Next values.
@@ -103,7 +104,7 @@ const withBackgroundEncryptedUpload = (Component) => {
           )
             .catch((error) => {
               addPageAction('IdV: document capture async upload encryption', { success: false });
-              noticeError(error);
+              trackError(error);
 
               // Rethrow error to skip upload and proceed from next `catch` block.
               throw error;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -19,21 +19,9 @@ import { trackEvent } from '@18f/identity-analytics';
 /** @typedef {import('@18f/identity-i18n').I18n} I18n */
 
 /**
- * @typedef NewRelicAgent
- *
- * @prop {(error:Error)=>void} noticeError Log an error without affecting application behavior.
- */
-
-/**
  * @typedef LoginGov
  *
  * @prop {Record<string,string>} assets
- */
-
-/**
- * @typedef NewRelicGlobals
- *
- * @prop {NewRelicAgent=} newrelic New Relic agent.
  */
 
 /**
@@ -43,7 +31,7 @@ import { trackEvent } from '@18f/identity-analytics';
  */
 
 /**
- * @typedef {typeof window & NewRelicGlobals & LoginGovGlobals} DocumentCaptureGlobal
+ * @typedef {typeof window & LoginGovGlobals} DocumentCaptureGlobal
  */
 
 /**
@@ -109,10 +97,6 @@ function addPageAction(event, payload) {
   return trackEvent(event, { ...payload, flow_path: flowPath });
 }
 
-/** @type {import('@18f/identity-document-capture/context/analytics').NoticeError} */
-const noticeError = (error) =>
-  /** @type {DocumentCaptureGlobal} */ (window).newrelic?.noticeError(error);
-
 (async () => {
   const backgroundUploadURLs = getBackgroundUploadURLs();
   const isAsyncForm = Object.keys(backgroundUploadURLs).length > 0;
@@ -159,7 +143,7 @@ const noticeError = (error) =>
     [AppContext.Provider, { value: { appName } }],
     [HelpCenterContextProvider, { value: { helpCenterRedirectURL } }],
     [DeviceContext.Provider, { value: device }],
-    [AnalyticsContext.Provider, { value: { addPageAction, noticeError } }],
+    [AnalyticsContext.Provider, { value: { addPageAction } }],
     [
       AcuantContextProvider,
       {


### PR DESCRIPTION
Builds on: #6509

**Why**: So that we don't need to maintain multiple separate implementations for tracking errors.