### PR TITLE
LG-7305 Make sure ThreatMetrix failure results in disabled account

### DIFF
--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -60,6 +60,8 @@ module Api
         :gpo_verification_pending
       elsif pending_in_person_enrollment?
         :in_person_verification_pending
+      elsif threatmetrix_failed_and_needs_review?
+        :threatmetrix_review_pending
       end
     end
 
@@ -171,6 +173,14 @@ module Api
     def in_person_enrollment?
       return false unless IdentityConfig.store.in_person_proofing_enabled
       ProofingComponent.find_by(user: user)&.document_check == Idp::Constants::Vendors::USPS
+    end
+
+    def threatmetrix_failed_and_needs_review?
+      return unless IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
+      return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
+      component = ProofingComponent.find_by(user: user)
+      return true unless component
+      !(component.threatmetrix_enabled && component.threatmetrix_review_status == 'pass')
     end
   end
 end

--- a/app/forms/api/profile_creation_form.rb
+++ b/app/forms/api/profile_creation_form.rb
@@ -180,7 +180,7 @@ module Api
       return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
       component = ProofingComponent.find_by(user: user)
       return true unless component
-      !(component.threatmetrix_enabled && component.threatmetrix_review_status == 'pass')
+      !(component.threatmetrix && component.threatmetrix_review_status == 'pass')
     end
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,6 +16,7 @@ class Profile < ApplicationRecord
     gpo_verification_pending: 3,
     verification_cancelled: 4,
     in_person_verification_pending: 5,
+    threatmetrix_review_pending: 6,
   }
 
   attr_reader :personal_key

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -152,6 +152,7 @@ lexisnexis_threatmetrix_policy: test-policy
 lexisnexis_threatmetrix_timeout: 1.0
 lexisnexis_threatmetrix_enabled: false
 lexisnexis_threatmetrix_mock_enabled: true
+lexisnexis_threatmetrix_required_to_verify: false
 ###################################################################
 lockout_period_in_minutes: 10
 log_to_stdout: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -224,6 +224,7 @@ class IdentityConfig
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string)
     config.add(:lexisnexis_threatmetrix_policy, type: :string)
+    config.add(:lexisnexis_threatmetrix_required_to_verify, type: :boolean)
     config.add(:lexisnexis_threatmetrix_timeout, type: :float)
     config.add(:liveness_checking_enabled, type: :boolean)
     config.add(:lockout_period_in_minutes, type: :integer)

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -267,6 +267,37 @@ describe Api::Verify::PasswordConfirmController do
         end
       end
 
+      context 'with threatmetrix required but review status did not pass' do
+        let(:applicant) {
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(same_address_as_id: true)
+        }
+        let(:stub_idv_session) do
+          stub_user_with_applicant_data(user, applicant)
+        end
+        let(:stub_usps_response) do
+          stub_request_enroll
+        end
+
+        before(:each) do
+          stub_request_token
+          stub_usps_response
+          ProofingComponent.create(
+            user: user,
+            threatmetrix: true,
+            threatmetrix_review_status: 'review',
+          )
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+            and_return(true)
+        end
+
+        it 'creates a disabled profile' do
+          post :create, params: { password: password, user_bundle_token: jwt }
+
+          expect(user.profiles.last.deactivation_reason).to eq('threatmetrix_review_pending')
+        end
+      end
+
       context 'with associated sp session' do
         before do
           session[:sp] = { issuer: create(:service_provider).issuer }

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -136,6 +136,31 @@ RSpec.describe Api::ProfileCreationForm do
         end
       end
 
+      context 'with the user failing threatmetrix and it never ran' do
+        let(:metadata) do
+          {
+            vendor_phone_confirmation: true,
+            user_phone_confirmation: true,
+          }
+        end
+        before do
+          ProofingComponent.create(
+            user: user,
+          )
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+            and_return(true)
+        end
+
+        it 'sets profile to pending threatmetrix review' do
+          subject.submit
+          profile = user.profiles.first
+
+          expect(profile.active?).to be false
+          expect(profile.deactivation_reason).to eq('threatmetrix_review_pending')
+        end
+      end
+
       context 'with the user failing threatmetrix but it is not required' do
         let(:metadata) do
           {

--- a/spec/forms/api/profile_creation_form_spec.rb
+++ b/spec/forms/api/profile_creation_form_spec.rb
@@ -162,6 +162,32 @@ RSpec.describe Api::ProfileCreationForm do
         end
       end
 
+      context 'with the user passing threatmetrix when it is required' do
+        let(:metadata) do
+          {
+            vendor_phone_confirmation: true,
+            user_phone_confirmation: true,
+          }
+        end
+        before do
+          ProofingComponent.create(
+            user: user,
+            threatmetrix: true,
+            threatmetrix_review_status: 'pass',
+          )
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+            and_return(true)
+        end
+
+        it 'activates profile' do
+          subject.submit
+          profile = user.profiles.first
+
+          expect(profile.active?).to be true
+        end
+      end
+
       context 'with the user having verified their address via GPO letter' do
         let(:metadata) do
           {


### PR DESCRIPTION
**Why**: To prevent fraudulent verified profiles by using the lexisnexis threatmetrix API saving those profiles that have not passed threatmetrix in a pending state `threatmetrix_review_pending` so they can be reviewed and potentially enabled by the fraud team.
**How**: Threatmetrix review_status must be 'pass' if threatmetrix is enabled and required via new feature flag `lexisnexis_threatmetrix_required_to_verify`.  Otherwise the profile will be created in a pending state.  If threatmetrix is enabled but not required the threatmetrix backend calls will run and store the results but it will NOT disable the verified profile.  Follows from these prs: https://github.com/18F/identity-idp/pull/6806
