### PR TITLE
Remove FSMv2 configuration override in in-person feature specs

### DIFF
--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe 'In Person Proofing', js: true do
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:idv_api_enabled_steps).and_return(
-      ['password_confirm',
-       'personal_key',
-       'personal_key_confirm'],
-    )
   end
 
   it 'works for a happy path', allow_browser_log: true do


### PR DESCRIPTION
**Why**: The specs should pass regardless of the configured value, as in-person proofing does not depend on FSMv2 and shouldn't be concerned with the configuration. Additionally, we should expect that the default value is the more commonly-desired value (and likely matches the production experience).

I expect this is likely a hold-over from before #6635 where in-person proofing only supported FSMv2.