### PR TITLE
use Analytics instead of IdentityJobLogSubscriber to log GetUspsProofingResultsJob events

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -52,6 +52,10 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   private
 
+  def analytics
+    @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
+  end
+
   def handle_bad_request_error(err, enrollment)
     case err.response&.[](:body)&.[]('responseMessage')
     when IPP_INCOMPLETE_ERROR_MESSAGE
@@ -60,79 +64,60 @@ class GetUspsProofingResultsJob < ApplicationJob
       # Customer's IPP enrollment has expired
       enrollment.update(status: :expired)
     else
-      IdentityJobLogSubscriber.logger.warn(
-        {
-          name: 'get_usps_proofing_results_job.errors.request_exception',
-          enrollment_id: enrollment.id,
-          exception: {
-            class: err.class.to_s,
-            message: err.message,
-            backtrace: err.backtrace,
-          },
-        }.to_json,
+      analytics.idv_in_person_usps_proofing_results_job_exception(
+        reason: 'Request exception',
+        enrollment_id: enrollment.id,
+        exception_class: err.class.to_s,
+        exception_message: err.message,
       )
     end
   end
 
   def handle_standard_error(err, enrollment)
-    IdentityJobLogSubscriber.logger.error(
-      {
-        name: 'get_usps_proofing_results_job.errors.request_exception',
-        enrollment_id: enrollment.id,
-        exception: {
-          class: err.class.to_s,
-          message: err.message,
-          backtrace: err.backtrace,
-        },
-      }.to_json,
+    analytics.idv_in_person_usps_proofing_results_job_exception(
+      reason: 'Request exception',
+      enrollment_id: enrollment.id,
+      exception_class: err.class.to_s,
+      exception_message: err.message,
     )
   end
 
   def handle_response_is_not_a_hash(enrollment)
-    IdentityJobLogSubscriber.logger.error(
-      {
-        name: 'get_usps_proofing_results_job.errors.bad_response_structure',
-        enrollment_id: enrollment.id,
-      }.to_json,
+    analytics.idv_in_person_usps_proofing_results_job_exception(
+      reason: 'Bad response structure',
+      enrollment_id: enrollment.id,
     )
   end
 
   def handle_unsupported_status(enrollment, status)
-    IdentityJobLogSubscriber.logger.error(
-      {
-        name: 'get_usps_proofing_results_job.errors.unsupported_status',
-        enrollment_id: enrollment.id,
-        status: status,
-      }.to_json,
+    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+      reason: 'Unsupported status',
+      enrollment_id: enrollment.id,
+      status: status,
     )
   end
 
   def handle_unsupported_id_type(enrollment, primary_id_type)
-    IdentityJobLogSubscriber.logger.warn(
-      {
-        name: 'get_usps_proofing_results_job.errors.unsupported_id_type',
-        enrollment_id: enrollment.id,
-        primary_id_type: primary_id_type,
-      }.to_json,
+    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+      reason: 'Unsupported ID type',
+      enrollment_id: enrollment.id,
+      primary_id_type: primary_id_type,
     )
   end
 
   def handle_failed_status(enrollment, response)
-    IdentityJobLogSubscriber.logger.warn(
-      {
-        name: 'get_usps_proofing_results_job.errors.failed_status',
-        enrollment_id: enrollment.id,
-        failure_reason: response['failureReason'],
-        fraud_suspected: response['fraudSuspected'],
-        primary_id_type: response['primaryIdType'],
-        proofing_city: response['proofingCity'],
-        proofing_confirmation_number: response['proofingConfirmationNumber'],
-        proofing_post_office: response['proofingPostOffice'],
-        proofing_state: response['proofingState'],
-        secondary_id_type: response['secondaryIdType'],
-        transaction_end_date_time: response['transactionEndDateTime'],
-        transaction_start_date_time: response['transactionStartDateTime'],
-      }.to_json,
+    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+      reason: 'Failed status',
+      enrollment_id: enrollment.id,
+      failure_reason: response['failureReason'],
+      fraud_suspected: response['fraudSuspected'],
+      primary_id_type: response['primaryIdType'],
+      proofing_city: response['proofingCity'],
+      proofing_post_office: response['proofingPostOffice'],
+      proofing_state: response['proofingState'],
+      secondary_id_type: response['secondaryIdType'],
+      transaction_end_date_time: response['transactionEndDateTime'],
+      transaction_start_date_time: response['transactionStartDateTime'],
     )
   end
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -52,8 +52,8 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   private
 
-  def analytics
-    @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
+  def analytics(user: AnonymousUser.new)
+    Analytics.new(user: user, request: nil, session: {}, sp: nil)
   end
 
   def handle_bad_request_error(err, enrollment)
@@ -64,7 +64,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       # Customer's IPP enrollment has expired
       enrollment.update(status: :expired)
     else
-      analytics.idv_in_person_usps_proofing_results_job_exception(
+      analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_exception(
         reason: 'Request exception',
         enrollment_id: enrollment.id,
         exception_class: err.class.to_s,
@@ -74,7 +74,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def handle_standard_error(err, enrollment)
-    analytics.idv_in_person_usps_proofing_results_job_exception(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_exception(
       reason: 'Request exception',
       enrollment_id: enrollment.id,
       exception_class: err.class.to_s,
@@ -83,14 +83,14 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def handle_response_is_not_a_hash(enrollment)
-    analytics.idv_in_person_usps_proofing_results_job_exception(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_exception(
       reason: 'Bad response structure',
       enrollment_id: enrollment.id,
     )
   end
 
   def handle_unsupported_status(enrollment, status)
-    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_failure(
       reason: 'Unsupported status',
       enrollment_id: enrollment.id,
       status: status,
@@ -98,7 +98,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def handle_unsupported_id_type(enrollment, primary_id_type)
-    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_failure(
       reason: 'Unsupported ID type',
       enrollment_id: enrollment.id,
       primary_id_type: primary_id_type,
@@ -106,7 +106,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def handle_failed_status(enrollment, response)
-    analytics.idv_in_person_usps_proofing_results_job_enrollment_failure(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_failure(
       reason: 'Failed status',
       enrollment_id: enrollment.id,
       failure_reason: response['failureReason'],

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2311,5 +2311,35 @@ module AnalyticsEvents
       **extra,
     )
   end
+
+  # Tracks exceptions that are raised when running GetUspsProofingResultsJob
+  # @param [String] reason why was the exception raised?
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_usps_proofing_results_job_exception(
+    reason:, enrollment_id:, exception_class: nil, exception_message: nil, **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised',
+      reason: reason,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # Tracks individual enrollments that fail during GetUspsProofingResultsJob
+  # @param [String] reason why did this enrollment fail?
+  # @param [String] enrollment_id
+  def idv_in_person_usps_proofing_results_job_enrollment_failure(reason:, enrollment_id:, **extra)
+    track_event(
+      'GetUspsProofingResultsJob: Enrollment failed proofing',
+      reason: reason,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/fixtures/usps_ipp_responses/request_passed_proofing_unsupported_status_results_response.json
+++ b/spec/fixtures/usps_ipp_responses/request_passed_proofing_unsupported_status_results_response.json
@@ -1,0 +1,13 @@
+{
+  "status": "Not supported",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197504352",
+  "primaryIdType": "State driver's license",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346701",
+  "ippAssuranceLevel": "1.5"
+}

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe GetUspsProofingResultsJob do
   include UspsIppHelper
 
   let(:job) { GetUspsProofingResultsJob.new }
+  let(:job_analytics) { FakeAnalytics.new }
+
+  before do
+    allow(job).to receive(:analytics).and_return(job_analytics)
+  end
 
   describe '#perform' do
     describe 'IPP enabled' do
@@ -93,38 +98,28 @@ RSpec.describe GetUspsProofingResultsJob do
         stub_request_failed_proofing_results
 
         allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-              and_return([pending_enrollment])
-
-        # see request_failed_proofing_supported_id_results_response.json
-        expect(IdentityJobLogSubscriber.logger).to receive(:warn).
-            with(
-              satisfy do |event|
-                expect(event).to be_instance_of(String)
-                parsed_event = JSON.parse(event)
-                expect(parsed_event).to be_instance_of(Hash).
-                and include(
-                  'name' => 'get_usps_proofing_results_job.errors.failed_status',
-                  'enrollment_id' => pending_enrollment.id,
-                  'failure_reason' => 'Clerk indicates that ID name or address' \
-                                      ' does not match source data.',
-                  'fraud_suspected' => false,
-                  'primary_id_type' => 'Uniformed Services identification card',
-                  'proofing_city' => 'WILKES BARRE',
-                  'proofing_confirmation_number' => '350040248346707',
-                  'proofing_post_office' => 'WILKES BARRE',
-                  'proofing_state' => 'PA',
-                  'secondary_id_type' => 'Deed of Trust',
-                  'transaction_end_date_time' => '12/17/2020 034055',
-                  'transaction_start_date_time' => '12/17/2020 033855',
-                )
-              end,
-            )
+          and_return([pending_enrollment])
 
         job.perform(Time.zone.now)
 
         pending_enrollment.reload
 
         expect(pending_enrollment.failed?).to be_truthy
+
+        expect(job_analytics).to have_logged_event(
+          'GetUspsProofingResultsJob: Enrollment failed proofing',
+          reason: 'Failed status',
+          enrollment_id: pending_enrollment.id,
+          failure_reason: 'Clerk indicates that ID name or address does not match source data.',
+          fraud_suspected: false,
+          primary_id_type: 'Uniformed Services identification card',
+          proofing_city: 'WILKES BARRE',
+          proofing_post_office: 'WILKES BARRE',
+          proofing_state: 'PA',
+          secondary_id_type: 'Deed of Trust',
+          transaction_end_date_time: '12/17/2020 034055',
+          transaction_start_date_time: '12/17/2020 033855',
+        )
       end
 
       it 'updates enrollment records on 2xx responses with valid JSON' do
@@ -151,26 +146,19 @@ RSpec.describe GetUspsProofingResultsJob do
         stub_request_proofing_results_with_invalid_response
 
         allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-              and_return([pending_enrollment])
-
-        expect(IdentityJobLogSubscriber.logger).to receive(:error).
-            with(
-              satisfy do |event|
-                expect(event).to be_instance_of(String)
-                parsed_event = JSON.parse(event)
-                expect(parsed_event).to be_instance_of(Hash).
-                and include(
-                  'name' => 'get_usps_proofing_results_job.errors.request_exception',
-                  'enrollment_id' => pending_enrollment.id,
-                )
-              end,
-            )
+          and_return([pending_enrollment])
 
         job.perform(Time.zone.now)
 
         pending_enrollment.reload
 
         expect(pending_enrollment.pending?).to be_truthy
+
+        expect(job_analytics).to have_logged_event(
+          'GetUspsProofingResultsJob: Exception raised',
+          reason: 'Request exception',
+          enrollment_id: pending_enrollment.id,
+        )
       end
 
       it 'reports a low-priority error on 4xx responses' do
@@ -178,26 +166,19 @@ RSpec.describe GetUspsProofingResultsJob do
         stub_request_proofing_results_with_responses({ status: 400 })
 
         allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-              and_return([pending_enrollment])
-
-        expect(IdentityJobLogSubscriber.logger).to receive(:warn).
-            with(
-              satisfy do |event|
-                expect(event).to be_instance_of(String)
-                parsed_event = JSON.parse(event)
-                expect(parsed_event).to be_instance_of(Hash).
-                and include(
-                  'name' => 'get_usps_proofing_results_job.errors.request_exception',
-                  'enrollment_id' => pending_enrollment.id,
-                )
-              end,
-            )
+          and_return([pending_enrollment])
 
         job.perform(Time.zone.now)
 
         pending_enrollment.reload
 
         expect(pending_enrollment.pending?).to be_truthy
+
+        expect(job_analytics).to have_logged_event(
+          'GetUspsProofingResultsJob: Exception raised',
+          reason: 'Request exception',
+          enrollment_id: pending_enrollment.id,
+        )
       end
 
       it 'marks enrollments as expired when USPS says they have expired' do
@@ -229,26 +210,19 @@ RSpec.describe GetUspsProofingResultsJob do
         stub_request_proofing_results_with_responses({ status: 500 })
 
         allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-              and_return([pending_enrollment])
-
-        expect(IdentityJobLogSubscriber.logger).to receive(:error).
-            with(
-              satisfy do |event|
-                expect(event).to be_instance_of(String)
-                parsed_event = JSON.parse(event)
-                expect(parsed_event).to be_instance_of(Hash).
-                and include(
-                  'name' => 'get_usps_proofing_results_job.errors.request_exception',
-                  'enrollment_id' => pending_enrollment.id,
-                )
-              end,
-            )
+          and_return([pending_enrollment])
 
         job.perform(Time.zone.now)
 
         pending_enrollment.reload
 
         expect(pending_enrollment.pending?).to be_truthy
+
+        expect(job_analytics).to have_logged_event(
+          'GetUspsProofingResultsJob: Exception raised',
+          reason: 'Request exception',
+          enrollment_id: pending_enrollment.id,
+        )
       end
 
       it 'fails enrollment for unsupported ID types' do
@@ -256,27 +230,20 @@ RSpec.describe GetUspsProofingResultsJob do
         stub_request_passed_proofing_unsupported_id_results
 
         allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-              and_return([pending_enrollment])
-
-        expect(IdentityJobLogSubscriber.logger).to receive(:warn).
-            with(
-              satisfy do |event|
-                expect(event).to be_instance_of(String)
-                parsed_event = JSON.parse(event)
-                expect(parsed_event).to be_instance_of(Hash).
-                and include(
-                  'name' => 'get_usps_proofing_results_job.errors.unsupported_id_type',
-                  'enrollment_id' => pending_enrollment.id,
-                  'primary_id_type' => 'Not supported',
-                )
-              end,
-            )
+          and_return([pending_enrollment])
 
         expect(pending_enrollment.pending?).to be_truthy
 
         job.perform Time.zone.now
 
         expect(pending_enrollment.reload.failed?).to be_truthy
+
+        expect(job_analytics).to have_logged_event(
+          'GetUspsProofingResultsJob: Enrollment failed proofing',
+          reason: 'Unsupported ID type',
+          enrollment_id: pending_enrollment.id,
+          primary_id_type: 'Not supported',
+        )
       end
     end
 

--- a/spec/support/usps_ipp_fixtures.rb
+++ b/spec/support/usps_ipp_fixtures.rb
@@ -31,6 +31,10 @@ class UspsIppFixtures
     load_response_fixture('request_passed_proofing_results_response.json')
   end
 
+  def self.request_passed_proofing_unsupported_status_results_response
+    load_response_fixture('request_passed_proofing_unsupported_status_results_response.json')
+  end
+
   def self.request_in_progress_proofing_results_response
     load_response_fixture('request_in_progress_proofing_results_response.json')
   end

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -39,6 +39,13 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_passed_proofing_unsupported_status_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200,
+      body: UspsIppFixtures.request_passed_proofing_unsupported_status_results_response,
+    )
+  end
+
   def stub_request_passed_proofing_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       status: 200, body: UspsIppFixtures.request_passed_proofing_results_response,


### PR DESCRIPTION
use `Analytics` instead of `IdentityJobLogSubscriber` to log `GetUspsProofingResultsJob` events

**Why**
We typically look for log events in `events.log`, which is logged to via the Analytics class. The `IdentityJobLogSubscriber` is used for logging timing information.