### PR TITLE
Enable subresource integrity for JavaScript packs

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -23,7 +23,13 @@ module ScriptHelper
         [
           javascript_assets_tag(*@scripts),
           javascript_polyfill_pack_tag,
-          javascript_include_tag(*sources, crossorigin: local_crossorigin_sources? ? true : nil),
+          *sources.map do |source|
+            javascript_include_tag(
+              source,
+              crossorigin: local_crossorigin_sources? ? true : nil,
+              integrity: AssetSources.get_integrity(source),
+            )
+          end,
         ],
       )
     end

--- a/lib/asset_sources.rb
+++ b/lib/asset_sources.rb
@@ -30,6 +30,8 @@ class AssetSources
     end
 
     def get_integrity(path)
+      load_manifest_if_needed
+
       manifest&.dig('integrity', path)
     end
 

--- a/lib/asset_sources.rb
+++ b/lib/asset_sources.rb
@@ -9,7 +9,7 @@ class AssetSources
       # See: app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
       regexp_locale_suffix = %r{\.(#{I18n.available_locales.join('|')})\.js$}
 
-      load_manifest if !manifest || !cache_manifest
+      load_manifest_if_needed
 
       locale_sources, sources = names.flat_map do |name|
         manifest&.dig('entrypoints', name, 'assets', 'js')
@@ -22,11 +22,15 @@ class AssetSources
     end
 
     def get_assets(*names)
-      load_manifest if !manifest || !cache_manifest
+      load_manifest_if_needed
 
       names.flat_map do |name|
         manifest&.dig('entrypoints', name, 'assets')&.except('js')&.values&.flatten
       end.uniq.compact
+    end
+
+    def get_integrity(path)
+      manifest&.dig('integrity', path)
     end
 
     def load_manifest
@@ -35,6 +39,12 @@ class AssetSources
       rescue JSON::ParserError, Errno::ENOENT
         nil
       end
+    end
+
+    private
+
+    def load_manifest_if_needed
+      load_manifest if !manifest || !cache_manifest
     end
   end
 end

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe ScriptHelper do
         )
       end
 
+      context 'with script integrity available' do
+        before do
+          allow(AssetSources).to receive(:get_integrity).and_return(nil)
+          allow(AssetSources).to receive(:get_integrity).with('/application.js').
+            and_return('sha256-aztp/wpATyjXXpigZtP8ZP/9mUCHDMaL7OKFRbmnUIazQ9ehNmg4CD5Ljzym/TyA')
+        end
+
+        it 'adds integrity attribute' do
+          output = render_javascript_pack_once_tags
+
+          expect(output).to have_css(
+            "script[src^='/polyfill.js']:not([integrity]) ~ \
+            script[src^='/application.js'][integrity^='sha256-']",
+            count: 1,
+            visible: :all,
+          )
+        end
+      end
+
       context 'local development crossorigin sources' do
         let(:webpack_port) { '3035' }
 

--- a/spec/lib/asset_sources_spec.rb
+++ b/spec/lib/asset_sources_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe AssetSources do
               ]
             }
           }
+        },
+        "integrity": {
+          "vendor.js": "sha256-aztp/wpATyjXXpigZtP8ZP/9mUCHDMaL7OKFRbmnUIazQ9ehNmg4CD5Ljzym/TyA"
         }
       }
     STR
@@ -132,6 +135,23 @@ RSpec.describe AssetSources do
 
         AssetSources.get_assets('application')
         AssetSources.get_assets('input')
+      end
+    end
+  end
+
+  describe '.get_integrity' do
+    let(:path) { 'vendor.js' }
+    subject(:integrity) { AssetSources.get_integrity(path) }
+
+    it 'returns the integrity hash' do
+      expect(integrity).to start_with('sha256-')
+    end
+
+    context 'a path which does not exist in the manifest' do
+      let(:path) { 'missing.js' }
+
+      it 'returns nil' do
+        expect(integrity).to be_nil
       end
     end
   end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,20 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
           : filename;
       },
       writeToDisk: true,
+      integrity: isProductionEnv,
       output: 'manifest.json',
+      transform(manifest) {
+        const srcIntegrity = {};
+        for (const [key, { src, integrity }] of Object.entries(manifest)) {
+          if (integrity) {
+            srcIntegrity[src] = integrity;
+            delete manifest[key];
+          }
+        }
+
+        manifest.integrity = srcIntegrity;
+        return manifest;
+      },
     }),
     new RailsI18nWebpackPlugin({
       onMissingString(key, locale) {


### PR DESCRIPTION
**Why**: For additional protection against script manipulation, particularly in combination with CDN.

See: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

**Testing Instructions:**

1. `NODE_ENV=production yarn build`
2. `rails s`
3. Go to http://localhost:3000
4. Observe:
   a. No errors in console
   b. JavaScript still works
