### PR TITLE
LG-7076: Include partner links in in-person proofing emails

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -6,7 +6,7 @@ module Idv
       include UspsInPersonProofing
       include EffectiveUser
 
-      before_action :redirect_unless_effective_user, only: [:update]
+      before_action :confirm_authenticated_for_api, only: [:update]
 
       # get the list of all pilot Post Office locations
       def index
@@ -32,8 +32,8 @@ module Idv
 
       protected
 
-      def redirect_unless_effective_user
-        redirect_to root_url if !effective_user
+      def confirm_authenticated_for_api
+        render json: { success: false }, status: :unauthorized if !effective_user
       end
 
       def enrollment

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -239,7 +239,10 @@ class UserMailer < ActionMailer::Base
   def in_person_verified(user, email_address, enrollment:)
     with_user_locale(user) do
       @hide_title = true
-      @presenter = Idv::InPerson::VerificationResultsEmailPresenter.new(enrollment: enrollment)
+      @presenter = Idv::InPerson::VerificationResultsEmailPresenter.new(
+        enrollment: enrollment,
+        url_options: url_options,
+      )
       mail(
         to: email_address.email,
         subject: t('user_mailer.in_person_verified.subject', app_name: APP_NAME),
@@ -249,7 +252,10 @@ class UserMailer < ActionMailer::Base
 
   def in_person_failed(user, email_address, enrollment:)
     with_user_locale(user) do
-      @presenter = Idv::InPerson::VerificationResultsEmailPresenter.new(enrollment: enrollment)
+      @presenter = Idv::InPerson::VerificationResultsEmailPresenter.new(
+        enrollment: enrollment,
+        url_options: url_options,
+      )
       mail(
         to: email_address.email,
         subject: t('user_mailer.in_person_failed.subject', app_name: APP_NAME),

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -3,6 +3,9 @@ require 'securerandom'
 class InPersonEnrollment < ApplicationRecord
   belongs_to :user
   belongs_to :profile
+  # rubocop:disable Rails/InverseOf
+  belongs_to :service_provider, foreign_key: 'issuer', primary_key: 'issuer', optional: true
+  # rubocop:enable Rails/InverseOf
   enum status: {
     establishing: 0,
     pending: 1,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -3,9 +3,11 @@ require 'securerandom'
 class InPersonEnrollment < ApplicationRecord
   belongs_to :user
   belongs_to :profile
-  # rubocop:disable Rails/InverseOf
-  belongs_to :service_provider, foreign_key: 'issuer', primary_key: 'issuer', optional: true
-  # rubocop:enable Rails/InverseOf
+  belongs_to :service_provider,
+             foreign_key: 'issuer',
+             primary_key: 'issuer',
+             inverse_of: :in_person_enrollments,
+             optional: true
   enum status: {
     establishing: 0,
     pending: 1,

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -10,6 +10,11 @@ class ServiceProvider < ApplicationRecord
                         primary_key: 'issuer',
                         class_name: 'ServiceProviderIdentity'
   # rubocop:enable Rails/HasManyOrHasOneDependent
+  has_many :in_person_enrollments,
+           inverse_of: :service_provider,
+           foreign_key: 'issuer',
+           primary_key: 'issuer',
+           dependent: :destroy
 
   # Do not define validations in this model.
   # See https://github.com/18F/identity_validations

--- a/app/presenters/idv/in_person/verification_results_email_presenter.rb
+++ b/app/presenters/idv/in_person/verification_results_email_presenter.rb
@@ -44,8 +44,13 @@ module Idv
       end
 
       def service_provider_homepage_url
-        return unless service_provider
-        SpReturnUrlResolver.new(service_provider: service_provider).homepage_url
+        sp_return_url_resolver.homepage_url if service_provider
+      end
+
+      private
+
+      def sp_return_url_resolver
+        SpReturnUrlResolver.new(service_provider: service_provider)
       end
     end
   end

--- a/app/presenters/idv/in_person/verification_results_email_presenter.rb
+++ b/app/presenters/idv/in_person/verification_results_email_presenter.rb
@@ -36,7 +36,7 @@ module Idv
       end
 
       def show_cta?
-        !service_provider || service_provider_homepage_url
+        !service_provider || service_provider_homepage_url.present?
       end
 
       def sign_in_url

--- a/app/presenters/idv/in_person/verification_results_email_presenter.rb
+++ b/app/presenters/idv/in_person/verification_results_email_presenter.rb
@@ -1,21 +1,51 @@
 module Idv
   module InPerson
     class VerificationResultsEmailPresenter
+      include Rails.application.routes.url_helpers
+
+      attr_reader :enrollment, :url_options
+
       # update to user's time zone when out of pilot
       USPS_SERVER_TIMEZONE = ActiveSupport::TimeZone['America/New_York']
 
-      def initialize(enrollment:)
+      def initialize(enrollment:, url_options:)
         @enrollment = enrollment
+        @url_options = url_options
       end
 
       def location_name
-        @enrollment.selected_location_details['name']
+        enrollment.selected_location_details['name']
       end
 
       def formatted_verified_date
-        @enrollment.status_updated_at.in_time_zone(USPS_SERVER_TIMEZONE).strftime(
+        enrollment.status_updated_at.in_time_zone(USPS_SERVER_TIMEZONE).strftime(
           I18n.t('time.formats.event_date'),
         )
+      end
+
+      def service_provider
+        enrollment.service_provider
+      end
+
+      def service_provider_or_app_name
+        if service_provider
+          service_provider.friendly_name
+        else
+          APP_NAME
+        end
+      end
+
+      def show_cta?
+        !service_provider || service_provider_homepage_url
+      end
+
+      def sign_in_url
+        service_provider_homepage_url || root_url
+      end
+
+      def service_provider_homepage_url
+        return unless service_provider
+        SpReturnUrlResolver.new(service_provider: service_provider).homepage_url
       end
     end
   end

--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -17,6 +17,10 @@ class SpReturnUrlResolver
     service_provider.failure_to_proof_url.presence || return_to_sp_url
   end
 
+  def homepage_url
+    service_provider.return_to_sp_url
+  end
+
   private
 
   def inferred_redirect_url

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -31,13 +31,6 @@ module UspsInPersonProofing
         end
       end
 
-      def establishing_in_person_enrollment_for_user(user)
-        enrollment = user.establishing_in_person_enrollment
-        return enrollment if enrollment.present?
-
-        InPersonEnrollment.create!(user: user, profile: nil)
-      end
-
       def usps_proofer
         if IdentityConfig.store.usps_mock_fallback
           UspsInPersonProofing::Mock::Proofer.new

--- a/app/views/shared/_in-person-verification-results-email-lower.html.erb
+++ b/app/views/shared/_in-person-verification-results-email-lower.html.erb
@@ -1,38 +1,40 @@
-<div class="margin-top-5">
-  <table class="button expanded large radius">
-    <tbody>
-      <tr>
-        <td>
-          <table>
-            <tbody>
-              <tr>
-                <td style="text-align: center">
-                  <%= link_to t('user_mailer.in_person_verified.sign_in'),
-                              idv_url,
-                              target: '_blank',
-                              class: 'float-center',
-                              rel: 'noopener' %>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </td>
-        <td class="expander"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+<% if @presenter.show_cta? %>
+  <div class="margin-top-5">
+    <table class="button expanded large radius">
+      <tbody>
+        <tr>
+          <td>
+            <table>
+              <tbody>
+                <tr>
+                  <td style="text-align: center">
+                    <%= link_to t('user_mailer.in_person_verified.sign_in'),
+                                idv_url,
+                                target: '_blank',
+                                class: 'float-center',
+                                rel: 'noopener' %>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+          <td class="expander"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
-<p>
-  <%= link_to idv_url, idv_url, target: '_blank', rel: 'noopener' %>
-</p>
+  <p>
+    <%= link_to @presenter.sign_in_url, @presenter.sign_in_url, target: '_blank', rel: 'noopener' %>
+  </p>
+<% end %>
 
 <div class="s16">
   <br />
   <%= t(
         'user_mailer.in_person_verified.warning_contact_us_html',
         contact_us_url: MarketingSite.contact_url,
-        sign_in_url: idv_url,
+        sign_in_url: root_url,
       )
   %>
 </div>

--- a/app/views/user_mailer/in_person_failed.html.erb
+++ b/app/views/user_mailer/in_person_failed.html.erb
@@ -14,7 +14,7 @@
       <%= t('user_mailer.in_person_failed.body.without_cta', sp_name: @presenter.service_provider.friendly_name) %>
     <% end %>
   </p>
-  <p><strong><%= t('user_mailer.in_person_failed.verifying_identity') %></strong></p>
+  <p class="s16"><strong><%= t('user_mailer.in_person_failed.verifying_identity') %></strong></p>
   <ul class="usa-list">
     <li><%= t('user_mailer.in_person_failed.verifying_step_not_expired') %></li>
     <li><%= t('user_mailer.in_person_failed.verifying_step_proof_of_address') %></li>

--- a/app/views/user_mailer/in_person_failed.html.erb
+++ b/app/views/user_mailer/in_person_failed.html.erb
@@ -8,9 +8,13 @@
         ) %>
   </p>
   <p class="s16">
-    <%= t('user_mailer.in_person_failed.body', app_name: APP_NAME) %><br><br />
+    <% if @presenter.show_cta? %>
+      <%= t('user_mailer.in_person_failed.body.with_cta', sp_or_app_name: @presenter.service_provider_or_app_name) %>
+    <% else %>
+      <%= t('user_mailer.in_person_failed.body.without_cta', sp_name: @presenter.service_provider.friendly_name) %>
+    <% end %>
   </p>
-  <strong><%= t('user_mailer.in_person_failed.verifying_identity') %></strong><br>
+  <p><strong><%= t('user_mailer.in_person_failed.verifying_identity') %></strong></p>
   <ul class="usa-list">
     <li><%= t('user_mailer.in_person_failed.verifying_step_not_expired') %></li>
     <li><%= t('user_mailer.in_person_failed.verifying_step_proof_of_address') %></li>

--- a/app/views/user_mailer/in_person_verified.html.erb
+++ b/app/views/user_mailer/in_person_verified.html.erb
@@ -12,8 +12,18 @@
         'user_mailer.in_person_verified.intro',
         location: @presenter.location_name,
         date: @presenter.formatted_verified_date,
-      ) %><br /><br />
-  <%= t('user_mailer.in_person_verified.next_sign_in', app_name: APP_NAME) %>
+      ) %>
+</p>
+<p class="s16">
+  <% if @presenter.service_provider.present? %>
+    <% if @presenter.show_cta? %>
+      <%= t('user_mailer.in_person_verified.next_sign_in.with_sp.with_cta', sp_name: @presenter.service_provider.friendly_name) %>
+    <% else %>
+      <%= t('user_mailer.in_person_verified.next_sign_in.with_sp.without_cta', sp_name: @presenter.service_provider.friendly_name) %>
+    <% end %>
+  <% else %>
+    <%= t('user_mailer.in_person_verified.next_sign_in.without_sp', app_name: APP_NAME) %>
+  <% end %>
 </p>
 
 <%= render 'shared/in-person-verification-results-email-lower' %>

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -101,9 +101,13 @@ en:
       subject: Email address deleted
     help_link_text: Help Center
     in_person_failed:
-      body: Click the button or copy the link below to try verifying your identity
-        online again through %{app_name}. If you are still experiencing issues,
-        please contact the agency you are trying to access.
+      body:
+        with_cta: Click the button or copy the link below to try verifying your identity
+          online again through %{sp_or_app_name}. If you are still experiencing
+          issues, please contact the agency you are trying to access.
+        without_cta: Please try verifying your identity again from %{sp_name}’s website.
+          If you are still experiencing issues, please contact the agency you
+          are trying to access.
       intro: Your identity could not be verified at the %{location} Post Office on
         %{date}.
       subject: Your identity could not be verified in person
@@ -123,7 +127,13 @@ en:
       greeting: Hello,
       intro: You successfully verified your identity at the %{location} Post Office on
         %{date}.
-      next_sign_in: Next, click the button or copy the link below to sign in to %{app_name}.
+      next_sign_in:
+        with_sp:
+          with_cta: Next, click the button or copy the link below to access %{sp_name} and
+            sign in.
+          without_cta: You can now sign in from %{sp_name}’s website.
+        without_sp: Next, click the button or copy the link below to sign in to
+          %{app_name}.
       sign_in: Sign in
       subject: You successfully verified your identity with %{app_name}
       warning_contact_us_html: If you did not attempt to verify your identity in

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -107,9 +107,14 @@ es:
       subject: Dirección de correo electrónico eliminada
     help_link_text: Centro de Ayuda
     in_person_failed:
-      body: Haga clic en el botón o copie el enlace siguiente para volver a intentar
-        verificar su identidad en línea con %{app_name}. Si sigue teniendo
-        problemas, póngase en contacto con la agencia a la que intenta acceder.
+      body:
+        with_cta: Haga clic en el botón o copie el enlace siguiente para volver a
+          intentar verificar su identidad en línea con %{sp_or_app_name}. Si
+          sigue teniendo problemas, póngase en contacto con la agencia a la que
+          intenta acceder.
+        without_cta: Vuelva a comprobar su identidad desde el sitio web de la
+          %{sp_name}. En caso de persistir los problemas, contacte con la
+          agencia a la que intenta entrar.
       intro: El %{date}, no se pudo verificar su identidad en la oficina de correos de
         %{location}.
       subject: No se pudo verificar su identidad en persona
@@ -130,8 +135,13 @@ es:
       greeting: Hola,
       intro: El %{date}, verificó correctamente su identidad en la oficina de correos
         de %{location}.
-      next_sign_in: Luego, haga clic en el botón o copie el enlace que aparece a
-        continuación para iniciar sesión en %{app_name}.
+      next_sign_in:
+        with_sp:
+          with_cta: Seguidamente, haga clic en el botón o copie el siguiente enlace para
+            poder entrar en la %{sp_name} e inicie la sesión.
+          without_cta: Ya puede iniciar la sesión desde el sitio web de la %{sp_name}.
+        without_sp: Luego, haga clic en el botón o copie el enlace que aparece a
+          continuación para iniciar sesión en %{app_name}.
       sign_in: Iniciar sesión
       subject: Verificó correctamente su identidad con %{app_name}
       warning_contact_us_html: Si usted no intentó verificar su identidad en persona,

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -110,10 +110,14 @@ fr:
       subject: Adresse email supprimée
     help_link_text: Centre d’aide
     in_person_failed:
-      body: Cliquez sur le bouton ou copiez le lien ci-dessous pour essayer de
-        vérifier à nouveau votre identité en ligne par le biais de %{app_name}.
-        Si vous rencontrez toujours des problèmes, veuillez contacter l’agence à
-        laquelle vous essayez d’accéder.
+      body:
+        with_cta: Cliquez sur le bouton ou copiez le lien ci-dessous pour essayer de
+          vérifier à nouveau votre identité en ligne par le biais de
+          %{sp_or_app_name}. Si vous rencontrez toujours des problèmes, veuillez
+          contacter l’agence à laquelle vous essayez d’accéder.
+        without_cta: Veuillez essayer de confirmer votre identité à nouveau sur le site
+          Web de %{sp_name}. Si vous rencontrez toujours des difficultés,
+          veuillez contacter l’agence à laquelle vous essayez d’accéder.
       intro: Votre identité n’a pas pu être vérifiée au bureau de poste de %{location}
         le %{date}.
       subject: Votre identité n’a pas pu être vérifiée en personne
@@ -135,8 +139,14 @@ fr:
       greeting: Bonjour,
       intro: Vous avez vérifié avec succès votre identité au bureau de poste de
         %{location} le %{date}.
-      next_sign_in: Ensuite, cliquez sur le bouton ou copiez le lien ci-dessous pour
-        vous connecter à %{app_name}.
+      next_sign_in:
+        with_sp:
+          with_cta: Ensuite, cliquez sur le bouton ou copiez le lien ci-dessous pour
+            accéder à %{sp_name} et connectez-vous.
+          without_cta: Vous pouvez maintenant vous connecter à partir du site Web de
+            %{sp_name}.
+        without_sp: Ensuite, cliquez sur le bouton ou copiez le lien ci-dessous pour
+          vous connecter à %{app_name}.
       sign_in: Se connecter
       subject: Vous avez vérifié avec succès votre identité avec %{app_name}
       warning_contact_us_html: Si vous n’avez pas essayé de vérifier votre identité en

--- a/db/primary_migrate/20220808140030_add_issuer_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20220808140030_add_issuer_to_in_person_enrollments.rb
@@ -1,0 +1,8 @@
+class AddIssuerToInPersonEnrollments < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :in_person_enrollments, :issuer, :string, null: true, comment: "Issuer associated with the enrollment at time of creation"
+    add_foreign_key :in_person_enrollments, :service_providers, column: :issuer, primary_key: :issuer, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_28_223843) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_08_140030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -293,6 +293,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_223843) do
     t.jsonb "selected_location_details", comment: "The location details of the Post Office the user selected (including title, address, hours of operation)"
     t.string "unique_id", comment: "Unique ID to use with the USPS service"
     t.datetime "enrollment_established_at", comment: "When the enrollment was successfully established"
