### PR TITLE
LG-6980: Make USPS proofing results job frequency configurable

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -23,7 +23,11 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     proofer = UspsInPersonProofing::Proofer.new
 
-    InPersonEnrollment.needs_usps_status_check(...5.minutes.ago).each do |enrollment|
+    reprocess_delay_minutes = IdentityConfig.store.
+      get_usps_proofing_results_job_reprocess_delay_minutes.to_f
+    InPersonEnrollment.needs_usps_status_check(
+      ...reprocess_delay_minutes.minutes.ago,
+    ).each do |enrollment|
       # Record and commit attempt to check enrollment status to database
       enrollment.update(status_check_attempted_at: Time.zone.now)
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -24,7 +24,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     proofer = UspsInPersonProofing::Proofer.new
 
     reprocess_delay_minutes = IdentityConfig.store.
-      get_usps_proofing_results_job_reprocess_delay_minutes.to_f
+      get_usps_proofing_results_job_reprocess_delay_minutes
     InPersonEnrollment.needs_usps_status_check(
       ...reprocess_delay_minutes.minutes.ago,
     ).each do |enrollment|

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -277,6 +277,8 @@ usps_ipp_request_timeout: 10
 usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
 usps_mock_fallback: true
+get_usps_proofing_results_job_cron: '0/10 * * * *'
+get_usps_proofing_results_job_reprocess_delay_minutes: 5
 gpo_allowed_for_strict_ial2: true
 voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -1,6 +1,5 @@
 cron_1m = '* * * * *'
 cron_5m = '0/5 * * * *'
-cron_10m = '0/10 * * * *'
 cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT
@@ -210,7 +209,7 @@ else
       # Queue usps proofing job to GoodJob
       get_usps_proofing_results_job: {
         class: 'GetUspsProofingResultsJob',
-        cron: cron_10m,
+        cron: IdentityConfig.store.get_usps_proofing_results_job_cron,
         args: -> { [Time.zone.now] },
       },
     }

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -358,6 +358,11 @@ class IdentityConfig
     config.add(:usps_ipp_username, type: :string)
     config.add(:usps_ipp_request_timeout, type: :integer)
     config.add(:usps_upload_enabled, type: :boolean)
+    config.add(:get_usps_proofing_results_job_cron, type: :string, allow_nil: true)
+    config.add(
+      :get_usps_proofing_results_job_reprocess_delay_minutes, type: :string,
+                                                              allow_nil: true
+    )
     config.add(:gpo_allowed_for_strict_ial2, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)
     config.add(:usps_upload_sftp_host, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -358,11 +358,8 @@ class IdentityConfig
     config.add(:usps_ipp_username, type: :string)
     config.add(:usps_ipp_request_timeout, type: :integer)
     config.add(:usps_upload_enabled, type: :boolean)
-    config.add(:get_usps_proofing_results_job_cron, type: :string, allow_nil: true)
-    config.add(
-      :get_usps_proofing_results_job_reprocess_delay_minutes, type: :string,
-                                                              allow_nil: true
-    )
+    config.add(:get_usps_proofing_results_job_cron, type: :string)
+    config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)
     config.add(:gpo_allowed_for_strict_ial2, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)
     config.add(:usps_upload_sftp_host, type: :string)


### PR DESCRIPTION
### Description

This introduces two new configuration values:

- `get_usps_proofing_results_job_cron`
    Cron expression for the USPS proofing cron job. Default: `'0/10 * * * *'`
- `get_usps_proofing_results_job_reprocess_delay_minutes`
   Minimum delay in minutes between checks for each enrollment for the USPS proofing cron job. Default: `5`

### Testing

1. Override one or both values in `application.yml`
    ```
    get_usps_proofing_results_job_cron: '0/3 * * * *'
    get_usps_proofing_results_job_reprocess_delay_minutes: 2
    ```
2. Run through the IPP workflow until the review page
3. Repeatedly check the enrollment record's `status_check_attempted_at` field to determine if the frequency with which it was processed matches the configured values.
    ```
    $ psql
    psql (14.3)
    Type "help" for help.
    
    postgres=# \c identity_idp_development
    You are now connected to database "identity_idp_development" as user "postgres".
    identity_idp_development=# SELECT status_check_attempted_at FROM in_person_enrollments ORDER BY id DESC LIMIT 1;
     status_check_attempted_at  
    ----------------------------
     2022-08-17 00:13:00.156808
    (1 row)
    ```