### PR TITLE
LG-6091 Increase width of ID number field on in-person proofing state ID page

### DIFF
--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -61,7 +61,7 @@
         ) %>
   </div>
 
-  <div class="tablet:grid-col-7 margin-bottom-5">
+  <div class="tablet:grid-col-8 margin-bottom-5">
     <%= render ValidatedFieldComponent.new(
           name: :state_id_number,
           form: f,


### PR DESCRIPTION
Increase the width of the ID number field on the in-person proofing state ID page from 268 to 306, as per comment from @lizzieamanning on LG-6091.

**screenshots:**
<details>
<summary>Desktop</summary>

![desktop-new-width](https://user-images.githubusercontent.com/45415133/176000710-bfe97463-31fa-4d1c-9c9b-7e1c756de3a8.png)

</details>

<details>
<summary>Mobile</summary>
(375px wide)

![mobile-new-width](https://user-images.githubusercontent.com/45415133/176000744-62898e08-da3b-42f1-be69-f11417e1f286.png)

</details>
