### PR TITLE
Fix duplicate event logging for MFA Setup Complete event

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -7,13 +7,15 @@ module MfaSetupConcern
     elsif next_setup_choice
       confirmation_path
     else
+      if user_session[:mfa_selections]
+        analytics.user_registration_mfa_setup_complete(
+          mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
+          enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+          pii_like_keypaths: [[:mfa_method_counts, :phone]],
+          success: true,
+        )
+      end
       user_session.delete(:mfa_selections)
-      analytics.user_registration_mfa_setup_complete(
-        mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
-        enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
-        success: true,
-      )
       nil
     end
   end

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -94,14 +94,6 @@ describe Users::WebauthnSetupController do
             platform_authenticator: false,
           })
 
-        expect(@analytics).to receive(:track_event).
-          with('User Registration: MFA Setup Complete', {
-            enabled_mfa_methods_count: 3,
-            mfa_method_counts: { auth_app: 1, phone: 1, webauthn: 1 },
-            pii_like_keypaths: [[:mfa_method_counts, :phone]],
-            success: true,
-          })
-
         patch :confirm, params: params
       end
     end


### PR DESCRIPTION
Currently, the `next_setup_path` is called after any MFA setup, which includes MFA setups _after_ account registration, and this event was only intended to be logged during registration.

To fix that, this event should only be logged if there are MFA selections (which only exist during account registration).