### PR TITLE
Jskinner lg5949 analytics events 28

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -40,7 +40,8 @@ module SamlIdpAuthConcern
 
     return if @result.success?
 
-    analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
+    #analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
+    analytics.saml_auth(@result.to_h)
     render 'saml_idp/auth/error', status: :bad_request
   end
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -40,7 +40,6 @@ module SamlIdpAuthConcern
 
     return if @result.success?
 
-    #analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
     analytics.saml_auth(@result.to_h)
     render 'saml_idp/auth/error', status: :bad_request
   end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -40,7 +40,7 @@ module SamlIdpAuthConcern
 
     return if @result.success?
 
-    analytics.saml_auth(@result.to_h)
+    analytics.saml_auth(**@result.to_h)
     render 'saml_idp/auth/error', status: :bad_request
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -120,7 +120,7 @@ class SamlIdpController < ApplicationController
       finish_profile: profile_needs_verification?,
       requested_ial: requested_ial,
     )
-    analytics.saml_auth(analytics_payload)
+    analytics.saml_auth(**analytics_payload)
   end
 
   def log_external_saml_auth_request

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -120,7 +120,7 @@ class SamlIdpController < ApplicationController
       finish_profile: profile_needs_verification?,
       requested_ial: requested_ial,
     )
-    analytics.track_event(Analytics::SAML_AUTH, analytics_payload)
+    analytics.saml_auth(analytics_payload)
   end
 
   def log_external_saml_auth_request

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -20,7 +20,6 @@ module Users
     def create
       generate_codes
       result = BackupCodeSetupForm.new(current_user).submit
-      #analytics.track_event(Analytics::BACKUP_CODE_SETUP_VISIT, result.to_h)
       analytics.backup_code_setup_visit(result.to_h)
       save_backup_codes
       track_backup_codes_created

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -20,7 +20,8 @@ module Users
     def create
       generate_codes
       result = BackupCodeSetupForm.new(current_user).submit
-      analytics.track_event(Analytics::BACKUP_CODE_SETUP_VISIT, result.to_h)
+      #analytics.track_event(Analytics::BACKUP_CODE_SETUP_VISIT, result.to_h)
+      analytics.backup_code_setup_visit(result.to_h)
       save_backup_codes
       track_backup_codes_created
     end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -20,7 +20,7 @@ module Users
     def create
       generate_codes
       result = BackupCodeSetupForm.new(current_user).submit
-      analytics.backup_code_setup_visit(result.to_h)
+      analytics.backup_code_setup_visit(**result.to_h)
       save_backup_codes
       track_backup_codes_created
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -59,7 +59,7 @@ module Users
     end
 
     def timeout
-      analytics.track_event(Analytics::SESSION_TIMED_OUT)
+      analytics.session_timed_out
       request_id = sp_session[:request_id]
       sign_out
       flash[:info] = t(

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -139,7 +139,7 @@ class Analytics
   BACKUP_CODE_DELETED = 'Backup Code Delete'
   BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
   BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'
-  SAML_AUTH = 'SAML Auth'
+  #SAML_AUTH = 'SAML Auth'
   #SESSION_TIMED_OUT = 'Session Timed Out'
   SP_REDIRECT_INITIATED = 'SP redirect initiated'
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -137,7 +137,7 @@ class Analytics
 
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
   BACKUP_CODE_DELETED = 'Backup Code Delete'
-  BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
+  #BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
   BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'
   #SAML_AUTH = 'SAML Auth'
   #SESSION_TIMED_OUT = 'Session Timed Out'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -136,11 +136,6 @@ class Analytics
   end
 
   DOC_AUTH = 'Doc Auth' # visited or submitted is appended
-  BACKUP_CODE_DELETED = 'Backup Code Delete'
-  #BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
-  BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'
-  #SAML_AUTH = 'SAML Auth'
-  #SESSION_TIMED_OUT = 'Session Timed Out'
   SP_REDIRECT_INITIATED = 'SP redirect initiated'
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'
   THROTTLER_RATE_LIMIT_TRIGGERED = 'Throttler Rate Limit Triggered'

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -140,7 +140,7 @@ class Analytics
   BACKUP_CODE_SETUP_VISIT = 'Backup Code Setup Visited'
   BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'
   SAML_AUTH = 'SAML Auth'
-  SESSION_TIMED_OUT = 'Session Timed Out'
+  #SESSION_TIMED_OUT = 'Session Timed Out'
   SP_REDIRECT_INITIATED = 'SP redirect initiated'
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'
   THROTTLER_RATE_LIMIT_TRIGGERED = 'Throttler Rate Limit Triggered'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -173,6 +173,11 @@ module AnalyticsEvents
     )
   end
 
+  # Track user creating new BackupCodeSetupForm, record form submission Hash
+  def backup_code_setup_visit(form_submit)
+    track_event('Backup Code Setup Visited', form_submit)
+  end
+
   # A user that has been banned from an SP has authenticated, they are redirected
   # to a page showing them that they have been banned
   def banned_user_redirect

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1840,6 +1840,11 @@ module AnalyticsEvents
     )
   end
 
