### PR TITLE
Allow triggering different review_status values in mock DDP proofer

### DIFF
--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -20,9 +20,27 @@ module Proofing
 
       TRANSACTION_ID = 'ddp-mock-transaction-id-123'
 
+      # Trigger the "REJECT" status
+      REJECT_STATUS_SSN = '666-77-8888'
+
+      # Trigger the "REVIEW" status
+      REVIEW_STATUS_SSN = '666-77-9999'
+
+      # Trigger a nil status
+      NIL_STATUS_SSN = '666-77-0000'
+
       proof do |applicant, result|
         result.transaction_id = TRANSACTION_ID
-        result.review_status = 'pass'
+        result.review_status = case SsnFormatter.format(applicant[:ssn])
+        when REJECT_STATUS_SSN
+          'reject'
+        when REVIEW_STATUS_SSN
+          'review'
+        when NIL_STATUS_SSN
+          nil
+        else
+          'pass'
+        end
       end
     end
   end

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Mock::DdpMockClient do
+  let(:applicant) {
+    Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(threatmetrix_session_id: 'ABCD-1234')
+  }
+
+  subject(:instance) { described_class.new }
+
+  describe '#proof' do
+    subject(:result) { instance.proof(applicant) }
+
+    it 'passes by default' do
+      expect(result.review_status).to eq('pass')
+    end
+
+    context 'with magic "reject" SSN' do
+      let(:applicant) { super().merge(ssn: '666-77-8888') }
+      it 'fails' do
+        expect(result.review_status).to eq('reject')
+      end
+    end
+
+    context 'with magic "review" SSN' do
+      let(:applicant) { super().merge(ssn: '666-77-9999') }
+      it 'fails' do
+        expect(result.review_status).to eq('review')
+      end
+    end
+
+    context 'with magic "nil" SSN' do
+      let(:applicant) { super().merge(ssn: '666-77-0000') }
+      it 'fails' do
+        expect(result.review_status).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds 3 "magic" SSNs that will trigger `review_status` values from the mock LexisNexis DDP proofer:

| SSN | Status |
| -- | -- |
| 666-77-8888 | `"reject"` |
| 666-77-9999 | `"review"` |
| 666-77-0000 | `nil` |

Any other SSN will return `pass`, as before. This will support testing of the integration of the proofer into the ID verification flow.