### PR TITLE
LG-6308: Show in-person step indicator in initial steps

### DIFF
--- a/app/javascript/packages/verify-flow/index.ts
+++ b/app/javascript/packages/verify-flow/index.ts
@@ -4,7 +4,7 @@ export { default as FlowContext } from './context/flow-context';
 export { SecretsContextProvider } from './context/secrets-context';
 export { default as Cancel } from './cancel';
 export { default as VerifyFlow } from './verify-flow';
-export { default as VerifyFlowStepIndicator } from './verify-flow-step-indicator';
+export { default as VerifyFlowStepIndicator, VerifyFlowPath } from './verify-flow-step-indicator';
 
 export { default as personalKeyStep } from './steps/personal-key';
 export { default as personalKeyConfirmStep } from './steps/personal-key-confirm';

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
@@ -1,7 +1,10 @@
 import { render } from '@testing-library/react';
 import { StepStatus } from '@18f/identity-step-indicator';
 import { AddressVerificationMethodContextProvider } from './context/address-verification-method-context';
-import VerifyFlowStepIndicator, { getStepStatus } from './verify-flow-step-indicator';
+import VerifyFlowStepIndicator, {
+  getStepStatus,
+  VerifyFlowPath,
+} from './verify-flow-step-indicator';
 
 describe('getStepStatus', () => {
   it('returns incomplete if step is after current step', () => {
@@ -44,6 +47,17 @@ describe('VerifyFlowStepIndicator', () => {
 
       const previous = getByText('step_indicator.flows.idv.verify_phone_or_address');
       expect(previous.closest('.step-indicator__step--pending')).to.exist();
+    });
+  });
+
+  context('with in-person flow path', () => {
+    it('renders step indicator for the current step', () => {
+      const { getByText } = render(
+        <VerifyFlowStepIndicator currentStep="document_capture" path={VerifyFlowPath.IN_PERSON} />,
+      );
+
+      const current = getByText('step_indicator.flows.idv.find_a_post_office');
+      expect(current.closest('.step-indicator__step--current')).to.exist();
     });
   });
 });

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
@@ -124,7 +124,6 @@ function VerifyFlowStepIndicator({
   const { addressVerificationMethod } = useContext(AddressVerificationMethodContext);
   const statusOverrides = getStatusOverrides({ addressVerificationMethod });
 
-  // i18n-tasks-use t('step_indicator.flows.idv.find_a_post_office')
   // i18n-tasks-use t('step_indicator.flows.idv.getting_started')
   // i18n-tasks-use t('step_indicator.flows.idv.verify_id')
   // i18n-tasks-use t('step_indicator.flows.idv.verify_info')

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.tsx
@@ -106,7 +106,7 @@ function getStatusOverrides({
 }: {
   addressVerificationMethod: AddressVerificationMethod;
 }) {
-  const statuses: Partial<Record<string, StepStatus>> = {};
+  const statuses: Partial<Record<VerifyFlowStepIndicatorStep, StepStatus>> = {};
 
   if (addressVerificationMethod === 'gpo') {
     statuses.verify_phone_or_address = StepStatus.PENDING;

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -28,10 +28,6 @@ module Idv
       #          we finish setting up IPP step indicators
       # i18n-tasks-use t('step_indicator.flows.idv.go_to_the_post_office')
 
-      # WILLFIX: (LG-6308) move this to the location page when
-      #          we finish setting up IPP step indicators
-      # i18n-tasks-use t('step_indicator.flows.idv.find_a_post_office')
-
       STEP_INDICATOR_STEPS = [
         { name: :find_a_post_office },
         { name: :verify_info },

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -12,10 +12,7 @@ feature 'doc auth verify step', :js do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_address_path)
     expect(page).to have_content(t('doc_auth.headings.address'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_info'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
   end
 
   it 'allows the user to enter in a new address' do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -98,10 +98,7 @@ feature 'doc auth document capture step', :js do
       expect(current_path).to eq(idv_doc_auth_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
       # Document capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
@@ -187,10 +184,7 @@ feature 'doc auth document capture step', :js do
       expect(current_path).to eq(idv_doc_auth_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
       # Document capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -15,9 +15,6 @@ feature 'doc auth email sent step' do
     expect(page).to have_content(
       t('doc_auth.instructions.email_sent', email: user.confirmed_email_addresses.first.email),
     )
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -18,10 +18,7 @@ feature 'doc auth link sent step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
     expect(page).to have_content(t('doc_auth.headings.text_message'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
   end
 
   it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -20,10 +20,7 @@ feature 'doc auth send link step' do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_send_link_step)
     expect(page).to have_content(t('doc_auth.headings.take_picture'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
   end
 
   it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -15,10 +15,7 @@ feature 'doc auth ssn step', :js do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
       expect(page).to have_content(t('doc_auth.headings.ssn'))
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
     end
 
     it 'proceeds to the next page with valid info' do
@@ -51,10 +48,7 @@ feature 'doc auth ssn step', :js do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
       expect(page).to have_content(t('doc_auth.headings.ssn'))
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_info'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
     end
 
     it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -19,10 +19,7 @@ feature 'doc auth upload step' do
 
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
     end
 
     it 'proceeds to send link via email page when user chooses to upload from computer' do
@@ -47,10 +44,7 @@ feature 'doc auth upload step' do
   context 'on a desktop device' do
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
     end
 
     it 'proceeds to document capture when user chooses to upload from computer' do

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -17,10 +17,7 @@ feature 'doc auth verify step', :js do
 
     expect(page).to have_current_path(idv_doc_auth_verify_step)
     expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_info'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
 
     # SSN is masked until revealed
     expect(page).to have_text('9**-**-***4')

--- a/spec/features/idv/doc_capture/capture_complete_step_spec.rb
+++ b/spec/features/idv/doc_capture/capture_complete_step_spec.rb
@@ -13,9 +13,6 @@ feature 'capture complete step', :js do
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_capture_doc_capture_complete_step)
     expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_id'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
   end
 end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -214,10 +214,7 @@ feature 'doc capture document capture step', js: true do
         expect(current_path).to eq(idv_capture_doc_document_capture_step)
         expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
         expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-        expect(page).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.verify_id'),
-        )
+        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
         # Doc capture tips
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
@@ -285,10 +282,7 @@ feature 'doc capture document capture step', js: true do
       expect(current_path).to eq(idv_capture_doc_document_capture_step)
       expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
       expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_id'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
       # Document capture tips
       expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe 'In Person Proofing', js: true do
     begin_in_person_proofing(user)
 
     # location page
+    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
     expect(page).to have_content(t('in_person_proofing.headings.location'))
     bethesda_location = page.find_all('.location-collection-item')[1]
     bethesda_location.click_button(t('in_person_proofing.body.location.location_button'))
 
     # prepare page
+    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
     expect(page).to have_content(t('in_person_proofing.headings.prepare'))
     complete_prepare_step(user)
 

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -20,10 +20,7 @@ feature 'idv confirmation step', js: true do
 
   it 'shows status content for phone verification progress' do
     expect(page).to have_content(t('idv.messages.confirm'))
-    expect(page).to have_css(
-      '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.secure_account'),
-    )
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
     expect(page).to have_css(
       '.step-indicator__step--complete',
       text: t('step_indicator.flows.idv.verify_phone_or_address'),
@@ -72,10 +69,7 @@ feature 'idv confirmation step', js: true do
 
     it 'shows status content for gpo verification progress' do
       expect(page).to have_content(t('idv.messages.mail_sent'))
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.secure_account'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
       expect(page).to have_css(
         '.step-indicator__step--pending',
         text: t('step_indicator.flows.idv.verify_phone_or_address'),

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -19,10 +19,7 @@ feature 'verify profile with OTP' do
     it 'shows step indicator progress with current verify step, completed secure account' do
       sign_in_live_with_2fa(user)
 
-      expect(page).to have_css(
-        '.step-indicator__step--current',
-        text: t('step_indicator.flows.idv.verify_phone_or_address'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone_or_address'))
       expect(page).to have_css(
         '.step-indicator__step--complete',
         text: t('step_indicator.flows.idv.secure_account'),

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'verify profile with OTP' do
+  include IdvStepHelper
+
   let(:user) { create(:user, :signed_up) }
   let(:otp) { 'ABC123' }
 

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -15,6 +15,7 @@ import {
 import DocumentCapture, {
   except,
 } from '@18f/identity-document-capture/components/document-capture';
+import { FlowContext } from '@18f/identity-verify-flow';
 import { expect } from 'chai';
 import { useSandbox, useDefineProperty } from '@18f/identity-test-helpers';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
@@ -621,6 +622,71 @@ describe('document-capture/components/document-capture', () => {
       await new Promise((resolve) => {
         onSubmit.callsFake(resolve);
         userEvent.click(getByText('forms.buttons.submit.default'));
+      });
+    });
+  });
+
+  describe('step indicator', () => {
+    it('renders the step indicator', () => {
+      const { getByText } = render(<DocumentCapture />);
+
+      const step = getByText('step_indicator.flows.idv.verify_id');
+
+      expect(step).to.be.ok();
+      expect(step.closest('.step-indicator__step--current')).to.exist();
+    });
+
+    context('in person steps', () => {
+      it('renders the step indicator', async () => {
+        const endpoint = '/upload';
+        const { getByLabelText, getByText, findByText } = render(
+          <UploadContextProvider upload={httpUpload} endpoint={endpoint}>
+            <ServiceProviderContextProvider value={{ isLivenessRequired: false }}>
+              <FlowContext.Provider
+                value={{
+                  cancelURL: '/cancel',
+                  inPersonURL: '/in_person',
+                  currentStep: 'document_capture',
+                }}
+              >
+                <DocumentCapture />
+              </FlowContext.Provider>
+            </ServiceProviderContextProvider>
+          </UploadContextProvider>,
+        );
+
+        sandbox
+          .stub(window, 'fetch')
+          .withArgs(endpoint)
+          .resolves({
+            ok: false,
+            status: 400,
+            url: endpoint,
+            json: () => ({ success: false, remaining_attempts: 1, errors: [{}] }),
+          });
+
+        const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
+        const backImage = getByLabelText('doc_auth.headings.document_capture_back');
+        await userEvent.upload(frontImage, validUpload);
+        await userEvent.upload(backImage, validUpload);
+        await waitFor(() => frontImage.src && backImage.src);
+
+        await userEvent.click(getByText('forms.buttons.submit.default'));
+
+        const verifyInPersonButton = await findByText(
+          'idv.troubleshooting.options.verify_in_person',
+        );
+        await userEvent.click(verifyInPersonButton);
+
+        expect(console).to.have.loggedError(/^Error: Uncaught/);
+        expect(console).to.have.loggedError(
+          /React will try to recreate this component tree from scratch using the error boundary you provided/,
+        );
+
+        const step = await findByText('step_indicator.flows.idv.find_a_post_office');
+
+        expect(step).to.be.ok();
+        expect(step.closest('.step-indicator__step--current')).to.exist();
       });
     });
   });

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -1,4 +1,5 @@
 require_relative 'interaction_helper'
+require_relative 'javascript_driver_helper'
 
 module IdvHelper
   include ActiveJob::TestHelper

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -1,3 +1,8 @@
+require_relative 'idv_helper'
+require_relative 'javascript_driver_helper'
+require_relative 'doc_auth_helper'
+require_relative '../saml_auth_helper'
+
 module IdvStepHelper
   def self.included(base)
     base.class_eval do
@@ -113,6 +118,10 @@ module IdvStepHelper
 
   def complete_idv_steps_before_step(step, user = user_with_2fa)
     send("complete_idv_steps_before_#{step}_step", user)
+  end
+
+  def expect_step_indicator_current_step(text)
+    expect(page).to have_css('.step-indicator__step--current', text: text)
   end
 
   private

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -1,6 +1,8 @@
+require_relative 'idv_step_helper'
 require_relative 'doc_auth_helper'
 
 module InPersonHelper
+  include IdvStepHelper
   include DocAuthHelper
 
   GOOD_FIRST_NAME = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
@@ -77,5 +79,17 @@ module InPersonHelper
     complete_address_step(user)
     complete_ssn_step(user)
     complete_verify_step(user)
+  end
+
+  def expect_in_person_step_indicator_current_step(text)
+    # Normally we're only concerned with the "current" step, but since some steps are shared between
+    # flows, we also want to make sure that at least one of the in-person-specific steps exists in
+    # the step indicator.
+    expect(page).to have_css(
+      '.step-indicator__step',
+      text: t('step_indicator.flows.idv.find_a_post_office'),
+    )
+
+    expect_step_indicator_current_step(text)
   end
 end


### PR DESCRIPTION
**Why**: It's expected that the step indicator should update to reflect in-person steps as soon as the user opts to verify in-person, which technically occurs while the user is still at the document capture step.

**Screenshots:**

Step|Before|After
---|---|---
Document Capture|![image](https://user-images.githubusercontent.com/1779930/186463408-32402c40-931a-4b42-9370-3eb4196b3ef2.png)|![image](https://user-images.githubusercontent.com/1779930/186463408-32402c40-931a-4b42-9370-3eb4196b3ef2.png)
Location|![image](https://user-images.githubusercontent.com/1779930/186463490-60072413-a271-4517-9bb1-6958ec86e847.png)|![image](https://user-images.githubusercontent.com/1779930/186463210-2823c4f0-40a6-4cdb-90ad-2e7c8f3705bc.png)
Prepare|![image](https://user-images.githubusercontent.com/1779930/186463543-bc6723cc-784a-47c3-950b-0d0f1d20917b.png)|![image](https://user-images.githubusercontent.com/1779930/186463246-10fb9da8-8688-4463-9b17-7a33d572082d.png)
Hybrid Switch Back|![image](https://user-images.githubusercontent.com/1779930/186463567-63a867a0-aae4-4bbc-b8c2-63926989bcfe.png)|![image](https://user-images.githubusercontent.com/1779930/186463271-9a3c9c6b-d1ae-4d38-8683-28d41a23b757.png)