### PR TITLE
LG-5945 Document the rest of analytics events #26

### DIFF
--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -40,14 +40,14 @@ module Reports
 
     def track_global_user_total_events
       track_global_registered_users
-      track_users_linked_to_sps(ial: 1, event: Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT)
-      track_users_linked_to_sps(ial: 2, event: Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT)
+      track_users_linked_to_sps(ial: 1, event: 'Report IAL1 Users Linked to SPs Count')
+      track_users_linked_to_sps(ial: 2, event: 'Report IAL2 Users Linked to SPs Count')
     end
 
     def track_global_registered_users
       transaction_with_timeout do
         track_report_data_event(
-          Analytics::REPORT_REGISTERED_USERS_COUNT,
+          'Report Registered Users Count',
           count: Funnel::Registration::TotalRegisteredCount.call,
         )
       end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -137,11 +137,6 @@ class Analytics
 
   # rubocop:disable Layout/LineLength
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  PROOFING_RESOLUTION_RESULT_MISSING = 'Proofing Resolution Result Missing' # Previously "Proofing Resolution Timeout"
-  RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'
-  REPORT_REGISTERED_USERS_COUNT = 'Report Registered Users Count'
-  REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT = 'Report IAL1 Users Linked to SPs Count'
-  REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT = 'Report IAL2 Users Linked to SPs Count'
   SP_HANDOFF_BOUNCED_DETECTED = 'SP handoff bounced detected'
   SP_HANDOFF_BOUNCED_VISIT = 'SP handoff bounced visited'
   SP_INACTIVE_VISIT = 'SP inactive visited'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1599,8 +1599,8 @@ module AnalyticsEvents
 
   # Rate limit triggered
   # @param [String] type
-  def rate_limit_triggered(type:)
-    track_event('Rate Limit Triggered', type: type)
+  def rate_limit_triggered(type:, **extra)
+    track_event('Rate Limit Triggered', type: type, **extra)
   end
 
   # User authenticated by a remembered device

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -909,7 +909,7 @@ module AnalyticsEvents
     )
   end
 
-  # The system encountered an error and the proofing results is missing
+  # The system encountered an error and the proofing results are missing
   def idv_proofing_resolution_result_missing
     track_event('Proofing Resolution Result Missing')
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -909,6 +909,11 @@ module AnalyticsEvents
     )
   end
 
+  # The system encountered an error and the proofing results is missing
+  def idv_proofing_resolution_result_missing
+    track_event('Proofing Resolution Result Missing')
+  end
+
   # User submitted IDV password confirm page
   def idv_review_complete
     track_event('IdV: review complete')
@@ -1590,6 +1595,12 @@ module AnalyticsEvents
   # place during the expected time frame
   def proofing_document_result_missing
     track_event('Proofing Document Result Missing')
+  end
+
+  # Rate limit triggered
+  # @param [String] type
+  def rate_limit_triggered(type:)
+    track_event('Rate Limit Triggered', type: type)
   end
 
   # User authenticated by a remembered device

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -20,7 +20,7 @@ module Idv
           flash[:error] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
-          @flow.analytics.track_event(Analytics::PROOFING_RESOLUTION_RESULT_MISSING)
+          @flow.analytics.idv_proofing_resolution_result_missing
         elsif current_async_state.done?
           async_state_done(current_async_state)
         end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -226,5 +226,5 @@ ActiveSupport::Notifications.subscribe(
   req = payload[:request]
   user = req.env['warden'].user || AnonymousUser.new
   analytics = Analytics.new(user: user, request: req, session: {}, sp: nil)
-  analytics.track_event(Analytics::RATE_LIMIT_TRIGGERED, type: req.env['rack.attack.matched'])
+  analytics.rate_limit_triggered(type: req.env['rack.attack.matched'])
 end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -232,7 +232,7 @@ feature 'doc auth verify step', :js do
         and_return(nil)
 
       click_idv_continue
-      expect(fake_analytics).to have_logged_event(Analytics::PROOFING_RESOLUTION_RESULT_MISSING, {})
+      expect(fake_analytics).to have_logged_event('Proofing Resolution Result Missing', {})
       expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_doc_auth_verify_step)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -27,17 +27,17 @@ describe Reports::SpUserCountsReport do
         user_total: 3,
       )
       expect(subject).to receive(:write_hash_to_reports_log).with(
-        name: Analytics::REPORT_REGISTERED_USERS_COUNT,
+        name: 'Report Registered Users Count',
         time: timestamp,
         count: 0,
       )
       expect(subject).to receive(:write_hash_to_reports_log).with(
-        name: Analytics::REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT,
+        name: 'Report IAL1 Users Linked to SPs Count',
         time: timestamp,
         count: 2,
       )
       expect(subject).to receive(:write_hash_to_reports_log).with(
-        name: Analytics::REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT,
+        name: 'Report IAL2 Users Linked to SPs Count',
         time: timestamp,
         count: 1,
       )

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -77,7 +77,7 @@ describe 'throttling requests' do
           to include('Please wait a few minutes before you try again.')
         expect(response.header['Content-type']).to include('text/html')
         expect(analytics).
-          to have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, type: 'req/ip')
+          to have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
       end
 
       it 'does not throttle if the path is in the allowlist' do
@@ -95,7 +95,7 @@ describe 'throttling requests' do
         expect(response.body).
           to_not include('Please wait a few minutes before you try again.')
         expect(analytics).
-          to_not have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, type: 'req/ip')
+          to_not have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
       end
 
       it 'does not throttle if the ip is in the CIDR block allowlist' do
@@ -111,7 +111,7 @@ describe 'throttling requests' do
         expect(response.body).
           to_not include('Please wait a few minutes before you try again.')
         expect(analytics).
-          to_not have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, type: 'req/ip')
+          to_not have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
       end
     end
 
@@ -144,7 +144,7 @@ describe 'throttling requests' do
           expect(arguments[:user]).to eq user
         end
         expect(analytics).
-          to have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, type: 'req/ip')
+          to have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
       end
     end
   end
@@ -211,7 +211,7 @@ describe 'throttling requests' do
           to include('Please wait a few minutes before you try again.')
         expect(response.header['Content-type']).to include('text/html')
         expect(analytics).
-          to have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, type: 'logins/ip')
+          to have_received(:track_event).with('Rate Limit Triggered', type: 'logins/ip')
       end
     end
   end
@@ -271,7 +271,7 @@ describe 'throttling requests' do
           to include('Please wait a few minutes before you try again.')
         expect(response.header['Content-type']).to include('text/html')
         expect(analytics).
-          to have_received(:track_event).with(Analytics::RATE_LIMIT_TRIGGERED, analytics_hash)
+          to have_received(:track_event).with('Rate Limit Triggered', analytics_hash)
       end
     end
 


### PR DESCRIPTION
**Why**: PROOFING_RESOLUTION_RESULT_MISSING, RATE_LIMIT_TRIGGERED, REPORT_REGISTERED_USERS_COUNT, 
REPORT_IAL1_USERS_LINKED_TO_SPS_COUNT, REPORT_IAL2_USERS_LINKED_TO_SPS_COUNT
**How**: REPORT events go to reports.log and are thus not currently documented