### PR TITLE
Show "Cancel" links for in-person proofing steps

### DIFF
--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -91,4 +91,6 @@
   <% end %>
 <% end %>
 
+<%= render 'idv/doc_auth/cancel', step: 'address' %>
+
 <%= javascript_packs_tag_once('formatted-fields') %>

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -89,3 +89,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= render 'idv/doc_auth/cancel', step: 'state_id' %>


### PR DESCRIPTION
**Why**: Per designs, a user should have an opportunity to cancel or start over at any point in the flow.

