### PR TITLE
LG-6668 safeguard failed message

### DIFF
--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -97,10 +97,10 @@ module DocAuth
 
         def get_alert_result(log_alert_results, side, alert_name_key, result)
           if log_alert_results.dig(alert_name_key, side.to_sym).present?
-            log_alert_results[alert_name_key][side.to_sym] + ", #{result}"
-          else
-            result
+            Rails.logger.
+              info("ALERT ALREADY HAS A VALUE: #{log_alert_results[alert_name_key][side.to_sym]}, #{result}")
           end
+          result
         end
 
         def log_alerts(alerts)
@@ -119,8 +119,7 @@ module DocAuth
                   side,
                   alert_name_key,
                   alert[:result],
-                  ).
-                    split(', ').uniq.join(', ') }
+                  ) }
             end
           end
           log_alert_results

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -97,12 +97,16 @@ module DocAuth
 
         def log_alerts(alerts)
           log_alert_results = {}
+          has_failed = {}
+
           alerts.keys.each do |key|
             alerts[key.to_sym].each do |alert|
-              side = alert[:side] || 'no_side'
-              log_alert_results[alert[:name].
+              alert_name_key = alert[:name].
                 downcase.
-                parameterize(separator: '_').to_sym] = { "#{side}": alert[:result] }
+                parameterize(separator: '_')
+              side = alert[:side] || 'no_side'
+              log_alert_results[alert_name_key.to_sym] = { "#{side}": alert[:result] } unless has_failed[alert_name_key.to_sym]
+              has_failed[alert_name_key.to_sym] = key == 'passed'.to_sym ? false : true
             end
           end
           log_alert_results

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -53,13 +53,14 @@ module DocAuth
         def create_response_info
           alerts = processed_alerts
 
+          log_alert_formatter = DocAuth::ProcessedAlertToLogAlertFormatter.new
           {
             vendor: 'Acuant',
             billed: result_code.billed,
             doc_auth_result: result_code.name,
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,
-            log_alert_results: log_alerts(alerts),
+            log_alert_results: log_alert_formatter.log_alerts(alerts),
             image_metrics: processed_image_metrics,
             tamper_result: tamper_result_code&.name,
           }
@@ -93,37 +94,6 @@ module DocAuth
 
         def processed_alerts
           @processed_alerts ||= process_raw_alerts(raw_alerts)
-        end
-
-        def get_alert_result(log_alert_results, side, alert_name_key, result)
-          if log_alert_results.dig(alert_name_key, side.to_sym).present?
-            alert_value = log_alert_results[alert_name_key][side.to_sym]
-            Rails.logger.
-              info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
-          end
-          result
-        end
-
-        def log_alerts(alerts)
-          log_alert_results = {}
-
-          alerts.keys.each do |key|
-            alerts[key.to_sym].each do |alert|
-              alert_name_key = alert[:name].
-                downcase.
-                parameterize(separator: '_').to_sym
-              side = alert[:side] || 'no_side'
-
-              log_alert_results[alert_name_key] =
-                { "#{side}": get_alert_result(
-                  log_alert_results,
-                  side,
-                  alert_name_key,
-                  alert[:result],
-                ) }
-            end
-          end
-          log_alert_results
         end
 
         def processed_image_metrics

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -105,8 +105,11 @@ module DocAuth
                 downcase.
                 parameterize(separator: '_')
               side = alert[:side] || 'no_side'
-              log_alert_results[alert_name_key.to_sym] = { "#{side}": alert[:result] } unless has_failed[alert_name_key.to_sym]
-              has_failed[alert_name_key.to_sym] = key == 'passed'.to_sym ? false : true
+              unless has_failed[alert_name_key.to_sym]
+                log_alert_results[alert_name_key.to_sym] =
+                  { "#{side}": alert[:result] }
+              end
+              has_failed[alert_name_key.to_sym] = !(key == :passed)
             end
           end
           log_alert_results

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -105,7 +105,6 @@ module DocAuth
 
         def log_alerts(alerts)
           log_alert_results = {}
-          has_failed = {}
 
           alerts.keys.each do |key|
             alerts[key.to_sym].each do |alert|
@@ -122,7 +121,6 @@ module DocAuth
                   alert[:result],
                   ).
                     split(', ').uniq.join(', ') }
