### PR TITLE
Rename / Reorg for standard

### DIFF
--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -20,7 +20,7 @@ module TwoFactorAuthentication
       @backup_code_form = BackupCodeVerificationForm.new(current_user)
       result = @backup_code_form.submit(backup_code_params)
       analytics.track_mfa_submit_event(result.to_h)
-      irs_attempts_api_tracker.multi_factor_auth_verify_backup_code(success: result.success?)
+      irs_attempts_api_tracker.mfa_verify_backup_code(success: result.success?)
       handle_result(result)
     end
 

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -19,7 +19,7 @@ module TwoFactorAuthentication
       result = TotpVerificationForm.new(current_user, params.require(:code).strip).submit
 
       analytics.track_mfa_submit_event(result.to_h)
-      irs_attempts_api_tracker.multi_factor_auth_verify_totp(success: result.success?)
+      irs_attempts_api_tracker.mfa_verify_totp(success: result.success?)
 
       if result.success?
         handle_valid_otp

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -21,7 +21,7 @@ module Users
       generate_codes
       result = BackupCodeSetupForm.new(current_user).submit
       analytics.backup_code_setup_visit(**result.to_h)
-      irs_attempts_api_tracker.multi_factor_auth_enroll_backup_code(success: result.success?)
+      irs_attempts_api_tracker.mfa_enroll_backup_code(success: result.success?)
 
       save_backup_codes
       track_backup_codes_created

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -27,7 +27,7 @@ module Users
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
 
-      irs_attempts_api_tracker.multi_factor_auth_enroll_totp(
+      irs_attempts_api_tracker.mfa_enroll_totp(
         success: result.success?,
       )
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -212,19 +212,19 @@ module Users
       )
 
       if UserSessionContext.authentication_context?(context)
