### PR TITLE
LG-6897/LG-6868/LG-6437: Set pending profile state for IPP

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -3,6 +3,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :redirect_if_mail_bounced
     before_action :redirect_if_pending_profile
+    before_action :redirect_if_pending_in_person_enrollment
     before_action :extend_timeout_using_meta_refresh_for_select_paths
 
     include IdvSession # remove if we retire the non docauth LOA3 flow
@@ -34,6 +35,10 @@ module Idv
       return if sp_session[:ial2_strict] &&
                 !IdentityConfig.store.gpo_allowed_for_strict_ial2
       redirect_to idv_gpo_verify_url if current_user.decorate.pending_profile_requires_verification?
+    end
+
+    def redirect_if_pending_in_person_enrollment
+      redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
     end
 
     def update_if_skipping_upload

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -38,6 +38,7 @@ module Idv
     end
 
     def redirect_if_pending_in_person_enrollment
+      return if !IdentityConfig.store.in_person_proofing_enabled
       redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
     end
 

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -36,8 +36,12 @@ module Idv
             sp_name: decorated_session.sp_name,
             disavowal_token: event.disavowal_token,
           )
-          flash[:success] = t('account.index.verification.success')
-          redirect_to sign_up_completed_url
+          if result.extra[:pending_in_person_enrollment]
+            redirect_to idv_in_person_ready_to_verify_url
+          else
+            flash[:success] = t('account.index.verification.success')
+            redirect_to sign_up_completed_url
+          end
         else
           flash[:error] = @gpo_verify_form.errors.first.message
           redirect_to idv_gpo_verify_url

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -20,7 +20,7 @@ module Idv
     private
 
     def cancel_verification_attempt_if_pending_profile
-      return if current_user.profiles.verification_pending.blank?
+      return if current_user.profiles.gpo_verification_pending.blank?
       Idv::CancelVerificationAttempt.new(user: current_user).call
     end
 

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -6,6 +6,7 @@ module Idv
 
     def destroy
       cancel_verification_attempt_if_pending_profile
+      cancel_in_person_enrollment_if_exists
       analytics.idv_start_over(
         step: location_params[:step],
         location: location_params[:location],
@@ -21,6 +22,11 @@ module Idv
     def cancel_verification_attempt_if_pending_profile
       return if current_user.profiles.verification_pending.blank?
       Idv::CancelVerificationAttempt.new(user: current_user).call
+    end
+
+    def cancel_in_person_enrollment_if_exists
+      return if !IdentityConfig.store.in_person_proofing_enabled
+      current_user.pending_in_person_enrollment&.update(status: :cancelled)
     end
 
     def location_params

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -52,8 +52,13 @@ module Api
     end
 
     def complete_session
-      complete_profile if phone_confirmed?
+      complete_profile if phone_confirmed? && !pending_in_person_enrollment?
       create_gpo_entry if user_bundle.gpo_address_verification?
+    end
+
+    def pending_in_person_enrollment?
+      return false unless IdentityConfig.store.in_person_proofing_enabled
+      # TBD: Enrollment isn't created yet. Read from proofing component?
     end
 
     def phone_confirmed?

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -18,7 +18,7 @@ class GpoVerifyForm
     result = valid?
     if result
       if pending_in_person_enrollment?
-        # TBD: Need to redirect back to IDV initial step.
+        user.pending_profile&.deactivate(:in_person_verification_pending)
       else
         activate_profile
       end
@@ -30,6 +30,7 @@ class GpoVerifyForm
       errors: errors,
       extra: {
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+        pending_in_person_enrollment: pending_in_person_enrollment?,
       },
     )
   end
@@ -71,7 +72,7 @@ class GpoVerifyForm
 
   def pending_in_person_enrollment?
     return false unless IdentityConfig.store.in_person_proofing_enabled
-    # TBD
+    user.pending_in_person_enrollment.present?
   end
 
   def activate_profile

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -17,7 +17,11 @@ class GpoVerifyForm
   def submit
     result = valid?
     if result
-      activate_profile
+      if pending_in_person_enrollment?
+        # TBD: Need to redirect back to IDV initial step.
+      else
+        activate_profile
+      end
     else
       reset_sensitive_fields
     end
@@ -63,6 +67,11 @@ class GpoVerifyForm
 
   def reset_sensitive_fields
     self.otp = nil
