### PR TITLE
Use existing IdV events for FSMv2 steps

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -6,8 +6,8 @@ class FrontendLogController < ApplicationController
   before_action :validate_parameter_types
 
   EVENT_MAP = {
-    'IdV: password confirm visited' => :idv_password_confirm_visited,
-    'IdV: password confirm submitted' => :idv_password_confirm_submitted,
+    'IdV: password confirm visited' => :idv_review_info_visited,
+    'IdV: password confirm submitted' => :idv_review_complete,
     'IdV: personal key visited' => :idv_personal_key_visited,
     'IdV: personal key submitted' => :idv_personal_key_submitted,
     'IdV: personal key confirm visited' => :idv_personal_key_confirm_visited,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -672,16 +672,6 @@ module AnalyticsEvents
     )
   end
 
-  # User visited IDV password confirm page
-  def idv_password_confirm_visited
-    track_event('IdV: password confirm visited')
-  end
-
-  # User submitted IDV password confirm page
-  def idv_password_confirm_submitted
-    track_event('IdV: password confirm submitted')
-  end
-
   # User visited IDV personal key page
   def idv_personal_key_visited
     track_event('IdV: personal key visited')
@@ -919,12 +909,12 @@ module AnalyticsEvents
     )
   end
 
-  # User completed idv
+  # User submitted IDV password confirm page
   def idv_review_complete
     track_event('IdV: review complete')
   end
 
-  # User visited idv phone of record
+  # User visited IDV password confirm page
   def idv_review_info_visited
     track_event('IdV: review info visited')
   end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -39,14 +39,10 @@ feature 'Analytics Regression', js: true do
     }
     {
       FSMv1: common_events.merge(
-        'IdV: review info visited' => {},
-        'IdV: review complete' => {},
         'IdV: final resolution' => { success: true },
         'Frontend: IdV: show personal key modal' => {},
       ),
       FSMv2: common_events.merge(
-        'IdV: password confirm visited' => {},
-        'IdV: password confirm submitted' => {},
         'IdV: personal key confirm visited' => {},
         'IdV: personal key confirm submitted' => {},
       ),


### PR DESCRIPTION
**Why**: To avoid conflicts with existing queries and dashboards.

Draft pending outcome of discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1656335577047989