### PR TITLE
Add basic linting for IdentityConfig types and key names

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -48,7 +48,9 @@ class ResolutionProofingJob < ApplicationJob
                           )
                         end
 
-    add_threatmetrix_result_to_callback_result(callback_log_data.result, threatmetrix_result)
+    if use_lexisnexis_ddp_threatmetrix_before_rdp_instant_verify?
+      add_threatmetrix_result_to_callback_result(callback_log_data.result, threatmetrix_result)
+    end
 
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
     document_capture_session.store_proofing_result(callback_log_data.result)

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe IdentityConfig do
   describe '.key_types' do
     it 'has all _enabled keys as booleans' do
       aggregate_failures do
-        IdentityConfig.key_types.select { |key, _type| key =~ /_enabled$/ }.
+        IdentityConfig.key_types.select { |key, _type| key.to_s.end_with?('_enabled') }.
           each do |key, type|
             expect(type).to eq(:boolean), "expected #{key} to be a boolean"
           end
@@ -13,7 +13,7 @@ RSpec.describe IdentityConfig do
 
     it 'has all _at keys as timestamps' do
       aggregate_failures do
-        IdentityConfig.key_types.select { |key, _type| key =~ /_at$/ }.
+        IdentityConfig.key_types.select { |key, _type| key.to_s.end_with?('_at') }.
           each do |key, type|
             expect(type).to eq(:timestamp), "expected #{key} to be a timestamp"
           end

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe IdentityConfig do
           end
       end
     end
+
+    it 'has all _timeout keys as numbers' do
+      aggregate_failures do
+        IdentityConfig.key_types.select { |key, _type| key.to_s.end_with?('_timeout') }.
+          each do |key, type|
+            expect(type).to eq(:float).or(eq(:integer)), "expected #{key} to be a number"
+          end
+      end
+    end
   end
 end

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe IdentityConfig do
+  describe '.key_types' do
+    it 'has all _enabled keys as booleans' do
+      aggregate_failures do
+        IdentityConfig.key_types.select { |key, _type| key =~ /_enabled$/ }.
+          each do |key, type|
+            expect(type).to eq(:boolean), "expected #{key} to be a boolean"
+          end
+      end
+    end
+
+    it 'has all _at keys as timestamps' do
+      aggregate_failures do
+        IdentityConfig.key_types.select { |key, _type| key =~ /_at$/ }.
+          each do |key, type|
+            expect(type).to eq(:timestamp), "expected #{key} to be a timestamp"
+          end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Could have prevented #6764 if we had a check like this
in place, can hopefully catch the next one

changelog: Internal, Source code, Add check to catch config type errors