### PR TITLE
Collapse profile creation to single method

### DIFF
--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -87,8 +87,6 @@ module Idv
 
     def init_profile
       idv_session.create_profile_from_applicant_with_password(password)
-      idv_session.cache_encrypted_pii(password)
-      idv_session.complete_session
 
       if idv_session.profile.active?
         event = create_user_event_with_disavowal(:account_verified)

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -34,7 +34,10 @@ module Api
 
     def create_profile
       profile_maker = build_profile_maker
-      profile = profile_maker.save_profile(deactivation_reason: deactivation_reason)
+      profile = profile_maker.save_profile(
+        active: deactivation_reason.nil?,
+        deactivation_reason: deactivation_reason,
+      )
       @profile = profile
       session[:pii] = profile_maker.pii_attributes
       session[:profile_id] = profile.id
@@ -43,21 +46,19 @@ module Api
       cache_encrypted_pii
       associate_in_person_enrollment_with_profile
 
-      if user_bundle.gpo_address_verification?
+      if profile.active
+        move_pii_to_user_session
+      elsif user_bundle.gpo_address_verification?
         create_gpo_entry
-      elsif phone_confirmed?
-        if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, session[:pii])
-        else
-          complete_profile
-        end
+      elsif pending_in_person_enrollment?
+        UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, session[:pii])
       end
     end
 
     def deactivation_reason
-      if user_bundle.gpo_address_verification?
+      if !phone_confirmed? || user_bundle.gpo_address_verification?
         :gpo_verification_pending
-      elsif phone_confirmed? && pending_in_person_enrollment?
+      elsif pending_in_person_enrollment?
         :in_person_verification_pending
       end
     end
@@ -79,11 +80,6 @@ module Api
 
     def phone_confirmed?
       user_bundle.vendor_phone_confirmation? && user_bundle.user_phone_confirmation?
-    end
-
-    def complete_profile
-      profile.activate
-      move_pii_to_user_session
     end
 
     def move_pii_to_user_session

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -18,12 +18,7 @@ module Api
 
     def submit
       @form_valid = valid?
-
-      if form_valid?
-        create_profile
-        cache_encrypted_pii
-        complete_session
-      end
+      create_profile if form_valid?
 
       response = FormResponse.new(
         success: form_valid?,
@@ -39,32 +34,37 @@ module Api
 
     def create_profile
       profile_maker = build_profile_maker
-      profile = profile_maker.save_profile
+      profile = profile_maker.save_profile(deactivation_reason: deactivation_reason)
       @profile = profile
       session[:pii] = profile_maker.pii_attributes
       session[:profile_id] = profile.id
       session[:personal_key] = profile.personal_key
+
+      cache_encrypted_pii
+      associate_in_person_enrollment_with_profile
+
+      if user_bundle.gpo_address_verification?
+        create_gpo_entry
+      elsif phone_confirmed?
+        if pending_in_person_enrollment?
+          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, session[:pii])
+        else
+          complete_profile
+        end
+      end
+    end
+
+    def deactivation_reason
+      if user_bundle.gpo_address_verification?
+        :gpo_verification_pending
+      elsif phone_confirmed? && pending_in_person_enrollment?
+        :in_person_verification_pending
+      end
     end
 
     def cache_encrypted_pii
       cacher = Pii::Cacher.new(user, session)
       cacher.save(password, profile)
-    end
-
-    def complete_session
-      associate_in_person_enrollment_with_profile
-
-      if user_bundle.gpo_address_verification?
-        profile.deactivate(:gpo_verification_pending)
-        create_gpo_entry
-      elsif phone_confirmed?
-        if pending_in_person_enrollment?
-          UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, session[:pii])
-          profile.deactivate(:in_person_verification_pending)
-        else
-          complete_profile
-        end
-      end
     end
 
     def associate_in_person_enrollment_with_profile

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -8,8 +8,8 @@ module Idv
       self.user_password = user_password
     end
 
-    def save_profile
-      profile = Profile.new(user: user, active: false)
+    def save_profile(deactivation_reason: nil)
+      profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -8,11 +8,12 @@ module Idv
       self.user_password = user_password
     end
 
-    def save_profile(deactivation_reason: nil)
+    def save_profile(active:, deactivation_reason: nil)
       profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!
+      profile.activate if active
       profile
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -18,7 +18,7 @@ describe Idv::PersonalKeyController do
       user: user,
       user_password: password,
     )
-    profile = profile_maker.save_profile
+    profile = profile_maker.save_profile(active: false)
     idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id
     idv_session.personal_key = profile.personal_key

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -27,17 +27,7 @@ describe Idv::PersonalKeyController do
 
   let(:password) { 'sekrit phrase' }
   let(:user) { create(:user, :signed_up, password: password) }
-  let(:applicant) do
-    {
-      first_name: 'Some',
-      last_name: 'One',
-      address1: '123 Any St',
-      address2: 'Ste 456',
-      city: 'Anywhere',
-      state: 'KS',
-      zipcode: '66666',
-    }
-  end
+  let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
   let(:profile) { subject.idv_session.profile }
 
   describe 'before_actions' do
@@ -150,7 +140,7 @@ describe Idv::PersonalKeyController do
         subject.idv_session.address_verification_mechanism = 'phone'
         subject.idv_session.vendor_phone_confirmation = true
         subject.idv_session.user_phone_confirmation = true
-        subject.idv_session.complete_session
+        subject.idv_session.create_profile_from_applicant_with_password(password)
       end
 
       it 'redirects to sign up completed for an sp' do
@@ -177,7 +167,7 @@ describe Idv::PersonalKeyController do
     context 'user selected gpo verification' do
       before do
         subject.idv_session.address_verification_mechanism = 'gpo'
-        subject.idv_session.complete_session
+        subject.idv_session.create_profile_from_applicant_with_password(password)
       end
 
       it 'redirects to come back later path' do

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -16,7 +16,7 @@ describe Idv::ProfileMaker do
 
     it 'creates an inactive Profile with encrypted PII' do
       proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'acuant')
-      profile = subject.save_profile
+      profile = subject.save_profile(active: false)
       pii = subject.pii_attributes
 
       expect(profile).to be_a Profile
@@ -30,6 +30,27 @@ describe Idv::ProfileMaker do
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name).to eq 'Some'
       expect(profile.reproof_at).to be_nil
+    end
+
+    context 'with deactivation reason' do
+      it 'creates an inactive profile with deactivation reason' do
+        profile = subject.save_profile(
+          active: false,
+          deactivation_reason: :gpo_verification_pending,
+        )
+
+        expect(profile.active).to eq false
+        expect(profile.deactivation_reason).to eq 'gpo_verification_pending'
+      end
+    end
+
+    context 'as active' do
+      it 'creates an active profile' do
+        profile = subject.save_profile(active: true, deactivation_reason: nil)
+
+        expect(profile.active).to eq true
+        expect(profile.deactivation_reason).to be_nil
+      end
     end
   end
 end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -104,8 +104,6 @@ describe Idv::Session do
       end
 
       it 'sets profile to pending gpo verification' do
-        subject.applicant = {}
-        subject.create_profile_from_applicant_with_password(user.password)
         subject.create_profile_from_applicant_with_password(user.password)
 
         expect(subject).not_to have_received(:complete_profile)


### PR DESCRIPTION
Context: https://github.com/18F/identity-idp/pull/6634#discussion_r931178284

**Why**: So that deactivation_reason can be assigned in initial creation of the profile, rather than as an immediate follow-on transaction.
