### PR TITLE
LG-6349 Consistently use 'Update' language on verify and update pages

### DIFF
--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
@@ -66,15 +66,15 @@ function BarcodeAttentionWarning({ onDismiss, pii }: BarcodeAttentionWarningProp
       <p>{t('doc_auth.errors.barcode_attention.confirm_info')}</p>
       <dl className="add-list-reset">
         <div>
-          <dt className="display-inline">{t('doc_auth.forms.first_name')}:</dt>
+          <dt className="display-inline">{t('idv.form.first_name')}:</dt>
           <dd className="display-inline margin-left-05">{pii.first_name}</dd>
         </div>
         <div>
-          <dt className="display-inline">{t('doc_auth.forms.last_name')}:</dt>
+          <dt className="display-inline">{t('idv.form.last_name')}:</dt>
           <dd className="display-inline margin-left-05">{pii.last_name}</dd>
         </div>
         <div>
-          <dt className="display-inline">{t('doc_auth.forms.dob')}:</dt>
+          <dt className="display-inline">{t('idv.form.dob')}:</dt>
           <dd className="display-inline margin-left-05">{pii.dob}</dd>
         </div>
       </dl>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -27,7 +27,7 @@
                            input_html: { value: @pii['address2'] } %>
     <div class="margin-bottom-4">
       <%= f.input :city,  label: t('idv.form.city'), required: true, maxlength: 255, wrapper: false,
-                          input_html: { aria: { invalid: false }, class: 'usa-input', value: @pii['city'] } %>
+                          input_html: { aria: { invalid: false }, value: @pii['city'] } %>
       <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
         <%= t('simple_form.required.text') %>
       </span>
@@ -42,7 +42,7 @@
                             label: t('idv.form.zipcode'), required: true,
                             pattern: '(\d{5}([\-]\d{4})?)',
                             wrapper: false,
-                            input_html: { aria: { invalid: false }, class: 'usa-input', value: @pii['zipcode'] } %>
+                            input_html: { aria: { invalid: false }, value: @pii['zipcode'] } %>
       <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
         <%= t('simple_form.required.text') %>
       </span>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -53,7 +53,7 @@
     </div>
     <div class="margin-top-0">
       <button type="submit" class="usa-button usa-button--big usa-button--wide margin-top-2">
-        <%= t('forms.buttons.continue') %>
+        <%= t('forms.buttons.submit.update') %>
       </button>
     </div>
   <% end %>

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -82,8 +82,12 @@
         wrapper: :uswds_radio_buttons,
       ) %>
 
-   <%= render ButtonComponent.new(big: true, wide: true, class: 'margin-top-1') do %>
-    <%= t('forms.buttons.continue') %>
+  <%= render ButtonComponent.new(big: true, wide: true, class: 'margin-top-1') do %>
+    <% if updating_address %>
+      <%= t('forms.buttons.submit.update') %>
+    <% else %>
+      <%= t('forms.buttons.continue') %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -81,8 +81,11 @@
         ) %>
   </div>
 
-  <%= f.button :button,
-               t('doc_auth.buttons.continue'),
-               type: :submit,
-               class: 'usa-button--big usa-button--wide' %>
+  <%= render ButtonComponent.new(big: true, wide: true) do %>
+    <% if updating_state_id %>
+      <%= t('forms.buttons.submit.update') %>
+    <% else %>
+      <%= t('forms.buttons.continue') %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -62,7 +62,7 @@
       ) %>
   <div class="margin-y-5">
     <%= render SpinnerButtonComponent.new(
-          action_message: t('doc_auth.info.verifying'),
+          action_message: t('idv.messages.verifying'),
           type: :submit,
           big: true,
           wide: true,

--- a/app/views/idv/shared/_ssn.html.erb
+++ b/app/views/idv/shared/_ssn.html.erb
@@ -51,7 +51,11 @@ locals:
   <p><%= flow_session[:error_message] %></p>
 
   <button type="submit" class="display-block margin-y-5 usa-button usa-button--big usa-button--wide">
-    <%= t('forms.buttons.continue') %>
+    <% if updating_ssn %>
+      <%= t('forms.buttons.submit.update') %>
+    <% else %>
+      <%= t('forms.buttons.continue') %>
+    <% end %>
   </button>
 <% end %>
 

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -9,22 +9,26 @@ locals:
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
-    <div class='grid-col-fill'>
+    <dl class="grid-col-fill margin-bottom-0">
       <div>
-        <%= "#{t('idv.form.first_name')}: #{pii[:first_name]}" %>
+        <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:first_name] %> </dd>
       </div>
       <div>
-        <%= "#{t('idv.form.last_name')}: #{pii[:last_name]}" %>
+        <dt class="display-inline"> <%= t('idv.form.last_name') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:last_name] %> </dd>
       </div>
       <div>
-        <%= "#{t('idv.form.dob')}: #{pii[:dob]}" %>
+        <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:dob] %> </dd>
       </div>
       <% if !remote_identity_proofing %>
         <div>
-          <%= "#{t('idv.form.id_number')}: #{pii[:state_id_number]}" %>
+          <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
+          <dd class="display-inline margin-left-05"> <%= pii[:state_id_number] %> </dd>
         </div>
       <% end %>
