### PR TITLE
LG-7140 Set max doc auth attempts to 5

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -76,7 +76,7 @@ doc_auth_s3_request_timeout: 5
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
-doc_auth_max_attempts: 20
+doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_tips: 3
 doc_capture_request_valid_for_minutes: 15
 email_from: no-reply@login.gov


### PR DESCRIPTION
We looked at the data. 95% of users don't make more than 5 attemtps and very few people are not successful after the 3rd attempts