### PR TITLE
LG-7130: Add links to help center articles for in-person proofing

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -14,8 +14,7 @@ import { useI18n } from '@18f/identity-react-i18n';
 import { FormStepsButton } from '@18f/identity-form-steps';
 import UploadContext from '../context/upload';
 import BackButton from './back-button';
-// WILLFIX: Hiding this component until help links are finalized; see LG-6875
-// import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
+import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
 
 function InPersonPrepareStep({ toPreviousStep, value }) {
   const { t } = useI18n();
@@ -92,11 +91,8 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
           </Button>
         </div>
       )}
-      <BackButton includeBorder onClick={toPreviousStep} />
-      {/*
-      WILLFIX: Hiding this component until help links are finalized; see LG-6875
       <InPersonTroubleshootingOptions />
-      */}
+      <BackButton includeBorder onClick={toPreviousStep} />
     </>
   );
 }

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -8,9 +8,13 @@
 
 <p>
   <%= t('in_person_proofing.body.address.info') %>
-  <%# WILLFIX: Hiding the link below until help links are finalized; see LG-6875 %>
-  <%# i18n-tasks-use t('in_person_proofing.body.address.learn_more') %>
-  <%# new_window_link_to(t('in_person_proofing.body.address.learn_more'), MarketingSite.security_and_privacy_practices_url) %>
+  <%= new_window_link_to(
+        t('in_person_proofing.body.address.learn_more'),
+        MarketingSite.help_center_article_url(
+          category: 'verify-your-identity',
+          article: 'how-to-verify-in-person',
+        ),
+      ) %>
 </p>
 
 <%= simple_form_for(

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -59,9 +59,8 @@
     <% end %>
   <% end %>
   <p class="margin-bottom-0">
-    <%# WILLFIX: Hiding this text and link until help links are finalized; see LG-6875 %>
-    <%# t('in_person_proofing.body.barcode.items_to_bring_questions') %>
-    <%# new_window_link_to(
+    <%= t('in_person_proofing.body.barcode.items_to_bring_questions') %>
+    <%= new_window_link_to(
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -61,10 +61,8 @@
     <% end %>
   </table>
   <p class="margin-bottom-0">
-    <%# WILLFIX: Hiding this text and link until help links are finalized; see LG-6875 %>
-    <%# i18n-tasks-use t('in_person_proofing.body.barcode.items_to_bring_questions') %>
-    <%# t('in_person_proofing.body.barcode.items_to_bring_questions') %>
-    <%# link_to(
+    <%= t('in_person_proofing.body.barcode.items_to_bring_questions') %>
+    <%= link_to(
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',


### PR DESCRIPTION
**Why**: So that a user can learn more about how to complete the in-person proofing process.

Related: https://github.com/18F/identity-site/pull/920

**Screenshots:**

Screen|Before|After
---|---|---
Prepare|![7130-prepare-before](https://user-images.githubusercontent.com/1779930/184144544-3fb17001-c885-4513-a2b7-642f4b77d1c5.png)|![7130-prepare-after](https://user-images.githubusercontent.com/1779930/184144542-7c0ad976-9db3-4406-9401-f3305a5f35f2.png)
Address|![7130-address-before](https://user-images.githubusercontent.com/1779930/184144531-75c42fbe-fecb-41ec-8ddf-0246c53d79f5.png)|![7130-address-after](https://user-images.githubusercontent.com/1779930/184144525-9fc05159-8696-4734-9bd0-04a99ec492cd.png)
Ready to Verify|![7130-ready-before](https://user-images.githubusercontent.com/1779930/184144551-7f46de38-c344-4d2f-87b9-970eabaa45ad.png)|![7130-ready-after](https://user-images.githubusercontent.com/1779930/184144547-9739296f-16c7-4673-8186-9d8ddd49e758.png)
Ready to Verify Email|![7130-mailer-before](https://user-images.githubusercontent.com/1779930/184144538-b5964e3d-1c5f-45b9-9f40-057f0c30f696.png)|![7130-mailer-after](https://user-images.githubusercontent.com/1779930/184144533-9f300e40-c7d0-4eb5-8f1e-a90456126ea0.png)