### PR TITLE
Initialize IPP pii_from_user with user UUID

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -78,7 +78,10 @@ module Idv
     def non_address_pii
       pii_to_h.
         slice('first_name', 'middle_name', 'last_name', 'dob', 'phone', 'ssn').
-        merge(uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id)
+        merge(
+          uuid: current_user.uuid,
+          uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
+        )
     end
 
     def pii_to_h

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -41,7 +41,7 @@ module Idv
         @idv_session = self.class.session_idv(session)
         super(controller, STEPS, ACTIONS, session[name])
         @flow_session ||= {}
-        @flow_session[:pii_from_user] ||= {}
+        @flow_session[:pii_from_user] ||= { uuid: current_user.uuid }
         # there may be data in @idv_session to copy to @flow_session
         applicant = @idv_session['applicant'] || {}
         @flow_session[:pii_from_user] = @flow_session[:pii_from_user].to_h.merge(applicant)

--- a/app/services/proofing/mock/resolution_mock_client.rb
+++ b/app/services/proofing/mock/resolution_mock_client.rb
@@ -3,9 +3,17 @@ module Proofing
     class ResolutionMockClient < Proofing::Base
       vendor_name 'ResolutionMock'
 
-      required_attributes :first_name, :ssn, :zipcode
+      required_attributes :uuid,
+                          :first_name,
+                          :last_name,
+                          :dob,
+                          :ssn,
+                          :address1,
+                          :city,
+                          :state,
+                          :zipcode
 
-      optional_attributes :uuid, :uuid_prefix
+      optional_attributes :address2, :uuid_prefix, :dob_year_only
 
       stage :resolution
 

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -4,6 +4,8 @@ require 'ostruct'
 describe Idv::Agent do
   include IdvHelper
 
+  let(:user) { build(:user) }
+
   let(:bad_phone) do
     Proofing::Mock::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER
   end
@@ -20,8 +22,7 @@ describe Idv::Agent do
       context 'proofing state_id enabled' do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new(
-            { ssn: '444-55-6666', first_name: Faker::Name.first_name,
-              zipcode: '11111' },
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '444-55-6666'),
           )
           agent.proof_resolution(
             document_capture_session, should_proof_state_id: true, trace_id: trace_id
@@ -33,14 +34,7 @@ describe Idv::Agent do
         end
 
         it 'does proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(
-            ssn: '900-55-8888',
-            first_name: Faker::Name.first_name,
-            zipcode: '11111',
-            state_id_number: '123456789',
-            state_id_type: 'drivers_license',
-            state_id_jurisdiction: 'MD',
-          )
+          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(uuid: user.uuid))
           agent.proof_resolution(
             document_capture_session, should_proof_state_id: true, trace_id: trace_id
           )
@@ -55,8 +49,7 @@ describe Idv::Agent do
       context 'proofing state_id disabled' do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new(
-            { ssn: '444-55-6666', first_name: Faker::Name.first_name,
-              zipcode: '11111' },
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '444-55-6666'),
           )
           agent.proof_resolution(
             document_capture_session, should_proof_state_id: true, trace_id: trace_id
@@ -67,10 +60,7 @@ describe Idv::Agent do
         end
 
         it 'does not proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(
-            { ssn: '900-55-8888', first_name: Faker::Name.first_name,
-              zipcode: '11111' },
-          )
+          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(uuid: user.uuid))
           agent.proof_resolution(
             document_capture_session, should_proof_state_id: false, trace_id: trace_id
           )
@@ -84,8 +74,7 @@ describe Idv::Agent do
 
         it 'returns a successful result if SSN does not start with 900 but is in SSN allowlist' do
           agent = Idv::Agent.new(
-            ssn: '999-99-9999', first_name: Faker::Name.first_name,
-            zipcode: '11111'
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '999-99-9999'),
           )
 
           agent.proof_resolution(
@@ -101,8 +90,10 @@ describe Idv::Agent do
 
       it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
         agent = Idv::Agent.new(
-          ssn: '900-55-8888', first_name: 'Time Exception',
-          zipcode: '11111'
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+            uuid: user.uuid,
+            first_name: 'Time Exception',
+          ),
         )
 
         agent.proof_resolution(


### PR DESCRIPTION
**Why**: Because it's a required attribute for the real resolution vendor implementation, which otherwise fails without it.
