### PR TITLE
LG-7243: Add CSP config for ThreatMetrix JS

### DIFF
--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Idv
+  module ThreatMetrixConcern
+    THREAT_METRIX_DOMAIN = 'h.online-metrix.net'
+    THREAT_METRIX_WILDCARD_DOMAIN = '*.online-metrix.net'
+
+    def override_csp_for_threat_metrix
+      return unless Rails.env.production?
+
+      return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
+
+      return if params[:step] != 'ssn'
+
+      policy = current_content_security_policy
+
+      # ThreatMetrix requires additional Content Security Policy (CSP)
+      # directives to be added to the response to enable its JS to run
+      # in the browser.
+
+      # `script-src` must be updated to enable:
+      #   - The domain hosting ThreatMetrix JS (so it can be included on the page)
+      #   - `unsafe-eval`, since the ThreatMetrix JS uses eval() internally.
+      add_to_policy policy, :script_src, THREAT_METRIX_DOMAIN, :unsafe_eval
+
+      # `style-src` must be update to enable:
+      #   - `unsafe-inline`, since the ThreatMetrix library applies inline
+      #      styles to elements it inserts into the DOM
+      add_to_policy policy, :style_src, :unsafe_inline
+
+      # `img-src` must be updated to enable:
+      #   - The domain hosting ThreatMetrix JS, since ThreatMetrix loads
+      #     images from this domain as part of its fingerprinting process.
+      add_to_policy policy, :img_src, THREAT_METRIX_WILDCARD_DOMAIN
+
+      # `connect-src` must be updated to enable:
+      #   - The domain hosting ThreatMetrix JS, since ThreatMetrix makes XHR
+      #     requests to this domain.
+      add_to_policy policy, :connect_src, THREAT_METRIX_DOMAIN
+
+      # `child-src` must be updated to enable:
+      #   - The domain hosting ThreatMetrix JS, which used to load a fallback
+      #     `<iframe>` element when Javascript is disabled.
+      add_to_policy policy, :child_src, THREAT_METRIX_DOMAIN
+
+      request.content_security_policy = policy
+    end
+
+    private
+
+    def add_to_policy(policy, directive, *values)
+      existing_values = policy.directives[directive]
+
+      new_values = [existing_values, values].flatten.uniq.compact
+
+      policy.send(directive, *new_values)
+    end
+  end
+end

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -19,39 +19,29 @@ module Idv
       # `script-src` must be updated to enable:
       #   - The domain hosting ThreatMetrix JS (so it can be included on the page)
       #   - `unsafe-eval`, since the ThreatMetrix JS uses eval() internally.
-      add_to_policy policy, :script_src, THREAT_METRIX_DOMAIN, :unsafe_eval
+      policy.script_src(*(policy.script_src.to_set.merge([THREAT_METRIX_DOMAIN, :unsafe_eval])))
 
       # `style-src` must be updated to enable:
       #   - `unsafe-inline`, since the ThreatMetrix library applies inline
       #      styles to elements it inserts into the DOM
-      add_to_policy policy, :style_src, :unsafe_inline
+      policy.style_src(*(policy.style_src.to_set << :unsafe_inline))
 
       # `img-src` must be updated to enable:
-      #   - The domain hosting ThreatMetrix JS, since ThreatMetrix loads
-      #     images from this domain as part of its fingerprinting process.
-      add_to_policy policy, :img_src, THREAT_METRIX_WILDCARD_DOMAIN
+      #   - A wildcard domain, since the JS loads images from different 
+      #     subdomains of the main ThreatMetrix domain.
+      policy.img_src(*(policy.img_src.to_set << THREAT_METRIX_WILDCARD_DOMAIN))
 
       # `connect-src` must be updated to enable:
       #   - The domain hosting ThreatMetrix JS, since ThreatMetrix makes XHR
       #     requests to this domain.
-      add_to_policy policy, :connect_src, THREAT_METRIX_DOMAIN
+      policy.connect_src(*(policy.connect_src.to_set << THREAT_METRIX_DOMAIN))
 
       # `child-src` must be updated to enable:
       #   - The domain hosting ThreatMetrix JS, which used to load a fallback
       #     `<iframe>` element when Javascript is disabled.
-      add_to_policy policy, :child_src, THREAT_METRIX_DOMAIN
+      policy.child_src(*(policy.child_src.to_set << THREAT_METRIX_DOMAIN))
 
       request.content_security_policy = policy
-    end
-
-    private
-
-    def add_to_policy(policy, directive, *values)
-      existing_values = policy.directives[directive]
-
-      new_values = [existing_values, values].flatten.uniq.compact
-
-      policy.send(directive, *new_values)
     end
   end
 end

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -23,7 +23,7 @@ module Idv
       #   - `unsafe-eval`, since the ThreatMetrix JS uses eval() internally.
       add_to_policy policy, :script_src, THREAT_METRIX_DOMAIN, :unsafe_eval
 
