### PR TITLE
Add MultilineMethodCallIndentation cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -227,6 +227,10 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: aligned
+
 Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: true
   EnforcedStyle: symmetrical

--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -25,7 +25,7 @@ module Api
 
       def enqueue_job
         verify_document_capture_session = DocumentCaptureSession.
-          find_by(uuid: params[:document_capture_session_uuid])
+                                          find_by(uuid: params[:document_capture_session_uuid])
         verify_document_capture_session.requested_at = Time.zone.now
         verify_document_capture_session.create_doc_auth_session
 

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -24,8 +24,8 @@ module SamlIdpLogoutConcern
   def handle_valid_sp_remote_logout_request(user_id)
     # Remotely delete the user's current session
     session_id = ServiceProviderIdentity.
-      find_by(user_id: user_id, service_provider: saml_request.issuer).
-      rails_session_id
+                 find_by(user_id: user_id, service_provider: saml_request.issuer).
+                 rails_session_id
 
     OutOfBandSessionAccessor.new(session_id).destroy
     sign_out if user_signed_in?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,8 +28,8 @@ class EventsController < ApplicationController
     return if !device
 
     @events = Event.where(user_id: user_id, device_id: device.id).order(created_at: :desc).
-      limit(EVENTS_PAGE_SIZE).
-      map(&:decorate)
+              limit(EVENTS_PAGE_SIZE).
+              map(&:decorate)
     @device = device.decorate
   end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -109,7 +109,7 @@ class UserDecorator
 
   def recent_devices
     @recent_devices ||= user.devices.order(last_used_at: :desc).limit(MAX_RECENT_DEVICES).
-      map(&:decorate)
+                        map(&:decorate)
   end
 
   def devices?

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -233,15 +233,15 @@ module Idv
 
     def image_metadata
       @image_metadata ||= params.permit(:front_image_metadata, :back_image_metadata).
-        to_h.
-        transform_values do |str|
-          JSON.parse(str)
-        rescue JSON::ParserError
-          nil
-        end.
-        compact.
-        transform_keys { |key| key.gsub(/_image_metadata$/, '') }.
-        deep_symbolize_keys
+                          to_h.
+                          transform_values do |str|
+                            JSON.parse(str)
+      rescue JSON::ParserError
+        nil
+                          end.
+                          compact.
+                          transform_keys { |key| key.gsub(/_image_metadata$/, '') }.
+                          deep_symbolize_keys
     end
 
     def add_costs(response)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -24,7 +24,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     proofer = UspsInPersonProofing::Proofer.new
 
     reprocess_delay_minutes = IdentityConfig.store.
-      get_usps_proofing_results_job_reprocess_delay_minutes
+                              get_usps_proofing_results_job_reprocess_delay_minutes
     InPersonEnrollment.needs_usps_status_check(
       ...reprocess_delay_minutes.minutes.ago,
     ).each do |enrollment|

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -52,11 +52,11 @@ module Reports
       end
 
       by_issuer_iaa_issuer_year_months = by_issuer_results.
-        group_by { |r| r[:iaa] }.
-        transform_values do |iaa|
-          iaa.group_by { |r| r[:issuer] }.
-            transform_values { |issuer| issuer.group_by { |r| r[:year_month] } }
-        end
+                                         group_by { |r| r[:iaa] }.
+                                         transform_values do |iaa|
+        iaa.group_by { |r| r[:issuer] }.
+          transform_values { |issuer| issuer.group_by { |r| r[:year_month] } }
+      end
 
       # rubocop:disable Metrics/BlockLength
       CSV.generate do |csv|

--- a/app/models/backup_code_configuration.rb
+++ b/app/models/backup_code_configuration.rb
@@ -39,10 +39,10 @@ class BackupCodeConfiguration < ApplicationRecord
       code = RandomPhrase.normalize(code)
 
       user_salt_costs = select(:code_salt, :code_cost).
-        distinct.
-        where(user_id: user_id).
-        where.not(code_salt: nil).where.not(code_cost: nil).
-        pluck(:code_salt, :code_cost)
+                        distinct.
+                        where(user_id: user_id).
+                        where.not(code_salt: nil).where.not(code_cost: nil).
+                        pluck(:code_salt, :code_cost)
 
       salted_fingerprints = user_salt_costs.map do |salt, cost|
         scrypt_password_digest(password: code, salt: salt, cost: cost)

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -24,11 +24,11 @@ class InPersonEnrollment < ApplicationRecord
   # Find enrollments that need a status check via the USPS API
   def self.needs_usps_status_check(check_interval)
     where(status: :pending).