+    t.string "issuer", comment: "Issuer associated with the enrollment at time of creation"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true
     t.index ["user_id", "status"], name: "index_in_person_enrollments_on_user_id_and_status", unique: true, where: "(status = 1)"
@@ -639,6 +640,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_223843) do
   add_foreign_key "iaa_gtcs", "partner_accounts"
   add_foreign_key "iaa_orders", "iaa_gtcs"
   add_foreign_key "in_person_enrollments", "profiles"
+  add_foreign_key "in_person_enrollments", "service_providers", column: "issuer", primary_key: "issuer"
   add_foreign_key "in_person_enrollments", "users"
   add_foreign_key "integration_usages", "iaa_orders"
   add_foreign_key "integration_usages", "integrations"

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -115,7 +115,7 @@ describe Idv::InPerson::UspsLocationsController do
       it 'writes the passed location to in-person enrollment associated with effective user' do
         response
 
-        enrollment = user.reload.establishing_in_person_enrollment
+        enrollment = effective_user.reload.establishing_in_person_enrollment
 
         expect(enrollment.selected_location_details).to eq(
           selected_location[:usps_location].as_json,

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -87,8 +87,8 @@ describe Idv::InPerson::UspsLocationsController do
     context 'when unauthenticated' do
       let(:user) { nil }
 
-      it 'redirects to the root url' do
-        expect(response).to redirect_to root_url
+      it 'renders an unauthorized status' do
+        expect(response.status).to eq(401)
       end
     end
 

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -4,6 +4,7 @@ describe Idv::InPerson::UspsLocationsController do
   include IdvHelper
 
   let(:user) { create(:user) }
+  let(:sp) { nil }
   let(:in_person_proofing_enabled) { false }
   let(:selected_location) do
     {
@@ -21,9 +22,10 @@ describe Idv::InPerson::UspsLocationsController do
 
   before do
     stub_analytics
-    stub_sign_in(user)
+    stub_sign_in(user) if user
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
       and_return(in_person_proofing_enabled)
+    allow(controller).to receive(:current_sp).and_return(sp)
   end
 
   describe '#index' do
@@ -71,12 +73,35 @@ describe Idv::InPerson::UspsLocationsController do
   end
 
   describe '#update' do
-    it 'writes the passed location to in-person enrollment' do
-      put :update, params: selected_location
+    subject(:response) { put :update, params: selected_location }
 
-      expect(user.reload.establishing_in_person_enrollment.selected_location_details).to eq(
-        selected_location[:usps_location].as_json,
-      )
+    it 'writes the passed location to in-person enrollment' do
+      response
+
+      enrollment = user.reload.establishing_in_person_enrollment
+
+      expect(enrollment.selected_location_details).to eq(selected_location[:usps_location].as_json)
+      expect(enrollment.service_provider).to be_nil
+    end
+
+    context 'when unauthenticated' do
+      let(:user) { nil }
+
+      it 'redirects to the root url' do
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'with associated service provider' do
+      let(:sp) { create(:service_provider) }
+
+      it 'assigns services provider to in-person enrollment' do
+        response
+
+        enrollment = user.reload.establishing_in_person_enrollment
+
+        expect(enrollment.issuer).to eq(sp.issuer)
+      end
     end
 
     context 'with hybrid user' do
@@ -88,11 +113,14 @@ describe Idv::InPerson::UspsLocationsController do
       end
 
       it 'writes the passed location to in-person enrollment associated with effective user' do
-        put :update, params: selected_location
+        response
 
-        expect(
-          effective_user.reload.establishing_in_person_enrollment.selected_location_details,
-        ).to eq(selected_location[:usps_location].as_json)
+        enrollment = user.reload.establishing_in_person_enrollment
+
+        expect(enrollment.selected_location_details).to eq(
+          selected_location[:usps_location].as_json,
+        )
+        expect(enrollment.service_provider).to be_nil
       end
     end
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -191,6 +191,7 @@ class UserMailerPreview < ActionMailer::Preview
           'saturday_hours' => '9:00 AM - 12:00 PM',
           'sunday_hours' => 'Closed',
         },
+        service_provider: params[:issuer] ? ServiceProvider.find_by(issuer: params[:issuer]) : nil,
       ),
     )
   end

