### PR TITLE
LG-6562 Preserve personal key after the user cancels personal key confirmation

### DIFF
--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -58,6 +58,22 @@ describe('PersonalKeyConfirmStep', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: hide personal key modal');
   });
 
+  it('passes the value the user has entered to this point to the child PersonalKeyInput', async () => {
+    const props = Object.assign(DEFAULT_PROPS, {
+      value: {
+        personalKey: '',
+        personalKeyConfirm: '1234-asdf',
+      },
+      toPreviousStep: () => {},
+    });
+
+    const { getByRole } = render(<PersonalKeyConfirmStep {...props} />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    expect(input.value).to.equal('1234-asdf-');
+  });
+
   it('allows the user to continue only with a correct value', async () => {
     const onComplete = sinon.spy();
     const { getByLabelText, getAllByText, container } = render(

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -59,13 +59,14 @@ describe('PersonalKeyConfirmStep', () => {
   });
 
   it('passes the value the user has entered to this point to the child PersonalKeyInput', () => {
-    const props = Object.assign(DEFAULT_PROPS, {
+    const props = {
+      ...DEFAULT_PROPS,
       value: {
         personalKey: '',
         personalKeyConfirm: '1234-asdf',
       },
       toPreviousStep: () => {},
-    });
+    };
 
     const { getByRole } = render(<PersonalKeyConfirmStep {...props} />);
 

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.spec.tsx
@@ -58,7 +58,7 @@ describe('PersonalKeyConfirmStep', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('IdV: hide personal key modal');
   });
 
-  it('passes the value the user has entered to this point to the child PersonalKeyInput', async () => {
+  it('passes the value the user has entered to this point to the child PersonalKeyInput', () => {
     const props = Object.assign(DEFAULT_PROPS, {
       value: {
         personalKey: '',

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -14,6 +14,7 @@ interface PersonalKeyConfirmStepProps extends FormStepComponentProps<VerifyFlowV
 function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
   const { registerField, value, onChange, toPreviousStep } = stepProps;
   const personalKey = value.personalKey!;
+  const enteredPersonalKey = value.personalKeyConfirm;
 
   const closeModalActions = () => {
     trackEvent('IdV: hide personal key modal');
@@ -40,6 +41,7 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
             the form is not rendered in the same DOM hierarchy, it is not invalid nesting. */}
         <form noValidate>
           <PersonalKeyInput
+            initialValue={enteredPersonalKey}
             expectedValue={personalKey}
             ref={registerField('personalKeyConfirm')}
             onChange={(personalKeyConfirm) => onChange({ personalKeyConfirm })}

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-confirm-step.tsx
@@ -41,7 +41,7 @@ function PersonalKeyConfirmStep(stepProps: PersonalKeyConfirmStepProps) {
             the form is not rendered in the same DOM hierarchy, it is not invalid nesting. */}
         <form noValidate>
           <PersonalKeyInput
-            initialValue={enteredPersonalKey}
+            value={enteredPersonalKey}
             expectedValue={personalKey}
             ref={registerField('personalKeyConfirm')}
             onChange={(personalKeyConfirm) => onChange({ personalKeyConfirm })}

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -76,7 +76,7 @@ describe('PersonalKeyInput', () => {
 
   it('renders the input with an initial value if one is provided', () => {
     const { getByRole } = render(
-      <PersonalKeyInput initialValue="1234-asdf" expectedValue="abcd-0011-DEFG-1111" />,
+      <PersonalKeyInput value="1234-asdf" expectedValue="abcd-0011-DEFG-1111" />,
     );
     const input = getByRole('textbox') as HTMLInputElement;
 

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -74,7 +74,7 @@ describe('PersonalKeyInput', () => {
     expect(input.validity.valid).to.be.true();
   });
 
-  it('renders the input with an initial value if one is provided', async () => {
+  it('renders the input with an initial value if one is provided', () => {
     const { getByRole } = render(
       <PersonalKeyInput initialValue="1234-asdf" expectedValue="abcd-0011-DEFG-1111" />,
     );

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.spec.tsx
@@ -73,4 +73,13 @@ describe('PersonalKeyInput', () => {
     input.checkValidity();
     expect(input.validity.valid).to.be.true();
   });
+
+  it('renders the input with an initial value if one is provided', async () => {
+    const { getByRole } = render(
+      <PersonalKeyInput initialValue="1234-asdf" expectedValue="abcd-0011-DEFG-1111" />,
+    );
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    expect(input.value).to.equal('1234-asdf-');
+  });
 });

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -15,6 +15,12 @@ interface CleaveInstanceInternalAPI {
 
 interface PersonalKeyInputProps {
   /**
+   * The personal key to initially render the form with. This value is used when the user has
+   * entered a partial personal key and clicked the "back" button.
+   */
+  initialValue?: string;
+
+  /**
    * The correct personal key to validate against.
    */
   expectedValue?: string;
@@ -35,7 +41,7 @@ interface PersonalKeyInputProps {
 const normalize = (string: string) => string.toLowerCase().replace(/o/g, '0').replace(/[il]/g, '1');
 
 function PersonalKeyInput(
-  { expectedValue, onChange = () => {} }: PersonalKeyInputProps,
+  { initialValue, expectedValue, onChange = () => {} }: PersonalKeyInputProps,
   ref: ForwardedRef<HTMLElement>,
 ) {
   const validate = useCallback<ValidatedFieldValidator>(
@@ -53,6 +59,7 @@ function PersonalKeyInput(
         onInit={(owner) => {
           (owner as ReactInstanceWithCleave & CleaveInstanceInternalAPI).updateValueState();
         }}
+        value={initialValue}
         options={{
           blocks: [4, 4, 4, 4],
           delimiter: '-',

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -45,8 +45,8 @@ function PersonalKeyInput(
   ref: ForwardedRef<HTMLElement>,
 ) {
   const validate = useCallback<ValidatedFieldValidator>(
-    (value) => {
-      if (expectedValue && normalize(value) !== normalize(expectedValue)) {
+    (personalKey) => {
+      if (expectedValue && normalize(personalKey) !== normalize(expectedValue)) {
         throw new Error(t('users.personal_key.confirmation_error'));
       }
     },

--- a/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
+++ b/app/javascript/packages/verify-flow/steps/personal-key-confirm/personal-key-input.tsx
@@ -18,7 +18,7 @@ interface PersonalKeyInputProps {
    * The personal key to initially render the form with. This value is used when the user has
    * entered a partial personal key and clicked the "back" button.
    */
-  initialValue?: string;
+  value?: string;
 
   /**
    * The correct personal key to validate against.
@@ -41,7 +41,7 @@ interface PersonalKeyInputProps {
 const normalize = (string: string) => string.toLowerCase().replace(/o/g, '0').replace(/[il]/g, '1');
 
 function PersonalKeyInput(
-  { initialValue, expectedValue, onChange = () => {} }: PersonalKeyInputProps,
+  { value, expectedValue, onChange = () => {} }: PersonalKeyInputProps,
   ref: ForwardedRef<HTMLElement>,
 ) {
   const validate = useCallback<ValidatedFieldValidator>(
@@ -59,7 +59,7 @@ function PersonalKeyInput(
         onInit={(owner) => {
           (owner as ReactInstanceWithCleave & CleaveInstanceInternalAPI).updateValueState();
         }}
-        value={initialValue}
+        value={value}
         options={{
           blocks: [4, 4, 4, 4],
           delimiter: '-',


### PR DESCRIPTION
Prior to this commit, when a user cancels personal key entry the personal key is not preserved in the confirmation dialog. This commit makes a change to preserve that value so it remains so the user does not have to re-type.