+  end
+
+  def pending_in_person_enrollment?
+    return false unless IdentityConfig.store.in_person_proofing_enabled
+    # TBD
   end
 
   def activate_profile

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -9,7 +9,7 @@ class InPersonEnrollment < ApplicationRecord
     passed: 2,
     failed: 3,
     expired: 4,
-    canceled: 5,
+    cancelled: 5,
   }
 
   validate :profile_belongs_to_user

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,6 +15,7 @@ class Profile < ApplicationRecord
     encryption_error: 2,
     verification_pending: 3,
     verification_cancelled: 4,
+    in_person_verification_pending: 5,
   }
 
   attr_reader :personal_key

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,7 +13,7 @@ class Profile < ApplicationRecord
   enum deactivation_reason: {
     password_reset: 1,
     encryption_error: 2,
-    verification_pending: 3,
+    gpo_verification_pending: 3,
     verification_cancelled: 4,
     in_person_verification_pending: 5,
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    profiles.verification_pending.order(created_at: :desc).first
+    profiles.gpo_verification_pending.order(created_at: :desc).first
   end
 
   def default_phone_configuration

--- a/app/services/idv/cancel_verification_attempt.rb
+++ b/app/services/idv/cancel_verification_attempt.rb
@@ -7,7 +7,7 @@ module Idv
     end
 
     def call
-      user.profiles.verification_pending.each do |profile|
+      user.profiles.gpo_verification_pending.each do |profile|
         profile.update!(
           active: false,
           deactivation_reason: :verification_cancelled,

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -10,7 +10,7 @@ module Idv
 
     def save_profile
       profile = Profile.new(
-        deactivation_reason: :verification_pending,
+        deactivation_reason: :gpo_verification_pending,
         user: user,
       )
       profile.encrypt_pii(pii_attributes, user_password)

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -9,10 +9,7 @@ module Idv
     end
 
     def save_profile
-      profile = Profile.new(
-        deactivation_reason: :gpo_verification_pending,
-        user: user,
-      )
+      profile = Profile.new(user: user, active: false)
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -82,19 +82,20 @@ module Idv
     end
 
     def complete_session
-      if phone_confirmed?
+      if address_verification_mechanism == 'gpo'
+        profile.deactivate(:gpo_verification_pending)
+        create_gpo_entry
+      elsif phone_confirmed?
         if pending_in_person_enrollment?
-          current_user.pending_profile&.deactivate(:in_person_verification_pending)
+          profile.deactivate(:in_person_verification_pending)
         else
           complete_profile
         end
       end
-
-      create_gpo_entry if address_verification_mechanism == 'gpo'
     end
 
     def complete_profile
-      current_user.pending_profile&.activate
+      profile.activate
       move_pii_to_user_session
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -72,12 +72,17 @@ module Idv
       user_session.delete(:idv)
     end
 
+    def pending_in_person_enrollment?
+      return false unless IdentityConfig.store.in_person_proofing_enabled
+      # TBD: Enrollment isn't created yet. Read from proofing component?
+    end
+
     def phone_confirmed?
       vendor_phone_confirmation == true && user_phone_confirmation == true
     end
 
     def complete_session
-      complete_profile if phone_confirmed?
+      complete_profile if phone_confirmed? && !pending_in_person_enrollment?
       create_gpo_entry if address_verification_mechanism == 'gpo'
     end
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -63,7 +63,7 @@ describe AccountsController do
         user = create(
           :user,
           :signed_up,
-          profiles: [build(:profile, deactivation_reason: :verification_pending)],
+          profiles: [build(:profile, deactivation_reason: :gpo_verification_pending)],
         )
 
         sign_in user

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -146,7 +146,13 @@ describe Api::Verify::PasswordConfirmController do
       end
 
       context 'with pending profile' do
-        let(:jwt_metadata) { { vendor_phone_confirmation: false, user_phone_confirmation: false } }
+        let(:jwt_metadata) do
+          {
+            vendor_phone_confirmation: false,
+            user_phone_confirmation: false,
+            address_verification_mechanism: 'gpo',
+          }
+        end
 
         it 'creates a profile and returns completion url' do
           post :create, params: { password: password, user_bundle_token: jwt }

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -49,7 +49,7 @@ describe Idv::SessionsController do
       let(:user) do
         create(
           :user,
-          profiles: [create(:profile, deactivation_reason: :verification_pending)],
+          profiles: [create(:profile, deactivation_reason: :gpo_verification_pending)],
         )
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -316,7 +316,7 @@ describe Users::SessionsController, devise: true do
         user = create(:user, :signed_up)
         create(
           :profile,
-          deactivation_reason: :verification_pending,
+          deactivation_reason: :gpo_verification_pending,
           user: user, pii: { ssn: '1234' }
         )
 
@@ -564,7 +564,7 @@ describe Users::SessionsController, devise: true do
       it 'redirects to the verify profile page' do
         profile = create(
           :profile,
-          deactivation_reason: :verification_pending,
+          deactivation_reason: :gpo_verification_pending,
           pii: { ssn: '6666', dob: '1920-01-01' },
         )
         user = profile.user

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'In Person Proofing', js: true do
     expect(page).to have_content(Idv::InPerson::EnrollmentCodeFormatter.format(enrollment_code))
     expect(page).to have_content(t('in_person_proofing.body.barcode.deadline', deadline: deadline))
 
-    # re-entering flow
+    # signing in again before completing in-person proofing at a post office
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_welcome_step
     expect(page).to have_current_path(idv_in_person_ready_to_verify_path)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).to have_current_path(idv_come_back_later_path)
 
       click_idv_continue
+      expect(page).to have_current_path(account_path)
+      expect(page).not_to have_content(t('headings.account.verified_account'))
       click_on t('account.index.verification.reactivate_button')
       click_button t('forms.verify_profile.submit')
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -125,5 +125,19 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
       expect(page).not_to have_content(t('account.index.verification.success'))
     end
+
+    it 'lets the user clear and start over from gpo confirmation', allow_browser_log: true do
+      begin_in_person_proofing
+      complete_all_in_person_proofing_steps
+      click_on t('idv.troubleshooting.options.verify_by_mail')
+      click_on t('idv.buttons.mail.send')
+      complete_review_step
+      acknowledge_and_confirm_personal_key
+      click_idv_continue
+      click_on t('account.index.verification.reactivate_button')
+      click_on t('idv.messages.clear_and_start_over')
+
+      expect(page).to have_current_path(idv_doc_auth_welcome_step)
+    end
   end
 end

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -64,7 +64,7 @@ feature 'idv gpo step', :js do
       profile = user.profiles.first
 
       expect(profile.active?).to eq false
-      expect(profile.deactivation_reason).to eq 'verification_pending'
+      expect(profile.deactivation_reason).to eq 'gpo_verification_pending'
     end
   end
 end

--- a/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
+++ b/spec/features/idv/strict_ial2/usps_upload_disallowed_spec.rb
@@ -51,7 +51,7 @@ feature 'Strict IAL2 with usps upload disallowed', js: true do
   it 'does not prompt a pending user for a mailed code' do
     user = create(
       :profile,
-      deactivation_reason: :verification_pending,
+      deactivation_reason: :gpo_verification_pending,
       pii: { first_name: 'John', ssn: '111223333' },
     ).user
 

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -85,7 +85,7 @@ feature 'IAL2 Single Sign On' do
     let(:profile) do
       create(
         :profile,
-        deactivation_reason: :verification_pending,
+        deactivation_reason: :gpo_verification_pending,
         pii: { ssn: '6666', dob: '1920-01-01' },
       )
     end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -7,7 +7,7 @@ feature 'verify profile with OTP' do
   before do
     profile = create(
       :profile,
-      deactivation_reason: :verification_pending,
+      deactivation_reason: :gpo_verification_pending,
       pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '+1 703-555-9999' },
       user: user,
     )

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe Api::ProfileCreationForm do
 
           expect(stored_pii['first_name']).to eq 'Ada'
         end