-      # `style-src` must be update to enable:
+      # `style-src` must be updated to enable:
       #   - `unsafe-inline`, since the ThreatMetrix library applies inline
       #      styles to elements it inserts into the DOM
       add_to_policy policy, :style_src, :unsafe_inline

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -19,7 +19,7 @@ module Idv
       # `script-src` must be updated to enable:
       #   - The domain hosting ThreatMetrix JS (so it can be included on the page)
       #   - `unsafe-eval`, since the ThreatMetrix JS uses eval() internally.
-      policy.script_src(*(policy.script_src.to_set.merge([THREAT_METRIX_DOMAIN, :unsafe_eval])))
+      policy.script_src(*policy.script_src.to_set.merge([THREAT_METRIX_DOMAIN, :unsafe_eval]))
 
       # `style-src` must be updated to enable:
       #   - `unsafe-inline`, since the ThreatMetrix library applies inline
@@ -27,7 +27,7 @@ module Idv
       policy.style_src(*(policy.style_src.to_set << :unsafe_inline))
 
       # `img-src` must be updated to enable:
-      #   - A wildcard domain, since the JS loads images from different 
+      #   - A wildcard domain, since the JS loads images from different
       #     subdomains of the main ThreatMetrix domain.
       policy.img_src(*(policy.img_src.to_set << THREAT_METRIX_WILDCARD_DOMAIN))
 

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -6,8 +6,6 @@ module Idv
     THREAT_METRIX_WILDCARD_DOMAIN = '*.online-metrix.net'
 
     def override_csp_for_threat_metrix
-      return unless Rails.env.production?
-
       return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
 
       return if params[:step] != 'ssn'

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -9,6 +9,7 @@ module Idv
     include IdvSession
     include Flow::FlowStateMachine
     include Idv::DocumentCaptureConcern
+    include Idv::ThreatMetrixConcern
 
     before_action :redirect_if_flow_completed
     before_action :override_document_capture_step_csp
@@ -16,6 +17,8 @@ module Idv
     # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :check_for_outage, only: :show
     # rubocop:enable Rails/LexicallyScopedActionFilter
+
+    before_action :override_csp_for_threat_metrix
 
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_doc_auth_step_url,

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
+  controller ApplicationController do
+    include Idv::ThreatMetrixConcern
+
+    before_action :override_csp_for_threat_metrix
+
+    def index; end
+  end
+
+  describe '#override_csp_for_threat_metrix' do
+    context 'non-production environment' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+      it 'does not modify CSP headers for SSN step' do
+        assert_csp_is_not_modified 'ssn'
+      end
+      it 'does not modify CSP headers for any other step' do
+        assert_csp_is_not_modified 'some_other_step'
+      end
+    end
+
+    context 'production enviroment' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      context 'ff is set' do
+        before do
+          allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
+            and_return(true)
+        end
+        it 'modifies CSP headers for SSN step' do
+          assert_csp_is_modified 'ssn'
+        end
+
+        it 'does not modify CSP headers for any other step' do
+          assert_csp_is_not_modified 'some_other_step'
+        end
+      end
+
+      context 'ff is not set' do
+        before do
+          allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
+            and_return(false)
+        end
+
+        it 'does not modify CSP headers for SSN step' do
+          assert_csp_is_not_modified 'ssn'
+        end
+        it 'does not modify CSP headers for any other step' do
+          assert_csp_is_not_modified 'some_other_step'
+        end
+      end
+    end
+  end
+
+  private
+
+  def assert_csp_is_modified(step)
+    get :index, params: { step: step }
+
+    csp = response.request.content_security_policy
+
+    expect(csp.directives['script-src']).to include('h.online-metrix.net')
+    expect(csp.directives['script-src']).to include("'unsafe-eval'")
+
+    expect(csp.directives['style-src']).to include("'unsafe-inline'")
+
+    expect(csp.directives['child-src']).to include('h.online-metrix.net')
+
+    expect(csp.directives['connect-src']).to include('h.online-metrix.net')
+
+    expect(csp.directives['img-src']).to include('*.online-metrix.net')
+  end
+
+  def assert_csp_is_not_modified(step)
+    get :index, params: { step: step }
+    secure_header_config = response.request.headers.env['secure_headers_request_config']
+    expect(secure_header_config).to be_nil
+  end
+end

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -66,16 +66,18 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
 
     csp = response.request.content_security_policy
 
-    expect(csp.directives['script-src']).to include('h.online-metrix.net')
-    expect(csp.directives['script-src']).to include("'unsafe-eval'")
+    aggregate_failures do
+      expect(csp.directives['script-src']).to include('h.online-metrix.net')
+      expect(csp.directives['script-src']).to include("'unsafe-eval'")
 
-    expect(csp.directives['style-src']).to include("'unsafe-inline'")
+      expect(csp.directives['style-src']).to include("'unsafe-inline'")
 
-    expect(csp.directives['child-src']).to include('h.online-metrix.net')
+      expect(csp.directives['child-src']).to include('h.online-metrix.net')
 