-    and(
-      where(status_check_attempted_at: check_interval).
-      or(where(status_check_attempted_at: nil)),
-    ).
-    order(status_check_attempted_at: :asc)
+      and(
+        where(status_check_attempted_at: check_interval).
+        or(where(status_check_attempted_at: nil)),
+      ).
+      order(status_check_attempted_at: :asc)
   end
 
   # Does this enrollment need a status check via the USPS API?

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -20,9 +20,9 @@ module Db
         iaa_range = (iaa_start_date..iaa_end_date)
 
         full_months, partial_months = Reports::MonthHelper.months(iaa_range).
-          partition do |month_range|
-            Reports::MonthHelper.full_month?(month_range)
-          end
+                                      partition do |month_range|
+          Reports::MonthHelper.full_month?(month_range)
+        end
 
         # The subqueries create a uniform representation of data:
         # - full months from monthly_sp_auth_counts

--- a/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
+++ b/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
@@ -16,9 +16,9 @@ module Db
         return [] if !date_range || issuers.blank?
 
         full_months, partial_months = Reports::MonthHelper.months(date_range).
-          partition do |month_range|
-            Reports::MonthHelper.full_month?(month_range)
-          end
+                                      partition do |month_range|
+          Reports::MonthHelper.full_month?(month_range)
+        end
 
         # The subqueries create a uniform representation of data:
         # - full months from monthly_sp_auth_counts

--- a/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
+++ b/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
@@ -15,8 +15,8 @@ module DocAuth
       alerts.keys.each do |key|
         alerts[key.to_sym].each do |alert|
           alert_name_key = alert[:name].
-            downcase.
-            parameterize(separator: '_').to_sym
+                           downcase.
+                           parameterize(separator: '_').to_sym
           side = alert[:side] || 'no_side'
 
           log_alert_results[alert_name_key] =

--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -47,7 +47,7 @@ module Proofing
       def aamva_proof(applicant, result)
         aamva_applicant = Aamva::Applicant.from_proofer_applicant(OpenStruct.new(applicant))
         response = Aamva::VerificationClient.new(config).
-          send_verification_request(applicant: aamva_applicant)
+                   send_verification_request(applicant: aamva_applicant)
         result.transaction_id = response.transaction_locator_id
         unless response.success?
           response.verification_results.each do |attribute, v_result|

--- a/app/services/uuid_reporter.rb
+++ b/app/services/uuid_reporter.rb
@@ -63,10 +63,10 @@ class UuidReporter
 
   def all_issuers_belong_to_same_agency?
     agency_count = Agency.
-      joins(:service_providers).
-      where(service_providers: { issuer: issuers }).
-      distinct.
-      count
+                   joins(:service_providers).
+                   where(service_providers: { issuer: issuers }).
+                   distinct.
+                   count
 
     return if agency_count == 1
 
@@ -101,11 +101,11 @@ class UuidReporter
     # advantage of the composite indexes and are highly non-performant.
     actual_user_ids = emails_to_user_ids.values.select(&:present?)
     user_ids_with_identities = ServiceProviderIdentity.
-      where(user_id: actual_user_ids, service_provider: issuers).
-      pluck(:user_id)
+                               where(user_id: actual_user_ids, service_provider: issuers).
+                               pluck(:user_id)
     agency_identities = AgencyIdentity.
-      select(:uuid, :user_id).
-      where(user_id: user_ids_with_identities, agency_id: agency.id)
+                        select(:uuid, :user_id).
+                        where(user_id: user_ids_with_identities, agency_id: agency.id)
 
     uuid_hash = agency_identities.map { |record| [record.user_id, record.uuid] }.to_h
     emails_to_user_ids.transform_values { |user_id| uuid_hash[user_id] }

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -156,7 +156,7 @@ class AnalyticsEventsDocumenter
     database.select do |_k, object|
       # this check will fail if the namespace is nested more than once
       method_object_name_parts = [object.namespace&.parent&.name, object.namespace&.name].
