### PR TITLE
run GetUspsProofingResultsJob every 10 minutes

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -1,5 +1,6 @@
 cron_1m = '* * * * *'
 cron_5m = '0/5 * * * *'
+cron_10m = '0/10 * * * *'
 cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT
@@ -209,7 +210,7 @@ else
       # Queue usps proofing job to GoodJob
       get_usps_proofing_results_job: {
         class: 'GetUspsProofingResultsJob',
-        cron: cron_1h,
+        cron: cron_10m,
         args: -> { [Time.zone.now] },
       },
     }


### PR DESCRIPTION
Run the `GetUspsProofingResultsJob` every 10 minutes instead of every hour.

**Why**
I had originally asked that it be set to a very conservative once an hour; having it run every ten minutes will make testing easier.