### PR TITLE
Add MultilineMethodCallIndentation cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -227,6 +227,10 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
 Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: true
   EnforcedStyle: symmetrical

--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -40,7 +40,7 @@ module Accounts
       end
 
       telephony_responses = MfaContext.new(current_user).
-                            phone_configurations.map do |phone_configuration|
+        phone_configurations.map do |phone_configuration|
         phone = phone_configuration.phone
         Telephony.send_personal_key_regeneration_notice(
           to: phone,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -321,10 +321,10 @@ class ApplicationController < ActionController::Base
     return prompt_to_setup_mfa unless two_factor_enabled?
     return prompt_to_verify_mfa unless user_fully_authenticated?
     return prompt_to_setup_mfa if service_provider_mfa_policy.
-                                  user_needs_sp_auth_method_setup?
+      user_needs_sp_auth_method_setup?
     return prompt_to_setup_non_restricted_mfa if two_factor_kantara_enabled?
     return prompt_to_verify_sp_required_mfa if service_provider_mfa_policy.
-                                               user_needs_sp_auth_method_verification?
+      user_needs_sp_auth_method_verification?
     enforce_total_session_duration_timeout
     true
   end

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -45,8 +45,9 @@ module UnconfirmedUserConcern
   end
 
   def email_confirmation_token_validator
-    @email_confirmation_token_validator ||= EmailConfirmationTokenValidator.
-      new(@email_address, current_user)
+    @email_confirmation_token_validator ||= begin
+      EmailConfirmationTokenValidator.new(@email_address, current_user)
+    end
   end
 
   def process_valid_confirmation_token

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -46,7 +46,7 @@ module UnconfirmedUserConcern
 
   def email_confirmation_token_validator
     @email_confirmation_token_validator ||= EmailConfirmationTokenValidator.
-                                            new(@email_address, current_user)
+      new(@email_address, current_user)
   end
 
   def process_valid_confirmation_token

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -45,9 +45,12 @@ module OpenidConnect
 
     def confirm_user_is_authenticated_with_fresh_mfa
       bump_auth_count unless user_fully_authenticated?
-      return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated? &&
-                                                                 service_provider_mfa_policy.
-                                                                   auth_method_confirms_to_sp_request?
+
+      unless user_fully_authenticated? && service_provider_mfa_policy.
+          auth_method_confirms_to_sp_request?
+        return confirm_two_factor_authenticated(request_id)
+      end
+
       redirect_to user_two_factor_authentication_url if device_not_remembered?
     end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -47,7 +47,7 @@ module OpenidConnect
       bump_auth_count unless user_fully_authenticated?
       return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated? &&
                                                                  service_provider_mfa_policy.
-                                                                 auth_method_confirms_to_sp_request?
+                                                                   auth_method_confirms_to_sp_request?
       redirect_to user_two_factor_authentication_url if device_not_remembered?
     end
 
@@ -82,7 +82,7 @@ module OpenidConnect
 
     def track_authorize_analytics(result)
       analytics_attributes = result.to_h.except(:redirect_uri).
-                             merge(user_fully_authenticated: user_fully_authenticated?)
+        merge(user_fully_authenticated: user_fully_authenticated?)
 
       analytics.openid_connect_request_authorization(**analytics_attributes)
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -85,7 +85,7 @@ class SamlIdpController < ApplicationController
     bump_auth_count unless user_fully_authenticated?
     return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated? &&
                                                                service_provider_mfa_policy.
-                                                               auth_method_confirms_to_sp_request?
+                                                                 auth_method_confirms_to_sp_request?
     redirect_to user_two_factor_authentication_url if remember_device_expired_for_sp?
   end
 

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -18,7 +18,7 @@ module Users
 
     def email_confirmation_token_validator
       @email_confirmation_token_validator ||= EmailConfirmationTokenValidator.
-                                              new(email_address, current_user)
+        new(email_address, current_user)
     end
 
     def email_address_already_confirmed?

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -17,8 +17,12 @@ module Users
     end
 
     def email_confirmation_token_validator
-      @email_confirmation_token_validator ||= EmailConfirmationTokenValidator.
-        new(email_address, current_user)
+      @email_confirmation_token_validator ||= begin
+        EmailConfirmationTokenValidator.new(
+          email_address,
+          current_user,
+        )
+      end
     end
 
     def email_address_already_confirmed?

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -99,7 +99,7 @@ class UserDecorator
 
   def recent_events
     events = Event.where(user_id: user.id).order('created_at DESC').limit(MAX_RECENT_EVENTS).
-             map(&:decorate)
+      map(&:decorate)
     (events + identity_events).sort_by(&:happened_at).reverse
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -69,7 +69,7 @@ class OpenidConnectTokenForm
     return if code.blank? || code.include?("\x00")
 
     @identity = ServiceProviderIdentity.where(session_uuid: code).
-                order(updated_at: :desc).first
+      order(updated_at: :desc).first
   end
 
   def pkce?

--- a/app/jobs/reports/doc_auth_drop_off_rates_per_sprint_report.rb
+++ b/app/jobs/reports/doc_auth_drop_off_rates_per_sprint_report.rb
@@ -33,7 +33,7 @@ module Reports
           start = date
           finish = date.next_day(14)
           ret << Db::DocAuthLog::BlanketDropOffRatesAllSpsInRange.new.
-                 call('Sprint', fmt(start), fmt(finish))
+            call('Sprint', fmt(start), fmt(finish))
           date = finish
         end
       end

--- a/app/jobs/reports/doc_auth_drop_off_rates_report.rb
+++ b/app/jobs/reports/doc_auth_drop_off_rates_report.rb
@@ -67,62 +67,62 @@ module Reports
 
     def overall_drop_off_rates_all_sps_all_time(ret)
       ret << Db::DocAuthLog::OverallDropOffRatesAllSpsAllTime.new.
-             call('Overall drop off rates for all SPs all time')
+        call('Overall drop off rates for all SPs all time')
     end
 
     def overall_drop_off_rates_all_sps_last_24_hours(ret)
       ret << Db::DocAuthLog::OverallDropOffRatesAllSpsInRange.new.
-             call('Overall drop off rates for all SPs last 24 hours', Date.yesterday, today)
+        call('Overall drop off rates for all SPs last 24 hours', Date.yesterday, today)
     end
 
     def overall_drop_off_rates_all_sps_last_30_days(ret)
       ret << Db::DocAuthLog::OverallDropOffRatesAllSpsInRange.new.
-             call('Overall drop off rates for all SPs last 30 days', today - 30.days, today)
+        call('Overall drop off rates for all SPs last 30 days', today - 30.days, today)
     end
 
     def blanket_drop_off_rates_all_sps_all_time(ret)
       ret << Db::DocAuthLog::BlanketDropOffRatesAllSpsAllTime.new.
-             call('Blanket drop off rates for all SPs all time')
+        call('Blanket drop off rates for all SPs all time')
     end
 
     def blanket_drop_off_rates_all_sps_last_24_hours(ret)
       ret << Db::DocAuthLog::BlanketDropOffRatesAllSpsInRange.new.
-             call('Blanket drop off rates for all SPs last 24 hours', Date.yesterday, today)
+        call('Blanket drop off rates for all SPs last 24 hours', Date.yesterday, today)
     end
 
     def blanket_drop_off_rates_all_sps_last_30_days(ret)
       ret << Db::DocAuthLog::BlanketDropOffRatesAllSpsInRange.new.
-             call('Blanket drop off rates for all SPs last 30 days', today - 30.days, today)
+        call('Blanket drop off rates for all SPs last 30 days', today - 30.days, today)
     end
 
     def blanket_drop_off_rates_per_sp_all_time(ret, sp)
       ret << Db::DocAuthLog::BlanketDropOffRatesPerSpAllTime.new.
-             call('Blanket drop off rates per SP all time', sp.issuer)
+        call('Blanket drop off rates per SP all time', sp.issuer)
     end
 
     def blanket_drop_off_rates_per_sp_last_24_hours(ret, sp)
       ret << Db::DocAuthLog::BlanketDropOffRatesPerSpInRange.new.
-             call('Blanket drop off rates last 24 hours', sp.issuer, Date.yesterday, today)
+        call('Blanket drop off rates last 24 hours', sp.issuer, Date.yesterday, today)
     end
 
     def blanket_drop_off_rates_per_sp_last_30_days(ret, sp)
       ret << Db::DocAuthLog::BlanketDropOffRatesPerSpInRange.new.
-             call('Blanket drop off rates last 30 days', sp.issuer, today - 30.days, today)
+        call('Blanket drop off rates last 30 days', sp.issuer, today - 30.days, today)
     end
 
     def overall_drop_off_rates_per_sp_all_time(ret, sp)
       ret << Db::DocAuthLog::OverallDropOffRatesPerSpAllTime.new.
-             call('Overall drop off rates per SP all time', sp.issuer)
+        call('Overall drop off rates per SP all time', sp.issuer)
     end
 
     def overall_drop_off_rates_per_sp_last_24_hours(ret, sp)
       ret << Db::DocAuthLog::OverallDropOffRatesPerSpInRange.new.
-             call('Overall drop off rates last 24 hours', sp.issuer, Date.yesterday, today)
+        call('Overall drop off rates last 24 hours', sp.issuer, Date.yesterday, today)
     end
 
     def overall_drop_off_rates_per_sp_last_30_days(ret, sp)
       ret << Db::DocAuthLog::OverallDropOffRatesPerSpInRange.new.
-             call('Overall drop off rates last 30 days', sp.issuer, today - 30.days, today)
+        call('Overall drop off rates last 30 days', sp.issuer, today - 30.days, today)
     end
 
     def today

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -24,11 +24,11 @@ class InPersonEnrollment < ApplicationRecord
   # Find enrollments that need a status check via the USPS API
   def self.needs_usps_status_check(check_interval)
     where(status: :pending).
-    and(
-      where(status_check_attempted_at: check_interval).
-      or(where(status_check_attempted_at: nil)),
-    ).
-    order(status_check_attempted_at: :asc)
+      and(
+        where(status_check_attempted_at: check_interval).
+        or(where(status_check_attempted_at: nil)),
+      ).
+      order(status_check_attempted_at: :asc)
   end
 
   # Does this enrollment need a status check via the USPS API?

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -22,9 +22,9 @@ module Idv
 
     def user_mail_events
       @user_mail_events ||= current_user.events.
-                            gpo_mail_sent.
-                            order('updated_at DESC').
-                            limit(MAX_MAIL_EVENTS)
+        gpo_mail_sent.
+        order('updated_at DESC').
+        limit(MAX_MAIL_EVENTS)
     end
 
     def max_events?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -33,7 +33,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   if auth.env['action_dispatch.cookies']
     expected_cookie_value = "#{user.class}-#{user.id}"
     actual_cookie_value = auth.env['action_dispatch.cookies'].
-                          signed[TwoFactorAuthenticatable::REMEMBER_2FA_COOKIE]
+      signed[TwoFactorAuthenticatable::REMEMBER_2FA_COOKIE]
     bypass_by_cookie = actual_cookie_value == expected_cookie_value
   end
 

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
 
     before do
       allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-      and_return(ff_enabled)
+        and_return(ff_enabled)
     end
 
     context 'ff is set' do

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -140,7 +140,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(:mfa_verify_backup_code, success: false)
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -172,7 +172,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           with(properties)
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -156,7 +156,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(properties)
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -211,7 +211,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         )
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -94,7 +94,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(attributes)
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_verify_totp, success: false)
         expect(PushNotification::HttpPush).to receive(:deliver).

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -151,8 +151,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           let(:view_context) { ActionController::Base.new.view_context }
           before do
             allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
