### PR TITLE
hide broken help links on in-person proofing pages

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -13,7 +13,8 @@ import { FlowContext } from '@18f/identity-verify-flow';
 import { useI18n } from '@18f/identity-react-i18n';
 import { FormStepsButton } from '@18f/identity-form-steps';
 import UploadContext from '../context/upload';
-import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
+// WILLFIX: Hiding this component until help links are finalized; see LG-6875
+// import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
 
 function InPersonPrepareStep({ value }) {
   const { t } = useI18n();

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -90,7 +90,10 @@ function InPersonPrepareStep({ value }) {
           </Button>
         </div>
       )}
+      {/*
+      WILLFIX: Hiding this component until help links are finalized; see LG-6875
       <InPersonTroubleshootingOptions />
+      */}
     </>
   );
 }

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -9,6 +9,7 @@
 <p>
   <%= t('in_person_proofing.body.address.info') %>
   <%# WILLFIX: Hiding the link below until help links are finalized; see LG-6875 %>
+  <%# i18n-tasks-use t('in_person_proofing.body.address.learn_more') %>
   <%# new_window_link_to(t('in_person_proofing.body.address.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
 </p>
 

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -8,7 +8,8 @@
 
 <p>
   <%= t('in_person_proofing.body.address.info') %>
-  <%= new_window_link_to(t('in_person_proofing.body.address.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
+  <%# WILLFIX: Hiding the link below until help links are finalized; see LG-6875 %>
+  <%# new_window_link_to(t('in_person_proofing.body.address.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
 </p>
 
 <%= simple_form_for(

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -59,8 +59,9 @@
     <% end %>
   <% end %>
   <p class="margin-bottom-0">
-    <%= t('in_person_proofing.body.barcode.items_to_bring_questions') %>
-    <%= new_window_link_to(
+    <%# WILLFIX: Hiding this text and link until help links are finalized; see LG-6875 %>
+    <%# t('in_person_proofing.body.barcode.items_to_bring_questions') %>
+    <%# new_window_link_to(
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -62,6 +62,7 @@
   </table>
   <p class="margin-bottom-0">
     <%# WILLFIX: Hiding this text and link until help links are finalized; see LG-6875 %>
+    <%# i18n-tasks-use t('in_person_proofing.body.barcode.items_to_bring_questions') %>
     <%# t('in_person_proofing.body.barcode.items_to_bring_questions') %>
     <%# link_to(
           t('in_person_proofing.body.barcode.learn_more'),

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -61,8 +61,9 @@
     <% end %>
   </table>
   <p class="margin-bottom-0">
-    <%= t('in_person_proofing.body.barcode.items_to_bring_questions') %>
-    <%= link_to(
+    <%# WILLFIX: Hiding this text and link until help links are finalized; see LG-6875 %>
+    <%# t('in_person_proofing.body.barcode.items_to_bring_questions') %>
+    <%# link_to(
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',


### PR DESCRIPTION
Hide links to help content that has not been created yet. They will be restored as a part of LG-6875, when the help content is published. The links have been removed in these four places:

<details>
<summary>Prepare page</summary>

![prepare-page](https://user-images.githubusercontent.com/45415133/182452659-8b6b7d7b-a2df-4254-b148-4f9244fe4e9c.gif)

</details>

<details>
<summary>Address page</summary>

![address-page](https://user-images.githubusercontent.com/45415133/182452678-abd4f42e-f5de-4953-80da-a4bfaaded1c1.gif)

</details>

<details>
<summary>Ready to verify page</summary>

![ready-page](https://user-images.githubusercontent.com/45415133/182452699-0d751b2a-6192-49f8-8338-212c2daf02cd.gif)

</details>

<details>
<summary>Ready to verify email</summary>

![ready-email](https://user-images.githubusercontent.com/45415133/182452733-c5d22644-3d25-4f24-aa12-5f832c4cc29f.gif)

</details>