-    </div>
+    </dl>
     <% if !remote_identity_proofing %>
       <div class='grid-auto'>
         <%= button_to(
@@ -37,20 +41,24 @@ locals:
     <% end %>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">
-    <div class='grid-col-fill'>
+    <dl class='grid-col-fill margin-bottom-0'>
       <div>
-        <%= "#{t('idv.form.address1')}: #{pii[:address1]}" %>
+        <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:address1] %> </dd>
       </div>
       <div>
-        <%= "#{t('idv.form.city')}: #{pii[:city]}" %>
+        <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:city] %> </dd>
       </div>
       <div>
-        <%= "#{t('idv.form.state')}: #{pii[:state]}" %>
+        <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:state] %> </dd>
       </div>
       <div>
-        <%= "#{t('idv.form.zipcode')}: #{pii[:zipcode]}" %>
+        <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
+        <dd class="display-inline margin-left-05"> <%= pii[:zipcode] %> </dd>
       </div>
-    </div>
+    </dl>
     <div class='grid-auto'>
       <%= button_to(
             step_url.call(step: :redo_address),
@@ -62,18 +70,20 @@ locals:
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">
     <div class='grid-col-fill'>
-      <%= t('idv.form.ssn') %>:
-      <%= render(
-            'shared/masked_text',
-            text: SsnFormatter.format(pii[:ssn]),
-            masked_text: SsnFormatter.format_masked(pii[:ssn]),
-            accessible_masked_text: t(
-              'idv.accessible_labels.masked_ssn',
-              first_number: pii[:ssn][0],
-              last_number: pii[:ssn][-1],
-            ),
-            toggle_label: t('forms.ssn.show'),
-          ) %>
+      <%= t('idv.form.ssn') %>: 
+      <div class="display-inline margin-left-05">
+        <%= render(
+          'shared/masked_text',
+          text: SsnFormatter.format(pii[:ssn]),
+          masked_text: SsnFormatter.format_masked(pii[:ssn]),
+          accessible_masked_text: t(
+            'idv.accessible_labels.masked_ssn',
+            first_number: pii[:ssn][0],
+            last_number: pii[:ssn][-1],
+          ),
+          toggle_label: t('forms.ssn.show'),
+        ) %>
+      </div>
     </div>
     <div class='grid-auto'>
       <%= button_to(

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -12,20 +12,20 @@ locals:
     <dl class="grid-col-fill margin-bottom-0">
       <div>
         <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:first_name] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:first_name] %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.last_name') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:last_name] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:last_name] %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:dob] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:dob] %> </dd>
       </div>
       <% if !remote_identity_proofing %>
         <div>
           <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
-          <dd class="display-inline margin-left-05"> <%= pii[:state_id_number] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:state_id_number] %> </dd>
         </div>
       <% end %>
     </dl>
@@ -44,19 +44,19 @@ locals:
     <dl class='grid-col-fill margin-bottom-0'>
       <div>
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:address1] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:address1] %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:city] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:city] %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:state] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:state] %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-        <dd class="display-inline margin-left-05"> <%= pii[:zipcode] %> </dd>
+        <dd class="display-inline margin-left-0"> <%= pii[:zipcode] %> </dd>
       </div>
     </dl>
     <div class='grid-auto'>
@@ -71,19 +71,17 @@ locals:
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">
     <div class='grid-col-fill'>
       <%= t('idv.form.ssn') %>: 
-      <div class="display-inline margin-left-05">
-        <%= render(
-              'shared/masked_text',
-              text: SsnFormatter.format(pii[:ssn]),
-              masked_text: SsnFormatter.format_masked(pii[:ssn]),
-              accessible_masked_text: t(
-                'idv.accessible_labels.masked_ssn',
-                first_number: pii[:ssn][0],
-                last_number: pii[:ssn][-1],
-              ),
-              toggle_label: t('forms.ssn.show'),
-            ) %>
-      </div>
+      <%= render(
+            'shared/masked_text',
+            text: SsnFormatter.format(pii[:ssn]),
+            masked_text: SsnFormatter.format_masked(pii[:ssn]),
+            accessible_masked_text: t(
+              'idv.accessible_labels.masked_ssn',
+              first_number: pii[:ssn][0],
+              last_number: pii[:ssn][-1],
+            ),
+            toggle_label: t('forms.ssn.show'),
+          ) %>
     </div>
     <div class='grid-auto'>
       <%= button_to(

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -4,24 +4,24 @@ locals:
   remote_identity_proofing - true if we're doing RIDP, false if we're doing IPP
   step_url - generator for step URLs
 %>
-<% title t('titles.doc_auth.verify_info') %>
+<% title t('titles.idv.verify_info') %>
 
-<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.verify')) %>
+<%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
     <div class='grid-col-fill'>
       <div>
-        <%= "#{t('doc_auth.forms.first_name')}: #{pii[:first_name]}" %>
+        <%= "#{t('idv.form.first_name')}: #{pii[:first_name]}" %>
       </div>
       <div>
-        <%= "#{t('doc_auth.forms.last_name')}: #{pii[:last_name]}" %>
+        <%= "#{t('idv.form.last_name')}: #{pii[:last_name]}" %>
       </div>
       <div>
-        <%= "#{t('doc_auth.forms.dob')}: #{pii[:dob]}" %>
+        <%= "#{t('idv.form.dob')}: #{pii[:dob]}" %>
       </div>
       <% if !remote_identity_proofing %>
         <div>
-          <%= "#{t('doc_auth.forms.id_number')}: #{pii[:state_id_number]}" %>
+          <%= "#{t('idv.form.id_number')}: #{pii[:state_id_number]}" %>
         </div>
       <% end %>
     </div>
@@ -31,24 +31,24 @@ locals:
               step_url.call(step: :redo_state_id),
               method: :put,
               class: 'usa-button usa-button--unstyled',
-              'aria-label': t('doc_auth.buttons.change_state_id_label'),
-            ) { t('doc_auth.buttons.change_label') } %>
+              'aria-label': t('idv.buttons.change_state_id_label'),
+            ) { t('idv.buttons.change_label') } %>
       </div>
     <% end %>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">
     <div class='grid-col-fill'>
       <div>
