### PR TITLE
LG-7035: Clear in-person proofing session when starting over

### DIFF
--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -12,6 +12,7 @@ module Idv
         location: location_params[:location],
       )
       user_session['idv/doc_auth'] = {}
+      user_session['idv/in_person'] = {}
       idv_session.clear
       Pii::Cacher.new(current_user, user_session).delete
       redirect_to idv_url

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -17,6 +17,7 @@ describe Idv::SessionsController do
       allow(idv_session).to receive(:clear)
       allow(subject).to receive(:idv_session).and_return(idv_session)
       controller.user_session['idv/doc_auth'] = flow_session
+      controller.user_session['idv/in_person'] = flow_session
       controller.user_session[:decrypted_pii] = pii
     end
 
@@ -26,6 +27,7 @@ describe Idv::SessionsController do
       delete :destroy
 
       expect(controller.user_session['idv/doc_auth']).to be_blank
+      expect(controller.user_session['idv/in_person']).to be_blank
       expect(controller.user_session[:decrypted_pii]).to be_blank
     end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe 'In Person Proofing', js: true do
     end
 
     it 'lets the user clear and start over from gpo confirmation', allow_browser_log: true do
+      sign_in_and_2fa_user
       begin_in_person_proofing
       complete_all_in_person_proofing_steps
       click_on t('idv.troubleshooting.options.verify_by_mail')

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'In Person Proofing', js: true do
   it 'works for a happy path', allow_browser_log: true do
     user = user_with_2fa
 
+    sign_in_and_2fa_user(user)
     begin_in_person_proofing(user)
 
     # location page
@@ -107,12 +108,26 @@ RSpec.describe 'In Person Proofing', js: true do
     expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
   end
 
+  it 'allows the user to cancel and start over from the beginning', allow_browser_log: true do
+    sign_in_and_2fa_user
+    begin_in_person_proofing
+    complete_all_in_person_proofing_steps
+
+    click_link t('links.cancel')
+    click_on t('idv.cancel.actions.start_over')
+
+    expect(page).to have_current_path(idv_doc_auth_welcome_step)
+    begin_in_person_proofing
+    complete_all_in_person_proofing_steps
+  end
+
   context 'verify address by mail (GPO letter)' do
     before do
       allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
     end
 
     it 'requires address verification before showing instructions', allow_browser_log: true do
+      sign_in_and_2fa_user
       begin_in_person_proofing
       complete_all_in_person_proofing_steps
       click_on t('idv.troubleshooting.options.verify_by_mail')

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -34,8 +34,7 @@ module InPersonHelper
     choose t('in_person_proofing.form.address.same_address_choice_yes')
   end
 
-  def begin_in_person_proofing(user = user_with_2fa)
-    sign_in_and_2fa_user(user)
+  def begin_in_person_proofing(_user = user_with_2fa)
     complete_doc_auth_steps_before_document_capture_step
     mock_doc_auth_attention_with_barcode
     attach_and_submit_images


### PR DESCRIPTION
**Why**: So that a user can start over from the beginning and not be skipped past other steps.
