### PR TITLE
LG-6927: Omit in-person troubleshooting option when already in flow

### DIFF
--- a/app/components/troubleshooting_options_component.html.erb
+++ b/app/components/troubleshooting_options_component.html.erb
@@ -1,10 +1,4 @@
 <%= tag.section(**tag_options, class: css_class) do %>
-  <% if new_features? %>
-    <span class="usa-tag bg-accent-cool-darker text-uppercase display-inline-block">
-      <%= t('components.troubleshooting_options.new_feature') %>
-    </span>
-  <% end %>
-
   <%= header %>
   <ul class="troubleshooting-options__options">
     <% options.each do |option| %>

--- a/app/components/troubleshooting_options_component.rb
+++ b/app/components/troubleshooting_options_component.rb
@@ -4,17 +4,12 @@ class TroubleshootingOptionsComponent < BaseComponent
 
   attr_reader :tag_options
 
-  def initialize(new_features: false, **tag_options)
-    @new_features = new_features
+  def initialize(**tag_options)
     @tag_options = tag_options.dup
   end
 
   def render?
     options?
-  end
-
-  def new_features?
-    @new_features
   end
 
   def css_class

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -7,9 +7,7 @@ module Idv
     before_action :confirm_idv_session_step_needed
     before_action :set_try_again_path, only: [:warning, :exception]
 
