### PR TITLE
LG-7003: Activate the user's profile when they pass USPS in-person proofing

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -125,6 +125,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     case response['status']
     when IPP_STATUS_PASSED
       if SUPPORTED_ID_TYPES.include?(response['primaryIdType'])
+        enrollment.profile.activate
         enrollment.update(status: :passed)
       else
         # Unsupported ID type

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe GetUspsProofingResultsJob do
         )
       end
 
-      it 'updates enrollment records on 2xx responses with valid JSON' do
+      it 'updates enrollment records and activates profiles on 2xx responses with valid JSON' do
         stub_request_token
         stub_request_passed_proofing_results
 
@@ -138,6 +138,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(enrollment.status_updated_at).to satisfy do |timestamp|
             expected_range.cover?(timestamp)
           end
+          expect(enrollment.profile.active).to be(true)
         end
       end
 


### PR DESCRIPTION
Updates the USPS IPP polling job so that when a user successfully completes in-person proofing we mark their profile as activated. This is the final step which allows them to continue to the service provider's website with a verified account.