### PR TITLE
Log whether a requested GPO letter is being resent

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -55,7 +55,7 @@ module Idv
     private
 
     def update_tracking
-      analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now)
+      analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now, resend: true)
       create_user_event(:gpo_mail_sent, current_user)
 
       ProofingComponent.create_or_find_by(user: current_user).update(address_check: 'gpo_letter')

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -89,7 +89,7 @@ module Idv
       idv_session.create_profile_from_applicant_with_password(password)
 
       if idv_session.address_verification_mechanism == 'gpo'
-        analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now)
+        analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now, resend: false)
       end
 
       if idv_session.profile.active?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -636,7 +636,7 @@ module AnalyticsEvents
   end
 
   # @param [DateTime] enqueued_at
-  # params [Boolean] resend
+  # @param [Boolean] resend
   # GPO letter was requested and time was recorded
   def idv_gpo_address_letter_requested(enqueued_at:, resend:, **extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -635,13 +635,14 @@ module AnalyticsEvents
     track_event('IdV: forgot password confirmed')
   end
 
-  # GPO address letter requested
   # @param [DateTime] enqueued_at
+  # params [Boolean] resend
   # GPO letter was requested and time was recorded
-  def idv_gpo_address_letter_requested(enqueued_at: Time.zone.now, **extra)
+  def idv_gpo_address_letter_requested(enqueued_at:, resend:, **extra)
     track_event(
       'IdV: USPS address letter requested',
       enqueued_at: enqueued_at,
+      resend: resend,
       **extra,
     )
   end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -227,18 +227,4 @@ describe Analytics do
       analytics.track_event('Trackable Event')
     end
   end
-
-  describe '#idv_gpo_address_letter_requested' do
-    let(:analytics) { FakeAnalytics.new }
-
-    it 'logs letter requested with enqueued at' do
-      enqueued_at = Time.zone.now
-      analytics.idv_gpo_address_letter_requested(enqueued_at: enqueued_at)
-
-      expect(analytics).to have_logged_event(
-        'IdV: USPS address letter requested',
-        enqueued_at: enqueued_at,
-      )
-    end
-  end
 end


### PR DESCRIPTION
This change allows us to sort between users requesting a new letter and users who are requesting their first letter. This allows us to group users requesting letters into cohorts based on when they requested their first letter by filtering out resends.