### PR TITLE
Clear session storage on additional IdV flow exit paths (FSMv2)

### DIFF
--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -25,6 +25,11 @@ export interface FlowContextValue {
    * The path to which the current step is appended to create the current step URL.
    */
   basePath: string;
+
+  /**
+   * Handle flow completion with a given destination URL.
+   */
+  onComplete({ completionURL: string }): void;
 }
 
 const FlowContext = createContext<FlowContextValue>({
@@ -33,6 +38,7 @@ const FlowContext = createContext<FlowContextValue>({
   inPersonURL: null,
   currentStep: '',
   basePath: '',
+  onComplete() {},
 });
 
 FlowContext.displayName = 'FlowContext';

--- a/app/javascript/packages/verify-flow/start-over-or-cancel.spec.tsx
+++ b/app/javascript/packages/verify-flow/start-over-or-cancel.spec.tsx
@@ -29,6 +29,7 @@ describe('StartOverOrCancel', () => {
             currentStep: 'one',
             basePath: '',
             inPersonURL: null,
+            onComplete() {},
           }}
         >
           <StartOverOrCancel />

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { useSandbox } from '@18f/identity-test-helpers';
 import PasswordResetButton, { API_ENDPOINT } from './password-reset-button';
 import * as api from '../../services/api';
+import FlowContext, { FlowContextValue } from '../../context/flow-context';
 
 describe('PasswordResetButton', () => {
   const sandbox = useSandbox();
@@ -17,18 +18,22 @@ describe('PasswordResetButton', () => {
   });
 
   it('triggers password reset API call and redirects', (done) => {
-    function onNavigate(url) {
+    function onComplete({ completionURL }) {
       let error;
 
       try {
-        expect(url).to.equal(REDIRECT_URL);
+        expect(completionURL).to.equal(REDIRECT_URL);
       } catch (assertionError) {
         error = assertionError;
       }
 
       done(error);
     }
-    const { getByRole } = render(<PasswordResetButton onNavigate={onNavigate} />);
+    const { getByRole } = render(
+      <FlowContext.Provider value={{ onComplete } as FlowContextValue}>
+        <PasswordResetButton />
+      </FlowContext.Provider>,
+    );
 
     const button = getByRole('button');
     userEvent.click(button);

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.tsx
@@ -1,7 +1,9 @@
+import { useContext } from 'react';
 import { SpinnerButton } from '@18f/identity-spinner-button';
 import { t } from '@18f/identity-i18n';
 import { isErrorResponse, post } from '../../services/api';
 import type { ErrorResponse } from '../../services/api';
+import FlowContext from '../../context/flow-context';
 
 /**
  * API endpoint for password reset.
@@ -20,21 +22,14 @@ interface PasswordResetSuccessResponse {
  */
 type PasswordResetResponse = PasswordResetSuccessResponse | ErrorResponse;
 
-/**
- * Navigates user to the given URL.
- *
- * @param url Destination URL.
- */
-function navigate(url) {
-  window.location.href = url;
-}
+function PasswordResetButton() {
+  const { onComplete } = useContext(FlowContext);
 
-function PasswordResetButton({ onNavigate = navigate }) {
   async function requestReset() {
     const json = await post<PasswordResetResponse>(API_ENDPOINT, {}, { csrf: true, json: true });
     if (!isErrorResponse(json)) {
-      const { redirect_url: redirectURL } = json;
-      onNavigate(redirectURL);
+      const { redirect_url: completionURL } = json;
+      onComplete({ completionURL });
     }
   }
 

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -127,7 +127,14 @@ function VerifyFlow({
   const [syncedValues, setSyncedValues] = useSyncedSecretValues(initialValues);
   const [currentStep, setCurrentStep] = useState(steps[0].name);
   const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, steps);
-  const context = useObjectMemo({ startOverURL, cancelURL, inPersonURL, currentStep, basePath });
+  const context = useObjectMemo({
+    startOverURL,
+    cancelURL,
+    inPersonURL,
+    currentStep,
+    basePath,
+    onComplete,
+  });
   useEffect(() => {
     logStepVisited(currentStep);
   }, [currentStep]);

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -74,7 +74,8 @@ function notifyNewRelic(request, error, actionName) {
   });
 }
 
-function forceRedirect(redirectURL: string) {
+function handleTimeout(redirectURL: string) {
+  window.dispatchEvent(new window.CustomEvent('lg:session-timeout'));
   window.onbeforeunload = null;
   window.onunload = null;
   window.location.href = redirectURL;
@@ -86,7 +87,7 @@ function success(data: PingResponse) {
 
   if (!data.live) {
     if (timeoutUrl) {
-      forceRedirect(timeoutUrl);
+      handleTimeout(timeoutUrl);
     }
     return;
   }

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -1,4 +1,4 @@
-import { render } from 'react-dom';
+import { render, unmountComponentAtNode } from 'react-dom';
 import {
   VerifyFlow,
   SecretsContextProvider,
@@ -73,6 +73,8 @@ export async function initialize() {
   const initialValues: Partial<VerifyFlowValues> = JSON.parse(initialValuesJSON);
   const enabledStepNames = JSON.parse(enabledStepNamesJSON) as string[];
 
+  const tearDown = () => unmountComponentAtNode(appRoot);
+
   let cryptoKey: CryptoKey;
   let initialAddressVerificationMethod: AddressVerificationMethod | undefined;
   try {
@@ -98,7 +100,7 @@ export async function initialize() {
       </FlowContext.Provider>,
       appRoot,
     );
-    return;
+    return tearDown;
   }
 
   function onComplete({ completionURL }: VerifyFlowValues) {
@@ -125,6 +127,8 @@ export async function initialize() {
     </SecretsContextProvider>,
     appRoot,
   );
+
+  return tearDown;
 }
 
 if (process.env.NODE_ENV !== 'test') {

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -109,6 +109,8 @@ const storage = new SecretSessionStorage<SecretValues>('verify');
     }
   }
 
+  window.addEventListener('lg:session-timeout', () => storage.clear());
+
   render(
     <SecretsContextProvider storage={storage}>
       <VerifyFlow

--- a/spec/javascripts/packs/verify-flow-spec.ts
+++ b/spec/javascripts/packs/verify-flow-spec.ts
@@ -1,0 +1,28 @@
+import { initialize } from '../../../app/javascript/packs/verify-flow';
+
+describe('verify-flow', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div
+        id="app-root"
+        data-initial-values="{}"
+        data-enabled-step-names='["password_confirm"]'
+        data-base-path="/"
+        data-start-over-url="/"
+        data-cancel-url="/"
+        data-in-person-url="/"
+        data-store-key="dK00lFMxejQH3y5BWt+LwOShw+WSRt/6OudNYI/N9X4="
+      ></div>
+    `;
+
+    await initialize();
+  });
+
+  it('clears session storage on session timeout', () => {
+    expect(sessionStorage).to.have.lengthOf(1);
+
+    window.dispatchEvent(new window.CustomEvent('lg:session-timeout'));
+
+    expect(sessionStorage).to.have.lengthOf(0);
+  });
+});

--- a/spec/javascripts/packs/verify-flow-spec.ts
+++ b/spec/javascripts/packs/verify-flow-spec.ts
@@ -1,6 +1,8 @@
 import { initialize } from '../../../app/javascript/packs/verify-flow';
 
 describe('verify-flow', () => {
+  let tearDown;
+
   beforeEach(async () => {
     document.body.innerHTML = `
       <div
@@ -15,7 +17,11 @@ describe('verify-flow', () => {
       ></div>
     `;
 
-    await initialize();
+    tearDown = await initialize();
+  });
+
+  afterEach(() => {
+    tearDown();
   });
 
   it('clears session storage on session timeout', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "app/components",
     "app/javascript/packages",
     "app/javascript/packs",
-    "spec/javascripts/spec_helper.d.ts"
+    "spec/javascripts/spec_helper.d.ts",
+    "spec/javascripts/**/*.ts"
   ],
   "exclude": [
     "**/fixtures",


### PR DESCRIPTION
**Why**: So that we're consistently handling flow completion behaviors, reducing risk profile by proactively removing the encrypted `sessionStorage` value.

Specifically, this covers:

- Clear session storage on session timeout (03ea9e12004cb2b16ef428fbf1fc4fed29127b0e)
- Handle IdV forgot password confirmation as flow completion (df329fa7412fb6c3e75b6a1cb0e254dcdcc6ecb4)

**Testing Instructions:**

This is easier to test by configuring `config/application.yml` setting `session_timeout_in_minutes` to a low number (e.g. `session_timeout_in_minutes: 2`).

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to password re-entry
5. In developer tools console, enter `sessionStorage.length` and observe value is `1`
6. Perform either/both of the following:
   1. Wait for session to timeout
   2. Click "Forgot password?" link and confirm "Reset Password"
7.  In developer tools console, enter `sessionStorage.length` and observe value is `0`