### PR TITLE
Add threatmetrix policy config

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -23,6 +23,7 @@ module Proofing
             drivers_license_number_hash: applicant[:state_id_number] ?
               OpenSSL::Digest::SHA256.hexdigest(applicant[:state_id_number].gsub(/\W/, '')) : '',
             event_type: 'ACCOUNT_CREATION',
+            policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',
             session_id: applicant[:threatmetrix_session_id],
             ssn_hash: OpenSSL::Digest::SHA256.hexdigest(applicant[:ssn].gsub(/\D/, '')),

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -146,6 +146,7 @@ lexisnexis_trueid_noliveness_nocropping_workflow: customers.gsa.trueid.workflow
 lexisnexis_threatmetrix_api_key: test_api_key
 lexisnexis_threatmetrix_base_url: https://www.example.com
 lexisnexis_threatmetrix_org_id: test_account
+lexisnexis_threatmetrix_policy: test-policy
 lexisnexis_threatmetrix_timeout: 1.0
 lexisnexis_threatmetrix_enabled: false
 lexisnexis_threatmetrix_mock_enabled: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -221,6 +221,7 @@ class IdentityConfig
     config.add(:lexisnexis_threatmetrix_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string)
+    config.add(:lexisnexis_threatmetrix_test_policy, type: :string)
     config.add(:lexisnexis_threatmetrix_timeout, type: :float)
     config.add(:liveness_checking_enabled, type: :boolean)
     config.add(:lockout_period_in_minutes, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -221,7 +221,7 @@ class IdentityConfig
     config.add(:lexisnexis_threatmetrix_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string)
-    config.add(:lexisnexis_threatmetrix_test_policy, type: :string)
+    config.add(:lexisnexis_threatmetrix_policy, type: :string)
     config.add(:lexisnexis_threatmetrix_timeout, type: :float)
     config.add(:liveness_checking_enabled, type: :boolean)
     config.add(:lockout_period_in_minutes, type: :integer)

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -14,6 +14,7 @@
   "account_telephone": "",
   "drivers_license_number_hash": "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f",
   "event_type": "ACCOUNT_CREATION",
+  "policy": "test-policy",
   "service_type": "all",
   "session_id": "UNIQUE_SESSION_ID",
   "ssn_hash": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225"


### PR DESCRIPTION
**Why**: To be able to change the policy we use to call threatmetrix instead of relying on the default.