-        <%= "#{t('doc_auth.forms.address1')}: #{pii[:address1]}" %>
+        <%= "#{t('idv.form.address1')}: #{pii[:address1]}" %>
       </div>
       <div>
-        <%= "#{t('doc_auth.forms.city')}: #{pii[:city]}" %>
+        <%= "#{t('idv.form.city')}: #{pii[:city]}" %>
       </div>
       <div>
-        <%= "#{t('doc_auth.forms.state')}: #{pii[:state]}" %>
+        <%= "#{t('idv.form.state')}: #{pii[:state]}" %>
       </div>
       <div>
-        <%= "#{t('doc_auth.forms.zip_code')}: #{pii[:zipcode]}" %>
+        <%= "#{t('idv.form.zipcode')}: #{pii[:zipcode]}" %>
       </div>
     </div>
     <div class='grid-auto'>
@@ -56,13 +56,13 @@ locals:
             step_url.call(step: :redo_address),
             method: :put,
             class: 'usa-button usa-button--unstyled',
-            'aria-label': t('doc_auth.buttons.change_address_label'),
-          ) { t('doc_auth.buttons.change_label') } %>
+            'aria-label': t('idv.buttons.change_address_label'),
+          ) { t('idv.buttons.change_label') } %>
     </div>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">
     <div class='grid-col-fill'>
-      <%= t('doc_auth.forms.ssn') %>:
+      <%= t('idv.form.ssn') %>:
       <%= render(
             'shared/masked_text',
             text: SsnFormatter.format(pii[:ssn]),
@@ -80,8 +80,8 @@ locals:
             step_url.call(step: :redo_ssn),
             method: :put,
             class: 'usa-button usa-button--unstyled',
-            'aria-label': t('doc_auth.buttons.change_ssn_label'),
-          ) { t('doc_auth.buttons.change_label') } %>
+            'aria-label': t('idv.buttons.change_ssn_label'),
+          ) { t('idv.buttons.change_label') } %>
     </div>
   </div>
   <div class="margin-top-5">
@@ -91,7 +91,7 @@ locals:
           end,
           big: true,
           wide: true,
-          action_message: t('doc_auth.info.verifying'),
+          action_message: t('idv.messages.verifying'),
           method: :put,
           form: {
             class: 'button_to',

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -73,16 +73,16 @@ locals:
       <%= t('idv.form.ssn') %>: 
       <div class="display-inline margin-left-05">
         <%= render(
-          'shared/masked_text',
-          text: SsnFormatter.format(pii[:ssn]),
-          masked_text: SsnFormatter.format_masked(pii[:ssn]),
-          accessible_masked_text: t(
-            'idv.accessible_labels.masked_ssn',
-            first_number: pii[:ssn][0],
-            last_number: pii[:ssn][-1],
-          ),
-          toggle_label: t('forms.ssn.show'),
-        ) %>
+              'shared/masked_text',
+              text: SsnFormatter.format(pii[:ssn]),
+              masked_text: SsnFormatter.format_masked(pii[:ssn]),
+              accessible_masked_text: t(
+                'idv.accessible_labels.masked_ssn',
+                first_number: pii[:ssn][0],
+                last_number: pii[:ssn][-1],
+              ),
+              toggle_label: t('forms.ssn.show'),
+            ) %>
       </div>
     </div>
     <div class='grid-auto'>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -49,7 +49,7 @@ en:
         instructions: Your profile was recently deactivated due to a password reset.
         link: Reactivate your profile now.
       sign_in_location_and_ip: From %{ip} (IP address potentially located in %{location})
-      ssn: Social Security Number
+      ssn: Social Security number
       totp_confirm_delete: Yes, remove authentication app
       unknown_location: unknown location
       verification:

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -9,8 +9,8 @@ en:
     buttons:
       add_new_photos: Add new photos
       change_address_label: Change address
-      change_label: Change
-      change_ssn_label: Change Social Security Number
+      change_label: Update
+      change_ssn_label: Change Social Security number
       change_state_id_label: Change state ID
       continue: Continue
       start_over: Start over
@@ -115,15 +115,15 @@ en:
       change_file: Change file
       choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
       city: City
-      dob: Date of Birth
+      dob: Date of birth
       doc_success: We have verified your personal information
-      first_name: First Name
-      id_number: ID Number
-      last_name: Last Name
+      first_name: First name
+      id_number: ID number
+      last_name: Last name
       selected_file: Selected file
