### PR TITLE
LG-6439: Allow per-SP access to IPP option

### DIFF
--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -1,6 +1,6 @@
 module Idv
   class InPersonController < ApplicationController
-    before_action :render_404_unless_allowed
+    before_action :render_404_if_disabled
     before_action :confirm_two_factor_authenticated
 
     include Flow::FlowStateMachine
@@ -14,7 +14,7 @@ module Idv
 
     private
 
-    def render_404_unless_allowed
+    def render_404_if_disabled
       render_not_found unless InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
     end
   end

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -1,6 +1,6 @@
 module Idv
   class InPersonController < ApplicationController
-    before_action :render_404_if_disabled
+    before_action :render_404_unless_allowed
     before_action :confirm_two_factor_authenticated
 
     include Flow::FlowStateMachine
@@ -12,8 +12,14 @@ module Idv
       analytics_id: 'In Person Proofing',
     }.freeze
 
-    def render_404_if_disabled
-      render_not_found unless IdentityConfig.store.in_person_proofing_enabled
+    private
+
+    def render_404_unless_allowed
+      render_not_found unless in_person_proofing_allowed?
+    end
+
+    def in_person_proofing_allowed?
+      IdentityConfig.store.in_person_proofing_enabled_issuers.include?(current_sp&.issuer)
     end
   end
 end

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -15,11 +15,7 @@ module Idv
     private
 
     def render_404_unless_allowed
-      render_not_found unless in_person_proofing_allowed?
-    end
-
-    def in_person_proofing_allowed?
-      IdentityConfig.store.in_person_proofing_enabled_issuers.include?(current_sp&.issuer)
+      render_not_found unless InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
     end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -24,7 +24,7 @@ class VerifyController < ApplicationController
     {
       base_path: idv_app_path,
       cancel_url: idv_cancel_path,
-      in_person_url: IdentityConfig.store.in_person_proofing_enabled ? idv_in_person_url : nil,
+      in_person_url: in_person_url,
       initial_values: initial_values,
       reset_password_url: forgot_password_url,
       enabled_step_names: IdentityConfig.store.idv_api_enabled_steps,
@@ -45,6 +45,14 @@ class VerifyController < ApplicationController
 
   def enabled_steps
     IdentityConfig.store.idv_api_enabled_steps
+  end
+
+  def in_person_url
+    idv_in_person_url if in_person_proofing_allowed?
+  end
+
+  def in_person_proofing_allowed?
+    IdentityConfig.store.in_person_proofing_enabled_issuers.include?(current_sp&.issuer)
   end
 
   def step_enabled?(step)

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -48,11 +48,7 @@ class VerifyController < ApplicationController
   end
 
   def in_person_url
-    idv_in_person_url if in_person_proofing_allowed?
-  end
-
-  def in_person_proofing_allowed?
-    IdentityConfig.store.in_person_proofing_enabled_issuers.include?(current_sp&.issuer)
+    idv_in_person_url if Idv::InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
   end
 
   def step_enabled?(step)

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -77,6 +77,10 @@ class ServiceProviderSessionDecorator
     sp.friendly_name || sp.agency&.name
   end
 
+  def sp_issuer
+    sp.issuer
+  end
+
   def cancel_link_url
     view_context.new_user_session_url(request_id: sp_session[:request_id])
   end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -29,6 +29,8 @@ class SessionDecorator
 
   def sp_name; end
 
+  def sp_issuer; end
+
   def sp_logo; end
 
   def sp_logo_url; end

--- a/app/services/idv/in_person_config.rb
+++ b/app/services/idv/in_person_config.rb
@@ -1,0 +1,15 @@
+module Idv
+  class InPersonConfig
+    def self.enabled_for_issuer?(issuer)
+      enabled? && (issuer.nil? || enabled_issuers.include?(issuer))
+    end
+
+    def self.enabled?
+      IdentityConfig.store.in_person_proofing_enabled
+    end
+
+    def self.enabled_issuers
+      IdentityConfig.store.in_person_proofing_enabled_issuers
+    end
+  end
+end

--- a/app/views/idv/session_errors/_in_person_proofing_options.html.erb
+++ b/app/views/idv/session_errors/_in_person_proofing_options.html.erb
@@ -1,4 +1,4 @@
-<% if IdentityConfig.store.in_person_proofing_enabled %>
+<% if IdentityConfig.store.in_person_proofing_enabled_issuers.include?(decorated_session.sp_issuer) %>
   <%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
     <% c.header { t('idv.troubleshooting.headings.are_you_near') } %>
     <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>

--- a/app/views/idv/session_errors/_in_person_proofing_options.html.erb
+++ b/app/views/idv/session_errors/_in_person_proofing_options.html.erb
@@ -1,4 +1,4 @@
-<% if IdentityConfig.store.in_person_proofing_enabled_issuers.include?(decorated_session.sp_issuer) %>
+<% if Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) %>
   <%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
     <% c.header { t('idv.troubleshooting.headings.are_you_near') } %>
     <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -37,7 +37,9 @@
       back_image_upload_url: back_image_upload_url,
       selfie_image_upload_url: selfie_image_upload_url,
       keep_alive_endpoint: sessions_keepalive_url,
