### PR TITLE
Fix Help Center article links for in-person proofing

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-troubleshooting-options.tsx
@@ -33,7 +33,7 @@ function InPersonTroubleshootingOptions({
           {
             url: getHelpCenterURL({
               category: 'verify-your-identity',
-              article: 'how-to-verify-in-person',
+              article: 'verify-your-identity-in-person',
               location,
             }),
             text: t('idv.troubleshooting.options.learn_more_verify_in_person'),

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -9,7 +9,7 @@ class MarketingSite
     signing-in/what-is-a-hardware-security-key
     verify-your-identity/accepted-state-issued-identification
     verify-your-identity/how-to-add-images-of-your-state-issued-id
-    verify-your-identity/how-to-verify-in-person
+    verify-your-identity/verify-your-identity-in-person
     verify-your-identity/phone-number-and-phone-plan-in-your-name
     verify-your-identity/verify-your-address-by-mail
     get-started/authentication-options

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -12,7 +12,7 @@
         t('in_person_proofing.body.address.learn_more'),
         MarketingSite.help_center_article_url(
           category: 'verify-your-identity',
-          article: 'how-to-verify-in-person',
+          article: 'verify-your-identity-in-person',
         ),
       ) %>
 </p>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -64,7 +64,7 @@
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',
-            article: 'how-to-verify-in-person',
+            article: 'verify-your-identity-in-person',
           ),
         ) %>
   </p>

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -67,7 +67,7 @@
           t('in_person_proofing.body.barcode.learn_more'),
           MarketingSite.help_center_article_url(
             category: 'verify-your-identity',
-            article: 'how-to-verify-in-person',
+            article: 'verify-your-identity-in-person',
           ),
         ) %>
   </p>


### PR DESCRIPTION
**Why**: Since the URL selected for the help center content is different than the URL we assumed it would be in the code implementation.

Reference: https://github.com/18F/identity-site/pull/920/files#diff-971600dd227c5e00268280c324335790b0945672ba708c65bf5a5f8bc54d402fR4