-      ssn: Social Security Number
+      ssn: Social Security number
       state: State
-      zip_code: Zip Code
+      zip_code: ZIP Code
     headings:
       address: Update your mailing address
       back: Back

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -8,10 +8,6 @@ en:
       selfie_alt_text: An uploaded image
     buttons:
       add_new_photos: Add new photos
-      change_address_label: Change address
-      change_label: Update
-      change_ssn_label: Change Social Security number
-      change_state_id_label: Change state ID
       continue: Continue
       start_over: Start over
       take_or_upload_picture: '<lg-take-photo>Take photo</lg-take-photo> or
@@ -110,20 +106,11 @@ en:
           Try taking new pictures in a bright area.
       upload_error: Sorry, something went wrong on our end.
     forms:
-      address1: Address
       captured_image: Captured Image
       change_file: Change file
       choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
-      city: City
-      dob: Date of birth
       doc_success: We have verified your personal information
-      first_name: First name
-      id_number: ID number
-      last_name: Last name
       selected_file: Selected file
-      ssn: Social Security number
-      state: State
-      zip_code: ZIP Code
     headings:
       address: Update your mailing address
       back: Back
@@ -151,7 +138,6 @@ en:
       upload_from_phone: Take a photo with a mobile phone to upload your ID
       upload_from_phone_liveness_enabled: Use a mobile phone to add your ID and take a photo of yourself
       upload_liveness_enabled: How would you like to verify your identity?
-      verify: Verify your information
       verify_identity: Verify your identity
       welcome: Get started verifying your identity
     info:
@@ -202,7 +188,6 @@ en:
       upload_no_image_storage: We do not store images you upload. We only verify your identity.
       verify_identity: We’ll ask for your personal information to verify your identity
         against public records.
-      verifying: Verifying…
       welcome_html: '%{sp_name} needs to make sure you are you — not someone
         pretending to be you.'
     instructions:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -136,10 +136,8 @@ es:
       change_file: Cambiar archivo
       choose_file_html: Arrastre el archivo aquí o <lg-underline>elija de la
         carpeta</lg-underline>
-      city: Ciudad
       doc_success: Hemos verificado su información personal
       selected_file: Archivo seleccionado
-      state: Estado
     headings:
       address: Actualice su dirección postal
       back: Parte Trasera
@@ -224,7 +222,6 @@ es:
       upload_no_image_storage: No almacenamos imágenes que cargue. Solo verificamos su identidad.
       verify_identity: Le preguntaremos sus datos personales para verificar su
         identidad comparándola con los registros públicos.
-      verifying: Verificando…
       welcome_html: '%{sp_name} necesita asegurarse de que sea usted y no alguien que
         se haga pasar por usted.'
     instructions:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -8,10 +8,6 @@ es:
       selfie_alt_text: Una foto subida
     buttons:
       add_new_photos: Añadir nuevas fotos
-      change_address_label: Cambiar dirección
-      change_label: Cambio
-      change_ssn_label: Cambiar número de Seguridad Social
-      change_state_id_label: Cambiar ID de estado
       continue: Continuar
       start_over: Comenzar de nuevo
       take_or_upload_picture: '<lg-take-photo>Toma una foto</lg-take-photo> o
@@ -136,21 +132,14 @@ es:
           área iluminada.
       upload_error: Lo siento, algo salió mal por nuestra parte.
     forms:
-      address1: Dirección
       captured_image: Imagen capturada
       change_file: Cambiar archivo
       choose_file_html: Arrastre el archivo aquí o <lg-underline>elija de la
         carpeta</lg-underline>
       city: Ciudad
-      dob: Fecha de nacimiento
       doc_success: Hemos verificado su información personal
-      first_name: Nombre de pila
-      id_number: Número de identificación
-      last_name: Apellido
       selected_file: Archivo seleccionado
-      ssn: Número de seguridad social
       state: Estado
-      zip_code: Código postal
     headings:
       address: Actualice su dirección postal
       back: Parte Trasera
@@ -180,7 +169,6 @@ es:
       upload_from_phone: Tome una foto con un teléfono móvil para cargar su identificación
       upload_from_phone_liveness_enabled: Utilice un celular para agregar su documento de identidad y tomarse
       upload_liveness_enabled: '¿Cómo te gustaría verificar su identidad?'
-      verify: Verifica tus datos
       verify_identity: Verifique su identidad
       welcome: Empiece con la verificación de su identidad
     info:

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -8,10 +8,6 @@ fr:
       selfie_alt_text: Une photo téléversée
     buttons:
       add_new_photos: Ajoutez de nouvelles photos
-      change_address_label: Changement d’adresse
-      change_label: Changement
-      change_ssn_label: Changement de numéro de sécurité sociale
-      change_state_id_label: Modifier l’ID d’état
       continue: Continuer
       start_over: Recommencer
       take_or_upload_picture: '<lg-take-photo>Prendre une photo</lg-take-photo> ou
@@ -142,21 +138,12 @@ fr:
           photos dans un endroit lumineux.
       upload_error: Désolé, quelque chose a mal tourné de notre côté.
     forms:
-      address1: Adresse
       captured_image: Image capturée
       change_file: Changer de fichier
       choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez un
         dossier</lg-underline>
-      city: Ville
-      dob: Date de naissance
       doc_success: Nous avons vérifié vos informations personnelles
