### PR TITLE
LG-6872: Create USPS barcode using the user's enrollment code

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -96,6 +96,7 @@ module Api
         enrollment = InPersonEnrollment.create!(
           profile: profile,
           user: user,
+          current_address_matches_id: user_session.dig(:idv, :applicant, :same_address_as_id),
           selected_location_details: {
             'name' => 'BALTIMORE — Post Office™',
             'streetAddress' => '900 E FAYETTE ST RM 118',

--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -96,6 +96,26 @@ module Api
         enrollment = InPersonEnrollment.create!(
           profile: profile,
           user: user,
+          selected_location_details: {
+            'name' => 'BALTIMORE — Post Office™',
+            'streetAddress' => '900 E FAYETTE ST RM 118',
+            'city' => 'BALTIMORE',
+            'state' => 'MD',
+            'zip5' => '21233',
+            'zip4' => '9715',
+            'phone' => '555-123-6409',
+            'hours' => [
+              {
+                'weekdayHours' => '8:30 AM - 4:30 PM',
+              },
+              {
+                'saturdayHours' => '9:00 AM - 12:00 PM',
+              },
+              {
+                'sundayHours' => 'Closed',
+              },
+            ],
+          },
         )
 
         enrollment_code = create_usps_enrollment(enrollment)

--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -20,32 +20,7 @@ module Idv
       end
 
       def enrollment
-        InPersonEnrollment.new(
-          user: current_user,
-          enrollment_code: '2048702198804358',
-          created_at: Time.zone.now,
-          current_address_matches_id: true,
-          selected_location_details: {
-            'name' => 'BALTIMORE — Post Office™',
-            'streetAddress' => '900 E FAYETTE ST RM 118',
-            'city' => 'BALTIMORE',
-            'state' => 'MD',
-            'zip5' => '21233',
-            'zip4' => '9715',
-            'phone' => '555-123-6409',
-            'hours' => [
-              {
-                'weekdayHours' => '8:30 AM - 4:30 PM',
-              },
-              {
-                'saturdayHours' => '9:00 AM - 12:00 PM',
-              },
-              {
-                'sundayHours' => 'Closed',
-              },
-            ],
-          },
-        )
+        current_user.pending_in_person_enrollment
       end
     end
   end

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -3,14 +3,12 @@ require 'rails_helper'
 describe Idv::InPerson::ReadyToVerifyController do
   let(:user) { create(:user) }
   let(:in_person_proofing_enabled) { false }
-  let(:enrollment) { nil }
 
   before do
     stub_analytics
     stub_sign_in(user)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
       and_return(in_person_proofing_enabled)
-    allow(controller).to receive(:enrollment).and_return(enrollment)
   end
 
   describe 'before_actions' do
@@ -34,15 +32,8 @@ describe Idv::InPerson::ReadyToVerifyController do
       end
 
       context 'with enrollment' do
+        let(:user) { create(:user, :with_pending_in_person_enrollment) }
         let(:profile) { create(:profile, :with_pii, user: user) }
-        let(:enrollment) do
-          InPersonEnrollment.new(
-            user: user,
-            profile: profile,
-            enrollment_code: '2048702198804358',
-            created_at: Time.zone.now,
-          )
-        end
 
         it 'renders show template' do
           expect(response).to render_template :show

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -2,5 +2,12 @@ FactoryBot.define do
   factory :in_person_enrollment do
     user { association :user, :signed_up }
     profile { association :profile, user: user }
+
+    trait :pending do
+      after :build do |enrollment|
+        enrollment.status = :pending
+        enrollment.enrollment_code = Faker::Number.number(digits: 16)
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -194,7 +194,8 @@ FactoryBot.define do
 
     trait :with_pending_in_person_enrollment do
       after :build do |user|
-        create(:in_person_enrollment, :pending, user: user)
+        profile = create(:profile, :with_pii, user: user)
+        create(:in_person_enrollment, :pending, user: user, profile: profile)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -192,6 +192,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pending_in_person_enrollment do
+      after :build do |user|
+        create(:in_person_enrollment, :pending, user: user)
+      end
+    end
+
     trait :deactivated_password_reset_profile do
       signed_up
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'In Person Proofing', js: true do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(
       ['password_confirm',
-       'personal_key', 'personal_key_confirm'],
+       'personal_key',
+       'personal_key_confirm'],
     )
   end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'In Person Proofing', js: true do
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(
+      ['password_confirm',
+       'personal_key', 'personal_key_confirm'],
+    )
   end
 
   it 'works for a happy path', allow_browser_log: true do
@@ -84,7 +88,7 @@ RSpec.describe 'In Person Proofing', js: true do
     end
 
     # ready to verify page
-    enrollment_code = JSON.parse(UspsIppFixtures.request_enrollment_code_response)['enrollmentCode']
+    enrollment_code = JSON.parse(UspsIppFixtures.request_enroll_response)['enrollmentCode']
     expect(page).to have_content(t('in_person_proofing.headings.barcode'))
     expect(page).to have_content(Idv::InPerson::EnrollmentCodeFormatter.format(enrollment_code))
     expect(page).to have_content(t('in_person_proofing.body.barcode.deadline', deadline: deadline))


### PR DESCRIPTION
#6615 made it so that when a user completes the IPP flow we will create a pending in-person enrollment record with the enrollment code we receive from the USPS. This PR updates the "Ready to verify" page to use that enrollment code rather than using a hard-coded value