### PR TITLE
LG-7167: Verify establishing enrollment for in-person flow

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -10,7 +10,7 @@ module Idv
     include Flow::FlowStateMachine
     include Idv::DocumentCaptureConcern
 
-    before_action :redirect_if_session_applicant
+    before_action :redirect_if_flow_completed
     before_action :override_document_capture_step_csp
     before_action :update_if_skipping_upload
     # rubocop:disable Rails/LexicallyScopedActionFilter
@@ -38,7 +38,7 @@ module Idv
       redirect_to idv_gpo_verify_url if current_user.decorate.pending_profile_requires_verification?
     end
 
-    def redirect_if_session_applicant
+    def redirect_if_flow_completed
       flow_finish if idv_session.applicant
     end
 

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -6,10 +6,11 @@ module Idv
     before_action :redirect_if_pending_in_person_enrollment
     before_action :extend_timeout_using_meta_refresh_for_select_paths
 
-    include IdvSession # remove if we retire the non docauth LOA3 flow
+    include IdvSession
     include Flow::FlowStateMachine
     include Idv::DocumentCaptureConcern
 
+    before_action :redirect_if_session_applicant
     before_action :override_document_capture_step_csp
     before_action :update_if_skipping_upload
     # rubocop:disable Rails/LexicallyScopedActionFilter
@@ -35,6 +36,10 @@ module Idv
       return if sp_session[:ial2_strict] &&
                 !IdentityConfig.store.gpo_allowed_for_strict_ial2
       redirect_to idv_gpo_verify_url if current_user.decorate.pending_profile_requires_verification?
+    end
+
+    def redirect_if_session_applicant
+      flow_finish if idv_session.applicant
     end
 
     def redirect_if_pending_in_person_enrollment

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -2,8 +2,12 @@ module Idv
   class InPersonController < ApplicationController
     before_action :render_404_if_disabled
     before_action :confirm_two_factor_authenticated
+    before_action :redirect_unless_enrollment
 
+    include IdvSession
     include Flow::FlowStateMachine
+
+    before_action :redirect_if_session_applicant
 
     FSM_SETTINGS = {
       step_url: :idv_in_person_step_url,
@@ -16,6 +20,14 @@ module Idv
 
     def render_404_if_disabled
       render_not_found unless InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
+    end
+
+    def redirect_unless_enrollment
+      redirect_to idv_url unless current_user.establishing_in_person_enrollment
+    end
+
+    def redirect_if_session_applicant
+      flow_finish if idv_session.applicant
     end
   end
 end

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -7,7 +7,7 @@ module Idv
     include IdvSession
     include Flow::FlowStateMachine
 
-    before_action :redirect_if_session_applicant
+    before_action :redirect_if_flow_completed
 
     FSM_SETTINGS = {
       step_url: :idv_in_person_step_url,
@@ -26,7 +26,7 @@ module Idv
       redirect_to idv_url unless current_user.establishing_in_person_enrollment
     end
 
-    def redirect_if_session_applicant
+    def redirect_if_flow_completed
       flow_finish if idv_session.applicant
     end
   end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -146,8 +146,7 @@ module Idv
     attr_accessor :user_session
 
     def set_idv_session
-      return if session.present?
-      user_session[:idv] = new_idv_session
+      user_session[:idv] = new_idv_session unless user_session.key?(:idv)
     end
 
     def new_idv_session

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -36,6 +36,7 @@ module Idv
         flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
         if store_in_session
           flow_session[:pii_from_doc] = flow_session[:pii_from_doc].to_h.merge(pii_from_doc)
+          idv_session.delete('applicant')
         end
         track_document_state(pii_from_doc[:state])
       end

--- a/app/services/idv/steps/ipp/ssn_step.rb
+++ b/app/services/idv/steps/ipp/ssn_step.rb
@@ -6,6 +6,7 @@ module Idv
 
         def call
           flow_session[:pii_from_user][:ssn] = flow_params[:ssn]
+          idv_session.delete('applicant')
         end
 
         def extra_view_variables

--- a/app/services/idv/steps/ipp/verify_step.rb
+++ b/app/services/idv/steps/ipp/verify_step.rb
@@ -24,6 +24,10 @@ module Idv
             create_or_find_by(user: current_user).
             update(document_check: Idp::Constants::Vendors::USPS)
         end
+
+        def pii
+          flow_session[:pii_from_user]
+        end
       end
     end
   end

--- a/app/services/idv/steps/ipp/verify_wait_step_show.rb
+++ b/app/services/idv/steps/ipp/verify_wait_step_show.rb
@@ -19,6 +19,14 @@ module Idv
         def warning_url
           idv_session_errors_warning_url(flow: :in_person)
         end
+
+        def pii
+          flow_session[:pii_from_user]
+        end
+
+        def delete_pii
+          flow_session.delete(:pii_from_user)
+        end
       end
     end
   end

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -7,6 +7,7 @@ module Idv
         return invalid_state_response if invalid_state?
 
         flow_session[:pii_from_doc][:ssn] = flow_params[:ssn]
+        idv_session.delete('applicant')
       end
 
       def extra_view_variables

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -56,12 +56,11 @@ module Idv
       end
 
       def pii
-        flow_session[:pii_from_doc].presence || flow_session[:pii_from_user]
+        raise NotImplementedError
       end
 
       def delete_pii
-        flow_session.delete(:pii_from_doc)
-        flow_session.delete(:pii_from_user)
+        raise NotImplementedError
       end
 
       def throttle
@@ -115,13 +114,13 @@ module Idv
         idv_result.except(:errors, :success)
       end
 
-      def should_use_aamva?(pii_from_doc)
-        aamva_state?(pii_from_doc) && !aamva_disallowed_for_service_provider?
+      def should_use_aamva?(pii)
+        aamva_state?(pii) && !aamva_disallowed_for_service_provider?
       end
 
-      def aamva_state?(pii_from_doc)
+      def aamva_state?(pii)
         IdentityConfig.store.aamva_supported_jurisdictions.include?(
-          pii_from_doc['state_id_jurisdiction'],
+          pii['state_id_jurisdiction'],
         )
       end
 

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -13,6 +13,12 @@ module Idv
           step_url: method(:idv_doc_auth_step_url),
         }
       end
+
+      private
+
+      def pii
+        flow_session[:pii_from_doc]
+      end
     end
   end
 end

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -8,6 +8,16 @@ module Idv
 
         process_async_state(async_state)
       end
+
+      private
+
+      def pii
+        flow_session[:pii_from_doc]
+      end
+
+      def delete_pii
+        flow_session.delete(:pii_from_doc)
+      end
     end
   end
 end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -20,6 +20,8 @@ describe Idv::DocAuthController do
     end
   end
 
+  let(:user) { build(:user) }
+
   before do |example|
     stub_sign_in(user) if user
     stub_analytics
@@ -129,6 +131,24 @@ describe Idv::DocAuthController do
         hash_including(step: 'welcome', step_count: 2),
       )
     end
