### PR TITLE
Add 4 more db connections to the worker connection pool

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -57,6 +57,7 @@ country_phone_number_overrides: '{}'
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_sharpness_threshold: 40
 doc_auth_error_glare_threshold: 40
+database_pool_extra_connections_for_worker: 4
 database_pool_idp: 5
 database_statement_timeout: 2_500
 database_timeout: 5_000

--- a/config/database.yml
+++ b/config/database.yml
@@ -52,7 +52,7 @@ test:
 
 <%
   pool = if Identity::Hostdata.instance_role == 'worker'
-    IdentityConfig.store.good_job_max_threads + IdentityConfig.store.database_pool_idp
+    IdentityConfig.store.good_job_max_threads + IdentityConfig.store.database_pool_idp + 4
   else
     IdentityConfig.store.database_pool_idp
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -52,7 +52,7 @@ test:
 
 <%
   pool = if Identity::Hostdata.instance_role == 'worker'
-    IdentityConfig.store.good_job_max_threads + IdentityConfig.store.database_pool_idp + 4
+    IdentityConfig.store.good_job_max_threads + IdentityConfig.store.database_pool_idp + IdentityConfig.store.database_pool_extra_connections_for_worker
   else
     IdentityConfig.store.database_pool_idp
   end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -119,6 +119,7 @@ class IdentityConfig
     config.add(:database_readonly_username, type: :string)
     config.add(:database_read_replica_host, type: :string)
     config.add(:database_password, type: :string)
+    config.add(:database_pool_extra_connections_for_worker, :integer)
     config.add(:database_pool_idp, type: :integer)
     config.add(:database_statement_timeout, type: :integer)
     config.add(:database_timeout, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -119,7 +119,7 @@ class IdentityConfig
     config.add(:database_readonly_username, type: :string)
     config.add(:database_read_replica_host, type: :string)
     config.add(:database_password, type: :string)
-    config.add(:database_pool_extra_connections_for_worker, :integer)
+    config.add(:database_pool_extra_connections_for_worker, type: :integer)
     config.add(:database_pool_idp, type: :integer)
     config.add(:database_statement_timeout, type: :integer)
     config.add(:database_timeout, type: :integer)


### PR DESCRIPTION
We've seen a few report jobs fail when they are unable to get a connection. It looks like GoodJob also suggests this sort of approach to db connections.

changelog Internal, Database, More db connections were added to the worker nodes