### PR TITLE
Use custom event for pushState URL changes

### DIFF
--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -53,36 +53,10 @@ export function setUp() {
     });
   }
 
-  /**
-   * Recursive function which monkey patches the behavior of window.history.pushState and window.history.replaceState
-   * which are used in the react app to manage url routing.
-   *
-   * @return {function}  Tear-down function
-   */
-  function createWindowHistoryPatch() {
-    return ['pushState', 'replaceState'].reduce(
-      (tearDownPrevious, functionName) => {
-        const originalFunction = History.prototype[functionName];
-        History.prototype[functionName] = function (...args) {
-          const result = originalFunction.apply(this, args);
-          syncLanguageLinkURLs();
-          return result;
-        };
-
-        return () => {
-          tearDownPrevious();
-          History.prototype[functionName] = originalFunction;
-        };
-      },
-      () => {},
-    );
-  }
-
-  const tearDownWindowHistoryPatch = createWindowHistoryPatch();
-
-  window.addEventListener('popstate', syncLanguageLinkURLs);
-
-  return tearDownWindowHistoryPatch;
+  window.addEventListener('lg:url-change', syncLanguageLinkURLs);
+  return () => {
+    window.removeEventListener('lg:url-change', syncLanguageLinkURLs);
+  };
 }
 
 /**

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -53,6 +53,8 @@ export function setUp() {
     });
   }
 
+  syncLanguageLinkURLs();
+
   window.addEventListener('lg:url-change', syncLanguageLinkURLs);
   return () => {
     window.removeEventListener('lg:url-change', syncLanguageLinkURLs);

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -118,7 +118,9 @@ describe('useHistoryParam', () => {
   it('syncs by history events', async () => {
     const { getByText, getByDisplayValue, findByDisplayValue } = render(<TestComponent />);
 
+    onURLChange.callsFake(() => expect(window.location.hash).to.equal('#1'));
     await userEvent.click(getByText('Increment'));
+    onURLChange.resetBehavior();
 
     expect(getByDisplayValue('1')).to.be.ok();
     expect(window.location.hash).to.equal('#1');
@@ -130,7 +132,9 @@ describe('useHistoryParam', () => {
     expect(window.location.hash).to.equal('#2');
     expect(onURLChange).to.have.been.calledTwice();
 
+    onURLChange.callsFake(() => expect(window.location.hash).to.equal('#1'));
     window.history.back();
+    onURLChange.resetBehavior();
 
     expect(await findByDisplayValue('1')).to.be.ok();
     expect(window.location.hash).to.equal('#1');
@@ -261,7 +265,9 @@ describe('useHistoryParam', () => {
           });
 
           it('syncs to URL', () => {
+            onURLChange.callsFake(() => expect(window.location.pathname).to.equal('/base/1'));
             render(<TestComponent initialValue="1" basePath={basePath} />);
+            onURLChange.resetBehavior();
 
             expect(window.location.pathname).to.equal('/base/1');
             expect(window.history.length).to.equal(1);

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -206,6 +206,7 @@ describe('useHistoryParam', () => {
 
           expect(getByDisplayValue('1')).to.be.ok();
           expect(window.location.pathname).to.equal('/base/1');
+          expect(onURLChange).to.have.been.calledOnce();
 
           await userEvent.click(getByText('Increment'));
 

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -35,6 +35,7 @@ describe('getStepParam', () => {
 describe('useHistoryParam', () => {
   const sandbox = sinon.createSandbox();
   const defineProperty = useDefineProperty();
+  const onURLChange = sandbox.stub();
 
   function TestComponent({ initialValue, basePath }: { initialValue?: string; basePath?: string }) {
     const [count = 0, setCount] = useHistoryParam(initialValue, { basePath });
@@ -57,11 +58,13 @@ describe('useHistoryParam', () => {
 
   beforeEach(() => {
     originalHash = window.location.hash;
+    window.addEventListener('lg:url-change', onURLChange);
   });
 
   afterEach(() => {
     window.location.hash = originalHash;
     sandbox.restore();
+    window.removeEventListener('lg:url-change', onURLChange);
   });
 
   it('returns undefined value if absent from initial URL', () => {

--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -63,8 +63,8 @@ function useHistoryParam(
     // Push the next value to history, both to update the URL, and to allow the user to return to
     // an earlier value (see `popstate` sync behavior).
     if (nextValue !== value) {
-      onURLChange();
       window.history.pushState(null, '', getParamURL(nextValue, { basePath }));
+      onURLChange();
       subscribers.forEach((sync) => sync());
     }
 
@@ -75,8 +75,8 @@ function useHistoryParam(
 
   useEffect(() => {
     if (initialValue && initialValue !== getCurrentValue()) {
-      onURLChange();
       window.history.replaceState(null, '', getParamURL(initialValue, { basePath }));
+      onURLChange();
     }
 
     window.addEventListener('popstate', syncValue);

--- a/spec/javascripts/app/i18n-dropdown-spec.js
+++ b/spec/javascripts/app/i18n-dropdown-spec.js
@@ -6,9 +6,9 @@ describe('i18n-dropdown', () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <div class="i18n-dropdown">
-        <a href="/" lang="en">English</a>
-        <a href="/" lang="fr">Français</a>
-        <a href="/" lang="es">Español</a>
+        <a href="/wrong" lang="en">English</a>
+        <a href="/wrong" lang="fr">Français</a>
+        <a href="/wrong" lang="es">Español</a>
       </div>
     `;
 
@@ -20,7 +20,13 @@ describe('i18n-dropdown', () => {
   });
 
   context('with default language', () => {
-    it('updates links', () => {
+    it('updates links on initialization', () => {
+      expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
+      expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
+      expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
+    });
+
+    it('updates links on url change', () => {
       window.history.replaceState(null, '', '/foo');
       window.dispatchEvent(new window.CustomEvent('lg:url-change'));
 
@@ -35,7 +41,13 @@ describe('i18n-dropdown', () => {
       document.documentElement.lang = 'fr';
     });
 
-    it('updates links', () => {
+    it('updates links on initialization', () => {
+      expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
+      expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
+      expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
+    });
+
+    it('updates links on url change', () => {
       window.history.replaceState(null, '', '/fr/bar');
       window.dispatchEvent(new window.CustomEvent('lg:url-change'));
 

--- a/spec/javascripts/app/i18n-dropdown-spec.js
+++ b/spec/javascripts/app/i18n-dropdown-spec.js
@@ -1,11 +1,6 @@
-import sinon from 'sinon';
-import { useDefineProperty } from '@18f/identity-test-helpers';
 import { setUp } from '../../../app/javascript/app/i18n-dropdown';
 
 describe('i18n-dropdown', () => {
-  const sandbox = sinon.createSandbox();
-  const defineProperty = useDefineProperty();
-
   let tearDown;
 
   beforeEach(() => {
@@ -17,110 +12,36 @@ describe('i18n-dropdown', () => {
       </div>
     `;
 
-    const history = [window.location.href];
-    defineProperty(window, 'location', {
-      value: {
-        get href() {
-          return history[history.length - 1];
-        },
-      },
-    });
-    sandbox.stub(History.prototype, 'pushState').callsFake((_data, _unused, url) => {
-      history.push(new URL(url, window.location.href).toString());
-    });
-    sandbox.stub(History.prototype, 'replaceState').callsFake((_data, _unused, url) => {
-      history.push(new URL(url, window.location.href).toString());
-    });
-    sandbox.stub(History.prototype, 'back').callsFake(() => {
-      history.pop();
-      window.dispatchEvent(new CustomEvent('popstate'));
-    });
-
     tearDown = setUp();
   });
 
   afterEach(() => {
     tearDown();
-    sandbox.restore();
   });
 
-  describe('using history.pushState', () => {
-    context('with default language', () => {
-      it('updates links', () => {
-        window.history.pushState(null, '', '/foo');
+  context('with default language', () => {
+    it('updates links', () => {
+      window.history.replaceState(null, '', '/foo');
+      window.dispatchEvent(new window.CustomEvent('lg:url-change'));
 
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/foo');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/foo');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/foo');
-      });
-    });
-
-    context('with non default language', () => {
-      beforeEach(() => {
-        document.documentElement.lang = 'fr';
-      });
-
-      it('updates links', () => {
-        window.history.pushState(null, '', '/fr/bar');
-
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/bar');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/bar');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/bar');
-      });
+      expect(document.querySelector('a[lang="en"]').pathname).to.equal('/foo');
+      expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/foo');
+      expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/foo');
     });
   });
 
-  describe('using history.replaceState', () => {
-    context('with default language', () => {
-      it('updates links', () => {
-        window.history.replaceState(null, '', '/foo');
-
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/foo');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/foo');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/foo');
-      });
+  context('with non default language', () => {
+    beforeEach(() => {
+      document.documentElement.lang = 'fr';
     });
 
-    context('with non default language', () => {
-      beforeEach(() => {
-        document.documentElement.lang = 'fr';
-      });
+    it('updates links', () => {
+      window.history.replaceState(null, '', '/fr/bar');
+      window.dispatchEvent(new window.CustomEvent('lg:url-change'));
 
-      it('updates links', () => {
-        window.history.replaceState(null, '', '/fr/bar');
-
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/bar');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/bar');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/bar');
-      });
-    });
-  });
-
-  describe('updates links on popstate event', () => {
-    context('with default language', () => {
-      it('updates links', () => {
-        window.history.pushState(null, '', '/foo');
-        window.history.back();
-
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
-      });
-    });
-
-    context('with non default language', () => {
-      beforeEach(() => {
-        document.documentElement.lang = 'fr';
-      });
-
-      it('updates links', () => {
-        window.history.pushState(null, '', '/fr/foo');
-        window.history.back();
-
-        expect(document.querySelector('a[lang="en"]').pathname).to.equal('/');
-        expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/');
-        expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/');
-      });
+      expect(document.querySelector('a[lang="en"]').pathname).to.equal('/bar');
+      expect(document.querySelector('a[lang="es"]').pathname).to.equal('/es/bar');
+      expect(document.querySelector('a[lang="fr"]').pathname).to.equal('/fr/bar');
     });
   });
 });


### PR DESCRIPTION
**Why**: Since NewRelic also patches history in a way which conflicts with our initial implementation. Patching is more all-encompassing, but also more fragile (case in point).

Previously: https://github.com/18F/identity-idp/pull/6519