+
+        context 'with pending in person enrollment' do
+          before do
+            ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+          end
+
+          it 'sets profile to pending in person verification' do
+            subject.submit
+            profile = user.profiles.first
+
+            expect(profile.active?).to be false
+            expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+          end
+        end
       end
 
       context 'with the user having verified their address via GPO letter' do
@@ -92,6 +107,7 @@ RSpec.describe Api::ProfileCreationForm do
           profile = user.profiles.first
 
           expect(profile.active?).to be false
+          expect(profile.deactivation_reason).to eq('verification_pending')
         end
 
         it 'moves the pii to the user_session' do
@@ -119,6 +135,21 @@ RSpec.describe Api::ProfileCreationForm do
             gpo_code = GpoConfirmation.last.entry[:otp]
 
             expect(subject.gpo_code).to eq(gpo_code)
+          end
+        end
+
+        context 'with pending in person enrollment' do
+          before do
+            ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+          end
+
+          it 'does not activate the user profile' do
+            subject.submit
+            profile = user.profiles.first
+
+            expect(profile.active?).to be false
+            expect(profile.deactivation_reason).to eq('verification_pending')
           end
         end
       end

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Api::ProfileCreationForm do
           profile = user.profiles.first
 
           expect(profile.active?).to be false
-          expect(profile.deactivation_reason).to eq('verification_pending')
+          expect(profile.deactivation_reason).to eq('gpo_verification_pending')
         end
 
         it 'moves the pii to the user_session' do
