### PR TITLE
LG-7201 - Added attempt events - MFA submitted rate limited

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -116,7 +116,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   # Method will be renamed in the next refactor.
   # You can pass in any "type" with a corresponding I18n key in
   # two_factor_authentication.invalid_#{type}
-  def handle_invalid_otp(context: nil, type: 'otp')
+  def handle_invalid_otp(context: nil, type:)
     update_invalid_user
 
     flash.now[:error] = invalid_otp_error(type)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -17,11 +17,19 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     authenticate_user!(force: true)
   end
 
-  def handle_second_factor_locked_user(type)
+  def handle_second_factor_locked_user(type:, context: nil, phone: nil)
     analytics.multi_factor_auth_max_attempts
     event = PushNotification::MfaLimitAccountLockedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)
     handle_max_attempts(type + '_login_attempts')
+
+    if !context.nil? || !phone.nil?
+      if UserSessionContext.authentication_context?(context)
+        irs_attempts_api_tracker.mfa_verify_phone_otp_rate_limited(phone_number: phone)
+      elsif UserSessionContext.confirmation_context?(context)
+        irs_attempts_api_tracker.mfa_enroll_phone_otp_rate_limited(phone_number: phone)
+      end
+    end
   end
 
   def handle_too_many_otp_sends
@@ -108,13 +116,13 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   # Method will be renamed in the next refactor.
   # You can pass in any "type" with a corresponding I18n key in
   # two_factor_authentication.invalid_#{type}
-  def handle_invalid_otp(type: 'otp')
+  def handle_invalid_otp(type: 'otp', context: nil, phone: nil)
     update_invalid_user
 
     flash.now[:error] = invalid_otp_error(type)
 
     if decorated_user.locked_out?
-      handle_second_factor_locked_user(type)
+      handle_second_factor_locked_user(type: type, context: context, phone: phone)
     else
       render_show_after_invalid
     end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -17,7 +17,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     authenticate_user!(force: true)
   end
 
-  def handle_second_factor_locked_user(context: nil, type:)
+  def handle_second_factor_locked_user(type:, context: nil)
     analytics.multi_factor_auth_max_attempts
     event = PushNotification::MfaLimitAccountLockedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -116,7 +116,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   # Method will be renamed in the next refactor.
   # You can pass in any "type" with a corresponding I18n key in
   # two_factor_authentication.invalid_#{type}
-  def handle_invalid_otp(context: nil, type:)
+  def handle_invalid_otp(type:, context: nil)
     update_invalid_user
 
     flash.now[:error] = invalid_otp_error(type)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -25,7 +25,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
     if context
       if UserSessionContext.authentication_context?(context)
-        irs_attempts_api_tracker.mfa_verify_rate_limited(type: type)
+        irs_attempts_api_tracker.mfa_login_rate_limited(type: type)
       elsif UserSessionContext.confirmation_context?(context)
         irs_attempts_api_tracker.mfa_enroll_rate_limited(type: type)
       end

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -53,7 +53,7 @@ module TwoFactorAuthentication
       flash.now[:error] = t('two_factor_authentication.invalid_backup_code')
 
       if decorated_user.locked_out?
-        handle_second_factor_locked_user('backup_code')
+        handle_second_factor_locked_user(context: context, type: 'backup_code')
       else
         render_show_after_invalid
       end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_otp
       else
-        handle_invalid_otp(context: context, type: "otp")
+        handle_invalid_otp(context: context, type: 'otp')
       end
     end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_otp
       else
-        handle_invalid_otp
+        handle_invalid_otp(context: context, phone: phone)
       end
     end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_otp
       else
-        handle_invalid_otp(context: context, phone: phone)
+        handle_invalid_otp(context: context, type: "otp")
       end
     end
 

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -40,7 +40,7 @@ module TwoFactorAuthentication
         generate_new_personal_key_for_verified_users_otherwise_retire_the_key_and_ensure_two_mfa
         handle_valid_otp
       else
-        handle_invalid_otp(type: 'personal_key')
+        handle_invalid_otp(context: context, type: 'personal_key')
       end
     end
 

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -57,7 +57,7 @@ module TwoFactorAuthentication
 
     def handle_invalid_piv_cac
       clear_piv_cac_information
-      handle_invalid_otp(type: 'piv_cac')
+      handle_invalid_otp(context: context, type: 'piv_cac')
     end
 
     # This overrides the method in TwoFactorAuthenticatable so that we

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_otp
       else
-        handle_invalid_otp
+        handle_invalid_otp(context: context, type: "totp")
       end
     end
 

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_otp
       else
-        handle_invalid_otp(context: context, type: "totp")
+        handle_invalid_otp(context: context, type: 'totp')
       end
     end
 

