### PR TITLE
Update disable-on-submit styling to use active styling

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -24,10 +24,7 @@
   }
 }
 
-.usa-button:disabled,
-.usa-button--disabled {
-  &.usa-button--active,
-  &:active {
-    @include set-text-and-bg('primary-darker', $context: 'Button');
-  }
+.usa-button:disabled.usa-button--active,
+.usa-button--disabled.usa-button--active {
+  @include set-text-and-bg('primary-darker', $context: 'Button');
 }

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -23,3 +23,11 @@
     background-color: transparent;
   }
 }
+
+.usa-button:disabled,
+.usa-button--disabled {
+  &.usa-button--active,
+  &:active {
+    @include set-text-and-bg('primary-darker', $context: 'Button');
+  }
+}

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -1,17 +1,5 @@
 import { t } from '@18f/identity-i18n';
 
-/**
- * Given a submit event, disables all submit buttons within the target form.
- *
- * @param {Event} event Submit event.
- */
-function disableFormSubmit(event) {
-  const form = /** @type {HTMLFormElement} */ (event.target);
-  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((submit) => {
-    /** @type {HTMLInputElement|HTMLButtonElement} */ (submit).disabled = true;
-  });
-}
-
 function resetInput(input) {
   if (input.hasAttribute('data-form-validation-message')) {
     input.setCustomValidity('');
@@ -66,7 +54,6 @@ export function initialize(form) {
   /** @type {HTMLInputElement[]} */
   const fields = Array.from(form.querySelectorAll('.field,[required]'));
   fields.forEach(validateInput);
-  form.addEventListener('submit', disableFormSubmit);
 }
 
 /** @type {HTMLFormElement[]} */

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -7,8 +7,10 @@ import { t } from '@18f/identity-i18n';
  */
 function disableFormSubmit(event) {
   const form = /** @type {HTMLFormElement} */ (event.target);
-  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((submit) => {
-    /** @type {HTMLInputElement|HTMLButtonElement} */ (submit).disabled = true;
+  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((element) => {
+    const submit = /** @type {HTMLInputElement|HTMLButtonElement} */ (element);
+    submit.disabled = true;
+    submit.classList.add('usa-button--active');
   });
 }
 

--- a/app/javascript/packs/form-validation.js
+++ b/app/javascript/packs/form-validation.js
@@ -1,5 +1,17 @@
 import { t } from '@18f/identity-i18n';
 
+/**
+ * Given a submit event, disables all submit buttons within the target form.
+ *
+ * @param {Event} event Submit event.
+ */
+function disableFormSubmit(event) {
+  const form = /** @type {HTMLFormElement} */ (event.target);
+  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((submit) => {
+    /** @type {HTMLInputElement|HTMLButtonElement} */ (submit).disabled = true;
+  });
+}
+
 function resetInput(input) {
   if (input.hasAttribute('data-form-validation-message')) {
     input.setCustomValidity('');
@@ -54,6 +66,7 @@ export function initialize(form) {
   /** @type {HTMLInputElement[]} */
   const fields = Array.from(form.querySelectorAll('.field,[required]'));
   fields.forEach(validateInput);
+  form.addEventListener('submit', disableFormSubmit);
 }
 
 /** @type {HTMLFormElement[]} */

--- a/app/javascript/packs/form-validation.ts
+++ b/app/javascript/packs/form-validation.ts
@@ -7,11 +7,13 @@ import { t } from '@18f/identity-i18n';
  */
 function disableFormSubmit(event: Event) {
   const form = event.target as HTMLFormElement;
-  Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((element) => {
-    const submit = element as HTMLInputElement | HTMLButtonElement;
-    submit.disabled = true;
-    submit.classList.add('usa-button--active');
-  });
+  Array.from(form.querySelectorAll(['button:not([type])', '[type="submit"]'].join())).forEach(
+    (element) => {
+      const submit = element as HTMLInputElement | HTMLButtonElement;
+      submit.disabled = true;
+      submit.classList.add('usa-button--active');
+    },
+  );
 }
 
 function resetInput(input) {
@@ -65,7 +67,9 @@ function validateInput(input: HTMLInputElement) {
  * @param form Form to initialize.
  */
 export function initialize(form: HTMLFormElement) {
-  const fields: HTMLInputElement[] = Array.from(form.querySelectorAll('.field,[required]'));
+  const fields: HTMLInputElement[] = Array.from(
+    form.querySelectorAll(['.field', '[required]'].join()),
+  );
   fields.forEach(validateInput);
   form.addEventListener('submit', disableFormSubmit);
 }

--- a/app/javascript/packs/form-validation.ts
+++ b/app/javascript/packs/form-validation.ts
@@ -3,12 +3,12 @@ import { t } from '@18f/identity-i18n';
 /**
  * Given a submit event, disables all submit buttons within the target form.
  *
- * @param {Event} event Submit event.
+ * @param event Submit event.
  */
-function disableFormSubmit(event) {
-  const form = /** @type {HTMLFormElement} */ (event.target);
+function disableFormSubmit(event: Event) {
+  const form = event.target as HTMLFormElement;
   Array.from(form.querySelectorAll('button:not([type]),[type="submit"]')).forEach((element) => {
-    const submit = /** @type {HTMLInputElement|HTMLButtonElement} */ (element);
+    const submit = element as HTMLInputElement | HTMLButtonElement;
     submit.disabled = true;
     submit.classList.add('usa-button--active');
   });
@@ -26,11 +26,11 @@ function resetInput(input) {
 /**
  * Given an `input` or `invalid` event, updates custom validity of the given input.
  *
- * @param {Event} event Input or invalid event.
+ * @param event Input or invalid event.
  */
 
-function checkInputValidity(event) {
-  const input = /** @type {HTMLInputElement} */ (event.target);
+function checkInputValidity(event: Event) {
+  const input = event.target as HTMLInputElement;
   resetInput(input);
   if (
     event.type === 'invalid' &&
@@ -52,9 +52,9 @@ function checkInputValidity(event) {
 /**
  * Binds validation to a given input.
  *
- * @param {HTMLInputElement} input Input element.
+ * @param input Input element.
  */
-function validateInput(input) {
+function validateInput(input: HTMLInputElement) {
   input.addEventListener('input', checkInputValidity);
   input.addEventListener('invalid', checkInputValidity);
 }
@@ -62,15 +62,13 @@ function validateInput(input) {
 /**
  * Initializes validation on a form element.
  *
- * @param {HTMLFormElement} form Form to initialize.
+ * @param form Form to initialize.
  */
-export function initialize(form) {
-  /** @type {HTMLInputElement[]} */
-  const fields = Array.from(form.querySelectorAll('.field,[required]'));
+export function initialize(form: HTMLFormElement) {
+  const fields: HTMLInputElement[] = Array.from(form.querySelectorAll('.field,[required]'));
   fields.forEach(validateInput);
   form.addEventListener('submit', disableFormSubmit);
 }
 
-/** @type {HTMLFormElement[]} */
-const forms = Array.from(document.querySelectorAll('form[data-validate]'));
+const forms: HTMLFormElement[] = Array.from(document.querySelectorAll('form[data-validate]'));
 forms.forEach(initialize);

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -13,7 +13,7 @@ describe('form-validation', () => {
     window.removeEventListener('submit', onSubmit);
   });
 
-  it('disables submit buttons on submit', () => {
+  it('adds active, disabled effect to submit buttons on submit', () => {
     document.body.innerHTML = `
       <form>
         <button>Submit1</button>
@@ -34,10 +34,15 @@ describe('form-validation', () => {
     submit1.click();
 
     expect(submit1.disabled).to.be.true();
+    expect(submit1.classList.contains('usa-button--active')).to.be.true();
     expect(submit2.disabled).to.be.true();
+    expect(submit2.classList.contains('usa-button--active')).to.be.true();
     expect(submit3.disabled).to.be.true();
+    expect(submit3.classList.contains('usa-button--active')).to.be.true();
     expect(button1.disabled).to.be.false();
+    expect(button1.classList.contains('usa-button--active')).to.be.false();
     expect(input1.disabled).to.be.false();
+    expect(input1.classList.contains('usa-button--active')).to.be.false();
   });
 
   it('checks validity of inputs', async () => {

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -3,43 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { initialize } from '../../../app/javascript/packs/form-validation';
 
 describe('form-validation', () => {
-  const onSubmit = (event) => event.preventDefault();
-
-  beforeEach(() => {
-    window.addEventListener('submit', onSubmit);
-  });
-
-  afterEach(() => {
-    window.removeEventListener('submit', onSubmit);
-  });
-
-  it('disables submit buttons on submit', () => {
-    document.body.innerHTML = `
-      <form>
-        <button>Submit1</button>
-        <button type="submit">Submit2</button>
-        <button type="button">Button1</button>
-        <input type="submit" value="Submit3"></form>
-        <input value="Input1"></form>
-      </form>`;
-
-    const submit1 = screen.getByText('Submit1');
-    const submit2 = screen.getByText('Submit2');
-    const submit3 = screen.getByText('Submit3');
-    const button1 = screen.getByText('Button1');
-    const input1 = screen.getByDisplayValue('Input1');
-
-    const form = submit1.closest('form');
-    initialize(form);
-    submit1.click();
-
-    expect(submit1.disabled).to.be.true();
-    expect(submit2.disabled).to.be.true();
-    expect(submit3.disabled).to.be.true();
-    expect(button1.disabled).to.be.false();
-    expect(input1.disabled).to.be.false();
-  });
-
   it('checks validity of inputs', async () => {
     document.body.innerHTML = `
       <form>
@@ -64,7 +27,6 @@ describe('form-validation', () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="required field" required class="field">
-        <button>Submit</button>
       </form>`;
 
     const form = document.querySelector('form');
@@ -82,7 +44,6 @@ describe('form-validation', () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="field" class="field">
-        <button>Submit</button>
       </form>`;
 
     const form = document.querySelector('form');

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -3,6 +3,43 @@ import userEvent from '@testing-library/user-event';
 import { initialize } from '../../../app/javascript/packs/form-validation';
 
 describe('form-validation', () => {
+  const onSubmit = (event) => event.preventDefault();
+
+  beforeEach(() => {
+    window.addEventListener('submit', onSubmit);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('submit', onSubmit);
+  });
+
+  it('disables submit buttons on submit', () => {
+    document.body.innerHTML = `
+      <form>
+        <button>Submit1</button>
+        <button type="submit">Submit2</button>
+        <button type="button">Button1</button>
+        <input type="submit" value="Submit3"></form>
+        <input value="Input1"></form>
+      </form>`;
+
+    const submit1 = screen.getByText('Submit1');
+    const submit2 = screen.getByText('Submit2');
+    const submit3 = screen.getByText('Submit3');
+    const button1 = screen.getByText('Button1');
+    const input1 = screen.getByDisplayValue('Input1');
+
+    const form = submit1.closest('form');
+    initialize(form);
+    submit1.click();
+
+    expect(submit1.disabled).to.be.true();
+    expect(submit2.disabled).to.be.true();
+    expect(submit3.disabled).to.be.true();
+    expect(button1.disabled).to.be.false();
+    expect(input1.disabled).to.be.false();
+  });
+
   it('checks validity of inputs', async () => {
     document.body.innerHTML = `
       <form>
@@ -27,6 +64,7 @@ describe('form-validation', () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="required field" required class="field">
+        <button>Submit</button>
       </form>`;
 
     const form = document.querySelector('form');
@@ -44,6 +82,7 @@ describe('form-validation', () => {
     document.body.innerHTML = `
       <form>
         <input type="text" aria-label="field" class="field">
+        <button>Submit</button>
       </form>`;
 
     const form = document.querySelector('form');


### PR DESCRIPTION
**Why:**

- For consistency with spinner button activation, which shows with dark blue background while awaiting completion
- To reduce the abruptness of transitioning from an active to disabled button on submission

**Screen recording:**

_Before:_

https://user-images.githubusercontent.com/1779930/183421143-47473cf9-e5ee-47a6-8d90-ccdb20fe39d5.mov

_After:_

https://user-images.githubusercontent.com/1779930/183421151-f6dfd601-23c8-4a18-bc15-5f86af6e0a80.mov

**Background:**

Previously, this pull request was aimed at removing the disable-on-submit effect altogether:

<details><summary>Click to see previous summary</summary>

**Why**:

- Improve consistency: Currently, this behavior happens in some forms and not others. This makes it so that a button is never disabled on form submission.
- It's unnecessary: Our controllers should be tolerant to handling repeated submissions, and if they aren't, that should be addressed at the controller level, and not by relying on some fragile/unpredictable client-side behavior.
- Contributing toward an eventual removal of the `form-validation` JavaScript pack
- Improve performance: The `form-validation` pack is in the critical path for JavaScript (sign-in page), and reduction in its code size should contribute to smaller bundle sizes and faster page loads
</details>