### PR TITLE
Fix 500 error when handling invalid state in SSN step

### DIFF
--- a/app/services/idv/actions/cancel_update_ssn_action.rb
+++ b/app/services/idv/actions/cancel_update_ssn_action.rb
@@ -2,7 +2,7 @@ module Idv
   module Actions
     class CancelUpdateSsnAction < Idv::Steps::DocAuthBaseStep
       def call
-        mark_step_complete(:ssn) if flow_session[:pii_from_doc][:ssn]
+        mark_step_complete(:ssn) if flow_session.dig(:pii_from_doc, :ssn)
       end
     end
   end

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -11,7 +11,7 @@ module Idv
 
       def extra_view_variables
         {
-          updating_ssn: flow_session[:pii_from_doc][:ssn].present?,
+          updating_ssn: flow_session.dig(:pii_from_doc, :ssn).present?,
         }
       end
 


### PR DESCRIPTION
Fixes a 500 from [New Relic](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=3f08d13b-64f5-5b0e-bb2c-5a502ff37af6)