### PR TITLE
LG-6949 | Add test for email_and_password_auth event

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -191,7 +191,6 @@ describe Users::SessionsController, devise: true do
     it 'tracks the successful authentication for existing user' do
       user = create(:user, :signed_up)
       subject.session['user_return_to'] = 'http://example.com'
-      email = user.email.upcase
 
       stub_analytics
       analytics_hash = {
@@ -207,9 +206,9 @@ describe Users::SessionsController, devise: true do
         with('Email and Password Authentication', analytics_hash)
 
       expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:email_and_password_auth).
-        with(email: email, success: true)
+        with(email: user.email, success: true)
 
-      post :create, params: { user: { email: email, password: user.password } }
+      post :create, params: { user: { email: user.email, password: user.password } }
     end
 
     it 'tracks the unsuccessful authentication for existing user' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -191,6 +191,7 @@ describe Users::SessionsController, devise: true do
     it 'tracks the successful authentication for existing user' do
       user = create(:user, :signed_up)
       subject.session['user_return_to'] = 'http://example.com'
+      email = user.email.upcase
 
       stub_analytics
       analytics_hash = {
@@ -205,7 +206,10 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with('Email and Password Authentication', analytics_hash)
 
-      post :create, params: { user: { email: user.email.upcase, password: user.password } }
+      expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:email_and_password_auth).
+        with(email: email, success: true)
+
+      post :create, params: { user: { email: email, password: user.password } }
     end
 
     it 'tracks the unsuccessful authentication for existing user' do


### PR DESCRIPTION
Failing to record the event should cause a test failure, but did not.

## Demo

Commenting the call to the tracker out:

```ruby
    def track_authentication_attempt(email)
      user = User.find_with_email(email) || AnonymousUser.new

      success = user_signed_in_and_not_locked_out?(user)
      analytics.email_and_password_auth(
        success: success,
        user_id: user.uuid,
        user_locked_out: user_locked_out?(user),
        stored_location: session['user_return_to'],
        sp_request_url_present: sp_session[:request_url].present?,
        remember_device: remember_device_cookie.present?,
      )
      # irs_attempts_api_tracker.email_and_password_auth(
      #   email: email,
      #   success: success,
      # )
    end
```

This now triggers a failure:

```
RSpec::Mocks::MockExpectationError: Exactly one instance should have received the following message(s) but didn't: email_and_password_auth

  0) Users::SessionsController POST / tracks the successful authentication for existing user
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       Exactly one instance should have received the following message(s) but didn't: email_and_password_auth
      [ ... lengthy backtrace omitted ...]
    tracks the successful authentication for existing user (FAILED - 1)
```