### PR TITLE
Store and fetch IRS Attempts events by timestamp

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1053,18 +1053,17 @@ module AnalyticsEvents
   end
 
   # @param [Integer] rendered_event_count how many events were rendered in the API response
-  # @param [String] set_errors JSON encoded representation of SET errors from the client
-  # An IRS Attempt API client has acknowledged receipt of security event tokens and polled for a
-  # new set of events
+  # @param [Boolean] success
+  # An IRS Attempt API client has requested events
   def irs_attempts_api_events(
     rendered_event_count:,
-    set_errors:,
+    success:,
     **extra
   )
     track_event(
       'IRS Attempt API: Events submitted',
       rendered_event_count: rendered_event_count,
-      set_errors: set_errors,
+      success: success,
       **extra,
     )
   end

--- a/app/services/irs_attempts_api/redis_client.rb
+++ b/app/services/irs_attempts_api/redis_client.rb
@@ -9,24 +9,23 @@ module IrsAttemptsApi
       end
     end
 
-    def write_event(jti:, jwe:)
+    def write_event(jti:, jwe:, timestamp:)
+      key = key(timestamp)
       redis_pool.with do |client|
-        client.setex(jti, IdentityConfig.store.irs_attempt_api_event_ttl_seconds, jwe)
+        client.hset(key, jti, jwe)
+        client.expire(key, IdentityConfig.store.irs_attempt_api_event_ttl_seconds)
       end
     end
 
-    def delete_events(event_ids)
+    def read_events(timestamp:)
+      key = key(timestamp)
       redis_pool.with do |client|
-        client.del(*event_ids)
+        client.hgetall(key)
       end
     end
 
-    def read_events(count = 1000)
-      redis_pool.with do |client|
-        keys = client.scan(0, count: count).last.first(count)
-        next {} if keys.empty?
-        client.mapped_mget(*keys)
-      end
+    def key(timestamp)
+      timestamp.in_time_zone('UTC').change(min: 0, sec: 0).iso8601
     end
 
     def self.clear_attempts!

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -33,7 +33,11 @@ module IrsAttemptsApi
         event_metadata: event_metadata,
       )
 
-      redis_client.write_event(jti: event.jti, jwe: event.to_jwe)
+      redis_client.write_event(
+        jti: event.jti,
+        jwe: event.to_jwe,
+        timestamp: event.occurred_at,
+      )
 
       event
     end

--- a/lib/tasks/attempts.rake
+++ b/lib/tasks/attempts.rake
@@ -6,8 +6,9 @@ namespace :attempts do
   desc 'Retrieve events via the API'
   task fetch_events: :environment do
     conn = Faraday.new(url: 'http://localhost:3000')
+    body = "timestamp=#{Time.zone.now.iso8601}"
 
-    resp = conn.post('/api/irs_attempts_api/security_events') do |req|
+    resp = conn.post('/api/irs_attempts_api/security_events', body) do |req|
       req.headers['Authorization'] =
         "Bearer #{IdentityConfig.store.irs_attempt_api_csp_id} #{auth_token}"
     end.body

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Api::IrsAttemptsApiController do
       expect(response.status).to eq(404)
     end
 
+    it 'returns an error without required timestamp parameter' do
+      post :create, params: {}
+      expect(response.status).to eq 422
+    end
+
+    it 'returns an error with empty timestamp parameter' do
+      post :create, params: { timestamp: '' }
+      expect(response.status).to eq 422
+    end
+
+    it 'returns an error with invalid timestamp parameter' do
+      post :create, params: { timestamp: 'abc' }
+      expect(response.status).to eq 422
+    end
+
     it 'authenticates the client' do
       request.headers['Authorization'] = auth_token # Missing Bearer prefix
 

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -20,52 +20,58 @@ feature 'IRS Attempts API Event Tracking' do
   end
 
   scenario 'signing in from an IRS SP with an attempts api session id tracks events' do
-    user = create(:user, :signed_up)
+    freeze_time do
+      user = create(:user, :signed_up)
 
-    visit_idp_from_ial1_oidc_sp(
-      client_id: service_provider.issuer,
-      irs_attempts_api_session_id: 'test-session-id',
-    )
+      visit_idp_from_ial1_oidc_sp(
+        client_id: service_provider.issuer,
+        irs_attempts_api_session_id: 'test-session-id',
+      )
 
-    sign_in_user(user)
+      sign_in_user(user)
 
-    events = irs_attempts_api_tracked_events
-    expected_event_types = ['email-and-password-auth', 'mfa-verify-phone-otp-sent']
+      events = irs_attempts_api_tracked_events(timestamp: Time.zone.now)
+      expected_event_types = ['email-and-password-auth', 'mfa-verify-phone-otp-sent']
 
