### PR TITLE
Improve IdV verify feature specs

### DIFF
--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -16,21 +16,18 @@ feature 'doc auth verify step', :js do
     end
   end
 
-  it 'is on the correct page' do
+  it 'displays the expected content' do
     expect(page).to have_current_path(idv_doc_auth_verify_step)
     expect(page).to have_content(t('headings.verify'))
     expect(page).to have_css(
       '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.verify_info'),
     )
-  end
 
-  it 'masks the ssn until toggled visible' do
+    # SSN is masked until revealed
     expect(page).to have_text('9**-**-***4')
     expect(page).not_to have_text(DocAuthHelper::GOOD_SSN)
-
     check t('forms.ssn.show')
-
     expect(page).not_to have_text('9**-**-***4')
     expect(page).to have_text(DocAuthHelper::GOOD_SSN)
   end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -152,19 +152,21 @@ feature 'doc auth verify step', :js do
       allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
         [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
       )
+      expect_any_instance_of(Idv::Agent).
+        to receive(:proof_resolution).
+        with(
+          anything,
+          should_proof_state_id: true,
+          trace_id: anything,
+        ).
+        and_call_original
 
-      sign_in_and_2fa_user
+      user = create(:user, :signed_up)
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
-      agent = instance_double(Idv::Agent)
-      allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof_resolution).and_return(
-        success: true, errors: {}, context: { stages: [] },
-      )
       click_idv_continue
 
-      expect(agent).to have_received(:proof_resolution).with(
-        anything, should_proof_state_id: true, trace_id: anything
-      )
+      expect(DocAuthLog.find_by(user_id: user.id).aamva).not_to be_nil
     end
   end
 
@@ -174,19 +176,20 @@ feature 'doc auth verify step', :js do
         IdentityConfig.store.aamva_supported_jurisdictions -
           [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
       )
+      expect_any_instance_of(Idv::Agent).
+        to receive(:proof_resolution).
+        with(
+          anything,
+          should_proof_state_id: false,
+          trace_id: anything,
+        ).
+        and_call_original
 
-      sign_in_and_2fa_user
+      user = create(:user, :signed_up)
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
-      agent = instance_double(Idv::Agent)
-      allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof_resolution).and_return(
-        success: true, errors: {}, context: { stages: [] },
-      )
       click_idv_continue
 
-      expect(agent).to have_received(:proof_resolution).with(
-        anything, should_proof_state_id: false, trace_id: anything
-      )
       expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
     end
   end
@@ -195,20 +198,22 @@ feature 'doc auth verify step', :js do
     it 'does not perform the state ID check' do
       allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
         and_return('["urn:gov:gsa:openidconnect:sp:server"]')
+      expect_any_instance_of(Idv::Agent).
+        to receive(:proof_resolution).
+        with(
+          anything,
+          should_proof_state_id: false,
+          trace_id: anything,
+        ).
+        and_call_original
 
       visit_idp_from_sp_with_ial1(:oidc)
-      sign_in_and_2fa_user
+      user = create(:user, :signed_up)
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
-      agent = instance_double(Idv::Agent)
-      allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof_resolution).and_return(
-        success: true, errors: {}, context: { stages: [] },
-      )
       click_idv_continue
 
-      expect(agent).to have_received(:proof_resolution).with(
-        anything, should_proof_state_id: false, trace_id: anything
-      )
+      expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
     end
   end
 

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -230,24 +230,6 @@ feature 'doc auth verify step', :js do
     end
   end
 
-  context 'resolution failure' do
-    let(:skip_step_completion) { true }
-
-    it 'does not proceed to the next page' do
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_ssn_step
-      fill_out_ssn_form_with_ssn_that_fails_resolution
-      click_idv_continue
-      click_idv_continue
-
-      expect(page).to have_current_path(idv_session_errors_warning_path)
-
-      click_on t('idv.failure.button.warning')
-
-      expect(page).to have_current_path(idv_doc_auth_verify_step)
-    end
-  end
-
   context 'async timed out' do
     it 'allows resubmitting form' do
       allow(DocumentCaptureSession).to receive(:find_by).

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -230,19 +230,6 @@ feature 'doc auth verify step', :js do
     end
   end
 
-  it 'can toggle viewing the ssn' do
-    expect(page).to have_text('9**-**-***4')
-    expect(page).not_to have_text(DocAuthHelper::GOOD_SSN)
-
-    check t('forms.ssn.show')
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN)
-    expect(page).not_to have_text('9**-**-***4')
-
-    uncheck t('forms.ssn.show')
-    expect(page).to have_text('9**-**-***4')
-    expect(page).not_to have_text(DocAuthHelper::GOOD_SSN)
-  end
-
   context 'resolution failure' do
     let(:skip_step_completion) { true }
 

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -7,16 +7,14 @@ feature 'doc auth verify step', :js do
   let(:skip_step_completion) { false }
   let(:max_attempts) { Throttle.max_attempts(:idv_resolution) }
   let(:fake_analytics) { FakeAnalytics.new }
