### PR TITLE
Create stricter Content Security Policy (CSP) for document capture hosts

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -4,6 +4,7 @@ module Idv
       return if params[:step] != 'document_capture'
 
       policy = current_content_security_policy
+      policy.connect_src(*policy.connect_src, 'us.acas.acuant.net')
       policy.script_src(*policy.script_src, :unsafe_eval)
       policy.style_src(*policy.style_src, :unsafe_inline)
       policy.img_src(*policy.img_src, 'blob:')

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,7 +2,7 @@ require 'feature_management'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.config.content_security_policy do |policy|
-  connect_src = ["'self'", '*.nr-data.net', 'us.acas.acuant.net']
+  connect_src = ["'self'", '*.nr-data.net']
 
   font_src = [:self, :data, IdentityConfig.store.asset_host.presence].compact
 
@@ -11,7 +11,6 @@ Rails.application.config.content_security_policy do |policy|
     'data:',
     'login.gov',
     IdentityConfig.store.asset_host.presence,
-    'idscangoweb.acuant.com',
     IdentityConfig.store.aws_region.presence &&
       "https://s3.#{IdentityConfig.store.aws_region}.amazonaws.com",
   ].select(&:present?)

--- a/spec/requests/csp_spec.rb
+++ b/spec/requests/csp_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
       expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net us.acas.acuant.net",
+        "'self' *.nr-data.net",
       )
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq(
         "'self' http://localhost:7654 https://example.com http://www.example.com",
       )
       expect(content_security_policy['img-src']).to eq(
-        "'self' data: login.gov idscangoweb.acuant.com https://s3.us-west-2.amazonaws.com",
+        "'self' data: login.gov https://s3.us-west-2.amazonaws.com",
       )
       expect(content_security_policy['media-src']).to eq("'self'")
       expect(content_security_policy['object-src']).to eq("'none'")
@@ -40,12 +40,12 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
       expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net us.acas.acuant.net",
+        "'self' *.nr-data.net",
       )
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq("'self'")
       expect(content_security_policy['img-src']).to eq(
-        "'self' data: login.gov idscangoweb.acuant.com https://s3.us-west-2.amazonaws.com",
+        "'self' data: login.gov https://s3.us-west-2.amazonaws.com",
       )
       expect(content_security_policy['media-src']).to eq("'self'")
       expect(content_security_policy['object-src']).to eq("'none'")

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -55,7 +55,7 @@ describe 'idv/shared/_document_capture.html.erb' do
 
         connect_src = controller.request.content_security_policy.connect_src
         expect(connect_src).to eq(
-          ["'self'", '*.nr-data.net', 'us.acas.acuant.net'],
+          ["'self'", '*.nr-data.net'],
         )
       end
     end


### PR DESCRIPTION
Currently, we include `idscangoweb.acuant.com` in the CSP `img_src`, but it is not used.  It was included in changes in https://github.com/18F/identity-idp/pull/3671/files#diff-66cc7258886071348febbf60314501e02948b7d31e616fe88121ccc338ddb449R18.  Most of those changes were undone in https://github.com/18F/identity-idp/commit/3b1772cdf918f314d1862e482076109429f88356.  The removed script included a reference to that domain: https://github.com/18F/identity-idp/blob/28d480fa69dd5fd86284041991941f752ee3e881/public/idscan-go.js#L58 so this should be safe to remove.

`us.acas.acuant.net` is used in a token call when the SDK is loaded, and we can more precisely allow the host by making use of the existing CSP overrides we do for document capture.