-    def exception
-      @in_person_flow = in_person_flow?
-    end
+    def exception; end
 
     def warning
       @remaining_attempts = Throttle.new(

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -7,7 +7,9 @@ module Idv
     before_action :confirm_idv_session_step_needed
     before_action :set_try_again_path, only: [:warning, :exception]
 
-    def exception; end
+    def exception
+      @in_person_flow = in_person_flow?
+    end
 
     def warning
       @remaining_attempts = Throttle.new(
@@ -56,11 +58,15 @@ module Idv
     end
 
     def set_try_again_path
-      if params[:from]&.starts_with? idv_in_person_path
+      if in_person_flow?
         @try_again_path = idv_in_person_path
       else
         @try_again_path = idv_doc_auth_path
       end
+    end
+
+    def in_person_flow?
+      params[:flow] == 'in_person'
     end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -24,7 +24,6 @@ class VerifyController < ApplicationController
     {
       base_path: idv_app_path,
       cancel_url: idv_cancel_path,
-      in_person_url: in_person_url,
       initial_values: initial_values,
       reset_password_url: forgot_password_url,
       enabled_step_names: IdentityConfig.store.idv_api_enabled_steps,
@@ -45,10 +44,6 @@ class VerifyController < ApplicationController
 
   def enabled_steps
     IdentityConfig.store.idv_api_enabled_steps
-  end
-
-  def in_person_url
-    idv_in_person_url if Idv::InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
   end
 
   def step_enabled?(step)

--- a/app/javascript/packages/verify-flow/cancel.spec.tsx
+++ b/app/javascript/packages/verify-flow/cancel.spec.tsx
@@ -17,7 +17,6 @@ describe('Cancel', () => {
             cancelURL: 'http://example.test/cancel',
             currentStep: 'one',
             basePath: '',
-            inPersonURL: null,
             onComplete() {},
           }}
         >

--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -9,7 +9,7 @@ export interface FlowContextValue {
   /**
    * URL to in-person proofing alternative flow, if enabled.
    */
-  inPersonURL?: string | null;
+  inPersonURL?: string;
 
   /**
    * Current step name.
@@ -29,7 +29,6 @@ export interface FlowContextValue {
 
 const FlowContext = createContext<FlowContextValue>({
   cancelURL: '',
-  inPersonURL: null,
   currentStep: '',
   basePath: '',
   onComplete() {},

--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -9,7 +9,7 @@ export interface FlowContextValue {
   /**
    * URL to in-person proofing alternative flow, if enabled.
    */
-  inPersonURL: string | null;
+  inPersonURL?: string | null;
 
   /**
    * Current step name.

--- a/app/javascript/packages/verify-flow/verify-flow-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-troubleshooting-options.spec.tsx
@@ -1,6 +1,4 @@
 import { render } from '@testing-library/react';
-import type { ComponentType } from 'react';
-import FlowContext, { FlowContextValue } from './context/flow-context';
 import VerifyFlowTroubleshootingOptions from './verify-flow-troubleshooting-options';
 
 describe('VerifyFlowTroubleshootingOptions', () => {
@@ -17,38 +15,5 @@ describe('VerifyFlowTroubleshootingOptions', () => {
     expect(options[0].textContent).to.equal(
       'idv.troubleshooting.options.contact_support links.new_window',
     );
-  });
-
-  context('with in-person proofing option', () => {
-    const inPersonURL = 'http://example.com';
-    const wrapper: ComponentType = ({ children }) => (
-      <FlowContext.Provider value={{ inPersonURL } as FlowContextValue}>
-        {children}
-      </FlowContext.Provider>
-    );
-
-    it('renders additional troubleshooting options', () => {
-      it('renders troubleshooting options', () => {
-        const { getAllByRole } = render(<VerifyFlowTroubleshootingOptions />, { wrapper });
-
-        const headings = getAllByRole('heading');
-        const options = getAllByRole('link');
-
-        expect(headings).to.have.lengthOf(2);
-        expect(headings[0].textContent).to.equal(
-          'components.troubleshooting_options.default_heading',
-        );
-        expect(headings[0].textContent).to.equal('idv.troubleshooting.headings.are_you_near');
-        expect(options).to.have.lengthOf(2);
-        expect(options[0].getAttribute('href')).to.equal('https://login.gov/contact/');
-        expect(options[0].getAttribute('target')).to.equal('_blank');
-        expect(options[0].textContent).to.equal(
-          'idv.troubleshooting.options.contact_support links.new_window',
-        );
-        expect(options[1].getAttribute('href')).to.equal(inPersonURL);
-        expect(options[1].getAttribute('target')).to.equal('');
-        expect(options[1].textContent).to.equal('idv.troubleshooting.options.verify_in_person');
-      });
-    });
   });
 });

--- a/app/javascript/packages/verify-flow/verify-flow-troubleshooting-options.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-troubleshooting-options.tsx
@@ -1,39 +1,21 @@
-import { useContext } from 'react';
 import { TroubleshootingOptions } from '@18f/identity-components';
 import { getConfigValue } from '@18f/identity-config';
 import { t } from '@18f/identity-i18n';
-import FlowContext from './context/flow-context';
 
 function VerifyFlowTroubleshootingOptions() {
-  const { inPersonURL } = useContext(FlowContext);
-
   return (
-    <>
-      <TroubleshootingOptions
-        heading={t('components.troubleshooting_options.default_heading')}
-        options={[
-          {
-            url: 'https://login.gov/contact/',
-            text: t('idv.troubleshooting.options.contact_support', {
-              app_name: getConfigValue('appName'),
-            }),
-            isExternal: true,
-          },
-        ]}
-      />
-      {inPersonURL && (
-        <TroubleshootingOptions
-          isNewFeatures
-          heading={t('idv.troubleshooting.headings.are_you_near')}
-          options={[
-            {
-              url: inPersonURL,
-              text: t('idv.troubleshooting.options.verify_in_person'),
-            },
-          ]}
-        />
-      )}
-    </>
+    <TroubleshootingOptions
+      heading={t('components.troubleshooting_options.default_heading')}
+      options={[
+        {
+          url: 'https://login.gov/contact/',
+          text: t('idv.troubleshooting.options.contact_support', {
+            app_name: getConfigValue('appName'),
+          }),
+          isExternal: true,
+        },
+      ]}
+    />
   );
 }
 

--- a/app/javascript/packages/verify-flow/verify-flow.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow.tsx
@@ -68,11 +68,6 @@ export interface VerifyFlowProps {
   cancelURL?: string;
 
   /**
-   * URL to in-person proofing alternative flow, if enabled.
-   */
-  inPersonURL?: string | null;
-
-  /**
    * Initial value for address verification method.
    */
   initialAddressVerificationMethod?: AddressVerificationMethod;
@@ -109,7 +104,6 @@ function VerifyFlow({
   enabledStepNames,
   basePath,
   cancelURL = '',
-  inPersonURL = null,
   initialAddressVerificationMethod,
   onComplete,
 }: VerifyFlowProps) {
@@ -123,7 +117,6 @@ function VerifyFlow({
   const [initialStep, setCompletedStep] = useInitialStepValidation(basePath, steps);
   const context = useObjectMemo({
     cancelURL,
-    inPersonURL,
     currentStep,
     basePath,
     onComplete,

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -134,7 +134,7 @@ function addPageAction(event, payload) {
     appName,
     flowPath,
     cancelUrl: cancelURL,
-    idvInPersonUrl: inPersonURL = null,
+    idvInPersonUrl: inPersonURL,
   } = /** @type {AppRootData} */ (appRoot.dataset);
 
   const App = composeComponents(

--- a/app/javascript/packs/verify-flow.tsx
+++ b/app/javascript/packs/verify-flow.tsx
@@ -5,11 +5,10 @@ import {
   decodeUserBundle,
   AddressVerificationMethod,
   ErrorStatusPage,
-  FlowContext,
 } from '@18f/identity-verify-flow';
 import { trackError } from '@18f/identity-analytics';
 import SecretSessionStorage, { s2ab } from '@18f/identity-secret-session-storage';
-import type { SecretValues, VerifyFlowValues, FlowContextValue } from '@18f/identity-verify-flow';
+import type { SecretValues, VerifyFlowValues } from '@18f/identity-verify-flow';
 
 interface AppRootValues {
   /**
@@ -31,11 +30,6 @@ interface AppRootValues {
    * URL to path for session cancel.
    */
   cancelUrl: string;
-
-  /**
-   * URL to in-person proofing alternative flow, if enabled.
-   */
-  inPersonUrl: string | null;
 
   /**
    * Base64-encoded encryption key for secret session store.
@@ -61,7 +55,6 @@ export async function initialize() {
     enabledStepNames: enabledStepNamesJSON,
     basePath,
     cancelUrl: cancelURL,
-    inPersonUrl: inPersonURL,
     storeKey: storeKeyBase64,
   } = appRoot.dataset;
   const initialValues: Partial<VerifyFlowValues> = JSON.parse(initialValuesJSON);
@@ -88,12 +81,7 @@ export async function initialize() {
     }
   } catch (error) {
     trackError(error);
-    render(
-      <FlowContext.Provider value={{ inPersonURL } as FlowContextValue}>
-        <ErrorStatusPage />
-      </FlowContext.Provider>,
-      appRoot,
-    );
+    render(<ErrorStatusPage />, appRoot);
     return tearDown;
   }
 
@@ -112,7 +100,6 @@ export async function initialize() {
         initialValues={initialValues}
         enabledStepNames={enabledStepNames}
         cancelURL={cancelURL}
-        inPersonURL={inPersonURL}
         basePath={basePath}
         onComplete={onComplete}
         initialAddressVerificationMethod={initialAddressVerificationMethod}

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -1,6 +1,6 @@
 module Idv
   module Actions
-    class VerifyDocumentStatusAction < Idv::Steps::VerifyBaseStep
+    class VerifyDocumentStatusAction < Idv::Steps::DocAuthBaseStep
       def call
         process_async_state(async_state)
       end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -7,41 +7,6 @@ module Idv
 
       private
 
-      def throttle
-        @throttle ||= Throttle.new(
-          user: current_user,
-          throttle_type: :idv_resolution,
-        )
-      end
-
-      def idv_failure(result)
-        throttle.increment! if result.extra.dig(:proofing_results, :exception).blank?
-        if throttle.throttled?
-          @flow.analytics.throttler_rate_limit_triggered(
-            throttle_type: :idv_resolution,
-            step_name: self.class.name,
-          )
-          redirect_to idv_session_errors_failure_url
-        elsif result.extra.dig(:proofing_results, :exception).present?
-          @flow.analytics.idv_doc_auth_exception_visited(
-            step_name: self.class.name,
-            remaining_attempts: throttle.remaining_count,
-          )
-          redirect_to idv_session_errors_exception_url(
-            from: request.path,
-          )
-        else
-          @flow.analytics.idv_doc_auth_warning_visited(
-            step_name: self.class.name,
-            remaining_attempts: throttle.remaining_count,
-          )
-          redirect_to idv_session_errors_warning_url(
-            from: request.path,
-          )
-        end
-        result
-      end
-
       def save_proofing_components
         return unless current_user
 

--- a/app/services/idv/steps/ipp/verify_wait_step_show.rb
+++ b/app/services/idv/steps/ipp/verify_wait_step_show.rb
@@ -9,6 +9,16 @@ module Idv
 
           process_async_state(async_state)
         end
+
+        private
+
+        def exception_url
+          idv_session_errors_exception_url(flow: :in_person)
+        end
+
+        def warning_url
+          idv_session_errors_warning_url(flow: :in_person)
+        end
       end
     end
   end

--- a/app/services/proofing/mock/resolution_mock_client.rb
+++ b/app/services/proofing/mock/resolution_mock_client.rb
@@ -18,7 +18,7 @@ module Proofing
       stage :resolution
 
       UNVERIFIABLE_ZIP_CODE = '00000'
-      NO_CONTACT_SSN = '000-00-0000'
+      NO_CONTACT_SSN = /000-?00-?0000/
       TRANSACTION_ID = 'resolution-mock-transaction-id-123'
       REFERENCE = 'aaa-bbb-ccc'
 
@@ -27,7 +27,7 @@ module Proofing
         ssn = applicant[:ssn]
 
         raise 'Failed to contact proofing vendor' if /Fail/i.match?(first_name)
-        raise 'Failed to contact proofing vendor' if ssn == NO_CONTACT_SSN
+        raise 'Failed to contact proofing vendor' if ssn.match?(NO_CONTACT_SSN)
 
         if first_name.match?(/Bad/i)
           result.add_error(:first_name, 'Unverified first name.')

--- a/app/views/idv/session_errors/_in_person_proofing_options.html.erb
+++ b/app/views/idv/session_errors/_in_person_proofing_options.html.erb
@@ -1,6 +1,0 @@
-<% if Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) %>
-  <%= render TroubleshootingOptionsComponent.new(new_features: true) do |c| %>
-    <% c.header { t('idv.troubleshooting.headings.are_you_near') } %>
-    <% c.option(url: idv_in_person_url, new_tab: false).with_content(t('idv.troubleshooting.options.verify_in_person')) %>
-  <% end %>
-<% end %>

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -29,7 +29,3 @@
             ) %>
       </p>
     <% end %>
-
-<% unless @in_person_flow %>
-  <%= render partial: 'idv/session_errors/in_person_proofing_options' %>
-<% end %>

--- a/app/views/idv/session_errors/exception.html.erb
+++ b/app/views/idv/session_errors/exception.html.erb
@@ -30,4 +30,6 @@
       </p>
     <% end %>
 
-<%= render partial: 'idv/session_errors/in_person_proofing_options' %>
+<% unless @in_person_flow %>
+  <%= render partial: 'idv/session_errors/in_person_proofing_options' %>
+<% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -31,4 +31,3 @@
       </p>
     <% end %>
 
-<%= render partial: 'idv/session_errors/in_person_proofing_options' %>

--- a/spec/components/troubleshooting_options_component_spec.rb
+++ b/spec/components/troubleshooting_options_component_spec.rb
@@ -30,19 +30,6 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
       end
     end
 
-    context 'with :new_features' do
-      it 'renders a new features tag' do
-        rendered = render_inline(
-          TroubleshootingOptionsComponent.new(new_features: true),
-        ) { |c| c.option(url: '/').with_content('Link Text') }
-
-        expect(rendered).to have_css(
-          '.troubleshooting-options .usa-tag.text-uppercase',
-          text: t('components.troubleshooting_options.new_feature'),
-        )
-      end
-    end
-
     context 'with header' do
       it 'renders header' do
         rendered = render_inline(TroubleshootingOptionsComponent.new) do |c|

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -68,26 +68,6 @@ describe Idv::SessionErrorsController do
     subject(:response) { get action, params: params }
 
     it_behaves_like 'an idv session errors controller action'
-
-    context 'signed in' do
-      let(:user) { build(:user) }
-
-      it 'sets in_person_flow local assign' do
-        response
-
-        expect(assigns(:in_person_flow)).to eq(false)
-      end
-
-      context 'in in-person proofing flow' do
-        let(:params) { { flow: 'in_person' } }
-
-        it 'sets in_person_flow local assign' do
-          response
-
-          expect(assigns(:in_person_flow)).to eq(true)
-        end
-      end
-    end
   end
 
   describe '#warning' do

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 shared_examples_for 'an idv session errors controller action' do
   context 'the user is authenticated and has not confirmed their profile' do
-    it 'renders the error' do
-      stub_sign_in(create(:user))
+    let(:user) { build(:user) }
 
+    it 'renders the error' do
       get action
 
       expect(response).to render_template(template)
@@ -13,10 +13,9 @@ shared_examples_for 'an idv session errors controller action' do
 
   context 'the user is authenticated and has confirmed their profile' do
     let(:idv_session_profile_confirmation) { true }
+    let(:user) { build(:user) }
 
     it 'redirects to the phone url' do
-      stub_sign_in
-
       get action
 
       expect(response).to redirect_to(idv_phone_url)
@@ -46,11 +45,13 @@ end
 describe Idv::SessionErrorsController do
   let(:idv_session) { double }
   let(:idv_session_profile_confirmation) { false }
+  let(:user) { nil }
 
   before do
     allow(idv_session).to receive(:profile_confirmation).
       and_return(idv_session_profile_confirmation)
     allow(controller).to receive(:idv_session).and_return(idv_session)
+    stub_sign_in(user) if user
   end
 
   describe 'before_actions' do
@@ -59,34 +60,69 @@ describe Idv::SessionErrorsController do
     end
   end
 
+  describe '#exception' do
+    let(:action) { :exception }
+    let(:template) { 'idv/session_errors/exception' }
+    let(:params) { {} }
+
+    subject(:response) { get action, params: params }
+
+    it_behaves_like 'an idv session errors controller action'
+
+    context 'signed in' do
+      let(:user) { build(:user) }
+
+      it 'sets in_person_flow local assign' do
+        response
+
+        expect(assigns(:in_person_flow)).to eq(false)
+      end
+
+      context 'in in-person proofing flow' do
+        let(:params) { { flow: 'in_person' } }
+
+        it 'sets in_person_flow local assign' do
+          response
+
+          expect(assigns(:in_person_flow)).to eq(true)
+        end
+      end
+    end
+  end
+
   describe '#warning' do
     let(:action) { :warning }
     let(:template) { 'idv/session_errors/warning' }
+    let(:params) { {} }
+
+    subject(:response) { get :warning, params: params }
 
     it_behaves_like 'an idv session errors controller action'
 
     context 'with throttle attempts' do
+      let(:user) { create(:user) }
+
       before do
-        user = create(:user)
-        stub_sign_in(user)
         Throttle.new(throttle_type: :proof_address, user: user).increment!
       end
 
       it 'assigns remaining count' do
-        get action
+        response
 
         expect(assigns(:remaining_attempts)).to be_kind_of(Numeric)
       end
 
       it 'assigns URL to try again' do
-        get action
+        response
 
         expect(assigns(:try_again_path)).to eq(idv_doc_auth_path)
       end
 
-      context 'referrer is page from In-Person Proofing flow' do
+      context 'in in-person proofing flow' do
+        let(:params) { { flow: 'in_person' } }
+
         it 'assigns URL to try again' do
-          get action, params: { from: idv_in_person_ready_to_verify_path }
+          response
 
           expect(assigns(:try_again_path)).to eq(idv_in_person_path)
         end
@@ -101,9 +137,9 @@ describe Idv::SessionErrorsController do
     it_behaves_like 'an idv session errors controller action'
 
     context 'while throttled' do
+      let(:user) { create(:user) }
+
       before do
-        user = create(:user)
-        stub_sign_in(user)
         Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!
       end
 
@@ -122,6 +158,7 @@ describe Idv::SessionErrorsController do
     it_behaves_like 'an idv session errors controller action'
 
     context 'while throttled' do
+      let(:user) { build(:user) }
       let(:ssn) { '666666666' }
 
       around do |ex|
@@ -129,7 +166,6 @@ describe Idv::SessionErrorsController do
       end
 
       before do
-        stub_sign_in
         Throttle.new(
           throttle_type: :proof_ssn,
           target: Pii::Fingerprinter.fingerprint(ssn),
@@ -152,9 +188,9 @@ describe Idv::SessionErrorsController do
     it_behaves_like 'an idv session errors controller action'
 
     context 'while throttled' do
+      let(:user) { create(:user) }
+
       before do
-        user = create(:user)
-        stub_sign_in(user)
         Throttle.new(throttle_type: :idv_doc_auth, user: user).increment_to_throttled!
       end
 

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 describe VerifyController do
   describe '#show' do
     let(:idv_api_enabled_steps) { [] }
-    let(:in_person_proofing_enabled) { false }
-    let(:in_person_proofing_enabled_issuers) { [] }
     let(:password) { 'sekrit phrase' }
     let(:user) { create(:user, :signed_up, password: password) }
     let(:applicant) do
@@ -28,10 +26,6 @@ describe VerifyController do
     before do
       allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).
         and_return(idv_api_enabled_steps)
-      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-        and_return(in_person_proofing_enabled)
-      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
-        and_return(in_person_proofing_enabled_issuers)
       allow(controller).to receive(:current_sp).and_return(sp)
       stub_sign_in(user)
       stub_idv_session
@@ -64,7 +58,6 @@ describe VerifyController do
         expect(assigns[:app_data]).to include(
           base_path: idv_app_path,
           cancel_url: idv_cancel_path,
-          in_person_url: nil,
           enabled_step_names: idv_api_enabled_steps,
           initial_values: { 'userBundleToken' => kind_of(String) },
           store_key: kind_of(String),
@@ -76,36 +69,6 @@ describe VerifyController do
 
         it 'renders view' do
           expect(response).to render_template(:show)
-        end
-      end
-
-      context 'with in-person proofing enabled' do
-        let(:in_person_proofing_enabled) { true }
-
-        it 'includes in-person URL as app data' do
-          response
-
-          expect(assigns[:app_data][:in_person_url]).to eq(idv_in_person_url)
-        end
-
-        context 'with associated service provider' do
-          let(:sp) { build(:service_provider) }
-
-          it 'does not include in-person URL as app data' do
-            response
-
-            expect(assigns[:app_data][:in_person_url]).to be_nil
-          end
-
-          context 'with in-person proofing enabled for service provider' do
-            let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
-
-            it 'includes in-person URL as app data' do
-              response
-
-              expect(assigns[:app_data][:in_person_url]).to eq(idv_in_person_url)
-            end
-          end
         end
       end
     end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -99,9 +99,7 @@ feature 'doc auth verify step', :js do
       step_name: 'Idv::Steps::VerifyWaitStepShow',
       remaining_attempts: 4,
     )
-    expect(page).to have_current_path(
-      idv_session_errors_warning_path(from: idv_doc_auth_step_path(step: :verify_wait)),
-    )
+    expect(page).to have_current_path(idv_session_errors_warning_path)
 
     click_on t('idv.failure.button.warning')
 
@@ -120,9 +118,14 @@ feature 'doc auth verify step', :js do
       step_name: 'Idv::Steps::VerifyWaitStepShow',
       remaining_attempts: 5,
     )
-    expect(page).to have_current_path(
-      idv_session_errors_exception_path(from: idv_doc_auth_step_path(step: :verify_wait)),
-    )
+    expect(page).to have_current_path(idv_session_errors_exception_path)
+
+    # Cheap check to ensure the in-person proofing option should be visible, but only if the feature
+    # is enabled.
+    expect(page).not_to have_link(href: idv_in_person_url)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    visit current_path
+    expect(page).to have_link(href: idv_in_person_url)
 
     click_on t('idv.failure.button.warning')
 
@@ -136,9 +139,7 @@ feature 'doc auth verify step', :js do
     click_idv_continue
     (max_attempts - 1).times do
       click_idv_continue
-      expect(page).to have_current_path(
-        idv_session_errors_warning_path(from: idv_doc_auth_step_path(step: :verify_wait)),
-      )
+      expect(page).to have_current_path(idv_session_errors_warning_path)
       visit idv_doc_auth_verify_step
     end
     click_idv_continue

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -120,13 +120,6 @@ feature 'doc auth verify step', :js do
     )
     expect(page).to have_current_path(idv_session_errors_exception_path)
 
-    # Cheap check to ensure the in-person proofing option should be visible, but only if the feature
-    # is enabled.
-    expect(page).not_to have_link(href: idv_in_person_url)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-    visit current_path
-    expect(page).to have_link(href: idv_in_person_url)
-
     click_on t('idv.failure.button.warning')
 
     expect(page).to have_current_path(idv_doc_auth_verify_step)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -213,21 +213,4 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).to have_current_path(idv_doc_auth_welcome_step)
     end
   end
-
-  context 'with verify step exception' do
-    it 'does not present the option to proof in-person', allow_browser_log: true do
-      sign_in_and_2fa_user
-      begin_in_person_proofing
-      complete_location_step
-      complete_prepare_step
-      complete_state_id_step
-      complete_address_step
-      fill_out_ssn_form_with_ssn_that_raises_exception
-      click_idv_continue
-      click_idv_continue
-
-      expect(page).to have_current_path(idv_session_errors_exception_path(flow: :in_person))
-      expect(page).not_to have_link(href: idv_in_person_url)
-    end
-  end
 end

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -213,4 +213,21 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).to have_current_path(idv_doc_auth_welcome_step)
     end
   end
+
+  context 'with verify step exception' do
+    it 'does not present the option to proof in-person', allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing
+      complete_location_step
+      complete_prepare_step
+      complete_state_id_step
+      complete_address_step
+      fill_out_ssn_form_with_ssn_that_raises_exception
+      click_idv_continue
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_session_errors_exception_path(flow: :in_person))
+      expect(page).not_to have_link(href: idv_in_person_url)
+    end
+  end
 end

--- a/spec/javascripts/packs/verify-flow-spec.ts
+++ b/spec/javascripts/packs/verify-flow-spec.ts
@@ -11,7 +11,6 @@ describe('verify-flow', () => {
         data-enabled-step-names='["password_confirm"]'
         data-base-path="/"
         data-cancel-url="/"
-        data-in-person-url="/"
         data-store-key="dK00lFMxejQH3y5BWt+LwOShw+WSRt/6OudNYI/N9X4="
       ></div>
     `;

--- a/spec/services/idv/steps/ipp/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/ipp/verify_wait_step_show_spec.rb
@@ -130,11 +130,7 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
       end
 
       it 'marks the verify step incomplete and redirects to the warning page' do
-        expect(step).to receive(:redirect_to).with(
-          idv_session_errors_warning_url(
-            from: request.path,
-          ),
-        )
+        expect(step).to receive(:redirect_to).with(idv_session_errors_warning_url(flow: :in_person))
         expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
         step.call
 
@@ -154,9 +150,7 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
 
       it 'marks the verify step incomplete and redirects to the exception page' do
         expect(step).to receive(:redirect_to).with(
-          idv_session_errors_exception_url(
-            from: request.path,
-          ),
+          idv_session_errors_exception_url(flow: :in_person),
         )
         expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
         step.call

--- a/spec/services/proofing/mock/resolution_mock_client_spec.rb
+++ b/spec/services/proofing/mock/resolution_mock_client_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Mock::ResolutionMockClient do
+  let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(uuid: '1234-abcd') }
+  subject(:instance) { described_class.new }
+
+  describe '#proof' do
+    subject(:result) { instance.proof(applicant) }
+
+    context 'with simulated failed to contact by SSN' do
+      let(:applicant) { super().merge(ssn: '000-00-0000') }
+
+      it 'returns an unsuccessful result with exception' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to be_blank
+        expect(result.exception).to be_present
+        expect(result.exception.message).to eq('Failed to contact proofing vendor')
+      end
+
+      context 'with dashes omitted from SSN' do
+        let(:applicant) { super().merge(ssn: '000000000') }
+
+        it 'returns an unsuccessful result with exception' do
+          expect(result.success?).to eq(false)
+          expect(result.errors).to be_blank
+          expect(result.exception).to be_present
+          expect(result.exception.message).to eq('Failed to contact proofing vendor')
+        end
+      end
+    end
+  end
+end

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe 'idv/session_errors/exception.html.erb' do
   let(:in_person_proofing_enabled) { false }
   let(:in_person_proofing_enabled_issuers) { [] }
   let(:try_again_path) { '/example/path' }
+  let(:in_person_flow) { false }
 
   before do
     decorated_session = instance_double(
@@ -20,6 +21,7 @@ describe 'idv/session_errors/exception.html.erb' do
       and_return(in_person_proofing_enabled_issuers)
 
     assign(:try_again_path, try_again_path)
+    assign(:in_person_flow, in_person_flow)
 
     render
   end
@@ -47,6 +49,14 @@ describe 'idv/session_errors/exception.html.erb' do
         t('idv.troubleshooting.options.verify_in_person'),
         href: idv_in_person_url,
       )
+    end
+
+    context 'while already in in-person flow' do
+      let(:in_person_flow) { true }
+
+      it 'does not render an in person proofing link' do
+        expect(rendered).not_to have_link(href: idv_in_person_url)
+      end
     end
   end
 

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 describe 'idv/session_errors/exception.html.erb' do
   let(:sp_name) { nil }
   let(:sp_issuer) { nil }
-  let(:in_person_proofing_enabled) { false }
-  let(:in_person_proofing_enabled_issuers) { [] }
   let(:try_again_path) { '/example/path' }
-  let(:in_person_flow) { false }
 
   before do
     decorated_session = instance_double(
@@ -15,13 +12,8 @@ describe 'idv/session_errors/exception.html.erb' do
       sp_issuer: sp_issuer,
     )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
-      and_return(in_person_proofing_enabled_issuers)
 
     assign(:try_again_path, try_again_path)
-    assign(:in_person_flow, in_person_flow)
 
     render
   end
@@ -37,29 +29,6 @@ describe 'idv/session_errors/exception.html.erb' do
     )
   end
 
-  it 'does not render an in person proofing link' do
-    expect(rendered).not_to have_link(href: idv_in_person_url)
-  end
-
-  context 'with in person proofing enabled' do
-    let(:in_person_proofing_enabled) { true }
-
-    it 'renders an in person proofing link' do
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.verify_in_person'),
-        href: idv_in_person_url,
-      )
-    end
-
-    context 'while already in in-person flow' do
-      let(:in_person_flow) { true }
-
-      it 'does not render an in person proofing link' do
-        expect(rendered).not_to have_link(href: idv_in_person_url)
-      end
-    end
-  end
-
   context 'with associated service provider' do
     let(:sp_name) { 'Example SP' }
     let(:sp_issuer) { 'example-issuer' }
@@ -73,25 +42,6 @@ describe 'idv/session_errors/exception.html.erb' do
         t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
         href: MarketingSite.contact_url,
       )
-    end
-
-    context 'with in person proofing enabled' do
-      let(:in_person_proofing_enabled) { true }
-
-      it 'does not render an in person proofing link' do
-        expect(rendered).not_to have_link(href: idv_in_person_url)
-      end
-
-      context 'with in person proofing enabled for service provider' do
-        let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
-
-        it 'renders an in person proofing link' do
-          expect(rendered).to have_link(
-            t('idv.troubleshooting.options.verify_in_person'),
-            href: idv_in_person_url,
-          )
-        end
-      end
     end
   end
 end

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -4,8 +4,6 @@ describe 'idv/session_errors/throttled.html.erb' do
   let(:sp_name) { nil }
   let(:sp_issuer) { nil }
   let(:liveness_checking_enabled) { false }
-  let(:in_person_proofing_enabled) { false }
-  let(:in_person_proofing_enabled_issuers) { [] }
 
   before do
     decorated_session = instance_double(
@@ -15,10 +13,6 @@ describe 'idv/session_errors/throttled.html.erb' do
     )
     allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(view).to receive(:liveness_checking_enabled?).and_return(liveness_checking_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
-      and_return(in_person_proofing_enabled_issuers)
 
     render
   end
@@ -30,17 +24,6 @@ describe 'idv/session_errors/throttled.html.erb' do
         href: MarketingSite.contact_url,
       )
       expect(rendered).not_to have_link(href: return_to_sp_cancel_path)
-    end
-
-    context 'with in person proofing enabled' do
-      let(:in_person_proofing_enabled) { true }
-
-      it 'renders an in person proofing link' do
-        expect(rendered).to have_link(
-          t('idv.troubleshooting.options.verify_in_person'),
-          href: idv_in_person_url,
-        )
-      end
     end
   end
 
@@ -58,25 +41,6 @@ describe 'idv/session_errors/throttled.html.erb' do
         href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
     end
-
-    context 'with in person proofing enabled' do
-      let(:in_person_proofing_enabled) { true }
-
-      it 'does not render an in person proofing link' do
-        expect(rendered).not_to have_link(href: idv_in_person_url)
-      end
-
-      context 'with in person proofing enabled for SP' do
-        let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
-
-        it 'renders an in person proofing link' do
-          expect(rendered).to have_link(
-            t('idv.troubleshooting.options.verify_in_person'),
-            href: idv_in_person_url,
-          )
-        end
-      end
-    end
   end
 
   context 'with liveness feature disabled' do
@@ -92,14 +56,6 @@ describe 'idv/session_errors/throttled.html.erb' do
 
     it 'renders expected heading' do
       expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
-    end
-  end
-
-  context 'with in person proofing disabled' do
-    let(:in_person_proofing_enabled) { false }
-
-    it 'does not render an in person proofing link' do
-      expect(rendered).not_to have_link(href: idv_in_person_url)
     end
   end
 end


### PR DESCRIPTION
**Why**: So that the user doesn't get stuck in a loop of attempting to troubleshoot by verifying in-person.

**Testing Instructions:**

1. Navigate to http://localhost:3000
2. Sign in or create an account
3. Navigate to http://localhost:3000/verify
4. Complete proofing flow, optionally choosing to proof in-person
5. At SSN step, use value "000-00-0000"
6. Continue to "Verify your information" step
7. Click "Continue"
8. Observe that the in-person proofing troubleshooting option is only visible if you are not already in the in-person proofing flow

**Screenshots:**

Before|After
---|---
![Screen Shot 2022-08-03 at 9 36 11 AM](https://user-images.githubusercontent.com/1779930/182640846-de6701bb-510a-4be5-ab7d-be7e210da534.png)|![Screen Shot 2022-08-03 at 9 36 00 AM](https://user-images.githubusercontent.com/1779930/182640858-e51812c5-a786-465c-ab54-0dd0deb8fcbf.png)

