### PR TITLE
Shanice/lg 6920 unique id usps service

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -97,6 +97,7 @@ module Api
           profile: profile,
           user: user,
           current_address_matches_id: user_session.dig(:idv, :applicant, :same_address_as_id),
+          unique_id: InPersonEnrollment.generate_unique_id,
           selected_location_details: {
             'name' => 'BALTIMORE — Post Office™',
             'streetAddress' => '900 E FAYETTE ST RM 118',

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -27,13 +27,13 @@ class GetUspsProofingResultsJob < ApplicationJob
       # Record and commit attempt to check enrollment status to database
       enrollment.update(status_check_attempted_at: Time.zone.now)
 
-      if enrollment.unique_id.blank?
-        enrollment.update(unique_id: enrollment.usps_unique_id)
-      end
+      enrollment.update(unique_id: enrollment.usps_unique_id) if enrollment.unique_id.blank?
       response = nil
 
       begin
-        response = proofer.request_proofing_results(enrollment.unique_id, enrollment.enrollment_code)
+        response = proofer.request_proofing_results(
+          enrollment.unique_id, enrollment.enrollment_code
+        )
       rescue Faraday::BadRequestError => err
         handle_bad_request_error(err, enrollment)
         next

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -26,7 +26,9 @@ class GetUspsProofingResultsJob < ApplicationJob
     InPersonEnrollment.needs_usps_status_check(...5.minutes.ago).each do |enrollment|
       # Record and commit attempt to check enrollment status to database
       enrollment.update(status_check_attempted_at: Time.zone.now)
-      unique_id = enrollment.usps_unique_id
+      unique_id = enrollment.generate_unique_id
+      new_enrollment = InPersonEnrollment.new(unique_id: unique_id,)
+      
       response = nil
 
       begin

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -27,10 +27,9 @@ class GetUspsProofingResultsJob < ApplicationJob
       # Record and commit attempt to check enrollment status to database
       enrollment.update(status_check_attempted_at: Time.zone.now)
 
-      if enrollment.unique_id.blank? 
+      if enrollment.unique_id.blank?
         enrollment.update(unique_id: enrollment.usps_unique_id)
       end
-      
       response = nil
 
       begin

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class InPersonEnrollment < ApplicationRecord
   belongs_to :user
   belongs_to :profile
@@ -35,6 +37,10 @@ class InPersonEnrollment < ApplicationRecord
   # Returns the value to use for the USPS enrollment ID
   def usps_unique_id
     user.uuid.delete('-').slice(0, 18)
+  end
+
+  def self.generate_unique_id
+    SecureRandom.hex(9)
   end
 
   private

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -39,6 +39,7 @@ class InPersonEnrollment < ApplicationRecord
     user.uuid.delete('-').slice(0, 18)
   end
 
+ # Generates a random 18-digit string, the hex returns a string of length n*2
   def self.generate_unique_id
     SecureRandom.hex(9)
   end

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -34,12 +34,12 @@ class InPersonEnrollment < ApplicationRecord
     )
   end
 
-  # Returns the value to use for the USPS enrollment ID
+  # (deprecated) Returns the value to use for the USPS enrollment ID
   def usps_unique_id
     user.uuid.delete('-').slice(0, 18)
   end
 
- # Generates a random 18-digit string, the hex returns a string of length n*2
+  # Generates a random 18-digit string, the hex returns a string of length n*2
   def self.generate_unique_id
     SecureRandom.hex(9)
   end

--- a/db/primary_migrate/20220721170157_create_new_unique_id_usps_service.rb
+++ b/db/primary_migrate/20220721170157_create_new_unique_id_usps_service.rb
@@ -1,5 +1,8 @@
 class CreateNewUniqueIdUspsService < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
   def change
-    add_column :in_person_enrollments, :unique_id, :string, :uniqueness => true, comment: "Unique ID to use with the USPS service"
-    end
+    add_column :in_person_enrollments, :unique_id, :string, comment: "Unique ID to use with the USPS service"
+    add_index :in_person_enrollments, :unique_id, unique: true, algorithm: :concurrently
   end
+end

--- a/db/primary_migrate/20220721170157_create_new_unique_id_usps_service.rb
+++ b/db/primary_migrate/20220721170157_create_new_unique_id_usps_service.rb
@@ -1,0 +1,5 @@
+class CreateNewUniqueIdUspsService < ActiveRecord::Migration[6.1]
+  def change
+    add_column :in_person_enrollments, :unique_id, :string, :uniqueness => true, comment: "Unique ID to use with the USPS service"
+    end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_05_200821) do
+ActiveRecord::Schema.define(version: 2022_07_21_170157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -292,7 +292,9 @@ ActiveRecord::Schema.define(version: 2022_07_05_200821) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "current_address_matches_id", comment: "True if the user indicates that their current address matches the address on the ID they're bringing to the Post Office."
     t.jsonb "selected_location_details", comment: "The location details of the Post Office the user selected (including title, address, hours of operation)"
+    t.string "unique_id", comment: "Unique ID to use with the USPS service"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
+    t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true
     t.index ["user_id", "status"], name: "index_in_person_enrollments_on_user_id_and_status", unique: true, where: "(status = 1)"
     t.index ["user_id"], name: "index_in_person_enrollments_on_user_id"
   end

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :in_person_enrollment do
     user { association :user, :signed_up }
     profile { association :profile, user: user }
-
+    unique_id { Faker::Number.number(digits: 18) }
     trait :pending do
       after :build do |enrollment|
         enrollment.status = :pending

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :in_person_enrollment do
     user { association :user, :signed_up }
     profile { association :profile, user: user }
-    unique_id { Faker::Number.number(digits: 18) }
+    unique_id { Faker::Number.hexadecimal(digits: 18) }
     trait :pending do
       after :build do |enrollment|
         enrollment.status = :pending

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe InPersonEnrollment, type: :model do
       expect(InPersonEnrollment.pending.count).to eq 1
     end
 
+    it 'does not allow duplicate unique ids' do
+      user = create(:user)
+      profile = create(:profile, :verification_pending, user: user)
+      unique_id = InPersonEnrollment.generate_unique_id
+      create(:in_person_enrollment, user: user, profile: profile, unique_id: unique_id)
+      expect { create(:in_person_enrollment, user: user, profile: profile, unique_id: unique_id) }.
+        to raise_error ActiveRecord::RecordNotUnique
+      expect(InPersonEnrollment.count).to eq 1
+    end
+
     it 'does not constrain enrollments for non-pending status' do
       user = create(:user)
       expect {

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       user: user,
       profile: profile,
       enrollment_code: enrollment_code,
+      unique_id: InPersonEnrollment.generate_unique_id,
       created_at: created_at,
       current_address_matches_id: current_address_matches_id,
       selected_location_details:

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -13,6 +13,7 @@ describe 'idv/in_person/ready_to_verify/show.html.erb' do
       user: user,
       profile: profile,
       enrollment_code: enrollment_code,
+      unique_id: InPersonEnrollment.generate_unique_id,
       created_at: created_at,
       current_address_matches_id: current_address_matches_id,
       selected_location_details:


### PR DESCRIPTION
- Added a new column to the in_person_enrollments table to hold a unique ID; the column is a string and it has an unique constraint.
- When an enrollment is created, it generates and saves a 18-character unique ID