### PR TITLE
Remove documentation for params that don't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ public/api/_analytics-events.json: .yardoc .yardoc/objects/root.dat
 
 .yardoc .yardoc/objects/root.dat: app/services/analytics_events.rb
 	bundle exec yard doc \
+		--fail-on-warning \
 		--type-tag identity.idp.previous_event_name:"Previous Event Name" \
 		--no-output \
 		--db $@ \

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2014,7 +2014,6 @@ module AnalyticsEvents
   end
 
   # Tracks when user's piv cac setup
-  # @param [Integer] enabled_mfa_methods_count
   def user_registration_piv_cac_setup_visit(**extra)
     track_event(
       'User Registration: piv cac setup visited',
@@ -2144,7 +2143,6 @@ module AnalyticsEvents
   # @param [Boolean] throttled
   # @param [Hash] errors
   # @param [Hash] error_details
-  # @param [Boolean] email_already_exists
   # @param [String] user_id
   # @param [String] domain_name
   def user_registration_email(


### PR DESCRIPTION
- Also updates yardoc commant to fail on warning (catch these earlier)

