### PR TITLE
LG-7303 - send IP address to TMX, LG-7304 - send app_id to TMX

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -13,7 +13,8 @@ class ResolutionProofingJob < ApplicationJob
   )
 
   def perform(result_id:, encrypted_arguments:, trace_id:, should_proof_state_id:,
-              dob_year_only:, user_id: nil, threatmetrix_session_id: nil)
+              dob_year_only:, user_id: nil, threatmetrix_session_id: nil,
+              uuid_prefix: nil, request_ip: nil)
     timer = JobHelpers::Timer.new
 
     raise_stale_job! if stale_job?(enqueued_at)
@@ -25,10 +26,14 @@ class ResolutionProofingJob < ApplicationJob
 
     applicant_pii = decrypted_args[:applicant_pii]
 
+    user = User.find_by(id: user_id)
+
     optional_threatmetrix_result = proof_lexisnexis_ddp_with_threatmetrix_if_needed(
-      applicant_pii,
-      user_id,
-      threatmetrix_session_id,
+      { applicant_pii: applicant_pii,
+        user: user,
+        threatmetrix_session_id: threatmetrix_session_id,
+        request_ip: request_ip,
+        uuid_prefix: uuid_prefix },
     )
 
     callback_log_data = if dob_year_only && should_proof_state_id
@@ -84,29 +89,25 @@ class ResolutionProofingJob < ApplicationJob
     callback_log_data_result[:threatmetrix_request_id] = threatmetrix_result.transaction_id
   end
 
-  def proof_lexisnexis_ddp_with_threatmetrix_if_needed(
-    applicant_pii,
-    user_id,
-    threatmetrix_session_id
-  )
+  def proof_lexisnexis_ddp_with_threatmetrix_if_needed(args)
     return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
 
     # The API call will fail without a session ID, so do not attempt to make
     # it to avoid leaking data when not required.
-    return if threatmetrix_session_id.blank?
+    return if args[:threatmetrix_session_id].blank?
 
-    return unless applicant_pii
+    return unless args[:applicant_pii]
 
-    user = User.find_by(id: user_id)
-
-    ddp_pii = applicant_pii.dup
-    ddp_pii[:threatmetrix_session_id] = threatmetrix_session_id
-    ddp_pii[:email] = user&.confirmed_email_addresses&.first&.email
+    ddp_pii = args[:applicant_pii].dup
+    ddp_pii[:threatmetrix_session_id] = args[:threatmetrix_session_id]
+    ddp_pii[:email] = args[:user]&.confirmed_email_addresses&.first&.email
+    ddp_pii[:input_ip_address] = args[:request_ip]
+    ddp_pii[:local_attrib_1] = args[:uuid_prefix]
 
     result = lexisnexis_ddp_proofer.proof(ddp_pii)
 
-    log_threatmetrix_info(result, user)
-    add_threatmetrix_proofing_component(user_id, result)
+    log_threatmetrix_info(result, args[:user])
+    add_threatmetrix_proofing_component(args[:user].id, result)
 
     result
   end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -14,7 +14,9 @@ module Proofing
                             :address1,
                             :city,
                             :state,
-                            :zipcode
+                            :zipcode,
+                            :request_ip,
+                            :uuid_prefix
 
         optional_attributes :address2, :phone, :email
 

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -27,6 +27,8 @@ module Proofing
             service_type: 'all',
             session_id: applicant[:threatmetrix_session_id],
             ssn_hash: OpenSSL::Digest::SHA256.hexdigest(applicant[:ssn].gsub(/\D/, '')),
+            input_ip_address: applicant[:request_ip],
+            local_attrib_1: applicant[:uuid_prefix],
           }.to_json
         end
 

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -17,5 +17,8 @@
   "policy": "test-policy",
   "service_type": "all",
   "session_id": "UNIQUE_SESSION_ID",
-  "ssn_hash": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225"
+  "ssn_hash": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+  "input_ip_address": "127.0.0.1",
+  "local_attrib_1": "ABCD"
+
 }

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:user) { create(:user, :signed_up) }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:threatmetrix_request_id) { Proofing::Mock::DdpMockClient::TRANSACTION_ID }
+  let(:request_ip) { '127.0.0.1' }
+  let(:uuid_prefix) { 'ABC' }
 
   describe '.perform_later' do
     it 'stores results' do
@@ -53,6 +55,8 @@ RSpec.describe ResolutionProofingJob, type: :job do
         trace_id: trace_id,
         user_id: user.id,
         threatmetrix_session_id: threatmetrix_session_id,
+        request_ip: request_ip,
+        uuid_prefix: uuid_prefix,
       )
 
       result = document_capture_session.load_proofing_result[:result]
@@ -72,6 +76,8 @@ RSpec.describe ResolutionProofingJob, type: :job do
         trace_id: trace_id,
         user_id: user.id,
         threatmetrix_session_id: threatmetrix_session_id,
+        request_ip: request_ip,
+        uuid_prefix: uuid_prefix,
       )
     end
 

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -16,6 +16,8 @@ describe Proofing::LexisNexis::Ddp::Proofer do
       threatmetrix_session_id: '123456',
       phone: '5551231234',
       email: 'test@example.com',
+      request_ip: '127.0.0.1',
+      uuid_prefix: 'ABCD',
     }
   end
   let(:verification_request) do

--- a/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
@@ -17,6 +17,8 @@ describe Proofing::LexisNexis::Ddp::VerificationRequest do
       threatmetrix_session_id: 'UNIQUE_SESSION_ID',
       phone: '5551231234',
       email: 'test@example.com',
+      request_ip: '127.0.0.1',
+      uuid_prefix: 'ABCD',
     }
   end
 


### PR DESCRIPTION
LG-7303 - send IP address to TMX, LG-7304 - send app_id to TMX

changelog: Internal, DDP Proofer, send ip_address and app_id to API