### PR TITLE
LG-7180: Fix printed appearance of Barcode

### DIFF
--- a/app/assets/stylesheets/components/_barcode.scss
+++ b/app/assets/stylesheets/components/_barcode.scss
@@ -5,10 +5,11 @@
 }
 
 .barcode .barby-cell {
-  width: 2px;
+  padding: 0;
+  border-right: 2px solid color('white');
   height: 96px;
 
   &.on {
-    background-color: #000;
+    border-right-color: color('black');
   }
 }


### PR DESCRIPTION
**Why**: Since apparently table cell background colors are made transparent in default printing behavior, whereas cell border coloring is not.

**Testing instructions:**

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. Use [attention result test YAML document](https://developers.login.gov/testing/#document-upload)
6. Click "Verify your ID in person"
7. Complete in-person proofing flow
8. Observe barcode is visible on "You're ready to verify" screen
9. Print the barcode
10. Observe barcode is visible and accurate

**Screenshots:**

Browser content (visually unchanged):

Before|After
---|---
![Screen Shot 2022-08-12 at 10 17 36 AM](https://user-images.githubusercontent.com/1779930/184379577-617ff2ec-10b8-4777-8b63-aa4d4835c73c.png)|![Screen Shot 2022-08-12 at 10 17 38 AM](https://user-images.githubusercontent.com/1779930/184379588-d1999449-c6b8-4d6e-bd72-1205034aeff6.png)

Printed content:

Before|After
---|---
![Screen Shot 2022-08-12 at 10 17 14 AM](https://user-images.githubusercontent.com/1779930/184379573-13b5ebd7-88f1-466a-be23-45426f4d24d0.png)|![Screen Shot 2022-08-12 at 10 17 25 AM](https://user-images.githubusercontent.com/1779930/184379576-2fd19a66-b71d-4a8a-bc07-8ecfbb7bf6b9.png)

(the appearance in the preview seems to be affected by scaling)