### PR TITLE
Do not specify sender_id and origination_number configuration together

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -27,6 +27,9 @@ module Telephony
           start = Time.zone.now
           client = build_client(sms_config)
           next if client.nil?
+
+          sender_config = build_sender_config(country_code, sms_config, sender_id)
+
           pinpoint_response = client.send_messages(
             application_id: sms_config.application_id,
             message_request: {
@@ -39,9 +42,7 @@ module Telephony
                 sms_message: {
                   body: message,
                   message_type: 'TRANSACTIONAL',
-                  origination_number: origination_number(country_code, sms_config, sender_id),
-                  sender_id: sender_id,
-                },
+                }.merge(sender_config),
               },
             },
           )
@@ -135,15 +136,24 @@ module Telephony
         )
       end
 
-      # To ensure Sender ID is used where needed, the origination number must not be
-      # specified.
-      def origination_number(country_code, sms_config, sender_id)
-        return nil if sender_id
-
+      def origination_number(country_code, sms_config)
         if sms_config.country_code_longcode_pool&.dig(country_code).present?
           sms_config.country_code_longcode_pool[country_code].sample
         else
           sms_config.shortcode
+        end
+      end
+
+      # If we are sending with Sender ID, we should not include origination_number
+      def build_sender_config(country_code, sms_config, sender_id)
+        if sender_id
+          {
+            sender_id: sender_id,
+          }
+        else
+          {
+            origination_number: origination_number(country_code, sms_config),
+          }
         end
       end
 

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -192,7 +192,6 @@ describe Telephony::Pinpoint::SmsSender do
               sms_message: {
                 body: 'This is a test!',
                 message_type: 'TRANSACTIONAL',
-                origination_number: nil,
                 sender_id: 'sender2',
               },
             },
@@ -226,7 +225,6 @@ describe Telephony::Pinpoint::SmsSender do
                 body: 'This is a test!',
                 message_type: 'TRANSACTIONAL',
                 origination_number: '123456',
-                sender_id: nil,
               },
             },
           },
@@ -261,7 +259,6 @@ describe Telephony::Pinpoint::SmsSender do
                 body: 'This is a test!',
                 message_type: 'TRANSACTIONAL',
                 origination_number: '+19393334444',
-                sender_id: nil,
               },
             },
           },


### PR DESCRIPTION
Follow up to #6572 because AWS has clarified that we should drop the configuration keys in the API call, rather than setting to `nil`