### PR TITLE
Support attr methods for url_options linter

### DIFF
--- a/app/presenters/cancellation_presenter.rb
+++ b/app/presenters/cancellation_presenter.rb
@@ -1,7 +1,7 @@
 class CancellationPresenter
   include Rails.application.routes.url_helpers
 
-  attr_reader :referer
+  attr_reader :referer, :url_options
 
   def initialize(referer:, url_options:)
     @referer = referer
@@ -10,10 +10,6 @@ class CancellationPresenter
 
   def go_back_path
     referer_path || authentication_methods_setup_path
-  end
-
-  def url_options
-    @url_options
   end
 
   private

--- a/app/presenters/idv/gpo_presenter.rb
+++ b/app/presenters/idv/gpo_presenter.rb
@@ -2,7 +2,7 @@ module Idv
   class GpoPresenter
     include Rails.application.routes.url_helpers
 
-    attr_reader :current_user
+    attr_reader :current_user, :url_options
 
     def initialize(current_user, url_options)
       @current_user = current_user
@@ -35,10 +35,6 @@ module Idv
 
     def letter_already_sent?
       gpo_mail_service.any_mail_sent?
-    end
-
-    def url_options
-      @url_options
     end
 
     private

--- a/app/presenters/navigation_presenter.rb
+++ b/app/presenters/navigation_presenter.rb
@@ -3,7 +3,7 @@ class NavigationPresenter
 
   NavItem = Struct.new(:title, :href, :children)
 
-  attr_reader :user
+  attr_reader :user, :url_options
 
   def initialize(user:, url_options:)
     @user = user
@@ -56,10 +56,6 @@ class NavigationPresenter
       ),
       NavItem.new(I18n.t('account.navigation.customer_support'), MarketingSite.help_url, []),
     ]
-  end
-
-  def url_options
-    @url_options
   end
 
   def backup_codes_path

--- a/app/presenters/piv_cac_authentication_login_presenter.rb
+++ b/app/presenters/piv_cac_authentication_login_presenter.rb
@@ -2,7 +2,7 @@ class PivCacAuthenticationLoginPresenter
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :form
+  attr_reader :form, :url_options
 
   def initialize(form, url_options)
     @form = form
@@ -27,9 +27,5 @@ class PivCacAuthenticationLoginPresenter
 
   def info
     t('instructions.mfa.piv_cac.sign_in', app_name: APP_NAME)
-  end
-
-  def url_options
-    @url_options
   end
 end

--- a/lib/linters/url_options_linter.rb
+++ b/lib/linters/url_options_linter.rb
@@ -20,16 +20,14 @@ module RuboCop
       #   class MyViewModelClass
       #     include Rails.application.routes.url_helpers
       #
+      #     attr_reader :url_options
+      #
       #     def initialize(url_options)
       #       @url_options = url_options
       #     end
       #
       #     def my_method
       #       account_path
-      #     end
-      #
-      #     def url_options
-      #       @url_options
       #     end
       #   end
       #

--- a/lib/linters/url_options_linter.rb
+++ b/lib/linters/url_options_linter.rb
@@ -59,7 +59,16 @@ module RuboCop
             return true if descendant.method?(:url_options)
           end
 
+          node.parent.each_descendant(:send) do |descendant|
+            return true if url_options_attr_method?(descendant)
+          end
+
           false
+        end
+
+        def url_options_attr_method?(descendant)
+          return false unless descendant.method_name.match?(/^attr_(reader|accessor)$/)
+          descendant.arguments.any? { |arg| arg.value == :url_options }
         end
       end
     end

--- a/spec/lib/linters/url_options_linter_spec.rb
+++ b/spec/lib/linters/url_options_linter_spec.rb
@@ -33,4 +33,22 @@ describe RuboCop::Cop::IdentityIdp::UrlOptionsLinter do
       end
     RUBY
   end
+
+  it 'registers no offense when including Rails url_helpers and defining attr_reader' do
+    expect_no_offenses(<<~RUBY)
+      class MyViewModelClass
+        include Rails.application.routes.url_helpers
+        attr_reader :url_options
+      end
+    RUBY
+  end
+
+  it 'registers no offense when including Rails url_helpers and defining attr_accessor' do
+    expect_no_offenses(<<~RUBY)
+      class MyViewModelClass
+        include Rails.application.routes.url_helpers
+        attr_accessor :url_options
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Extracted from #6542

**Why**: So that a class needn't define an explicit method just to access the instance variable, where an `attr_reader` would be more conventional and concise.