### PR TITLE
Drop users.encrypted_phone column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[totp_timestamp]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  self.ignored_columns = %w[encrypted_phone totp_timestamp]
+  self.ignored_columns = %w[totp_timestamp]
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/db/primary_migrate/20220705195340_drop_encrypted_phone_from_users.rb
+++ b/db/primary_migrate/20220705195340_drop_encrypted_phone_from_users.rb
@@ -1,0 +1,5 @@
+class DropEncryptedPhoneFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :users, :encrypted_phone, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_22_232047) do
+ActiveRecord::Schema.define(version: 2022_07_05_195340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -591,7 +591,6 @@ ActiveRecord::Schema.define(version: 2022_06_22_232047) do
     t.string "direct_otp"
     t.datetime "direct_otp_sent_at"
     t.string "unique_session_id"
-    t.text "encrypted_phone"
     t.integer "otp_delivery_preference", default: 0, null: false
     t.integer "totp_timestamp"
     t.string "encrypted_password_digest", default: ""

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_05_195340) do
+ActiveRecord::Schema.define(version: 2022_07_05_200821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -592,7 +592,6 @@ ActiveRecord::Schema.define(version: 2022_07_05_195340) do
     t.datetime "direct_otp_sent_at"
     t.string "unique_session_id"
     t.integer "otp_delivery_preference", default: 0, null: false
-    t.integer "totp_timestamp"
     t.string "encrypted_password_digest", default: ""
     t.string "encrypted_recovery_code_digest", default: ""
     t.datetime "remember_device_revoked_at"


### PR DESCRIPTION
**Why**: It was unused and normalized to the phone_configurations
table. Previously ignored in #6501

[skip changelog]