### PR TITLE
Instrument HTTP requests for In-Person-Proofing

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -24,7 +24,9 @@ module UspsInPersonProofing
       )
 
       parse_facilities(
-        faraday.post(url, body, headers).body,
+        faraday.post(url, body, headers) do |req|
+          req.options.context = { service_name: 'usps_facilities' }
+        end.body,
       )
     end
 
@@ -58,7 +60,9 @@ module UspsInPersonProofing
         IPPAssuranceLevel: '1.5',
       }
 
-      faraday.post(url, body, dynamic_headers).body
+      faraday.post(url, body, dynamic_headers) do |req|
+        req.options.context = { service_name: 'usps_enroll' }
+      end.body
     end
 
     # Makes HTTP request to retrieve proofing status
@@ -77,7 +81,9 @@ module UspsInPersonProofing
         enrollmentCode: enrollment_code,
       }
 
-      faraday.post(url, body, dynamic_headers).body
+      faraday.post(url, body, dynamic_headers) do |req|
+        req.options.context = { service_name: 'usps_proofing_results' }
+      end.body
     end
 
     # Makes HTTP request to retrieve enrollment code
@@ -94,7 +100,9 @@ module UspsInPersonProofing
         uniqueID: unique_id,
       }
 
-      faraday.post(url, body, dynamic_headers).body
+      faraday.post(url, body, dynamic_headers) do |req|
+        req.options.context = { service_name: 'usps_enrollment_code' }
+      end.body
     end
 
     # Makes a request to retrieve a new OAuth token
@@ -119,6 +127,9 @@ module UspsInPersonProofing
         conn.options.read_timeout = IdentityConfig.store.usps_ipp_request_timeout
         conn.options.open_timeout = IdentityConfig.store.usps_ipp_request_timeout
         conn.options.write_timeout = IdentityConfig.store.usps_ipp_request_timeout
+
+        # Log request metrics
+        conn.request :instrumentation, name: 'request_metric.faraday'
 
         # Raise an error subclassing Faraday::Error on 4xx, 5xx, and malformed responses
         # Note: The order of this matters for parsing the error response body.
@@ -162,7 +173,9 @@ module UspsInPersonProofing
         scope: 'ivs.ippaas.apis',
       }
 
-      faraday.post(url, body).body
+      faraday.post(url, body) do |req|
+        req.options.context = { service_name: 'usps_token' }
+      end.body
     end
 
     def root_url


### PR DESCRIPTION
So that we can have better visibility into the volume, success rate, and timing of the requests

(documentation for this added in https://github.com/18F/identity-idp/pull/6686)