-            to receive(:multiple_factors_enabled?).
-            and_return(true)
+              to receive(:multiple_factors_enabled?).
+              and_return(true)
           end
 
           it 'redirects to webauthn show page' do
@@ -175,8 +175,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         context 'User only has webauthn as an MFA method' do
           before do
             allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
-            to receive(:multiple_factors_enabled?).
-            and_return(false)
+              to receive(:multiple_factors_enabled?).
+              and_return(false)
           end
 
           it 'redirects to webauthn error page ' do

--- a/spec/controllers/users/additional_mfa_required_controller_spec.rb
+++ b/spec/controllers/users/additional_mfa_required_controller_spec.rb
@@ -28,7 +28,7 @@ describe Users::AdditionalMfaRequiredController do
     let(:enforcement_date) { Time.zone.today + 6.days }
     before do
       allow(IdentityConfig.store).to receive(:kantara_restriction_enforcement_date).
-      and_return(enforcement_date)
+        and_return(enforcement_date)
     end
 
     context 'before enforcement date' do
@@ -55,7 +55,7 @@ describe Users::AdditionalMfaRequiredController do
 
         user.reload
         expect(user.non_restricted_mfa_required_prompt_skip_date).
-        to eq Time.zone.today
+          to eq Time.zone.today
       end
 
       it 'does not allow unauthenticated users' do

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -14,9 +14,9 @@ describe Users::EmailConfirmationsController do
           )).ordered
 
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-            with(PushNotification::RecoveryInformationChangedEvent.new(
-              user: user,
-            )).ordered
+          with(PushNotification::RecoveryInformationChangedEvent.new(
+            user: user,
+          )).ordered
 
         add_email_form = AddUserEmailForm.new
         add_email_form.submit(user, email: new_email)

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Users::RulesOfUseController do
       it 'logs a failure analytics event' do
         stub_analytics
         expect(@analytics).to receive(:track_event).
