### PR TITLE
LG-6103: add warning about personal key to password reset screen

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -2,6 +2,8 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 
+<p><%= t('instructions.password.password_key') %></p>
+
 <%= validated_form_for(
       @reset_password_form,
       url: user_password_path,

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -92,6 +92,9 @@ en:
       info:
         lead: It must be at least %{min_length} characters long and not be a commonly
           used password. That’s it!
+      password_key: You need your 16-character personal key to reset your password if
+        you verified your identity with this account. If you don’t have it, you
+        can still reset your password and then reverify your identity.
       strength:
         i: Very weak
         ii: Weak

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -98,6 +98,10 @@ es:
       info:
         lead: Su contraseña debe tener al menos %{min_length} caracteres y no ser una
           contraseña común. ¡Eso es todo!
+      password_key: Si verificó su identidad con esta cuenta, necesita su clave
+        personal de 16 caracteres para restablecer su contraseña. Si no cuenta
+        con ella, de todos modos puede restablecer su contraseña y luego volver
+        a verificar su identidad.
       strength:
         i: Muy débil
         ii: Débil

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -108,6 +108,10 @@ fr:
       info:
         lead: Il doit avoir une longueur minimale de %{min_length} caractères et ne pas
           être un mot de passe couramment utilisé. C’est tout!
+      password_key: Vous avez besoin de votre clé personnelle de 16 caractères pour
+        réinitialiser votre mot de passe si vous avez vérifié votre identité
+        avec ce compte. Si vous ne l’avez pas, vous pouvez toujours
+        réinitialiser votre mot de passe et ensuite revérifier votre identité.
       strength:
         i: Très faible
         ii: Faible

--- a/spec/views/devise/passwords/edit.html.erb_spec.rb
+++ b/spec/views/devise/passwords/edit.html.erb_spec.rb
@@ -27,6 +27,6 @@ describe 'devise/passwords/edit.html.erb' do
   it 'has information about the password key' do
     render
 
-    expect (rendered).to have_selector('p', text: t('instructions.password.password_key'))
+    expect(rendered).to have_selector('p', text: t('instructions.password.password_key'))
   end
 end

--- a/spec/views/devise/passwords/edit.html.erb_spec.rb
+++ b/spec/views/devise/passwords/edit.html.erb_spec.rb
@@ -23,4 +23,10 @@ describe 'devise/passwords/edit.html.erb' do
 
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
+
+  it 'has information about the password key' do
+    render
+
+    expect (rendered).to have_selector('p', text: t('instructions.password.password_key'))
+  end
 end


### PR DESCRIPTION
Why: To notify users that if they verified their identity and wish to reset their password, they must have their 16 character personal key, or else they will have to reverify their identity.

Screenshots
| Before      | After |
| ----------- | ----------- |
| ![Screen Shot 2022-08-04 at 12 04 34 PM](https://user-images.githubusercontent.com/17969963/183144905-25e8c99b-7fe5-49ae-9d87-d5b2d78505d4.png) | ![Screen Shot 2022-08-05 at 1 12 00 PM](https://user-images.githubusercontent.com/17969963/183144978-b569f8d8-9455-4336-b61c-d34d17b46a30.png) |
