### PR TITLE
LG-7307: Remove ThreatMetrix from In-Person Proofing flow

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -46,7 +46,10 @@ class ResolutionProofingJob < ApplicationJob
                         end
 
     if optional_threatmetrix_result.present?
-      add_threatmetrix_result_to_callback_result(callback_log_data.result, optional_threatmetrix_result)
+      add_threatmetrix_result_to_callback_result(
+        callback_log_data.result,
+        optional_threatmetrix_result,
+      )
     end
 
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
@@ -81,7 +84,11 @@ class ResolutionProofingJob < ApplicationJob
     callback_log_data_result[:threatmetrix_request_id] = threatmetrix_result.transaction_id
   end
 
-  def proof_lexisnexis_ddp_with_threatmetrix_if_needed(applicant_pii, user_id, threatmetrix_session_id)
+  def proof_lexisnexis_ddp_with_threatmetrix_if_needed(
+    applicant_pii,
+    user_id,
+    threatmetrix_session_id
+  )
     return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
 
     # The API call will fail without a session ID, so do not attempt to make

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -45,7 +45,7 @@ class ResolutionProofingJob < ApplicationJob
                           )
                         end
 
-    unless optional_threatmetrix_result.nil?
+    if optional_threatmetrix_result.present?
       add_threatmetrix_result_to_callback_result(callback_log_data.result, optional_threatmetrix_result)
     end
 

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -25,14 +25,11 @@ class ResolutionProofingJob < ApplicationJob
 
     applicant_pii = decrypted_args[:applicant_pii]
 
-    threatmetrix_result = nil
-    if use_lexisnexis_ddp_threatmetrix_before_rdp_instant_verify?
-      user = User.find_by(id: user_id)
-      threatmetrix_result = proof_lexisnexis_ddp_with_threatmetrix(
-        applicant_pii, user, threatmetrix_session_id
-      )
-      log_threatmetrix_info(threatmetrix_result, user)
-    end
+    optional_threatmetrix_result = proof_lexisnexis_ddp_with_threatmetrix_if_needed(
+      applicant_pii,
+      user_id,
+      threatmetrix_session_id,
+    )
 
     callback_log_data = if dob_year_only && should_proof_state_id
                           proof_aamva_then_lexisnexis_dob_only(
@@ -48,8 +45,8 @@ class ResolutionProofingJob < ApplicationJob
                           )
                         end
 
-    if use_lexisnexis_ddp_threatmetrix_before_rdp_instant_verify?
-      add_threatmetrix_result_to_callback_result(callback_log_data.result, threatmetrix_result)
+    unless optional_threatmetrix_result.nil?
+      add_threatmetrix_result_to_callback_result(callback_log_data.result, optional_threatmetrix_result)
     end
 
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)
@@ -84,12 +81,26 @@ class ResolutionProofingJob < ApplicationJob
     callback_log_data_result[:threatmetrix_request_id] = threatmetrix_result.transaction_id
   end
 
-  def proof_lexisnexis_ddp_with_threatmetrix(applicant_pii, user, threatmetrix_session_id)
+  def proof_lexisnexis_ddp_with_threatmetrix_if_needed(applicant_pii, user_id, threatmetrix_session_id)
+    return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
+
+    # The API call will fail without a session ID, so do not attempt to make
+    # it to avoid leaking data when not required.
+    return if threatmetrix_session_id.blank?
+
     return unless applicant_pii
+
+    user = User.find_by(id: user_id)
+
     ddp_pii = applicant_pii.dup
     ddp_pii[:threatmetrix_session_id] = threatmetrix_session_id
     ddp_pii[:email] = user&.confirmed_email_addresses&.first&.email
-    lexisnexis_ddp_proofer.proof(ddp_pii)
+
+    result = lexisnexis_ddp_proofer.proof(ddp_pii)
+
+    log_threatmetrix_info(result, user)
+
+    result
   end
 
   # @return [CallbackLogData]
@@ -267,9 +278,5 @@ class ResolutionProofingJob < ApplicationJob
           verification_url: IdentityConfig.store.aamva_verification_url,
         )
       end
-  end
-
-  def use_lexisnexis_ddp_threatmetrix_before_rdp_instant_verify?
-    IdentityConfig.store.lexisnexis_threatmetrix_enabled
   end
 end

--- a/app/services/idv/steps/ipp/ssn_step.rb
+++ b/app/services/idv/steps/ipp/ssn_step.rb
@@ -13,7 +13,6 @@ module Idv
         def extra_view_variables
           {
             updating_ssn: updating_ssn,
-            threatmetrix_session_id: generate_threatmetrix_session_id,
           }
         end
 
