### PR TITLE
Log mfa methods metrics when user finishes MFA setup

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2060,6 +2060,30 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success
+  # @param [Hash] mfa_method_counts
+  # @param [Integer] enabled_mfa_methods_count
+  # @param [Hash] pii_like_keypaths
+  # Tracks when a user has completed MFA setup
+  def user_registration_mfa_setup_complete(
+    success:,
+    mfa_method_counts:,
+    enabled_mfa_methods_count:,
+    pii_like_keypaths:,
+    **extra
+  )
+    track_event(
+      'User Registration: MFA Setup Complete',
+      {
+        success: success,
+        mfa_method_counts: mfa_method_counts,
+        enabled_mfa_methods_count: enabled_mfa_methods_count,
+        pii_like_keypaths: pii_like_keypaths,
+        **extra,
+      }.compact,
+    )
+  end
+
   # Tracks when user's piv cac is disabled
   def user_registration_piv_cac_disabled
     track_event('User Registration: piv cac disabled')

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -93,6 +93,15 @@ describe Users::WebauthnSetupController do
             platform_authenticator: false,
           )
 
+        expect(@analytics).to receive(:track_event).
+          with(
+            'User Registration: MFA Setup Complete',
+            enabled_mfa_methods_count: 3,
+            mfa_method_counts: { auth_app: 1, phone: 1, webauthn: 1 },
+            pii_like_keypaths: [[:mfa_method_counts, :phone]],
+            success: true,
+          )
+
         patch :confirm, params: params
       end
     end


### PR DESCRIPTION
To be able to better understand how users are using the new multi-MFA process