### PR TITLE
LG-6970 create inherited proofing basic landing page

### DIFF
--- a/app/controllers/idv/inherited_proofing_controller.rb
+++ b/app/controllers/idv/inherited_proofing_controller.rb
@@ -1,0 +1,12 @@
+module Idv
+  class InheritedProofingController < ApplicationController
+    include Flow::FlowStateMachine
+
+    FLOW_STATE_MACHINE_SETTINGS = {
+      step_url: :idv_inherited_proofing_step_url,
+      final_url: nil,
+      flow: Idv::Flows::InheritedProofingFlow,
+      analytics_id: nil,
+    }.freeze
+  end
+end

--- a/app/controllers/idv/inherited_proofing_controller.rb
+++ b/app/controllers/idv/inherited_proofing_controller.rb
@@ -2,11 +2,19 @@ module Idv
   class InheritedProofingController < ApplicationController
     include Flow::FlowStateMachine
 
+    before_action :render_404_if_disabled
+
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_inherited_proofing_step_url,
       final_url: nil,
       flow: Idv::Flows::InheritedProofingFlow,
       analytics_id: nil,
     }.freeze
+
+    private
+
+    def render_404_if_disabled
+      render_not_found unless IdentityConfig.store.inherited_proofing_enabled
+    end
   end
 end

--- a/app/services/idv/flows/inherited_proofing_flow.rb
+++ b/app/services/idv/flows/inherited_proofing_flow.rb
@@ -1,0 +1,19 @@
+module Idv
+  module Flows
+    class InheritedProofingFlow < Flow::BaseFlow
+      STEPS = {
+        get_started: Idv::Steps::InheritedProofing::GetStartedStep,
+      }.freeze
+
+      STEP_INDICATOR_STEPS = [
+        { name: :getting_started },
+      ].freeze
+
+      ACTIONS = {}.freeze
+
+      def initialize(controller, session, name)
+        super(controller, STEPS, ACTIONS, session[name])
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/inherited_proofing/get_started_step.rb
+++ b/app/services/idv/steps/inherited_proofing/get_started_step.rb
@@ -1,0 +1,9 @@
+module Idv
+  module Steps
+    module InheritedProofing
+      class GetStartedStep < DocAuthBaseStep
+        STEP_INDICATOR_STEP = :getting_started
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/inherited_proofing_base_step.rb
+++ b/app/services/idv/steps/inherited_proofing_base_step.rb
@@ -4,8 +4,6 @@ module Idv
       def initialize(flow)
         super(flow, :inherited_proofing)
       end
-
-      delegate :idv_session, :session, :flow_path, to: :@flow
     end
   end
 end

--- a/app/services/idv/steps/inherited_proofing_base_step.rb
+++ b/app/services/idv/steps/inherited_proofing_base_step.rb
@@ -1,0 +1,11 @@
+module Idv
+  module Steps
+    class InheritedProofingBaseStep < Flow::BaseStep
+      def initialize(flow)
+        super(flow, :inherited_proofing)
+      end
+
+      delegate :idv_session, :session, :flow_path, to: :@flow
+    end
+  end
+end

--- a/app/views/idv/inherited_proofing/get_started.html.erb
+++ b/app/views/idv/inherited_proofing/get_started.html.erb
@@ -1,0 +1,38 @@
+<% title t('inherited_proofing.headings.welcome') %>
+
+<%= render JavascriptRequiredComponent.new(
+  header: t('idv.welcome.no_js_header'),
+  intro: t('idv.welcome.no_js_intro', sp_name: decorated_session.sp_name || t('inherited_proofing.info.no_sp_name')),
+) do %>
+  <%= render PageHeadingComponent.new.with_content(t('inherited_proofing.headings.welcome')) %>
+  <p>
+    <%= t('inherited_proofing.info.welcome_html', sp_name: decorated_session.sp_name || t('inherited_proofing.info.no_sp_name')) %>
+  </p>
+  <h2><%= t('inherited_proofing.instructions.welcome') %></h2>
+
+  <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
+    <%= c.item(heading: t('inherited_proofing.instructions.bullet1')) %>
+  <% end %>
+
+  <%= simple_form_for :inherited_proofing,
+                         url: url_for,
+                         method: 'put',
+                         html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+    <%= f.button :button,
+                 t('inherited_proofing.buttons.continue'),
+                 type: :submit,
+                 class: 'usa-button--big usa-button--wide' %>
+  <% end %>
+
+  <h3><%= t('inherited_proofing.instructions.privacy') %></h3>
+  <p>
+    <%= t(
+          'inherited_proofing.info.privacy_html',
+          app_name: APP_NAME,
+          link: new_window_link_to(
+            t('inherited_proofing.instructions.learn_more'),
+            MarketingSite.security_and_privacy_practices_url,
+          ),
+        ) %>
+  </p>
+<% end %>