-        select { |part| part.present? && part != :root }
+                                 select { |part| part.present? && part != :root }
 
       object.type == :method && method_object_name_parts == class_name_parts
     end.values

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -390,6 +390,6 @@ class IdentityConfig
 
     @key_types = config.key_types
     @store = RedactedStruct.new('IdentityConfig', *config.written_env.keys, keyword_init: true).
-      new(**config.written_env)
+             new(**config.written_env)
   end
 end

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -45,9 +45,9 @@ class PinpointSupportedCountries
     country_dialing_codes = load_country_dialing_codes
 
     duplicate_iso = country_dialing_codes.
-      group_by(&:iso_code).
-      select { |iso, arr| arr.size > 1 }.
-      keys
+                    group_by(&:iso_code).
+                    select { |iso, arr| arr.size > 1 }.
+                    keys
 
     raise "error countries with duplicate iso codes: #{duplicate_iso}" if duplicate_iso.size > 0
 

--- a/lib/query_tracker.rb
+++ b/lib/query_tracker.rb
@@ -10,21 +10,21 @@ class QueryTracker
     queries = Hash.new { |h, k| h[k] = [] }
 
     subscriber = ActiveSupport::Notifications.
-      subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
-        sql = payload[:sql]
+                 subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
 
-        action = sql.split(' ').first.downcase.to_sym
-        tables = PgQuery.parse(sql).tables.map(&:to_sym)
+      action = sql.split(' ').first.downcase.to_sym
+      tables = PgQuery.parse(sql).tables.map(&:to_sym)
 
-        root = Rails.root.to_s
-        location = caller.find do |line|
-          line.include?(root) && Gem.path.none? { |v| line.include?(v) }
-        end
-
-        tables.each do |table|
-          queries[table] << [action, location]
-        end
+      root = Rails.root.to_s
+      location = caller.find do |line|
+        line.include?(root) && Gem.path.none? { |v| line.include?(v) }
       end
+
+      tables.each do |table|
+        queries[table] << [action, location]
+      end
+    end
 
     yield
 

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -155,8 +155,8 @@ def format_changelog(changelog_entries)
   changelog = ''
   CATEGORIES.each do |category|
     category_changes = changelog_entries.
-      filter { |(changelog_category, _change), _changes| changelog_category == category }.
-      sort_by { |(_category, change), _changes| change }
+                       filter { |(changelog_category, _change), _changes| changelog_category == category }.
+                       sort_by { |(_category, change), _changes| change }
 
     next if category_changes.empty?
     changelog.concat("## #{category}\n")

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
 
     before do
       allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-      and_return(ff_enabled)
+        and_return(ff_enabled)
     end
 
     context 'ff is set' do

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Idv::GpoVerifyController do
         action
 
         disavowal_event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
-          where.not(disavowal_token_fingerprint: nil).count
+                                where.not(disavowal_token_fingerprint: nil).count
         expect(disavowal_event_count).to eq 1
         expect(response).to redirect_to(sign_up_completed_url)
       end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -360,7 +360,7 @@ describe Idv::ReviewController do
         it 'creates an `account_verified` event once per confirmation' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
           disavowal_event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
-            where.not(disavowal_token_fingerprint: nil).count
+                                  where.not(disavowal_token_fingerprint: nil).count
           expect(disavowal_event_count).to eq 1
         end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -140,7 +140,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(:mfa_verify_backup_code, success: false)
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -172,7 +172,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           with(properties)
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -156,7 +156,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(properties)
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -211,7 +211,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         )
 
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -94,7 +94,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(attributes)
         expect(@analytics).to receive(:track_event).
-                          with('Multi-Factor Authentication: max attempts reached')
+          with('Multi-Factor Authentication: max attempts reached')
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_verify_totp, success: false)
         expect(PushNotification::HttpPush).to receive(:deliver).

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -151,8 +151,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           let(:view_context) { ActionController::Base.new.view_context }
           before do
             allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
-            to receive(:multiple_factors_enabled?).
-            and_return(true)
+              to receive(:multiple_factors_enabled?).
+              and_return(true)
           end
 
           it 'redirects to webauthn show page' do
@@ -175,8 +175,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         context 'User only has webauthn as an MFA method' do
           before do
             allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
-            to receive(:multiple_factors_enabled?).
-            and_return(false)
+              to receive(:multiple_factors_enabled?).
+              and_return(false)
           end
 
           it 'redirects to webauthn error page ' do

