### PR TITLE
Ensure distinction between WebAuthn Roaming and Platform in registration funnel

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -152,12 +152,13 @@ module Users
         platform_authenticator: form.platform_authenticator?,
         enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
       )
-      Funnel::Registration::AddMfa.call(current_user.id, 'webauthn', analytics)
       mark_user_as_fully_authenticated
       handle_remember_device
       if form.platform_authenticator?
+        Funnel::Registration::AddMfa.call(current_user.id, 'webauthn_platform', analytics)
         flash[:success] = t('notices.webauthn_platform_configured')
       else
+        Funnel::Registration::AddMfa.call(current_user.id, 'webauthn', analytics)
         flash[:success] = t('notices.webauthn_configured')
       end
       user_session[:auth_method] = 'webauthn'

--- a/app/policies/service_provider_mfa_policy.rb
+++ b/app/policies/service_provider_mfa_policy.rb
@@ -1,5 +1,5 @@
 class ServiceProviderMfaPolicy
-  AAL3_METHODS = %w[webauthn piv_cac].freeze
+  AAL3_METHODS = %w[webauthn webauthn_platform piv_cac].freeze
 
   attr_reader :mfa_context, :auth_method, :service_provider
 

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -247,6 +247,11 @@ describe Users::WebauthnSetupController do
         end
         it 'should log expected events' do
           expect(@analytics).to receive(:track_event).with(
+            'User Registration: User Fully Registered',
+            { mfa_method: 'webauthn_platform' },
+          )
+
+          expect(@analytics).to receive(:track_event).with(
             'Multi-Factor Authentication Setup',
             {
               enabled_mfa_methods_count: 1,
@@ -272,7 +277,10 @@ describe Users::WebauthnSetupController do
             :mfa_enroll_webauthn_platform, success: true
           )
 
+          registration_log = Funnel::Registration::Create.call(user.id)
           patch :confirm, params: params
+
+          expect(registration_log.reload.first_mfa).to eq 'webauthn_platform'
         end
       end
 


### PR DESCRIPTION
Right now, both roaming/platform are logged as 'webauthn', but it would be helpful for us to distinguish them for this 🙂