### PR TITLE
Rename LexisNexis constant from "lexisnexis" to "lexis_nexis"

### DIFF
--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -168,7 +168,7 @@ module DocAuthRouter
           glare_threshold: IdentityConfig.store.doc_auth_error_glare_threshold,
         ),
       )
-    when Idp::Constants::Vendors::LEXIS_NEXIS
+    when Idp::Constants::Vendors::LEXIS_NEXIS, 'lexisnexis'
       DocAuthErrorTranslatorProxy.new(
         DocAuth::LexisNexis::LexisNexisClient.new(
           account_id: IdentityConfig.store.lexisnexis_account_id,

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -168,7 +168,7 @@ module DocAuthRouter
           glare_threshold: IdentityConfig.store.doc_auth_error_glare_threshold,
         ),
       )
-    when Idp::Constants::Vendors::LEXIS_NEXIS, 'lexisnexis'
+    when Idp::Constants::Vendors::LEXIS_NEXIS, 'lexisnexis' # Use constant once configured in prod
       DocAuthErrorTranslatorProxy.new(
         DocAuth::LexisNexis::LexisNexisClient.new(
           account_id: IdentityConfig.store.lexisnexis_account_id,

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -14,8 +14,8 @@ module Idv
 
       def add_proofing_components
         ProofingComponent.create_or_find_by(user: current_user).update(
-          resolution_check: 'lexis_nexis',
-          source_check: 'aamva',
+          resolution_check: Idp::Constants::Vendors::LEXIS_NEXIS,
+          source_check: Idp::Constants::Vendors::AAMVA,
         )
       end
 

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -2,9 +2,10 @@ module Idp
   module Constants
     module Vendors
       ACUANT = 'acuant'
-      LEXIS_NEXIS = 'lexisnexis'
+      LEXIS_NEXIS = 'lexis_nexis'
       MOCK = 'mock'
       USPS = 'usps'
+      AAMVA = 'aamva'
     end
 
     DEFAULT_IAL = 1

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -38,8 +38,8 @@ feature 'doc auth verify step', :js do
     expect(page).to have_current_path(idv_phone_path)
     expect(page).to have_content(t('doc_auth.forms.doc_success'))
     user = User.first
-    expect(user.proofing_component.resolution_check).to eq('lexis_nexis')
-    expect(user.proofing_component.source_check).to eq('aamva')
+    expect(user.proofing_component.resolution_check).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
+    expect(user.proofing_component.source_check).to eq(Idp::Constants::Vendors::AAMVA)
     expect(DocAuthLog.find_by(user_id: user.id).aamva).to eq(true)
     expect(fake_analytics).to have_logged_event(
       'IdV: doc auth optional verify_wait submitted',

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DocAuthRouter do
     end
 
     context 'for acuant' do
-      let(:doc_auth_vendor) { 'acuant' }
+      let(:doc_auth_vendor) { Idp::Constants::Vendors::ACUANT }
 
       it 'is a translation-proxied acuant client' do
         expect(DocAuthRouter.client).to be_a(DocAuthRouter::DocAuthErrorTranslatorProxy)
@@ -16,7 +16,7 @@ RSpec.describe DocAuthRouter do
     end
 
     context 'for lexisnexis' do
-      let(:doc_auth_vendor) { 'lexisnexis' }
+      let(:doc_auth_vendor) { Idp::Constants::Vendors::LEXIS_NEXIS }
 
       it 'is a translation-proxied lexisnexis client' do
         expect(DocAuthRouter.client).to be_a(DocAuthRouter::DocAuthErrorTranslatorProxy)
@@ -130,8 +130,8 @@ RSpec.describe DocAuthRouter do
       end
 
       it 'client returns randomized vendors when configured' do
-        doc_auth_vendor = 'acuant'
-        doc_auth_vendor_randomize_alternate_vendor = 'lexisnexis'
+        doc_auth_vendor = Idp::Constants::Vendors::ACUANT
+        doc_auth_vendor_randomize_alternate_vendor = Idp::Constants::Vendors::LEXIS_NEXIS
         doc_auth_vendor_randomize_percent = 35
 
         allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)


### PR DESCRIPTION
Context: https://github.com/18F/identity-idp/pull/6576#discussion_r919085206

**Why**: So that we're referencing vendor names consistently.

Temporarily merges to #6576.

Requires configuration changes which cannot be made for at least the next couple days ([see related Slack discussion](https://gsa-tts.slack.com/archives/C0NGESUN5/p1657655307643849)).