-              has_failed[alert_name_key] = !(key == :passed)
             end
           end
           log_alert_results

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -97,8 +97,9 @@ module DocAuth
 
         def get_alert_result(log_alert_results, side, alert_name_key, result)
           if log_alert_results.dig(alert_name_key, side.to_sym).present?
+            alert_value = log_alert_results[alert_name_key][side.to_sym]
             Rails.logger.
-              info("ALERT ALREADY HAS A VALUE: #{log_alert_results[alert_name_key][side.to_sym]}, #{result}")
+              info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
           end
           result
         end
@@ -119,7 +120,7 @@ module DocAuth
                   side,
                   alert_name_key,
                   alert[:result],
-                  ) }
+                ) }
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -124,12 +124,16 @@ module DocAuth
 
         def log_alerts(alerts)
           log_alert_results = {}
+          has_failed = {}
+
           alerts.keys.each do |key|
             alerts[key.to_sym].each do |alert|
-              side = alert[:side] || 'no_side'
-              log_alert_results[alert[:name].
+              alert_name_key = alert[:name].
                 downcase.
-                parameterize(separator: '_').to_sym] = { "#{side}": alert[:result] }
+                parameterize(separator: '_')
+              side = alert[:side] || 'no_side'
+              log_alert_results[alert_name_key.to_sym] = { "#{side}": alert[:result] } unless has_failed[alert_name_key.to_sym]
+              has_failed[alert_name_key.to_sym] = key == 'passed'.to_sym ? false : true
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -124,10 +124,10 @@ module DocAuth
 
         def get_alert_result(log_alert_results, side, alert_name_key, result)
           if log_alert_results.dig(alert_name_key, side.to_sym).present?
-            log_alert_results[alert_name_key][side.to_sym] + ", #{result}"
-          else
-            result
+            Rails.logger.
+              info("ALERT ALREADY HAS A VALUE: #{log_alert_results[alert_name_key][side.to_sym]}, #{result}")
           end
+          result
         end
 
         def log_alerts(alerts)
@@ -146,8 +146,7 @@ module DocAuth
                   side,
                   alert_name_key,
                   alert[:result],
-                ).
-                split(', ').uniq.join(', ') }
+                )}
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -132,8 +132,11 @@ module DocAuth
                 downcase.
                 parameterize(separator: '_')
               side = alert[:side] || 'no_side'
-              log_alert_results[alert_name_key.to_sym] = { "#{side}": alert[:result] } unless has_failed[alert_name_key.to_sym]
-              has_failed[alert_name_key.to_sym] = key == 'passed'.to_sym ? false : true
+              unless has_failed[alert_name_key.to_sym]
+                log_alert_results[alert_name_key.to_sym] =
+                  { "#{side}": alert[:result] }
+              end
+              has_failed[alert_name_key.to_sym] = !(key == :passed)
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -124,8 +124,9 @@ module DocAuth
 
         def get_alert_result(log_alert_results, side, alert_name_key, result)
           if log_alert_results.dig(alert_name_key, side.to_sym).present?
+            alert_value = log_alert_results[alert_name_key][side.to_sym]
             Rails.logger.
-              info("ALERT ALREADY HAS A VALUE: #{log_alert_results[alert_name_key][side.to_sym]}, #{result}")
+              info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
           end
           result
         end
@@ -146,7 +147,7 @@ module DocAuth
                   side,
                   alert_name_key,
                   alert[:result],
-                )}
+                ) }
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -122,6 +122,14 @@ module DocAuth
           @response_info ||= create_response_info
         end
 
+        def get_alert_result(log_alert_results, side, alert_name_key, result)
+          if log_alert_results.dig(alert_name_key, side.to_sym).present?
+            log_alert_results[alert_name_key][side.to_sym] + ", #{result}"
+          else
+            result
+          end
+        end
+
         def log_alerts(alerts)
           log_alert_results = {}
           has_failed = {}
@@ -130,13 +138,18 @@ module DocAuth
             alerts[key.to_sym].each do |alert|
               alert_name_key = alert[:name].
                 downcase.
-                parameterize(separator: '_')
+                parameterize(separator: '_').to_sym
               side = alert[:side] || 'no_side'
