### PR TITLE
Hash Device UUID for IRS Attempts API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,7 +86,7 @@ class ApplicationController < ActionController::Base
       request: request,
       user: effective_user,
       sp: current_sp,
-      device_fingerprint: cookies[:device],
+      cookie_device_uuid: cookies[:device],
       sp_request_uri: decorated_session.request_url_params[:redirect_uri],
       enabled_for_session: irs_attempt_api_enabled_for_session?,
     )

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -1,15 +1,15 @@
 module IrsAttemptsApi
   class Tracker
-    attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :device_fingerprint,
+    attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
                 :sp_request_uri
 
-    def initialize(session_id:, request:, user:, sp:, device_fingerprint:,
+    def initialize(session_id:, request:, user:, sp:, cookie_device_uuid:,
                    sp_request_uri:, enabled_for_session:)
       @session_id = session_id # IRS session ID
       @request = request
       @user = user
       @sp = sp
-      @device_fingerprint = device_fingerprint
+      @cookie_device_uuid = cookie_device_uuid
       @sp_request_uri = sp_request_uri
       @enabled_for_session = enabled_for_session
     end
@@ -21,7 +21,7 @@ module IrsAttemptsApi
         user_agent: request&.user_agent,
         unique_session_id: hashed_session_id,
         user_uuid: AgencyIdentityLinker.for(user: user, service_provider: sp)&.uuid,
-        device_fingerprint: device_fingerprint,
+        device_fingerprint: hashed_cookie_device_uuid,
         user_ip_address: request&.remote_ip,
         irs_application_url: sp_request_uri,
         client_port: CloudFrontHeaderParser.new(request).client_port,
@@ -50,6 +50,11 @@ module IrsAttemptsApi
     def hashed_session_id
       return nil unless user&.unique_session_id
       Digest::SHA1.hexdigest(user&.unique_session_id)
+    end
+
+    def hashed_cookie_device_uuid
+      return nil unless cookie_device_uuid
+      Digest::SHA1.hexdigest(cookie_device_uuid)
     end
 
     def enabled?

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe IrsAttemptsApi::Tracker do
   let(:enabled_for_session) { true }
   let(:request) { instance_double(ActionDispatch::Request) }
   let(:service_provider) { create(:service_provider) }
-  let(:device_fingerprint) { 'device_id' }
+  let(:cookie_device_uuid) { 'device_id' }
   let(:sp_request_uri) { 'https://example.com/auth_page' }
   let(:user) { create(:user) }
 
@@ -26,7 +26,7 @@ RSpec.describe IrsAttemptsApi::Tracker do
       request: request,
       user: user,
       sp: service_provider,
-      device_fingerprint: device_fingerprint,
+      cookie_device_uuid: cookie_device_uuid,
       sp_request_uri: sp_request_uri,
       enabled_for_session: enabled_for_session,
     )


### PR DESCRIPTION
The Device UUID should remain internal, so this hashes the string to keep the consistency but prevent misuse.

I also renamed the parameter to be a bit more explicit and avoid some ambiguity.