### PR TITLE
LG-6777 capture native camera after failed twice

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -17,6 +17,7 @@ class FrontendLogController < ApplicationController
     'IdV: personal key confirm visited' => :idv_personal_key_confirm_visited,
     'IdV: personal key confirm submitted' => :idv_personal_key_confirm_submitted,
     'IdV: download personal key' => :idv_personal_key_downloaded,
+    'IdV: Native camera forced after failed attempts' => :idv_native_camera_forced,
     'Multi-Factor Authentication: download backup code' => :multi_factor_auth_backup_code_download,
   }.transform_values do |method|
     method.is_a?(Proc) ? method : AnalyticsEvents.instance_method(method)

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -285,7 +285,6 @@ function AcuantCapture(
 
   const {
     failedCaptureAttempts,
-    maxAttemptsBeforeNativeCamera,
     onFailedCaptureAttempt,
     onResetFailedCaptureAttempts,
     forceNativeCamera,
@@ -388,6 +387,31 @@ function AcuantCapture(
   }
 
   /**
+   * Triggers upload to occur, regardless of support for direct capture. This is necessary since the
+   * default behavior for interacting with the file input is intercepted when capture is supported.
+   * Calling `forceUpload` will flag the click handling to skip intercepting the event as capture.
+   */
+  function forceUpload() {
+    if (!inputRef.current) {
+      return;
+    }
+
+    isForceUploading.current = true;
+
+    const originalCapture = inputRef.current.getAttribute('capture');
+
+    if (originalCapture !== null) {
+      inputRef.current.removeAttribute('capture');
+    }
+
+    withoutClickLogging(() => inputRef.current?.click());
+
+    if (originalCapture !== null) {
+      inputRef.current.setAttribute('capture', originalCapture);
+    }
+  }
+
+  /**
    * Responds to a click by starting capture if supported in the environment, or triggering the
    * default file picker prompt. The click event may originate from the file input itself, or
    * another element which aims to trigger the prompt of the file input.
@@ -426,31 +450,6 @@ function AcuantCapture(
       isForceUploading.current = false;
     } else {
       withoutClickLogging(() => inputRef.current?.click());
-    }
-  }
-
-  /**
-   * Triggers upload to occur, regardless of support for direct capture. This is necessary since the
-   * default behavior for interacting with the file input is intercepted when capture is supported.
-   * Calling `forceUpload` will flag the click handling to skip intercepting the event as capture.
-   */
-  function forceUpload() {
-    if (!inputRef.current) {
-      return;
-    }
-
-    isForceUploading.current = true;
-
-    const originalCapture = inputRef.current.getAttribute('capture');
-
-    if (originalCapture !== null) {
-      inputRef.current.removeAttribute('capture');
-    }
-
-    withoutClickLogging(() => inputRef.current?.click());
-
-    if (originalCapture !== null) {
-      inputRef.current.setAttribute('capture', originalCapture);
     }
   }
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -282,7 +282,7 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
-  const { failedCaptureAttempts, onFailedCaptureAttempt, onResetFailedCaptureAttempts } =
+  const { failedCaptureAttempts, maxAttemptsBeforeNativeCamera, onFailedCaptureAttempt, onResetFailedCaptureAttempts } =
     useContext(FailedCaptureAttemptsContext);
   const hasCapture = !isError && (isReady ? isCameraSupported : isMobile);
   useEffect(() => {
@@ -389,7 +389,11 @@ function AcuantCapture(
    */
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
-      if (failedCaptureAttempts >= 2) {
+
+      if (failedCaptureAttempts >= maxAttemptsBeforeNativeCamera) {
+        addPageAction(`IdV: Force native camera. Failed attempts: ${failedCaptureAttempts}`, {
+          field: name,
+        });
         return forceUpload();
       }
       const isAcuantCaptureCapable = hasCapture && !acuantFailureCookie;

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -421,8 +421,9 @@ function AcuantCapture(
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
       if (forceNativeCamera) {
-        addPageAction(`IdV: Force native camera. Failed attempts: ${failedCaptureAttempts}`, {
+        addPageAction('IdV: Native camera forced after failed attempts', {
           field: name,
+          failed_attempts: failedCaptureAttempts,
         });
         return forceUpload();
       }

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -282,9 +282,8 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
-  const { onFailedCaptureAttempt, onResetFailedCaptureAttempts } = useContext(
-    FailedCaptureAttemptsContext,
-  );
+  const { failedCaptureAttempts, onFailedCaptureAttempt, onResetFailedCaptureAttempts } =
+    useContext(FailedCaptureAttemptsContext);
   const hasCapture = !isError && (isReady ? isCameraSupported : isMobile);
   useEffect(() => {
     // If capture had started before Acuant was ready, stop capture if readiness reveals that no
@@ -390,6 +389,9 @@ function AcuantCapture(
    */
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
+      if (failedCaptureAttempts >= 2) {
+        return forceUpload();
+      }
       const isAcuantCaptureCapable = hasCapture && !acuantFailureCookie;
       const shouldStartAcuantCapture =
         isAcuantCaptureCapable && capture !== 'user' && !isForceUploading.current;

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -282,8 +282,15 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
-  const { failedCaptureAttempts, maxAttemptsBeforeNativeCamera, onFailedCaptureAttempt, onResetFailedCaptureAttempts } =
-    useContext(FailedCaptureAttemptsContext);
+
+  const {
+    failedCaptureAttempts,
+    maxAttemptsBeforeNativeCamera,
+    onFailedCaptureAttempt,
+    onResetFailedCaptureAttempts,
+    forceNativeCamera,
+  } = useContext(FailedCaptureAttemptsContext);
+
   const hasCapture = !isError && (isReady ? isCameraSupported : isMobile);
   useEffect(() => {
     // If capture had started before Acuant was ready, stop capture if readiness reveals that no
@@ -389,8 +396,7 @@ function AcuantCapture(
    */
   function startCaptureOrTriggerUpload(event) {
     if (event.target === inputRef.current) {
-
-      if (failedCaptureAttempts >= maxAttemptsBeforeNativeCamera) {
+      if (forceNativeCamera) {
         addPageAction(`IdV: Force native camera. Failed attempts: ${failedCaptureAttempts}`, {
           field: name,
         });

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
@@ -33,6 +33,7 @@ const FailedCaptureAttemptsContext = createContext(
     onFailedCaptureAttempt: () => {},
     onResetFailedCaptureAttempts: () => {},
     maxFailedAttemptsBeforeTips: Infinity,
+    maxAttemptsBeforeNativeCamera: Infinity,
     lastAttemptMetadata: DEFAULT_LAST_ATTEMPT_METADATA,
   }),
 );
@@ -49,7 +50,7 @@ FailedCaptureAttemptsContext.displayName = 'FailedCaptureAttemptsContext';
 /**
  * @param {FailedCaptureAttemptsContextProviderProps} props
  */
-function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBeforeTips }) {
+function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBeforeTips, maxAttemptsBeforeNativeCamera }) {
   const [lastAttemptMetadata, setLastAttemptMetadata] = useState(
     /** @type {CaptureAttemptMetadata} */ (DEFAULT_LAST_ATTEMPT_METADATA),
   );
@@ -71,6 +72,7 @@ function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBefor
         onFailedCaptureAttempt,
         onResetFailedCaptureAttempts,
         maxFailedAttemptsBeforeTips,
+        maxAttemptsBeforeNativeCamera,
         lastAttemptMetadata,
       }}
     >

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
@@ -18,7 +18,9 @@ import useCounter from '../hooks/use-counter';
  * attempt, to increment attempts.
  * @prop {() => void} onResetFailedCaptureAttempts Callback to trigger a reset of attempts.
  * @prop {number} maxFailedAttemptsBeforeTips Number of failed attempts before showing tips.
+ * @prop {number} maxAttemptsBeforeNativeCamera Number of attempts before forcing the use of the native camera (if available)
  * @prop {CaptureAttemptMetadata} lastAttemptMetadata Metadata about the last attempt.
+ * @prop {boolean} forceNativeCamera Whether or not to force use of the native camera. Is set to true if the number of failedCaptureAttempts is equal to or greater than maxAttemptsBeforeNativeCamera
  */
 
 /** @type {CaptureAttemptMetadata} */
@@ -35,6 +37,7 @@ const FailedCaptureAttemptsContext = createContext(
     maxAttemptsBeforeNativeCamera: Infinity,
     maxFailedAttemptsBeforeTips: Infinity,
     lastAttemptMetadata: DEFAULT_LAST_ATTEMPT_METADATA,
+    forceNativeCamera: false,
   }),
 );
 
@@ -45,17 +48,24 @@ FailedCaptureAttemptsContext.displayName = 'FailedCaptureAttemptsContext';
  *
  * @prop {ReactNode} children
  * @prop {number} maxFailedAttemptsBeforeTips
+ * @prop {number} maxAttemptsBeforeNativeCamera
  */
 
 /**
  * @param {FailedCaptureAttemptsContextProviderProps} props
  */
-function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBeforeTips, maxAttemptsBeforeNativeCamera }) {
+function FailedCaptureAttemptsContextProvider({
+  children,
+  maxFailedAttemptsBeforeTips,
+  maxAttemptsBeforeNativeCamera,
+}) {
   const [lastAttemptMetadata, setLastAttemptMetadata] = useState(
     /** @type {CaptureAttemptMetadata} */ (DEFAULT_LAST_ATTEMPT_METADATA),
   );
   const [failedCaptureAttempts, incrementFailedCaptureAttempts, onResetFailedCaptureAttempts] =
     useCounter();
+
+  const forceNativeCamera = failedCaptureAttempts >= maxAttemptsBeforeNativeCamera;
 
   /**
    * @param {CaptureAttemptMetadata} metadata
@@ -74,6 +84,7 @@ function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBefor
         maxAttemptsBeforeNativeCamera,
         maxFailedAttemptsBeforeTips,
         lastAttemptMetadata,
+        forceNativeCamera,
       }}
     >
       {children}

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.jsx
@@ -32,8 +32,8 @@ const FailedCaptureAttemptsContext = createContext(
     failedCaptureAttempts: 0,
     onFailedCaptureAttempt: () => {},
     onResetFailedCaptureAttempts: () => {},
-    maxFailedAttemptsBeforeTips: Infinity,
     maxAttemptsBeforeNativeCamera: Infinity,
+    maxFailedAttemptsBeforeTips: Infinity,
     lastAttemptMetadata: DEFAULT_LAST_ATTEMPT_METADATA,
   }),
 );
@@ -71,8 +71,8 @@ function FailedCaptureAttemptsContextProvider({ children, maxFailedAttemptsBefor
         failedCaptureAttempts,
         onFailedCaptureAttempt,
         onResetFailedCaptureAttempts,
-        maxFailedAttemptsBeforeTips,
         maxAttemptsBeforeNativeCamera,
+        maxFailedAttemptsBeforeTips,
         lastAttemptMetadata,
       }}
     >

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -131,6 +131,7 @@ function addPageAction(event, payload) {
   const {
     helpCenterRedirectUrl: helpCenterRedirectURL,
     maxCaptureAttemptsBeforeTips,
+    maxAttemptsBeforeNativeCamera,
     appName,
     flowPath,
     cancelUrl: cancelURL,
@@ -180,6 +181,7 @@ function addPageAction(event, payload) {
       FailedCaptureAttemptsContextProvider,
       {
         maxFailedAttemptsBeforeTips: Number(maxCaptureAttemptsBeforeTips),
+        maxAttemptsBeforeNativeCamera: Number(maxAttemptsBeforeNativeCamera),
       },
     ],
     [DocumentCapture, { isAsyncForm, onStepChange: keepAlive }],

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -40,6 +40,7 @@ import { trackEvent } from '@18f/identity-analytics';
  * @prop {string} helpCenterRedirectUrl
  * @prop {string} appName
  * @prop {string} maxCaptureAttemptsBeforeTips
+ * @prop {string} maxAttemptsBeforeNativeCamera
  * @prop {FlowPath} flowPath
  * @prop {string} cancelUrl
  * @prop {string=} idvInPersonUrl

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -467,6 +467,15 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] name the name to prepend to analytics events
+  # @param [Number] failed_attempts the number of failed document capture attempts so far
+  # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
+  # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
+  # camera, on mobile devices.
+  def idv_native_camera_forced(name:, failed_attempts, **extra)
+    track_event('IdV: Native camera forced after failed attempts', name: name, failed_attempts: failed_attempts)
+  end
+
   # @param [String] step the step that the user was on when they clicked cancel
   # The user confirmed their choice to cancel going through IDV
   def idv_cancellation_confirmed(step:, **extra)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -472,8 +472,13 @@ module AnalyticsEvents
   # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
   # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
   # camera, on mobile devices.
-  def idv_native_camera_forced(name:, failed_attempts, **extra)
-    track_event('IdV: Native camera forced after failed attempts', name: name, failed_attempts: failed_attempts)
+  def idv_native_camera_forced(name:, failed_attempts:, **extra)
+    track_event(
+      'IdV: Native camera forced after failed attempts',
+      name: name,
+      failed_attempts: failed_attempts,
+      **extra,
+    )
   end
 
   # @param [String] step the step that the user was on when they clicked cancel

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -29,6 +29,7 @@
       sharpness_threshold: IdentityConfig.store.doc_auth_client_sharpness_threshold,
       status_poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
       max_capture_attempts_before_tips: IdentityConfig.store.doc_auth_max_capture_attempts_before_tips,
+      max_attempts_before_native_camera: IdentityConfig.store.doc_auth_max_attempts_before_native_camera,
       sp_name: sp_name,
       flow_path: flow_path,
       cancel_url: idv_cancel_path,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -78,6 +78,7 @@ doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 20
 doc_auth_max_capture_attempts_before_tips: 3
+doc_auth_max_attempts_before_native_camera: 2
 doc_capture_request_valid_for_minutes: 15
 email_from: no-reply@login.gov
 email_from_display_name: Login.gov

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -142,6 +142,7 @@ class IdentityConfig
     config.add(:doc_auth_error_sharpness_threshold, type: :integer)
     config.add(:doc_auth_extend_timeout_by_minutes, type: :integer)
     config.add(:doc_auth_max_attempts, type: :integer)
+    config.add(:doc_auth_max_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_tips, type: :integer)
     config.add(:doc_auth_s3_request_timeout, type: :integer)
     config.add(:doc_auth_vendor, type: :string)

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -13,6 +13,7 @@ describe('document-capture/context/failed-capture-attempts', () => {
       'onFailedCaptureAttempt',
       'onResetFailedCaptureAttempts',
       'maxFailedAttemptsBeforeTips',
+      'maxAttemptsBeforeNativeCamera',
       'lastAttemptMetadata',
     ]);
     expect(result.current.failedCaptureAttempts).to.equal(0);

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -149,5 +149,34 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
       expect(addPageAction).to.have.been.called();
       expect(addPageAction).to.have.been.calledWith('IdV: Force native camera. Failed attempts: 0');
     });
+
+    it('Does not call analytics with native camera message when failed attempts less than 2', async function () {
+      let addPageAction = sinon.spy();
+      const acuantCaptureComponent = <AcuantCapture></AcuantCapture>;
+      const TestComponent = ({ children }) => {
+        return (
+          <AnalyticsContext.Provider value={{ addPageAction }}>
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+                <Provider maxAttemptsBeforeNativeCamera={2} maxFailedAttemptsBeforeTips={10}>
+                  {acuantCaptureComponent}
+                  {children}
+                </Provider>
+              </AcuantContextProvider>
+            </DeviceContext.Provider>
+          </AnalyticsContext.Provider>
+        );
+        initialize();
+      };
+      let result = render(<TestComponent></TestComponent>);
+      const user = userEvent.setup();
+      const fileInput = result.container.querySelector('input[type="file"]');
+      expect(fileInput).to.exist();
+      await user.click(fileInput);
+      //expect(addPageAction).to.have.been.called();
+      expect(addPageAction).to.not.have.been.calledWith(
+        'IdV: Force native camera. Failed attempts: 2',
+      );
+    });
   });
 });

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -1,8 +1,17 @@
 import { useContext } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import { DeviceContext, AnalyticsContext } from '@18f/identity-document-capture';
+import AcuantContext, {
+  dirname,
+  Provider as AcuantContextProvider,
+  DEFAULT_ACCEPTABLE_GLARE_SCORE,
+  DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
+} from '@18f/identity-document-capture/context/acuant';
+
 import FailedCaptureAttemptsContext, {
   Provider,
 } from '@18f/identity-document-capture/context/failed-capture-attempts';
+import sinon from "sinon";
 
 describe('document-capture/context/failed-capture-attempts', () => {
   it('has expected default properties', () => {
@@ -44,6 +53,32 @@ describe('document-capture/context/failed-capture-attempts', () => {
       result.current.onFailedCaptureAttempt(metadata);
 
       expect(result.current.lastAttemptMetadata).to.deep.equal(metadata);
+    });
+    context('failed acuant camera attempts', () => {
+      let result;
+      let addPageAction;
+
+
+        addPageAction = sinon.spy();
+        ({ result } = renderHook(() => useContext(AcuantContext), {
+          wrapper: ({ children }) => (
+            <AnalyticsContext.Provider value={{ addPageAction }}>
+              <DeviceContext.Provider value={{ isMobile: true }}>
+                <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+                  <Provider maxAttemptsBeforeNativeCamera={3}>{children}</Provider>
+                </AcuantContextProvider>
+              </DeviceContext.Provider>
+            </AnalyticsContext.Provider>
+          ),
+        }));
+
+
+      it('calls analytics with native camera message when failed attempts is greater than 2', () => {
+        expect(addPageAction).to.have.been.calledWith(
+          'IdV: Force native camera. Failed attempts: 3',
+          {success: true},
+        );
+      })
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -112,10 +112,18 @@ describe('FailedCaptureAttemptsContext testing of forceNativeCamera logic', () =
   });
 });
 
-describe('maxAttemptsBeforeNativeCamera loggin tests', () => {
+describe('maxAttemptsBeforeNativeCamera logging tests', () => {
   context('failed acuant camera attempts', function () {
     const { initialize } = useAcuant();
-    it('calls analytics with native camera message when failed attempts is greater than or equal to 2', async function () {
+    /**
+     * NOTE: We have to force maxAttemptsBeforeLogin to be 0 here
+     * in order to test this interactively. This is because the react
+     * testing library does not provide consistent ways to test using both
+     * a component's elements (for triggering clicks) and a component's
+     * subscribed context changes. You can use either render or renderHook,
+     * but not both.
+     */
+    it('calls analytics with native camera message when failed attempts is greater than or equal to 0', async function () {
       let addPageAction = sinon.spy();
       const acuantCaptureComponent = <AcuantCapture></AcuantCapture>;
       const TestComponent = ({ children }) => {
@@ -131,10 +139,9 @@ describe('maxAttemptsBeforeNativeCamera loggin tests', () => {
             </DeviceContext.Provider>
           </AnalyticsContext.Provider>
         );
-
         initialize();
       };
-      const result = render(<TestComponent></TestComponent>);
+      let result = render(<TestComponent></TestComponent>);
       const user = userEvent.setup();
       const fileInput = result.container.querySelector('input[type="file"]');
       expect(fileInput).to.exist();

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -8,7 +8,7 @@ import FailedCaptureAttemptsContext, {
   Provider,
 } from '@18f/identity-document-capture/context/failed-capture-attempts';
 import sinon from 'sinon';
-import { useAcuant, render } from '../../../support/document-capture';
+import { render } from '../../../support/document-capture';
 
 describe('document-capture/context/failed-capture-attempts', () => {
   it('has expected default properties', () => {
@@ -109,8 +109,6 @@ describe('FailedCaptureAttemptsContext testing of forceNativeCamera logic', () =
 
 describe('maxAttemptsBeforeNativeCamera logging tests', () => {
   context('failed acuant camera attempts', function () {
-    const { initialize } = useAcuant();
-    initialize();
     /**
      * NOTE: We have to force maxAttemptsBeforeLogin to be 0 here
      * in order to test this interactively. This is because the react

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -140,7 +140,9 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
       expect(fileInput).to.exist();
       await user.click(fileInput);
       expect(addPageAction).to.have.been.called();
-      expect(addPageAction).to.have.been.calledWith('IdV: Force native camera. Failed attempts: 0');
+      expect(addPageAction).to.have.been.calledWith(
+        'IdV: Native camera forced after failed attempts',
+      );
     });
 
     it('Does not call analytics with native camera message when failed attempts less than 2', async function () {
@@ -166,7 +168,7 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
       expect(fileInput).to.exist();
       await user.click(fileInput);
       expect(addPageAction).to.not.have.been.calledWith(
-        'IdV: Force native camera. Failed attempts: 2',
+        'IdV: Native camera forced after failed attempts',
       );
     });
   });

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -1,19 +1,14 @@
 import { useContext } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
-import { DeviceContext, AnalyticsContext, UploadContext } from '@18f/identity-document-capture';
-import AcuantContext, {
-  dirname,
-  Provider as AcuantContextProvider,
-  DEFAULT_ACCEPTABLE_GLARE_SCORE,
-  DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
-} from '@18f/identity-document-capture/context/acuant';
+import { DeviceContext, AnalyticsContext } from '@18f/identity-document-capture';
+import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
 import AcuantCapture from '@18f/identity-document-capture/components/acuant-capture';
-import { useAcuant, render } from '../../../support/document-capture';
 import FailedCaptureAttemptsContext, {
   Provider,
 } from '@18f/identity-document-capture/context/failed-capture-attempts';
 import sinon from 'sinon';
+import { useAcuant, render } from '../../../support/document-capture';
 
 describe('document-capture/context/failed-capture-attempts', () => {
   it('has expected default properties', () => {
@@ -115,6 +110,7 @@ describe('FailedCaptureAttemptsContext testing of forceNativeCamera logic', () =
 describe('maxAttemptsBeforeNativeCamera logging tests', () => {
   context('failed acuant camera attempts', function () {
     const { initialize } = useAcuant();
+    initialize();
     /**
      * NOTE: We have to force maxAttemptsBeforeLogin to be 0 here
      * in order to test this interactively. This is because the react
@@ -124,9 +120,9 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
      * but not both.
      */
     it('calls analytics with native camera message when failed attempts is greater than or equal to 0', async function () {
-      let addPageAction = sinon.spy();
-      const acuantCaptureComponent = <AcuantCapture></AcuantCapture>;
-      const TestComponent = ({ children }) => {
+      const addPageAction = sinon.spy();
+      const acuantCaptureComponent = <AcuantCapture />;
+      function TestComponent({ children }) {
         return (
           <AnalyticsContext.Provider value={{ addPageAction }}>
             <DeviceContext.Provider value={{ isMobile: true }}>
@@ -139,9 +135,8 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
             </DeviceContext.Provider>
           </AnalyticsContext.Provider>
         );
-        initialize();
-      };
-      let result = render(<TestComponent></TestComponent>);
+      }
+      const result = render(<TestComponent />);
       const user = userEvent.setup();
       const fileInput = result.container.querySelector('input[type="file"]');
       expect(fileInput).to.exist();
@@ -151,9 +146,9 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
     });
 
     it('Does not call analytics with native camera message when failed attempts less than 2', async function () {
-      let addPageAction = sinon.spy();
-      const acuantCaptureComponent = <AcuantCapture></AcuantCapture>;
-      const TestComponent = ({ children }) => {
+      const addPageAction = sinon.spy();
+      const acuantCaptureComponent = <AcuantCapture />;
+      function TestComponent({ children }) {
         return (
           <AnalyticsContext.Provider value={{ addPageAction }}>
             <DeviceContext.Provider value={{ isMobile: true }}>
@@ -166,14 +161,12 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
             </DeviceContext.Provider>
           </AnalyticsContext.Provider>
         );
-        initialize();
-      };
-      let result = render(<TestComponent></TestComponent>);
+      }
+      const result = render(<TestComponent />);
       const user = userEvent.setup();
       const fileInput = result.container.querySelector('input[type="file"]');
       expect(fileInput).to.exist();
       await user.click(fileInput);
-      //expect(addPageAction).to.have.been.called();
       expect(addPageAction).to.not.have.been.calledWith(
         'IdV: Force native camera. Failed attempts: 2',
       );


### PR DESCRIPTION
This pull request will force native camera to do the document capture after the sdk camera has failed twice.