-            with('Rules of Use Submitted', hash_including(success: false))
+          with('Rules of Use Submitted', hash_including(success: false))
 
         action
       end

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Users::ServiceProviderRevokeController do
           subject
         end
       end.to change { @identity.reload.deleted_at&.to_i }.
-      from(nil).to(now.to_i)
+        from(nil).to(now.to_i)
 
       expect(response).to redirect_to(account_connected_accounts_path)
     end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -107,8 +107,8 @@ describe Users::TwoFactorAuthenticationSetupController do
       stub_attempts_tracker
 
       expect(@irs_attempts_api_tracker).to receive(:track_event).
-      with(:mfa_enroll_options_selected, success: true,
-                                         mfa_device_types: ['voice', 'auth_app'])
+        with(:mfa_enroll_options_selected, success: true,
+                                           mfa_device_types: ['voice', 'auth_app'])
 
       patch :create, params: {
         two_factor_options_form: {

--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -55,8 +55,8 @@ feature 'Backup codes' do
       click_continue
 
       generated_at = user.backup_code_configurations.
-                     order(created_at: :asc).first.created_at.
-                     in_time_zone('UTC')
+        order(created_at: :asc).first.created_at.
+        in_time_zone('UTC')
       formatted_generated_at = l(generated_at, format: t('time.formats.event_timestamp'))
 
       expected_message = "#{t('account.index.backup_codes_exist')} #{formatted_generated_at}"

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -150,7 +150,7 @@ feature 'Multi Two Factor Authentication' do
 
     scenario 'redirects to the two_factor path with an error and phone option selected' do
       expect(page).
-      to have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+        to have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
       expect(
         URI.parse(current_url).path + '#' + URI.parse(current_url).fragment,
       ).to eq authentication_methods_setup_path(anchor: 'select_phone')
@@ -159,7 +159,7 @@ feature 'Multi Two Factor Authentication' do
     scenario 'clears the error when another mfa method is selected' do
       click_2fa_option('backup_code')
       expect(page).
-         to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+        to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
     end
 
     scenario 'clears the error when phone mfa method is unselected' do

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -54,9 +54,9 @@ describe DeleteUserEmailForm do
             email: email_address.email,
           )).ordered
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-            with(PushNotification::RecoveryInformationChangedEvent.new(
-              user: user,
-            )).ordered
+          with(PushNotification::RecoveryInformationChangedEvent.new(
+            user: user,
+          )).ordered
 
         submit
       end

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -13,12 +13,12 @@ describe Telephony::Pinpoint::VoiceSender do
 
   def mock_build_client
     allow(voice_sender).
