### PR TITLE
[LG-6798] Persist the VA Authorization Code during the inherited proofing process

### DIFF
--- a/app/controllers/concerns/inherited_proofing_concern.rb
+++ b/app/controllers/concerns/inherited_proofing_concern.rb
@@ -1,0 +1,30 @@
+# Methods to aid in handling incoming requests from 3rd-party
+# inherited proofing service providers. Exclusively, methods
+# to handle and help manage incoming requests to create a
+# Login.gov account.
+module InheritedProofingConcern
+  extend ActiveSupport::Concern
+
+  # Department of Veterans Affairs (VA) methods.
+  # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Inherited%20Proofing/MHV%20Inherited%20Proofing/inherited-proofing-interface.md
+
+  # Returns true if the incoming request has been identified as a
+  # request to create a Login.gov account via inherited proofing
+  # from the VA.
+  def va_inherited_proofing?
+    va_inherited_proofing_auth_code.present?
+  end
+
+  # The VA calls Login.gov to initiate inherited proofing of their
+  # users. An authorization code is passed as a query param that needs to
+  # be used in subsequent requests; this method returns this authorization
+  # code.
+  def va_inherited_proofing_auth_code
+    @va_inherited_proofing_auth_code ||=
+      decorated_session.request_url_params[va_inherited_proofing_auth_code_params_key]
+  end
+
+  def va_inherited_proofing_auth_code_params_key
+    'inherited_proofing_auth'
+  end
+end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -6,6 +6,7 @@ module OpenidConnect
     include SecureHeadersConcern
     include AuthorizationCountConcern
     include BillableEventTrackable
+    include InheritedProofingConcern
 
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :validate_authorize_form, only: [:index]

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -118,7 +118,17 @@ class ServiceProviderSessionDecorator
   end
 
   def irs_attempts_api_session_id
-    @irs_attempts_api_session_id ||= request_params['irs_attempts_api_session_id']
+    @irs_attempts_api_session_id ||= request_url_params['irs_attempts_api_session_id']
+  end
+
+  def request_url_params
+    @request_url_params ||= begin
+      if request_url.present?
+        UriService.params(request_url)
+      else
+        {}
+      end
+    end
   end
 
   private
@@ -142,16 +152,6 @@ class ServiceProviderSessionDecorator
   end
 
   def authorize_form
-    OpenidConnectAuthorizeForm.new(request_params)
-  end
-
-  def request_params
-    @request_params ||= begin
-      if request_url.present?
-        UriService.params(request_url)
-      else
-        {}
-      end
-    end
+    OpenidConnectAuthorizeForm.new(request_url_params)
   end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -434,6 +434,28 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
 
+      context 'with an inherited_proofing_auth code' do
+        before do
+          params[inherited_proofing_auth_key] = inherited_proofing_auth_value
+          action
+        end
+
+        let(:inherited_proofing_auth_key) { 'inherited_proofing_auth' }
+        let(:inherited_proofing_auth_value) { SecureRandom.hex }
+        let(:decorated_session) { controller.view_context.decorated_session }
+
+        it 'persists the inherited_proofing_auth value' do
+          expect(decorated_session.request_url_params[inherited_proofing_auth_key]).to \
+            eq inherited_proofing_auth_value
+        end
+
+        it 'redirects to SP landing page with the request_id in the params' do
+          sp_request_id = ServiceProviderRequestProxy.last.uuid
+
+          expect(response).to redirect_to new_user_session_url(request_id: sp_request_id)
+        end
+      end
+
       it 'redirects to SP landing page with the request_id in the params' do
         action
         sp_request_id = ServiceProviderRequestProxy.last.uuid

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -288,4 +288,24 @@ RSpec.describe ServiceProviderSessionDecorator do
       end
     end
   end
+
+  describe '#request_url_params' do
+    context 'without url params' do
+      it 'returns an empty hash' do
+        expect(subject.request_url_params).to eq({})
+      end
+    end
+
+    context 'with url params' do
+      let(:service_provider_request) do
+        url = 'https://example.com/auth?param0=p0&param1=p1&param2=p2'
+        ServiceProviderRequest.new(url: url)
+      end
+      let(:expected_hash) { { 'param0' => 'p0', 'param1' => 'p1', 'param2' => 'p2' } }
+
+      it 'returns the url parameters' do
+        expect(subject.request_url_params).to eq(expected_hash)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When the VA initiates inherited proofing with Login.gov, it passes an auth code that is necessary for subsequent requests to the VA. This change simply retrieves the auto code and persists it for subsequent requests.


https://cm-jira.usa.gov/browse/LG-6798

https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Inherited%20Proofing/MHV%20Inherited%20Proofing/inherited-proofing-interface.md