+
+    context 'with an existing applicant' do
+      before do
+        idv_session = Idv::Session.new(
+          user_session: controller.user_session,
+          current_user: user,
+          service_provider: nil,
+        )
+        idv_session.applicant = {}
+        allow(controller).to receive(:idv_session).and_return(idv_session)
+      end
+
+      it 'finishes the flow' do
+        get :show, params: { step: 'welcome' }
+
+        expect(response).to redirect_to idv_review_url
+      end
+    end
   end
 
   describe '#update' do
@@ -191,6 +211,24 @@ describe Idv::DocAuthController do
       expect(@analytics).to have_received(:track_event).with(
         'IdV: ' + "#{Analytics::DOC_AUTH} welcome submitted".downcase, result
       )
+    end
+
+    context 'with an existing applicant' do
+      before do
+        idv_session = Idv::Session.new(
+          user_session: controller.user_session,
+          current_user: user,
+          service_provider: nil,
+        )
+        idv_session.applicant = {}
+        allow(controller).to receive(:idv_session).and_return(idv_session)
+      end
+
+      it 'finishes the flow' do
+        put :update, params: { step: 'ssn' }
+
+        expect(response).to redirect_to idv_review_url
+      end
     end
   end
 

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -4,6 +4,7 @@ describe Idv::InPersonController do
   let(:in_person_proofing_enabled) { false }
   let(:in_person_proofing_enabled_issuers) { [] }
   let(:sp) { nil }
+  let(:user) { nil }
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
@@ -11,6 +12,7 @@ describe Idv::InPersonController do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
       and_return(in_person_proofing_enabled_issuers)
     allow(controller).to receive(:current_sp).and_return(sp)
+    stub_sign_in(user) if user
   end
 
   describe 'before_actions' do
@@ -41,30 +43,60 @@ describe Idv::InPersonController do
       end
 
       context 'signed in' do
-        before { stub_sign_in }
+        let(:user) { build(:user) }
 
-        it 'redirects to the first step' do
+        it 'redirects to idv' do
           get :index
 
-          expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+          expect(response).to redirect_to idv_url
         end
 
-        context 'with associated service provider' do
-          let(:sp) { build(:service_provider) }
-
-          it 'renders 404 not found' do
-            get :index
-
-            expect(response.status).to eq 404
+        context 'with establishing in-person enrollment' do
+          before do
+            create(:in_person_enrollment, :establishing, user: user, profile: nil)
           end
 
