### PR TITLE
[LG-7191] Suppress content security policy

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -2,6 +2,7 @@ module Idv
   module DocumentCaptureConcern
     def override_document_capture_step_csp
       return if params[:step] != 'document_capture'
+      return if IdentityConfig.store.suppress_content_security_policy
 
       policy = current_content_security_policy
       policy.script_src(*policy.script_src, :unsafe_eval)

--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -11,6 +11,8 @@ module SecureHeadersConcern
   end
 
   def override_form_action_csp(uris)
+    return if IdentityConfig.store.suppress_content_security_policy
+
     policy = current_content_security_policy
     policy.form_action(*uris)
     request.content_security_policy = policy

--- a/app/helpers/secure_headers_helper.rb
+++ b/app/helpers/secure_headers_helper.rb
@@ -15,6 +15,8 @@ module SecureHeadersHelper
   end
 
   def add_document_capture_image_urls_to_csp_with_rails_csp_tooling(request, urls)
+    return if IdentityConfig.store.suppress_content_security_policy
+
     policy = request.content_security_policy.clone
     policy.connect_src(*policy.connect_src, *urls)
     request.content_security_policy = policy

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -284,6 +284,7 @@ voip_check: true
 voip_block: true
 voip_allowed_phones: '[]'
 inherited_proofing_va_base_url: 'https://staging-api.va.gov'
+suppress_content_security_policy: false
 
 development:
   aamva_private_key: 123abc

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,7 +2,7 @@ require 'feature_management'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.config.content_security_policy do |policy|
-  return nil if IdentityConfig.store.suppress_content_security_policy
+  next if IdentityConfig.store.suppress_content_security_policy
 
   connect_src = ["'self'", '*.nr-data.net', '*.google-analytics.com', 'us.acas.acuant.net']
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,6 +2,8 @@ require 'feature_management'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.config.content_security_policy do |policy|
+  return nil if IdentityConfig.store.suppress_content_security_policy
+
   connect_src = ["'self'", '*.nr-data.net', '*.google-analytics.com', 'us.acas.acuant.net']
 
   font_src = [:self, :data, IdentityConfig.store.asset_host.presence].compact
@@ -59,6 +61,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.base_uri :self
 end
 # rubocop:enable Metrics/BlockLength
+
 Rails.application.configure do
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = ['script-src']

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -376,6 +376,7 @@ class IdentityConfig
     config.add(:voip_block, type: :boolean)
     config.add(:voip_check, type: :boolean)
     config.add(:inherited_proofing_va_base_url, type: :string)
+    config.add(:suppress_content_security_policy, type: :boolean)
 
     @store = RedactedStruct.new('IdentityConfig', *config.written_env.keys, keyword_init: true).
       new(**config.written_env)


### PR DESCRIPTION
Suppress content security policy if IdentityConfig.store.suppress_content_security_policy is true.

508 tools that rely on javascript execution (ANDI for example) are unable to execute in the development environment due to Content Security Policy (CSP) policies. 

Creating/setting IdentityConfig.store.suppress_content_security_policy in an AWS sandbox will allow developers to turn CSP off, allowing these valuable tools to run.