### PR TITLE
Remove custom "Required" form validation message

### DIFF
--- a/app/javascript/packs/form-validation.ts
+++ b/app/javascript/packs/form-validation.ts
@@ -1,5 +1,3 @@
-import { t } from '@18f/identity-i18n';
-
 /**
  * Given a submit event, disables all submit buttons within the target form.
  *
@@ -16,49 +14,12 @@ function disableFormSubmit(event: Event) {
   );
 }
 
-function resetInput(input) {
-  if (input.hasAttribute('data-form-validation-message')) {
-    input.setCustomValidity('');
-    input.removeAttribute('data-form-validation-message');
-  }
-  input.setAttribute('aria-invalid', 'false');
-  input.classList.remove('usa-input--error');
-}
-
-/**
- * Given an `input` or `invalid` event, updates custom validity of the given input.
- *
- * @param event Input or invalid event.
- */
-
-function checkInputValidity(event: Event) {
-  const input = event.target as HTMLInputElement;
-  resetInput(input);
-
-  if (input.validity.valueMissing) {
-    input.setCustomValidity(t('simple_form.required.text'));
-    input.setAttribute('data-form-validation-message', '');
-  }
-}
-
-/**
- * Binds validation to a given input.
- *
- * @param input Input element.
- */
-function validateInput(input: HTMLInputElement) {
-  input.addEventListener('input', checkInputValidity);
-  input.addEventListener('invalid', checkInputValidity);
-}
-
 /**
  * Initializes validation on a form element.
  *
  * @param form Form to initialize.
  */
 export function initialize(form: HTMLFormElement) {
-  const fields: HTMLInputElement[] = Array.from(form.querySelectorAll('[required]'));
-  fields.forEach(validateInput);
   form.addEventListener('submit', disableFormSubmit);
 }
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -20,13 +20,18 @@
       html: { autocomplete: 'off' },
     ) do |f|
 %>
-  <%= f.input :email,
-              label: t('account.index.email'),
-              required: true,
-              input_html: { class: 'margin-bottom-6',
-                            autocorrect: 'off',
-                            aria: { invalid: false } } %>
-  <%= render PasswordToggleComponent.new(form: f, required: true) %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :email,
+        label: t('account.index.email'),
+        required: true,
+        input_html: { autocorrect: 'off' },
+      ) %>
+  <%= render PasswordToggleComponent.new(
+        form: f,
+        required: true,
+        wrapper_html: { class: 'margin-top-6' },
+      ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: @request_id } %>
   <div class='margin-bottom-4'>
     <%= submit_tag t('links.next'), class: 'usa-button usa-button--primary usa-button--full-width margin-bottom-2' %>

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/dom';
-import userEvent from '@testing-library/user-event';
 import { initialize } from '../../../app/javascript/packs/form-validation';
 
 describe('form-validation', () => {
@@ -43,64 +42,5 @@ describe('form-validation', () => {
     expect(button1.classList.contains('usa-button--active')).to.be.false();
     expect(input1.disabled).to.be.false();
     expect(input1.classList.contains('usa-button--active')).to.be.false();
-  });
-
-  it('checks validity of inputs', async () => {
-    document.body.innerHTML = `
-      <form>
-        <input type="text" aria-label="not required field">
-        <input type="text" aria-label="required field" required class="field">
-      </form>`;
-
-    initialize(document.querySelector('form'));
-
-    const notRequiredField = screen.getByLabelText('not required field');
-    await userEvent.type(notRequiredField, 'a{Backspace}');
-    expect(notRequiredField.validationMessage).to.be.empty();
-
-    const requiredField = screen.getByLabelText('required field');
-    await userEvent.type(requiredField, 'a{Backspace}');
-    expect(requiredField.validationMessage).to.equal('simple_form.required.text');
-    await userEvent.type(requiredField, 'a');
-    expect(notRequiredField.validationMessage).to.be.empty();
-  });
-
-  it('resets its own custom validity message on input', async () => {
-    document.body.innerHTML = `
-      <form>
-        <input type="text" aria-label="required field" required class="field">
-        <button>Submit</button>
-      </form>`;
-
-    const form = document.querySelector('form');
-    initialize(form);
-
-    form.checkValidity();
-
-    const input = screen.getByLabelText('required field');
-    await userEvent.type(input, 'a');
-
-    expect(input.validity.customError).to.be.false();
-  });
-
-  it('does not reset external custom validity message on input', async () => {
-    document.body.innerHTML = `
-      <form>
-        <input type="text" aria-label="field" class="field">
-        <button>Submit</button>
-      </form>`;
-
-    const form = document.querySelector('form');
-    initialize(form);
-
-    form.checkValidity();
-
-    /** @type {HTMLInputElement} */
-    const input = screen.getByLabelText('field');
-    input.setCustomValidity('custom error');
-
-    await userEvent.type(input, 'a');
-
-    expect(input.validity.customError).to.be.true();
   });
 });


### PR DESCRIPTION
**Why**:

- They are inconsistent with desired error feedback UX, which should be implemented as design system error messages via ValidatedFieldComponent.
- Improves performance of critical path by reducing JavaScript (and locale data) bundle size.
  - For context, the Sign In page loads locale data which includes only this one string for required fields ([screenshot](https://user-images.githubusercontent.com/1779930/185402890-36f4d474-81aa-421d-8e2d-f1f21fd200b3.png)).
- Contributes toward removal of form-validation pack, to be removed between this and https://github.com/18F/identity-idp/pull/6771
- Reduces complexity, where this validation intervention has often conflicted with other validation (specifically, see `data-form-validation-message` handling and related context at #5631)

**Implementation Notes:**

While I did update the Sign In page for consistency, there may be other places in the application which still use native form validation, and in those cases the required field feedback will revert from the customized "This field is required" to the browser default (e.g. "Please fill in this field" in Chrome). I think we should aim to update these fields to the standard error feedback display than to continue propping up this non-standard error message customization.

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/185402214-51f45ec7-32f2-478a-bc9e-b75d4829770c.png)|![Screen Shot 2022-08-18 at 9 03 24 AM](https://user-images.githubusercontent.com/1779930/185402029-007b3525-c731-48d9-ad11-3005e2860370.png)

