### PR TITLE
Release RC 198.1 to Production

### DIFF
--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -174,7 +174,7 @@ describe Telephony::Pinpoint::SmsSender do
     context 'in a country with sender_id' do
       let(:country_code) { 'PH' }
 
-      it 'sends a message with a shortcode and sender_id' do
+      it 'sends a message with a sender_id and no origination number' do
         mock_build_client
         response = subject.send(
           message: 'This is a test!',
@@ -192,7 +192,7 @@ describe Telephony::Pinpoint::SmsSender do
               sms_message: {
                 body: 'This is a test!',
                 message_type: 'TRANSACTIONAL',
-                origination_number: '123456',
+                origination_number: nil,
                 sender_id: 'sender2',
               },
             },


### PR DESCRIPTION
Includes #6572 

# Changelog

## Internal
- Telephony: Do not specify origination number when sending SMS with Sender ID ([#6572](https://github.com/18F/identity-idp/pull/6572))