-    received_event_types = events.map(&:event_type)
+      received_event_types = events.map(&:event_type)
 
-    expect(events.count).to be > 0
-    expect(received_event_types.sort).to eq(expected_event_types.sort)
+      expect(events.count).to be > 0
+      expect(received_event_types.sort).to eq(expected_event_types.sort)
+    end
   end
 
   scenario 'signing in from an IRS SP without an attempts api session id does not track events' do
-    user = create(:user, :signed_up)
+    freeze_time do
+      user = create(:user, :signed_up)
 
-    visit_idp_from_ial1_oidc_sp(
-      client_id: service_provider.issuer,
-    )
+      visit_idp_from_ial1_oidc_sp(
+        client_id: service_provider.issuer,
+      )
 
-    sign_in_user(user)
+      sign_in_user(user)
 
-    events = irs_attempts_api_tracked_events
+      events = irs_attempts_api_tracked_events(timestamp: Time.zone.now)
 
-    expect(events.count).to eq(0)
+      expect(events.count).to eq(0)
+    end
   end
 
   scenario 'signing in from a non-IRS SP with an attempts api session id does not track events' do
-    service_provider.update!(irs_attempts_api_enabled: false)
+    freeze_time do
+      service_provider.update!(irs_attempts_api_enabled: false)
 
-    user = create(:user, :signed_up)
+      user = create(:user, :signed_up)
 
-    visit_idp_from_ial1_oidc_sp(
-      client_id: service_provider.issuer,
-      irs_attempts_api_session_id: 'test-session_id',
-    )
+      visit_idp_from_ial1_oidc_sp(
+        client_id: service_provider.issuer,
+        irs_attempts_api_session_id: 'test-session_id',
+      )
 
-    sign_in_user(user)
+      sign_in_user(user)
 
-    events = irs_attempts_api_tracked_events
+      events = irs_attempts_api_tracked_events(timestamp: Time.zone.now)
 
-    expect(events.count).to eq(0)
+      expect(events.count).to eq(0)
+    end
   end
 end

--- a/spec/services/irs_attempts_api/redis_client_spec.rb
+++ b/spec/services/irs_attempts_api/redis_client_spec.rb
@@ -3,28 +3,8 @@ require 'rails_helper'
 describe IrsAttemptsApi::RedisClient do
   describe '#write_event' do
     it 'writes the attempt data to redis with the JTI as the key' do
-      event = IrsAttemptsApi::AttemptEvent.new(
-        event_type: 'test_event',
-        session_id: 'test-session-id',
-        occurred_at: Time.zone.now,
-        event_metadata: { 'foo' => 'bar' },
-      )
-      jti = event.jti
-      jwe = event.to_jwe
-
-      subject.write_event(jti: jti, jwe: jwe)
-
-      result = subject.redis_pool.with do |client|
-        client.get(jti)
-      end
-      expect(result).to eq(jwe)
-    end
-  end
-
-  describe '#read_events' do
-    it 'reads the event events from redis' do
-      events = {}
-      3.times do
+      freeze_time do
+        now = Time.zone.now
         event = IrsAttemptsApi::AttemptEvent.new(
           event_type: 'test_event',
           session_id: 'test-session-id',
@@ -33,44 +13,66 @@ describe IrsAttemptsApi::RedisClient do
         )
         jti = event.jti
         jwe = event.to_jwe
-        events[jti] = jwe
-      end
-      events.each do |jti, jwe|
-        subject.write_event(jti: jti, jwe: jwe)
-      end
 
-      result = subject.read_events
+        subject.write_event(jti: jti, jwe: jwe, timestamp: now)
 
-      expect(result).to eq(events)
+        result = subject.redis_pool.with do |client|
+          client.hget(subject.key(now), jti)
+        end
+        expect(result).to eq(jwe)
+      end
     end
   end
 
-  describe '#delete_events' do
-    it 'deletes the events from redis' do
-      events = {}
-      3.times do
-        event = IrsAttemptsApi::AttemptEvent.new(
-          event_type: 'test_event',
-          session_id: 'test-session-id',
-          occurred_at: Time.zone.now,
-          event_metadata: { 'foo' => 'bar' },
-        )
-        jti = event.jti
-        events[jti] = event.to_jwe
-      end
-      events.each do |jti, jwe|
-        subject.write_event(jti: jti, jwe: jwe)
-      end
+  describe '#read_events' do
+    it 'reads the event events from redis' do
+      freeze_time do
+        now = Time.zone.now
+        events = {}
+        3.times do
+          event = IrsAttemptsApi::AttemptEvent.new(
+            event_type: 'test_event',
+            session_id: 'test-session-id',
+            occurred_at: now,
+            event_metadata: { 'foo' => 'bar' },
+          )
+          jti = event.jti
+          jwe = event.to_jwe
+          events[jti] = jwe
+        end
+        events.each do |jti, jwe|
+          subject.write_event(jti: jti, jwe: jwe, timestamp: now)
+        end
 
