### PR TITLE
Log the enqueued_at date when a user enters a code

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -31,6 +31,7 @@ class GpoVerifyForm
       success: result,
       errors: errors,
       extra: {
+        enqueued_at: gpo_confirmation_code&.code_sent_at,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: pending_in_person_enrollment?,
       },

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: true,
           errors: {},
           pending_in_person_enrollment: false,
+          enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
 
@@ -139,6 +140,7 @@ RSpec.describe Idv::GpoVerifyController do
             success: true,
             errors: {},
             pending_in_person_enrollment: true,
+            enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
             pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
           )
 
@@ -164,6 +166,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: false,
           errors: { otp: [t('errors.messages.confirmation_code_incorrect')] },
           pending_in_person_enrollment: false,
+          enqueued_at: nil,
           error_details: { otp: [:confirmation_code_incorrect] },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
@@ -191,6 +194,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: false,
           errors: { otp: [t('errors.messages.confirmation_code_incorrect')] },
           pending_in_person_enrollment: false,
+          enqueued_at: nil,
           error_details: { otp: [:confirmation_code_incorrect] },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         ).exactly(max_attempts).times

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -111,6 +111,13 @@ describe GpoVerifyForm do
         expect(pending_profile.reload).to be_active
       end
 
+      it 'logs the date the code was sent at' do
+        result = subject.submit
+
+        confirmation_code = pending_profile.gpo_confirmation_codes.last
+        expect(result.to_h[:enqueued_at]).to eq(confirmation_code.code_sent_at)
+      end
+
       context 'pending in person enrollment' do
         let!(:enrollment) do
           create(:in_person_enrollment, :establishing, profile: pending_profile, user: user)


### PR DESCRIPTION
This will allow us to bin letter sent and code entered events based on when the letter was sent