### PR TITLE
IdV API: Set last GPO code for auto-fill in local development

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -4,12 +4,12 @@ module Api
       self.required_step = 'password_confirm'
 
       def create
-        result, personal_key, gpo_code = form.submit
+        result, personal_key = form.submit
 
         if result.success?
           user = User.find_by(uuid: result.extra[:user_uuid])
           add_proofing_component(user)
-          set_session_last_gpo_code(gpo_code)
+          set_session_last_gpo_code(form.gpo_code)
           render json: {
             personal_key: personal_key,
             completion_url: completion_url(result),
@@ -22,7 +22,7 @@ module Api
       private
 
       def form
-        Api::ProfileCreationForm.new(
+        @form ||= Api::ProfileCreationForm.new(
           password: verify_params[:password],
           jwt: verify_params[:user_bundle_token],
           user_session: user_session,

--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -9,7 +9,7 @@ module Api
         if result.success?
           user = User.find_by(uuid: result.extra[:user_uuid])
           add_proofing_component(user)
-          session[:last_gpo_confirmation_code] = gpo_code if gpo_code
+          set_session_last_gpo_code(gpo_code)
           render json: {
             personal_key: personal_key,
             completion_url: completion_url(result),
@@ -28,6 +28,10 @@ module Api
           user_session: user_session,
           service_provider: current_sp,
         )
+      end
+
+      def set_session_last_gpo_code(code)
+        session[:last_gpo_confirmation_code] = code if code && FeatureManagement.reveal_gpo_code?
       end
 
       def verify_params

--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -9,7 +9,7 @@ module Api
         if result.success?
           user = User.find_by(uuid: result.extra[:user_uuid])
           add_proofing_component(user)
-          set_session_last_gpo_code(form.gpo_code)
+          store_session_last_gpo_code(form.gpo_code)
           render json: {
             personal_key: personal_key,
             completion_url: completion_url(result),
@@ -30,7 +30,7 @@ module Api
         )
       end
 
-      def set_session_last_gpo_code(code)
+      def store_session_last_gpo_code(code)
         session[:last_gpo_confirmation_code] = code if code && FeatureManagement.reveal_gpo_code?
       end
 

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -6,9 +6,7 @@ module Api
     validate :valid_user
     validate :valid_password
 
-    attr_reader :password, :user_bundle
-    attr_reader :user_session, :service_provider
-    attr_reader :profile
+    attr_reader :password, :user_bundle, :user_session, :service_provider, :profile, :gpo_code
 
     def initialize(password:, jwt:, user_session:, service_provider: nil)
       @password = password
@@ -32,7 +30,7 @@ module Api
         errors: errors,
         extra: extra_attributes,
       )
-      [response, personal_key]
+      [response, personal_key, gpo_code]
     end
 
     private
@@ -80,6 +78,7 @@ module Api
         profile: profile,
       )
       confirmation_maker.perform
+      @gpo_code = confirmation_maker.otp if FeatureManagement.reveal_gpo_code?
     end
 
     def build_profile_maker

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -30,7 +30,7 @@ module Api
         errors: errors,
         extra: extra_attributes,
       )
-      [response, personal_key, gpo_code]
+      [response, personal_key]
     end
 
     private

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -42,7 +42,7 @@ describe Api::Verify::PasswordConfirmController do
       end
 
       it 'creates a profile and returns a key and completion url' do
