### PR TITLE
LG-7200 - added mfa_phone_otp_sent_rate_limited events for login and enroll

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -172,9 +172,19 @@ module Users
     def handle_valid_otp_params(method, default = nil)
       otp_rate_limiter.reset_count_and_otp_last_sent_at if decorated_user.no_longer_locked_out?
 
-      return handle_too_many_otp_sends if exceeded_otp_send_limit?
+      if exceeded_otp_send_limit?
+        return handle_too_many_otp_sends(
+          phone: parsed_phone.e164,
+          context: context,
+        )
+      end
       otp_rate_limiter.increment
-      return handle_too_many_otp_sends if exceeded_otp_send_limit?
+      if exceeded_otp_send_limit?
+        return handle_too_many_otp_sends(
+          phone: parsed_phone.e164,
+          context: context,
+        )
+      end
       return handle_too_many_confirmation_sends if exceeded_phone_confirmation_limit?
 
       @telephony_result = send_user_otp(method)

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -128,6 +128,17 @@ module IrsAttemptsApi
       )
     end
 
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # @param [Boolean] success - True if the user was locked out
+    # The user has exceeded the rate limit for SMS OTP sends.
+    def mfa_enroll_phone_otp_sent_rate_limited(phone_number:, success:)
+      track_event(
+        :mfa_enroll_phone_otp_sent_rate_limited,
+        phone_number: phone_number,
+        success: success,
+      )
+    end
+
     # Tracks when the user has attempted to enroll the piv cac MFA method to their account
     # @param [String] subject_dn
     # @param [Boolean] success
@@ -199,6 +210,17 @@ module IrsAttemptsApi
       track_event(
         :mfa_login_phone_otp_sent,
         reauthentication: reauthentication,
+        phone_number: phone_number,
+        success: success,
+      )
+    end
+
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # @param [Boolean] success - True if the user was locked out
+    # The user has exceeded the rate limit for SMS OTP sends.
+    def mfa_login_phone_otp_sent_rate_limited(phone_number:, success:)
+      track_event(
+        :mfa_login_phone_otp_sent_rate_limited,
         phone_number: phone_number,
         success: success,
       )

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -360,6 +360,13 @@ describe Users::TwoFactorAuthenticationController do
       it 'marks the user as locked out after too many attempts' do
         expect(@user.second_factor_locked_at).to be_nil
 
+        allow(OtpRateLimiter).to receive(:exceeded_otp_send_limit?).
+          and_return(true)
+
+        stub_attempts_tracker
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_sent_rate_limited).
+          with(phone_number: '+12025551212', success: true)
+
         freeze_time do
           (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
             get :send_code, params: {
@@ -553,6 +560,34 @@ describe Users::TwoFactorAuthenticationController do
             ),
           )
           expect(response).to redirect_to authentication_methods_setup_url
+        end
+      end
+
+      it 'marks the user as locked out after too many attempts on sign up' do
+        sign_in_before_2fa(@user)
+        subject.user_session[:context] = 'confirmation'
+        subject.user_session[:unconfirmed_phone] = '+1 (202) 555-1213'
+
+        expect(@user.second_factor_locked_at).to be_nil
+
+        allow(OtpRateLimiter).to receive(:exceeded_otp_send_limit?).
+          and_return(true)
+
+        stub_attempts_tracker
+        expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_phone_otp_sent_rate_limited).
+          with(phone_number: '+12025551213', success: true)
+
+        freeze_time do
+          (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
+            get :send_code, params: {
+              otp_delivery_selection_form: {
+                otp_delivery_preference: 'sms',
+                otp_make_default_number: nil,
+              },
+            }
+          end
+
+          expect(@user.reload.second_factor_locked_at).to eq Time.zone.now
         end
       end
 


### PR DESCRIPTION
# Summary
1. Added `mfa_enroll_phone_otp_sent_rate_limited` attempt event.
2. Added `mfa_login_phone_otp_sent_rate_limited` attempt event.
3. Added unit tests in `two_factor_authentication_controller_spec.rb` for the above events.

changelog: Internal, Attempts API, Track additional events