### PR TITLE
Remove validated_form_for form helper

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -64,10 +64,4 @@ module FormHelper
       ['Wyoming', 'WY'],
     ]
   end
-
-  private
-
-  def validated_form_for(record, options = {}, &block)
-    simple_form_for(record, options, &block)
-  end
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,7 +4,7 @@
 
 <p><%= t('instructions.password.password_key') %></p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @reset_password_form,
       url: user_password_path,
       html: { autocomplete: 'off',

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
   <%= t('instructions.password.forgot') %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @password_reset_email_form,
       url: user_password_path,
       html: { autocomplete: 'off', method: :post },

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 <%= render 'shared/sp_alert' %>
 
-<%= validated_form_for(
+<%= simple_form_for(
       resource,
       as: resource_name,
       url: session_path(resource_name),

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @password_reset_from_disavowal_form,
       url: events_disavowal_url,
       html: { autocomplete: 'off',

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -16,9 +16,9 @@
   <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
-<%= validated_form_for @password_reset_email_form,
-                       html: { autocomplete: 'off', method: :post, class: 'margin-bottom-2' },
-                       url: user_password_path do |f| %>
+<%= simple_form_for @password_reset_email_form,
+                    html: { autocomplete: 'off', method: :post, class: 'margin-bottom-2' },
+                    url: user_password_path do |f| %>
 
   <%= f.input :email, as: :hidden %>
   <%= f.input :resend, as: :hidden %>

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -15,7 +15,7 @@
 <p class="margin-y-4"><strong><%= t('doc_auth.info.camera_required') %></strong></p>
 
 <p><%= t('doc_auth.instructions.send_sms') %></p>
-<%= validated_form_for(
+<%= simple_form_for(
       :doc_auth,
       url: url_for,
       method: 'PUT',

--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -46,7 +46,7 @@
       <% end %>
     </h2>
     <%= t('doc_auth.info.upload_from_phone') %>
-    <%= validated_form_for(
+    <%= simple_form_for(
           :doc_auth,
           url: url_for(type: :mobile),
           method: 'PUT',
@@ -61,7 +61,7 @@
 
 <div id="upload-comp-liveness-off" class="<%= 'display-none' if liveness_checking_enabled? %>">
   <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
-  <%= validated_form_for(
+  <%= simple_form_for(
         :doc_auth,
         url: url_for(type: :desktop),
         method: 'PUT',

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -28,10 +28,10 @@
       <% end %>
     <% end %>
 
-    <%= validated_form_for :doc_auth,
-                           url: url_for,
-                           method: 'put',
-                           html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+    <%= simple_form_for :doc_auth,
+                        url: url_for,
+                        method: 'put',
+                        html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
       <%= f.submit t('doc_auth.buttons.continue') %>
     <% end %>
 

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -10,10 +10,10 @@
   <%= t('in_person_proofing.body.state_id.info_html') %>
 </p>
 
-<%= validated_form_for :doc_auth,
-                       url: url_for,
-                       method: 'put',
-                       html: { autocomplete: 'off', class: 'margin-y-5' } do |f| %>
+<%= simple_form_for :doc_auth,
+                    url: url_for,
+                    method: 'put',
+                    html: { autocomplete: 'off', class: 'margin-y-5' } do |f| %>
 
   <div class="margin-bottom-4">
     <%= render ValidatedFieldComponent.new(

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -39,7 +39,7 @@
   <%= t('idv.messages.phone.final_note_html') %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @idv_form,
       url: idv_phone_path,
       data: {

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -41,7 +41,7 @@
       idv_in_person_url: Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,
     } %>
-  <%= validated_form_for(
+  <%= simple_form_for(
         :doc_auth,
         url: url_for,
         method: 'PUT',

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -8,7 +8,7 @@
         t('help_text.change_factor', factor: user_session[:factor_to_change]) %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       current_user,
       url: reauthn_user_password_path,
       html: { autocomplete: 'off', method: 'post', class: 'margin-top-6' },

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(password_header) %>
 
-<%= validated_form_for(
+<%= simple_form_for(
       current_user,
       as: :user,
       url: capture_password_url,

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -1,6 +1,6 @@
 <%#
 locals:
-* f: from validated_form_for
+* f: from simple_form_for
 * selection: the current language selection
 * hint: optional hint override
 %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 <% end %>
 <p>
-  <%= validated_form_for(:idv_form, url: sign_up_completed_path) do |f| %>
+  <%= simple_form_for(:idv_form, url: sign_up_completed_path) do |f| %>
     <%= f.submit t('sign_up.agree_and_continue') %>
   <% end %>
 </p>

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.confirmations.new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.confirmations.new')) %>
-<%= validated_form_for(
+<%= simple_form_for(
       @resend_email_confirmation_form,
       url: sign_up_register_path,
       html: { autocomplete: 'off', method: :post },

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -19,9 +19,9 @@
   <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
-<%= validated_form_for @resend_email_confirmation_form,
-                       html: { class: 'margin-bottom-2' },
-                       url: sign_up_register_path do |f| %>
+<%= simple_form_for @resend_email_confirmation_form,
+                    html: { class: 'margin-bottom-2' },
+                    url: sign_up_register_path do |f| %>
   <%= f.input :email, as: :hidden %>
   <%= f.input :resend, as: :hidden %>
   <%= f.input :request_id, as: :hidden %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -5,7 +5,7 @@
 <p class="margin-top-2 margin-bottom-0" id="password-description">
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
 </p>
-<%= validated_form_for(
+<%= simple_form_for(
       @password_form,
       url: sign_up_create_password_path,
       method: :post,

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -6,7 +6,7 @@
   <%= t('two_factor_authentication.backup_code_prompt') %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @backup_code_form,
       url: login_two_factor_backup_code_path,
       html: { autocomplete: 'off', method: :post },

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -8,7 +8,7 @@
   <%= @presenter.info %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @two_factor_options_form,
       html: { autocomplete: 'off' },
       method: :post,

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -6,7 +6,7 @@
   <%= t('two_factor_authentication.personal_key_prompt') %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @personal_key_form, url: login_two_factor_personal_key_path,
                           html: { autocomplete: 'off', method: :post }
     ) do |f| %>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.edit_info.phone') %>
 <%= render PageHeadingComponent.new.with_content(t('headings.edit_info.phone')) %>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @edit_phone_form,
       html: { autocomplete: 'off', method: :put },
       url: manage_phone_path(id: @phone_configuration.id),

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -12,7 +12,7 @@
       ) %>
 </p>
 
-<%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
+<%= simple_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
   <%= render partial: 'shared/email_languages',
              locals: { f: f, hint: false, selection: current_user.email_language } %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'grid-col-8 tablet:grid-col-6' %>

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -5,7 +5,7 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.add_email')) %>
 
 <div class="margin-bottom-6">
-  <%= validated_form_for(
+  <%= simple_form_for(
         @add_user_email_form,
         html: { autocomplete: 'off' },
         url: add_email_path,

--- a/app/views/users/mfa_selection/index.html.erb
+++ b/app/views/users/mfa_selection/index.html.erb
@@ -4,10 +4,10 @@
 
 <p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
 
-<%= validated_form_for @two_factor_options_form,
-                       html: { autocomplete: 'off' },
-                       method: :patch,
-                       url: second_mfa_setup_path do |f| %>
+<%= simple_form_for @two_factor_options_form,
+                    html: { autocomplete: 'off' },
+                    method: :patch,
+                    url: second_mfa_setup_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-0">
       <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.intro %></legend>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -6,7 +6,7 @@
   <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @update_user_password_form, url: manage_password_path,
                                   html: { autocomplete: 'off', method: :patch }
     ) do |f| %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @new_phone_form,
       html: { autocomplete: 'off', method: :patch },
       data: { international_phone_form: true },

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       @new_phone_form,
       html: { autocomplete: 'off', method: :post },
       data: { international_phone_form: true },

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -14,10 +14,10 @@
 
 <p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
 
-<%= validated_form_for @two_factor_options_form,
-                       html: { autocomplete: 'off' },
-                       method: :patch,
-                       url: authentication_methods_setup_path do |f| %>
+<%= simple_form_for @two_factor_options_form,
+                    html: { autocomplete: 'off' },
+                    method: :patch,
+                    url: authentication_methods_setup_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-0">
       <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.intro %></legend>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -6,7 +6,7 @@
   <%= t('idv.messages.sessions.review_message', app_name: APP_NAME) %>
 </p>
 
-<%= validated_form_for(
+<%= simple_form_for(
       current_user, url: update_verify_password_path,
                     html: { autocomplete: 'off', method: :put }
     ) do |f| %>


### PR DESCRIPTION
Follow-up to #6771 (see context at https://github.com/18F/identity-idp/pull/6771#discussion_r950182012)

**Why**: Because it's no longer needed as of #6771, since the purpose was to enhance forms with behaviors provided by the `form-validation.js` script, which was removed in #6771. The helper is now essentially an alias for simple_form_for, so we can call it directly instead.