@@ -149,7 +149,7 @@ RSpec.describe Api::ProfileCreationForm do
             profile = user.profiles.first
 
             expect(profile.active?).to be false
-            expect(profile.deactivation_reason).to eq('verification_pending')
+            expect(profile.deactivation_reason).to eq('gpo_verification_pending')
           end
         end
       end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -9,7 +9,7 @@ describe GpoVerifyForm do
   let(:entered_otp) { otp }
   let(:otp) { 'ABC123' }
   let(:code_sent_at) { Time.zone.now }
-  let(:pending_profile) { create(:profile, deactivation_reason: :verification_pending) }
+  let(:pending_profile) { create(:profile, deactivation_reason: :gpo_verification_pending) }
 
   before do
     next if pending_profile.blank?

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -101,6 +101,21 @@ describe GpoVerifyForm do
 
         expect(pending_profile.reload).to be_active
       end
+
+      context 'pending in person enrollment' do
+        before do
+          create(:in_person_enrollment, :pending, user: user, profile: pending_profile)
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        end
+
+        it 'sets profile to pending in person verification' do
+          subject.submit
+          pending_profile.reload
+
+          expect(pending_profile).not_to be_active
+          expect(pending_profile.deactivation_reason).to eq('in_person_verification_pending')
+        end
+      end
     end
 
     context 'incorrect OTP' do

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe InPersonEnrollment, type: :model do
     it 'requires the profile to be associated with the user' do
       user1 = create(:user)
       user2 = create(:user)
-      profile2 = create(:profile, :verification_pending, user: user2)
+      profile2 = create(:profile, :gpo_verification_pending, user: user2)
       expect { create(:in_person_enrollment, user: user1, profile: profile2) }.
         to raise_error ActiveRecord::RecordInvalid
       expect(InPersonEnrollment.count).to eq 0
@@ -25,8 +25,8 @@ RSpec.describe InPersonEnrollment, type: :model do
 
     it 'does not allow more than one pending enrollment per user' do
       user = create(:user)
-      profile = create(:profile, :verification_pending, user: user)
-      profile2 = create(:profile, :verification_pending, user: user)
+      profile = create(:profile, :gpo_verification_pending, user: user)
+      profile2 = create(:profile, :gpo_verification_pending, user: user)
       create(:in_person_enrollment, user: user, profile: profile, status: :pending)
       expect(InPersonEnrollment.pending.count).to eq 1
       expect { create(:in_person_enrollment, user: user, profile: profile2, status: :pending) }.
@@ -36,7 +36,7 @@ RSpec.describe InPersonEnrollment, type: :model do
 
     it 'does not allow duplicate unique ids' do
       user = create(:user)
-      profile = create(:profile, :verification_pending, user: user)
+      profile = create(:profile, :gpo_verification_pending, user: user)
       unique_id = InPersonEnrollment.generate_unique_id
       create(:in_person_enrollment, user: user, profile: profile, unique_id: unique_id)
       expect { create(:in_person_enrollment, user: user, profile: profile, unique_id: unique_id) }.
@@ -49,13 +49,13 @@ RSpec.describe InPersonEnrollment, type: :model do
       expect {
         InPersonEnrollment.statuses.each do |key,|
           status = InPersonEnrollment.statuses[key]
-          profile = create(:profile, :verification_pending, user: user)
+          profile = create(:profile, :gpo_verification_pending, user: user)
           create(:in_person_enrollment, user: user, profile: profile, status: status)
         end
         InPersonEnrollment.statuses.each do |key,|
           status = InPersonEnrollment.statuses[key]
           if status != InPersonEnrollment.statuses[:pending]
-            profile = create(:profile, :verification_pending, user: user)
+            profile = create(:profile, :gpo_verification_pending, user: user)
             create(:in_person_enrollment, user: user, profile: profile, status: status)
           end
         end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe InPersonEnrollment, type: :model do
   describe 'Status' do
     it 'defines enum correctly' do
       should define_enum_for(:status).
-        with_values([:establishing, :pending, :passed, :failed, :expired, :canceled])
+        with_values([:establishing, :pending, :passed, :failed, :expired, :cancelled])
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe User do
       create(:profile, :verification_cancelled, user: user, pii: { first_name: 'Jane' })
     }
     let(:profile2) {
-      create(:profile, :verification_pending, user: user, pii: { first_name: 'Susan' })
+      create(:profile, :gpo_verification_pending, user: user, pii: { first_name: 'Susan' })
     }
 
     let!(:enrollment1) { create(:in_person_enrollment, :failed, user: user, profile: profile1) }