-        irs_attempts_api_tracker.mfa_verify_phone(
+        irs_attempts_api_tracker.mfa_verify_phone_otp_sent(
           reauthentication: false,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )
       elsif UserSessionContext.reauthentication_context?(context)
-        irs_attempts_api_tracker.mfa_verify_phone(
+        irs_attempts_api_tracker.mfa_verify_phone_otp_sent(
           reauthentication: true,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )
       elsif UserSessionContext.confirmation_context?(context)
-        irs_attempts_api_tracker.mfa_enroll_phone(
+        irs_attempts_api_tracker.mfa_enroll_phone_otp_sent(
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -212,19 +212,19 @@ module Users
       )
 
       if UserSessionContext.authentication_context?(context)
-        irs_attempts_api_tracker.mfa_phone_verification_otp_sent(
+        irs_attempts_api_tracker.mfa_verify_phone(
           reauthentication: false,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )
       elsif UserSessionContext.reauthentication_context?(context)
-        irs_attempts_api_tracker.mfa_phone_verification_otp_sent(
+        irs_attempts_api_tracker.mfa_verify_phone(
           reauthentication: true,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )
       elsif UserSessionContext.confirmation_context?(context)
-        irs_attempts_api_tracker.mfa_phone_enrollment_otp_sent(
+        irs_attempts_api_tracker.mfa_enroll_phone(
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -31,11 +31,14 @@ module IrsAttemptsApi
       )
     end
 
-    # Tracks when the user has attempted to verify the Backup Codes MFA method to their account
-    # @param [Boolean] success
-    def mfa_verify_backup_code(success:)
+    # @param [String] phone_number - The user's phone_number used for multi-factor authentication
+    # @param [Boolean] success - True if the OTP Verification was sent
+    # Relevant only when the user is enrolling a phone as their MFA.
+    # The user has been sent an OTP by login.gov over SMS during the MFA enrollment process.
+    def mfa_enroll_phone(phone_number:, success:)
       track_event(
-        :mfa_verify_backup_code,
+        :mfa_enroll_phone,
+        phone_number: phone_number,
         success: success,
       )
     end
@@ -49,23 +52,11 @@ module IrsAttemptsApi
       )
     end
 
-    # Tracks when the user has attempted to verify via the TOTP MFA method to access their account
+    # Tracks when the user has attempted to verify the Backup Codes MFA method to their account
     # @param [Boolean] success
-    def mfa_verify_totp(success:)
+    def mfa_verify_backup_code(success:)
       track_event(
-        :mfa_verify_totp,
-        success: success,
-      )
-    end
-
-    # @param [String] phone_number - The user's phone_number used for multi-factor authentication
-    # @param [Boolean] success - True if the OTP Verification was sent
-    # Relevant only when the user is enrolling a phone as their MFA.
-    # The user has been sent an OTP by login.gov over SMS during the MFA enrollment process.
-    def mfa_enroll_phone(phone_number:, success:)
-      track_event(
-        :mfa_enroll_phone,
-        phone_number: phone_number,
+        :mfa_verify_backup_code,
         success: success,
       )
     end
@@ -79,6 +70,15 @@ module IrsAttemptsApi
         :mfa_verify_phone,
         reauthentication: reauthentication,
         phone_number: phone_number,
+        success: success,
+      )
+    end
+
+    # Tracks when the user has attempted to verify via the TOTP MFA method to access their account
+    # @param [Boolean] success
+    def mfa_verify_totp(success:)
+      track_event(
+        :mfa_verify_totp,
         success: success,
       )
     end

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -35,9 +35,9 @@ module IrsAttemptsApi
     # @param [Boolean] success - True if the OTP Verification was sent
     # Relevant only when the user is enrolling a phone as their MFA.
     # The user has been sent an OTP by login.gov over SMS during the MFA enrollment process.
-    def mfa_enroll_phone(phone_number:, success:)
+    def mfa_enroll_phone_otp_sent(phone_number:, success:)
       track_event(
-        :mfa_enroll_phone,
+        :mfa_enroll_phone_otp_sent,
         phone_number: phone_number,
         success: success,
       )
@@ -65,9 +65,9 @@ module IrsAttemptsApi
     # @param [String] phone_number - The user's phone_number used for multi-factor authentication
     # @param [Boolean] success - True if the OTP Verification was sent
     # During a login attempt, an OTP code has been sent via SMS.
-    def mfa_verify_phone(reauthentication:, phone_number:, success:)
+    def mfa_verify_phone_otp_sent(reauthentication:, phone_number:, success:)
       track_event(
-        :mfa_verify_phone,
+        :mfa_verify_phone_otp_sent,
         reauthentication: reauthentication,
         phone_number: phone_number,
         success: success,

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -24,36 +24,36 @@ module IrsAttemptsApi
 
     # Tracks when the user has attempted to enroll the Backup Codes MFA method to their account
     # @param [Boolean] success
-    def multi_factor_auth_enroll_backup_code(success:)
+    def mfa_enroll_backup_code(success:)
       track_event(
-        :backup_code_enroll,
+        :mfa_enroll_backup_code,
         success: success,
       )
     end
 
     # Tracks when the user has attempted to verify the Backup Codes MFA method to their account
     # @param [Boolean] success
-    def multi_factor_auth_verify_backup_code(success:)
+    def mfa_verify_backup_code(success:)
       track_event(
-        :backup_code_verify,
+        :mfa_verify_backup_code,
         success: success,
       )
     end
 
     # Tracks when the user has attempted to enroll the TOTP MFA method to their account
     # @param [Boolean] success
-    def multi_factor_auth_enroll_totp(success:)
+    def mfa_enroll_totp(success:)
       track_event(
-        :totp_enroll,
+        :mfa_enroll_totp,
         success: success,
       )
     end
 
     # Tracks when the user has attempted to verify via the TOTP MFA method to access their account
     # @param [Boolean] success
-    def multi_factor_auth_verify_totp(success:)
+    def mfa_verify_totp(success:)
       track_event(
-        :totp_verify,
+        :mfa_verify_totp,
         success: success,
       )
     end
@@ -62,9 +62,9 @@ module IrsAttemptsApi
     # @param [Boolean] success - True if the OTP Verification was sent
     # Relevant only when the user is enrolling a phone as their MFA.
     # The user has been sent an OTP by login.gov over SMS during the MFA enrollment process.
-    def mfa_phone_enrollment_otp_sent(phone_number:, success:)
+    def mfa_enroll_phone(phone_number:, success:)
       track_event(
-        :mfa_phone_enrollment_otp_sent,
+        :mfa_enroll_phone,
         phone_number: phone_number,
         success: success,
       )
@@ -74,9 +74,9 @@ module IrsAttemptsApi
     # @param [String] phone_number - The user's phone_number used for multi-factor authentication
     # @param [Boolean] success - True if the OTP Verification was sent
     # During a login attempt, an OTP code has been sent via SMS.
-    def mfa_phone_verification_otp_sent(reauthentication:, phone_number:, success:)
+    def mfa_verify_phone(reauthentication:, phone_number:, success:)
       track_event(
-        :mfa_phone_verification_otp_sent,
+        :mfa_verify_phone,
         reauthentication: reauthentication,
         phone_number: phone_number,
         success: success,

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -38,7 +38,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(analytics_hash)
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:backup_code_verify, success: true)
+          with(:mfa_verify_backup_code, success: true)
 
         post :create, params: payload
       end
@@ -64,7 +64,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(analytics_hash)
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:backup_code_verify, success: true)
+          with(:mfa_verify_backup_code, success: true)
 
         expect(@analytics).to receive(:track_event).
           with('User marked authenticated', authentication_type: :valid_2fa)
@@ -91,7 +91,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
       it 'renders the show page' do
         stub_attempts_tracker
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:backup_code_verify, success: false)
+          with(:mfa_verify_backup_code, success: false)
         post :create, params: payload
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_backup_code')
@@ -115,7 +115,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
       it 're-renders the backup code entry screen' do
         stub_attempts_tracker
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:backup_code_verify, success: false)
+          with(:mfa_verify_backup_code, success: false)
         post :create, params: payload
 
         expect(response).to render_template(:show)
@@ -137,7 +137,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(properties)
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:backup_code_verify, success: false)
+          with(:mfa_verify_backup_code, success: false)
 
         expect(@analytics).to receive(:track_event).
                           with('Multi-Factor Authentication: max attempts reached')

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -48,7 +48,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@analytics).to receive(:track_event).
           with('User marked authenticated', authentication_type: :valid_2fa)
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:totp_verify, success: true)
+          with(:mfa_verify_totp, success: true)
 
         post :create, params: { code: generate_totp_code(@secret) }
       end
