### PR TITLE
Fix 500 errors when handling unsafe redirects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -270,14 +270,9 @@ class ApplicationController < ActionController::Base
     flash[:error] = t('errors.general')
     begin
       redirect_back fallback_location: new_user_session_url, allow_other_host: false
-    rescue
+    rescue ActionController::Redirecting::UnsafeRedirectError => err
       # Exceptions raised inside exception handlers are not propagated up, so we manually rescue
-      analytics.unsafe_redirect_error(
-        controller: controller_info,
-        user_signed_in: user_signed_in?,
-        referer: request.referer,
-      )
-      redirect_to new_user_session_url
+      unsafe_redirect_error(err)
     end
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -997,6 +997,25 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] controller
+  # @param [String] referer
+  # @param [Boolean] user_signed_in
+  # Redirect was almost sent to an invalid external host unexpectedly
+  def unsafe_redirect_error(
+    controller:,
+    referer:,
+    user_signed_in: nil,
+    **extra
+  )
+    track_event(
+      'Unsafe Redirect',
+      controller: controller,
+      referer: referer,
+      user_signed_in: user_signed_in,
+      **extra,
+    )
+  end
+
   # @param [Integer] acknowledged_event_count number of acknowledged events in the API call
   # @param [Integer] rendered_event_count how many events were rendered in the API response
   # @param [String] set_errors JSON encoded representation of SET errors from the client


### PR DESCRIPTION
Seeing a couple of 500s in [staging](https://onenr.io/0MR2A7VzYwY) and [int](https://onenr.io/0Zw0Zn30ejv) that appear to be partly a result of the Rails 7 upgrade