### PR TITLE
Send "Ready to verify" email when IPP enrollment is created

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -127,6 +127,19 @@ module Api
         enrollment.enrollment_code = enrollment_code
         enrollment.status = :pending
         enrollment.save!
+
+        send_ready_to_verify_email(user, enrollment)
+      end
+
+      def send_ready_to_verify_email(user, enrollment)
+        user.confirmed_email_addresses.each do |email_address|
+          UserMailer.in_person_ready_to_verify(
+            user,
+            email_address,
+            first_name: user_session.dig(:idv, :pii, :first_name),
+            enrollment: enrollment,
+          ).deliver_now_or_later
+        end
       end
     end
   end

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -131,6 +131,22 @@ describe Api::Verify::PasswordConfirmController do
           expect(enrollment.user_id).to eq(user.id)
           expect(enrollment.enrollment_code).to be_nil
         end
+
+        it 'sends ready to verify email' do
+          mailer = instance_double(ActionMailer::MessageDelivery, deliver_now_or_later: true)
+          user.email_addresses.each do |email_address|
+            expect(UserMailer).to receive(:in_person_ready_to_verify).
+              with(
+                user,
+                email_address,
+                enrollment: instance_of(InPersonEnrollment),
+                first_name: kind_of(String),
+              ).
+              and_return(mailer)
+          end
+
+          post :create, params: { password: password, user_bundle_token: jwt }
+        end
       end
 
       context 'with associated sp session' do


### PR DESCRIPTION
**Why**: As a public user trying to proof online I want to see the details of my newly scheduled in-person proofing visit to the USPS as an email so that I can reference it later.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing process up to document capture
5. Use [attention result test YAML file](https://developers.login.gov/testing/#document-upload) for field upload
6. Click "Submit"
7. On warning screen, opt to verify in person
8. Complete proofing process up to "You're ready to verify in person"
9. Navigate to http://localhost:1080
10. Observe there is an email message with details of in-person verification

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/181054001-5014becc-9447-4ed7-9fca-91a361bf7df4.png)

**Implementation notes:**

- Currently, this is only implemented in the `PasswordConfirmController` version of this flow, not [`Idv::ReviewController`](https://github.com/18F/identity-idp/blob/main/app/controllers/idv/review_controller.rb) ([see related Slack thread](https://gsa-tts.slack.com/archives/C03FA4VBN76/p1658848010087409)). I'll update this pull request if necessary enrollment creation is merged before this one.

**Open questions:**

- This sends the email at the same time as the enrollment is created in USPS' system, which occurs at password creation. From a UX perspective, this is before the user has finished the personal key confirmation, though this step is _technically_ optional (the user has a profile and the USPS enrollment record is created regardless if they complete personal key step). 