### PR TITLE
LG-5948: Document more analytics events

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -37,7 +37,7 @@ module OpenidConnect
 
     def check_sp_handoff_bounced
       return unless SpHandoffBounce::IsBounced.call(sp_session)
-      analytics.track_event(Analytics::SP_HANDOFF_BOUNCED_DETECTED)
+      analytics.sp_handoff_bounced_detected
       redirect_to bounced_url
       true
     end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -51,8 +51,7 @@ module Users
     private
 
     def track_backup_codes_created
-      analytics.track_event(
-        Analytics::BACKUP_CODE_CREATED,
+      analytics.backup_code_created(
         enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
       )
       Funnel::Registration::AddMfa.call(current_user.id, 'backup_codes')

--- a/app/controllers/users/service_provider_inactive_controller.rb
+++ b/app/controllers/users/service_provider_inactive_controller.rb
@@ -3,7 +3,7 @@ module Users
     include FullyAuthenticatable
 
     def index
-      analytics.track_event(Analytics::SP_INACTIVE_VISIT)
+      analytics.sp_inactive_visit
 
       @sp_name = sp_from_sp_session&.friendly_name ||
                  I18n.t('service_providers.errors.generic_sp_name')

--- a/app/controllers/users/sp_handoff_bounced_controller.rb
+++ b/app/controllers/users/sp_handoff_bounced_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class SpHandoffBouncedController < Devise::SessionsController
     def bounced
-      analytics.track_event(Analytics::SP_HANDOFF_BOUNCED_VISIT)
+      analytics.sp_handoff_bounced_visit
       @sp_name = I18n.t('instructions.sp_handoff_bounced_with_no_sp')
       update_sp_info
     end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -137,10 +137,6 @@ class Analytics
 
   # rubocop:disable Layout/LineLength
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  SP_HANDOFF_BOUNCED_DETECTED = 'SP handoff bounced detected'
-  SP_HANDOFF_BOUNCED_VISIT = 'SP handoff bounced visited'
-  SP_INACTIVE_VISIT = 'SP inactive visited'
-  BACKUP_CODE_CREATED = 'Backup Code Created'
   BACKUP_CODE_DELETED = 'Backup Code Delete'
   BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
   BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -163,6 +163,16 @@ module AnalyticsEvents
     track_event('Authentication Confirmation: Reset selected')
   end
 
+  # Tracks when the user creates a set of backup mfa codes.
+  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
+  def backup_code_created(enabled_mfa_methods_count:, **extra)
+    track_event(
+      'Backup Code Created',
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
   # A user that has been banned from an SP has authenticated, they are redirected
   # to a page showing them that they have been banned
   def banned_user_redirect
@@ -1788,6 +1798,21 @@ module AnalyticsEvents
       client_id: client_id,
       **extra,
     )
+  end
+
+  # Tracks when a user is bounced back from the service provider due to an integration issue.
+  def sp_handoff_bounced_detected
+    track_event('SP handoff bounced detected')
+  end
+
+  # Tracks when a user visits the bounced page.
+  def sp_handoff_bounced_visit
+    track_event('SP handoff bounced visited')
+  end
+
+  # Tracks when a user vists the "This agency no longer uses Login.gov" page.
+  def sp_inactive_visit
+    track_event('SP inactive visited')
   end
 
   # Tracks when service provider consent is revoked


### PR DESCRIPTION
(This is a re-do of #6569, this time not from a fork.)

Document the following analytics events:

- `SP_HANDOFF_BOUNCED_DETECTED`
- `SP_HANDOFF_BOUNCED_VISIT`
- `SP_INACTIVE_VISIT`
- `BACKUP_CODE_CREATED`