+  # Record SAML authentication payload Hash
+  def saml_auth(analytics_payload)
+    track_event('SAML Auth', analytics_payload)
+  end
+
   # @param [Integer] requested_ial
   # @param [String] service_provider
   # An external request for SAML Authentication was received

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -174,8 +174,19 @@ module AnalyticsEvents
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash
-  def backup_code_setup_visit(form_submit)
-    track_event('Backup Code Setup Visited', form_submit)
+  def backup_code_setup_visit(
+    success:,
+    errors: nil,
+    error_details: nil,
+    **extra
+  )
+    track_event(
+      'Backup Code Setup Visited',
+      success: success,
+      errors: errors,
+      error_details: error_details,
+      **extra
+    )
   end
 
   # A user that has been banned from an SP has authenticated, they are redirected
@@ -1846,8 +1857,25 @@ module AnalyticsEvents
   end
 
   # Record SAML authentication payload Hash
-  def saml_auth(analytics_payload)
-    track_event('SAML Auth', analytics_payload)
+  def saml_auth(
+    success:,
+    errors:,
+    nameid_format:,
+    authn_context:,
+    authn_context_comparison:,
+    service_provider:,
+    **extra
+  )
+    track_event(
+      'SAML Auth',
+      success: success,
+      errors: errors,
+      nameid_format: nameid_format,
+      authn_context: authn_context,
+      authn_context_comparison: authn_context_comparison,
+      service_provider: service_provider,
+      **extra
+    )
   end
 
   # @param [Integer] requested_ial

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -185,7 +185,7 @@ module AnalyticsEvents
       success: success,
       errors: errors,
       error_details: error_details,
-      **extra
+      **extra,
     )
   end
 
@@ -1874,7 +1874,7 @@ module AnalyticsEvents
       authn_context: authn_context,
       authn_context_comparison: authn_context_comparison,
       service_provider: service_provider,
-      **extra
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -174,6 +174,9 @@ module AnalyticsEvents
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Hash] error_details
   def backup_code_setup_visit(
     success:,
     errors: nil,
@@ -1857,6 +1860,12 @@ module AnalyticsEvents
   end
 
   # Record SAML authentication payload Hash
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] nameid_format
+  # @param [Array] authn_context
+  # @param [String] authn_context_comparison
+  # @param [String] service_provider
   def saml_auth(
     success:,
     errors:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1863,6 +1863,11 @@ module AnalyticsEvents
     track_event('Session Kept Alive')
   end
 
+  # tracks if the session timed out
+  def session_timed_out
+    track_event('Session Timed Out')
+  end
+
   # tracks when a user's session is timed out
   def session_total_duration_timeout
     track_event('User Maximum Session Length Exceeded')

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -541,7 +541,7 @@ describe SamlIdpController do
                requested_ial: authn_context,
                service_provider: sp1_issuer)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SAML_AUTH,
+          with('SAML Auth',
                success: true,
                errors: {},
                nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
@@ -698,7 +698,7 @@ describe SamlIdpController do
                requested_ial: 'ialmax',
                service_provider: sp1_issuer)
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SAML_AUTH,
+          with('SAML Auth',
                success: true,
                errors: {},
                nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
@@ -756,7 +756,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -866,7 +866,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -909,7 +909,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -1144,7 +1144,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -1179,7 +1179,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
 
       it 'defaults to email when added to issuers_with_email_nameid_format' do
@@ -1212,7 +1212,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -1241,7 +1241,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -1282,7 +1282,7 @@ describe SamlIdpController do
 
         expect(name_id.children.first.to_s).to eq(user.agency_identities.last.uuid)
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
 
       it 'sends the appropriate identifier for email NameID SPs' do
@@ -1312,7 +1312,7 @@ describe SamlIdpController do
 
         expect(name_id.children.first.to_s).to eq(user.email_addresses.first.email)
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
 
       it 'sends the old user ID for legacy SPS' do
@@ -1342,7 +1342,7 @@ describe SamlIdpController do
 
         expect(name_id.children.first.to_s).to eq(user.id.to_s)
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
       end
     end
 
@@ -1832,7 +1832,7 @@ describe SamlIdpController do
                requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000')
         expect(@analytics).to receive(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+          with('SAML Auth', analytics_hash)
 
         get :auth
       end
@@ -1873,7 +1873,7 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000')
-        expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
+        expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(
             Analytics::SP_REDIRECT_INITIATED,
@@ -1910,7 +1910,7 @@ describe SamlIdpController do
           with('SAML Auth Request',
                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                service_provider: 'http://localhost:3000')
-        expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
+        expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).
           with(
             Analytics::SP_REDIRECT_INITIATED,

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -180,7 +180,7 @@ describe Users::SessionsController, devise: true do
       stub_analytics
       sign_in_as_user
 
-      expect(@analytics).to receive(:track_event).with(Analytics::SESSION_TIMED_OUT)
+      expect(@analytics).to receive(:track_event).with('Session Timed Out')
 
       get :timeout
     end


### PR DESCRIPTION
LG-5949
https://cm-jira.usa.gov/browse/LG-5949
analytics events number 28, replaces these 5 constants with methods:

1. BACKUP_CODE_DELETED
2. BACKUP_CODE_SETUP_VISIT
3. BACKUP_CODE_SETUP_SUBMITTED
4. SAML_AUTH
5. SESSION_TIMED_OUT

Found that numbers 1 and 3 were not used; these were simply removed.

Tested with:
```
bundle exec rspec spec/controllers/users/backup_code_setup_controller_spec.rb
bundle exec rspec spec/controllers/saml_idp_controller_spec.rb
bundle exec rspec spec/controllers/users/sessions_controller_spec.rb
```