-    to receive(:build_client).with(voice_config).and_return(pinpoint_client)
+      to receive(:build_client).with(voice_config).and_return(pinpoint_client)
   end
 
   def mock_build_backup_client
     allow(voice_sender).
-    to receive(:build_client).with(backup_voice_config).and_return(backup_pinpoint_client)
+      to receive(:build_client).with(backup_voice_config).and_return(backup_pinpoint_client)
   end
 
   describe '#send' do

--- a/spec/lib/telephony/telephony_spec.rb
+++ b/spec/lib/telephony/telephony_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Telephony do
 
       random_double_character = Telephony::GSM_DOUBLE_CHARACTERS.to_a.sample
       expect(Telephony.sms_character_length("abc\n¥ΔΦΓΛΩΠΨΣΘΞ#{random_double_character}")).
-             to eq 17
+        to eq 17
     end
 
     it 'calculates correct length of messages containing non-GSM characters' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe User do
     it { is_expected.to have_many(:in_person_enrollments).dependent(:destroy) }
     it {
       is_expected.to have_one(:pending_in_person_enrollment).
-      conditions(status: :pending).
-      order(created_at: :desc).
-      class_name('InPersonEnrollment').
-      with_foreign_key(:user_id).
-      inverse_of(:user).
-      dependent(:destroy)
+        conditions(status: :pending).
+        order(created_at: :desc).
+        class_name('InPersonEnrollment').
+        with_foreign_key(:user_id).
+        inverse_of(:user).
+        dependent(:destroy)
     }
   end
 