--- a/app/views/idv/inherited_proofing/get_started.html.erb
+++ b/app/views/idv/inherited_proofing/get_started.html.erb
@@ -17,16 +17,14 @@
   <%= simple_form_for :inherited_proofing,
                       url: url_for,
                       method: 'put',
-                      html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
-    <%= f.button :button,
-                 t('inherited_proofing.buttons.continue'),
-                 type: :submit,
-                 class: 'usa-button--big usa-button--wide' %>
+                      html: { autocomplete: 'off', class: 'margin-y-5' } do |f| %>
+    <%= f.submit t('inherited_proofing.buttons.continue') %>
   <% end %>
 
   <h3><%= t('inherited_proofing.instructions.privacy') %></h3>
   <p>
-    <%= t('inherited_proofing.info.privacy_html',
+    <%= t(
+          'inherited_proofing.info.privacy_html',
           app_name: APP_NAME,
           link: new_window_link_to(
             t('inherited_proofing.instructions.learn_more'),

--- a/app/views/idv/inherited_proofing/get_started.html.erb
+++ b/app/views/idv/inherited_proofing/get_started.html.erb
@@ -26,8 +26,7 @@
 
   <h3><%= t('inherited_proofing.instructions.privacy') %></h3>
   <p>
-    <%= t(
-          'inherited_proofing.info.privacy_html',
+    <%= t('inherited_proofing.info.privacy_html',
           app_name: APP_NAME,
           link: new_window_link_to(
             t('inherited_proofing.instructions.learn_more'),

--- a/app/views/idv/inherited_proofing/get_started.html.erb
+++ b/app/views/idv/inherited_proofing/get_started.html.erb
@@ -1,9 +1,9 @@
 <% title t('inherited_proofing.headings.welcome') %>
 
 <%= render JavascriptRequiredComponent.new(
-  header: t('idv.welcome.no_js_header'),
-  intro: t('idv.welcome.no_js_intro', sp_name: decorated_session.sp_name || t('inherited_proofing.info.no_sp_name')),
-) do %>
+      header: t('idv.welcome.no_js_header'),
+      intro: t('idv.welcome.no_js_intro', sp_name: decorated_session.sp_name || t('inherited_proofing.info.no_sp_name')),
+    ) do %>
   <%= render PageHeadingComponent.new.with_content(t('inherited_proofing.headings.welcome')) %>
   <p>
     <%= t('inherited_proofing.info.welcome_html', sp_name: decorated_session.sp_name || t('inherited_proofing.info.no_sp_name')) %>
@@ -15,9 +15,9 @@
   <% end %>
 
   <%= simple_form_for :inherited_proofing,
-                         url: url_for,
-                         method: 'put',
-                         html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+                      url: url_for,
+                      method: 'put',
+                      html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
     <%= f.button :button,
                  t('inherited_proofing.buttons.continue'),
                  type: :submit,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -111,6 +111,8 @@ in_person_proofing_enabled_issuers: '[]'
 in_person_enrollment_validity_in_days: 30
 in_person_results_delay_in_hours: 1
 include_slo_in_saml_metadata: false
+inherited_proofing_enabled: false
+inherited_proofing_va_base_url: 'https://staging-api.va.gov'
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''
 irs_attempt_api_csp_id: 'LOGIN.gov'
@@ -289,7 +291,6 @@ voice_otp_speech_rate: 'slow'
 voip_check: true
 voip_block: true
 voip_allowed_phones: '[]'
-inherited_proofing_va_base_url: 'https://staging-api.va.gov'
 
 development:
   aamva_private_key: 123abc
@@ -321,6 +322,7 @@ development:
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true
   in_person_proofing_enabled: true
+  inherited_proofing_enabled: true
   kantara_2fa_phone_restricted: true
   kantara_2fa_phone_existing_user_restriction: true
   kantara_restriction_enforcement_date: '2022-07-01'
@@ -473,6 +475,7 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
+  inherited_proofing_enabled: true
   irs_attempt_api_auth_tokens: 'test-token-1,test-token-2'
   irs_attempt_api_public_key: MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyut9Uio5XxsIUVrXARqCoHvcMVYT0p6WyU1BnbhxLRW4Q60p+4Bn32vVOt9nzeih7qvauYM5M0PZdKEmwOHflqPP+ABfKhL+6jxBhykN5P5UY375wTFBJZ20Fx8jOJbRhJD02oUQ49YKlDu3MG5Y0ApyD4ER4WKgxuB2OdyQKd9vg2ZZa+P2pw1HkFPEin0h8KBUFBeLGDZni8PIJdHBP6dA+xbayGBxSM/8xQC0JIg6KlGTcLql37QJIhP2oSv0nAJNb6idFPAz0uMCQDQWKKWV5FUDCsFVH7VuQz8xUCwnPn/SdaratB+29bwUpVhgHXrHdJ0i8vjBEX7smD7pI8CcFHuVgACt86NMlBnNCVkwumQgZNAAxe2mJoYcotEWOnhCuMc6MwSj985bj8XEdFlbf4ny9QO9rETd5aYcwXBiV/T6vd637uvHb0KenghNmlb1Tv9LMj2b9ZwNc9C6oeCnbN2YAfxSDrb8Ik+yq4hRewOvIK7f0CcpZYDXK25aHXnHm306Uu53KIwMGf1mha5T5LWTNaYy5XFoMWHJ9E+AnU/MUJSrwCAITH/S0JFcna5Oatn70aTE9pISATsqB5Iz1c46MvdrxD8hPoDjT7x6/EO316DZrxQfJhjbWsCB+R0QxYLkXPHczhB2Z0HPna9xB6RbJHzph7ifDizhZoMCAwEAAQ==
   kantara_2fa_phone_restricted: false

--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -1,0 +1,17 @@
+---
+en:
+  inherited_proofing:
+    buttons:
+      continue: Continue
+    headings:
+      welcome: Get started verifying your identity
+    info:
+      no_sp_name: The agency that you are trying to access
+      privacy_html: '%{app_name} is a secure, government website that adheres to the highest standards in data
+        protection. We only use your data to verify your identity. %{link} about our privacy and security measures.'
+      welcome_html: '%{sp_name} needs to make sure you are you — not someone pretending to be you.'
+    instructions:
+      bullet1: A phone number on a phone plan associated with your name
+      learn_more: Learn more
+      privacy: Our privacy and security standards
+      welcome: 'To verify your identity, you will need:'

--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -7,9 +7,11 @@ en:
       welcome: Get started verifying your identity
     info:
       no_sp_name: The agency that you are trying to access
-      privacy_html: '%{app_name} is a secure, government website that adheres to the highest standards in data
-        protection. We only use your data to verify your identity. %{link} about our privacy and security measures.'
-      welcome_html: '%{sp_name} needs to make sure you are you — not someone pretending to be you.'
+      privacy_html: '%{app_name} is a secure, government website that adheres to the
+        highest standards in data protection. We only use your data to verify
+        your identity. %{link} about our privacy and security measures.'
+      welcome_html: '%{sp_name} needs to make sure you are you — not someone
+        pretending to be you.'
     instructions:
       bullet1: A phone number on a phone plan associated with your name
       learn_more: Learn more

--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -7,8 +7,8 @@ es:
       welcome: replaceme
     info:
       no_sp_name: replaceme
-      privacy_html: replaceme
-      welcome_html: replaceme
+      privacy_html: replaceme %{app_name} %{link}
+      welcome_html: replaceme %{sp_name}
     instructions:
       bullet1: replaceme
       learn_more: replaceme

--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -1,0 +1,16 @@
+---
+es:
+  inherited_proofing:
+    buttons:
+      continue: replaceme
+    headings:
+      welcome: replaceme
+    info:
+      no_sp_name: replaceme
+      privacy_html: replaceme
+      welcome_html: replaceme
+    instructions:
+      bullet1: replaceme
+      learn_more: replaceme
+      privacy: replaceme
+      welcome: replaceme

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -7,8 +7,8 @@ fr:
       welcome: replaceme
     info:
       no_sp_name: replaceme
-      privacy_html: replaceme
-      welcome_html: replaceme
+      privacy_html: replaceme %{app_name} %{link}
+      welcome_html: replaceme %{sp_name}
     instructions:
       bullet1: replaceme
       learn_more: replaceme

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -2,15 +2,15 @@
 fr:
   inherited_proofing:
     buttons:
-      continue: replace me
+      continue: replaceme
     headings:
-      welcome: replace me
+      welcome: replaceme
     info:
-      no_sp_name: replace me
-      privacy_html: replace me
-      welcome_html: replace me
+      no_sp_name: replaceme
+      privacy_html: replaceme
+      welcome_html: replaceme
     instructions:
-      bullet1: replace me
-      learn_more: replace me
-      privacy: replace me
-      welcome: replace me
+      bullet1: replaceme
+      learn_more: replaceme
+      privacy: replaceme
+      welcome: replaceme

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -1,0 +1,16 @@
+---
+fr:
+  inherited_proofing:
+    buttons:
+      continue: replace me
+    headings:
+      welcome: replace me
+    info:
+      no_sp_name: replace me
+      privacy_html: replace me
+      welcome_html: replace me
+    instructions:
+      bullet1: replace me
+      learn_more: replace me
+      privacy: replace me
+      welcome: replace me

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,6 +337,9 @@ Rails.application.routes.draw do
       get '/in_person/:step' => 'in_person#show', as: :in_person_step
       put '/in_person/:step' => 'in_person#update'
 
+      get '/inherited_proofing' => 'inherited_proofing#index'
+      get '/inherited_proofing/:step' => 'inherited_proofing#show', as: :inherited_proofing_step
+
       # deprecated routes
       get '/confirmations' => 'personal_key#show'
       post '/confirmations' => 'personal_key#update'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -190,6 +190,8 @@ class IdentityConfig
     config.add(:in_person_enrollment_validity_in_days, type: :integer)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
+    config.add(:inherited_proofing_enabled, type: :boolean)
+    config.add(:inherited_proofing_va_base_url, type: :string)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)
     config.add(:irs_attempt_api_csp_id)
@@ -386,7 +388,6 @@ class IdentityConfig
     config.add(:voip_allowed_phones, type: :json)
     config.add(:voip_block, type: :boolean)
     config.add(:voip_check, type: :boolean)
-    config.add(:inherited_proofing_va_base_url, type: :string)
 
     @key_types = config.key_types
     @store = RedactedStruct.new('IdentityConfig', *config.written_env.keys, keyword_init: true).

--- a/spec/controllers/idv/inherited_proofing_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_controller_spec.rb
@@ -7,6 +7,16 @@ describe Idv::InheritedProofingController do
 
       expect(response).to redirect_to idv_inherited_proofing_step_url(step: :get_started)
     end
+
+    context 'when the inherited proofing feature flag is disabled' do
+      it 'returns 404 not found' do
+        allow(IdentityConfig.store).to receive(:inherited_proofing_enabled).and_return(false)
+
+        get :index
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/controllers/idv/inherited_proofing_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Idv::InheritedProofingController do
+  describe '#index' do
+    it 'redirects to the first step' do
+      get :index
+
+      expect(response).to redirect_to idv_inherited_proofing_step_url(step: :get_started)
+    end
+  end
+
+  describe '#show' do
+    it 'renders the correct template' do
+      expect(subject).to receive(:render).with(
+        template: 'layouts/flow_step',
+        locals: hash_including(
+          :flow_session,
+          flow_namespace: 'idv',
+          step_template: 'idv/inherited_proofing/get_started',
+          step_indicator: hash_including(
+            :steps,
+            current_step: :getting_started,
+          ),
+        ),
+      ).and_call_original
+
+      get :show, params: { step: 'get_started' }
+    end
+
+    it 'redirects to the configured next step' do
+      mock_next_step(:some_next_step)
+      get :show, params: { step: 'getting_started' }
+
+      expect(response).to redirect_to idv_inherited_proofing_step_url(:some_next_step)
+    end
+
+    it 'redirects to the first step if a non-existent step is given' do
+      get :show, params: { step: 'non_existent_step' }
+
+      expect(response).to redirect_to idv_inherited_proofing_step_url(step: :get_started)
+    end
+  end
+
+  def mock_next_step(step)
+    allow_any_instance_of(Idv::Flows::InheritedProofingFlow).to receive(:next_step).and_return(step)
+  end
+end

--- a/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
+++ b/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'idv/inherited_proofing/get_started.html.erb' do
+  let(:flow_session) { {} }
+  let(:sp_name) { nil }
+
+  before do
+    @decorated_session = instance_double(ServiceProviderSessionDecorator)
+    allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
+    allow(view).to receive(:decorated_session).and_return(@decorated_session)
+    allow(view).to receive(:flow_session).and_return(flow_session)
+    allow(view).to receive(:url_for).and_return('https://www.example.com/')
+  end
+
+  it 'renders the Continue button' do
+    render template: 'idv/inherited_proofing/get_started'
+
+    expect(rendered).to have_button(t('inherited_proofing.buttons.continue'))
+  end
+end


### PR DESCRIPTION
The objective is to create a single landing page with minimal code, that used the FSM (v2) methodology.

technical notes on creating the inherited_proofing_controller.rb and use of FSM (flow state machine):
  - user session management is not included
  - it does not (use these before hooks):
    :confirm_two_factor_authenticated, :redirect_if_pending_in_person_enrollment, :redirect_if_pending_profile,
    :extend_timeout_using_meta_refresh_for_select_paths, :redirect_if_flow_completed, :override_document_capture_step_csp,
    :update_if_skipping_upload, :check_for_outage, :override_csp_for_threat_metrix
  - analytics tracking is not included
  - getting_started.html.erb does not include: javascript_packs_tag_once('document-capture-welcome')
  - not feature flagged