-      first_name: Prénom
-      id_number: Numéro d’identification
-      last_name: Nom de famille
       selected_file: Fichier sélectionné
-      ssn: Numéro de sécurité sociale
-      state: Etat
-      zip_code: Code postal
     headings:
       address: Mettre à jour votre adresse postale
       back: Verso
@@ -188,7 +175,6 @@ fr:
       upload_from_phone_liveness_enabled: Utilisez un téléphone portable pour ajouter
         votre pièce d’identité et prendre une photo de vous-même
       upload_liveness_enabled: Comment souhaitez-vous vérifier votre identité?
-      verify: Vérifier votre information
       verify_identity: Vérifier votre identité
       welcome: Commencez à vérifier votre identité
     info:

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -235,7 +235,6 @@ fr:
       upload_no_image_storage: Nous ne stockons pas les images que vous téléchargez.
       verify_identity: Nous vous demanderons vos informations personnelles afin de
         vérifier votre identité par rapport aux registres publics.
-      verifying: Vérification…
       welcome_html: '%{sp_name} doit s’assurer que vous êtes bien vous, et non
         quelqu’un qui se fait passer pour vous.'
     instructions:

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -86,7 +86,7 @@ en:
         email: Enter your email address
         email_language: Select your email language preference
     ssn:
-      show: Show Social Security Number
+      show: Show Social Security number
     totp_delete:
       caution: If you remove your authentication app you won’t be able to use it to
         access your %{app_name} account.

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -64,6 +64,7 @@ en:
     sp_handoff_bounced: There was a problem connecting to %{sp_name}
     totp_setup:
       new: Add an authentication app
+    verify: Verify your information
     verify_email: Check your email
     verify_personal_key: Verify your personal key
     webauthn_platform_setup:

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -64,6 +64,7 @@ es:
     sp_handoff_bounced: Hubo un problema al conectarse a %{sp_name}
     totp_setup:
       new: Agregar una aplicación de autenticación
+    verify: Verifica tus datos
     verify_email: Revise su email
     verify_personal_key: Verifica tu clave personal
     webauthn_platform_setup:

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -67,6 +67,7 @@ fr:
     sp_handoff_bounced: Un problème est survenu lors de la connexion à %{sp_name}
     totp_setup:
       new: Ajouter une application d’authentification
+    verify: Vérifier votre information
     verify_email: Consultez vos courriels
     verify_personal_key: Vérifier votre clé personnelle
     webauthn_platform_setup:

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -14,7 +14,7 @@ en:
       intro_html: 'We’ll share this information with %{sp}:'
       outro_html: '%{sp} will only use this information to connect to your account.'
       phone: Phone number
-      social_security_number: Social Security Number
+      social_security_number: Social Security number
       verified_at: Updated on
       x509_issuer: PIV/CAC Issuer
       x509_subject: PIV/CAC Identity

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -30,7 +30,7 @@ en:
       incorrect_password: The password you entered is not correct.
       mail_limit_reached: You have requested too much mail in the last month.
       pattern_mismatch:
-        ssn: 'Your Social Security Number must be entered in as ###-##-####'
+        ssn: 'Your Social Security number must be entered in as ###-##-####'
         zipcode: Enter a 5 or 9 digit ZIP code
       unsupported_otp_delivery_method: Select a method to receive a code.
     failure:
@@ -78,7 +78,7 @@ en:
       address2: Address (optional)
       city: City
       password: Password
-      ssn_label_html: Social Security Number
+      ssn_label_html: Social Security number
       state: State
       zipcode: ZIP Code
     index:
@@ -141,7 +141,7 @@ en:
       dob: Date of birth
       full_name: Full name
       mailing_address: Mailing address
-      ssn: Social Security Number (SSN)
+      ssn: Social Security number (SSN)
     titles:
       activated: Your identity has already been verified
       come_back_later: Come back soon

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -89,7 +89,7 @@ en:
       ssn: Social Security number
       ssn_label_html: Social Security number
       state: State
-      zip_code: ZIP Code
+      zipcode: ZIP Code
     index:
       id:
         need_html: If you’re creating an account, you’ll need a <strong>current

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -5,10 +5,10 @@ en:
       masked_ssn: secure text, starting with %{first_number} and ending with %{last_number}
     buttons:
       cancel: Cancel and return to your profile
-      change_address_label: Change address
+      change_address_label: Update address
       change_label: Update
-      change_ssn_label: Change Social Security number
-      change_state_id_label: Change state ID
+      change_ssn_label: Update Social Security number
+      change_state_id_label: Update state ID
       continue_plain: Continue
       mail:
         resend: Send another letter

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -35,7 +35,7 @@ en:
       mail_limit_reached: You have requested too much mail in the last month.
       pattern_mismatch:
         ssn: 'Your Social Security number must be entered in as ###-##-####'
-        zipcode: Enter a 5 or 9 digit ZIP code
+        zipcode: Enter a 5 or 9 digit ZIP Code
       unsupported_otp_delivery_method: Select a method to receive a code.
     failure:
       attempts:
@@ -63,7 +63,7 @@ en:
           information online.'
         heading: We could not find records matching your personal information.
         warning: Please check the information you entered and try again. Common mistakes