--- a/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
@@ -1,17 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
+  include Rails.application.routes.url_helpers
+
   let(:location_name) { 'FRIENDSHIP' }
   let(:status_updated_at) { described_class::USPS_SERVER_TIMEZONE.parse('2022-07-14T00:00:00Z') }
+  let(:sp) { nil }
   let!(:enrollment) do
     create(
       :in_person_enrollment,
       :pending,
+      service_provider: sp,
       selected_location_details: { name: location_name },
     )
   end
 
-  subject(:presenter) { described_class.new(enrollment: enrollment) }
+  subject(:presenter) { described_class.new(enrollment: enrollment, url_options: {}) }
 
   describe '#location_name' do
     it 'returns the enrollment location name' do
@@ -27,6 +31,135 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
     it 'returns a formatted verified date' do
       enrollment.update(status_updated_at: status_updated_at)
       expect(presenter.formatted_verified_date).to eq 'July 13, 2022'
+    end
+  end
+
+  describe '#service_provider' do
+    it 'returns service provider associated with enrollment' do
+      expect(presenter.service_provider).to eq(enrollment.service_provider)
+    end
+  end
+
+  describe '#service_provider_or_app_name' do
+    context 'without service provider' do
+      let(:sp) { nil }
+
+      it 'returns app name' do
+        expect(presenter.service_provider_or_app_name).to eq(APP_NAME)
+      end
+    end
+
+    context 'with service provider' do
+      let(:sp) { create(:service_provider) }
+
+      it 'returns friendly name of service provider' do
+        expect(presenter.service_provider_or_app_name).to eq(sp.friendly_name)
+      end
+    end
+  end
+
+  describe '#show_cta?' do
+    context 'without service provider' do
+      let(:sp) { nil }
+
+      it { expect(presenter.show_cta?).to eq(true) }
+    end
+
+    context 'with service provider' do
+      let(:homepage_url) { nil }
+      let(:sp) { create(:service_provider) }
+
+      before do
+        resolver = instance_double(SpReturnUrlResolver)
+        allow(resolver).to receive(:homepage_url).and_return(homepage_url)
+        allow(SpReturnUrlResolver).to receive(:new).with(service_provider: sp).and_return(resolver)
+      end
+
+      context 'without homepage_url' do
+        let(:homepage_url) { nil }
+
+        it { expect(presenter.show_cta?).to eq(false) }
+      end
+
+      context 'with homepage_url' do
+        let(:homepage_url) { 'https://example.com' }
+
+        it { expect(presenter.show_cta?).to eq(true) }
+      end
+    end
+  end
+
+  describe '#sign_in_url' do
+    context 'without service provider' do
+      let(:sp) { nil }
+
+      it 'returns root url' do
+        expect(presenter.sign_in_url).to eq(root_url)
+      end
+    end
+
+    context 'with service provider' do
+      let(:homepage_url) { nil }
+      let(:sp) { create(:service_provider) }
+
+      before do
+        resolver = instance_double(SpReturnUrlResolver)
+        allow(resolver).to receive(:homepage_url).and_return(homepage_url)
+        allow(SpReturnUrlResolver).to receive(:new).with(service_provider: sp).and_return(resolver)
+      end
+
+      context 'without homepage_url' do
+        let(:homepage_url) { nil }
+
+        it 'returns root url' do
+          expect(presenter.sign_in_url).to eq(root_url)
+        end
+      end
+
+      context 'with homepage_url' do
+        let(:homepage_url) { 'https://example.com' }
+
+        it 'returns homepage url' do
+          expect(presenter.sign_in_url).to eq(homepage_url)
+        end
+      end
+    end
+  end
+
+  describe '#service_provider_homepage_url' do
+    context 'without service provider' do
+      let(:sp) { nil }
+
+      it 'returns nil' do
+        expect(presenter.service_provider_homepage_url).to be_nil
+      end
+    end
+
+    context 'with service provider' do
+      let(:homepage_url) { nil }
+      let(:sp) { create(:service_provider) }
+
+      before do
+        resolver = instance_double(SpReturnUrlResolver)
+        allow(resolver).to receive(:homepage_url).and_return(homepage_url)
+        allow(SpReturnUrlResolver).to receive(:new).with(service_provider: sp).and_return(resolver)
+      end
+
+      context 'without homepage_url' do
+        let(:homepage_url) { nil }
+
+        it 'returns root url' do
+          expect(presenter.service_provider_homepage_url).to be_nil
+        end
+      end
+
+      context 'with homepage_url' do
+        let(:homepage_url) { 'https://example.com' }
+
+        it 'returns homepage url' do
+          expect(presenter.service_provider_homepage_url).to eq(homepage_url)
+        end
+      end
     end
   end
 end

