### PR TITLE
Add additional dimensions to telephony-based one-time passcode verification attempts

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -87,10 +87,15 @@ module TwoFactorAuthentication
     end
 
     def analytics_properties
+      parsed_phone = Phonelib.parse(phone)
+
       {
         context: context,
         multi_factor_auth_method: params[:otp_delivery_preference],
         confirmation_for_add_phone: confirmation_for_add_phone?,
+        area_code: parsed_phone.area_code,
+        country_code: parsed_phone.country,
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
         phone_configuration_id: user_session[:phone_id] ||
           current_user.default_phone_configuration&.id,
       }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1061,6 +1061,9 @@ module AnalyticsEvents
   # @param [Integer] webauthn_configuration_id
   # @param [Integer] phone_configuration_id
   # @param [Boolean] confirmation_for_add_phone
+  # @param [String] area_code
+  # @param [String] country_code
+  # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # Multi-Factor Authentication
   def multi_factor_auth(
     success:,
@@ -1074,6 +1077,9 @@ module AnalyticsEvents
     confirmation_for_add_phone: nil,
     phone_configuration_id: nil,
     pii_like_keypaths: nil,
+    area_code: nil,
+    country_code: nil,
+    phone_fingerprint: nil,
     **extra
   )
     track_event(
@@ -1089,6 +1095,9 @@ module AnalyticsEvents
       confirmation_for_add_phone: confirmation_for_add_phone,
       phone_configuration_id: phone_configuration_id,
       pii_like_keypaths: pii_like_keypaths,
+      area_code: area_code,
+      country_code: country_code,
+      phone_fingerprint: phone_fingerprint,
       **extra,
     )
   end


### PR DESCRIPTION
Builds on #6460 to continue adding context to better understand telephony authentication failures