### PR TITLE
Use correct Spanish label for "Retail hours"

### DIFF
--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -18,7 +18,7 @@ es:
         learn_more: Más información
         location_details: Detalles de la ubicación
         no_appointment_required: No es necesario pedir cita.
-        retail_hours: Heures de vente au détail
+        retail_hours: Horario de atención al público
         retail_hours_closed: Cerrado
         retail_phone_label: Número de teléfono
         speak_to_associate: Puedes hablar con cualquier socio de ventas en esta oficina


### PR DESCRIPTION
**Why**: So that a Spanish user sees Spanish content, not French.