@@ -25,13 +24,6 @@ module Idv
 
         def updating_ssn
           flow_session.dig(:pii_from_user, :ssn).present?
-        end
-
-        def generate_threatmetrix_session_id
-          return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
-
-          flow_session[:threatmetrix_session_id] = SecureRandom.uuid if !updating_ssn
-          flow_session[:threatmetrix_session_id]
         end
       end
     end

--- a/app/views/idv/in_person/ssn.html.erb
+++ b/app/views/idv/in_person/ssn.html.erb
@@ -1,1 +1,1 @@
-<%= render 'idv/shared/ssn', flow_session: flow_session, success_alert_enabled: false, updating_ssn: updating_ssn, threatmetrix_session_id: threatmetrix_session_id %>
+<%= render 'idv/shared/ssn', flow_session: flow_session, success_alert_enabled: false, updating_ssn: updating_ssn %>

--- a/app/views/idv/shared/_ssn.html.erb
+++ b/app/views/idv/shared/_ssn.html.erb
@@ -30,11 +30,13 @@ locals:
 
 <% if IdentityConfig.store.proofing_device_profiling_collecting_enabled %>
   <% unless IdentityConfig.store.lexisnexis_threatmetrix_org_id.empty? %>
-    <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{flow_session[:threatmetrix_session_id]}", nonce: true %>
-    <noscript>
-      <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">
-      </iframe>
-    </noscript>
+    <% unless flow_session[:threatmetrix_session_id].nil? %>
+      <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{flow_session[:threatmetrix_session_id]}", nonce: true %>
+      <noscript>
+        <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">
+        </iframe>
+      </noscript>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/idv/shared/_ssn.html.erb
+++ b/app/views/idv/shared/_ssn.html.erb
@@ -30,7 +30,7 @@ locals:
 
 <% if IdentityConfig.store.proofing_device_profiling_collecting_enabled %>
   <% unless IdentityConfig.store.lexisnexis_threatmetrix_org_id.empty? %>
-    <% unless flow_session[:threatmetrix_session_id].nil? %>
+    <% if flow_session[:threatmetrix_session_id].present? %>
       <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{flow_session[:threatmetrix_session_id]}", nonce: true %>
       <noscript>
         <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -236,6 +236,15 @@ RSpec.describe ResolutionProofingJob, type: :job do
           )
         end
       end
+
+      context 'no threatmetrix_session_id' do
+        let(:threatmetrix_session_id) { nil }
+        it 'does not attempt to create a ddp proofer' do
+          perform
+
+          expect(instance).not_to receive(:lexisnexis_ddp_proofer)
+        end
+      end
     end
 
     context 'stubbing vendors' do

--- a/spec/services/idv/steps/ipp/ssn_step_spec.rb
+++ b/spec/services/idv/steps/ipp/ssn_step_spec.rb
@@ -46,13 +46,13 @@ describe Idv::Steps::Ipp::SsnStep do
     end
 
     context 'with proofing device profiling collecting enabled' do
-      it 'adds a session id to flow session' do
+      it 'does not add a threatmetrix session id to flow session' do
         allow(IdentityConfig.store).
           to receive(:proofing_device_profiling_collecting_enabled).
           and_return(true)
         step.extra_view_variables
 
-        expect(flow.flow_session[:threatmetrix_session_id]).to_not eq(nil)
+        expect(flow.flow_session[:threatmetrix_session_id]).to eq(nil)
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do

--- a/spec/views/idv/shared/_ssn.html.erb_spec.rb
+++ b/spec/views/idv/shared/_ssn.html.erb_spec.rb
@@ -51,6 +51,17 @@ describe 'idv/shared/_ssn.html.erb' do
             expect_noscript_tag_rendered
           end
         end
+
+        context 'session id not specified' do
+          let(:session_id) { nil }
+
+          it 'does not render <script> tag' do
+            expect_script_tag_not_rendered
+          end
+          it 'does not render <noscript> tag' do
+            expect_noscript_tag_not_rendered
+          end
+        end
       end
     end
 


### PR DESCRIPTION
To limit scope of ThreatMetrix implementation, this PR removes it from the in-person flow. It also updates the LexisNexis DDP proofer logic to _not_ make an API call if a `threatmetrix_session_id` is not present in `flow_session` (these API calls would fail anyway, so this way we avoid sending data to LN unnecessarily).