### PR TITLE
Create separate events for when a letter is requested and when it is enqueued

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -126,7 +126,7 @@ module Idv
     end
 
     def resend_letter
-      analytics.idv_gpo_address_letter_enqueued(enqueue_at: Time.zone.now, resend: true)
+      analytics.idv_gpo_address_letter_enqueued(enqueued_at: Time.zone.now, resend: true)
       confirmation_maker = confirmation_maker_perform
       send_reminder
       return unless FeatureManagement.reveal_gpo_code?

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -32,9 +32,9 @@ module Idv
       update_tracking
       idv_session.address_verification_mechanism = :gpo
 
-      if current_user.decorate.pending_profile_requires_verification? && pii_locked?
+      if resend_requested? && pii_locked?
         redirect_to capture_password_url
-      elsif current_user.decorate.pending_profile_requires_verification?
+      elsif resend_requested?
         resend_letter
         redirect_to idv_come_back_later_url
       else
@@ -55,10 +55,14 @@ module Idv
     private
 
     def update_tracking
-      analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now, resend: true)
+      analytics.idv_gpo_address_letter_requested(resend: resend_requested?)
       create_user_event(:gpo_mail_sent, current_user)
 
       ProofingComponent.create_or_find_by(user: current_user).update(address_check: 'gpo_letter')
+    end
+
+    def resend_requested?
+      current_user.decorate.pending_profile_requires_verification?
     end
 
     def failure
@@ -122,6 +126,7 @@ module Idv
     end
 
     def resend_letter
+      analytics.idv_gpo_address_letter_enqueued(enqueue_at: Time.zone.now, resend: true)
       confirmation_maker = confirmation_maker_perform
       send_reminder
       return unless FeatureManagement.reveal_gpo_code?

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -90,7 +90,7 @@ module Idv
       idv_session.create_profile_from_applicant_with_password(password)
 
       if idv_session.address_verification_mechanism == 'gpo'
-        analytics.idv_gpo_address_letter_requested(enqueued_at: Time.zone.now, resend: false)
+        analytics.idv_gpo_address_letter_enqueued(enqueued_at: Time.zone.now, resend: false)
       end
 
       if idv_session.profile.active?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -638,11 +638,12 @@ module AnalyticsEvents
   # @param [DateTime] enqueued_at
   # @param [Boolean] resend
   # GPO letter was enqueued and the time at which it was enqueued
-  def idv_gpo_address_letter_enqueued(enqueue_at:, resend:, **extra)
+  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, **extra)
     track_event(
       'IdV: USPS address letter enqueued',
-      enqueue_at: enqueue_at,
+      enqueued_at: enqueued_at,
       resend: resend,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -637,11 +637,20 @@ module AnalyticsEvents
 
   # @param [DateTime] enqueued_at
   # @param [Boolean] resend
+  # GPO letter was enqueued and the time at which it was enqueued
+  def idv_gpo_address_letter_enqueued(enqueue_at:, resend:, **extra)
+    track_event(
+      'IdV: USPS address letter enqueued',
+      enqueue_at: enqueue_at,
+      resend: resend,
+    )
+  end
+
+  # @param [Boolean] resend
   # GPO letter was requested and time was recorded
-  def idv_gpo_address_letter_requested(enqueued_at:, resend:, **extra)
+  def idv_gpo_address_letter_requested(resend:, **extra)
     track_event(
       'IdV: USPS address letter requested',
-      enqueued_at: enqueued_at,
       resend: resend,
       **extra,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -648,7 +648,7 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] resend
-  # GPO letter was requested and time was recorded
+  # GPO letter was requested
   def idv_gpo_address_letter_requested(resend:, **extra)
     track_event(
       'IdV: USPS address letter requested',


### PR DESCRIPTION
The letter is not necessarily sent when it is requested. At the end of proofing the user requests a letter, but the letter is not sent until the profile is created after the user enters their password. This commit adds different events for requested and enqueueing the letter so we can track both