-              unless has_failed[alert_name_key.to_sym]
-                log_alert_results[alert_name_key.to_sym] =
-                  { "#{side}": alert[:result] }
-              end
-              has_failed[alert_name_key.to_sym] = !(key == :passed)
+
+              log_alert_results[alert_name_key] =
+                { "#{side}": get_alert_result(
+                  log_alert_results,
+                  side,
+                  alert_name_key,
+                  alert[:result],
+                ).
+                split(', ').uniq.join(', ') }
+              has_failed[alert_name_key] = !(key == :passed)
             end
           end
           log_alert_results

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -122,39 +122,9 @@ module DocAuth
           @response_info ||= create_response_info
         end
 
-        def get_alert_result(log_alert_results, side, alert_name_key, result)
-          if log_alert_results.dig(alert_name_key, side.to_sym).present?
-            alert_value = log_alert_results[alert_name_key][side.to_sym]
-            Rails.logger.
-              info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
-          end
-          result
-        end
-
-        def log_alerts(alerts)
-          log_alert_results = {}
-
-          alerts.keys.each do |key|
-            alerts[key.to_sym].each do |alert|
-              alert_name_key = alert[:name].
-                downcase.
-                parameterize(separator: '_').to_sym
-              side = alert[:side] || 'no_side'
-
-              log_alert_results[alert_name_key] =
-                { "#{side}": get_alert_result(
-                  log_alert_results,
-                  side,
-                  alert_name_key,
-                  alert[:result],
-                ) }
-            end
-          end
-          log_alert_results
-        end
-
         def create_response_info
           alerts = parsed_alerts
+          log_alert_formatter = DocAuth::ProcessedAlertToLogAlertFormatter.new
 
           {
             liveness_enabled: @liveness_checking_enabled,
@@ -164,7 +134,7 @@ module DocAuth
             doc_auth_result: doc_auth_result,
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,
-            log_alert_results: log_alerts(alerts),
+            log_alert_results: log_alert_formatter.log_alerts(alerts),
             portrait_match_results: true_id_product[:PORTRAIT_MATCH_RESULT],
             image_metrics: parse_image_metrics,
           }

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -132,7 +132,6 @@ module DocAuth
 
         def log_alerts(alerts)
           log_alert_results = {}
-          has_failed = {}
 
           alerts.keys.each do |key|
             alerts[key.to_sym].each do |alert|
@@ -149,7 +148,6 @@ module DocAuth
                   alert[:result],
                 ).
                 split(', ').uniq.join(', ') }
-              has_failed[alert_name_key] = !(key == :passed)
             end
           end
           log_alert_results

--- a/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
+++ b/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
@@ -1,0 +1,34 @@
+module DocAuth
+  class ProcessedAlertToLogAlertFormatter
+    def get_alert_result(log_alert_results, side, alert_name_key, result)
+      if log_alert_results.dig(alert_name_key, side.to_sym).present?
+        alert_value = log_alert_results[alert_name_key][side.to_sym]
+        Rails.logger.
+          info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
+      end
+      result
+    end
+
+    def log_alerts(alerts)
+      log_alert_results = {}
+
+      alerts.keys.each do |key|
+        alerts[key.to_sym].each do |alert|
+          alert_name_key = alert[:name].
+            downcase.
+            parameterize(separator: '_').to_sym
+          side = alert[:side] || 'no_side'
+
+          log_alert_results[alert_name_key] =
+            { "#{side}": get_alert_result(
+              log_alert_results,
+              side,
+              alert_name_key,
+              alert[:result],
+            ) }
+        end
+      end
+      log_alert_results
+    end
+  end
+end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -164,33 +164,33 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
 
     context 'when visiual_pattern fails and passes' do
       let(:http_response) do
