### PR TITLE
Don't check for address 2 presence in in person flow if the test value is nil

### DIFF
--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'In Person Proofing' do
     expect(page).to have_text(InPersonHelper::GOOD_DOB)
     expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
     expect(page).to have_text(InPersonHelper::GOOD_ADDRESS1)
-    expect(page).to have_text(InPersonHelper::GOOD_ADDRESS2)
+    expect(page).to have_text(InPersonHelper::GOOD_ADDRESS2) if InPersonHelper::GOOD_ADDRESS2
     expect(page).to have_text(InPersonHelper::GOOD_CITY)
     expect(page).to have_text(InPersonHelper::GOOD_ZIPCODE)
     expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state])

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'In Person Proofing' do
     expect(page).to have_text(InPersonHelper::GOOD_DOB)
     expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
     expect(page).to have_text(InPersonHelper::GOOD_ADDRESS1)
-    expect(page).to have_text(InPersonHelper::GOOD_ADDRESS2) if InPersonHelper::GOOD_ADDRESS2
     expect(page).to have_text(InPersonHelper::GOOD_CITY)
     expect(page).to have_text(InPersonHelper::GOOD_ZIPCODE)
     expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state])


### PR DESCRIPTION
Don't check for address 2 precense in in person flow if the test value is nil

Currently this test renders this warning:

```
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead. /builds/lg/identity-idp/spec/features/idv/in_person_spec.rb:61
```

...and it does have a point. This commit adds a conditional which only runs the check if address 2 is present. Alternatively we could just remove that line entirely.