### PR TITLE
Add analytics for barcode attention warning actions

### DIFF
--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.spec.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSandbox } from '@18f/identity-test-helpers';
 import { t } from '@18f/identity-i18n';
+import * as analytics from '@18f/identity-analytics';
 import BarcodeAttentionWarning from './barcode-attention-warning';
 
 describe('BarcodeAttentionWarning', () => {
@@ -15,6 +16,7 @@ describe('BarcodeAttentionWarning', () => {
     document.body.appendChild(form);
 
     sandbox.stub(window, 'fetch').resolves();
+    sandbox.stub(analytics, 'trackEvent');
   });
 
   const DEFAULT_PROPS = {
@@ -46,6 +48,7 @@ describe('BarcodeAttentionWarning', () => {
 
     expect(form.submit).to.have.been.calledOnce();
     expect(onbeforeunload).not.to.have.been.called();
+    expect(analytics.trackEvent).to.have.been.calledWith('IdV: barcode warning continue clicked');
   });
 
   it('lets the user dismiss to take new photos', async () => {
@@ -60,5 +63,8 @@ describe('BarcodeAttentionWarning', () => {
     await userEvent.click(dismissButton);
 
     expect(onDismiss).to.have.been.calledOnce();
+    expect(analytics.trackEvent).to.have.been.calledWith(
+      'IdV: barcode warning retake photos clicked',
+    );
   });
 });


### PR DESCRIPTION
**Why**: So that we can have more insight into the choice that a user is making when presented with a barcode attention warning.