-      idv_in_person_url: IdentityConfig.store.in_person_proofing_enabled ? idv_in_person_url : nil,
+      idv_in_person_url: IdentityConfig.store.in_person_proofing_enabled_issuers.include?(decorated_session.sp_issuer) ?
+        idv_in_person_url :
+        nil,
     } %>
   <%= validated_form_for(
         :doc_auth,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -37,9 +37,7 @@
       back_image_upload_url: back_image_upload_url,
       selfie_image_upload_url: selfie_image_upload_url,
       keep_alive_endpoint: sessions_keepalive_url,
-      idv_in_person_url: IdentityConfig.store.in_person_proofing_enabled_issuers.include?(decorated_session.sp_issuer) ?
-        idv_in_person_url :
-        nil,
+      idv_in_person_url: Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) ? idv_in_person_url : nil,
     } %>
   <%= validated_form_for(
         :doc_auth,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -103,7 +103,7 @@ idv_private_key: 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCT2dJQkFBSkJBS3
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_sp_required: false
-in_person_proofing_enabled: true
+in_person_proofing_enabled_issuers: '[null]'
 include_slo_in_saml_metadata: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''
@@ -370,7 +370,7 @@ production:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'
   idv_sp_required: true
-  in_person_proofing_enabled: false
+  in_person_proofing_enabled_issuers: '[]'
   irs_attempt_api_public_key: change-me-pls
   kantara_2fa_phone_restricted: false
   kantara_2fa_phone_existing_user_restriction: false

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -103,7 +103,8 @@ idv_private_key: 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCT2dJQkFBSkJBS3
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_sp_required: false
-in_person_proofing_enabled_issuers: '[null]'
+in_person_proofing_enabled: false
+in_person_proofing_enabled_issuers: '[]'
 include_slo_in_saml_metadata: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''
@@ -298,6 +299,7 @@ development:
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true
   idv_api_enabled_steps: '["password_confirm", "personal_key","personal_key_confirm"]'
+  in_person_proofing_enabled: true
   kantara_2fa_phone_restricted: true
   kantara_2fa_phone_existing_user_restriction: true
   kantara_restriction_enforcement_date: '2022-07-01'
@@ -370,7 +372,6 @@ production:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue: '[]'
   idv_sp_required: true
-  in_person_proofing_enabled_issuers: '[]'
   irs_attempt_api_public_key: change-me-pls
   kantara_2fa_phone_restricted: false
   kantara_2fa_phone_existing_user_restriction: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -177,6 +177,7 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
+    config.add(:in_person_proofing_enabled, type: :boolean)
     config.add(:in_person_proofing_enabled_issuers, type: :json)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -177,7 +177,7 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
-    config.add(:in_person_proofing_enabled, type: :boolean)
+    config.add(:in_person_proofing_enabled_issuers, type: :json, options: { symbolize_names: true })
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -177,7 +177,7 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
-    config.add(:in_person_proofing_enabled_issuers, type: :json, options: { symbolize_names: true })
+    config.add(:in_person_proofing_enabled_issuers, type: :json)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 describe Idv::InPersonController do
+  let(:in_person_proofing_enabled) { false }
+  let(:in_person_proofing_enabled_issuers) { [] }
+  let(:sp) { nil }
+
+  before do
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
+      and_return(in_person_proofing_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+      and_return(in_person_proofing_enabled_issuers)
+    allow(controller).to receive(:current_sp).and_return(sp)
+  end
+
   describe 'before_actions' do
     it 'includes corrects before_actions' do
       expect(subject).to have_actions(
@@ -12,27 +24,51 @@ describe Idv::InPersonController do
     end
   end
 
-  describe 'unauthenticated', :skip_sign_in do
-    it 'redirects to the root url' do
-      get :index
-
-      expect(response).to redirect_to root_url
-    end
-  end
-
   describe '#index' do
-    before do |example|
-      stub_sign_in unless example.metadata[:skip_sign_in]
-      stub_analytics
-      allow(@analytics).to receive(:track_event)
-      allow(Identity::Hostdata::EC2).to receive(:load).
-          and_return(OpenStruct.new(region: 'us-west-2', domain: 'example.com'))
-    end
-
-    it 'redirects to the first step' do
+    it 'renders 404 not found' do
       get :index
 
-      expect(response).to redirect_to idv_in_person_step_url(step: :location)
+      expect(response.status).to eq 404
+    end
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled) { true }
+
+      it 'redirects to the root url' do
+        get :index
+
+        expect(response).to redirect_to root_url
+      end
+
+      context 'signed in' do
+        before { stub_sign_in }
+
+        it 'redirects to the first step' do
+          get :index
+
+          expect(response).to redirect_to idv_in_person_step_url(step: :location)
+        end
+
+        context 'with associated service provider' do
+          let(:sp) { build(:service_provider) }
+
+          it 'renders 404 not found' do
+            get :index
+
+            expect(response.status).to eq 404
+          end
+
+          context 'with in person proofing enabled for service provider' do
+            let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
+
+            it 'redirects to the first step' do
+              get :index
+
+              expect(response).to redirect_to idv_in_person_step_url(step: :location)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe VerifyController do
   describe '#show' do
     let(:idv_api_enabled_steps) { [] }
-    let(:in_person_proofing_enabled) { false }
+    let(:in_person_proofing_enabled_issuers) { [] }
     let(:password) { 'sekrit phrase' }
     let(:user) { create(:user, :signed_up, password: password) }
     let(:applicant) do
@@ -27,8 +27,9 @@ describe VerifyController do
     before do
       allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
         and_return(idv_api_enabled_steps)
-      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-        and_return(in_person_proofing_enabled)
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+        and_return(in_person_proofing_enabled_issuers)
+      allow(controller).to receive(:current_sp).and_return(sp)
       stub_sign_in(user)
       stub_idv_session
       session[:sp] = sp_session if sp_session
@@ -76,7 +77,7 @@ describe VerifyController do
       end
 
       context 'with in-person proofing enabled' do
-        let(:in_person_proofing_enabled) { true }
+        let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
 
         it 'includes in-person URL as app data' do
           response

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'In Person Proofing' do
   include IdvHelper
   include InPersonHelper
 
+  before do
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+  end
+
   it 'works for a happy path', js: true, allow_browser_log: true do
     user = sign_in_and_2fa_user
 

--- a/spec/services/idv/in_person_config_spec.rb
+++ b/spec/services/idv/in_person_config_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Idv::InPersonConfig do
+  let(:in_person_proofing_enabled) { false }
+  let(:in_person_proofing_enabled_issuers) { [] }
+
+  before do
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
+      and_return(in_person_proofing_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+      and_return(in_person_proofing_enabled_issuers)
+  end
+
+  describe '.enabled_for_issuer?' do
+    let(:issuer) { nil }
+    subject(:enabled_for_issuer) { described_class.enabled_for_issuer?(issuer) }
+
+    it { expect(enabled_for_issuer).to eq false }
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled) { true }
+
+      it { expect(enabled_for_issuer).to eq true }
+
+      context 'with issuer argument' do
+        let(:issuer) { 'example-issuer' }
+
+        it { expect(enabled_for_issuer).to eq false }
+
+        context 'with in person proofing enabled for issuer' do
+          let(:in_person_proofing_enabled_issuers) { [issuer] }
+
+          it { expect(enabled_for_issuer).to eq true }
+        end
+      end
+    end
+  end
+
+  describe '.enabled?' do
+    subject(:enabled) { described_class.enabled? }
+
+    it { expect(enabled).to eq false }
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled) { true }
+
+      it { expect(enabled).to eq true }
+    end
+  end
+
+  describe '.enabled_issuers' do
+    subject(:enabled_issuers) { described_class.enabled_issuers }
+
+    it 'returns enabled issuers' do
+      expect(enabled_issuers).to eq in_person_proofing_enabled_issuers
+    end
+  end
+end

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -2,14 +2,19 @@ require 'rails_helper'
 
 describe 'idv/session_errors/exception.html.erb' do
   let(:sp_name) { 'Example SP' }
-  let(:in_person_proofing_enabled) { false }
+  let(:sp_issuer) { 'example-issuer' }
+  let(:in_person_proofing_enabled_issuers) { [] }
 
   before do
-    decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
+    decorated_session = instance_double(
+      ServiceProviderSessionDecorator,
+      sp_name: sp_name,
+      sp_issuer: sp_issuer,
+    )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
 
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+      and_return(in_person_proofing_enabled_issuers)
 
     render
   end
@@ -30,7 +35,7 @@ describe 'idv/session_errors/exception.html.erb' do
   end
 
   context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled) { false }
