### PR TITLE
Fix FrontendLogController payload splatting

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -25,7 +25,7 @@ class FrontendLogController < ApplicationController
 
   def create
     event = log_params[:event]
-    payload = log_params[:payload].to_h
+    payload = log_params[:payload].to_h.symbolize_keys
     if (analytics_method = EVENT_MAP[event])
       if analytics_method.is_a?(Proc)
         analytics_method.call(analytics, **payload)

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -25,7 +25,7 @@ class FrontendLogController < ApplicationController
 
   def create
     event = log_params[:event]
-    payload = log_params[:payload].to_h.symbolize_keys
+    payload = log_params[:payload].to_h
     if (analytics_method = EVENT_MAP[event])
       if analytics_method.is_a?(Proc)
         analytics_method.call(analytics, **payload)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -467,8 +467,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] field the name of the field which was clicked
-  # @param [Number] failed_attempts the number of failed document capture attempts so far
   # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
   # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
   # camera, on mobile devices.

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -472,11 +472,9 @@ module AnalyticsEvents
   # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
   # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
   # camera, on mobile devices.
-  def idv_native_camera_forced(field:, failed_attempts:, **extra)
+  def idv_native_camera_forced(**extra)
     track_event(
       'IdV: Native camera forced after failed attempts',
-      field: field,
-      failed_attempts: failed_attempts,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -467,15 +467,15 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] name the name to prepend to analytics events
+  # @param [String] field the name of the field which was clicked
   # @param [Number] failed_attempts the number of failed document capture attempts so far
   # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
   # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
   # camera, on mobile devices.
-  def idv_native_camera_forced(name:, failed_attempts:, **extra)
+  def idv_native_camera_forced(field:, failed_attempts:, **extra)
     track_event(
       'IdV: Native camera forced after failed attempts',
-      name: name,
+      field: field,
       failed_attempts: failed_attempts,
       **extra,
     )

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -19,7 +19,7 @@ describe FrontendLogController do
 
       it 'succeeds' do
         expect(fake_analytics).to receive(:track_event).
-          with("Frontend: #{event}", payload.symbolize_keys)
+          with("Frontend: #{event}", payload)
 
         action
 
@@ -121,8 +121,7 @@ describe FrontendLogController do
 
         it 'logs the analytics event without the prefix' do
           expect(fake_analytics).to receive(:track_event).with(
-            'IdV: Native camera forced after failed attempts',
-            payload.symbolize_keys,
+            'IdV: Native camera forced after failed attempts', payload
           )
 
           action
@@ -156,10 +155,7 @@ describe FrontendLogController do
       end
 
       it 'succeeds' do
-        expect(fake_analytics).to receive(:track_event).with(
-          "Frontend: #{event}",
-          payload.symbolize_keys,
-        )
+        expect(fake_analytics).to receive(:track_event).with("Frontend: #{event}", payload)
 
         action
 

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -7,8 +7,8 @@ describe FrontendLogController do
     let(:fake_analytics) { FakeAnalytics.new }
     let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
     let(:event) { 'Custom Event' }
-    let(:payload) { { message: 'To be logged...' } }
-    let(:params) { { event: event, payload: payload } }
+    let(:payload) { { 'message' => 'To be logged...' } }
+    let(:params) { { 'event' => event, 'payload' => payload } }
     let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
     context 'user is signed in' do
@@ -92,7 +92,7 @@ describe FrontendLogController do
         it 'rejects a request without specifying event' do
           expect(fake_analytics).not_to receive(:track_event)
 
-          params.delete(:event)
+          params.delete('event')
           action
 
           expect(response).to have_http_status(:bad_request)
@@ -102,11 +102,32 @@ describe FrontendLogController do
         it 'rejects a request without specifying payload' do
           expect(fake_analytics).not_to receive(:track_event)
 
-          params.delete(:payload)
+          params.delete('payload')
           action
 
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
+        end
+      end
+
+      context 'for a named analytics method' do
+        let(:params) do
+          {
+            'event' => 'IdV: Native camera forced after failed attempts',
+            'payload' => { 'name' => 'front', 'failed_attempts' => 0 },
+          }
+        end
+
+        it 'logs the analytics event appropriatly' do
+          expect(fake_analytics).to receive(:track_event).with(
+            'Frontend: IdV: Native camera forced after failed attempts',
+            payload.symbolize_keys,
+          )
+
+          action
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:success]).to eq(true)
         end
       end
     end

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -19,7 +19,7 @@ describe FrontendLogController do
 
       it 'succeeds' do
         expect(fake_analytics).to receive(:track_event).
-          with("Frontend: #{event}", payload)
+          with("Frontend: #{event}", payload.symbolize_keys)
 
         action
 
@@ -111,16 +111,17 @@ describe FrontendLogController do
       end
 
       context 'for a named analytics method' do
+        let(:payload) { { 'field' => 'front', 'failed_attempts' => 0 } }
         let(:params) do
           {
             'event' => 'IdV: Native camera forced after failed attempts',
-            'payload' => { 'name' => 'front', 'failed_attempts' => 0 },
+            'payload' => payload,
           }
         end
 
-        it 'logs the analytics event appropriatly' do
+        it 'logs the analytics event without the prefix' do
           expect(fake_analytics).to receive(:track_event).with(
-            'Frontend: IdV: Native camera forced after failed attempts',
+            'IdV: Native camera forced after failed attempts',
             payload.symbolize_keys,
           )
 
@@ -155,7 +156,10 @@ describe FrontendLogController do
       end
 
       it 'succeeds' do
-        expect(fake_analytics).to receive(:track_event).with("Frontend: #{event}", payload)
+        expect(fake_analytics).to receive(:track_event).with(
+          "Frontend: #{event}",
+          payload.symbolize_keys,
+        )
 
         action
 

--- a/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -119,7 +119,7 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
      */
     it('calls analytics with native camera message when failed attempts is greater than or equal to 0', async function () {
       const addPageAction = sinon.spy();
-      const acuantCaptureComponent = <AcuantCapture />;
+      const acuantCaptureComponent = <AcuantCapture name="example" />;
       function TestComponent({ children }) {
         return (
           <AnalyticsContext.Provider value={{ addPageAction }}>
@@ -142,6 +142,7 @@ describe('maxAttemptsBeforeNativeCamera logging tests', () => {
       expect(addPageAction).to.have.been.called();
       expect(addPageAction).to.have.been.calledWith(
         'IdV: Native camera forced after failed attempts',
+        { field: 'example', failed_attempts: 0 },
       );
     });
 


### PR DESCRIPTION
**Why:** Payload would be parsed with string keys, which are incompatible with method kwargs expecting symbols.

See discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1660837978230519