--- a/spec/presenters/additional_mfa_required_presenter_spec.rb
+++ b/spec/presenters/additional_mfa_required_presenter_spec.rb
@@ -87,7 +87,7 @@ describe AdditionalMfaRequiredPresenter do
 
         it 'should return false' do
           expect(presenter.cant_skip_anymore?).
-          to be_falsey
+            to be_falsey
         end
       end
 
@@ -100,7 +100,7 @@ describe AdditionalMfaRequiredPresenter do
 
         it 'should return true' do
           expect(presenter.cant_skip_anymore?).
-          to be_truthy
+            to be_truthy
         end
       end
     end

--- a/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe TwoFactorAuthentication::PhoneSelectionPresenter do
 
     it 'includes a note to select an additional mfa method on first setup' do
       expect(presenter_without_mfa.info).
-          to eq(t('two_factor_authentication.two_factor_choice_options.phone_info_html'))
+        to eq(t('two_factor_authentication.two_factor_choice_options.phone_info_html'))
     end
 
     it 'does not include a note to select an additional mfa on additional setup' do
       expect(presenter_with_mfa.info).
-          to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
+        to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
     end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -78,7 +78,7 @@ describe Analytics do
       }
 
       expect(ahoy).to receive(:track).
-          with('Trackable Event', analytics_hash.merge(request_attributes))
+        with('Trackable Event', analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event', { success: false })
     end

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -258,11 +258,11 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
     context 'when the result is a pass' do
       it 'sends the requests and returns success' do
         get_face_stub = stub_request(:get, get_face_image_url).
-                        to_return(body: AcuantFixtures.get_face_image_response)
+          to_return(body: AcuantFixtures.get_face_image_response)
         facial_match_stub = stub_request(:post, full_facial_match_url).
-                            to_return(body: AcuantFixtures.facial_match_response_success)
+          to_return(body: AcuantFixtures.facial_match_response_success)
         liveness_stub = stub_request(:post, full_liveness_url).
-                        to_return(body: AcuantFixtures.liveness_response_success)
+          to_return(body: AcuantFixtures.liveness_response_success)
 
         result = subject.post_selfie(
           instance_id: instance_id,

--- a/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe DocAuth::Acuant::Requests::FacialMatchRequest do
 
       it 'returns a successful response' do
         request_stub = stub_request(:post, url).
-                       with(body: request_body).
-                       to_return(body: response_body)
+          with(body: request_body).
+          to_return(body: response_body)
 
         response = described_class.new(
           config: config,
@@ -53,8 +53,8 @@ RSpec.describe DocAuth::Acuant::Requests::FacialMatchRequest do
 
       it 'returns an unsuccessful response' do
         request_stub = stub_request(:post, url).
-                       with(body: request_body).
-                       to_return(body: response_body)
+          with(body: request_body).
+          to_return(body: response_body)
 
         response = described_class.new(
           config: config,

--- a/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe DocAuth::Acuant::Requests::LivenessRequest do
 
       it 'returns a successful response' do
         request_stub = stub_request(:post, url).
-                       with(body: request_body).
-                       to_return(body: response_body)
+          with(body: request_body).
+          to_return(body: response_body)
 
         response = request.fetch
 
@@ -51,8 +51,8 @@ RSpec.describe DocAuth::Acuant::Requests::LivenessRequest do
 
       it 'returns an unsuccessful response' do
         request_stub = stub_request(:post, url).
-                       with(body: request_body).
-                       to_return(body: response_body)
+          with(body: request_body).
+          to_return(body: response_body)
 
         response = request.fetch
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe IdTokenBuilder do
 
     it 'sets the code hash correctly' do
       leftmost_128_bits = Digest::SHA256.digest(code).
-                          byteslice(0, IdTokenBuilder::NUM_BYTES_FIRST_128_BITS)
+        byteslice(0, IdTokenBuilder::NUM_BYTES_FIRST_128_BITS)
       expected_hash = Base64.urlsafe_encode64(leftmost_128_bits, padding: false)
 
       expect(decoded_payload[:c_hash]).to eq(expected_hash)

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -18,8 +18,8 @@ describe IdentityLinker do
       }
 
       identity_attributes = last_identity.attributes.symbolize_keys.
-                            except(:created_at, :updated_at, :id, :session_uuid,
-                                   :last_authenticated_at, :nonce)
+        except(:created_at, :updated_at, :id, :session_uuid,
+               :last_authenticated_at, :nonce)
 
       expect(last_identity.session_uuid).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)
       expect(last_identity.last_authenticated_at).to be_present

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
   before do
     encoded_public_key = Base64.strict_encode64(irs_attempt_api_public_key.to_der)
     allow(IdentityConfig.store).to receive(:irs_attempt_api_public_key).
-                                   and_return(encoded_public_key)
+      and_return(encoded_public_key)
   end
 
   let(:jti) { 'test-unique-id' }

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MarketingSite do
   describe '.rules_of_use_url' do
     it 'points to the rules of use page' do
       expect(MarketingSite.rules_of_use_url).
-          to eq('https://www.login.gov/policy/rules-of-use/')
+        to eq('https://www.login.gov/policy/rules-of-use/')
     end
 
     context 'when the user has set their locale to :es' do
@@ -58,7 +58,7 @@ RSpec.describe MarketingSite do
 
       it 'points to the rules of use page with the locale appended' do
         expect(MarketingSite.rules_of_use_url).
-            to eq('https://www.login.gov/es/policy/rules-of-use/')
+          to eq('https://www.login.gov/es/policy/rules-of-use/')
       end
     end
   end

--- a/spec/services/proofing/aamva/request/security_token_request_spec.rb
+++ b/spec/services/proofing/aamva/request/security_token_request_spec.rb
@@ -31,9 +31,9 @@ describe Proofing::Aamva::Request::SecurityTokenRequest do
       expect(signature.text).to_not be_empty
 
       body_without_sig = security_token_request.body.
-                         gsub(public_key.text, '').
-                         gsub(signature.text, '').
-                         gsub(key_identifier.text, '')
+        gsub(public_key.text, '').
+        gsub(signature.text, '').
+        gsub(key_identifier.text, '')
 
       expect(body_without_sig).to eq(AamvaFixtures.security_token_request)
     end

--- a/spec/support/shared_examples_for_email_validation.rb
+++ b/spec/support/shared_examples_for_email_validation.rb
@@ -1,7 +1,7 @@
 shared_examples 'email validation' do
   it 'uses the valid_email gem with mx and ban_disposable options' do
     email_validator = subject._validators.values.flatten.
-                      detect { |v| v.instance_of?(EmailValidator) }
+      detect { |v| v.instance_of?(EmailValidator) }
 
     expect(email_validator.options).
       to eq(mx_with_fallback: true, ban_disposable_email: true)


### PR DESCRIPTION
Enforce 'indented' style, and correct existing occurrences

**Why**: Currently multi-line method calls do not have to be indented at all, and where they are, some use 'indented' and some use 'aligned'. Let's standardize on one for cleaner code.

changelog: Internal, Rubocop, Enable MultilineMethodCallIndentation=indented