+    let(:in_person_proofing_enabled_issuers) { [] }
 
     it 'does not render an in person proofing link' do
       expect(rendered).not_to have_link(href: idv_in_person_url)
@@ -38,7 +43,7 @@ describe 'idv/session_errors/exception.html.erb' do
   end
 
   context 'with in person proofing enabled' do
-    let(:in_person_proofing_enabled) { true }
+    let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
 
     it 'renders an in person proofing link' do
       expect(rendered).to have_link(

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 describe 'idv/session_errors/exception.html.erb' do
-  let(:sp_name) { 'Example SP' }
-  let(:sp_issuer) { 'example-issuer' }
+  let(:sp_name) { nil }
+  let(:sp_issuer) { nil }
+  let(:in_person_proofing_enabled) { false }
   let(:in_person_proofing_enabled_issuers) { [] }
 
   before do
@@ -12,7 +13,8 @@ describe 'idv/session_errors/exception.html.erb' do
       sp_issuer: sp_issuer,
     )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
-
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
+      and_return(in_person_proofing_enabled)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
       and_return(in_person_proofing_enabled_issuers)
 
@@ -25,31 +27,58 @@ describe 'idv/session_errors/exception.html.erb' do
 
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
-      t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'exception'),
-    )
-    expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
       href: MarketingSite.contact_url,
     )
   end
 
