### PR TITLE
LG -7015 Redirect user to "Sorry" page on TMX verification failure

### DIFF
--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -68,6 +68,8 @@ module Api
       def device_profiling_failed?(user)
         return false unless IdentityConfig.store.proofing_device_profiling_decisioning_enabled
         proofing_component = ProofingComponent.find_by(user: user)
+        # pass users who are inbetween feature flag being enabled and have not had a check run.
+        return false if proofing_component.threatmetrix_review_status.nil?
         proofing_component.threatmetrix_review_status != 'pass'
       end
 

--- a/app/controllers/api/verify/password_confirm_controller.rb
+++ b/app/controllers/api/verify/password_confirm_controller.rb
@@ -51,6 +51,8 @@ module Api
           idv_come_back_later_url
         elsif in_person_enrollment?(user)
           idv_in_person_ready_to_verify_url
+        elsif device_profiling_failed?(user)
+          idv_come_back_later_url
         elsif current_sp
           sign_up_completed_url
         else
@@ -61,6 +63,12 @@ module Api
       def in_person_enrollment?(user)
         return false unless IdentityConfig.store.in_person_proofing_enabled
         ProofingComponent.find_by(user: user)&.document_check == Idp::Constants::Vendors::USPS
+      end
+
+      def device_profiling_failed?(user)
+        return false unless IdentityConfig.store.proofing_device_profiling_decisioning_enabled
+        proofing_component = ProofingComponent.find_by(user: user)
+        proofing_component.threatmetrix_review_status != 'pass'
       end
 
       def handle_request_enroll_exception(err)

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -37,6 +37,8 @@ module Idv
         idv_come_back_later_url
       elsif in_person_enrollment?
         idv_in_person_ready_to_verify_url
+      elsif device_profiling_failed?
+        idv_come_back_later_url
       elsif session[:sp] && !pending_profile?
         sign_up_completed_url
       else
@@ -81,6 +83,11 @@ module Idv
 
     def pending_profile?
       current_user.pending_profile?
+    end
+
+    def device_profiling_failed?
+      return false unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
+      true
     end
   end
 end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -86,7 +86,7 @@ module Idv
     end
 
     def device_profiling_failed?
-      return false unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
+      return false unless IdentityConfig.store.proofing_device_profiling_decisioning_enabled
       proofing_component = ProofingComponent.find_by(user: current_user)
       proofing_component.threatmetrix_review_status != 'pass'
     end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -88,6 +88,8 @@ module Idv
     def device_profiling_failed?
       return false unless IdentityConfig.store.proofing_device_profiling_decisioning_enabled
       proofing_component = ProofingComponent.find_by(user: current_user)
+      # pass users who are inbetween feature flag being enabled and have not had a check run.
+      return false if proofing_component.threatmetrix_review_status.nil?
       proofing_component.threatmetrix_review_status != 'pass'
     end
   end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -87,7 +87,8 @@ module Idv
 
     def device_profiling_failed?
       return false unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
-      true
+      proofing_component = ProofingComponent.find_by(user: current_user)
+      proofing_component.threatmetrix_review_status != 'pass'
     end
   end
 end

--- a/spec/controllers/api/verify/password_confirm_controller_spec.rb
+++ b/spec/controllers/api/verify/password_confirm_controller_spec.rb
@@ -326,7 +326,7 @@ describe Api::Verify::PasswordConfirmController do
         it 'redirects to come back later path when threatmetrix review status is nil' do
           post :create, params: { password: password, user_bundle_token: jwt }
 
-          expect(JSON.parse(response.body)['completion_url']).to eq(idv_come_back_later_url)
+          expect(JSON.parse(response.body)['completion_url']).to eq(account_url)
         end
 
         it 'redirects to account path when device profiling passes' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -205,7 +205,7 @@ describe Idv::PersonalKeyController do
       end
     end
 
-    context 'with device profiling collecting enabled' do
+    context 'with device profiling decisioning enabled' do
       before do
         ProofingComponent.create(user: user, threatmetrix: true, threatmetrix_review_status: nil)
         allow(IdentityConfig.store).

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -212,10 +212,10 @@ describe Idv::PersonalKeyController do
           to receive(:proofing_device_profiling_decisioning_enabled).and_return(true)
       end
 
-      it 'redirects to come back later path when threatmetrix review status is nil' do
+      it 'redirects to account path when threatmetrix review status is nil' do
         patch :update
 
-        expect(response).to redirect_to idv_come_back_later_path
+        expect(response).to redirect_to account_path
       end
 
       it 'redirects to account path when device profiling passes' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -204,5 +204,18 @@ describe Idv::PersonalKeyController do
         expect(response).to redirect_to idv_in_person_ready_to_verify_url
       end
     end
+
+    context 'with device profiling collecting enabled' do
+      before do
+        allow(IdentityConfig.store).
+          to receive(:proofing_device_profiling_collecting_enabled).and_return(true)
+      end
+
+      it 'device profiling failed' do
+        patch :update
+
+        expect(response).to redirect_to idv_come_back_later_path
+      end
+    end
   end
 end

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -207,12 +207,25 @@ describe Idv::PersonalKeyController do
 
     context 'with device profiling collecting enabled' do
       before do
-        ProofingComponent.create(user: user, threatmetrix: true)
+        ProofingComponent.create(user: user, threatmetrix: true, threatmetrix_review_status: nil)
         allow(IdentityConfig.store).
-          to receive(:proofing_device_profiling_collecting_enabled).and_return(true)
+          to receive(:proofing_device_profiling_decisioning_enabled).and_return(true)
       end
 
-      it 'when device profiling fails redirect to come back later path' do
+      it 'redirects to come back later path when threatmetrix review status is nil' do
+        patch :update
+
+        expect(response).to redirect_to idv_come_back_later_path
+      end
+
+      it 'redirects to account path when device profiling passes' do
+        ProofingComponent.find_by(user: user).update(threatmetrix_review_status: 'pass')
+        patch :update
+
+        expect(response).to redirect_to account_path
+      end
+
+      it 'redirects to come back later path when device profiling fails' do
         ProofingComponent.find_by(user: user).update(threatmetrix_review_status: 'fail')
         patch :update
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -207,11 +207,13 @@ describe Idv::PersonalKeyController do
 
     context 'with device profiling collecting enabled' do
       before do
+        ProofingComponent.create(user: user, threatmetrix: true)
         allow(IdentityConfig.store).
           to receive(:proofing_device_profiling_collecting_enabled).and_return(true)
       end
 
-      it 'device profiling failed' do
+      it 'when device profiling fails redirect to come back later path' do
+        ProofingComponent.find_by(user: user).update(threatmetrix_review_status: 'fail')
         patch :update
 
         expect(response).to redirect_to idv_come_back_later_path


### PR DESCRIPTION
Why? 
If a user fails threatmetrix verification we want to redirect them to a come back later page.