@@ -96,7 +96,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@analytics).to receive(:track_event).
                           with('Multi-Factor Authentication: max attempts reached')
         expect(@irs_attempts_api_tracker).to receive(:track_event).
-          with(:totp_verify, success: false)
+          with(:mfa_verify_totp, success: false)
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -23,7 +23,7 @@ describe Users::BackupCodeSetupController do
         enabled_mfa_methods_count: 2,
       })
     expect(@irs_attempts_api_tracker).to receive(:track_event).
-      with(:backup_code_enroll, success: true)
+      with(:mfa_enroll_backup_code, success: true)
 
     post :create
 

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -310,7 +310,7 @@ describe Users::TotpSetupController, devise: true do
               with('Multi-Factor Authentication Setup', result)
 
             expect(@irs_attempts_api_tracker).to have_received(:track_event).
-              with(:mfa_enroll_totp, success:  true)
+              with(:mfa_enroll_totp, success: true)
           end
         end
 
@@ -335,7 +335,7 @@ describe Users::TotpSetupController, devise: true do
               with('Multi-Factor Authentication Setup', result)
 
             expect(@irs_attempts_api_tracker).to have_received(:track_event).
-              with(:mfa_enroll_totp, success:  true)
+              with(:mfa_enroll_totp, success: true)
           end
         end
       end

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -119,7 +119,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: false)
+            with(:mfa_enroll_totp, success: false)
         end
       end
 
