### PR TITLE
Refactor forms to use ValidatedFieldComponent

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -59,14 +59,6 @@ input::-webkit-inner-spin-button {
   [aria-invalid='true'] ~ & {
     display: block;
   }
-
-  [aria-invalid='value-missing'] ~ &.display-if-invalid--value-missing {
-    display: block;
-  }
-
-  [aria-invalid='pattern-mismatch'] ~ &.display-if-invalid--pattern-mismatch {
-    display: block;
-  }
 }
 
 // ===============================================

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -12,10 +12,6 @@ function disableFormSubmit(event) {
   });
 }
 
-function kebabCase(string) {
-  return string.replace(/(.)([A-Z])/g, '$1-$2').toLowerCase();
-}
-
 function resetInput(input) {
   if (input.hasAttribute('data-form-validation-message')) {
     input.setCustomValidity('');
@@ -40,11 +36,7 @@ function checkInputValidity(event) {
     input.parentNode?.querySelector('.display-if-invalid')
   ) {
     event.preventDefault();
-    const errors = Object.keys(ValidityState.prototype)
-      .filter((key) => key !== 'valid')
-      .filter((key) => input.validity[key]);
-
-    input.setAttribute('aria-invalid', errors.length ? kebabCase(errors[0]) : 'false');
+    input.setAttribute('aria-invalid', 'true');
     input.classList.add('usa-input--error');
     input.focus();
   }

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -11,53 +11,63 @@
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.address')) %>
 
-<div class="margin-top-4 margin-bottom-4">
-  <%= validated_form_for(
-        :idv_form, url: idv_address_path, method: 'POST',
-                   html: { autocomplete: 'off', class: 'margin-top-2' }
-      ) do |f| %>
-    <div class="margin-bottom-4">
-      <%= f.input :address1,  label: t('idv.form.address1'), wrapper: false,
-                              required: true, maxlength: 255, input_html: { aria: { invalid: false }, value: @pii['address1'] } %>
-      <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-        <%= t('simple_form.required.text') %>
-      </span>
-    </div>
-    <%= f.input :address2, label: t('idv.form.address2'), required: false, maxlength: 255,
-                           input_html: { value: @pii['address2'] } %>
-    <div class="margin-bottom-4">
-      <%= f.input :city,  label: t('idv.form.city'), required: true, maxlength: 255, wrapper: false,
-                          input_html: { aria: { invalid: false }, value: @pii['city'] } %>
-      <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-        <%= t('simple_form.required.text') %>
-      </span>
-    </div>
-
-    <%= f.input :state, collection: us_states_territories,
-                        label: t('idv.form.state'), required: true,
-                        selected: @pii['state'] %>
-    <div class="tablet:grid-col-6 margin-bottom-4">
-      <%# using :tel for mobile numeric keypad %>
-      <%= f.input :zipcode, as: :tel,
-                            label: t('idv.form.zipcode'), required: true,
-                            pattern: '(\d{5}([\-]\d{4})?)',
-                            wrapper: false,
-                            input_html: { aria: { invalid: false }, value: @pii['zipcode'] } %>
-      <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-        <%= t('simple_form.required.text') %>
-      </span>
-
-      <span class='usa-error-message margin-top-1 pattern-mismatch display-if-invalid display-if-invalid--pattern-mismatch margin-bottom-1' role='alert'>
-        <%= t('idv.errors.pattern_mismatch.zipcode') %>
-      </span>
-    </div>
-    <div class="margin-top-0">
-      <button type="submit" class="usa-button usa-button--big usa-button--wide margin-top-2">
-        <%= t('forms.buttons.submit.update') %>
-      </button>
-    </div>
+<%= validated_form_for(
+      :idv_form,
+      url: idv_address_path,
+      method: 'POST',
+      html: { autocomplete: 'off', class: 'margin-top-5' },
+    ) do |f| %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :address1,
+        label: t('idv.form.address1'),
+        required: true,
+        maxlength: 255,
+        input_html: { value: @pii['address1'] },
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :address2,
+        label: t('idv.form.address2'),
+        required: false,
+        maxlength: 255,
+        input_html: { value: @pii['address2'] },
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :city,
+        label: t('idv.form.city'),
+        required: true,
+        maxlength: 255,
+        input_html: { value: @pii['city'] },
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :state,
+        collection: us_states_territories,
+        label: t('idv.form.state'),
+        required: true,
+        selected: @pii['state'],
+      ) %>
+  <div class="tablet:grid-col-6">
+    <%# using :tel for mobile numeric keypad %>
+    <%= render ValidatedFieldComponent.new(
+          form: f,
+          name: :zipcode,
+          as: :tel,
+          label: t('idv.form.zipcode'),
+          required: true,
+          pattern: '(\d{5}([\-]\d{4})?)',
+          input_html: { value: @pii['zipcode'], class: 'zipcode' },
+          error_messages: {
+            patternMismatch: t('idv.errors.pattern_mismatch.zipcode'),
+          },
+        ) %>
+  </div>
+  <%= render ButtonComponent.new(big: true, wide: true, class: 'display-block margin-y-5') do %>
+    <%= t('forms.buttons.submit.update') %>
   <% end %>
-</div>
+<% end %>
 
 <%= render 'idv/doc_auth/back', step: 'verify' %>
 <%= javascript_packs_tag_once('formatted-fields') %>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -11,7 +11,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.address')) %>
 
-<%= validated_form_for(
+<%= simple_form_for(
       :idv_form,
       url: idv_address_path,
       method: 'POST',

--- a/app/views/idv/gpo/_new_address.html.erb
+++ b/app/views/idv/gpo/_new_address.html.erb
@@ -1,51 +1,55 @@
 <%= validated_form_for(
       :idv_form,
-      url: idv_gpo_path, method: 'POST',
-      html: { autocomplete: 'off', class: 'margin-top-2' }
+      url: idv_gpo_path,
+      method: 'POST',
+      html: { autocomplete: 'off' },
     ) do |f| %>
-
-  <div class="margin-bottom-4">
-    <%= f.input :address1, label: t('idv.form.address1'), wrapper: false,
-                           required: true, input_html: { aria: { invalid: false } }, maxlength: 255 %>
-    <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-      <%= t('simple_form.required.text') %>
-    </span>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :address1,
+        label: t('idv.form.address1'),
+        required: true,
+        maxlength: 255,
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :address2,
+        label: t('idv.form.address2'),
+        required: false,
+        maxlength: 255,
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :city,
+        label: t('idv.form.city'),
+        required: true,
+        maxlength: 255,
+      ) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :state,
+        collection: us_states_territories,
+        label: t('idv.form.state'),
+        required: true,
+      ) %>
+  <div class="tablet:grid-col-6">
+    <%# using :tel for mobile numeric keypad %>
+    <%= render ValidatedFieldComponent.new(
+          form: f,
+          name: :zipcode,
+          as: :tel,
+          label: t('idv.form.zipcode'),
+          required: true,
+          pattern: '(\d{5}([\-]\d{4})?)',
+          input_html: { class: 'zipcode' },
+          error_messages: {
+            patternMismatch: t('idv.errors.pattern_mismatch.zipcode'),
+          },
+        ) %>
   </div>
-  <%= f.input :address2, label: t('idv.form.address2'), required: false, maxlength: 255 %>
-
-  <div class="margin-bottom-4">
-    <%= f.input :city, label: t('idv.form.city'), wrapper: false, required: true, maxlength: 255 %>
-    <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-      <%= t('simple_form.required.text') %>
-    </span>
-  </div>
-
-  <div class="grid-row grid-gap-2">
-    <div class="grid-col-12 tablet:grid-col-8">
-      <%= f.input :state, collection: us_states_territories,
-                          label: t('idv.form.state'), required: true,
-                          prompt: '- Select -' %>
-    </div>
-
-    <div class="grid-col-12 tablet:grid-col-4">
-      <%# using :tel for mobile numeric keypad %>
-      <%= f.input :zipcode, as: :tel,
-                            label: t('idv.form.zipcode'), required: true,
-                            wrapper: false,
-                            pattern: '(\d{5}([\-]\d{4})?)' %>
-      <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing margin-bottom-1' role='alert'>
-        <%= t('simple_form.required.text') %>
-      </span>
-
-      <span class='usa-error-message margin-top-1 pattern-mismatch display-if-invalid display-if-invalid--pattern-mismatch margin-bottom-1' role='alert'>
-        <%= t('idv.errors.pattern_mismatch.zipcode') %>
-      </span>
-    </div>
-  </div>
-  <div class="margin-top-0">
-    <button type="submit" class="usa-button usa-button--big usa-button--wide">
-      <%= t('idv.buttons.mail.resend') %>
-    </button>
-  </div>
+  <%= render ButtonComponent.new(big: true, wide: true, class: 'display-block margin-y-5') do %>
+    <%= t('idv.buttons.mail.resend') %>
+  <% end %>
 <% end %>
+
 <%= javascript_packs_tag_once('formatted-fields') %>

--- a/app/views/idv/gpo/_new_address.html.erb
+++ b/app/views/idv/gpo/_new_address.html.erb
@@ -1,4 +1,4 @@
-<%= validated_form_for(
+<%= simple_form_for(
       :idv_form,
       url: idv_gpo_path,
       method: 'POST',

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -24,24 +24,20 @@
     ) do |f| %>
   <div class="grid-row margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
-      <%= f.input :otp,
-                  type: 'text',
-                  maxlength: 10,
-                  required: true,
-                  autofocus: true,
-                  input_html: {
-                    aria: { invalid: false },
-                    value: @code,
-                  },
-                  label: t('forms.verify_profile.name'),
-                  wrapper: false %>
-
-      <span class='usa-error-message margin-top-1 display-if-invalid display-if-invalid--value-missing' role='alert'>
-        <%= t('simple_form.required.text') %>
-      </span>
+      <%= render ValidatedFieldComponent.new(
+            form: f,
+            name: :otp,
+            maxlength: 10,
+            required: true,
+            autofocus: true,
+            input_html: {
+              value: @code,
+            },
+            label: t('forms.verify_profile.name'),
+          ) %>
       <%= f.button :submit,
                    t('forms.verify_profile.submit'),
-                   class: 'usa-button--big usa-button--full-width margin-top-5' %>
+                   class: 'usa-button--big usa-button--full-width display-block margin-top-5' %>
     </div>
   </div>
 <% end %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -17,7 +17,7 @@
   <%= t('forms.verify_profile.instructions') %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @gpo_verify_form,
       url: idv_gpo_verify_path,
       html: { autocomplete: 'off', method: :post },

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -59,7 +59,7 @@
           as: :tel,
           error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.zipcode') },
           form: f,
-          input_html: { value: pii[:zipcode] },
+          input_html: { value: pii[:zipcode], class: 'zipcode' },
           label: t('in_person_proofing.form.address.zipcode'),
           label_html: { class: 'usa-label' },
           name: :zipcode,

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -11,7 +11,7 @@
   <%= new_window_link_to(t('in_person_proofing.body.address.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       :doc_auth, url: url_for, method: 'PUT',
                  html: { autocomplete: 'off' }
     ) do |f| %>


### PR DESCRIPTION
**Why:** For consistency, improved developer ergonomics, and reduced risk of accessibility regressions.

This continues the work toward an eventual removal of `display-if-invalid` behaviors. After this pull request, only one usage remains in `_validation_message.html.erb` (used by IdV personal key page). The changes here also remove validation-specific handling (e.g. "value missing" or "pattern mismatch"), since only basic support is needed for this last remaining usage.

**Testing instructions:**

Verify no regressions in IdV address field, IdV GPO bounced address field, and GPO verification page:

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to "Verify your information" screen
5. Click "Update" in the address section
6. Observe no visual or behavioral difference in address form (required fields, pattern enforcement, etc)
   - Difference: ZIP code field will format itself with dash when given more than 5 digits, which was the expected behavior not previously working correctly 
8. Click "Update" with valid form
9. Continue proofing flow to phone screen
10. Opt to verify address by mail
11. Manually edit [`app/views/idv/gpo/index.html.erb`](https://github.com/18F/identity-idp/blob/1e0f7646aa37804f9f4dd42ff1c1d6952985de00/app/views/idv/gpo/index.html.erb#L20-L24) to replace `if @presenter.gpo_mail_bounced?` to `if true` (AFAIK, this address form is not actually reachable in the application)
12. Observe no visual or behavioral difference in address form (required fields, pattern enforcement, etc)
   - Difference: The layout of this page was updated to match the previous address screen ("State" field occupies full width)
   - Difference: State field will no longer show with a "- Select -" label. This label was previously not translated so I opted to remove it altogether
13. Restore changes edited in Step 11
14. Click "Send letter"
15. Complete proofing flow
16. On "Come back later" screen, click "Continue"
17. Click account page link to enter code received by mail
18. Observe no visual or behavioral difference in GPO code form (required field)