--- a/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
       before do
         resolver = instance_double(SpReturnUrlResolver)
         allow(resolver).to receive(:homepage_url).and_return(homepage_url)
-        allow(SpReturnUrlResolver).to receive(:new).with(service_provider: sp).and_return(resolver)
+        allow(presenter).to receive(:sp_return_url_resolver).and_return(resolver)
       end
 
       context 'without homepage_url' do

--- a/spec/services/sp_return_url_resolver_spec.rb
+++ b/spec/services/sp_return_url_resolver_spec.rb
@@ -121,4 +121,23 @@ RSpec.describe SpReturnUrlResolver do
       expect(failure_to_proof_url).to eq(configured_return_to_sp_url)
     end
   end
+
+  describe '#homepage_url' do
+    let(:return_to_sp_url) { nil }
+    let(:sp) { build(:service_provider, return_to_sp_url: return_to_sp_url) }
+    let(:instance) { described_class.new(service_provider: sp) }
+    subject(:homepage_url) { instance.homepage_url }
+
+    it 'returns nil' do
+      expect(homepage_url).to be_nil
+    end
+
+    context 'with return to sp url' do
+      let(:return_to_sp_url) { 'https://sp.gov/return_to_sp' }
+
+      it 'return return to sp url' do
+        expect(homepage_url).to eq(return_to_sp_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: As a user, I want to receive an email notification so that I know if my identity verification was successful or not. Those emails should direct me to the original service provider so that I can access the services I had originally sought to access.

**Screenshots:**

<table>
<tr><td></td><td colspan="2">With service provider</td><td>Without service provider</td></tr>
<tr><td></td><td>With homepage</td><td>Without home page</td><td></td></tr>
<tr><td>Success</td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183980036-4cedf94f-63e3-4802-ae52-07fff949f781.png"></td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183980147-a2406167-e7a2-43ec-b87a-5d64c685117b.png"></td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183979934-7b7ea451-8f63-4de6-bb75-96e039fb7299.png"></td></tr>
<tr><td>Failure</td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183980507-d63821fb-139f-475a-971b-6af5aedf214f.png"></td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183980597-44963015-00b5-4841-b970-7c596638db14.png"></td><td><img alt="screenshot" src="https://user-images.githubusercontent.com/1779930/183980397-903fe120-5a53-4884-be7d-83db5792d2e9.png"></td></tr>
</table>

**Testing Instructions:**

View previews for success and fail results, with or without an associated SP, and with or without an SP's known homepage:

- Success
   - [Without SP](http://localhost:3000/rails/mailers/user_mailer/in_person_verified)
   - With SP
      - [With homepage](http://localhost:3000/rails/mailers/user_mailer/in_person_verified?issuer=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard)
      - [Without homepage](http://localhost:3000/rails/mailers/user_mailer/in_person_verified?issuer=urn:gov:gsa:openidconnect:sp:sinatra)
- Failure
   - [Without SP](http://localhost:3000/rails/mailers/user_mailer/in_person_failed)
   - With SP
      - [With homepage](http://localhost:3000/rails/mailers/user_mailer/in_person_failed?issuer=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard)
      - [Without homepage](http://localhost:3000/rails/mailers/user_mailer/in_person_failed?issuer=urn:gov:gsa:openidconnect:sp:sinatra)