-          are an incorrect Social Security number or ZIP code.
+          are an incorrect Social Security number or ZIP Code.
       timeout: We are experiencing higher than usual wait time processing your
         request. Please try again.
     forgot_password:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -5,6 +5,10 @@ en:
       masked_ssn: secure text, starting with %{first_number} and ending with %{last_number}
     buttons:
       cancel: Cancel and return to your profile
+      change_address_label: Change address
+      change_label: Update
+      change_ssn_label: Change Social Security number
+      change_state_id_label: Change state ID
       continue_plain: Continue
       mail:
         resend: Send another letter
@@ -77,10 +81,15 @@ en:
       address1: Address
       address2: Address (optional)
       city: City
+      dob: Date of birth
+      first_name: First name
+      id_number: ID number
+      last_name: Last name
       password: Password
+      ssn: Social Security number
       ssn_label_html: Social Security number
       state: State
-      zipcode: ZIP Code
+      zip_code: ZIP Code
     index:
       id:
         need_html: If you’re creating an account, you’ll need a <strong>current
@@ -137,6 +146,7 @@ en:
         read_more_encrypt: Read more about how %{app_name} protects your personal information
         review_message: When you re-enter your password, %{app_name} will protect the
           information you’ve given us, so that only you can access it.
+      verifying: Verifying…
     review:
       dob: Date of birth
       full_name: Full name

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -6,6 +6,10 @@ es:
         %{last_number}
     buttons:
       cancel: Cancele y regrese a su perfil
+      change_address_label: Cambiar dirección
+      change_label: Cambio
+      change_ssn_label: Cambiar número de Seguridad Social
+      change_state_id_label: Cambiar ID de estado
       continue_plain: Continuar
       mail:
         resend: Enviar otra carta
@@ -83,7 +87,12 @@ es:
       address1: Dirección
       address2: Dirección (opcional)
       city: Ciudad
+      dob: Fecha de nacimiento
+      first_name: Nombre de pila
+      id_number: Número de identificación
+      last_name: Apellido
       password: Contraseña
+      ssn: Número de seguridad social
       ssn_label_html: Número de Seguro Social
       state: Estado
       zipcode: Código postal

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -152,8 +152,8 @@ es:
           propósitos de demostración) - SITIO DE PRUEBA
         read_more_encrypt: Lea más sobre cómo %{app_name} protege su información personal
         review_message: Cuando vuelva a ingresar su contraseña, %{app_name} cifrará sus
-      verifying: Verificando…
-          datos para asegurarse de que nadie más pueda acceder a ellos.
+      verifying: Verificando… datos para asegurarse de que nadie más pueda acceder a
+        ellos.
     review:
       dob: Fecha de nacimiento
       full_name: Nombre completo

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -152,6 +152,7 @@ es:
           propósitos de demostración) - SITIO DE PRUEBA
         read_more_encrypt: Lea más sobre cómo %{app_name} protege su información personal
         review_message: Cuando vuelva a ingresar su contraseña, %{app_name} cifrará sus
+      verifying: Verificando…
           datos para asegurarse de que nadie más pueda acceder a ellos.
     review:
       dob: Fecha de nacimiento

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -152,8 +152,8 @@ es:
           propósitos de demostración) - SITIO DE PRUEBA
         read_more_encrypt: Lea más sobre cómo %{app_name} protege su información personal
         review_message: Cuando vuelva a ingresar su contraseña, %{app_name} cifrará sus
-      verifying: Verificando… datos para asegurarse de que nadie más pueda acceder a
-        ellos.
+          datos para asegurarse de que nadie más pueda acceder a ellos.
+      verifying: Verificando…
     review:
       dob: Fecha de nacimiento
       full_name: Nombre completo

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -164,6 +164,7 @@ fr:
         read_more_encrypt: En savoir plus sur la façon dont %{app_name} protège vos
           informations personnelles
         review_message: Lorsque vous entrez à nouveau votre mot de passe, %{app_name}
+      verifying: Vérification…
           crypte vos données pour vous assurer que personne ne peut y accéder.
     review:
       dob: Date de naissance

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -164,8 +164,8 @@ fr:
         read_more_encrypt: En savoir plus sur la façon dont %{app_name} protège vos
           informations personnelles
         review_message: Lorsque vous entrez à nouveau votre mot de passe, %{app_name}
-      verifying: Vérification… crypte vos données pour vous assurer que personne ne
-        peut y accéder.
+          crypte vos données pour vous assurer que personne ne peut y accéder.
+      verifying: Vérification…
     review:
       dob: Date de naissance
       full_name: Nom complet

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -6,6 +6,10 @@ fr:
         %{last_number}
     buttons:
       cancel: Annuler et retourner à votre profil
+      change_address_label: Changement d’adresse
+      change_label: Changement
+      change_ssn_label: Changement de numéro de sécurité sociale
+      change_state_id_label: Modifier l’ID d’état
       continue_plain: Continuer
       mail:
         resend: Envoyer une autre lettre
@@ -86,11 +90,16 @@ fr:
     form:
       address1: Adresse
       address2: Adresse (optional)
-      city: Ville une lettre contenant un code.′
+      city: Ville
+      dob: Date de naissance
+      first_name: Prénom
+      id_number: Numéro d’identification
+      last_name: Nom de famille
       password: Mot de passe
