### PR TITLE
Bugfix.- small temporary bugfix for reauthentication param

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -211,15 +211,15 @@ module Users
         success: @telephony_result.success?,
       )
 
-      if UserSessionContext.authentication_context?(context)
+      if UserSessionContext.reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_sent(
-          reauthentication: false,
+          reauthentication: true,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )
-      elsif UserSessionContext.reauthentication_context?(context)
+      elsif UserSessionContext.authentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_sent(
-          reauthentication: true,
+          reauthentication: false,
           phone_number: parsed_phone.e164,
           success: @telephony_result.success?,
         )

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -333,6 +333,17 @@ describe Users::TwoFactorAuthenticationController do
           { otp_delivery_preference: 'sms' } }
       end
 
+      it 'tracks the attempt event when user session context is reauthentication' do
+        stub_attempts_tracker
+        subject.user_session[:context] = 'reauthentication'
+
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_sent).
+          with(phone_number: '+12025551212', reauthentication: true, success: true)
+
+        get :send_code, params: { otp_delivery_selection_form:
+          { otp_delivery_preference: 'sms' } }
+      end
+
       it 'calls OtpRateLimiter#exceeded_otp_send_limit? and #increment' do
         otp_rate_limiter = instance_double(OtpRateLimiter)
         allow(OtpRateLimiter).to receive(:new).


### PR DESCRIPTION
# Summary
1. A workaround that fixes a bug around tracking `mfa_login_phone_otp_sent` with reauthentication being false despite being in the reauthentication context.

This is sort of a dirty fix. I have created a ticket in the backlog with suggestions for a better fix that would involve a code refactor. As this is a very minor edge case anyway, and since we have the 9/1 deadline coming up, this workaround should suffice for the time being. 