### PR TITLE
Don't require a discriminator for randomized doc auth vendors.

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -555,6 +555,13 @@ module AnalyticsEvents
     )
   end
 
+  def idv_doc_auth_randomizer_defaulted
+    track_event(
+      'IdV: doc_auth random vendor error',
+      error: 'document_capture_session_uuid_key missing',
+    )
+  end
+
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [String] user_id

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -151,8 +151,8 @@ module DocAuthRouter
 
   # rubocop:disable Layout/LineLength
   # @param [Proc,nil] warn_notifier proc takes a hash, and should log that hash to events.log
-  def self.client(vendor_discriminator: nil, warn_notifier: nil)
-    case doc_auth_vendor(discriminator: vendor_discriminator)
+  def self.client(vendor_discriminator: nil, warn_notifier: nil, analytics: nil)
+    case doc_auth_vendor(discriminator: vendor_discriminator, analytics: analytics)
     when Idp::Constants::Vendors::ACUANT
       DocAuthErrorTranslatorProxy.new(
         DocAuth::Acuant::AcuantClient.new(
@@ -200,15 +200,11 @@ module DocAuthRouter
   end
   # rubocop:enable Layout/LineLength
 
-  def self.doc_auth_vendor(discriminator: nil)
+  def self.doc_auth_vendor(discriminator: nil, analytics: nil)
     if IdentityConfig.store.doc_auth_vendor_randomize
-      if discriminator.blank?
-        raise StandardError.new('doc_auth_vendor called without a discriminator when randomized!')
-      end
-
       target_percent = IdentityConfig.store.doc_auth_vendor_randomize_percent
 
-      if randomize?(target_percent, discriminator)
+      if randomize?(target_percent, discriminator, analytics)
         return IdentityConfig.store.doc_auth_vendor_randomize_alternate_vendor
       end
     end
@@ -216,7 +212,12 @@ module DocAuthRouter
     IdentityConfig.store.doc_auth_vendor
   end
 
-  def self.randomize?(target_percent, discriminator)
+  def self.randomize?(target_percent, discriminator, analytics)
+    if discriminator.blank?
+      analytics&.idv_doc_auth_randomizer_defaulted
+      return false
+    end
+
     max_sha = (16 ** 64) - 1
     user_value = Digest::SHA256.hexdigest(discriminator).to_i(16).to_f / max_sha * 100
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -44,6 +44,7 @@ module Idv
 
         doc_auth_vendor = DocAuthRouter.doc_auth_vendor(
           discriminator: flow_session[document_capture_session_uuid_key],
+          analytics: @flow.analytics,
         )
 
         component_attributes = {

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -108,8 +108,25 @@ RSpec.describe DocAuthRouter do
           or match({ 'test2' => iterations })
       end
 
-      it 'doc_auth_vendor returns an exception when called without a session_id when randomized' do
-        expect { DocAuthRouter.doc_auth_vendor(discriminator: nil) }.to raise_error
+      it 'doc_auth_vendor returns the default when called without a session_id when randomized' do
+        doc_auth_vendor = 'acuant'
+        doc_auth_vendor_randomize_alternate_vendor = 'lexisnexis'
+        doc_auth_vendor_randomize_percent = 35
+
+        allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
+        allow(IdentityConfig.store).to receive(:doc_auth_vendor_randomize_alternate_vendor).
+          and_return(doc_auth_vendor_randomize_alternate_vendor)
+        allow(IdentityConfig.store).to receive(:doc_auth_vendor_randomize_percent).
+          and_return(doc_auth_vendor_randomize_percent)
+
+        results = []
+        iterations.times do |i|
+          client = DocAuthRouter.client(vendor_discriminator: nil).client
+          results.push(client.class.to_s)
+        end
+
+        expect(results.tally['DocAuth::LexisNexis::LexisNexisClient'] || 0).
+          to be_within(iterations * percent_variance).of(0)
       end
 
       it 'client returns randomized vendors when configured' do


### PR DESCRIPTION
Workaround for the case where the discriminator is nil for whatever
reason. In this case the check will return the default vendor and log an
event that this occurred.