+      ssn: Numéro de sécurité sociale
       ssn_label_html: Numéro de sécurité sociale
       state: État
-      zipcode: Code ZIP
+      zip_code: Code ZIP
     index:
       id:
         need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -164,8 +164,8 @@ fr:
         read_more_encrypt: En savoir plus sur la façon dont %{app_name} protège vos
           informations personnelles
         review_message: Lorsque vous entrez à nouveau votre mot de passe, %{app_name}
-      verifying: Vérification…
-          crypte vos données pour vous assurer que personne ne peut y accéder.
+      verifying: Vérification… crypte vos données pour vous assurer que personne ne
+        peut y accéder.
     review:
       dob: Date de naissance
       full_name: Nom complet

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -99,7 +99,7 @@ fr:
       ssn: Numéro de sécurité sociale
       ssn_label_html: Numéro de sécurité sociale
       state: État
-      zip_code: Code ZIP
+      zipcode: Code ZIP
     index:
       id:
         need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -20,7 +20,6 @@ en:
       take_photo: Take photos of your ID with a phone
       upload: Verify your ID
       verify: Verify your identity
-      verify_info: Verify your information
     edit_info:
       email_language: Edit email language preference
       password: Edit your password
@@ -40,6 +39,7 @@ en:
       phone: Verify your phone number
       reset_password: Reset Password
       review: Re-enter your password
+      verify_info: Verify your information
     mfa_setup:
       suggest_second_mfa: You’ve added your first authentication method! Add a second
         method as a backup.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -15,7 +15,7 @@ en:
       link_sent: Link sent
       otp_delivery: Receive a security code
       processing_images: Processing your images
-      ssn: Enter your Social Security Number
+      ssn: Enter your Social Security number
       switch_back: Switch back to your computer
       take_photo: Take photos of your ID with a phone
       upload: Verify your ID

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -20,7 +20,6 @@ es:
       take_photo: Toma fotos de tu identificación con un teléfono
       upload: Verifica tu identificación
       verify: Verifica tu identidad
-      verify_info: Verifica tu información
     edit_info:
       email_language: Editar la preferencia de idioma del correo electrónico
       password: Edite su contraseña
@@ -40,6 +39,7 @@ es:
       phone: Verifica tu número telefónico
       reset_password: Restablecer la contraseña
       review: Vuelve a ingresar tu contraseña
+      verify_info: Verifica tu información
     mfa_setup:
       suggest_second_mfa: ¡Has agregado tu primer método de autenticación! Agrega un
         segundo método como respaldo.

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -20,7 +20,6 @@ fr:
       take_photo: Prenez des photos de votre pièce d’identité avec un téléphone
       upload: Vérifiez votre pièce d’identité
       verify: Vérifiez votre identité
-      verify_info: Vérifiez vos informations
     edit_info:
       email_language: Modifier la préférence de langue des e-mails
       password: Modifier votre mot de passe
@@ -40,6 +39,7 @@ fr:
       phone: Vérifiez votre numéro de téléphone
       reset_password: Réinitialisez le mot de passe
       review: Saisissez à nouveau votre mot de passe
+      verify_info: Vérifiez vos informations
     mfa_setup:
       suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification !
         Ajoutez-en une deuxième  en guise de sauvegarde.

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -21,14 +21,14 @@ feature 'doc auth verify step', :js do
   it 'allows the user to enter in a new address' do
     fill_out_address_form_ok
 
-    click_idv_continue
+    click_button t('forms.buttons.submit.update')
     expect(page).to have_current_path(idv_doc_auth_verify_step)
   end
 
   it 'does not allows the user to enter bad address info' do
     fill_out_address_form_fail
 
-    click_idv_continue
+    click_button t('forms.buttons.submit.update')
     expect(page).to have_current_path(idv_address_path)
   end
 

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -17,7 +17,7 @@ feature 'doc auth verify step', :js do
 
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_verify_step)
-    expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_content(t('headings.verify'))
     expect(page).to have_css(
       '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.verify_info'),
@@ -52,7 +52,7 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to address page prepopulated with defaults if the user clicks change address' do
-    click_button t('doc_auth.buttons.change_address_label')
+    click_button t('idv.buttons.change_address_label')
 
     expect(page).to have_current_path(idv_address_path)
     expect(page).to have_selector("input[value='1 FAKE RD']")
@@ -63,7 +63,7 @@ feature 'doc auth verify step', :js do
   it 'tracks when the user edits their address' do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
 
-    click_button t('doc_auth.buttons.change_address_label')
+    click_button t('idv.buttons.change_address_label')
     fill_out_address_form_ok
     click_idv_continue # address form
 
@@ -76,7 +76,7 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to the ssn page if the user clicks change ssn and allows user to go back' do
-    click_button t('doc_auth.buttons.change_ssn_label')
+    click_button t('idv.buttons.change_ssn_label')
 
     expect(page).to have_current_path(idv_doc_auth_ssn_step)
     expect(page).to have_content(t('doc_auth.headings.ssn_update'))

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -65,7 +65,7 @@ feature 'doc auth verify step', :js do
 
     click_button t('idv.buttons.change_address_label')
     fill_out_address_form_ok
-    click_idv_continue # address form
+    click_button t('forms.buttons.submit.update') # address form
 
     click_idv_continue
 

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -44,7 +44,7 @@ describe 'Hybrid Flow' do
       fill_out_ssn_form_ok
       click_idv_continue
 