@@ -156,7 +156,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: true)
+            with(:mfa_enroll_totp, success: true)
         end
       end
 
@@ -194,7 +194,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: false)
+            with(:mfa_enroll_totp, success: false)
         end
       end
 
@@ -233,7 +233,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: false)
+            with(:mfa_enroll_totp, success: false)
         end
       end
     end
@@ -270,7 +270,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: false)
+            with(:mfa_enroll_totp, success: false)
         end
       end
 
@@ -310,7 +310,7 @@ describe Users::TotpSetupController, devise: true do
               with('Multi-Factor Authentication Setup', result)
 
             expect(@irs_attempts_api_tracker).to have_received(:track_event).
-              with(:totp_enroll, success:  true)
+              with(:mfa_enroll_totp, success:  true)
           end
         end
 
@@ -335,7 +335,7 @@ describe Users::TotpSetupController, devise: true do
               with('Multi-Factor Authentication Setup', result)
 
             expect(@irs_attempts_api_tracker).to have_received(:track_event).
-              with(:totp_enroll, success:  true)
+              with(:mfa_enroll_totp, success:  true)
           end
         end
       end
@@ -371,7 +371,7 @@ describe Users::TotpSetupController, devise: true do
             with('Multi-Factor Authentication Setup', result)
 
           expect(@irs_attempts_api_tracker).to have_received(:track_event).
-            with(:totp_enroll, success: false)
+            with(:mfa_enroll_totp, success: false)
         end
       end
     end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -326,7 +326,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'tracks the verification attempt event' do
         expect_any_instance_of(IrsAttemptsApi::Tracker).
-          to receive(:mfa_phone_verification_otp_sent).
+          to receive(:mfa_verify_phone).
           with(phone_number: '+12025551212', reauthentication: false, success: true)
 
         get :send_code, params: { otp_delivery_selection_form:
@@ -512,7 +512,7 @@ describe Users::TwoFactorAuthenticationController do
         subject.user_session[:context] = 'confirmation'
         subject.user_session[:unconfirmed_phone] = @unconfirmed_phone
 
-        expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:mfa_phone_enrollment_otp_sent)
+        expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:mfa_enroll_phone)
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -326,7 +326,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'tracks the verification attempt event' do
         expect_any_instance_of(IrsAttemptsApi::Tracker).
-          to receive(:mfa_verify_phone).
+          to receive(:mfa_verify_phone_otp_sent).
           with(phone_number: '+12025551212', reauthentication: false, success: true)
 
         get :send_code, params: { otp_delivery_selection_form:
@@ -512,7 +512,7 @@ describe Users::TwoFactorAuthenticationController do
         subject.user_session[:context] = 'confirmation'
         subject.user_session[:unconfirmed_phone] = @unconfirmed_phone
 
-        expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:mfa_enroll_phone)
+        expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:mfa_enroll_phone_otp_sent)
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -30,7 +30,7 @@ feature 'IRS Attempts API Event Tracking' do
     sign_in_user(user)
 
     events = irs_attempts_api_tracked_events
-    expected_event_types = ['email-and-password-auth', 'mfa-verify-phone']
+    expected_event_types = ['email-and-password-auth', 'mfa-verify-phone-otp-sent']
 
     received_event_types = events.map(&:event_type)
 

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -30,7 +30,7 @@ feature 'IRS Attempts API Event Tracking' do
     sign_in_user(user)
 
     events = irs_attempts_api_tracked_events
-    expected_event_types = ['email-and-password-auth', 'mfa-phone-verification-otp-sent']
+    expected_event_types = ['email-and-password-auth', 'mfa-verify-phone']
 
     received_event_types = events.map(&:event_type)
 


### PR DESCRIPTION
Rename and reorganize MFA events to one standard

changelog: Internal, Attempts API, Track additional events