### PR TITLE
Update status page layout margins to correct value

### DIFF
--- a/app/components/status_page_component.html.erb
+++ b/app/components/status_page_component.html.erb
@@ -5,7 +5,7 @@
 <%= content %>
 
 <% if action_buttons? %>
-  <div class="margin-top-4">
+  <div class="margin-top-5">
     <% action_buttons.each do |action| %>
       <div class="margin-top-2">
         <%= action %>

--- a/app/javascript/packages/components/status-page.tsx
+++ b/app/javascript/packages/components/status-page.tsx
@@ -90,7 +90,7 @@ function StatusPage({
       <PageHeading>{header}</PageHeading>
       {children}
       {actionButtons.length > 0 && (
-        <div className="margin-top-4">
+        <div className="margin-top-5">
           {actionButtons.map((actionButton, index) => (
             <div key={index} className="margin-top-2">
               {actionButton}

--- a/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
@@ -24,7 +24,7 @@ export function ForgotPassword({ stepPath }: ForgotPasswordProps) {
           <li key={warning}>{warning}</li>
         ))}
       </ul>
-      <div className="margin-top-4">
+      <div className="margin-top-5">
         <HistoryLink basePath={stepPath} step={undefined} isVisualButton isBig isWide>
           {t('idv.forgot_password.try_again')}
         </HistoryLink>

--- a/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/forgot-password.tsx
@@ -1,6 +1,5 @@
-import { PageHeading } from '@18f/identity-components';
+import { StatusPage } from '@18f/identity-components';
 import { t } from '@18f/identity-i18n';
-import { getAssetPath } from '@18f/identity-assets';
 import { HistoryLink } from '@18f/identity-form-steps';
 import PasswordResetButton from './password-reset-button';
 
@@ -10,28 +9,29 @@ interface ForgotPasswordProps {
 
 export function ForgotPassword({ stepPath }: ForgotPasswordProps) {
   return (
-    <>
-      <img
-        src={getAssetPath('status/info-question.svg')}
-        width="54"
-        height="54"
-        alt={t('components.status_page.icons.question')}
-        className="margin-bottom-4"
-      />
-      <PageHeading>{t('idv.forgot_password.modal_header')}</PageHeading>
+    <StatusPage
+      status="info"
+      icon="question"
+      header={t('idv.forgot_password.modal_header')}
+      actionButtons={[
+        <HistoryLink
+          key="try_again"
+          basePath={stepPath}
+          step={undefined}
+          isVisualButton
+          isBig
+          isWide
+        >
+          {t('idv.forgot_password.try_again')}
+        </HistoryLink>,
+        <PasswordResetButton key="password_reset" />,
+      ]}
+    >
       <ul className="usa-list">
         {t(['idv.forgot_password.warnings']).map((warning) => (
           <li key={warning}>{warning}</li>
         ))}
       </ul>
-      <div className="margin-top-5">
-        <HistoryLink basePath={stepPath} step={undefined} isVisualButton isBig isWide>
-          {t('idv.forgot_password.try_again')}
-        </HistoryLink>
-      </div>
-      <div className="margin-top-2">
-        <PasswordResetButton />
-      </div>
-    </>
+    </StatusPage>
   );
 }

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -25,7 +25,7 @@ locals:
 <%= yield %>
 
 <% if local_assigns[:action] %>
-  <div class="margin-top-4">
+  <div class="margin-top-5">
     <%= button_or_link_to(
           action[:text],
           action[:url],


### PR DESCRIPTION
Extracted from https://github.com/18F/identity-idp/pull/6542

**Why:** Based on Figma designs, there should be 2.5rem of top margin above status page action buttons not 2rem.

Refactors `ForgotPassword` component to use `StatusPage` component to consolidate layout updates for these screens.

![Screen Shot 2022-07-01 at 10 28 10 AM](https://user-images.githubusercontent.com/1779930/176929671-47f4fca9-e3bd-45a4-8590-5127d46c382e.png)

