### PR TITLE
remove proofing post office and city from log

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -115,8 +115,6 @@ class GetUspsProofingResultsJob < ApplicationJob
       failure_reason: response['failureReason'],
       fraud_suspected: response['fraudSuspected'],
       primary_id_type: response['primaryIdType'],
-      proofing_city: response['proofingCity'],
-      proofing_post_office: response['proofingPostOffice'],
       proofing_state: response['proofingState'],
       secondary_id_type: response['secondaryIdType'],
       transaction_end_date_time: response['transactionEndDateTime'],

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe GetUspsProofingResultsJob do
           failure_reason: 'Clerk indicates that ID name or address does not match source data.',
           fraud_suspected: false,
           primary_id_type: 'Uniformed Services identification card',
-          proofing_city: 'WILKES BARRE',
-          proofing_post_office: 'WILKES BARRE',
           proofing_state: 'PA',
           secondary_id_type: 'Deed of Trust',
           transaction_end_date_time: '12/17/2020 034055',


### PR DESCRIPTION
Don't store proofing post office or city in logs for now.