-        parsed_response_body['Alerts'] <<  {
-          "Actions": "Check the visible (white) document image to verify the presence of the security feature.  Possible reasons this test may fail for a valid document may be that the document was moving during the capture, or the document may be excessively worn or damaged.",
-          "DataFieldReferences": [],
-          "Description": "Verified the presence of a pattern on the visible image.",
-          "Disposition": "A visible pattern was not found",
-          "FieldReferences": [],
-          "Id": "4add9651-27ed-40a2-90eb-7fa46a694156",
-          "ImageReferences": [],
-          "Information": "Verified that a security feature in the visible spectrum is present and in an expected location on the document.",
-          "Key": "Visible Pattern",
-          "Name": "Visible Pattern",
-          "RegionReferences": [],
-          "Result": 2,
+        parsed_response_body['Alerts'] << {
+          Actions: 'Check the visible (white) document image...',
+          DataFieldReferences: [],
+          Description: 'Verified the presence of a pattern on the visible image.',
+          Disposition: 'A visible pattern was not found',
+          FieldReferences: [],
+          Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
+          ImageReferences: [],
+          Information: 'Verified that a security feature...',
+          Key: 'Visible Pattern',
+          Name: 'Visible Pattern',
+          RegionReferences: [],
+          Result: 2,
         }
-        parsed_response_body['Alerts'] <<  {
-          "Actions": "Check the visible (white) document image to verify the presence of the security feature.  Possible reasons this test may fail for a valid document may be that the document was moving during the capture, or the document may be excessively worn or damaged.",
-          "DataFieldReferences": [],
-          "Description": "Verified the presence of a pattern on the visible image.",
-          "Disposition": "A visible pattern was not found",
-          "FieldReferences": [],
-          "Id": "4add9651-27ed-40a2-90eb-7fa46a694156",
-          "ImageReferences": [],
-          "Information": "Verified that a security feature in the visible spectrum is present and in an expected location on the document.",
-          "Key": "Visible Pattern",
-          "Name": "Visible Pattern",
-          "RegionReferences": [],
-          "Result": 1,
+        parsed_response_body['Alerts'] << {
+          Actions: 'Check the visible (white) document image...',
+          DataFieldReferences: [],
+          Description: 'Verified the presence of a pattern on the visible image.',
+          Disposition: 'A visible pattern was not found',
+          FieldReferences: [],
+          Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
+          ImageReferences: [],
+          Information: 'Verified that a security feature...',
+          Key: 'Visible Pattern',
+          Name: 'Visible Pattern',
+          RegionReferences: [],
+          Result: 1,
         }
 
         instance_double(
@@ -204,13 +204,14 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
           passed: [{ name: 'Visible Pattern', result: 'Passed' }],
           failed:
             [{ name: 'Document Classification',
-               result:'Failed' },
+               result: 'Failed' },
              { name: 'Visible Pattern',
-               result: 'Failed' }]
+               result: 'Failed' }],
         )
 
         expect(response.to_h[:log_alert_results]).to eq(
-          { visible_pattern: { no_side: 'Failed' }, :document_classification=>{ no_side: 'Failed' } }
+          { visible_pattern: { no_side: 'Failed' },
+            document_classification: { no_side: 'Failed' } },
         )
       end
     end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -162,9 +162,9 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       expect(response.result_code.billed?).to eq(false)
     end
 
-    context 'when visiual_pattern fails with multiple results' do
+    context 'when visiual_pattern passes and fails' do
       let(:http_response) do
-        [1, 2, 3, 4].each do |index|
+        [1, 2].each do |index|
           parsed_response_body['Alerts'] << {
             Key: 'Visible Pattern',
             Name: 'Visible Pattern',
@@ -186,15 +186,11 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
             [{ name: 'Document Classification',
                result: 'Failed' },
              { name: 'Visible Pattern',
-               result: 'Failed' },
-             { name: 'Visible Pattern',
-               result: 'Skipped' },
-             { name: 'Visible Pattern',
-               result: 'Caution' }],
+               result: 'Failed' }],
         )
 
         expect(response.to_h[:log_alert_results]).to eq(
-          { visible_pattern: { no_side: 'Passed, Failed, Skipped, Caution' },
+          { visible_pattern: { no_side: 'Failed' },
             document_classification: { no_side: 'Failed' } },
         )
       end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -165,19 +165,15 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
     context 'when visiual_pattern fails and passes' do
       let(:http_response) do
         parsed_response_body['Alerts'] << {
-          Description: 'Verified the presence of a pattern on the visible image.',
-          Disposition: 'A visible pattern was not found',
-          Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
           Key: 'Visible Pattern',
           Name: 'Visible Pattern',
+          RegionReferences: [],
           Result: 2,
         }
         parsed_response_body['Alerts'] << {
-          Description: 'Verified the presence of a pattern on the visible image.',
-          Disposition: 'A visible pattern was not found',
-          Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
           Key: 'Visible Pattern',
           Name: 'Visible Pattern',
+          RegionReferences: [],
           Result: 1,
         }
 

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
         hints: true,
       )
