### PR TITLE
Limit active disabled button styles to default button

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -10,18 +10,6 @@
   // of a link.
   display: inline;
   width: auto;
-
-  // Temporary: To be backported to design system. Unstyled buttons should not ever show the default
-  // opaque disabled background color. Typically a button would not be both disabled and active, but
-  // it is possible in some browsers when e.g. disabling a button in response to its own click.
-  &.usa-button:disabled:hover,
-  &.usa-button:disabled.usa-button--hover,
-  &.usa-button:disabled:active,
-  &.usa-button:disabled.usa-button--active,
-  &.usa-button:disabled:focus,
-  &.usa-button:disabled.usa-focus {
-    background-color: transparent;
-  }
 }
 
 .usa-button:disabled.usa-button--active,

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -14,5 +14,7 @@
 
 .usa-button:disabled.usa-button--active,
 .usa-button--disabled.usa-button--active {
-  @include set-text-and-bg('primary-darker', $context: 'Button');
+  &:not(.usa-button--unstyled, .usa-button--secondary, .usa-button--accent-cool, .usa-button--accent-warm, .usa-button--base, .usa-button--outline, .usa-button--inverse) {
+    @include set-text-and-bg('primary-darker', $context: 'Button');
+  }
 }


### PR DESCRIPTION
Fixes regression introduced in #6564

**Why**: Because the styling was only implemented with the expectation of use with the default button, and conflicts with other button states (e.g. unstyled buttons used as the submit buttons on some forms).

**Screenshot:**

State|Before|After
---|---|---
Default|![Screen Shot 2022-08-15 at 9 42 00 AM](https://user-images.githubusercontent.com/1779930/184647389-3054ed3d-2be3-4688-b57b-8a6dffcec3ec.png)|![Screen Shot 2022-08-15 at 9 42 00 AM](https://user-images.githubusercontent.com/1779930/184647389-3054ed3d-2be3-4688-b57b-8a6dffcec3ec.png)
Pressed|![Screen Shot 2022-08-15 at 9 38 32 AM](https://user-images.githubusercontent.com/1779930/184647384-89caf160-4f76-41d2-bf5a-a9b36e5a55fc.png)|![Screen Shot 2022-08-15 at 9 42 20 AM](https://user-images.githubusercontent.com/1779930/184647391-feac0b66-31e5-4d44-8fbe-9d80ed1e8d0a.png)

