### PR TITLE
LG-6436: Add hybrid document capture opt-in for in-person proofing

### DIFF
--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -31,6 +31,8 @@ module Idv
     end
 
     def redirect_url
+      return unless flow_session && document_capture_session
+
       if throttled?
         idv_session_errors_throttled_url
       elsif user_has_establishing_in_person_enrollment?

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -5,12 +5,7 @@ module Idv
     respond_to :json
 
     def show
-      render(
-        json: {
-          redirect: status == :too_many_requests ? idv_session_errors_throttled_url : nil,
-        }.compact,
-        status: status,
-      )
+      render(json: { redirect: redirect_url }.compact, status: status)
     end
 
     private
@@ -23,7 +18,7 @@ module Idv
           :gone
         elsif throttled?
           :too_many_requests
-        elsif confirmed_barcode_attention_result?
+        elsif confirmed_barcode_attention_result? || user_has_establishing_in_person_enrollment?
           :ok
         elsif session_result.blank? || pending_barcode_attention_confirmation?
           :accepted
@@ -32,6 +27,14 @@ module Idv
         else
           :ok
         end
+      end
+    end
+
+    def redirect_url
+      if throttled?
+        idv_session_errors_throttled_url
+      elsif user_has_establishing_in_person_enrollment?
+        idv_in_person_url
       end
     end
 
@@ -55,10 +58,16 @@ module Idv
     end
 
     def throttled?
-      Throttle.new(
-        user: document_capture_session.user,
-        throttle_type: :idv_doc_auth,
-      ).throttled?
+      throttle.throttled?
+    end
+
+    def throttle
+      @throttle ||= Throttle.new(user: document_capture_session.user, throttle_type: :idv_doc_auth)
+    end
+
+    def user_has_establishing_in_person_enrollment?
+      return false unless IdentityConfig.store.in_person_proofing_enabled
+      current_user.establishing_in_person_enrollment.present?
     end
 
     def confirmed_barcode_attention_result?

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -4,6 +4,7 @@ module Idv
   module InPerson
     class UspsLocationsController < ApplicationController
       include UspsInPersonProofing
+      include EffectiveUser
 
       # get the list of all pilot Post Office locations
       def index
@@ -28,7 +29,7 @@ module Idv
 
       def enrollment
         UspsInPersonProofing::EnrollmentHelper.
-          establishing_in_person_enrollment_for_user(current_user)
+          establishing_in_person_enrollment_for_user(effective_user)
       end
 
       def permitted_params

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -3,7 +3,6 @@ require 'json'
 module Idv
   module InPerson
     class UspsLocationsController < ApplicationController
-      include IdvSession
       include UspsInPersonProofing
 
       # get the list of all pilot Post Office locations
@@ -18,15 +17,19 @@ module Idv
         render json: usps_response.to_json
       end
 
-      # save the Post Office location the user selected to the session
+      # save the Post Office location the user selected to an enrollment
       def update
-        idv_session.applicant ||= {}
-        idv_session.applicant[:selected_location_details] = permitted_params.as_json
+        enrollment.update!(selected_location_details: permitted_params.as_json)
 
         render json: { success: true }, status: :ok
       end
 
       protected
+
+      def enrollment
+        UspsInPersonProofing::EnrollmentHelper.
+          establishing_in_person_enrollment_for_user(current_user)
+      end
 
       def permitted_params
         params.require(:usps_location).permit(

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -57,7 +57,7 @@ module Api
         create_gpo_entry
       elsif phone_confirmed?
         if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.new.save_in_person_enrollment(
+          UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
             user,
             profile,
             session[:pii],

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -52,21 +52,24 @@ module Api
     end
 
     def complete_session
+      associate_in_person_enrollment_with_profile
+
       if user_bundle.gpo_address_verification?
         profile.deactivate(:gpo_verification_pending)
         create_gpo_entry
       elsif phone_confirmed?
         if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
-            user,
-            profile,
-            session[:pii],
-          )
+          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, session[:pii])
           profile.deactivate(:in_person_verification_pending)
         else
           complete_profile
         end
       end
+    end
+
+    def associate_in_person_enrollment_with_profile
+      return unless pending_in_person_enrollment? && user.establishing_in_person_enrollment
+      user.establishing_in_person_enrollment.update(profile: profile)
     end
 
     def pending_in_person_enrollment?

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -57,7 +57,7 @@ module Api
         create_gpo_entry
       elsif phone_confirmed?
         if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
+          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
             user,
             profile,
             session[:pii],

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -61,7 +61,6 @@ module Api
             user,
             profile,
             session[:pii],
-            session.dig(:applicant, :selected_location_details),
           )
           profile.deactivate(:in_person_verification_pending)
         else

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -19,7 +19,7 @@ class GpoVerifyForm
     result = valid?
     if result
       if pending_in_person_enrollment?
-        UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
+        UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           user,
           pending_profile,
           pii,

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -19,11 +19,7 @@ class GpoVerifyForm
     result = valid?
     if result
       if pending_in_person_enrollment?
-        UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
-          user,
-          pending_profile,
-          pii,
-        )
+        UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
       else
         activate_profile

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -19,7 +19,7 @@ class GpoVerifyForm
     result = valid?
     if result
       if pending_in_person_enrollment?
