### PR TITLE
LG-6089: Pass location selection between pages

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -26,19 +26,6 @@ module Idv
         render json: { success: true }, status: :ok
       end
 
-      # return the Post Office location the user selected from the session
-      def show
-        selected_location = idv_session.applicant&.[](:selected_location_details) || {}
-
-        # camel case keys
-        returned_location = {}
-        selected_location.keys.each do |key|
-          returned_location[key.camelize(:lower)] = selected_location[key]
-        end
-
-        render json: returned_location.to_json, status: :ok
-      end
-
       protected
 
       def permitted_params

--- a/app/javascript/packages/document-capture/components/in-person-location-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-step.tsx
@@ -75,7 +75,7 @@ const prepToSend = (location: object) => {
   return sendObject;
 };
 
-function InPersonLocationStep() {
+function InPersonLocationStep({ onChange }) {
   const { t } = useI18n();
   const [locationData, setLocationData] = useState([] as FormattedLocation[]);
   const [inProgress, setInProgress] = useState(false);
@@ -95,6 +95,7 @@ function InPersonLocationStep() {
   // useCallBack here prevents unnecessary rerenders due to changing function identity
   const handleLocationSelect = useCallback(
     async (e: any, id: number) => {
+      onChange({ selectedLocationName: locationData[id].name });
       if (autoSubmit) {
         return;
       }

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -6,62 +6,25 @@ import {
   PageHeading,
   ProcessList,
   ProcessListItem,
-  SpinnerDots,
 } from '@18f/identity-components';
 import { removeUnloadProtection } from '@18f/identity-url';
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { useI18n } from '@18f/identity-react-i18n';
 import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
 
-const fetchSelectedLocation = () =>
-  fetch('/verify/in_person/usps_locations/selected').then((response) =>
-    response.json().catch((error) => {
-      throw error;
-    }),
-  );
-
-function InPersonPrepareStep() {
+function InPersonPrepareStep({ value }) {
   const { t } = useI18n();
   const { inPersonURL } = useContext(FlowContext);
-  const [selectedLocationName, setSelectedLocationName] = useState<string>('');
-  const [hasFetchError, setHasFetchError] = useState<boolean>(false);
+  const { selectedLocationName } = value;
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const fetchedLocation = await fetchSelectedLocation().catch((error) => {
-        if (cancelled) {
-          return;
-        }
-        setHasFetchError(true);
-        throw error;
-      });
-      setSelectedLocationName(fetchedLocation.name);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  let selectedLocationElement: React.ReactNode;
-  if (hasFetchError) {
-    selectedLocationElement = null;
-  } else if (selectedLocationName) {
-    selectedLocationElement = (
+  return (
+    <>
       <Alert type="success" className="margin-bottom-4">
         {t('in_person_proofing.body.prepare.alert_selected_post_office', {
           name: selectedLocationName,
         })}
       </Alert>
-    );
-  } else {
-    selectedLocationElement = <SpinnerDots />;
-  }
-
-  return (
-    <>
-      {selectedLocationElement}
       <PageHeading>{t('in_person_proofing.headings.prepare')}</PageHeading>
 
       <p>{t('in_person_proofing.body.prepare.verify_step_about')}</p>

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -20,11 +20,13 @@ function InPersonPrepareStep({ value }) {
 
   return (
     <>
-      <Alert type="success" className="margin-bottom-4">
-        {t('in_person_proofing.body.prepare.alert_selected_post_office', {
-          name: selectedLocationName,
-        })}
-      </Alert>
+      {selectedLocationName && (
+        <Alert type="success" className="margin-bottom-4">
+          {t('in_person_proofing.body.prepare.alert_selected_post_office', {
+            name: selectedLocationName,
+          })}
+        </Alert>
+      )}
       <PageHeading>{t('in_person_proofing.headings.prepare')}</PageHeading>
 
       <p>{t('in_person_proofing.body.prepare.verify_step_about')}</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,7 +331,6 @@ Rails.application.routes.draw do
           as: :in_person_ready_to_verify
       get '/in_person/usps_locations' => 'in_person/usps_locations#index'
       put '/in_person/usps_locations' => 'in_person/usps_locations#update'
-      get '/in_person/usps_locations/selected' => 'in_person/usps_locations#show'
       get '/in_person/:step' => 'in_person#show', as: :in_person_step
       put '/in_person/:step' => 'in_person#update'
 

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -93,18 +93,5 @@ describe Idv::InPerson::UspsLocationsController do
         end
       end
     end
-
-    describe '#show' do
-      it 'loads the saved location from session' do
-        put :update, params: selected_location
-
-        response = get :show
-        body = JSON.parse(response.body)
-        selected_location[:usps_location].keys.each do |key|
-          expect(body[key.to_s.camelize(:lower)]).
-            to eq(selected_location[:usps_location][key])
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Pass location selection between pages instead of loading the location from `UspsLocationsController`.

<details>
<summary>Screenshot:</summary>

![location-selection](https://user-images.githubusercontent.com/45415133/182097413-c464f2a7-5a74-4e5a-91fc-85e387a8c518.gif)

</details>