### PR TITLE
LG-7063: Avoid sending account verified email for in-person proofing

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -33,16 +33,16 @@ module Idv
         analytics.idv_gpo_verification_submitted(**result.to_h)
 
         if result.success?
-          event = create_user_event_with_disavowal(:account_verified)
-          UserAlerts::AlertUserAboutAccountVerified.call(
-            user: current_user,
-            date_time: event.created_at,
-            sp_name: decorated_session.sp_name,
-            disavowal_token: event.disavowal_token,
-          )
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
+            event = create_user_event_with_disavowal(:account_verified)
+            UserAlerts::AlertUserAboutAccountVerified.call(
+              user: current_user,
+              date_time: event.created_at,
+              sp_name: decorated_session.sp_name,
+              disavowal_token: event.disavowal_token,
+            )
             flash[:success] = t('account.index.verification.success')
             redirect_to sign_up_completed_url
           end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -90,7 +90,7 @@ module Idv
       idv_session.cache_encrypted_pii(password)
       idv_session.complete_session
 
-      if idv_session.phone_confirmed?
+      if idv_session.profile.active?
         event = create_user_event_with_disavowal(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -116,6 +116,12 @@ RSpec.describe Idv::GpoVerifyController do
         expect(response).to redirect_to(sign_up_completed_url)
       end
 
+      it 'dispatches account verified alert' do
+        expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+        action
+      end
+
       context 'with pending in person enrollment' do
         let(:proofing_components) {
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
@@ -139,6 +145,12 @@ RSpec.describe Idv::GpoVerifyController do
           action
 
           expect(response).to redirect_to(idv_in_person_ready_to_verify_url)
+        end
+
+        it 'does not dispatch account verified alert' do
+          expect(UserAlerts::AlertUserAboutAccountVerified).not_to receive(:call)
+
+          action
         end
       end
     end


### PR DESCRIPTION
**Why**: The user's profile is not verified until they finish proofing in person.
