### PR TITLE
LG-7383: Remove redundant in-person condition methods

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -74,8 +74,7 @@ class GpoVerifyForm
   end
 
   def pending_in_person_enrollment?
-    return false unless IdentityConfig.store.in_person_proofing_enabled
-    pending_profile.proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS
+    pending_profile&.proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS
   end
 
   def activate_profile


### PR DESCRIPTION
**Why**: Since they are duplicated and one is unused. Consolidate on the name without "pending" reference to avoid ambiguity between "establishing" and "pending" enrollment statuses (technically, the enrollment is still "establishing" at this point, not "pending"). Removes feature guard conditions to avoid future clean-up, since it would be safe to check the proofing component with the understanding that it would only be assigned in earlier steps if the feature were enabled.