### PR TITLE
Fix spinner button active color

### DIFF
--- a/app/assets/stylesheets/components/_spinner-button.scss
+++ b/app/assets/stylesheets/components/_spinner-button.scss
@@ -17,7 +17,9 @@ lg-spinner-button {
     a,
     button:not([type]),
     [type='submit'],
-    [type='button'] {
+    [type='button'],
+    .usa-button:disabled.usa-button--active:not(.usa-button--unstyled, .usa-button--secondary, .usa-button--accent-cool, .usa-button--accent-warm, .usa-button--base, .usa-button--outline, .usa-button--inverse),
+    .usa-button--disabled.usa-button--active:not(.usa-button--unstyled, .usa-button--secondary, .usa-button--accent-cool, .usa-button--accent-warm, .usa-button--base, .usa-button--outline, .usa-button--inverse) {
       color: transparent;
       opacity: 1;
     }


### PR DESCRIPTION
Fixes regression introduced in #6564

**Why**: Because the spinner button retains its original shape by setting the text color to transparent, which was being overridden by the new active styles introduced in #6564.

Before|After
---|---
![Screen Shot 2022-08-17 at 1 23 48 PM](https://user-images.githubusercontent.com/1779930/185205201-ac40ab34-2c98-4bc4-a735-af6b5610a6da.png)|![Screen Shot 2022-08-17 at 1 24 02 PM](https://user-images.githubusercontent.com/1779930/185205204-89223fbe-997f-489a-8aea-fa47664d73f2.png)