-  context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled_issuers) { [] }
-
-    it 'does not render an in person proofing link' do
-      expect(rendered).not_to have_link(href: idv_in_person_url)
-    end
+  it 'does not render an in person proofing link' do
+    expect(rendered).not_to have_link(href: idv_in_person_url)
   end
 
   context 'with in person proofing enabled' do
-    let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+    let(:in_person_proofing_enabled) { true }
 
     it 'renders an in person proofing link' do
       expect(rendered).to have_link(
         t('idv.troubleshooting.options.verify_in_person'),
         href: idv_in_person_url,
       )
+    end
+  end
+
+  context 'with associated service provider' do
+    let(:sp_name) { 'Example SP' }
+    let(:sp_issuer) { 'example-issuer' }
+
+    it 'renders a list of troubleshooting options' do
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+        href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'exception'),
+      )
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+        href: MarketingSite.contact_url,
+      )
+    end
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled) { true }
+
+      it 'does not render an in person proofing link' do
+        expect(rendered).not_to have_link(href: idv_in_person_url)
+      end
+
+      context 'with in person proofing enabled for service provider' do
+        let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+
+        it 'renders an in person proofing link' do
+          expect(rendered).to have_link(
+            t('idv.troubleshooting.options.verify_in_person'),
+            href: idv_in_person_url,
+          )
+        end
+      end
     end
   end
 end

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'idv/session_errors/failure.html.erb' do
   let(:sp_name) { 'Example SP' }
   let(:timeout_hours) { 6 }
-  let(:in_person_proofing_enabled) { false }
 
   around do |ex|
     freeze_time { ex.run }
