### PR TITLE
LG-7197: Delay sending in-person proofing results emails

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -55,6 +55,8 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   private
 
+  DEFAULT_EMAIL_DELAY_IN_HOURS = 1
+
   def analytics(user: AnonymousUser.new)
     Analytics.new(user: user, request: nil, session: {}, sp: nil)
   end
@@ -164,7 +166,7 @@ class GetUspsProofingResultsJob < ApplicationJob
         user,
         email_address,
         enrollment: enrollment,
-      ).deliver_now_or_later
+      ).deliver_now_or_later(**mail_delivery_params)
     end
   end
 
@@ -174,7 +176,19 @@ class GetUspsProofingResultsJob < ApplicationJob
         user,
         email_address,
         enrollment: enrollment,
-      ).deliver_now_or_later
+      ).deliver_now_or_later(**mail_delivery_params)
     end
+  end
+
+  def mail_delivery_params
+    config_delay = IdentityConfig.store.in_person_results_delay_in_hours
+    if config_delay.present?
+      if config_delay > 0
+        return { wait: config_delay.hours }
+      elsif (config_delay == 0)
+        return {}
+      end
+    end
+    { wait: DEFAULT_EMAIL_DELAY_IN_HOURS.hours }
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -107,6 +107,7 @@ idv_sp_required: false
 in_person_proofing_enabled: false
 in_person_proofing_enabled_issuers: '[]'
 in_person_enrollment_validity_in_days: 30
+in_person_results_delay_in_hours: 1
 include_slo_in_saml_metadata: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -181,6 +181,7 @@ class IdentityConfig
     config.add(:in_person_proofing_enabled, type: :boolean)
     config.add(:in_person_proofing_enabled_issuers, type: :json)
     config.add(:in_person_enrollment_validity_in_days, type: :integer)
+    config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)


### PR DESCRIPTION
Add a configurable delay (defaulting to one hour) before in-person proofing results emails are sent.
