### PR TITLE
Create stricter Content Security Policy (CSP) rules for Google Analytics

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,6 +19,7 @@ module Users
         flash: flash[:alert],
         stored_location: session['user_return_to'],
       )
+      override_csp_for_google_analytics
 
       @request_id = request_id_if_valid
       @ial = sp_session_ial
@@ -217,6 +218,14 @@ module Users
       request_id = (params[:request_id] || sp_session[:request_id]).to_s
 
       request_id if LETTERS_AND_DASHES.match?(request_id)
+    end
+
+    def override_csp_for_google_analytics
+      return unless IdentityConfig.store.participate_in_dap
+      policy = current_content_security_policy
+      policy.script_src(*policy.script_src, 'dap.digitalgov.gov', 'www.google-analytics.com')
+      policy.connect_src(*policy.connect_src, 'www.google-analytics.com')
+      request.content_security_policy = policy
     end
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,7 +2,7 @@ require 'feature_management'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.config.content_security_policy do |policy|
-  connect_src = ["'self'", '*.nr-data.net', '*.google-analytics.com', 'us.acas.acuant.net']
+  connect_src = ["'self'", '*.nr-data.net', 'us.acas.acuant.net']
 
   font_src = [:self, :data, IdentityConfig.store.asset_host.presence].compact
 
@@ -20,8 +20,6 @@ Rails.application.config.content_security_policy do |policy|
     :self,
     'js-agent.newrelic.com',
     '*.nr-data.net',
-    'dap.digitalgov.gov',
-    '*.google-analytics.com',
     IdentityConfig.store.asset_host.presence,
   ].compact
 

--- a/spec/requests/csp_spec.rb
+++ b/spec/requests/csp_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
       expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net *.google-analytics.com us.acas.acuant.net",
+        "'self' *.nr-data.net us.acas.acuant.net",
       )
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq(
@@ -40,7 +40,7 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
       expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net *.google-analytics.com us.acas.acuant.net",
+        "'self' *.nr-data.net us.acas.acuant.net",
       )
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq("'self'")

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -55,7 +55,7 @@ describe 'idv/shared/_document_capture.html.erb' do
 
         connect_src = controller.request.content_security_policy.connect_src
         expect(connect_src).to eq(
-          ["'self'", '*.nr-data.net', '*.google-analytics.com', 'us.acas.acuant.net'],
+          ["'self'", '*.nr-data.net', 'us.acas.acuant.net'],
         )
       end
     end


### PR DESCRIPTION
Currently, we only attempt to load the Digital Analytics Program (DAP) and Google Analytics (GA) on the unauthenticated home page.  The Content Security Policy, however, permits the domains across the site.

This PR brings the CSP in line with the implementation and expectations for DAP/GA.