-      subject.redis_pool.with do |client|
-        expect(client.exists(*events.keys)).to eq(3)
-      end
+        result = subject.read_events(timestamp: now)
 
-      subject.delete_events(events.keys)
-
-      subject.redis_pool.with do |client|
-        expect(client.exists(*events.keys)).to eq(0)
+        expect(result).to eq(events)
       end
+    end
+
+    it 'stores events in hourly buckets' do
+      time1 = Time.new(2022, 1, 1, 1, 0, 0, 'Z')
+      time2 = Time.new(2022, 1, 1, 2, 0, 0, 'Z')
+      event1 = IrsAttemptsApi::AttemptEvent.new(
+        event_type: 'test_event',
+        session_id: 'test-session-id',
+        occurred_at: time1,
+        event_metadata: { 'foo' => 'bar' },
+      )
+      event2 = IrsAttemptsApi::AttemptEvent.new(
+        event_type: 'test_event',
+        session_id: 'test-session-id',
+        occurred_at: time2,
+        event_metadata: { 'foo' => 'bar' },
+      )
+      jwe1 = event1.to_jwe
+      jwe2 = event2.to_jwe
+
+      subject.write_event(jti: event1.jti, jwe: jwe1, timestamp: event1.occurred_at)
+      subject.write_event(jti: event2.jti, jwe: jwe2, timestamp: event2.occurred_at)
+
+      expect(subject.read_events(timestamp: time1)).to eq({ event1.jti => jwe1 })
+      expect(subject.read_events(timestamp: time2)).to eq({ event2.jti => jwe2 })
     end
   end
 end

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -32,22 +32,26 @@ RSpec.describe IrsAttemptsApi::Tracker do
 
   describe '#track_event' do
     it 'records the event in redis' do
-      subject.track_event(:test_event, foo: :bar)
+      freeze_time do
+        subject.track_event(:test_event, foo: :bar)
 
-      events = IrsAttemptsApi::RedisClient.new.read_events
+        events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: Time.zone.now)
 
-      expect(events.values.length).to eq(1)
+        expect(events.values.length).to eq(1)
+      end
     end
 
     context 'the current session is not an IRS attempt API session' do
       let(:enabled_for_session) { false }
 
       it 'does not record any events in redis' do
-        subject.track_event(:test_event, foo: :bar)
+        freeze_time do
+          subject.track_event(:test_event, foo: :bar)
 
-        events = IrsAttemptsApi::RedisClient.new.read_events
+          events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: Time.zone.now)
 
-        expect(events.values.length).to eq(0)
+          expect(events.values.length).to eq(0)
+        end
       end
     end
 
@@ -55,11 +59,13 @@ RSpec.describe IrsAttemptsApi::Tracker do
       let(:irs_attempt_api_enabled) { false }
 
       it 'does not record any events in redis' do
-        subject.track_event(:test_event, foo: :bar)
+        freeze_time do
+          subject.track_event(:test_event, foo: :bar)
 
-        events = IrsAttemptsApi::RedisClient.new.read_events
+          events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: Time.zone.now)
 
-        expect(events.values.length).to eq(0)
+          expect(events.values.length).to eq(0)
+        end
       end
     end
   end

--- a/spec/support/features/irs_attempts_api_tracking_helper.rb
+++ b/spec/support/features/irs_attempts_api_tracking_helper.rb
@@ -8,8 +8,8 @@ module IrsAttemptsApiTrackingHelper
       @private_key ||= OpenSSL::PKey::RSA.new(4096)
     end
 
-    def decrypted_events_from_store
-      jwes = IrsAttemptsApi::RedisClient.new.read_events
+    def decrypted_events_from_store(timestamp:)
+      jwes = IrsAttemptsApi::RedisClient.new.read_events(timestamp: timestamp)
       jwes.transform_values do |jwe|
         IrsAttemptsApi::AttemptEvent.from_jwe(jwe, self.class.private_key)
       end
@@ -22,8 +22,8 @@ module IrsAttemptsApiTrackingHelper
       and_return(encoded_key)
   end
 
-  def irs_attempts_api_tracked_events
-    IrsAttemptsApiEventDecryptor.new.decrypted_events_from_store.values
+  def irs_attempts_api_tracked_events(timestamp:)
+    IrsAttemptsApiEventDecryptor.new.decrypted_events_from_store(timestamp: timestamp).values
   end
 
   def stub_attempts_tracker


### PR DESCRIPTION
Drops requesting by count and stores in a Redis hash by hourly timestamp rather than individually by event ID.  This is not a long-term storage solution.

The external API now requires requesting by timestamp (ultimately truncating hours and seconds) per the specification.