-          context 'with in person proofing enabled for service provider' do
-            let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
+          it 'redirects to the first step' do
+            get :index
 
-            it 'redirects to the first step' do
+            expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+          end
+
+          context 'with associated service provider' do
+            let(:sp) { build(:service_provider) }
+
+            it 'renders 404 not found' do
               get :index
 
-              expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+              expect(response.status).to eq 404
+            end
+
+            context 'with in person proofing enabled for service provider' do
+              let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
+
+              it 'redirects to the first step' do
+                get :index
+
+                expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+              end
+            end
+          end
+
+          context 'with an existing applicant' do
+            before do
+              idv_session = Idv::Session.new(
+                user_session: controller.user_session,
+                current_user: user,
+                service_provider: nil,
+              )
+              idv_session.applicant = {}
+              allow(controller).to receive(:idv_session).and_return(idv_session)
+            end
+
+            it 'finishes the flow' do
+              put :update, params: { step: 'state_id' }
+
+              expect(response).to redirect_to idv_phone_url
             end
           end
         end

--- a/spec/services/idv/actions/verify_document_status_action_spec.rb
+++ b/spec/services/idv/actions/verify_document_status_action_spec.rb
@@ -83,6 +83,14 @@ describe Idv::Actions::VerifyDocumentStatusAction do
         )
       end
 
+      context 'with existing applicant' do
+        let(:session) { super().merge(idv: { 'applicant' => {} }) }
+
+        it 'clears applicant' do
+          expect(session[:idv]['applicant']).to be_blank
+        end
+      end
+
       context 'unbilled' do
         let(:billed) { false }
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -8,6 +8,44 @@ describe Idv::Session do
     Idv::Session.new(user_session: user_session, current_user: user, service_provider: nil)
   }
 
+  describe '#initialize' do
+    context 'without idv user session' do
+      it 'initializes user session' do
+        expect_any_instance_of(Idv::Session).to receive(:new_idv_session).twice.and_call_original
+
+        subject
+
+        expect(user_session[:idv]).to eq(subject.new_idv_session)
+      end
+    end
+
+    context 'with idv user session' do
+      let(:idv_session) { { vendor_phone_confirmation: true } }
+      let(:user_session) { { idv: idv_session } }
+
+      it 'does not initialize user session' do
+        expect_any_instance_of(Idv::Session).not_to receive(:new_idv_session)
+
+        subject
+
+        expect(user_session[:idv]).to eq(idv_session)
+      end
+    end
+
+    context 'with empty idv user session' do
+      let(:idv_session) { {} }
+      let(:user_session) { { idv: idv_session } }
+
+      it 'does not initialize user session' do
+        expect_any_instance_of(Idv::Session).not_to receive(:new_idv_session)
+
+        subject
+
+        expect(user_session[:idv]).to eq(idv_session)
+      end
+    end
+  end
+
   describe '#method_missing' do
     it 'disallows un-supported attributes' do
       expect { subject.foo = 'bar' }.to raise_error NoMethodError

--- a/spec/services/idv/steps/ipp/ssn_step_spec.rb
+++ b/spec/services/idv/steps/ipp/ssn_step_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 describe Idv::Steps::Ipp::SsnStep do
-  let(:params) { { doc_auth: {} } }
+  let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
+  let(:params) { { doc_auth: { ssn: ssn } } }
+  let(:session) { { sp: { issuer: service_provider.issuer } } }
   let(:user) { build(:user) }
   let(:service_provider) { create(:service_provider) }
   let(:controller) do
     instance_double(
       'controller',
-      session: { sp: { issuer: service_provider.issuer } },
+      session: session,
       params: params,
       current_user: user,
     )
@@ -22,9 +24,20 @@ describe Idv::Steps::Ipp::SsnStep do
   end
 
   describe '#call' do
-    it 'works' do
-      result = step.call
-      expect(result).to be_nil
+    it 'merges ssn into pii session value' do
+      step.call
+
+      expect(flow.flow_session[:pii_from_user][:ssn]).to eq(ssn)
+    end
+
+    context 'with existing session applicant' do
+      let(:session) { super().merge(idv: { 'applicant' => {} }) }
+
+      it 'clears applicant' do
+        step.call
+
+        expect(session[:idv]['applicant']).to be_blank
+      end
     end
   end
 end

--- a/spec/services/idv/steps/ipp/verify_step_spec.rb
+++ b/spec/services/idv/steps/ipp/verify_step_spec.rb
@@ -99,7 +99,7 @@ describe Idv::Steps::Ipp::VerifyStep do
           flow.flow_session = { pii_from_user: pii }
         end
 
