### PR TITLE
LG-6406: Disable "Leave site?" prompt when starting IPP

### DIFF
--- a/app/javascript/packages/components/block-link.tsx
+++ b/app/javascript/packages/components/block-link.tsx
@@ -1,6 +1,6 @@
 import Link, { LinkProps } from './link';
 
-interface BlockLinkProps extends LinkProps {
+export interface BlockLinkProps extends LinkProps {
   /**
    * Link destination.
    */

--- a/app/javascript/packages/components/troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.tsx
@@ -57,6 +57,15 @@ describe('TroubleshootingOptions', () => {
     expect(container.innerHTML).to.be.empty();
   });
 
+  it('passes additional options props as link props', () => {
+    const options = [{ text: 'Option', url: '/', 'data-example': true }];
+    const { getByRole } = render(<TroubleshootingOptions {...DEFAULT_PROPS} options={options} />);
+
+    const link = getByRole('link');
+
+    expect(link.hasAttribute('data-example')).to.be.true();
+  });
+
   it('renders a new features tag with isNewFeatures', () => {
     const { getByText } = render(
       <TroubleshootingOptions

--- a/app/javascript/packages/components/troubleshooting-options.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.tsx
@@ -1,14 +1,15 @@
 import type { ReactNode } from 'react';
 import { BlockLink } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
+import { BlockLinkProps } from './block-link';
 
-export interface TroubleshootingOption {
+export type TroubleshootingOption = Omit<BlockLinkProps, 'href'> & {
   url: string;
 
   text: ReactNode;
 
   isExternal?: boolean;
-}
+};
 
 interface TroubleshootingOptionsProps {
   headingTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -45,9 +46,9 @@ function TroubleshootingOptions({
         {heading ?? t('components.troubleshooting_options.default_heading')}
       </HeadingTag>
       <ul className="troubleshooting-options__options">
-        {options.map(({ url, text, isExternal }) => (
+        {options.map(({ url, text, ...extraProps }) => (
           <li key={url}>
-            <BlockLink href={url} isExternal={isExternal}>
+            <BlockLink {...extraProps} href={url}>
               {text}
             </BlockLink>
           </li>

--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.spec.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.spec.tsx
@@ -19,6 +19,10 @@ describe('BarcodeAttentionWarning', () => {
     sandbox.stub(analytics, 'trackEvent');
   });
 
+  afterEach(() => {
+    window.onbeforeunload = null;
+  });
+
   const DEFAULT_PROPS = {
     onDismiss() {},
     pii: { first_name: 'Jane', last_name: 'Smith', dob: '1938-10-06' },

--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
@@ -3,6 +3,7 @@ import { Button, StatusPage } from '@18f/identity-components';
 import { SpinnerButton } from '@18f/identity-spinner-button';
 import { t } from '@18f/identity-i18n';
 import { trackEvent } from '@18f/identity-analytics';
+import { removeUnloadProtection } from '@18f/identity-url';
 import UploadContext from '../context/upload';
 import { toFormData } from '../services/upload';
 import type { PII } from '../services/upload';
@@ -33,7 +34,7 @@ function BarcodeAttentionWarning({ onDismiss, pii }: BarcodeAttentionWarningProp
         body: toFormData({ document_capture_session_uuid: formData.document_capture_session_uuid }),
       }),
     ]);
-    window.onbeforeunload = null;
+    removeUnloadProtection();
     const form = document.querySelector<HTMLFormElement>('.js-document-capture-form');
     form?.submit();
   }

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { TroubleshootingOptions } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
+import { removeUnloadProtection } from '@18f/identity-url';
 import type { TroubleshootingOption } from '@18f/identity-components/troubleshooting-options';
 import ServiceProviderContext from '../context/service-provider';
 import HelpCenterContext from '../context/help-center';
@@ -79,6 +80,7 @@ function DocumentCaptureTroubleshootingOptions({
             {
               url: inPersonURL,
               text: t('idv.troubleshooting.options.verify_in_person'),
+              onClick: removeUnloadProtection,
             },
           ]}
         />

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -1,4 +1,5 @@
 import { FormError } from '@18f/identity-form-steps';
+import { forceRedirect } from '@18f/identity-url';
 import type {
   UploadSuccessResponse,
   UploadErrorResponse,
@@ -78,8 +79,7 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
   }
 
   if (response.url !== endpoint) {
-    window.onbeforeunload = null;
-    window.location.href = response.url;
+    forceRedirect(response.url);
 
     // Avoid settling the promise, allowing the redirect to complete.
     return new Promise(() => {});
@@ -88,8 +88,7 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
   const result: UploadSuccessResponse | UploadErrorResponse = await response.json();
   if (!result.success) {
     if (result.redirect) {
-      window.onbeforeunload = null;
-      window.location.href = result.redirect;
+      forceRedirect(result.redirect);
 
       // Avoid settling the promise, allowing the redirect to complete.
       return new Promise(() => {});

--- a/app/javascript/packages/url/README.md
+++ b/app/javascript/packages/url/README.md
@@ -1,0 +1,3 @@
+# `@18f/identity-url`
+
+URL and navigation utilities for Login.gov.

--- a/app/javascript/packages/url/add-search-params.spec.ts
+++ b/app/javascript/packages/url/add-search-params.spec.ts
@@ -1,4 +1,4 @@
-import { addSearchParams } from './index';
+import addSearchParams from './add-search-params';
 
 describe('addSearchParams', () => {
   it('adds search params to an existing URL', () => {

--- a/app/javascript/packages/url/add-search-params.ts
+++ b/app/javascript/packages/url/add-search-params.ts
@@ -1,0 +1,16 @@
+/**
+ * Given a URL or a string fragment of search parameters and an object of parameters, returns a
+ * new URL or search parameters with the parameters added.
+ *
+ * @param url Original URL.
+ * @param params Search parameters to add.
+ *
+ * @return Modified URL.
+ */
+function addSearchParams(url: string, params: Record<string, any>): string {
+  const parsedURL = new URL(url, window.location.href);
+  Object.entries(params).forEach(([key, value]) => parsedURL.searchParams.set(key, value));
+  return parsedURL.toString();
+}
+
+export default addSearchParams;

--- a/app/javascript/packages/url/force-redirect.spec.ts
+++ b/app/javascript/packages/url/force-redirect.spec.ts
@@ -1,0 +1,22 @@
+import { useSandbox } from '@18f/identity-test-helpers';
+import forceRedirect from './force-redirect';
+
+describe('forceRedirect', () => {
+  const sandbox = useSandbox();
+
+  afterEach(() => {
+    window.onbeforeunload = null;
+  });
+
+  it('navigates to the given URL, bypassing any unload protection', () => {
+    const onbeforeunload = sandbox.stub();
+    const navigate = sandbox.stub();
+    const url = '/';
+    window.onbeforeunload = onbeforeunload;
+
+    forceRedirect(url, navigate);
+
+    expect(navigate).to.have.been.calledWith(url);
+    expect(onbeforeunload).not.to.have.been.called();
+  });
+});

--- a/app/javascript/packages/url/force-redirect.ts
+++ b/app/javascript/packages/url/force-redirect.ts
@@ -13,7 +13,7 @@ const DEFAULT_NAVIGATE: Navigate = (url) => {
  * @param url Destination URL.
  * @param navigate Navigation implementation, used for dependency injection.
  */
-function forceRedirect(url, navigate = DEFAULT_NAVIGATE) {
+function forceRedirect(url: string, navigate: Navigate = DEFAULT_NAVIGATE) {
   removeUnloadProtection();
   navigate(url);
 }

--- a/app/javascript/packages/url/force-redirect.ts
+++ b/app/javascript/packages/url/force-redirect.ts
@@ -1,0 +1,21 @@
+import removeUnloadProtection from './remove-unload-protection';
+
+type Navigate = (url: string) => void;
+
+const DEFAULT_NAVIGATE: Navigate = (url) => {
+  window.location.href = url;
+};
+
+/**
+ * Redirects the user to the given URL, bypassing any confirmation prompts that may exist to prevent
+ * the user from leaving.
+ *
+ * @param url Destination URL.
+ * @param navigate Navigation implementation, used for dependency injection.
+ */
+function forceRedirect(url, navigate = DEFAULT_NAVIGATE) {
+  removeUnloadProtection();
+  navigate(url);
+}
+
+export default forceRedirect;

--- a/app/javascript/packages/url/index.ts
+++ b/app/javascript/packages/url/index.ts
@@ -1,1 +1,3 @@
 export { default as addSearchParams } from './add-search-params';
+export { default as forceRedirect } from './force-redirect';
+export { default as removeUnloadProtection } from './remove-unload-protection';

--- a/app/javascript/packages/url/index.ts
+++ b/app/javascript/packages/url/index.ts
@@ -1,14 +1,1 @@
-/**
- * Given a URL or a string fragment of search parameters and an object of parameters, returns a
- * new URL or search parameters with the parameters added.
- *
- * @param url Original URL.
- * @param params Search parameters to add.
- *
- * @return Modified URL.
- */
-export function addSearchParams(url: string, params: Record<string, any>): string {
-  const parsedURL = new URL(url, window.location.href);
-  Object.entries(params).forEach(([key, value]) => parsedURL.searchParams.set(key, value));
-  return parsedURL.toString();
-}
+export { default as addSearchParams } from './add-search-params';

--- a/app/javascript/packages/url/remove-unload-protection.spec.ts
+++ b/app/javascript/packages/url/remove-unload-protection.spec.ts
@@ -1,0 +1,18 @@
+import removeUnloadProtection from './remove-unload-protection';
+
+describe('removeUnloadProtection', () => {
+  afterEach(() => {
+    window.onbeforeunload = null;
+    window.onunload = null;
+  });
+
+  it('neutralizes navigation confirmation prompts', () => {
+    window.onbeforeunload = () => {};
+    window.onunload = () => {};
+
+    removeUnloadProtection();
+
+    expect(window.onbeforeunload).not.to.exist();
+    expect(window.onunload).not.to.exist();
+  });
+});

--- a/app/javascript/packages/url/remove-unload-protection.ts
+++ b/app/javascript/packages/url/remove-unload-protection.ts
@@ -1,0 +1,10 @@
+/**
+ * Neutralizes any confirmation prompt which would otherwise occur when the user navigates to
+ * another page.
+ */
+function removeUnloadProtection() {
+  window.onbeforeunload = null;
+  window.onunload = null;
+}
+
+export default removeUnloadProtection;

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -1,3 +1,4 @@
+import { forceRedirect } from '@18f/identity-url';
 import type { CountdownElement } from '@18f/identity-countdown-element';
 
 interface NewRelicAgent {
@@ -76,9 +77,7 @@ function notifyNewRelic(request, error, actionName) {
 
 function handleTimeout(redirectURL: string) {
   window.dispatchEvent(new window.CustomEvent('lg:session-timeout'));
-  window.onbeforeunload = null;
-  window.onunload = null;
-  window.location.href = redirectURL;
+  forceRedirect(redirectURL);
 }
 
 function success(data: PingResponse) {

--- a/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-troubleshooting-options-spec.jsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   HelpCenterContextProvider,
   ServiceProviderContextProvider,
@@ -140,7 +141,7 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
         <FlowContext.Provider value={{ inPersonURL }}>{children}</FlowContext.Provider>
       );
 
-      it('has links to IPP information', () => {
+      it('has links to IPP information', async () => {
         const { getByText, getAllByRole } = render(
           <DocumentCaptureTroubleshootingOptions hasErrors />,
           { wrapper },
@@ -151,6 +152,10 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
         const links = getAllByRole('link');
         const ippLink = links.find(({ href }) => href === inPersonURL);
         expect(ippLink).to.exist();
+
+        window.onbeforeunload = () => {};
+        await userEvent.click(ippLink);
+        expect(window.onbeforeunload).not.to.exist();
       });
     });
   });


### PR DESCRIPTION
**Why**: A user who chooses to verify their identity in person should not be warned about leaving the page, since they have already made the choice to leave.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. Submit document capture with a [failing ID document](https://developers.login.gov/testing/#testing-identity-proofing)
6. Click option to proof in-person

Before: Prompted about leaving page
After: No prompt when leaving page

**Screenshot:**

The prompt in the following screenshot is the one being removed:

![image](https://user-images.githubusercontent.com/1779930/177856134-0e34eaa6-7ad9-4a36-a476-3bd8bb0a8e3e.png)