--- a/spec/controllers/users/additional_mfa_required_controller_spec.rb
+++ b/spec/controllers/users/additional_mfa_required_controller_spec.rb
@@ -28,7 +28,7 @@ describe Users::AdditionalMfaRequiredController do
     let(:enforcement_date) { Time.zone.today + 6.days }
     before do
       allow(IdentityConfig.store).to receive(:kantara_restriction_enforcement_date).
-      and_return(enforcement_date)
+        and_return(enforcement_date)
     end
 
     context 'before enforcement date' do
@@ -55,7 +55,7 @@ describe Users::AdditionalMfaRequiredController do
 
         user.reload
         expect(user.non_restricted_mfa_required_prompt_skip_date).
-        to eq Time.zone.today
+          to eq Time.zone.today
       end
 
       it 'does not allow unauthenticated users' do

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -14,9 +14,9 @@ describe Users::EmailConfirmationsController do
           )).ordered
 
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-            with(PushNotification::RecoveryInformationChangedEvent.new(
-              user: user,
-            )).ordered
+          with(PushNotification::RecoveryInformationChangedEvent.new(
+            user: user,
+          )).ordered
 
         add_email_form = AddUserEmailForm.new
         add_email_form.submit(user, email: new_email)

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Users::RulesOfUseController do
       it 'logs a failure analytics event' do
         stub_analytics
         expect(@analytics).to receive(:track_event).
-            with('Rules of Use Submitted', hash_including(success: false))
+          with('Rules of Use Submitted', hash_including(success: false))
 
         action
       end

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Users::ServiceProviderRevokeController do
           subject
         end
       end.to change { @identity.reload.deleted_at&.to_i }.
-      from(nil).to(now.to_i)
+        from(nil).to(now.to_i)
 
       expect(response).to redirect_to(account_connected_accounts_path)
     end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -107,8 +107,8 @@ describe Users::TwoFactorAuthenticationSetupController do
       stub_attempts_tracker
 
       expect(@irs_attempts_api_tracker).to receive(:track_event).
-      with(:mfa_enroll_options_selected, success: true,
-                                         mfa_device_types: ['voice', 'auth_app'])
+        with(:mfa_enroll_options_selected, success: true,
+                                           mfa_device_types: ['voice', 'auth_app'])
 
       patch :create, params: {
         two_factor_options_form: {

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'In Person Proofing', js: true do
     freeze_time do
       acknowledge_and_confirm_personal_key
       deadline = (Time.zone.now + IdentityConfig.store.in_person_enrollment_validity_in_days.days).
-        in_time_zone(Idv::InPerson::ReadyToVerifyPresenter::USPS_SERVER_TIMEZONE).
-        strftime(t('time.formats.event_date'))
+                 in_time_zone(Idv::InPerson::ReadyToVerifyPresenter::USPS_SERVER_TIMEZONE).
+                 strftime(t('time.formats.event_date'))
     end
 
     # ready to verify page

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -162,7 +162,7 @@ feature 'SAML logout' do
       send_saml_remote_logout_request(overrides: { sessionindex: agency_uuid })
 
       identity = ServiceProviderIdentity.
-        find_by(user_id: user.id, service_provider: saml_settings.issuer)
+                 find_by(user_id: user.id, service_provider: saml_settings.issuer)
       session_id = identity.rails_session_id
       expect(OutOfBandSessionAccessor.new(session_id).load).to be_empty
 

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -150,7 +150,7 @@ feature 'Multi Two Factor Authentication' do
 
     scenario 'redirects to the two_factor path with an error and phone option selected' do
       expect(page).
-      to have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+        to have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
       expect(
         URI.parse(current_url).path + '#' + URI.parse(current_url).fragment,
       ).to eq authentication_methods_setup_path(anchor: 'select_phone')
@@ -159,7 +159,7 @@ feature 'Multi Two Factor Authentication' do
     scenario 'clears the error when another mfa method is selected' do
       click_2fa_option('backup_code')
       expect(page).
-         to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
+        to_not have_content(t('errors.two_factor_auth_setup.must_select_additional_option'))
     end
 
     scenario 'clears the error when phone mfa method is unselected' do

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -54,9 +54,9 @@ describe DeleteUserEmailForm do
             email: email_address.email,
           )).ordered
         expect(PushNotification::HttpPush).to receive(:deliver).once.
