### PR TITLE
Use non-hashed SSN param, removed hashed version

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -26,7 +26,8 @@ module Proofing
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',
             session_id: applicant[:threatmetrix_session_id],
-            ssn_hash: OpenSSL::Digest::SHA256.hexdigest(applicant[:ssn].gsub(/\D/, '')),
+            national_id_number: applicant[:ssn].gsub(/\D/, ''),
+            national_id_type: 'US_SSN',
             input_ip_address: applicant[:request_ip],
             local_attrib_1: applicant[:uuid_prefix],
           }.to_json

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -17,7 +17,8 @@
   "policy": "test-policy",
   "service_type": "all",
   "session_id": "UNIQUE_SESSION_ID",
-  "ssn_hash": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+  "national_id_number": "123456789",
+  "national_id_type": "US_SSN",
   "input_ip_address": "127.0.0.1",
   "local_attrib_1": "ABCD"
 

--- a/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
@@ -1,18 +1,9 @@
 {
-  "account_address_result": "success",
-  "account_address_score": "0",
-  "account_email_result": "success",
-  "account_email_score": "0",
-  "account_name_result": "success",
-  "account_name_score": "0",
-  "account_telephone_result": "success",
-  "account_telephone_score": "0",
   "request_id": "1234",
   "request_result": "success",
   "review_status": "pass",
   "risk_rating": "trusted",
-  "ssn_hash_result": "success",
-  "ssn_hash_score": "0",
   "summary_risk_score": "-6",
-  "tmx_risk_rating": "neutral"
+  "tmx_risk_rating": "neutral",
+  "fraudpoint.score": "500"
 }


### PR DESCRIPTION
**Why:** Per LexisNexis email on 19 August 2022 we should use the `national_id_number` param instead of the `ssn_hash` param.

**How:** I have replaced params in the VerificationRequest and fixture file, and added `national_id_type` per [the documentation](https://portal.threatmetrix.us/kb/implementation/apis/session_query_api.htm).

changelog: Internal, ThreatMetrix API, Use non-hashed param