@@ -425,18 +425,18 @@ RSpec.describe User do
   end
 
   describe '#pending_profile' do
-    context 'when a profile with a verification_pending deactivation_reason exists' do
+    context 'when a profile with a gpo_verification_pending deactivation_reason exists' do
       it 'returns the most recent profile' do
         user = User.new
         _old_profile = create(
           :profile,
-          :verification_pending,
+          :gpo_verification_pending,
           created_at: 1.day.ago,
           user: user,
         )
         new_profile = create(
           :profile,
-          :verification_pending,
+          :gpo_verification_pending,
           user: user,
         )
 
@@ -444,7 +444,7 @@ RSpec.describe User do
       end
     end
 
-    context 'when a verification_pending profile does not exist' do
+    context 'when a gpo_verification_pending profile does not exist' do
       it 'returns nil' do
         user = User.new
         create(

--- a/spec/presenters/idv/gpo_presenter_spec.rb
+++ b/spec/presenters/idv/gpo_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Idv::GpoPresenter do
   describe '#fallback_back_path' do
     context 'when the user has a pending profile' do
       it 'returns the verify account path' do
-        create(:profile, user: user, deactivation_reason: :verification_pending)
+        create(:profile, user: user, deactivation_reason: :gpo_verification_pending)
         expect(subject.fallback_back_path).to eq('/account/verify')
       end
     end

--- a/spec/services/idv/cancel_verification_attempt_spec.rb
+++ b/spec/services/idv/cancel_verification_attempt_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Idv::CancelVerificationAttempt do
   let(:user) { create(:user, profiles: profiles) }
-  let(:profiles) { [create(:profile, deactivation_reason: :verification_pending)] }
+  let(:profiles) { [create(:profile, deactivation_reason: :gpo_verification_pending)] }
 
   subject { described_class.new(user: user) }
 
@@ -12,13 +12,13 @@ describe Idv::CancelVerificationAttempt do
 
       expect(profiles[0].active).to eq(false)
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
-      expect(user.reload.profiles.verification_pending).to be_empty
+      expect(user.reload.profiles.gpo_verification_pending).to be_empty
     end
   end
 
   context 'the user has multiple pending profiles' do
     let(:profiles) do
-      super().push(create(:profile, deactivation_reason: :verification_pending))
+      super().push(create(:profile, deactivation_reason: :gpo_verification_pending))
     end
 
     it 'deactivates both profiles' do
@@ -28,7 +28,7 @@ describe Idv::CancelVerificationAttempt do
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
       expect(profiles[1].active).to eq(false)
       expect(profiles[1].reload.deactivation_reason).to eq('verification_cancelled')
-      expect(user.reload.profiles.verification_pending).to be_empty
+      expect(user.reload.profiles.gpo_verification_pending).to be_empty
     end
   end
 
@@ -44,20 +44,20 @@ describe Idv::CancelVerificationAttempt do
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
       expect(profiles[1].active).to eq(true)
       expect(profiles[1].reload.deactivation_reason).to be_nil
-      expect(user.reload.profiles.verification_pending).to be_empty
+      expect(user.reload.profiles.gpo_verification_pending).to be_empty
     end
   end
 
   context 'when there are pending profiles for other users' do
     it 'only updates profiles for the specificed user' do
-      other_profile = create(:profile, deactivation_reason: :verification_pending)
+      other_profile = create(:profile, deactivation_reason: :gpo_verification_pending)
 
       subject.call
 
       expect(profiles[0].active).to eq(false)
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
       expect(other_profile.active).to eq(false)
-      expect(other_profile.reload.deactivation_reason).to eq('verification_pending')
+      expect(other_profile.reload.deactivation_reason).to eq('gpo_verification_pending')
     end
   end
 end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -13,7 +13,8 @@ describe Idv::ProfileMaker do
         user_password: user_password,
       )
     end