-  let(:user) { create(:user, :signed_up) }
   before do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-    unless skip_step_completion
-      sign_in_and_2fa_user(user)
-      complete_doc_auth_steps_before_verify_step
-    end
   end
 
   it 'displays the expected content' do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_verify_step
+
     expect(page).to have_current_path(idv_doc_auth_verify_step)
     expect(page).to have_content(t('headings.verify'))
     expect(page).to have_css(
@@ -33,6 +31,8 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to the next page upon confirmation' do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_verify_step
     click_idv_continue
 
     expect(page).to have_current_path(idv_phone_path)
@@ -48,6 +48,8 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to address page prepopulated with defaults if the user clicks change address' do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_verify_step
     click_button t('idv.buttons.change_address_label')
 
     expect(page).to have_current_path(idv_address_path)
@@ -57,6 +59,9 @@ feature 'doc auth verify step', :js do
   end
 
   it 'tracks when the user edits their address' do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_verify_step
+
     click_button t('idv.buttons.change_address_label')
     fill_out_address_form_ok
     click_button t('forms.buttons.submit.update') # address form
@@ -70,6 +75,9 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to the ssn page if the user clicks change ssn and allows user to go back' do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_verify_step
+
     click_button t('idv.buttons.change_ssn_label')
 
     expect(page).to have_current_path(idv_doc_auth_ssn_step)

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -9,6 +9,7 @@ feature 'doc auth verify step', :js do
   let(:fake_analytics) { FakeAnalytics.new }
   let(:user) { create(:user, :signed_up) }
   before do
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     unless skip_step_completion
       sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
@@ -35,8 +36,6 @@ feature 'doc auth verify step', :js do
   end
 
   it 'proceeds to the next page upon confirmation' do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-
     click_idv_continue
 
     expect(page).to have_current_path(idv_phone_path)
@@ -61,8 +60,6 @@ feature 'doc auth verify step', :js do
   end
 
   it 'tracks when the user edits their address' do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-
     click_button t('idv.buttons.change_address_label')
     fill_out_address_form_ok
     click_button t('forms.buttons.submit.update') # address form
@@ -86,8 +83,6 @@ feature 'doc auth verify step', :js do
   end
 
   it 'does not proceed to the next page if resolution fails' do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_ssn_step
     fill_out_ssn_form_with_ssn_that_fails_resolution
@@ -107,8 +102,6 @@ feature 'doc auth verify step', :js do
   end
 
   it 'does not proceed to the next page if resolution raises an exception' do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_ssn_step
     fill_out_ssn_form_with_ssn_that_raises_exception
@@ -128,7 +121,6 @@ feature 'doc auth verify step', :js do
   end
 
   it 'throttles resolution and continues when it expires' do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_ssn_step
     fill_out_ssn_form_with_ssn_that_fails_resolution
@@ -225,9 +217,6 @@ feature 'doc auth verify step', :js do
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_verify_step
 
-      allow_any_instance_of(ApplicationController).
-          to receive(:analytics).and_return(fake_analytics)
-
       allow(DocumentCaptureSession).to receive(:find_by).
         and_return(nil)
 
@@ -276,8 +265,6 @@ feature 'doc auth verify step', :js do
     it 'allows resubmitting form' do
       allow(DocumentCaptureSession).to receive(:find_by).
         and_return(nil)
-      allow_any_instance_of(ApplicationController).
-        to receive(:analytics).and_return(fake_analytics)
 
       click_idv_continue
       expect(page).to have_content(t('idv.failure.timeout'))


### PR DESCRIPTION
**Why**:

- Improve performance
   - Avoid duplicate preparation that currently exists in many specs which don't explicit opt-out using the  `skip_step_completion` option. Since that's easy to miss, the workaround here was to remove it and inline the preparation in each spec.
   - Consolidate content specs
   - Remove duplicate specs ("resolution failure" and "SSN toggle")
- Improve accuracy
   - The [assertion on `DocAuthLog`](https://github.com/18F/identity-idp/blob/b1299dfec37b09f21205a9692446f527b14323bb/spec/features/idv/doc_auth/verify_step_spec.rb#L198) was actually referencing a different user than the one which had just submitted the form, since [that sign in](https://github.com/18F/identity-idp/blob/b1299dfec37b09f21205a9692446f527b14323bb/spec/features/idv/doc_auth/verify_step_spec.rb#L186) was not the same as [the one in the initial test preparation](https://github.com/18F/identity-idp/blob/b1299dfec37b09f21205a9692446f527b14323bb/spec/features/idv/doc_auth/verify_step_spec.rb#L10-L13)
- Improve durability
   - The [previous agent mocking](https://github.com/18F/identity-idp/blob/b1299dfec37b09f21205a9692446f527b14323bb/spec/features/idv/doc_auth/verify_step_spec.rb#L167-L170) does not appear to be compatible with the changes proposed in #6550 
   - We were previously only checking `DocAuthLog#aamva` for one of the three AAMVA-related specs
- Simplify
   - Always stub `ApplicationController#analytics` rather than for each individual spec