-            with(PushNotification::RecoveryInformationChangedEvent.new(
-              user: user,
-            )).ordered
+          with(PushNotification::RecoveryInformationChangedEvent.new(
+            user: user,
+          )).ordered
 
         submit
       end

--- a/spec/jobs/risc_delivery_job_spec.rb
+++ b/spec/jobs/risc_delivery_job_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe RiscDeliveryJob do
 
     it 'POSTs the jwt to the given URL' do
       req = stub_request(:post, push_notification_url).
-        with(
-          body: jwt,
-          headers: {
-            'Content-Type' => 'application/secevent+jwt',
-            'Accept' => 'application/json',
-          },
-        )
+            with(
+              body: jwt,
+              headers: {
+                'Content-Type' => 'application/secevent+jwt',
+                'Accept' => 'application/json',
+              },
+            )
 
       perform
 

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -13,12 +13,12 @@ describe Telephony::Pinpoint::VoiceSender do
 
   def mock_build_client
     allow(voice_sender).
-    to receive(:build_client).with(voice_config).and_return(pinpoint_client)
+      to receive(:build_client).with(voice_config).and_return(pinpoint_client)
   end
 
   def mock_build_backup_client
     allow(voice_sender).
-    to receive(:build_client).with(backup_voice_config).and_return(backup_pinpoint_client)
+      to receive(:build_client).with(backup_voice_config).and_return(backup_pinpoint_client)
   end
 
   describe '#send' do

--- a/spec/lib/telephony/telephony_spec.rb
+++ b/spec/lib/telephony/telephony_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Telephony do
 
       random_double_character = Telephony::GSM_DOUBLE_CHARACTERS.to_a.sample
       expect(Telephony.sms_character_length("abc\n¥ΔΦΓΛΩΠΨΣΘΞ#{random_double_character}")).
-             to eq 17
+        to eq 17
     end
 
     it 'calculates correct length of messages containing non-GSM characters' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe User do
     it { is_expected.to have_many(:in_person_enrollments).dependent(:destroy) }
     it {
       is_expected.to have_one(:pending_in_person_enrollment).
-      conditions(status: :pending).
-      order(created_at: :desc).
-      class_name('InPersonEnrollment').
-      with_foreign_key(:user_id).
-      inverse_of(:user).
-      dependent(:destroy)
+        conditions(status: :pending).
+        order(created_at: :desc).
+        class_name('InPersonEnrollment').
+        with_foreign_key(:user_id).
+        inverse_of(:user).
+        dependent(:destroy)
     }
   end
 

--- a/spec/presenters/additional_mfa_required_presenter_spec.rb
+++ b/spec/presenters/additional_mfa_required_presenter_spec.rb
@@ -87,7 +87,7 @@ describe AdditionalMfaRequiredPresenter do
 
         it 'should return false' do
           expect(presenter.cant_skip_anymore?).
-          to be_falsey
+            to be_falsey
         end
       end
 
@@ -100,7 +100,7 @@ describe AdditionalMfaRequiredPresenter do
 
         it 'should return true' do
           expect(presenter.cant_skip_anymore?).
-          to be_truthy
+            to be_truthy
         end
       end
     end

--- a/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/phone_selection_presenter_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe TwoFactorAuthentication::PhoneSelectionPresenter do
 
     it 'includes a note to select an additional mfa method on first setup' do
       expect(presenter_without_mfa.info).
-          to eq(t('two_factor_authentication.two_factor_choice_options.phone_info_html'))
+        to eq(t('two_factor_authentication.two_factor_choice_options.phone_info_html'))
     end
 
     it 'does not include a note to select an additional mfa on additional setup' do
       expect(presenter_with_mfa.info).
-          to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
+        to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
     end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -78,7 +78,7 @@ describe Analytics do
       }
 
       expect(ahoy).to receive(:track).
