### PR TITLE
Use full path to load .ruby-version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "~> #{File.read('.ruby-version').strip}"
+ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
 
 gem 'rails', '~> 7.0.0'
 


### PR DESCRIPTION
Some tools (in my case it's the VS Code Ruby extension) attempt to load the `Gemfile` when running in  directories other than the project root. When this happens, `Gemfile` can't load `.ruby-version`, since it's not in the directory it's expecting. This leads to errors from tools complaining about missing `.ruby-version` files. 

This commit updates the `Gemfile` to always explicitly load `.ruby-version` from the same directory `Gemfile` is in.

[skip changelog]