### PR TITLE
LG-5918: Skip SSN step when retaking doc auth photos after barcode attention

### DIFF
--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -2,7 +2,6 @@ module Idv
   module Actions
     class RedoDocumentCaptureAction < Idv::Steps::DocAuthBaseStep
       def call
-        mark_step_incomplete(:ssn)
         mark_step_incomplete(:document_capture)
         unless flow_session[:skip_upload_step]
           mark_step_incomplete(:email_sent)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -65,7 +65,9 @@ module Idv
         )
 
         flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
-        flow_session[:pii_from_doc] = pii_from_doc if store_in_session
+        if store_in_session
+          flow_session[:pii_from_doc] = flow_session[:pii_from_doc].to_h.merge(pii_from_doc)
+        end
         track_document_state(pii_from_doc[:state])
       end
 

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -28,8 +28,10 @@ feature 'doc auth redo document capture action', js: true do
       complete_upload_step
       DocAuth::Mock::DocAuthMockClient.reset!
       attach_and_submit_images
-      complete_ssn_step
 
+      expect(current_path).to eq(idv_doc_auth_verify_step)
+      check t('forms.ssn.show')
+      expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
       expect(page).not_to have_css('[role="status"]')
     end
 
@@ -59,8 +61,10 @@ feature 'doc auth redo document capture action', js: true do
         expect(current_path).to eq(idv_doc_auth_document_capture_step)
         DocAuth::Mock::DocAuthMockClient.reset!
         attach_and_submit_images
-        complete_ssn_step
 
+        expect(current_path).to eq(idv_doc_auth_verify_step)
+        check t('forms.ssn.show')
+        expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
         expect(page).not_to have_css('[role="status"]')
       end
     end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -4,6 +4,7 @@ module DocAuthHelper
   include DocumentCaptureStepHelper
 
   GOOD_SSN = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
+  SSN_THAT_FAILS_RESOLUTION = '123-45-6666'
 
   def session_from_completed_flow_steps(finished_step)
     session = { doc_auth: {} }
@@ -15,7 +16,7 @@ module DocAuthHelper
   end
 
   def fill_out_ssn_form_with_ssn_that_fails_resolution
-    fill_in t('idv.form.ssn_label_html'), with: '123-45-6666'
+    fill_in t('idv.form.ssn_label_html'), with: SSN_THAT_FAILS_RESOLUTION
   end
 
   def fill_out_ssn_form_with_ssn_that_raises_exception


### PR DESCRIPTION
**Why**: Per the expected behavior in LG-5918, a user should not have to repeat entry of SSN if they choose to retake photos on the "Verify' step after a barcode attention document capture result.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. Use barcode attention result YAML test file for fields (see bottom of comment)
6. Submit document capture
7. Press "Continue" when prompted about attention result
8. Complete proofing flow up to "Verify your information step"
9. Click link in warning alert to retake photos
10. Complete proofing flow up to and including document capture

_Before:_ You are on the SSN page
_After:_ You are on the "Verify your information" page, with the SSN as entered in Step 8

**YAML Test File**

```yaml
document:
  type: license
  first_name: Susan
  last_name: Smith
  middle_name: Q
  address1: 1 Microsoft Way
  address2: Apt 3
  city: Bayside
  state: NY
  zipcode: "11364"
  dob: 10/06/1938
  phone: +1 314-555-1212
failed_alerts:
  - name: 2D Barcode Read
    result: Attention
```