### PR TITLE
LG-6809: IRS Attempt API controller skips CSRF protection

### DIFF
--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -6,6 +6,7 @@
 #
 module Api
   class IrsAttemptsApiController < ApplicationController
+    skip_before_action :verify_authenticity_token
     before_action :render_404_if_disabled
     before_action :authenticate_client
 

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe Api::IrsAttemptsApiController do
   let(:existing_event_jtis) { existing_events.map(&:first) }
 
   describe '#create' do
+    context 'with CSRF protection enabled' do
+      around do |ex|
+        ActionController::Base.allow_forgery_protection = true
+        ex.run
+        ActionController::Base.allow_forgery_protection = false
+      end
+
+      it 'allows authentication without error' do
+        request.headers['Authorization'] = "Bearer #{auth_token}"
+        post :create, params: {}
+
+        expect(response.status).to eq(200)
+      end
+    end
+
     it 'renders a 404 if disabled' do
       allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(false)
 

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Api::IrsAttemptsApiController do
       around do |ex|
         ActionController::Base.allow_forgery_protection = true
         ex.run
+      ensure
         ActionController::Base.allow_forgery_protection = false
       end
 

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
   let(:irs_attempt_api_public_key) { irs_attempt_api_private_key.public_key }
 
   before do
-    encoded_pubic_key = Base64.strict_encode64(irs_attempt_api_public_key.to_der)
+    encoded_public_key = Base64.strict_encode64(irs_attempt_api_public_key.to_der)
     allow(IdentityConfig.store).to receive(:irs_attempt_api_public_key).
-                                   and_return(encoded_pubic_key)
+                                   and_return(encoded_public_key)
   end
 
   let(:jti) { 'test-unique-id' }


### PR DESCRIPTION
**Why:** This is an API endpoint not using cookies, and doesn't actually work as-is without this change. Adds a test to prevent regression. (Kudos to Osman for catching this issue.)

Also sneaks in a minor typo fix in another test.

[skip changelog] because this is a temporary special-purpose endpoint. Is this the appropriate way to go with these, or should I code it as a bug fix?