### PR TITLE
Fix flaky VA Service spec

### DIFF
--- a/spec/services/inherited_proofing/va/service_spec.rb
+++ b/spec/services/inherited_proofing/va/service_spec.rb
@@ -27,21 +27,25 @@ RSpec.describe InheritedProofing::Va::Service do
       let(:auth_code) { 'mocked-auth-code-for-testing' }
 
       it 'makes an authenticated request' do
-        stub = stub_request(:get, request_uri).
-          with(headers: request_headers).
-          to_return(status: 200, body: '{}', headers: {})
+        freeze_time do
+          stub = stub_request(:get, request_uri).
+            with(headers: request_headers).
+            to_return(status: 200, body: '{}', headers: {})
 
-        service.execute
+          service.execute
 
-        expect(stub).to have_been_requested.once
+          expect(stub).to have_been_requested.once
+        end
       end
 
       it 'decrypts the response' do
-        stub_request(:get, request_uri).
-          with(headers: request_headers).
-          to_return(status: 200, body: encrypted_user_attributes, headers: {})
+        freeze_time do
+          stub_request(:get, request_uri).
+            with(headers: request_headers).
+            to_return(status: 200, body: encrypted_user_attributes, headers: {})
 
-        expect(service.execute).to eq user_attributes
+          expect(service.execute).to eq user_attributes
+        end
       end
     end
 


### PR DESCRIPTION
It looks like the expiration time encoded in the token is causing failures since it doesn't always match exactly:

```json
{
  "inherited_proofing_auth": "mocked-auth-code-for-testing",
  "exp": 1659640373
}
```

```json
{
  "inherited_proofing_auth": "mocked-auth-code-for-testing",
  "exp": 1659640374
}
```

This PR freezes the time to hopefully help it be a bit more reliable.