### PR TITLE
Add configuration for TOTP authentication interval

### DIFF
--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -9,7 +9,10 @@ module TwoFactorAuthentication
 
       @presenter = presenter_for_two_factor_authentication_method
       return unless FeatureManagement.prefill_otp_codes?
-      @code = ROTP::TOTP.new(current_user.auth_app_configurations.first.otp_secret_key).now
+      @code = ROTP::TOTP.new(
+        current_user.auth_app_configurations.first.otp_secret_key,
+        interval: IdentityConfig.store.totp_code_interval,
+      ).now
     end
 
     def create

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -82,6 +82,7 @@ class UserDecorator
       issuer: 'Login.gov',
       otp_secret_key: otp_secret_key,
       digits: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+      interval: IdentityConfig.store.totp_code_interval,
     }
     url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(email)
     qrcode = RQRCode::QRCode.new(url)

--- a/app/services/db/auth_app_configuration.rb
+++ b/app/services/db/auth_app_configuration.rb
@@ -11,7 +11,11 @@ module Db
 
     def self.authenticate(user, code)
       user.auth_app_configurations.each do |cfg|
-        totp = ROTP::TOTP.new(cfg.otp_secret_key, digits: TwoFactorAuthenticatable::OTP_LENGTH)
+        totp = ROTP::TOTP.new(
+          cfg.otp_secret_key,
+          digits: TwoFactorAuthenticatable::OTP_LENGTH,
+          interval: IdentityConfig.store.totp_code_interval,
+        )
         new_timestamp = totp.verify(
           code,
           drift_ahead: TwoFactorAuthenticatable::ALLOWED_OTP_DRIFT_SECONDS,
@@ -24,7 +28,11 @@ module Db
     end
 
     def self.confirm(secret, code)
-      totp = ROTP::TOTP.new(secret, digits: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH)
+      totp = ROTP::TOTP.new(
+        secret,
+        digits: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+        interval: IdentityConfig.store.totp_code_interval,
+      )
       totp.verify(
         code, drift_ahead: TwoFactorAuthenticatable::ALLOWED_OTP_DRIFT_SECONDS,
               drift_behind: TwoFactorAuthenticatable::ALLOWED_OTP_DRIFT_SECONDS

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -237,6 +237,7 @@ sp_context_needed_environment: 'prod'
 sp_handoff_bounce_max_seconds: 2
 show_user_attribute_deprecation_warnings: false
 test_ssn_allowed_list: ''
+totp_code_interval: 30
 unauthorized_scope_enabled: false
 usps_upload_enabled: false
 usps_upload_sftp_timeout: 5
@@ -491,6 +492,7 @@ test:
   state_tracking_enabled: true
   telephony_adapter: test
   test_ssn_allowed_list: '999999999'
+  totp_code_interval: 3
   verify_gpo_key_attempt_window_in_minutes: 3
   verify_gpo_key_max_attempts: 2
   verify_personal_key_attempt_window_in_minutes: 3

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -332,6 +332,7 @@ class IdentityConfig
     config.add(:state_tracking_enabled, type: :boolean)
     config.add(:telephony_adapter, type: :string)
     config.add(:test_ssn_allowed_list, type: :comma_separated_string_list)
+    config.add(:totp_code_interval, type: :integer)
     config.add(:unauthorized_scope_enabled, type: :boolean)
     config.add(:use_dashboard_service_providers, type: :boolean)
     config.add(:use_kms, type: :boolean)

--- a/spec/support/otp_helper.rb
+++ b/spec/support/otp_helper.rb
@@ -17,4 +17,11 @@ module OtpHelper
     end
     nil
   end
+
+  def last_totp(user)
+    ROTP::TOTP.new(
+      user.auth_app_configurations.first.otp_secret_key,
+      interval: IdentityConfig.store.totp_code_interval,
+    ).now
+  end
 end

--- a/spec/support/totp_helper.rb
+++ b/spec/support/totp_helper.rb
@@ -1,3 +1,3 @@
 def generate_totp_code(secret)
-  ROTP::TOTP.new(secret).at(Time.zone.now)
+  ROTP::TOTP.new(secret, interval: IdentityConfig.store.totp_code_interval).at(Time.zone.now)
 end


### PR DESCRIPTION
This PR is to primarily support the changes in #6545 

Our current setting is the [default interval](https://github.com/mdp/rotp/blob/62874be71d74380d252c73409dd81da08b021497/lib/rotp/totp.rb#L2) of 30 seconds and we do not want to change it (it is also correctly consistent with [RFC 6238](https://www.rfc-editor.org/rfc/rfc6238.html#section-5.2)).

A single TOTP is valid only once in an interval, and the default of 30 seconds does not always work well in tests where we may be logging in multiple times.

This PR adds the configuration to allow setting the interval and explicitly sets the interval to the configured value.