-    it 'creates a Profile with encrypted PII' do
+
+    it 'creates an inactive Profile with encrypted PII' do
       proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'acuant')
       profile = subject.save_profile
       pii = subject.pii_attributes
@@ -23,6 +24,8 @@ describe Idv::ProfileMaker do
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match 'Some'
       expect(profile.proofing_components).to match proofing_component.as_json
+      expect(profile.active).to eq false
+      expect(profile.deactivation_reason).to be_nil
 
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name).to eq 'Some'

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -68,7 +68,7 @@ describe Idv::Session do
         end
 
         it 'sets profile to pending in person verification' do
-          profile = create(:profile, deactivation_reason: :verification_pending, user: user)
+          profile = create(:profile, deactivation_reason: :gpo_verification_pending, user: user)
           subject.complete_session
 
           expect(subject).not_to have_received(:complete_profile)

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -39,7 +39,7 @@ describe Idv::Session do
   describe '#complete_session' do
     context 'with phone verifed by vendor' do
       before do
-        subject.address_verification_mechanism = :phone
+        subject.address_verification_mechanism = 'phone'
         subject.vendor_phone_confirmation = true
         allow(subject).to receive(:complete_profile)
       end
@@ -68,18 +68,36 @@ describe Idv::Session do
         end
 
         it 'sets profile to pending in person verification' do
-          profile = create(:profile, deactivation_reason: :gpo_verification_pending, user: user)
+          subject.applicant = {}
+          subject.create_profile_from_applicant_with_password(user.password)
           subject.complete_session
 
           expect(subject).not_to have_received(:complete_profile)
-          expect(profile.reload.deactivation_reason).to eq('in_person_verification_pending')
+          expect(subject.profile.deactivation_reason).to eq('in_person_verification_pending')
         end
+      end
+    end
+
+    context 'with gpo address verification' do
+      before do
+        subject.address_verification_mechanism = 'gpo'
+        subject.vendor_phone_confirmation = false
+        allow(subject).to receive(:complete_profile)
+      end
+
+      it 'sets profile to pending gpo verification' do
+        subject.applicant = {}
+        subject.create_profile_from_applicant_with_password(user.password)
+        subject.complete_session
+
+        expect(subject).not_to have_received(:complete_profile)
+        expect(subject.profile.deactivation_reason).to eq('gpo_verification_pending')
       end
     end
 
     context 'without a confirmed phone number' do
       before do
-        subject.address_verification_mechanism = :phone
+        subject.address_verification_mechanism = 'phone'
         subject.vendor_phone_confirmation = false
       end
 

--- a/spec/support/features/interaction_helper.rb
+++ b/spec/support/features/interaction_helper.rb
@@ -1,6 +1,6 @@
 module InteractionHelper
   def click_spinner_button_and_wait(...)
-    click_button(...)
+    click_on(...)
     expect(page).to have_no_css('lg-spinner-button.spinner-button--spinner-active', wait: 10)
   end
 end

--- a/spec/support/idv_examples/gpo_otp_verification_step.rb
+++ b/spec/support/idv_examples/gpo_otp_verification_step.rb
@@ -3,7 +3,7 @@ shared_examples 'gpo otp verification step' do |sp|
   let(:profile) do
     create(
       :profile,
-      deactivation_reason: :verification_pending,
+      deactivation_reason: :gpo_verification_pending,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
     )
   end


### PR DESCRIPTION
**Why**: So that a user's profile is not activated until they complete the in-person enrollment, and any attempts to revisit the identity verification will present them with the instructions to proof in-person (after GPO confirmation if applicable).

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. Use [attention result YAML test document](https://developers.login.gov/testing/#document-upload) as file upload
6. Click Submit
7. Click troubleshooting option to "Verify your ID in person at a Post Office"
8. Complete proofing flow
   1. Optional: Choose to verify address by mail (click "Verify your address by mail instead" on the "Enter a phone number with your name on the plan" step)
9. After the "You're ready to verify in person", return to account page by clicking the logo
10. Navigate to http://localhost:3000/verify
11. Observe that you see the "You're ready to verify in person" instructions

**Screen recordings:**

Finalizing GPO redirects to in person instructions:

https://user-images.githubusercontent.com/1779930/181138750-213e6ba1-a6ff-4b7b-b328-b5e2bd788474.mov

Navigating to `/verify` with pending profile shows instructions:

https://user-images.githubusercontent.com/1779930/181138740-22298393-7b80-4453-bc8d-2b768d7e62fb.mov