### PR TITLE
Add alt attribute for "Ready to verify" illustration

### DIFF
--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -14,6 +14,7 @@
       width: 136,
       height: 136,
       class: 'display-block margin-x-auto margin-bottom-4',
+      alt: '',
     ) %>
 
 <%= render PageHeadingComponent.new(class: 'text-center') do %>

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'axe-rspec'
 
 RSpec.describe 'In Person Proofing', js: true do
   include IdvStepHelper
@@ -89,6 +90,7 @@ RSpec.describe 'In Person Proofing', js: true do
     end
 
     # ready to verify page
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
     enrollment_code = JSON.parse(UspsIppFixtures.request_enroll_response)['enrollmentCode']
     expect(page).to have_content(t('in_person_proofing.headings.barcode'))
     expect(page).to have_content(Idv::InPerson::EnrollmentCodeFormatter.format(enrollment_code))


### PR DESCRIPTION
**Why**: Every image should include an alt value.

This image:

![image](https://user-images.githubusercontent.com/1779930/179608832-63784501-7fe5-4b61-986b-6b88984883a4.png)


Setting as draft because we need to decide whether this should be treated as a [decorative image](https://www.w3.org/WAI/tutorials/images/decorative/) or whether we need to create content to use as [text alternative](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html).