-          with('Trackable Event', analytics_hash.merge(request_attributes))
+        with('Trackable Event', analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event', { success: false })
     end

--- a/spec/services/idv/inherited_proofing/va/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/service_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Idv::InheritedProofing::Va::Service do
       it 'makes an authenticated request' do
         freeze_time do
           stub = stub_request(:get, request_uri).
-            with(headers: request_headers).
-            to_return(status: 200, body: '{}', headers: {})
+                 with(headers: request_headers).
+                 to_return(status: 200, body: '{}', headers: {})
 
           service.execute
 

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
   before do
     encoded_public_key = Base64.strict_encode64(irs_attempt_api_public_key.to_der)
     allow(IdentityConfig.store).to receive(:irs_attempt_api_public_key).
-                                   and_return(encoded_public_key)
+      and_return(encoded_public_key)
   end
 
   let(:jti) { 'test-unique-id' }

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MarketingSite do
   describe '.rules_of_use_url' do
     it 'points to the rules of use page' do
       expect(MarketingSite.rules_of_use_url).
-          to eq('https://www.login.gov/policy/rules-of-use/')
+        to eq('https://www.login.gov/policy/rules-of-use/')
     end
 
     context 'when the user has set their locale to :es' do
@@ -58,7 +58,7 @@ RSpec.describe MarketingSite do
 
       it 'points to the rules of use page with the locale appended' do
         expect(MarketingSite.rules_of_use_url).
-            to eq('https://www.login.gov/es/policy/rules-of-use/')
+          to eq('https://www.login.gov/es/policy/rules-of-use/')
       end
     end
   end

--- a/spec/services/proofing/aamva/verification_client_spec.rb
+++ b/spec/services/proofing/aamva/verification_client_spec.rb
@@ -25,10 +25,10 @@ describe Proofing::Aamva::VerificationClient do
       allow(Proofing::Aamva::AuthenticationClient).to receive(:new).and_return(auth_client)
 
       verification_stub = stub_request(:post, AamvaFixtures.example_config.verification_url).
-        to_return(body: AamvaFixtures.verification_response, status: 200).
-        with do |request|
-          xml_text_at_path(request.body, '//ns:token').gsub(/\s/, '') == 'ThisIsTheToken'
-        end
+                          to_return(body: AamvaFixtures.verification_response, status: 200).
+                          with do |request|
+        xml_text_at_path(request.body, '//ns:token').gsub(/\s/, '') == 'ThisIsTheToken'
+      end
 
       verification_client.send_verification_request(
         applicant: applicant,

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -40,8 +40,8 @@ describe Proofing::LexisNexis::Ddp::Proofer do
     context 'when the request is made' do
       it 'it looks like the right request' do
         request = stub_request(:post, verification_request.url).
-          with(body: verification_request.body, headers: verification_request.headers).
-          to_return(body: LexisNexisFixtures.ddp_success_response_json, status: 200)
+                  with(body: verification_request.body, headers: verification_request.headers).
+                  to_return(body: LexisNexisFixtures.ddp_success_response_json, status: 200)
 
         verification_request.send
 

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
@@ -40,8 +40,8 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
     context 'when the request is made' do
       it 'it looks like the right request' do
         request = stub_request(:post, verification_request.url).
-          with(body: verification_request.body, headers: verification_request.headers).
-          to_return(body: LexisNexisFixtures.instant_verify_success_response_json, status: 200)
+                  with(body: verification_request.body, headers: verification_request.headers).
+                  to_return(body: LexisNexisFixtures.instant_verify_success_response_json, status: 200)
 
         verification_request.send
 

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -21,8 +21,8 @@ class SimplecovHelper
         #  This is not necessarily folder name friendly, so non-alphabetic/numeric characters are
         #  removed.
         job_name = ENV['CI_JOB_NAME'].downcase.
-          gsub(/[^a-z0-9]/, '-')[0..62].
-          gsub(/(\A-+|-+\z)/, '')
+                   gsub(/[^a-z0-9]/, '-')[0..62].
+                   gsub(/(\A-+|-+\z)/, '')
         command_name job_name
         coverage_dir "coverage/#{job_name}"
       end

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -9,7 +9,7 @@ shared_examples 'remember device' do
     user = remember_device_and_sign_out_user
 
     days_to_travel = (IdentityConfig.store.remember_device_expiration_hours_aal_1 + 1).
-      hours.from_now
+                     hours.from_now
     travel_to(days_to_travel)
     sign_in_user(user)
 


### PR DESCRIPTION
Enforce 'aligned' style, and correct existing occurrences

changelog: Internal, Rubocop, Enable MultilineMethodCallIndentation=aligned

*NB*: There is an alternative to this using [indented](https://github.com/18F/identity-idp/pull/6786) which I personally think works better, but I'm sharing this option for visibility.