--- a/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
+++ b/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
@@ -19,6 +19,10 @@ module TwoFactorAuthCode
         t('two_factor_authentication.max_otp_login_attempts_reached')
       when 'otp_requests'
         t('two_factor_authentication.max_otp_requests_reached')
+      when 'totp_login_attempts'
+        t('two_factor_authentication.max_otp_login_attempts_reached')
+      when 'totp_requests'
+        t('two_factor_authentication.max_otp_requests_reached')
       when 'personal_key_login_attempts'
         t('two_factor_authentication.max_personal_key_login_attempts_reached')
       when 'piv_cac_login_attempts'

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -167,8 +167,9 @@ module IrsAttemptsApi
       )
     end
 
-    # Tracks when user has attempted to verify via the WebAuthn-Platform MFA method to their account
+    # Tracks when the user has attempted to log in with the piv cac MFA method to their account
     # @param [Boolean] success
+    # @param [String] subject_dn
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     def mfa_login_piv_cac(
       success:,

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -97,8 +97,8 @@ module IrsAttemptsApi
       )
     end
     
-    # @param [String] phone_number the user's phone_number used for multi-factor authentication
-    # The user has exceeded the rate limit for SMS OTP during enrollment
+    # @param [String] the type of multi-factor authentication used
+    # The user has exceeded the rate limit during enrollment
     # and account has been locked
     def mfa_enroll_rate_limited(type:)
       track_event(
@@ -167,10 +167,8 @@ module IrsAttemptsApi
       )
     end
 
-    # Tracks when the user has attempted to log in with the piv cac MFA method to their account
-    # @param [String] subject_dn
-    # @param [String] phone_number - the user's phone_number used for multi-factor authentication
-    # The user has exceeded the rate limit for SMS OTP during verification
+    # @param [String] the type of multi-factor authentication used
+    # The user has exceeded the rate limit during verification
     # and account has been locked
     def mfa_verify_rate_limited(type)
       track_event(

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -96,6 +96,16 @@ module IrsAttemptsApi
         failure_reason: failure_reason,
       )
     end
+    
+    # @param [String] phone_number the user's phone_number used for multi-factor authentication
+    # The user has exceeded the rate limit for SMS OTP during enrollment
+    # and account has been locked
+    def mfa_enroll_rate_limited(type:)
+      track_event(
+        :mfa_enroll_rate_limited,
+        type: type,
+      )
+    end
 
     # Tracks when the user has attempted to enroll the TOTP MFA method to their account
     # @param [Boolean] success
@@ -159,6 +169,26 @@ module IrsAttemptsApi
 
     # Tracks when the user has attempted to log in with the piv cac MFA method to their account
     # @param [String] subject_dn
+    # @param [String] phone_number - the user's phone_number used for multi-factor authentication
+    # The user has exceeded the rate limit for SMS OTP during verification
+    # and account has been locked
+    def mfa_verify_rate_limited(type)
+      track_event(
+        :mfa_verify_rate_limited,
+        type: type,
+      )
+    end
+
+    # Tracks when the user has attempted to verify via the TOTP MFA method to access their account
+    # @param [Boolean] success
+    def mfa_verify_totp(success:)
+      track_event(
+        :mfa_verify_totp,
+        success: success,
+      )
+    end
+
+    # Tracks when user has attempted to verify via the WebAuthn-Platform MFA method to their account
     # @param [Boolean] success
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     def mfa_login_piv_cac(

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -97,7 +97,7 @@ module IrsAttemptsApi
       )
     end
     
-    # @param [String] the type of multi-factor authentication used
+    # @param [String] type - the type of multi-factor authentication used
     # The user has exceeded the rate limit during enrollment
     # and account has been locked
     def mfa_enroll_rate_limited(type:)
@@ -167,10 +167,10 @@ module IrsAttemptsApi
       )
     end
 
-    # @param [String] the type of multi-factor authentication used
+    # @param [String] type - the type of multi-factor authentication used
     # The user has exceeded the rate limit during verification
     # and account has been locked
-    def mfa_verify_rate_limited(type)
+    def mfa_verify_rate_limited(type:)
       track_event(
         :mfa_verify_rate_limited,
         type: type,

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -96,7 +96,7 @@ module IrsAttemptsApi
         failure_reason: failure_reason,
       )
     end
-    
+
     # @param [String] type - the type of multi-factor authentication used
     # The user has exceeded the rate limit during enrollment
     # and account has been locked
@@ -167,25 +167,6 @@ module IrsAttemptsApi
       )
     end
 