-      expect(page).to have_content(t('doc_auth.headings.verify'))
+      expect(page).to have_content(t('headings.verify'))
       click_idv_continue
 
       fill_out_phone_form_mfa_phone(user)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'In Person Proofing' do
     click_idv_continue
 
     # verify page
-    expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_content(t('headings.verify'))
     expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
     expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
     expect(page).to have_text(InPersonHelper::GOOD_DOB)
@@ -65,23 +65,23 @@ RSpec.describe 'In Person Proofing' do
     expect(page).to have_text('9**-**-***4')
 
     # click update state ID button
-    click_button t('doc_auth.buttons.change_state_id_label')
+    click_button t('idv.change_state_id_label')
     expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
     click_idv_continue
-    expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_content(t('headings.verify'))
 
     # click update address button
-    click_button t('doc_auth.buttons.change_address_label')
+    click_button t('idv.buttons.change_address_label')
     expect(page).to have_content(t('in_person_proofing.headings.update_address'))
     click_idv_continue
-    expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_content(t('headings.verify'))
 
     # click update ssn button
-    click_button t('doc_auth.buttons.change_ssn_label')
+    click_button t('idv.buttons.change_ssn_label')
     expect(page).to have_content(t('doc_auth.headings.ssn_update'))
     fill_out_ssn_form_ok
     click_idv_continue
-    expect(page).to have_content(t('doc_auth.headings.verify'))
+    expect(page).to have_content(t('headings.verify'))
     click_idv_continue
 
     # phone page

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -65,22 +65,22 @@ RSpec.describe 'In Person Proofing' do
     expect(page).to have_text('9**-**-***4')
 
     # click update state ID button
-    click_button t('idv.change_state_id_label')
+    click_button t('idv.buttons.change_state_id_label')
     expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
-    click_idv_continue
+    click_button t('forms.buttons.submit.update')
     expect(page).to have_content(t('headings.verify'))
 
     # click update address button
     click_button t('idv.buttons.change_address_label')
     expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    click_idv_continue
+    click_button t('forms.buttons.submit.update')
     expect(page).to have_content(t('headings.verify'))
 
     # click update ssn button
     click_button t('idv.buttons.change_ssn_label')
     expect(page).to have_content(t('doc_auth.headings.ssn_update'))
     fill_out_ssn_form_ok
-    click_idv_continue
+    click_button t('forms.buttons.submit.update')
     expect(page).to have_content(t('headings.verify'))
     click_idv_continue
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -154,7 +154,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_doc_auth_steps_before_address_step(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step
     expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
-    click_button t('doc_auth.buttons.change_address_label')
+    click_button t('idv.buttons.change_address_label')
   end
 
   def complete_doc_auth_steps_before_send_link_step


### PR DESCRIPTION
* Updates the verify page's labels to use sentence case ("First name") instead of title case ("First Name")
* Changes "Social Security Number" to "Social Security number" per designs
* Changes "Zip Code" to "ZIP Code"
* Updates the pages where users update their address, state ID information, and Social Security number to have an "Update" button instead of "Continue" button
* Changes the HTML semantics of the verify page key/value pairs to be [HTML description lists](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) instead of just divs with text
* Moves a bunch of content strings that were previously only used in the doc auth flow but are now also used in the in-person proofing flow. I moved them from doc auth namespaces/files into idv namespaces/files

## 📋 Not included

* Back/cancel/start over buttons of any sort

## 📺 Demo

You can try these changes in the [sbachstein sandbox](https://idp.sbachstein.identitysandbox.gov/).

<details>
<summary>Verify page (doc auth)</summary>

![localhost_3000_verify_doc_auth_verify (5)](https://user-images.githubusercontent.com/9039672/177216349-9934e5de-3433-46ed-abb1-2bcde29c6d5d.png)

</details>

<details>
<summary>Change address page (doc auth)</summary>

![localhost_3000_verify_address (1)](https://user-images.githubusercontent.com/9039672/177222957-3e5f65dd-a0ef-4666-a6a6-ecece835caea.png)

</details>

<details>
<summary>Verify page (in-person proofing)</summary>

![localhost_3000_verify_in_person_verify (3)](https://user-images.githubusercontent.com/9039672/177216377-c5677cd2-fe52-4c1a-9cfd-ea0dd05e7dca.png)

</details>

<details>
<summary>Change address page (in-person proofing)</summary>

![localhost_3000_verify_in_person_address (6)](https://user-images.githubusercontent.com/9039672/177216472-5700b245-fb1c-4c5d-8f64-fa7f9c7acfae.png)

</details>

<details>
<summary>Change state ID page</summary>

![localhost_3000_verify_in_person_state_id](https://user-images.githubusercontent.com/9039672/177216510-c4f1e640-698b-4cd1-b551-10f661cc0b8f.png)

</details>

<details>
<summary>Change SSN page</summary>

**Note:** this is the doc auth page which is the same for in-person except in-person's step indicator is different.

![localhost_3000_verify_doc_auth_ssn (2)](https://user-images.githubusercontent.com/9039672/177216566-1bec8942-377f-44fa-8faf-be3bd9d69c9b.png)

</details>