### PR TITLE
LG-7005 Add feature flags for Device Profiling

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -187,6 +187,8 @@ piv_cac_verify_token_url: https://localhost:8443/
 platform_authentication_enabled: true
 poll_rate_for_verify_in_seconds: 3
 proofer_mock_fallback: true
+proofing_device_profiling_collecting_enabled: false
+proofing_device_profiling_decisioning_enabled: false
 proofing_send_partial_dob: false
 proof_address_max_attempts: 5
 proof_address_max_attempt_window_in_minutes: 360

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -271,6 +271,8 @@ class IdentityConfig
     config.add(:platform_authentication_enabled, type: :boolean)
     config.add(:poll_rate_for_verify_in_seconds, type: :integer)
     config.add(:proofer_mock_fallback, type: :boolean)
+    config.add(:proofing_device_profiling_collecting_enabled, type: :boolean)
+    config.add(:proofing_device_profiling_decisioning_enabled, type: :boolean)
     config.add(:proofing_send_partial_dob, type: :boolean)
     config.add(:proof_address_max_attempts, type: :integer)
     config.add(:proof_address_max_attempt_window_in_minutes, type: :integer)


### PR DESCRIPTION
changelog: Upcoming Features, Config,  Add feature flags for Device
Profiling

Why? We are adding feature flags to enable collecting information from devices that we will send to LexisNexis' ThreatMetrix platform.

* proofing_device_profiling_collecting_enabled enables the device profiling integration with
  ThreatMetrix

* proofing_device_profiling_decisioning_enabled enables decisioning
  based on the results from ThreatMetrix