### PR TITLE
[LG-7075] Add security event for password resets

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -38,11 +38,17 @@ module Users
     end
 
     def handle_valid_password
+      send_password_reset_risc_event
       create_event_and_notify_user_about_password_change
       bypass_sign_in current_user
 
       flash[:personal_key] = @update_user_password_form.personal_key
       redirect_to account_url, flash: { info: t('notices.password_changed') }
+    end
+
+    def send_password_reset_risc_event
+      event = PushNotification::PasswordResetEvent.new(user: current_user)
+      PushNotification::HttpPush.deliver(event)
     end
 
     def create_event_and_notify_user_about_password_change

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -111,9 +111,15 @@ module Users
     end
 
     def handle_successful_password_reset
+      send_password_reset_risc_event
       create_reset_event_and_send_notification
       flash[:info] = t('devise.passwords.updated_not_active') if is_flashing_format?
       redirect_to new_user_session_url
+    end
+
+    def send_password_reset_risc_event
+      event = PushNotification::PasswordResetEvent.new(user: resource)
+      PushNotification::HttpPush.deliver(event)
     end
 
     def handle_unsuccessful_password_reset(result)

--- a/app/services/push_notification/password_reset_event.rb
+++ b/app/services/push_notification/password_reset_event.rb
@@ -1,0 +1,17 @@
+module PushNotification
+  class PasswordResetEvent
+    include IssSubEvent
+
+    EVENT_TYPE = 'https://schemas.login.gov/secevent/risc/event-type/password-reset'.freeze
+
+    attr_reader :user
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def event_type
+      EVENT_TYPE
+    end
+  end
+end

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -419,6 +419,7 @@ development:
     redirect_uris:
       - 'http://localhost:3001/auth/logindotgov/callback'
       - 'http://localhost:3001'
+    push_notification_url: http://localhost:3001/api/security_events
 
   'urn:gov:gsa:openidconnect:development':
     redirect_uris:

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -47,6 +47,16 @@ describe Users::PasswordsController do
         patch :update, params: { update_user_password_form: params }
       end
 
+      it 'sends a security event' do
+        user = create(:user)
+        stub_sign_in(user)
+        security_event = PushNotification::PasswordResetEvent.new(user: user)
+        expect(PushNotification::HttpPush).to receive(:deliver).with(security_event)
+
+        params = { password: 'salty new password' }
+        patch :update, params: { update_user_password_form: params }
+      end
+
       it 'sends the user an email' do
         user = create(:user)
         mail = double

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -194,6 +194,9 @@ describe Users::ResetPasswordsController, devise: true do
           old_confirmed_at = user.reload.confirmed_at
           allow(user).to receive(:active_profile).and_return(nil)
 
+          security_event = PushNotification::PasswordResetEvent.new(user: user)
+          expect(PushNotification::HttpPush).to receive(:deliver).with(security_event)
+
           stub_user_mailer(user)
 
           password = 'a really long passw0rd'
@@ -235,6 +238,9 @@ describe Users::ResetPasswordsController, devise: true do
         )
         _profile = create(:profile, :active, :verified, user: user)
 
+        security_event = PushNotification::PasswordResetEvent.new(user: user)
+        expect(PushNotification::HttpPush).to receive(:deliver).with(security_event)
+
         stub_user_mailer(user)
 
         get :edit, params: { reset_password_token: raw_reset_token }
@@ -273,6 +279,9 @@ describe Users::ResetPasswordsController, devise: true do
           reset_password_token: db_confirmation_token,
           reset_password_sent_at: Time.zone.now,
         )
+
+        security_event = PushNotification::PasswordResetEvent.new(user: user)
+        expect(PushNotification::HttpPush).to receive(:deliver).with(security_event)
 
         stub_user_mailer(user)
 

--- a/spec/services/push_notification/password_reset_event_spec.rb
+++ b/spec/services/push_notification/password_reset_event_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PushNotification::PasswordResetEvent do
+  include Rails.application.routes.url_helpers
+
+  subject(:event) do
+    described_class.new(user: user)
+  end
+
+  let(:user) { build(:user) }
+
+  describe '#event_type' do
+    it 'is the RISC event type' do
+      expect(event.event_type).to eq(described_class::EVENT_TYPE)
+    end
+  end
+
+  describe '#payload' do
+    let(:iss_sub) { SecureRandom.uuid }
+
+    subject(:payload) { event.payload(iss_sub: iss_sub) }
+
+    it 'is a subject with the provided iss_sub ' do
+      expect(payload).to eq(
+        subject: {
+          subject_type: 'iss-sub',
+          sub: iss_sub,
+          iss: root_url,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
Resolves LG-7075

Adds a new security event for when users change their passwords, both
for account recovery as well as for intentional password changes.

Also updates the default SP config to include a push notification URL
for the local Dashboard in development.

changelog: Improvements, Security, Add security event for password resets