### PR TITLE
Use RenderConditionConcern consistently for feature-guarding controllers

### DIFF
--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -6,8 +6,11 @@
 #
 module Api
   class IrsAttemptsApiController < ApplicationController
+    include RenderConditionConcern
+
+    check_or_render_not_found -> { IdentityConfig.store.irs_attempt_api_enabled }
+
     skip_before_action :verify_authenticity_token
-    before_action :render_404_if_disabled
     before_action :authenticate_client
 
     respond_to :json
@@ -19,10 +22,6 @@ module Api
     end
 
     private
-
-    def render_404_if_disabled
-      render_not_found unless IdentityConfig.store.irs_attempt_api_enabled
-    end
 
     def authenticate_client
       bearer, token = request.authorization.split(' ', 2)

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -3,8 +3,11 @@ require 'json'
 module Idv
   module InPerson
     class UspsLocationsController < ApplicationController
+      include RenderConditionConcern
       include UspsInPersonProofing
       include EffectiveUser
+
+      check_or_render_not_found -> { InPersonConfig.enabled? }
 
       before_action :confirm_authenticated_for_api, only: [:update]
 

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -1,6 +1,9 @@
 module Idv
   class InPersonController < ApplicationController
-    before_action :render_404_if_disabled
+    include RenderConditionConcern
+
+    check_or_render_not_found -> { InPersonConfig.enabled_for_issuer?(current_sp&.issuer) }
+
     before_action :confirm_two_factor_authenticated
     before_action :redirect_unless_enrollment
 

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -5,7 +5,7 @@ describe Idv::InPerson::UspsLocationsController do
 
   let(:user) { create(:user) }
   let(:sp) { nil }
-  let(:in_person_proofing_enabled) { false }
+  let(:in_person_proofing_enabled) { true }
   let(:selected_location) do
     {
       usps_location: {
@@ -70,6 +70,14 @@ describe Idv::InPerson::UspsLocationsController do
         expect(facilities.length).to eq 0
       end
     end
+
+    context 'with feature disabled' do
+      let(:in_person_proofing_enabled) { false }
+
+      it 'renders 404' do
+        expect(response.status).to eq(404)
+      end
+    end
   end
 
   describe '#update' do
@@ -121,6 +129,14 @@ describe Idv::InPerson::UspsLocationsController do
           selected_location[:usps_location].as_json,
         )
         expect(enrollment.service_provider).to be_nil
+      end
+    end
+
+    context 'with feature disabled' do
+      let(:in_person_proofing_enabled) { false }
+
+      it 'renders 404' do
+        expect(response.status).to eq(404)
       end
     end
   end


### PR DESCRIPTION
Context: https://github.com/18F/identity-idp/pull/6624#discussion_r931071558

**Why**:

- The intent of the concern is to DRY this common behavior
- Include USPS locations controller as feature-guarded by IPP