-    expect(csp.directives['connect-src']).to include('h.online-metrix.net')
+      expect(csp.directives['connect-src']).to include('h.online-metrix.net')
 
-    expect(csp.directives['img-src']).to include('*.online-metrix.net')
+      expect(csp.directives['img-src']).to include('*.online-metrix.net')
+    end
   end
 
   def assert_csp_is_not_modified(step)

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -12,18 +12,17 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
   end
 
   describe '#override_csp_for_threat_metrix' do
+    let(:production) { true }
+    let(:ff_enabled) { true }
 
-    let (:production) { true }
-    let (:ff_enabled) { true }
-
-    before do 
+    before do
       allow(Rails.env).to receive(:production?).and_return(true)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
       and_return(ff_enabled)
-    end 
+    end
 
     context 'non-production environment' do
-      let (:production) { false }
+      let(:production) { false }
       it 'does not modify CSP headers for SSN step' do
         assert_csp_is_not_modified 'ssn'
       end
@@ -44,7 +43,7 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
       end
 
       context 'ff is not set' do
-        let (:ff_enabled) { false }
+        let(:ff_enabled) { false }
         it 'does not modify CSP headers for SSN step' do
           assert_csp_is_not_modified 'ssn'
         end

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -12,44 +12,30 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
   end
 
   describe '#override_csp_for_threat_metrix' do
-    let(:production) { true }
     let(:ff_enabled) { true }
 
     before do
-      allow(Rails.env).to receive(:production?).and_return(true)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
       and_return(ff_enabled)
     end
 
-    context 'non-production environment' do
-      let(:production) { false }
-      it 'does not modify CSP headers for SSN step' do
-        assert_csp_is_not_modified 'ssn'
+    context 'ff is set' do
+      it 'modifies CSP headers for SSN step' do
+        assert_csp_is_modified 'ssn'
       end
+
       it 'does not modify CSP headers for any other step' do
         assert_csp_is_not_modified 'some_other_step'
       end
     end
 
-    context 'production enviroment' do
-      context 'ff is set' do
-        it 'modifies CSP headers for SSN step' do
-          assert_csp_is_modified 'ssn'
-        end
-
-        it 'does not modify CSP headers for any other step' do
-          assert_csp_is_not_modified 'some_other_step'
-        end
+    context 'ff is not set' do
+      let(:ff_enabled) { false }
+      it 'does not modify CSP headers for SSN step' do
+        assert_csp_is_not_modified 'ssn'
       end
-
-      context 'ff is not set' do
-        let(:ff_enabled) { false }
-        it 'does not modify CSP headers for SSN step' do
-          assert_csp_is_not_modified 'ssn'
-        end
-        it 'does not modify CSP headers for any other step' do
-          assert_csp_is_not_modified 'some_other_step'
-        end
+      it 'does not modify CSP headers for any other step' do
+        assert_csp_is_not_modified 'some_other_step'
       end
     end
   end

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -12,10 +12,18 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
   end
 
   describe '#override_csp_for_threat_metrix' do
+
+    let (:production) { true }
+    let (:ff_enabled) { true }
+
+    before do 
+      allow(Rails.env).to receive(:production?).and_return(true)
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
+      and_return(ff_enabled)
+    end 
+
     context 'non-production environment' do
-      before do
-        allow(Rails.env).to receive(:production?).and_return(false)
-      end
+      let (:production) { false }
       it 'does not modify CSP headers for SSN step' do
         assert_csp_is_not_modified 'ssn'
       end
@@ -25,15 +33,7 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
     end
 
     context 'production enviroment' do
-      before do
-        allow(Rails.env).to receive(:production?).and_return(true)
-      end
-
       context 'ff is set' do
-        before do
-          allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-            and_return(true)
-        end
         it 'modifies CSP headers for SSN step' do
           assert_csp_is_modified 'ssn'
         end
@@ -44,11 +44,7 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
       end
 
       context 'ff is not set' do
-        before do
-          allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-            and_return(false)
-        end
-
+        let (:ff_enabled) { false }
         it 'does not modify CSP headers for SSN step' do
           assert_csp_is_not_modified 'ssn'
         end


### PR DESCRIPTION
This PR selectively pokes holes in our Content Security Policy (CSP) to allow ThreatMetrix to do its thing. Updated CSP headers are only included on pages using the ThreatMetrix JS (currently SSN entry form).

Updates to headers include:

| Directive | New value(s) | Why? | 
| -- | -- | -- |
| `script-src` | `h.online-metrix.net`, `"unsafe-eval"` | TM javascript is loaded from this domain; the JS itself uses `eval()` as part of its source obfuscation |
| `style-src` | `"unsafe-inline"` | TM adds inline styles to DOM elements it creates as part of the fingerprinting process |
| `img-src` | `*.online-metrix.net` | TM loads images from different domains under `online-metrix.net` as part of the fingerprinting process |
| `connect-src` | `h.online-metrix.net` | TM makes XHR requests to this domain. |
| `child-src` | `h.online-metrix.net` | TM uses iframes that reference this domain. |
