### PR TITLE
LG-7179 | Refer to HTTP header properly

### DIFF
--- a/app/services/cloud_front_header_parser.rb
+++ b/app/services/cloud_front_header_parser.rb
@@ -10,6 +10,6 @@ class CloudFrontHeaderParser
 
   # Source IP and port for client connection to CloudFront
   def viewer_address
-    @request.get_header 'CloudFront-Viewer-Address'
+    @request.get_header 'HTTP_CLOUDFRONT_VIEWER_ADDRESS'
   end
 end

--- a/app/services/cloud_front_header_parser.rb
+++ b/app/services/cloud_front_header_parser.rb
@@ -10,6 +10,6 @@ class CloudFrontHeaderParser
 
   # Source IP and port for client connection to CloudFront
   def viewer_address
-    @request.get_header 'HTTP_CLOUDFRONT_VIEWER_ADDRESS'
+    @request.headers['CloudFront-Viewer-Address']
   end
 end

--- a/spec/services/cloud_front_header_parser_spec.rb
+++ b/spec/services/cloud_front_header_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CloudFrontHeaderParser do
     let(:ip) { '192.0.2.1' }
 
     before do
-      req.add_header('CloudFront-Viewer-Address', "#{ip}:#{port}")
+      req.add_header('HTTP_CLOUDFRONT_VIEWER_ADDRESS', "#{ip}:#{port}")
     end
 
     describe '#client_port' do
@@ -28,7 +28,7 @@ RSpec.describe CloudFrontHeaderParser do
     let(:ip) { '[2001:DB8::1]' }
 
     before do
-      req.add_header('CloudFront-Viewer-Address', "#{ip}:#{port}")
+      req.add_header('HTTP_CLOUDFRONT_VIEWER_ADDRESS', "#{ip}:#{port}")
     end
 
     describe '#client_port' do

--- a/spec/services/cloud_front_header_parser_spec.rb
+++ b/spec/services/cloud_front_header_parser_spec.rb
@@ -1,12 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CloudFrontHeaderParser do
-  let(:url) { 'http://example.com' }
-  let(:req) { Rack::Request.new(Rack::MockRequest.env_for(url, remote_addr_header)) }
+  let(:req) { ActionDispatch::TestRequest.new({}) }
   let(:port) { '1234' }
-  let(:remote_addr_header) do
-    { 'REMOTE_ADDR' => ip }
-  end
 
   subject { described_class.new(req) }
 
@@ -14,7 +10,7 @@ RSpec.describe CloudFrontHeaderParser do
     let(:ip) { '192.0.2.1' }
 
     before do
-      req.add_header('HTTP_CLOUDFRONT_VIEWER_ADDRESS', "#{ip}:#{port}")
+      req.headers['CloudFront-Viewer-Address'] = "#{ip}:#{port}"
     end
 
     describe '#client_port' do
@@ -28,7 +24,7 @@ RSpec.describe CloudFrontHeaderParser do
     let(:ip) { '[2001:DB8::1]' }
 
     before do
-      req.add_header('HTTP_CLOUDFRONT_VIEWER_ADDRESS', "#{ip}:#{port}")
+      req.headers['CloudFront-Viewer-Address'] = "#{ip}:#{port}"
     end
 
     describe '#client_port' do

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe IrsAttemptsApi::Tracker do
     )
     allow(request).to receive(:user_agent).and_return('example/1.0')
     allow(request).to receive(:remote_ip).and_return('192.0.2.1')
-    allow(request).to receive(:get_header).with('CloudFront-Viewer-Address').
-      and_return('192.0.2.1:1234')
+    allow(request).to receive(:headers).and_return(
+      { 'CloudFront-Viewer-Address' => '192.0.2.1:1234' },
+    )
   end
 
   let(:irs_attempt_api_enabled) { true }


### PR DESCRIPTION
Turns out that if the app is passed 'CloudFront-Viewer-Address',
what get_header() sees is 'HTTP_CLOUDFRONT_VIEWER_ADDRESS'.

This seems hard to express in an automated test...

changelog: Internal, Attempts API, Fixes client port HTTP header