### PR TITLE
LG-7605 Small changes to in-person enrollment email copy

### DIFF
--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -48,7 +48,7 @@
     </tr>
     <% if @presenter.needs_proof_of_address? %>
       <tr>
-        <td><div class="process-list__circle">4</div></td>
+        <td><div class="process-list__circle">3</div></td>
         <td>
           <h3 class="font-heading-md text-bold"><%= t('in_person_proofing.process.proof_of_address.heading') %></h3>
           <p class="margin-bottom-105"><%= t('in_person_proofing.process.proof_of_address.info') %></p>

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -19,7 +19,6 @@
   <h2 class="margin-top-0 margin-bottom-2 font-heading-lg text-bold">
     <%= t('in_person_proofing.body.barcode.items_to_bring') %>
   </h2>
-  <p><%= t('in_person_proofing.body.barcode.emailed_info') %></p>
   <table class="process-list">
     <tr>
       <td><div class="process-list__circle">1</div></td>


### PR DESCRIPTION
Make two small adjustments to email copy:
1. Number the third item in the process list `3` instead of `4`.
2. Remove the line "We have emailed this information to the email you used to log in."

<details>
<summary>Screenshot</summary>

![email-screenshot](https://user-images.githubusercontent.com/45415133/181571802-cf3fdb69-4bc2-4da1-b2d5-886934c351fe.png)

</details>