-        UspsInPersonProofing::EnrollmentHelper.new.save_in_person_enrollment(
+        UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
           user,
           pending_profile,
           pii,

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -82,10 +82,7 @@ export class DocumentCapturePolling {
     this.toggleFormVisible(true);
   }
 
-  async onComplete({
-    result = ResultType.SUCCESS,
-    redirect,
-  }: { result?: ResultType; redirect?: string } = {}) {
+  async onComplete({ result, redirect }: { result: ResultType; redirect?: string }) {
     await this.trackEvent('IdV: Link sent capture doc polling complete', {
       isCancelled: result === ResultType.CANCELLED,
       isThrottled: result === ResultType.THROTTLED,
@@ -109,10 +106,11 @@ export class DocumentCapturePolling {
 
   async poll() {
     const response = await window.fetch(this.statusEndpoint);
+    const { redirect } = (await response.json()) as { redirect?: string };
 
     switch (response.status) {
       case StatusCodes.SUCCESS:
-        this.onComplete();
+        this.onComplete({ result: ResultType.SUCCESS, redirect });
         break;
 
       case StatusCodes.GONE:
@@ -120,7 +118,6 @@ export class DocumentCapturePolling {
         break;
 
       case StatusCodes.TOO_MANY_REQUESTS: {
-        const { redirect } = await response.json();
         this.onComplete({ result: ResultType.THROTTLED, redirect });
         break;
       }

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -6,49 +6,49 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
   DOC_CAPTURE_TIMEOUT / DOC_CAPTURE_POLL_INTERVAL,
 );
 
-/**
- * @typedef DocumentCapturePollingElements
- *
- * @prop {HTMLFormElement} form
- * @prop {HTMLAnchorElement} backLink
- */
+interface DocumentCapturePollingElements {
+  form: HTMLFormElement;
 
-/**
- * @typedef DocumentCapturePollingOptions
- *
- * @prop {string} statusEndpoint
- * @prop {DocumentCapturePollingElements} elements
- * @prop {typeof defaultTrackEvent=} trackEvent
- */
+  backLink: HTMLAnchorElement;
+}
 
-/**
- * @enum {number}
- */
-const StatusCodes = {
-  SUCCESS: 200,
-  GONE: 410,
-  TOO_MANY_REQUESTS: 429,
-};
+interface DocumentCapturePollingOptions {
+  statusEndpoint: string;
 
-/**
- * @enum {string}
- */
-const ResultType = {
-  SUCCESS: 'SUCCESS',
-  CANCELLED: 'CANCELLED',
-  THROTTLED: 'THROTTLED',
-};
+  elements: DocumentCapturePollingElements;
+
+  trackEvent?: typeof defaultTrackEvent;
+}
+
+enum StatusCodes {
+  SUCCESS = 200,
+  GONE = 410,
+  TOO_MANY_REQUESTS = 429,
+}
+
+enum ResultType {
+  SUCCESS = 'SUCCESS',
+  CANCELLED = 'CANCELLED',
+  THROTTLED = 'THROTTLED',
+}
 
 /**
  * Manages polling requests for document capture hybrid flow.
  */
 export class DocumentCapturePolling {
+  elements: DocumentCapturePollingElements;
+
+  statusEndpoint: string;
+
+  trackEvent: typeof defaultTrackEvent;
+
   pollAttempts = 0;
 
-  /**
-   * @param {DocumentCapturePollingOptions} options
-   */
-  constructor({ elements, statusEndpoint, trackEvent = defaultTrackEvent }) {
+  constructor({
+    elements,
+    statusEndpoint,
+    trackEvent = defaultTrackEvent,
+  }: DocumentCapturePollingOptions) {
     this.elements = elements;
     this.statusEndpoint = statusEndpoint;
     this.trackEvent = trackEvent;
@@ -62,10 +62,7 @@ export class DocumentCapturePolling {
     this.elements.backLink.addEventListener('click', () => this.bindPromptOnNavigate(false));
   }
 
-  /**
-   * @param {boolean} isVisible
-   */
-  toggleFormVisible(isVisible) {
+  toggleFormVisible(isVisible: boolean) {
     this.elements.form.classList.toggle('display-none', !isVisible);
   }
 
@@ -85,10 +82,10 @@ export class DocumentCapturePolling {
     this.toggleFormVisible(true);
   }
 
-  /**
-   * @param {{ result?: ResultType, redirect?: string }} params
-   */
-  async onComplete({ result = ResultType.SUCCESS, redirect } = {}) {
+  async onComplete({
+    result = ResultType.SUCCESS,
+    redirect,
+  }: { result?: ResultType; redirect?: string } = {}) {
     await this.trackEvent('IdV: Link sent capture doc polling complete', {
       isCancelled: result === ResultType.CANCELLED,
       isThrottled: result === ResultType.THROTTLED,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -101,7 +101,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
   const inPersonSteps =
     inPersonURL === undefined
       ? []
-      : [
+      : /** @type {FormStep[]} */ ([
           {
             name: 'location',
             form: InPersonLocationStep,
@@ -114,11 +114,11 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
             name: 'switch_back',
             form: InPersonSwitchBackStep,
           },
-        ].filter(Boolean);
+        ]).filter(Boolean);
 
   /** @type {FormStep[]} */
   const steps = submissionError
-    ? [
+    ? /** @type {FormStep[]} */ ([
         {
           name: 'review',
           form:
@@ -131,7 +131,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
                 })(ReviewIssuesStep)
               : ReviewIssuesStep,
         },
-      ]
+      ])
         .concat(inPersonSteps)
         .filter(Boolean)
     : /** @type {FormStep[]} */ (

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -8,6 +8,7 @@ import DocumentsStep from './documents-step';
 import SelfieStep from './selfie-step';
 import InPersonPrepareStep from './in-person-prepare-step';
 import InPersonLocationStep from './in-person-location-step';
+import InPersonSwitchBackStep from './in-person-switch-back-step';
 import ReviewIssuesStep from './review-issues-step';
 import ServiceProviderContext from '../context/service-provider';
 import UploadContext from '../context/upload';
@@ -109,7 +110,11 @@ function DocumentCapture({ isAsyncForm = false, onStepChange }) {
             name: 'prepare',
             form: InPersonPrepareStep,
           },
-        ];
+          flowPath === 'hybrid' && {
+            name: 'switch_back',
+            form: InPersonSwitchBackStep,
+          },
+        ].filter(Boolean);
 
   /** @type {FormStep[]} */
   const steps = submissionError

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -11,11 +11,14 @@ import { removeUnloadProtection } from '@18f/identity-url';
 import { useContext } from 'react';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { useI18n } from '@18f/identity-react-i18n';
+import { FormStepsButton } from '@18f/identity-form-steps';
+import UploadContext from '../context/upload';
 import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
 
 function InPersonPrepareStep({ value }) {
   const { t } = useI18n();
   const { inPersonURL } = useContext(FlowContext);
+  const { flowPath } = useContext(UploadContext);
   const { selectedLocationName } = value;
 
   return (
@@ -79,7 +82,8 @@ function InPersonPrepareStep({ value }) {
           </ul>
         </IconListItem>
       </IconList>
-      {inPersonURL && (
+      {flowPath === 'hybrid' && <FormStepsButton.Continue />}
+      {inPersonURL && flowPath === 'standard' && (
         <div className="margin-y-5">
           <Button href={inPersonURL} onClick={removeUnloadProtection} isBig isWide>
             {t('forms.buttons.continue')}

--- a/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
@@ -10,7 +10,11 @@ function InPersonSwitchBackStep({ onChange }: FormStepComponentProps<any>) {
   return (
     <>
       <PageHeading>{t('doc_auth.instructions.switch_back')}</PageHeading>
-      <img src={getAssetPath('idv/switch.png')} width={193} />
+      <img
+        src={getAssetPath('idv/switch.png')}
+        width={193}
+        alt={t('doc_auth.instructions.switch_back_image')}
+      />
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { PageHeading } from '@18f/identity-components';
+import { getAssetPath } from '@18f/identity-assets';
+import { t } from '@18f/identity-i18n';
+import type { FormStepComponentProps } from '@18f/identity-form-steps';
+
+function InPersonSwitchBackStep({ onChange }: FormStepComponentProps<any>) {
+  useEffect(() => onChange({}, { patch: false }), []);
+
+  return (
+    <>
+      <PageHeading>{t('doc_auth.instructions.switch_back')}</PageHeading>
+      <img src={getAssetPath('idv/switch.png')} width={193} />
+    </>
+  );
+}
+
+export default InPersonSwitchBackStep;

--- a/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
@@ -9,7 +9,7 @@ function InPersonSwitchBackStep({ onChange }: FormStepComponentProps<any>) {
 
   return (
     <>
-      <PageHeading>{t('doc_auth.instructions.switch_back')}</PageHeading>
+      <PageHeading>{t('in_person_proofing.headings.switch_back')}</PageHeading>
       <img
         src={getAssetPath('idv/switch.png')}
         width={193}

--- a/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx
@@ -1,11 +1,15 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { PageHeading } from '@18f/identity-components';
 import { getAssetPath } from '@18f/identity-assets';
 import { t } from '@18f/identity-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 
 function InPersonSwitchBackStep({ onChange }: FormStepComponentProps<any>) {
-  useEffect(() => onChange({}, { patch: false }), []);
+  // Resetting the value prevents the user from being prompted about unsaved changes when closing
+  // the tab. `useLayoutEffect` is used to avoid race conditions where the callback could occur at
+  // the same time as the change handler's `ifStillMounted` wrapping `useEffect`, which would treat
+  // it as unmounted and not update the value.
+  useLayoutEffect(() => onChange({}, { patch: false }), []);
 
   return (
     <>

--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
@@ -248,6 +248,43 @@ describe('FormSteps', () => {
     expect(onChange).to.have.been.calledWith({ changed: true, secondInputOne: 'o' });
     expect(onChange).to.have.been.calledWith({ changed: true, secondInputOne: 'on' });
     expect(onChange).to.have.been.calledWith({ changed: true, secondInputOne: 'one' });
+  });
+
+  it('provides set onChange option for non-patch value change', async () => {
+    const steps = [
+      {
+        name: 'first',
+        title: 'First Title',
+        form: ({ onChange, value }) => (
+          <>
+            <button
+              type="button"
+              onClick={useCallback(
+                sinon
+                  .stub()
+                  .onFirstCall()
+                  .callsFake(() => onChange({ a: 1 }))
+                  .onSecondCall()
+                  .callsFake(() => onChange({ b: 2 }, { patch: false })),
+                [],
+              )}
+            >
+              Change Value
+            </button>
+            <span data-testid="value">{JSON.stringify(value)}</span>
+          </>
+        ),
+      },
+    ];
+
+    const { getByRole, getByTestId } = render(<FormSteps steps={steps} />);
+
+    const button = getByRole('button', { name: 'Change Value' });
+    await userEvent.click(button);
+    await userEvent.click(button);
+
+    const value = getByTestId('value');
+    expect(value.textContent).to.equal('{"b":2}');
   });
 
   it('submits with form values', async () => {

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -39,9 +39,9 @@ type FormValues = Record<string, any>;
 
 export interface FormStepComponentProps<V> {
   /**
-   * Update values, merging with existing values.
+   * Update values, merging with existing values if configured as a patch.
    */
-  onChange: (nextValues: Partial<V>) => void;
+  onChange: (nextValues: Partial<V>, options?: { patch: boolean }) => void;
 
   /**
    * Trigger a field error.
@@ -426,11 +426,15 @@ function FormSteps({
           value={values}
           errors={activeErrors}
           unknownFieldErrors={unknownFieldErrors}
-          onChange={ifStillMounted((nextValuesPatch) => {
+          onChange={ifStillMounted((nextValues, { patch } = { patch: true }) => {
             setActiveErrors((prevActiveErrors) =>
-              prevActiveErrors.filter(({ field }) => !field || !(field in nextValuesPatch)),
+              prevActiveErrors.filter(({ field }) => !field || !(field in nextValues)),
             );
-            setPatchValues(nextValuesPatch);
+            if (patch) {
+              setPatchValues(nextValues);
+            } else {
+              setValues(nextValues);
+            }
           })}
           onError={ifStillMounted((error, { field } = {}) => {
             if (field) {

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -51,7 +51,9 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def profile_belongs_to_user
-    unless profile&.user == user
+    return unless profile.present?
+
+    unless profile.user == user
       errors.add :profile, I18n.t('idv.failure.exceptions.internal_error'),
                  type: :in_person_enrollment_user_profile_mismatch
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ApplicationRecord
           dependent: :destroy
 
   has_one :establishing_in_person_enrollment,
-          -> { where(status: :establishing).order(created_at: :desc) },
+          -> { where(status: :establishing, profile: nil).order(created_at: :desc) },
           class_name: 'InPersonEnrollment', foreign_key: :user_id, inverse_of: :user,
           dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ApplicationRecord
           dependent: :destroy
 
   has_one :establishing_in_person_enrollment,
-          -> { where(status: :establishing, profile: nil).order(created_at: :desc) },
+          -> { where(status: :establishing).order(created_at: :desc) },
           class_name: 'InPersonEnrollment', foreign_key: :user_id, inverse_of: :user,
           dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,13 @@ class User < ApplicationRecord
   has_many :sign_in_restrictions, dependent: :destroy
   has_many :in_person_enrollments, dependent: :destroy
 
-  has_one :pending_in_person_enrollment, -> { where(status: :pending).order(created_at: :desc) },
+  has_one :pending_in_person_enrollment,
+          -> { where(status: :pending).order(created_at: :desc) },
+          class_name: 'InPersonEnrollment', foreign_key: :user_id, inverse_of: :user,
+          dependent: :destroy
+
+  has_one :establishing_in_person_enrollment,
+          -> { where(status: :establishing).order(created_at: :desc) },
           class_name: 'InPersonEnrollment', foreign_key: :user_id, inverse_of: :user,
           dependent: :destroy
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -82,6 +82,8 @@ module Idv
     end
 
     def complete_session
+      associate_in_person_enrollment_with_profile
+
       if address_verification_mechanism == 'gpo'
         profile.deactivate(:gpo_verification_pending)
         create_gpo_entry
@@ -89,7 +91,6 @@ module Idv
         if pending_in_person_enrollment?
           UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
             current_user,
-            profile,
             applicant,
           )
           profile.deactivate(:in_person_verification_pending)
@@ -97,6 +98,11 @@ module Idv
           complete_profile
         end
       end
+    end
+
+    def associate_in_person_enrollment_with_profile
+      return unless pending_in_person_enrollment? && current_user.establishing_in_person_enrollment
+      current_user.establishing_in_person_enrollment.update(profile: profile)
     end
 
     def complete_profile

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -91,7 +91,6 @@ module Idv
             current_user,
             profile,
             applicant,
-            session.dig(:applicant, :selected_location_details),
           )
           profile.deactivate(:in_person_verification_pending)
         else

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -87,7 +87,7 @@ module Idv
         create_gpo_entry
       elsif phone_confirmed?
         if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
+          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
             current_user,
             profile,
             applicant,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -87,7 +87,7 @@ module Idv
         create_gpo_entry
       elsif phone_confirmed?
         if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.new.save_in_person_enrollment(
+          UspsInPersonProofing::EnrollmentHelper.new.schedule_in_person_enrollment(
             current_user,
             profile,
             applicant,

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -18,6 +18,7 @@ module Idv
       end
 
       def cancel_previous_in_person_enrollments
+        return unless IdentityConfig.store.in_person_proofing_enabled
         UspsInPersonProofing::EnrollmentHelper.
           cancel_stale_establishing_enrollments_for_user(current_user)
       end

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -6,6 +6,7 @@ module Idv
       def call
         return no_camera_redirect if params[:no_camera]
         create_document_capture_session(document_capture_session_uuid_key)
+        cancel_previous_in_person_enrollments
       end
 
       private
@@ -14,6 +15,11 @@ module Idv
         redirect_to idv_doc_auth_errors_no_camera_url
         msg = 'Doc Auth error: Javascript could not detect camera on mobile device.'
         failure(msg)
+      end
+
+      def cancel_previous_in_person_enrollments
+        UspsInPersonProofing::EnrollmentHelper.
+          cancel_stale_establishing_enrollments_for_user(current_user)
       end
     end
   end

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -71,22 +71,10 @@ module UspsInPersonProofing
         response['enrollmentCode']
       end
 
-      private
-
       def cancel_stale_establishing_enrollments_for_user(user)
-        # cancel any establishing enrollments that have profiles
         user.
           in_person_enrollments.
           where(status: :establishing).
-          where.not(profile: nil).
-          each(&:cancelled!)
-        # and all but the most recent without profiles
-        user.
-          in_person_enrollments.
-          where(status: :establishing).
-          where(profile: nil).
-          order(created_at: :desc).
-          drop(1).
           each(&:cancelled!)
       end
     end

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -14,6 +14,7 @@ module UspsInPersonProofing
       # update the enrollment to status pending
       enrollment.enrollment_code = enrollment_code
       enrollment.status = :pending
+      enrollment.enrollment_established_at = Time.zone.now
       enrollment.save!
 
       send_ready_to_verify_email(user, pii, enrollment)

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -1,15 +1,12 @@
 module UspsInPersonProofing
   class EnrollmentHelper
     class << self
-      def schedule_in_person_enrollment(user, profile, pii, selected_location_details = nil)
+      def schedule_in_person_enrollment(user, profile, pii)
         enrollment = user.establishing_in_person_enrollment ||
                      InPersonEnrollment.create!(user: user)
 
         enrollment.profile = profile
         enrollment.current_address_matches_id = pii['same_address_as_id']
-        if enrollment.selected_location_details.blank?
-          enrollment.selected_location_details = selected_location_details
-        end
         enrollment.save!
 
         enrollment_code = create_usps_enrollment(enrollment, pii)

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -1,12 +1,14 @@
 module UspsInPersonProofing
   class EnrollmentHelper
-    def save_in_person_enrollment(user, profile, pii, selected_location_details = nil)
-      enrollment = InPersonEnrollment.create!(
-        profile: profile,
-        user: user,
-        current_address_matches_id: pii['same_address_as_id'],
-        selected_location_details: selected_location_details,
-      )
+    def schedule_in_person_enrollment(user, profile, pii, selected_location_details = nil)
+      enrollment = user.establishing_in_person_enrollment || InPersonEnrollment.create!(user: user)
+
+      enrollment.profile = profile
+      enrollment.current_address_matches_id = pii['same_address_as_id']
+      if enrollment.selected_location_details.blank?
+        enrollment.selected_location_details = selected_location_details
+      end
+      enrollment.save!
 
       enrollment_code = create_usps_enrollment(enrollment, pii)
       return unless enrollment_code

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -36,7 +36,6 @@ module UspsInPersonProofing
       end
 
       def establishing_in_person_enrollment_for_user(user)
-        cancel_stale_establishing_enrollments_for_user(user)
         enrollment = user.establishing_in_person_enrollment
         return enrollment if enrollment.present?
 

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -1,11 +1,10 @@
 module UspsInPersonProofing
   class EnrollmentHelper
     class << self
-      def schedule_in_person_enrollment(user, profile, pii)
-        enrollment = user.establishing_in_person_enrollment ||
-                     InPersonEnrollment.create!(user: user)
+      def schedule_in_person_enrollment(user, pii)
+        enrollment = user.establishing_in_person_enrollment
+        return unless enrollment
 
-        enrollment.profile = profile
         enrollment.current_address_matches_id = pii['same_address_as_id']
         enrollment.save!
 
@@ -36,7 +35,7 @@ module UspsInPersonProofing
         enrollment = user.establishing_in_person_enrollment
         return enrollment if enrollment.present?
 
-        InPersonEnrollment.create!(user: user)
+        InPersonEnrollment.create!(user: user, profile: nil)
       end
 
       def usps_proofer

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -4,5 +4,5 @@
   <% c.header { t('idv.cancel.headings.confirmation.hybrid') } %>
 
   <p><%= t('doc_auth.instructions.switch_back') %></p>
-  <%= image_tag(asset_url('idv/switch.png'), width: 193) %>
+  <%= image_tag(asset_url('idv/switch.png'), width: 193, alt: t('doc_auth.instructions.switch_back_image')) %>
 <% end %>

--- a/app/views/idv/capture_doc/capture_complete.html.erb
+++ b/app/views/idv/capture_doc/capture_complete.html.erb
@@ -6,4 +6,4 @@
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.instructions.switch_back')) %>
 
-<%= image_tag(asset_url('idv/switch.png'), width: 193) %>
+<%= image_tag(asset_url('idv/switch.png'), width: 193, alt: t('doc_auth.instructions.switch_back_image')) %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -215,6 +215,7 @@ en:
       send_sms: We’ll send a text message to your device with a link.  Follow that
         link to your browser to take photos of the front and back of your ID.
       switch_back: Switch back to your computer to finish verifying your identity.
+      switch_back_image: Arrow pointing from phone to computer
       test_ssn: In the test environment only SSNs that begin with “900-” or “666-” are
         considered valid. Do not enter real PII in this field.
       text1a: such as a phone or computer.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -251,6 +251,7 @@ es:
         trasera de su identificación.
       switch_back: Regrese a su computadora para continuar con la verificación de su
         identidad.
+      switch_back_image: Flecha que apunta del teléfono a la computadora
       test_ssn: En el entorno de prueba solo los SSN que comienzan con “900-” o “666-”
         se consideran válidos. No ingrese PII real en este campo.
       text1a: como un teléfono o una computadora.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -266,6 +266,7 @@ fr:
         ce lien vers votre navigateur pour prendre des photos du recto et du
         verso de votre identifiant.
       switch_back: Retournez sur votre ordinateur pour continuer à vérifier votre identité.
+      switch_back_image: Flèche pointant du téléphone vers l’ordinateur
       test_ssn: Dans l’environnement de test seuls les SSN commençant par “900-” ou
         “900-” sont considérés comme valides. N’entrez pas de vrais PII dans ce
         champ.

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -88,6 +88,7 @@ en:
       location: Select a location to verify your ID
       prepare: Verify your identity in person
       state_id: Enter the information on your ID
+      switch_back: Switch back to your computer to prepare to verify your identity in person
       update_address: Update your current address
       update_state_id: Update the information on your ID
     process:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -92,6 +92,8 @@ es:
       location: Seleccione un lugar para verificar su cédula
       prepare: Verifique su identidad en persona
       state_id: Ingrese la información de su cédula
+      switch_back: Vuelva a su computadora para prepararse para verificar su identidad
+        en persona
       update_address: Actualizar su dirección actual
       update_state_id: Actualizar la información de su cédula de identidad
     process:

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -96,6 +96,8 @@ fr:
       location: Sélectionnez un lieu pour vérifier votre identité
       prepare: Vérifiez votre identité en personne
       state_id: Saisissez les informations figurant sur votre document d’identité
+      switch_back: Retournez sur votre ordinateur pour vous préparer à vérifier votre
+        identité en personne
       update_address: Mettre à jour votre adresse actuelle
       update_state_id: Mettre à jour les informations figurant sur votre document d’identité
     process:

--- a/db/primary_migrate/20220728223809_allow_null_profiles_on_in_person_enrollments.rb
+++ b/db/primary_migrate/20220728223809_allow_null_profiles_on_in_person_enrollments.rb
@@ -1,0 +1,5 @@
+class AllowNullProfilesOnInPersonEnrollments < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :in_person_enrollments, :profile_id, true
+  end
+end

--- a/db/primary_migrate/20220728223843_add_enrollment_established_at_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20220728223843_add_enrollment_established_at_to_in_person_enrollments.rb
@@ -1,0 +1,5 @@
+class AddEnrollmentEstablishedAtToInPersonEnrollments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :in_person_enrollments, :enrollment_established_at, :datetime, null: true, comment: "When the enrollment was successfully established"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_21_170157) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_28_223843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -282,7 +282,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_170157) do
 
   create_table "in_person_enrollments", comment: "Details and status of an in-person proofing enrollment for one user and profile", force: :cascade do |t|
     t.bigint "user_id", null: false, comment: "Foreign key to the user this enrollment belongs to"
-    t.bigint "profile_id", null: false, comment: "Foreign key to the profile this enrollment belongs to"
+    t.bigint "profile_id", comment: "Foreign key to the profile this enrollment belongs to"
     t.string "enrollment_code", comment: "The code returned by the USPS service"
     t.datetime "status_check_attempted_at", precision: nil, comment: "The last time a status check was attempted"
     t.datetime "status_updated_at", precision: nil, comment: "The last time the status was successfully updated with a value from the USPS API"
@@ -292,6 +292,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_170157) do
     t.boolean "current_address_matches_id", comment: "True if the user indicates that their current address matches the address on the ID they're bringing to the Post Office."
     t.jsonb "selected_location_details", comment: "The location details of the Post Office the user selected (including title, address, hours of operation)"
     t.string "unique_id", comment: "Unique ID to use with the USPS service"
+    t.datetime "enrollment_established_at", comment: "When the enrollment was successfully established"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true
     t.index ["user_id", "status"], name: "index_in_person_enrollments_on_user_id_and_status", unique: true, where: "(status = 1)"

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -66,6 +66,7 @@ describe Api::Verify::PasswordConfirmController do
         let(:stub_idv_session) do
           stub_user_with_applicant_data(user, applicant)
         end
+        let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
 
         before do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
@@ -113,27 +114,28 @@ describe Api::Verify::PasswordConfirmController do
           post :create, params: { password: password, user_bundle_token: jwt }
         end
 
-        it 'creates an in-person enrollment record' do
-          expect(InPersonEnrollment.count).to be(0)
+        it 'updates in-person enrollment record to associate profile' do
           post :create, params: { password: password, user_bundle_token: jwt }
 
-          expect(InPersonEnrollment.count).to be(1)
-          enrollment = InPersonEnrollment.where(user_id: user.id).first
+          enrollment.reload
+
           expect(enrollment.status).to eq('pending')
           expect(enrollment.user_id).to eq(user.id)
           expect(enrollment.enrollment_code).to be_a(String)
+          expect(enrollment.profile).to eq(user.profiles.last)
+          expect(enrollment.profile.deactivation_reason).to eq('in_person_verification_pending')
         end
 
         it 'leaves the enrollment in establishing when no enrollment code is returned' do
           proofer = UspsInPersonProofing::Mock::Proofer.new
           expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_return(proofer)
           expect(proofer).to receive(:request_enroll).and_return({})
-          expect(InPersonEnrollment.count).to be(0)
 
           post :create, params: { password: password, user_bundle_token: jwt }
 
+          enrollment.reload
+
           expect(InPersonEnrollment.count).to be(1)
-          enrollment = InPersonEnrollment.where(user_id: user.id).first
           expect(enrollment.status).to eq('establishing')
           expect(enrollment.user_id).to be(user.id)
           expect(enrollment.enrollment_code).to be_nil

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -245,6 +245,7 @@ describe Idv::CaptureDocStatusController do
         get :show
 
         expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to include('redirect' => idv_in_person_url)
       end
     end
   end

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -234,5 +234,18 @@ describe Idv::CaptureDocStatusController do
         end
       end
     end
+
+    context 'when user opted for in-person proofing' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        create(:in_person_enrollment, :establishing, user: user, profile: nil)
+      end
+
+      it 'returns success with redirect' do
+        get :show
+
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Idv::GpoVerifyController do
         action
       end
 
-      context 'with pending in person enrollment' do
+      context 'with establishing in person enrollment' do
         let(:proofing_components) {
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
         }

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe Api::ProfileCreationForm do
         end
 
         context 'with pending in person enrollment' do
+          let!(:enrollment) do
+            create(:in_person_enrollment, :establishing, user: user, profile: nil)
+          end
+
           before do
             ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
             allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
@@ -96,13 +100,11 @@ RSpec.describe Api::ProfileCreationForm do
           it 'saves in person enrollment' do
             expect(UspsInPersonProofing::EnrollmentHelper).
               to receive(:schedule_in_person_enrollment).
-              with(
-                user,
-                kind_of(Profile),
-                Pii::Attributes.new_from_hash(pii),
-              )
+              with(user, Pii::Attributes.new_from_hash(pii))
 
             subject.submit
+
+            expect(enrollment.reload.profile).to eq(user.profiles.last)
           end
         end
       end

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -99,15 +99,14 @@ RSpec.describe Api::ProfileCreationForm do
           end
 
           it 'saves in person enrollment' do
-            enrollment_helper = instance_double(UspsInPersonProofing::EnrollmentHelper)
-            allow(UspsInPersonProofing::EnrollmentHelper).to receive(:new).
-              and_return(enrollment_helper)
-            expect(enrollment_helper).to receive(:schedule_in_person_enrollment).with(
-              user,
-              kind_of(Profile),
-              Pii::Attributes.new_from_hash(pii),
-              selected_location_details,
-            )
+            expect(UspsInPersonProofing::EnrollmentHelper).
+              to receive(:schedule_in_person_enrollment).
+              with(
+                user,
+                kind_of(Profile),
+                Pii::Attributes.new_from_hash(pii),
+                selected_location_details,
+              )
 
             subject.submit
           end

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -80,11 +80,6 @@ RSpec.describe Api::ProfileCreationForm do
         end
 
         context 'with pending in person enrollment' do
-          let(:selected_location_details) { { name: 'Example' } }
-          let(:user_session) do
-            { idv: { applicant: { selected_location_details: selected_location_details } } }
-          end
-
           before do
             ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
             allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
@@ -105,7 +100,6 @@ RSpec.describe Api::ProfileCreationForm do
                 user,
                 kind_of(Profile),
                 Pii::Attributes.new_from_hash(pii),
-                selected_location_details,
               )
 
             subject.submit

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Api::ProfileCreationForm do
           expect(stored_pii['first_name']).to eq 'Ada'
         end
 
-        context 'with pending in person enrollment' do
+        context 'with establishing in person enrollment' do
           let!(:enrollment) do
             create(:in_person_enrollment, :establishing, user: user, profile: nil)
           end
@@ -152,7 +152,7 @@ RSpec.describe Api::ProfileCreationForm do
           end
         end
 
-        context 'with pending in person enrollment' do
+        context 'with establishing in person enrollment' do
           before do
             ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
             allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Api::ProfileCreationForm do
             enrollment_helper = instance_double(UspsInPersonProofing::EnrollmentHelper)
             allow(UspsInPersonProofing::EnrollmentHelper).to receive(:new).
               and_return(enrollment_helper)
-            expect(enrollment_helper).to receive(:save_in_person_enrollment).with(
+            expect(enrollment_helper).to receive(:schedule_in_person_enrollment).with(
               user,
               kind_of(Profile),
               Pii::Attributes.new_from_hash(pii),

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -112,6 +112,9 @@ describe GpoVerifyForm do
       end
 
       context 'pending in person enrollment' do
+        let!(:enrollment) do
+          create(:in_person_enrollment, :establishing, profile: pending_profile, user: user)
+        end
         let(:proofing_components) {
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
         }
@@ -127,10 +130,11 @@ describe GpoVerifyForm do
           expect(pending_profile.deactivation_reason).to eq('in_person_verification_pending')
         end
 
-        it 'creates an in-person enrollment' do
+        it 'updates establishing in-person enrollment to pending' do
           subject.submit
 
-          enrollment = InPersonEnrollment.where(user_id: user.id).first
+          enrollment.reload
+
           expect(enrollment.status).to eq('pending')
           expect(enrollment.user_id).to eq(user.id)
           expect(enrollment.enrollment_code).to be_a(String)

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -59,6 +59,10 @@ describe Idv::Session do
       end
 
       context 'with pending in person enrollment' do
+        let!(:enrollment) do
+          create(:in_person_enrollment, :establishing, user: user, profile: nil)
+        end
+
         before do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
@@ -79,13 +83,11 @@ describe Idv::Session do
         it 'creates a USPS enrollment' do
           expect(UspsInPersonProofing::EnrollmentHelper).
             to receive(:schedule_in_person_enrollment).
-            with(
-              user,
-              kind_of(Profile),
-              subject.applicant.transform_keys(&:to_s),
-            )
+            with(user, subject.applicant.transform_keys(&:to_s))
 
           subject.complete_session
+
+          expect(enrollment.reload.profile).to eq(user.profiles.last)
         end
       end
     end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -58,7 +58,7 @@ describe Idv::Session do
         expect(subject).not_to have_received(:complete_profile)
       end
 
-      context 'with pending in person enrollment' do
+      context 'with establishing in person enrollment' do
         let!(:enrollment) do
           create(:in_person_enrollment, :establishing, user: user, profile: nil)
         end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -59,15 +59,12 @@ describe Idv::Session do
       end
 
       context 'with pending in person enrollment' do
-        let(:selected_location_details) { { name: 'Example' } }
-
         before do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
           subject.user_phone_confirmation = true
           subject.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(
             same_address_as_id: true,
-            selected_location_details: selected_location_details,
           ).with_indifferent_access
           subject.create_profile_from_applicant_with_password(user.password)
         end
@@ -86,7 +83,6 @@ describe Idv::Session do
               user,
               kind_of(Profile),
               subject.applicant.transform_keys(&:to_s),
-              selected_location_details,
             )
 
           subject.complete_session

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -83,7 +83,7 @@ describe Idv::Session do
           enrollment_helper = instance_double(UspsInPersonProofing::EnrollmentHelper)
           allow(UspsInPersonProofing::EnrollmentHelper).to receive(:new).
             and_return(enrollment_helper)
-          expect(enrollment_helper).to receive(:save_in_person_enrollment).with(
+          expect(enrollment_helper).to receive(:schedule_in_person_enrollment).with(
             user,
             kind_of(Profile),
             subject.applicant.transform_keys(&:to_s),

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -80,15 +80,14 @@ describe Idv::Session do
         end
 
         it 'creates a USPS enrollment' do
-          enrollment_helper = instance_double(UspsInPersonProofing::EnrollmentHelper)
-          allow(UspsInPersonProofing::EnrollmentHelper).to receive(:new).
-            and_return(enrollment_helper)
-          expect(enrollment_helper).to receive(:schedule_in_person_enrollment).with(
-            user,
-            kind_of(Profile),
-            subject.applicant.transform_keys(&:to_s),
-            selected_location_details,
-          )
+          expect(UspsInPersonProofing::EnrollmentHelper).
+            to receive(:schedule_in_person_enrollment).
+            with(
+              user,
+              kind_of(Profile),
+              subject.applicant.transform_keys(&:to_s),
+              selected_location_details,
+            )
 
           subject.complete_session
         end

--- a/spec/services/idv/steps/welcome_step_spec.rb
+++ b/spec/services/idv/steps/welcome_step_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe Idv::Steps::WelcomeStep do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { build(:user) }
+  let(:params) { {} }
+  let(:controller) do
+    instance_double('controller', current_user: user, params: params, session: {}, url_options: {})
+  end
+  let(:flow) do
+    Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
+      flow.flow_session = {}
+    end
+  end
+
+  subject(:step) { Idv::Steps::WelcomeStep.new(flow) }
+
+  describe '#call' do
+    context 'without camera' do
+      let(:params) { { no_camera: true } }
+
+      it 'redirects to no camera error page' do
+        result = step.call
+
+        expect(redirect).to eq(idv_doc_auth_errors_no_camera_url)
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(
+          message: 'Doc Auth error: Javascript could not detect camera on mobile device.',
+        )
+      end
+    end
+
+    context 'with previous establishing in-person enrollments' do
+      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
+
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      end
+
+      it 'cancels all previous establishing enrollments' do
+        step.call
+
+        expect(enrollment.reload.status).to eq('cancelled')
+        expect(user.establishing_in_person_enrollment).to be_blank
+      end
+    end
+  end
+
+  def redirect
+    step.instance_variable_get(:@flow).instance_variable_get(:@redirect)
+  end
+end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
         enrollment = user.in_person_enrollments.first
         expect(enrollment.profile).to eq(profile)
         expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
-        expect(enrollment.selected_location_details).to be_nil
       end
     end
 
@@ -34,24 +33,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
 
         expect(enrollment.profile).to eq(profile)
         expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
-        expect(enrollment.selected_location_details).to be_nil
-      end
-
-      it 'does not overwrite selected_location_details' do
-        enrollment.update!(selected_location_details: { name: 'BALTIMORE' })
-
-        subject.schedule_in_person_enrollment(user, profile, pii)
-        enrollment.reload
-
-        expect(enrollment.selected_location_details).to_not be_nil
-      end
-
-      it 'does write selected_location_details if none are already set' do
-        selected_location_details = { name: 'FRIENDSHIP' }
-        subject.schedule_in_person_enrollment(user, profile, pii, selected_location_details)
-        enrollment.reload
-
-        expect(enrollment.selected_location_details).to_not be_nil
       end
     end
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       merge(same_address_as_id: current_address_matches_id).
       transform_keys(&:to_s)
   end
-  let(:subject) { described_class.new }
+  let(:subject) { described_class }
 
   describe '#schedule_in_person_enrollment' do
     context 'no establishing enrollment record exists for the user' do

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe UspsInPersonProofing::EnrollmentHelper do
   let(:user) { build(:user) }
-  let(:profile) { build(:profile, user: user) }
   let(:current_address_matches_id) { false }
   let(:pii) do
     Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.
@@ -12,72 +11,63 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
   let(:subject) { described_class }
 
   describe '#schedule_in_person_enrollment' do
-    context 'no establishing enrollment record exists for the user' do
-      it 'creates an enrollment record' do
-        subject.schedule_in_person_enrollment(user, profile, pii)
-
-        enrollment = user.in_person_enrollments.first
-        expect(enrollment.profile).to eq(profile)
-        expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
-      end
-    end
-
     context 'an establishing enrollment record exists for the user' do
-      let!(:enrollment) { create(:in_person_enrollment, user: user, status: :establishing) }
+      let!(:enrollment) do
+        create(:in_person_enrollment, user: user, status: :establishing, profile: nil)
+      end
 
       it 'updates the existing enrollment record' do
         expect(user.in_person_enrollments.length).to eq(1)
 
-        subject.schedule_in_person_enrollment(user, profile, pii)
+        subject.schedule_in_person_enrollment(user, pii)
         enrollment.reload
 
-        expect(enrollment.profile).to eq(profile)
         expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
       end
-    end
 
-    it 'creates usps enrollment' do
-      proofer = UspsInPersonProofing::Mock::Proofer.new
-      mock = double
+      it 'creates usps enrollment' do
+        proofer = UspsInPersonProofing::Mock::Proofer.new
+        mock = double
 
-      expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_return(mock)
-      expect(mock).to receive(:request_enroll) do |applicant|
-        expect(applicant.first_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
-        expect(applicant.last_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
-        expect(applicant.address).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
-        expect(applicant.city).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:city])
-        expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-        expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-        expect(applicant.email).to eq('no-reply@login.gov')
-        expect(applicant.unique_id).to be_a(String)
+        expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_return(mock)
+        expect(mock).to receive(:request_enroll) do |applicant|
+          expect(applicant.first_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+          expect(applicant.last_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
+          expect(applicant.address).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
+          expect(applicant.city).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:city])
+          expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
+          expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
+          expect(applicant.email).to eq('no-reply@login.gov')
+          expect(applicant.unique_id).to be_a(String)
 
-        proofer.request_enroll(applicant)
+          proofer.request_enroll(applicant)
+        end
+
+        subject.schedule_in_person_enrollment(user, pii)
       end
 
-      subject.schedule_in_person_enrollment(user, profile, pii)
-    end
+      it 'sets enrollment status to pending and sets enrollment established at date' do
+        subject.schedule_in_person_enrollment(user, pii)
 
-    it 'sets enrollment status to pending and sets enrollment established at date' do
-      subject.schedule_in_person_enrollment(user, profile, pii)
-
-      expect(user.in_person_enrollments.first.status).to eq('pending')
-      expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
-    end
-
-    it 'sends verification emails' do
-      mailer = instance_double(ActionMailer::MessageDelivery, deliver_now_or_later: true)
-      user.email_addresses.each do |email_address|
-        expect(UserMailer).to receive(:in_person_ready_to_verify).
-          with(
-            user,
-            email_address,
-            enrollment: instance_of(InPersonEnrollment),
-            first_name: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:first_name],
-          ).
-          and_return(mailer)
+        expect(user.in_person_enrollments.first.status).to eq('pending')
+        expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
       end
 
-      subject.schedule_in_person_enrollment(user, profile, pii)
+      it 'sends verification emails' do
+        mailer = instance_double(ActionMailer::MessageDelivery, deliver_now_or_later: true)
+        user.email_addresses.each do |email_address|
+          expect(UserMailer).to receive(:in_person_ready_to_verify).
+            with(
+              user,
+              email_address,
+              enrollment: instance_of(InPersonEnrollment),
+              first_name: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:first_name],
+            ).
+            and_return(mailer)
+        end
+
+        subject.schedule_in_person_enrollment(user, pii)
+      end
     end
   end
 end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -42,10 +42,11 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       subject.save_in_person_enrollment(user, profile, pii)
     end
 
-    it 'sets enrollment to pending' do
+    it 'sets enrollment status to pending and sets enrollment established at date' do
       subject.save_in_person_enrollment(user, profile, pii)
 
       expect(user.in_person_enrollments.first.status).to eq('pending')
+      expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
     end
 
     it 'sends verification emails' do


### PR DESCRIPTION
**Why:** So that anyone who is unsuccessful with document capture has an option to navigate to the in-person proofing flow, even if they're doing document capture through the "hybrid" experience.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow up to "How would you like to upload your state-issued ID?"
5. Click "Use your phone"
6. Enter a phone number and click "Continue"
7. In a private/incognito browser session, navigate to http://localhost:3000/test/telephony
8. Copy the URL from the first message and navigate to it in the private/incognito session
9. Use an [attention result YAML test document](https://developers.login.gov/testing/#document-upload) for the fields
10. Click Submit
11. Click "Verify your ID in person"
12. Select a location and continue
13. Click Continue
14. Observe that you are prompted to switch back to your computer
15. Observe that in the initial browser selection, you are redirected to the in-person flow 

**Screen Recording:**

https://user-images.githubusercontent.com/1779930/182161076-3ef1cb2a-f8de-4d0a-a5a9-1e8a19bc1ab8.mov

