### PR TITLE
Enforce in-person enrollment issuer foreign key validation

### DIFF
--- a/db/primary_migrate/20220812155204_validate_in_person_enrollments_issuer.rb
+++ b/db/primary_migrate/20220812155204_validate_in_person_enrollments_issuer.rb
@@ -1,0 +1,5 @@
+class ValidateInPersonEnrollmentsIssuer < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :in_person_enrollments, :service_providers, column: :issuer, primary_key: :issuer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_08_140030) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_12_155204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"


### PR DESCRIPTION
**Why**: Because it should occur as a separate migration from the introduction of the relationship, as a follow-up task to https://github.com/18F/identity-idp/pull/6707#discussion_r940644111 (see https://github.com/ankane/strong_migrations#good-9).
