### PR TITLE
Log origination phone number for voice calls

### DIFF
--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -17,6 +17,9 @@ module Telephony
           start = Time.zone.now
           client = build_client(voice_config)
           next if client.nil?
+
+          origination_phone_number = voice_config.longcode_pool.sample
+
           response = client.send_voice_message(
             content: {
               ssml_message: {
@@ -26,7 +29,7 @@ module Telephony
               },
             },
             destination_phone_number: to,
-            origination_phone_number: voice_config.longcode_pool.sample,
+            origination_phone_number: origination_phone_number,
           )
           finish = Time.zone.now
           return Response.new(
@@ -35,6 +38,7 @@ module Telephony
             extra: {
               message_id: response.message_id,
               duration_ms: Util.duration_ms(start: start, finish: finish),
+              origination_phone_number: origination_phone_number,
             },
           )
         rescue Aws::PinpointSMSVoice::Errors::ServiceError,

--- a/lib/telephony/test/voice_sender.rb
+++ b/lib/telephony/test/voice_sender.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module Telephony
   module Test
     class VoiceSender
+      ORIGINATION_PHONE_NUMBER = '+1888LOGINGOV'
+
       # rubocop:disable Lint/UnusedMethodArgument
       def send(message:, to:, country_code:, otp: nil)
         error = ErrorSimulator.new.error_for_number(to)
@@ -10,7 +14,7 @@ module Telephony
             success: true,
             extra: {
               request_id: 'fake-message-request-id',
-              origination_phone_number: '+1888LOGINGOV'
+              origination_phone_number: ORIGINATION_PHONE_NUMBER,
             },
           )
         else
@@ -19,7 +23,7 @@ module Telephony
             error: error,
             extra: {
               request_id: 'fake-message-request-id',
-              origination_phone_number: '+1888LOGINGOV'
+              origination_phone_number: ORIGINATION_PHONE_NUMBER,
             },
           )
         end

--- a/lib/telephony/test/voice_sender.rb
+++ b/lib/telephony/test/voice_sender.rb
@@ -6,10 +6,21 @@ module Telephony
         error = ErrorSimulator.new.error_for_number(to)
         if error.nil?
           Call.calls.push(Call.new(body: message, to: to, otp: otp))
-          Response.new(success: true, extra: { request_id: 'fake-message-request-id' })
+          Response.new(
+            success: true,
+            extra: {
+              request_id: 'fake-message-request-id',
+              origination_phone_number: '+1888LOGINGOV'
+            },
+          )
         else
           Response.new(
-            success: false, error: error, extra: { request_id: 'fake-message-request-id' },
+            success: false,
+            error: error,
+            extra: {
+              request_id: 'fake-message-request-id',
+              origination_phone_number: '+1888LOGINGOV'
+            },
           )
         end
       end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -453,6 +453,9 @@ describe Users::TwoFactorAuthenticationController do
             success: true,
             otp_delivery_preference: 'voice',
             country_code: 'US',
+            telephony_response: hash_including(
+              origination_phone_number: Telephony::Test::VoiceSender::ORIGINATION_PHONE_NUMBER,
+            ),
           ))
 
         get :send_code, params: {

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -58,6 +58,7 @@ describe Telephony::Pinpoint::VoiceSender do
 
       expect(response.success?).to eq(true)
       expect(response.extra[:message_id]).to eq('fake-message-id')
+      expect(response.extra[:origination_phone_number]).to eq(sending_phone)
     end
 
     context 'when the current locale is spanish' do

--- a/spec/lib/telephony/test/voice_sender_spec.rb
+++ b/spec/lib/telephony/test/voice_sender_spec.rb
@@ -17,6 +17,7 @@ describe Telephony::Test::VoiceSender do
       expect(response.success?).to eq(true)
       expect(response.error).to eq(nil)
       expect(response.extra[:request_id]).to eq('fake-message-request-id')
+      expect(response.extra[:origination_phone_number]).to be_present
     end
 
     it 'simulates a telephony error' do
@@ -27,6 +28,7 @@ describe Telephony::Test::VoiceSender do
       expect(response.success?).to eq(false)
       expect(response.error).to eq(Telephony::TelephonyError.new('Simulated telephony error'))
       expect(response.extra[:request_id]).to eq('fake-message-request-id')
+      expect(response.extra[:origination_phone_number]).to be_present
       expect(last_call).to eq(nil)
     end
 


### PR DESCRIPTION
**Why**: So we can triage which phone numbers are associated
with errors on the customer side
