### PR TITLE
Rescue more generic pinpoint error

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -94,7 +94,7 @@ module Telephony
           )
           break if response
         rescue Seahorse::Client::NetworkingError,
-               Aws::Pinpoint::Errors::InternalServerErrorException => error
+               Aws::Pinpoint::Errors::ServiceError => error
           PinpointHelper.notify_pinpoint_failover(
             error: error,
             region: sms_config.region,


### PR DESCRIPTION
**Why**: because other errors were slipping through and
not being rescued correctly

changelog: Bug fixes, Multi-factor authentication, handle errors from vendors better

See: https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=1800000&state=37783449-3874-df80-5a9f-08fc1def99cb