-
       expect(response.to_h[:log_alert_results]).to eq(
         document_classification: { no_side: 'Failed' },
       )

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -165,31 +165,19 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
     context 'when visiual_pattern fails and passes' do
       let(:http_response) do
         parsed_response_body['Alerts'] << {
-          Actions: 'Check the visible (white) document image...',
-          DataFieldReferences: [],
           Description: 'Verified the presence of a pattern on the visible image.',
           Disposition: 'A visible pattern was not found',
-          FieldReferences: [],
           Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
-          ImageReferences: [],
-          Information: 'Verified that a security feature...',
           Key: 'Visible Pattern',
           Name: 'Visible Pattern',
-          RegionReferences: [],
           Result: 2,
         }
         parsed_response_body['Alerts'] << {
-          Actions: 'Check the visible (white) document image...',
-          DataFieldReferences: [],
           Description: 'Verified the presence of a pattern on the visible image.',
           Disposition: 'A visible pattern was not found',
-          FieldReferences: [],
           Id: '4add9651-27ed-40a2-90eb-7fa46a694156',
-          ImageReferences: [],
-          Information: 'Verified that a security feature...',
           Key: 'Visible Pattern',
           Name: 'Visible Pattern',
-          RegionReferences: [],
           Result: 1,
         }
 

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -185,6 +185,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:hints]).to eq(true)
     end
 
+    it 'returns log_alert_results, visible_pattern as false when alerts has it as true and false' do
+      output = described_class.new(failure_response_no_liveness, false, config).to_h
+      expect(output.to_h[:log_alert_results]).to match(a_hash_including('visible_pattern': { no_side: 'Failed' }))
+    end
+
     it 'produces appropriate errors with liveness' do
       output = described_class.new(failure_response_with_liveness, true, config).to_h
       errors = output[:errors]

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         transaction_reason_code: 'trueid_pass',
         product_status: 'pass',
         doc_auth_result: 'Passed',
-        processed_alerts: a_hash_including(:passed, :failed),
+        processed_alerts: a_hash_including(:failed),
         alert_failure_count: a_kind_of(Numeric),
         portrait_match_results: nil,
         image_metrics: a_hash_including(:front, :back),
@@ -170,7 +170,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         layout_valid: { no_side: 'Passed' },
         sex_crosscheck: { no_side: 'Passed' },
         visible_color_response: { no_side: 'Passed' },
-        visible_pattern: { no_side: 'Passed, Failed' },
+        visible_pattern: { no_side: 'Failed' },
         visible_photo_characteristics: { no_side: 'Passed' },
         '1d_control_number_valid': { no_side: 'Failed' },
         '2d_barcode_content': { no_side: 'Failed' },
@@ -185,10 +185,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:hints]).to eq(true)
     end
 
-    it 'returns all of the alerts for log_alert_results, comma delimited' do
+    it 'returns Failed for visible_pattern when it gets passed and failed value ' do
       output = described_class.new(failure_response_no_liveness, false, config).to_h
       expect(output.to_h[:log_alert_results]).
-        to match(a_hash_including(visible_pattern: { no_side: 'Passed, Failed' }))
+        to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
     end
 
     it 'produces appropriate errors with liveness' do
@@ -210,7 +210,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         layout_valid: { no_side: 'Passed' },
         sex_crosscheck: { no_side: 'Passed' },
         visible_color_response: { no_side: 'Passed' },
-        visible_pattern: { no_side: 'Passed, Failed' },
+        visible_pattern: { no_side: 'Failed' },
         visible_photo_characteristics: { no_side: 'Passed' },
         '1d_control_number_valid': { no_side: 'Failed' },
         '2d_barcode_content': { no_side: 'Failed' },

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         layout_valid: { no_side: 'Passed' },
         sex_crosscheck: { no_side: 'Passed' },
         visible_color_response: { no_side: 'Passed' },
-        visible_pattern: { no_side: 'Failed' },
+        visible_pattern: { no_side: 'Passed, Failed' },
         visible_photo_characteristics: { no_side: 'Passed' },
         '1d_control_number_valid': { no_side: 'Failed' },
         '2d_barcode_content': { no_side: 'Failed' },
