### PR TITLE
Fix spec flakiness for non-unique component class name

### DIFF
--- a/spec/components/block_link_component_spec.rb
+++ b/spec/components/block_link_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BlockLinkComponent, type: :component do
   end
 
   context 'with custom renderer' do
-    class ExampleComponent < BaseComponent
+    class ExampleBlockLinkCustomRendererComponent < BaseComponent
       def initialize(href:, **)
         @href = href
       end
@@ -43,7 +43,7 @@ RSpec.describe BlockLinkComponent, type: :component do
     it 'renders using the custom renderer' do
       rendered = render_inline BlockLinkComponent.new(
         url: '/',
-        action: ExampleComponent.method(:new),
+        action: ExampleBlockLinkCustomRendererComponent.method(:new),
       ).with_content('Link Text')
 
       expect(rendered).to have_css('button[data-href="/"]', text: 'Example Link Text')


### PR DESCRIPTION
**Why**: To reduce intermittent spec failures

The component in this spec uses the same name as [one in the `BaseComponent` specs](https://github.com/18F/identity-idp/blob/5a5e738bca8c75ad07dd3508cfbe6897af3b2d82/spec/components/base_component_spec.rb#L4), which can (apparently) cause conflicts.

Example failure: https://gitlab.login.gov/lg/identity-idp/-/jobs/33554