@@ -13,8 +12,6 @@ describe 'idv/session_errors/failure.html.erb' do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
 
     @expires_at = Time.zone.now + timeout_hours.hours
 

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -2,15 +2,20 @@ require 'rails_helper'
 
 describe 'idv/session_errors/throttled.html.erb' do
   let(:sp_name) { nil }
+  let(:sp_issuer) { nil }
   let(:liveness_checking_enabled) { false }
-  let(:in_person_proofing_enabled) { false }
+  let(:in_person_proofing_enabled_issuers) { [] }
 
   before do
-    decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
+    decorated_session = instance_double(
+      ServiceProviderSessionDecorator,
+      sp_name: sp_name,
+      sp_issuer: sp_issuer,
+    )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:liveness_checking_enabled?).and_return(liveness_checking_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+      and_return(in_person_proofing_enabled_issuers)
 
     render
   end
@@ -23,10 +28,22 @@ describe 'idv/session_errors/throttled.html.erb' do
       )
       expect(rendered).not_to have_link(href: return_to_sp_cancel_path)
     end
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled_issuers) { [nil] }
+
+      it 'renders an in person proofing link' do
+        expect(rendered).to have_link(
+          t('idv.troubleshooting.options.verify_in_person'),
+          href: idv_in_person_url,
+        )
+      end
+    end
   end
 
   context 'with an SP' do
     let(:sp_name) { 'Example SP' }
+    let(:sp_issuer) { 'example-issuer' }
 
     it 'renders a list of troubleshooting options' do
       expect(rendered).to have_link(
@@ -37,6 +54,17 @@ describe 'idv/session_errors/throttled.html.erb' do
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
         href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
+    end
+
+    context 'with in person proofing enabled' do
+      let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+
+      it 'renders an in person proofing link' do
+        expect(rendered).to have_link(
+          t('idv.troubleshooting.options.verify_in_person'),
+          href: idv_in_person_url,
+        )
+      end
     end
   end
 
@@ -57,21 +85,10 @@ describe 'idv/session_errors/throttled.html.erb' do
   end
 
   context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled) { false }
+    let(:in_person_proofing_enabled_issuers) { [] }
 
     it 'does not render an in person proofing link' do
       expect(rendered).not_to have_link(href: idv_in_person_url)
-    end
-  end
-
-  context 'with in person proofing enabled' do
-    let(:in_person_proofing_enabled) { true }
-
-    it 'renders an in person proofing link' do
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.verify_in_person'),
-        href: idv_in_person_url,
-      )
     end
   end
 end

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe 'idv/session_errors/throttled.html.erb' do
   let(:sp_name) { nil }
   let(:sp_issuer) { nil }
   let(:liveness_checking_enabled) { false }
+  let(:in_person_proofing_enabled) { false }
   let(:in_person_proofing_enabled_issuers) { [] }
 
   before do
@@ -14,6 +15,8 @@ describe 'idv/session_errors/throttled.html.erb' do
     )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:liveness_checking_enabled?).and_return(liveness_checking_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
+      and_return(in_person_proofing_enabled)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
       and_return(in_person_proofing_enabled_issuers)
 
@@ -30,7 +33,7 @@ describe 'idv/session_errors/throttled.html.erb' do
     end
 
     context 'with in person proofing enabled' do
-      let(:in_person_proofing_enabled_issuers) { [nil] }
+      let(:in_person_proofing_enabled) { true }
 
       it 'renders an in person proofing link' do
         expect(rendered).to have_link(
@@ -57,13 +60,21 @@ describe 'idv/session_errors/throttled.html.erb' do
     end
 
     context 'with in person proofing enabled' do
-      let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+      let(:in_person_proofing_enabled) { true }
 
-      it 'renders an in person proofing link' do
-        expect(rendered).to have_link(
-          t('idv.troubleshooting.options.verify_in_person'),
-          href: idv_in_person_url,
-        )
+      it 'does not render an in person proofing link' do
+        expect(rendered).not_to have_link(href: idv_in_person_url)
+      end
+
+      context 'with in person proofing enabled for SP' do
+        let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+
+        it 'renders an in person proofing link' do
+          expect(rendered).to have_link(
+            t('idv.troubleshooting.options.verify_in_person'),
+            href: idv_in_person_url,
+          )
+        end
       end
     end
   end
@@ -85,7 +96,7 @@ describe 'idv/session_errors/throttled.html.erb' do
   end
 
   context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled_issuers) { [] }
+    let(:in_person_proofing_enabled) { false }
 
     it 'does not render an in person proofing link' do
       expect(rendered).not_to have_link(href: idv_in_person_url)

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -3,15 +3,12 @@ require 'rails_helper'
 describe 'idv/session_errors/warning.html.erb' do
   let(:sp_name) { nil }
   let(:remaining_attempts) { 5 }
-  let(:in_person_proofing_enabled) { false }
   let(:user_session) { {} }
 
   before do
     decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:user_session).and_return(user_session)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
 
     assign(:remaining_attempts, remaining_attempts)
 

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -3,19 +3,30 @@ require 'rails_helper'
 describe 'idv/shared/_document_capture.html.erb' do
   include Devise::Test::ControllerHelpers
 
