### PR TITLE
Do not require a second MFA if multiple are selected and one is set up

### DIFF
--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -51,7 +51,12 @@ module Users
 
     def process_valid_form
       user_session[:mfa_selections] = @two_factor_options_form.selection
-      redirect_to confirmation_path(user_session[:mfa_selections].first)
+
+      if user_session[:mfa_selections].first.present?
+        redirect_to confirmation_path(user_session[:mfa_selections].first)
+      else
+        redirect_to after_mfa_setup_path
+      end
     end
 
     def two_factor_options_form_params

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -141,39 +141,6 @@ feature 'Multi Two Factor Authentication' do
     end
   end
 
-  scenario 'redirects to the second_mfa path with an error' do
-    sign_in_before_2fa
-
-    expect(current_path).to eq authentication_methods_setup_path
-
-    click_2fa_option('backup_code')
-
-    click_continue
-
-    expect(current_path).to eq backup_code_setup_path
-
-    click_continue
-
-    expect(page).to have_link(t('forms.backup_code.download'))
-
-    click_continue
-
-    expect(page).to have_content(t('notices.backup_codes_configured'))
-
-    expect(page).to have_current_path(
-      auth_method_confirmation_path,
-    )
-
-    click_link t('mfa.add')
-
-    expect(page).to have_current_path(second_mfa_setup_path)
-
-    click_continue
-
-    expect(page).
-      to have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
-  end
-
   describe 'user attempts to submit with only the phone MFA method selected', js: true do
     before do
       sign_in_before_2fa

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -36,6 +36,20 @@ describe TwoFactorOptionsForm do
       end
     end
 
+    it 'is unsuccessful if the selection is empty' do
+      result = subject.submit(selection: [])
+
+      expect(result.success?).to eq false
+      expect(result.errors).to include :selection
+    end
+
+    it 'is successful if user has existing method and does not select any options' do
+      create(:phone_configuration, user: user)
+
+      result = subject.submit(selection: [])
+      expect(result.success?).to eq true
+    end
+
     it 'includes analytics hash with a methods count of zero' do
       result = subject.submit(selection: 'piv_cac')
 


### PR DESCRIPTION
If a person selects setting up multiple MFA, and later changes their mind or is unable to set up a method following the first, they may be unable to continue with account setup unless they set up another MFA