### PR TITLE
Add logging to "Forgot Password" subpage (FSMv2)

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -6,6 +6,7 @@ class FrontendLogController < ApplicationController
   before_action :validate_parameter_types
 
   EVENT_MAP = {
+    'IdV: forgot password visited' => :idv_forgot_password,
     'IdV: password confirm visited' => :idv_password_confirm_visited,
     'IdV: password confirm submitted' => :idv_password_confirm_submitted,
     'IdV: personal key visited' => :idv_personal_key_visited,

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.spec.tsx
@@ -116,6 +116,8 @@ describe('PasswordConfirmStep', () => {
       await userEvent.click(getByRole('link', { name: 'idv.forgot_password.link_text' }));
 
       expect(window.location.pathname).to.equal('/password_confirm/forgot_password');
+      expect(analytics.trackEvent).to.have.been.calledWith('IdV: forgot password visited');
+      expect(analytics.trackEvent).not.to.have.been.calledWith('IdV: password confirm visited');
     });
 
     it('navigates back from forgot password subpage', async () => {
@@ -125,6 +127,8 @@ describe('PasswordConfirmStep', () => {
       await userEvent.click(getByRole('link', { name: 'idv.forgot_password.try_again' }));
 
       expect(window.location.pathname).to.equal('/password_confirm');
+      expect(analytics.trackEvent).to.have.been.calledWith('IdV: forgot password visited');
+      expect(analytics.trackEvent).to.have.been.calledWith('IdV: password confirm visited');
     });
   });
 

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-confirm-step.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import type { ChangeEvent } from 'react';
 import { useDidUpdateEffect } from '@18f/identity-react-hooks';
 import { t } from '@18f/identity-i18n';
 import {
@@ -12,7 +13,7 @@ import { FlowContext } from '@18f/identity-verify-flow';
 import { formatHTML } from '@18f/identity-react-i18n';
 import { PageHeading, Accordion, Alert, Link, ScrollIntoView } from '@18f/identity-components';
 import { getConfigValue } from '@18f/identity-config';
-import type { ChangeEvent } from 'react';
+import { trackEvent } from '@18f/identity-analytics';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import { ForgotPassword } from './forgot-password';
 import PersonalInfoSummary from './personal-info-summary';
@@ -25,6 +26,18 @@ interface PasswordConfirmStepProps extends FormStepComponentProps<VerifyFlowValu
 
 const FORGOT_PASSWORD_PATH = 'forgot_password';
 
+function useSubpageEventLogger(path) {
+  useDidUpdateEffect(() => {
+    switch (path) {
+      case 'forgot_password':
+        trackEvent('IdV: forgot password visited');
+        break;
+      default:
+        trackEvent('IdV: password confirm visited');
+    }
+  }, [path]);
+}
+
 function PasswordConfirmStep({ errors, registerField, onChange, value }: PasswordConfirmStepProps) {
   const { basePath } = useContext(FlowContext);
   const { onPageTransition } = useContext(FormStepsContext);
@@ -32,6 +45,7 @@ function PasswordConfirmStep({ errors, registerField, onChange, value }: Passwor
   const stepPath = `${basePath}/password_confirm`;
   const [path] = useHistoryParam(undefined, { basePath: stepPath });
   useDidUpdateEffect(onPageTransition, [path]);
+  useSubpageEventLogger(path);
 
   if (path === FORGOT_PASSWORD_PATH) {
     return <ForgotPassword stepPath={stepPath} />;


### PR DESCRIPTION
**Why**: For feature parity with existing logging:

https://github.com/18F/identity-idp/blob/dd9d24cc16f2da919001d1d0321b80b1322a7ab6/app/controllers/idv/forgot_password_controller.rb#L8-L10

This was not covered by #6412 since this falls outside the "happy path".

Confirming password reset is already being logged:

https://github.com/18F/identity-idp/blob/dd9d24cc16f2da919001d1d0321b80b1322a7ab6/app/controllers/api/verify/password_reset_controller.rb#L6-L7

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to phone step
5. Start observing logs in your terminal: `tail -F -n0 log/events.log | jq .`
6. Click "Continue"
7. Click link with "Forgot password? Follow these instructions"
8. Click " Try again"
9. Observe in your terminal three logged events:
   1. `IdV: password confirm visited` 
   2. `IdV: forgot password visited`
   3. `IdV: password confirm visited`