### PR TITLE
Show "Come Back Later" as final screen with GPO + IPP

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -43,10 +43,10 @@ module Api
       end
 
       def completion_url(result, user)
-        if in_person_enrollment?(user)
-          idv_in_person_ready_to_verify_url
-        elsif result.extra[:profile_pending]
+        if result.extra[:profile_pending]
           idv_come_back_later_url
+        elsif in_person_enrollment?(user)
+          idv_in_person_ready_to_verify_url
         elsif current_sp
           sign_up_completed_url
         else

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -33,12 +33,12 @@ module Idv
     end
 
     def next_step
-      if in_person_enrollment?
+      if pending_profile? && idv_session.address_verification_mechanism == 'gpo'
+        idv_come_back_later_url
+      elsif in_person_enrollment?
         idv_in_person_ready_to_verify_url
       elsif session[:sp] && !pending_profile?
         sign_up_completed_url
-      elsif pending_profile? && idv_session.address_verification_mechanism == 'gpo'
-        idv_come_back_later_url
       else
         after_sign_in_path_for(current_user)
       end

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -94,6 +94,19 @@ describe Api::Verify::PasswordConfirmController do
 
           expect(JSON.parse(response.body)['completion_url']).to eq(idv_come_back_later_url)
         end
+
+        context 'with in person profile' do
+          before do
+            ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+          end
+
+          it 'creates a profile and returns completion url' do
+            post :create, params: { password: password, user_bundle_token: jwt }
+
+            expect(JSON.parse(response.body)['completion_url']).to eq(idv_come_back_later_url)
+          end
+        end
       end
 
       context 'with gpo_code returned from form submission and reveal gpo feature enabled' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -185,6 +185,19 @@ describe Idv::PersonalKeyController do
 
         expect(response).to redirect_to idv_come_back_later_path
       end
+
+      context 'with in person profile' do
+        before do
+          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        end
+
+        it 'creates a profile and returns completion url' do
+          patch :update
+
+          expect(response).to redirect_to idv_come_back_later_path
+        end
+      end
     end
 
     context 'with in person profile' do

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'In Person Proofing', js: true do
   end
 
   context 'verify address by mail (GPO letter)' do
-    it 'concludes with "come back later" screen', allow_browser_log: true do
+    it 'requires address verification before showing instructions', allow_browser_log: true do
       begin_in_person_proofing
       complete_all_in_person_proofing_steps
       click_on t('idv.troubleshooting.options.verify_by_mail')
@@ -101,6 +101,8 @@ RSpec.describe 'In Person Proofing', js: true do
 
       expect(page).to have_content(t('idv.titles.come_back_later'))
       expect(page).to have_current_path(idv_come_back_later_path)
+
+      # WILLFIX: After LG-6897, assert that "Ready to Verify" content is shown after code entry.
     end
   end
 end

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -70,16 +70,11 @@ RSpec.describe 'In Person Proofing' do
 
     # phone page
     expect(page).to have_content(t('idv.titles.session.phone'))
-    fill_out_phone_form_mfa_phone(user)
-    click_idv_continue
-    verify_phone_otp
+    complete_phone_step(user)
 
     # password confirm page
-    expect(page).to have_content(
-      t('idv.titles.session.review', app_name: APP_NAME),
-    )
-    fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
-    click_idv_continue
+    expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+    complete_review_step(user)
 
     # personal key page
     expect(page).to have_content(t('titles.idv.personal_key'))

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -60,7 +60,7 @@ module IdvStepHelper
     end
   end
 
-  def complete_review_step(user)
+  def complete_review_step(user = user_with_2fa)
     password = user.password || user_password
     fill_in 'Password', with: password
     click_idv_continue

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -1,4 +1,8 @@
+require_relative 'doc_auth_helper'
+
 module InPersonHelper
+  include DocAuthHelper
+
   GOOD_FIRST_NAME = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
   GOOD_LAST_NAME = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
   GOOD_DOB = Idp::Constants::MOCK_IDV_APPLICANT[:dob]
@@ -28,5 +32,14 @@ module InPersonHelper
     fill_in t('in_person_proofing.form.address.zipcode'), with: GOOD_ZIPCODE
     select GOOD_STATE, from: t('in_person_proofing.form.address.state')
     choose t('in_person_proofing.form.address.same_address_choice_yes')
+  end
+
+  def begin_in_person_proofing_session(user = user_with_2fa)
+    sign_in_and_2fa_user(user)
+    complete_doc_auth_steps_before_document_capture_step
+    mock_doc_auth_attention_with_barcode
+    attach_and_submit_images
+
+    click_button t('idv.troubleshooting.options.verify_in_person')
   end
 end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -34,12 +34,48 @@ module InPersonHelper
     choose t('in_person_proofing.form.address.same_address_choice_yes')
   end
 
-  def begin_in_person_proofing_session(user = user_with_2fa)
+  def begin_in_person_proofing(user = user_with_2fa)
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_document_capture_step
     mock_doc_auth_attention_with_barcode
     attach_and_submit_images
 
     click_button t('idv.troubleshooting.options.verify_in_person')
+  end
+
+  def complete_location_step(_user = user_with_2fa)
+    click_idv_continue
+  end
+
+  def complete_prepare_step(_user = user_with_2fa)
+    click_link t('forms.buttons.continue')
+  end
+
+  def complete_state_id_step(_user = user_with_2fa)
+    fill_out_state_id_form_ok
+    click_idv_continue
+  end
+
+  def complete_address_step(_user = user_with_2fa)
+    fill_out_address_form_ok
+    click_idv_continue
+  end
+
+  def complete_ssn_step(_user = user_with_2fa)
+    fill_out_ssn_form_ok
+    click_idv_continue
+  end
+
+  def complete_verify_step(_user = user_with_2fa)
+    click_idv_continue
+  end
+
+  def complete_all_in_person_proofing_steps(user = user_with_2fa)
+    complete_location_step(user)
+    complete_prepare_step(user)
+    complete_state_id_step(user)
+    complete_address_step(user)
+    complete_ssn_step(user)
+    complete_verify_step(user)
   end
 end


### PR DESCRIPTION
**Why**: A user who completes the in-person proofing flow while opting to verify their address by receiving a letter (GPO) should be shown the "Come Back Later" screen at the conclusion of the flow, and not be shown instructions directing them to proof in person.

This is a correction to the behavior implemented in #6576. Previously, a user would always be redirected to "Ready to verify", regardless of how they had selected to verify their address.