### PR TITLE
Fix 500 error when not providing Authorization header in Attempts API

### DIFF
--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -35,7 +35,7 @@ module Api
     private
 
     def authenticate_client
-      bearer, csp_id, token = request.authorization.split(' ', 3)
+      bearer, csp_id, token = request.authorization&.split(' ', 3)
       if bearer != 'Bearer' || !valid_auth_tokens.include?(token) ||
          csp_id != IdentityConfig.store.irs_attempt_api_csp_id
         render json: { status: 401, description: 'Unauthorized' }, status: :unauthorized

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe Api::IrsAttemptsApiController do
       post :create, params: { timestamp: time.iso8601 }
 
       expect(response.status).to eq(401)
+
+      request.headers['Authorization'] = nil
+
+      post :create, params: { timestamp: time.iso8601 }
+
+      expect(response.status).to eq(401)
     end
 
     it 'renders encrypted events' do


### PR DESCRIPTION
Adds a failing spec and the fix.  Current implementation will 500 with:

```
     NoMethodError:
       undefined method `split' for nil:NilClass
```