### PR TITLE
LG-7302 Record overall result from TMX in the database

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -106,6 +106,7 @@ class ResolutionProofingJob < ApplicationJob
     result = lexisnexis_ddp_proofer.proof(ddp_pii)
 
     log_threatmetrix_info(result, user)
+    add_threatmetrix_proofing_component(user_id, result)
 
     result
   end
@@ -285,5 +286,12 @@ class ResolutionProofingJob < ApplicationJob
           verification_url: IdentityConfig.store.aamva_verification_url,
         )
       end
+  end
+
+  def add_threatmetrix_proofing_component(user_id, threatmetrix_result)
+    ProofingComponent.
+      create_or_find_by(user_id: user_id).
+      update(threatmetrix: true,
+             threatmetrix_review_status: threatmetrix_result.review_status)
   end
 end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -40,6 +40,7 @@ module Proofing
           result.transaction_id = body['request_id']
           request_result = body['request_result']
           review_status = body['review_status']
+          result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
         end

--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -22,6 +22,7 @@ module Proofing
 
       proof do |applicant, result|
         result.transaction_id = TRANSACTION_ID
+        result.review_status = 'pass'
       end
     end
   end

--- a/app/services/proofing/result.rb
+++ b/app/services/proofing/result.rb
@@ -1,7 +1,7 @@
 module Proofing
   class Result
     attr_reader :exception
-    attr_accessor :context, :transaction_id, :reference
+    attr_accessor :context, :transaction_id, :reference, :review_status
 
     def initialize(
       errors: {},

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           threatmetrix_success: true,
           threatmetrix_request_id: threatmetrix_request_id,
         )
-        proofing_component = ProofingComponent.first
+        proofing_component = user.proofing_component
         expect(proofing_component.threatmetrix).to equal(true)
         expect(proofing_component.threatmetrix_review_status).to eq('pass')
       end
@@ -286,7 +286,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
           perform
 
-          proofing_component = ProofingComponent.first
+          proofing_component = user.proofing_component
           expect(proofing_component.threatmetrix).to equal(true)
           expect(proofing_component.threatmetrix_review_status).to eq('pass')
         end


### PR DESCRIPTION
**Why**: To track what went into a verified profile and also to allow the front end to query the db at the end of the IdV flow to either store the profile as disabled  and present a sad screen if the threatmetrix_review_status is either: 'reject', 'review', or 'challenge' as well as threatmetrix component completely missing.
**How**: Use the new fields we added in proofing_components here https://github.com/18F/identity-idp/pull/6655 Other fields are still undecided.