### PR TITLE
Add nonce to ThreatMetrix <script> tag

### DIFF
--- a/app/views/idv/shared/_ssn.html.erb
+++ b/app/views/idv/shared/_ssn.html.erb
@@ -30,8 +30,7 @@ locals:
 
 <% if IdentityConfig.store.proofing_device_profiling_collecting_enabled %>
   <% unless IdentityConfig.store.lexisnexis_threatmetrix_org_id.empty? %>
-    <script type="text/javascript" src="https://h.online-metrix.net/fp/tags.js?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">
-    </script>
+    <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{flow_session[:threatmetrix_session_id]}", nonce: true %>
     <noscript>
       <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">
       </iframe>

--- a/spec/views/idv/shared/_ssn.html.erb_spec.rb
+++ b/spec/views/idv/shared/_ssn.html.erb_spec.rb
@@ -78,7 +78,7 @@ describe 'idv/shared/_ssn.html.erb' do
   end
 
   def expect_script_tag_rendered
-    expect(rendered).to have_css("script[src='#{tags_js_url}']", visible: false)
+    expect(rendered).to have_css("script[nonce][src='#{tags_js_url}']", visible: false)
   end
 
   def expect_noscript_tag_rendered


### PR DESCRIPTION
Nonce is required to allow TM to execute.

changelog: Bug Fixes, ThreatMetrix, add nonce to script tag