@@ -185,10 +185,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:hints]).to eq(true)
     end
 
-    it 'returns log_alert_results, visible_pattern as false when alerts has it as true and false' do
+    it 'returns all of the alerts for log_alert_results, comma delimited' do
       output = described_class.new(failure_response_no_liveness, false, config).to_h
       expect(output.to_h[:log_alert_results]).
-        to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
+        to match(a_hash_including(visible_pattern: { no_side: 'Passed, Failed' }))
     end
 
     it 'produces appropriate errors with liveness' do
@@ -210,7 +210,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         layout_valid: { no_side: 'Passed' },
         sex_crosscheck: { no_side: 'Passed' },
         visible_color_response: { no_side: 'Passed' },
-        visible_pattern: { no_side: 'Failed' },
+        visible_pattern: { no_side: 'Passed, Failed' },
         visible_photo_characteristics: { no_side: 'Passed' },
         '1d_control_number_valid': { no_side: 'Failed' },
         '2d_barcode_content': { no_side: 'Failed' },

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -187,7 +187,8 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
     it 'returns log_alert_results, visible_pattern as false when alerts has it as true and false' do
       output = described_class.new(failure_response_no_liveness, false, config).to_h
-      expect(output.to_h[:log_alert_results]).to match(a_hash_including('visible_pattern': { no_side: 'Failed' }))
+      expect(output.to_h[:log_alert_results]).
+        to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
     end
 
     it 'produces appropriate errors with liveness' do

--- a/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
+++ b/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do
+  let(:alerts) do
+    { passed: [{ alert: 'Alert_1', name: 'Visible Pattern', result: 'Passed' }],
+      failed:
+       [
+         { alert: 'Alert_1', name: '2D Barcode Read', result: 'Failed' },
+         { alert: 'Alert_2', name: 'Layout Valid', result: 'Attention' },
+         { alert: 'Alert_3', name: '2D Barcode Read', result: 'Failed' },
+         { alert: 'Alert_4', name: 'Visible Pattern', result: 'Failed' },
+         { alert: 'Alert_5', name: 'Visible Photo Characteristics', result: 'Failed' },
+       ] }
+  end
+
+  context('when ProcessedAlertToLogAlertFormatter is called') do
+    subject {
+        DocAuth::ProcessedAlertToLogAlertFormatter.new.log_alerts(alerts)
+    }
+
+    it('returns failed if both passed and failed are returned by the alert') do
+      expect(subject).to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
+    end
+
+    it('returns the formatted log hash') do
+      expect(subject).to eq(
+        { '2d_barcode_read': { no_side: 'Failed' },
+          layout_valid: { no_side: 'Attention' },
+          visible_pattern: { no_side: 'Failed' },
+          visible_photo_characteristics: { no_side: 'Failed' } },
+      )
+    end
+  end
+end

--- a/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
+++ b/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
@@ -1,3 +1,6 @@
+# Take the proccessed alerts and reformat them in a hash so that its easier to search and collect stats
+# through cloudwatch.
+
 require 'rails_helper'
 
 RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do

--- a/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
+++ b/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
@@ -1,5 +1,5 @@
-# Take the proccessed alerts and reformat them in a hash so that its easier to search and collect stats
-# through cloudwatch.
+# Take the proccessed alerts and reformat them in a hash so that its easier to search and collect
+# stats through cloudwatch.
 
 require 'rails_helper'
 
@@ -18,7 +18,7 @@ RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do
 
   context('when ProcessedAlertToLogAlertFormatter is called') do
     subject {
-        DocAuth::ProcessedAlertToLogAlertFormatter.new.log_alerts(alerts)
+      DocAuth::ProcessedAlertToLogAlertFormatter.new.log_alerts(alerts)
     }
 
     it('returns failed if both passed and failed are returned by the alert') do


### PR DESCRIPTION
This pull request adds a safe guard so that if the alert had failed and passed, that the failed alert is logged and not written over. The chances currently of this happening is zero because the 'Passed alerts are processed first' but as a safeguard, I added a check to ensure failed is always logged and updated the test.

Currently a work in progress and not review for review just yet. 