+  let(:async_uploads_enabled) { false }
   let(:flow_session) { {} }
   let(:sp_name) { nil }
+  let(:sp_issuer) { nil }
   let(:flow_path) { 'standard' }
   let(:failure_to_proof_url) { return_to_sp_failure_to_proof_path }
+  let(:in_person_proofing_enabled_issuers) { [] }
   let(:front_image_upload_url) { nil }
   let(:back_image_upload_url) { nil }
   let(:selfie_image_upload_url) { nil }
 
   before do
+    decorated_session = instance_double(
+      ServiceProviderSessionDecorator,
+      sp_name: sp_name,
+      sp_issuer: sp_issuer,
+    )
+    allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:url_for).and_return('https://example.com/')
 
     allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
       and_return(async_uploads_enabled)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
+      and_return(in_person_proofing_enabled_issuers)
 
     assign(:step_url, :idv_doc_auth_step_url)
   end
@@ -59,6 +70,32 @@ describe 'idv/shared/_document_capture.html.erb' do
         expect(connect_src).to include('https://s3.example.com/bucket/a')
         expect(connect_src).to include('https://s3.example.com/bucket/b')
         expect(connect_src).to include('https://s3.example.com/bucket/c')
+      end
+    end
+  end
+
+  describe 'in person url' do
+    context 'when in person proofing is disabled' do
+      let(:in_person_proofing_enabled_issuers) { [] }
+
+      it 'initializes without in person url' do
+        render_partial
+
+        expect(rendered).to_not have_css('#document-capture-form[data-idv-in-person-url]')
+      end
+    end
+
+    context 'when in person proofing is enabled' do
+      let(:sp_name) { 'Example SP' }
+      let(:sp_issuer) { 'example-issuer' }
+      let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+
+      it 'initializes with in person url' do
+        render_partial
+
+        expect(rendered).to have_css(
+          "#document-capture-form[data-idv-in-person-url='#{idv_in_person_url}']",
+        )
       end
     end
   end


### PR DESCRIPTION
**Why**: So that we can have more discrete control over which users will be presented with and allowed to leverage the in-person proofing flow.

**Testing Instructions:**

1. Start the proofing flow
   - With an associated SP: Run [`identity-oidc-sinatra`](https://github.com/18F/identity-oidc-sinatra) in a separate process and begin from http://localhost:9292/?ial=2
   - Without an associated SP: Sign in at http://localhost:3000, then navigate to http://localhost:3000/verify
2. Complete proofing flow up to one of the in-person proofing options
   - e.g. use a [failing test document](https://developers.login.gov/testing/#testing-identity-proofing) for document capture 
3. Observe that the proofing option is only shown if allowed for the configured service providers

Edit `config/application.yml` to assign `in_person_proofing_enabled` and `in_person_proofing_enabled_issuers` to one of the supported scenarios:
- Disallowed for everyone:
   - `in_person_proofing_enabled: false`
- Disallowed except for direct access:
   - `in_person_proofing_enabled: true`
   - `in_person_proofing_enabled_issuers: '[]'`
- Allowed for direct access and sample app:
   - `in_person_proofing_enabled: true`
   - `in_person_proofing_enabled_issuers: '["urn:gov:gsa:openidconnect:sp:sinatra"]`