### PR TITLE
Fix format validation of OTPs when input type is not number

### DIFF
--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -21,7 +21,7 @@ class OtpVerificationForm
   end
 
   def pattern_matching_otp_code_format
-    if IdentityConfig.store.enable_numeric_authentication_otp
+    if IdentityConfig.store.enable_numeric_authentication_otp_input
       /\A[0-9]{#{otp_code_length}}\z/i
     else
       /\A[a-z0-9]{#{otp_code_length}}\z/i


### PR DESCRIPTION
Fixes a small bug where we may have been validating strictly numeric when still sending alphanumeric in the 50/50 deploy state