-        Idv::Steps::VerifyStep.new(flow)
+        Idv::Steps::Ipp::VerifyStep.new(flow)
       end
 
       before do

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -136,11 +136,7 @@ describe Idv::Steps::VerifyWaitStepShow do
       end
 
       it 'marks the verify step incomplete and redirects to the warning page' do
-        expect(step).to receive(:redirect_to).with(
-          idv_session_errors_warning_url(
-            from: request.path,
-          ),
-        )
+        expect(step).to receive(:redirect_to).with(idv_session_errors_warning_url)
         expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
@@ -159,11 +155,7 @@ describe Idv::Steps::VerifyWaitStepShow do
       end
 
       it 'marks the verify step incomplete and redirects to the exception page' do
-        expect(step).to receive(:redirect_to).with(
-          idv_session_errors_exception_url(
-            from: request.path,
-          ),
-        )
+        expect(step).to receive(:redirect_to).with(idv_session_errors_exception_url)
         expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Idv::Steps::Ipp::VerifyWaitStepShow do
+describe Idv::Steps::VerifyWaitStepShow do
   include Rails.application.routes.url_helpers
 
   let(:user) { build(:user) }
@@ -47,27 +47,27 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
   let(:flow_session) do
     {
       idv_verify_step_document_capture_session_uuid: dcs_uuid,
-      'Idv::Steps::Ipp::VerifyStep' => true,
-      pii_from_user: pii,
+      'Idv::Steps::VerifyStep' => true,
+      pii_from_doc: pii,
     }
   end
 
   let(:flow) do
-    Idv::Flows::InPersonFlow.new(controller, {}, 'idv/in_person').tap do |flow|
+    Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth').tap do |flow|
       flow.flow_session = flow_session
     end
   end
 
   subject(:step) do
-    Idv::Steps::Ipp::VerifyWaitStepShow.new(flow)
+    Idv::Steps::VerifyWaitStepShow.new(flow)
   end
 
   describe '#call' do
     it 'moves to the next page' do
-      expect(flow.flow_session['Idv::Steps::Ipp::VerifyWaitStep']).to be_nil
+      expect(flow.flow_session['Idv::Steps::VerifyWaitStep']).to be_nil
       step.call
 
-      expect(flow.flow_session['Idv::Steps::Ipp::VerifyWaitStep']).to be true
+      expect(flow.flow_session['Idv::Steps::VerifyWaitStep']).to be true
     end
 
     it 'adds costs' do
@@ -81,22 +81,22 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
     it 'clears pii from session' do
       step.call
 
-      expect(flow_session[:pii_from_user]).to be_blank
+      expect(flow_session[:pii_from_doc]).to be_blank
     end
 
     context 'when there is no document capture session ID' do
       let(:flow_session) do
         {
-          'Idv::Steps::Ipp::VerifyStep' => true,
-          pii_from_user: pii,
+          'Idv::Steps::VerifyStep' => true,
+          pii_from_doc: pii,
         }
       end
 
       it 'returns to the verify page' do
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be_nil
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be_nil
       end
     end
 
@@ -105,10 +105,10 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
       let(:document_capture_session) { nil }
 
       it 'deletes the document capture session and returns to the verify page' do
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be_nil
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be_nil
         expect(flow.flow_session[:idv_verify_step_document_capture_session_uuid]).to be_nil
       end
     end
@@ -117,10 +117,10 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
       let(:document_capture_session) { DocumentCaptureSession.create!(user: user) }
 
       it 'deletes the document capture session and returns to the verify page' do
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be_nil
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be_nil
         expect(flow.flow_session[:idv_verify_step_document_capture_session_uuid]).to be_nil
       end
     end
@@ -136,11 +136,15 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
       end
 
       it 'marks the verify step incomplete and redirects to the warning page' do
-        expect(step).to receive(:redirect_to).with(idv_session_errors_warning_url(flow: :in_person))
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
+        expect(step).to receive(:redirect_to).with(
+          idv_session_errors_warning_url(
+            from: request.path,
+          ),
+        )
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be_nil
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be_nil
       end
     end
 
@@ -156,12 +160,14 @@ describe Idv::Steps::Ipp::VerifyWaitStepShow do
 
       it 'marks the verify step incomplete and redirects to the exception page' do
         expect(step).to receive(:redirect_to).with(
-          idv_session_errors_exception_url(flow: :in_person),
+          idv_session_errors_exception_url(
+            from: request.path,
+          ),
         )
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be true
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be true
         step.call
 
-        expect(flow.flow_session['Idv::Steps::Ipp::VerifyStep']).to be_nil
+        expect(flow.flow_session['Idv::Steps::VerifyStep']).to be_nil
       end
     end
   end


### PR DESCRIPTION
**Why**: Since a user will need to select a location as part of establishing an enrollment before proceeding with the in-person flow.