-        post :create, params: { password: 'iambatman', user_bundle_token: jwt }
+        post :create, params: { password: password, user_bundle_token: jwt }
         parsed_body = JSON.parse(response.body)
         expect(parsed_body).to include(
           'personal_key' => kind_of(String),
@@ -65,7 +65,7 @@ describe Api::Verify::PasswordConfirmController do
         end
 
         it 'creates a profile and returns completion url' do
-          post :create, params: { password: 'iambatman', user_bundle_token: jwt }
+          post :create, params: { password: password, user_bundle_token: jwt }
 
           expect(JSON.parse(response.body)['completion_url']).to eq(sign_up_completed_url)
         end
@@ -75,9 +75,35 @@ describe Api::Verify::PasswordConfirmController do
         let(:jwt_metadata) { { vendor_phone_confirmation: false, user_phone_confirmation: false } }
 
         it 'creates a profile and returns completion url' do
-          post :create, params: { password: 'iambatman', user_bundle_token: jwt }
+          post :create, params: { password: password, user_bundle_token: jwt }
 
           expect(JSON.parse(response.body)['completion_url']).to eq(idv_come_back_later_url)
+        end
+      end
+
+      context 'with gpo_code returned from form submission' do
+        let(:gpo_code) { 'ABC1234' }
+
+        let(:form) do
+          Api::ProfileCreationForm.new(
+            password: password,
+            jwt: jwt_metadata,
+            user_session: {},
+            service_provider: {},
+          )
+        end
+
+        before do
+          allow(subject).to receive(:form).and_return(form)
+          allow(form).to receive(:submit).and_return(
+            [FormResponse.new(success: true, extra: { user_uuid: user.uuid }), '', gpo_code],
+          )
+        end
+
+        it 'sets code into the session' do
+          post :create, params: { password: password, user_bundle_token: jwt }
+
+          expect(session[:last_gpo_confirmation_code]).to eq(gpo_code)
         end
       end
     end
@@ -88,7 +114,7 @@ describe Api::Verify::PasswordConfirmController do
       end
 
       it 'responds with not found' do
-        post :create, params: { password: 'iambatman', user_bundle_token: jwt }, as: :json
+        post :create, params: { password: password, user_bundle_token: jwt }, as: :json
         expect(response.status).to eq 404
         expect(JSON.parse(response.body)['error']).
           to eq "The page you were looking for doesn't exist"

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -81,8 +81,8 @@ describe Api::Verify::PasswordConfirmController do
         end
       end
 
-      context 'with gpo_code returned from form submission' do
-        let(:gpo_code) { 'ABC1234' }
+      context 'with gpo_code returned from form submission and reveal gpo feature enabled' do
+        let(:gpo_code) { SecureRandom.hex }
 
         let(:form) do
           Api::ProfileCreationForm.new(
@@ -94,6 +94,7 @@ describe Api::Verify::PasswordConfirmController do
         end
 
         before do
+          allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
           allow(subject).to receive(:form).and_return(form)
           allow(form).to receive(:submit).and_return(
             [FormResponse.new(success: true, extra: { user_uuid: user.uuid }), '', gpo_code],

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -87,7 +87,7 @@ describe Api::Verify::PasswordConfirmController do
         let(:form) do
           Api::ProfileCreationForm.new(
             password: password,
-            jwt: jwt_metadata,
+            jwt: jwt,
             user_session: {},
             service_provider: {},
           )
@@ -96,9 +96,7 @@ describe Api::Verify::PasswordConfirmController do
         before do
           allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
           allow(subject).to receive(:form).and_return(form)
-          allow(form).to receive(:submit).and_return(
-            [FormResponse.new(success: true, extra: { user_uuid: user.uuid }), '', gpo_code],
-          )
+          allow(form).to receive(:gpo_code).and_return(gpo_code)
         end
 
         it 'sets code into the session' do

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe Api::ProfileCreationForm do
             allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
           end
 
-          it 'returns code from the submission result the session' do
-            _response, _personal_key, actual_gpo_code = subject.submit
-            expected_gpo_code = GpoConfirmation.last.entry[:otp]
+          it 'assigns gpo code' do
+            subject.submit
+            gpo_code = GpoConfirmation.last.entry[:otp]
 
-            expect(actual_gpo_code).to eq(expected_gpo_code)
+            expect(subject.gpo_code).to eq(gpo_code)
           end
         end
       end

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe Api::ProfileCreationForm do
 
           expect(profile.gpo_confirmation_codes.first_with_otp(gpo_otp)).not_to be_nil
         end
+
+        context 'with reveal_gpo_code? feature enabled' do
+          before do
+            allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
+          end
+
+          it 'returns code from the submission result the session' do
+            _response, _personal_key, actual_gpo_code = subject.submit
+            expected_gpo_code = GpoConfirmation.last.entry[:otp]
+
+            expect(actual_gpo_code).to eq(expected_gpo_code)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
**Why**: So that a developer can complete the GPO proofing flow locally.

**Testing Instructions:**

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow, opting to verify address by mail at the phone step
5. On "Come back later" screen, click Continue
6. On account screen, click to enter the GPO code received by mail
7. Observe there is a code pre-filled
8. Submit the form
9. Observe the profile is confirmed

**Notes:**

Referenced here: 

https://github.com/18F/identity-idp/blob/1e0f7646aa37804f9f4dd42ff1c1d6952985de00/app/controllers/idv/gpo_verify_controller.rb#L13

Assigned in previous flow here:

https://github.com/18F/identity-idp/blob/1e0f7646aa37804f9f4dd42ff1c1d6952985de00/app/controllers/idv/review_controller.rb#L52-L53