-    # @param [String] type - the type of multi-factor authentication used
-    # The user has exceeded the rate limit during verification
-    # and account has been locked
-    def mfa_verify_rate_limited(type:)
-      track_event(
-        :mfa_verify_rate_limited,
-        type: type,
-      )
-    end
-
-    # Tracks when the user has attempted to verify via the TOTP MFA method to access their account
-    # @param [Boolean] success
-    def mfa_verify_totp(success:)
-      track_event(
-        :mfa_verify_totp,
-        success: success,
-      )
-    end
-
     # Tracks when user has attempted to verify via the WebAuthn-Platform MFA method to their account
     # @param [Boolean] success
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
@@ -199,6 +180,16 @@ module IrsAttemptsApi
         success: success,
         subject_dn: subject_dn,
         failure_reason: failure_reason,
+      )
+    end
+
+    # @param [String] type - the type of multi-factor authentication used
+    # The user has exceeded the rate limit during verification
+    # and account has been locked
+    def mfa_login_rate_limited(type:)
+      track_event(
+        :mfa_login_rate_limited,
+        type: type,
       )
     end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -142,7 +142,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: max attempts reached')
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(type: 'backup_code')
 
         expect(PushNotification::HttpPush).to receive(:deliver).

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -141,6 +141,10 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
 
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: max attempts reached')
+
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+          with(type: 'backup_code')
+
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -179,8 +179,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
           with({ reauthentication: false, success: false })
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_phone_otp_rate_limited).
-          with({ phone_number: '+1 202-555-1212' })
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+          with(type: 'otp')
 
         post :create, params:
         { code: '12345',
@@ -383,7 +383,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             controller.user_session[:phone_id] = phone_id
 
             expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_phone_otp_submitted).
-              with({ success: true })
+              with(success: true)
 
             post(
               :create,
@@ -413,7 +413,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         context 'user enters an invalid code' do
           before do
             expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_phone_otp_submitted).
-              with({ success: false })
+              with(success: false)
 
             post(
               :create,
@@ -471,12 +471,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
               sign_in_before_2fa
 
               stub_attempts_tracker
-              expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_phone_otp_rate_limited).
-                with(phone_number: '+1 202-555-1212')
+              expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_rate_limited).
+                with(type: 'otp')
 
-              post :create, params:
-              { code: '12345',
-                otp_delivery_preference: 'sms' }
+              post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
             end
           end
         end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -179,7 +179,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
           with({ reauthentication: false, success: false })
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(type: 'otp')
 
         post :create, params:

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -238,7 +238,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           with('User marked authenticated', authentication_type: :valid_2fa)
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
-          with({ reauthentication: false, success: true })
+          with(reauthentication: false, success: true)
 
         post :create, params: {
           code: subject.current_user.reload.direct_otp,

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -152,11 +152,16 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         }
 
         stub_analytics
+        stub_attempts_tracker
 
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(properties)
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: max attempts reached')
+
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+          with(type: 'personal_key')
+
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -159,7 +159,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: max attempts reached')
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(type: 'personal_key')
 
         expect(PushNotification::HttpPush).to receive(:deliver).

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -192,7 +192,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: enter PIV CAC visited', attributes)
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(type: 'piv_cac')
 
         submit_attributes = {

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -192,6 +192,9 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: enter PIV CAC visited', attributes)
 
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited)
+          .with(type: 'piv_cac')
+
         submit_attributes = {
           success: false,
           errors: { type: 'user.piv_cac_mismatch' },

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -192,8 +192,8 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         expect(@analytics).to receive(:track_event).
           with('Multi-Factor Authentication: enter PIV CAC visited', attributes)
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited)
-          .with(type: 'piv_cac')
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+          with(type: 'piv_cac')
 
         submit_attributes = {
           success: false,

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -97,6 +97,10 @@ describe TwoFactorAuthentication::TotpVerificationController do
           with('Multi-Factor Authentication: max attempts reached')
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: false)
+
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited)
+          .with(type: 'totp')
+
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -98,8 +98,8 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: false)
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited)
-          .with(type: 'totp')
+        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+          with(type: 'totp')
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -98,7 +98,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: false)
 
-        expect(@irs_attempts_api_tracker).to receive(:mfa_verify_rate_limited).
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(type: 'totp')
 
         expect(PushNotification::HttpPush).to receive(:deliver).


### PR DESCRIPTION
# Summary of changes
1. Added `mfa_enroll_rate_limited` attempt event.
2. Added `mfa_verify_rate_limited` attempt event. EDIT: now `mfa_login_rate_limited`
3. Added tests in various `two_factor_authentication` spec files for the above events.
4. Modified several functions starting with `handle_invalid_otp` in order to support the above events.

changelog: Internal, Attempts API, Track additional events