### PR TITLE
LG-6307: Remove pending steps from step indicator

### DIFF
--- a/app/assets/images/alert/pending.svg
+++ b/app/assets/images/alert/pending.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.88 16c4.352 0 7.88-3.582 7.88-8s-3.528-8-7.88-8S0 3.582 0 8s3.528 8 7.88 8z" fill="#A8B6C6"/><circle cx="5" cy="8" r="1" fill="#fff"/><circle cx="8" cy="8" r="1" fill="#fff"/><circle cx="11" cy="8" r="1" fill="#fff"/></svg>

--- a/app/assets/stylesheets/components/_step-indicator.scss
+++ b/app/assets/stylesheets/components/_step-indicator.scss
@@ -1,6 +1,5 @@
 $step-indicator-current-step-border-width: 3px;
 $step-indicator-line-height: 4px;
-$step-indicator-pending-color: #a8b6c6;
 
 lg-step-indicator {
   display: block;
@@ -106,13 +105,9 @@ lg-step-indicator {
   border: $step-indicator-current-step-border-width solid color('success');
 }
 
-.step-indicator__step--complete:not(.step-indicator__step--pending)::before {
+.step-indicator__step--complete::before {
   background-color: color('white');
   background-image: url('alert/success.svg');
-}
-
-.step-indicator__step--pending::before {
-  background-image: url('alert/pending.svg');
 }
 
 .step-indicator__step:not(:last-child)::after {
@@ -126,11 +121,7 @@ lg-step-indicator {
   width: calc(100% - 1rem - #{$step-indicator-line-height * 2});
 }
 
-.step-indicator__step--pending:not(:last-child)::after {
-  background-color: $step-indicator-pending-color;
-}
-
-.step-indicator__step--complete:not(.step-indicator__step--pending):not(:last-child)::after {
+.step-indicator__step--complete:not(:last-child)::after {
   background-color: color('success');
 }
 

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -27,10 +27,10 @@ module Idv
     private
 
     def step_indicator_steps
-      steps = Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
-      return steps if idv_session.address_verification_mechanism != 'gpo'
-      steps.map do |step|
-        step[:name] == :verify_phone_or_address ? step.merge(status: :pending) : step
+      if idv_session.address_verification_mechanism == 'gpo'
+        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO
+      else
+        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
       end
     end
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -65,10 +65,10 @@ module Idv
     end
 
     def step_indicator_steps
-      steps = Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
-      return steps if idv_session.address_verification_mechanism != 'gpo'
-      steps.map do |step|
-        step[:name] == :verify_phone_or_address ? step.merge(status: :pending) : step
+      if idv_session.address_verification_mechanism == 'gpo'
+        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO
+      else
+        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
       end
     end
 

--- a/app/javascript/packages/eslint-plugin/CHANGELOG.md
+++ b/app/javascript/packages/eslint-plugin/CHANGELOG.md
@@ -46,6 +46,7 @@
   - `no-useless-constructor`
 - React: The following rules are no longer enforced:
   - `react/no-array-index-key`
+- `prefer-const` is only enforced on destructuring assignment if all variables should be `const` ([`destructuring: 'all'` option](https://eslint.org/docs/latest/rules/prefer-const#destructuring)).
 
 ## v2.0.0 (2022-03-14)
 

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -55,6 +55,7 @@ const config = {
     'object-curly-spacing': 'off',
     'operator-linebreak': 'off',
     'padded-blocks': 'off',
+    'prefer-const': ['error', { destructuring: 'all' }],
     'quote-props': 'off',
     'require-await': 'error',
     'rest-spread-spacing': 'off',

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -55,7 +55,7 @@ const config = {
     'object-curly-spacing': 'off',
     'operator-linebreak': 'off',
     'padded-blocks': 'off',
-    'prefer-const': ['error', { destructuring: 'all' }],
+    'prefer-const': ['error', { destructuring: 'all', ignoreReadBeforeAssign: true }],
     'quote-props': 'off',
     'require-await': 'error',
     'rest-spread-spacing': 'off',

--- a/app/javascript/packages/step-indicator/step-indicator-step.spec.tsx
+++ b/app/javascript/packages/step-indicator/step-indicator-step.spec.tsx
@@ -14,7 +14,6 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.true();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.false();
-      expect(step.classList.contains('step-indicator__step--pending')).to.be.false();
       expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
     });
@@ -32,27 +31,8 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.false();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.true();
-      expect(step.classList.contains('step-indicator__step--pending')).to.be.false();
       expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
-    });
-  });
-
-  context('pending step', () => {
-    it('renders step', () => {
-      const { getByText } = render(<StepIndicatorStep title="Step" status={StepStatus.PENDING} />);
-
-      const title = getByText('Step');
-      const status = getByText('step_indicator.status.pending');
-      const step = title.closest('.step-indicator__step')!;
-
-      expect(title).to.be.ok();
-      expect(status).to.be.ok();
-      expect(step.classList.contains('step-indicator__step--current')).to.be.false();
-      expect(step.classList.contains('step-indicator__step--complete')).to.be.false();
-      expect(step.classList.contains('step-indicator__step--pending')).to.be.true();
-      expect(status.classList.contains('step-indicator__step-subtitle')).to.be.true();
-      expect(status.classList.contains('usa-sr-only')).to.be.false();
     });
   });
 
@@ -70,7 +50,6 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.false();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.false();
-      expect(step.classList.contains('step-indicator__step--pending')).to.be.false();
       expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
     });

--- a/app/javascript/packages/step-indicator/step-indicator-step.tsx
+++ b/app/javascript/packages/step-indicator/step-indicator-step.tsx
@@ -26,7 +26,6 @@ function StepIndicatorStep({ title, status }: StepIndicatorStepProps) {
     'step-indicator__step',
     status === CURRENT && 'step-indicator__step--current',
     status === COMPLETE && 'step-indicator__step--complete',
-    status === PENDING && 'step-indicator__step--pending',
   ]
     .filter(Boolean)
     .join(' ');

--- a/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
+++ b/app/javascript/packages/verify-flow/verify-flow-step-indicator.spec.tsx
@@ -38,15 +38,18 @@ describe('VerifyFlowStepIndicator', () => {
   });
 
   context('with gpo as address verification method', () => {
-    it('renders address verification as pending', () => {
-      const { getByText } = render(
+    it('revises the flow path to omit address verification and add letter step', () => {
+      const { queryByText } = render(
         <AddressVerificationMethodContextProvider initialMethod="gpo">
           <VerifyFlowStepIndicator currentStep="personal_key" />
         </AddressVerificationMethodContextProvider>,
       );
 
-      const previous = getByText('step_indicator.flows.idv.verify_phone_or_address');
-      expect(previous.closest('.step-indicator__step--pending')).to.exist();
+      const verifyAddress = queryByText('step_indicator.flows.idv.verify_phone_or_address');
+      const getALetter = queryByText('step_indicator.flows.idv.get_a_letter');
+
+      expect(verifyAddress).to.not.exist();
+      expect(getALetter).to.exist();
     });
   });
 

--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -22,6 +22,14 @@ module Idv
         { name: :secure_account },
       ].freeze
 
+      STEP_INDICATOR_STEPS_GPO = [
+        { name: :getting_started },
+        { name: :verify_id },
+        { name: :verify_info },
+        { name: :secure_account },
+        { name: :get_a_letter },
+      ].freeze
+
       OPTIONAL_SHOW_STEPS = {
         verify_wait: Idv::Steps::VerifyWaitStepShow,
       }.freeze

--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -1,9 +1,7 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
-          step[:name] == :secure_account ? step.merge(status: :complete) : step
-        end,
-        current_step: :verify_phone_or_address,
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO,
+        current_step: :get_a_letter,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
       } %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -1,9 +1,7 @@
 <% content_for(:pre_flash_content) do %>
   <%= render 'shared/step_indicator', {
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS.map do |step|
-          step[:name] == :secure_account ? step.merge(status: :complete) : step
-        end,
-        current_step: :verify_phone_or_address,
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO,
+        current_step: :get_a_letter,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
       } %>

--- a/app/views/shared/_step_indicator_step.html.erb
+++ b/app/views/shared/_step_indicator_step.html.erb
@@ -7,8 +7,7 @@ locals:
    status = local_assigns[:status] || :not_complete
    classes = ['step-indicator__step']
    classes << 'step-indicator__step--current' if local_assigns[:status] == :current
-   classes << 'step-indicator__step--complete' if local_assigns[:status] == :complete
-   classes << 'step-indicator__step--pending' if local_assigns[:status] == :pending %>
+   classes << 'step-indicator__step--complete' if local_assigns[:status] == :complete %>
 
 <%#
 Using `aria-current="step"` would be the preferred method to indicate the current step, but at the

--- a/config/locales/step_indicator/en.yml
+++ b/config/locales/step_indicator/en.yml
@@ -5,6 +5,7 @@ en:
     flows:
       idv:
         find_a_post_office: Find a Post Office
+        get_a_letter: Get a letter in the mail
         getting_started: Getting started
         go_to_the_post_office: Go to the Post Office
         secure_account: Secure your account

--- a/config/locales/step_indicator/es.yml
+++ b/config/locales/step_indicator/es.yml
@@ -5,6 +5,7 @@ es:
     flows:
       idv:
         find_a_post_office: Encontrar una oficina de correos
+        get_a_letter: Reciba una carta por correo
         getting_started: Inicio
         go_to_the_post_office: Ir a la oficina de correos
         secure_account: Proteje tu cuenta

--- a/config/locales/step_indicator/fr.yml
+++ b/config/locales/step_indicator/fr.yml
@@ -5,6 +5,7 @@ fr:
     flows:
       idv:
         find_a_post_office: Trouver un bureau de poste
+        get_a_letter: Recevoir une lettre par la poste
         getting_started: Démarrer
         go_to_the_post_office: Se rendre au bureau de poste
         secure_account: Sécurisez votre compte

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -119,13 +119,13 @@ describe Idv::PersonalKeyController do
         subject.idv_session.address_verification_mechanism = 'gpo'
       end
 
-      it 'assigns step indicator steps with pending status' do
+      it 'assigns step indicator steps with gpo letter step' do
         get :show
 
+        steps = assigns(:step_indicator_steps)
+
         expect(flash.now[:success]).to eq t('idv.messages.mail_sent')
-        expect(assigns(:step_indicator_steps)).to include(
-          hash_including(name: :verify_phone_or_address, status: :pending),
-        )
+        expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO)
       end
     end
   end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -212,9 +212,9 @@ describe Idv::ReviewController do
       it 'shows steps' do
         get :new
 
-        expect(subject.view_assigns['step_indicator_steps']).not_to include(
-          hash_including(name: :verify_phone_or_address, status: :pending),
-        )
+        steps = subject.view_assigns['step_indicator_steps']
+
+        expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)
       end
 
       context 'idv app password confirm step is enabled' do
@@ -236,12 +236,12 @@ describe Idv::ReviewController do
         idv_session.address_verification_mechanism = 'gpo'
       end
 
-      it 'shows revises steps to show pending address verification' do
+      it 'shows gpo steps' do
         get :new
 
-        expect(subject.view_assigns['step_indicator_steps']).to include(
-          hash_including(name: :verify_phone_or_address, status: :pending),
-        )
+        steps = subject.view_assigns['step_indicator_steps']
+
+        expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO)
       end
     end
 

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -70,10 +70,7 @@ feature 'idv confirmation step', js: true do
     it 'shows status content for gpo verification progress' do
       expect(page).to have_content(t('idv.messages.mail_sent'))
       expect_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
-      expect(page).to have_css(
-        '.step-indicator__step--incomplete',
-        text: t('step_indicator.flows.idv.get_a_letter'),
-      )
+      expect(page).to have_content(t('step_indicator.flows.idv.get_a_letter'))
       expect(page).not_to have_content(t('step_indicator.flows.idv.verify_phone_or_address'))
     end
 

--- a/spec/features/idv/steps/confirmation_step_spec.rb
+++ b/spec/features/idv/steps/confirmation_step_spec.rb
@@ -25,7 +25,7 @@ feature 'idv confirmation step', js: true do
       '.step-indicator__step--complete',
       text: t('step_indicator.flows.idv.verify_phone_or_address'),
     )
-    expect(page).not_to have_css('.step-indicator__step--pending')
+    expect(page).not_to have_content(t('step_indicator.flows.idv.get_a_letter'))
   end
 
   it 'allows the user to refresh and still displays the personal key' do
@@ -71,9 +71,10 @@ feature 'idv confirmation step', js: true do
       expect(page).to have_content(t('idv.messages.mail_sent'))
       expect_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
       expect(page).to have_css(
-        '.step-indicator__step--pending',
-        text: t('step_indicator.flows.idv.verify_phone_or_address'),
+        '.step-indicator__step--incomplete',
+        text: t('step_indicator.flows.idv.get_a_letter'),
       )
+      expect(page).not_to have_content(t('step_indicator.flows.idv.verify_phone_or_address'))
     end
 
     it_behaves_like 'personal key page', :gpo

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -18,14 +18,10 @@ feature 'verify profile with OTP' do
   end
 
   context 'GPO letter' do
-    it 'shows step indicator progress with current verify step, completed secure account' do
+    it 'shows step indicator progress with current step' do
       sign_in_live_with_2fa(user)
 
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone_or_address'))
-      expect(page).to have_css(
-        '.step-indicator__step--complete',
-        text: t('step_indicator.flows.idv.secure_account'),
-      )
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
     end
 
     scenario 'valid OTP' do

--- a/spec/views/idv/come_back_later/show.html.erb_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.erb_spec.rb
@@ -55,16 +55,12 @@ describe 'idv/come_back_later/show.html.erb' do
     end
   end
 
-  it 'shows step indicator with pending status' do
+  it 'shows step indicator with current step' do
     render
 
     expect(view.content_for(:pre_flash_content)).to have_css(
       '.step-indicator__step--current',
-      text: t('step_indicator.flows.idv.verify_phone_or_address'),
-    )
-    expect(view.content_for(:pre_flash_content)).to have_css(
-      '.step-indicator__step--complete',
-      text: t('step_indicator.flows.idv.secure_account'),
+      text: t('step_indicator.flows.idv.get_a_letter'),
     )
   end
 end

--- a/spec/views/shared/_step_indicator.html.erb_spec.rb
+++ b/spec/views/shared/_step_indicator.html.erb_spec.rb
@@ -75,12 +75,12 @@ describe 'shared/_step_indicator.html.erb' do
     end
 
     context 'explicit step status' do
-      let(:steps) { [{ name: :one, status: :pending }, { name: :two }] }
+      let(:steps) { [{ name: :one, status: :complete }, { name: :two }] }
       let(:current_step) { :two }
 
       it 'renders with status' do
         expect(rendered).to have_css(
-          '.step-indicator__step--pending',
+          '.step-indicator__step--complete',
           text: t('step_indicator.flows.example.one'),
         )
       end

--- a/spec/views/shared/_step_indicator_step.html.erb_spec.rb
+++ b/spec/views/shared/_step_indicator_step.html.erb_spec.rb
@@ -24,7 +24,6 @@ describe 'shared/_step_indicator_step.html.erb' do
         it 'renders incomplete step' do
           expect(rendered).to have_selector('.step-indicator__step')
           expect(rendered).not_to have_selector('.step-indicator__step--current')
-          expect(rendered).not_to have_selector('.step-indicator__step--pending')
           expect(rendered).not_to have_selector('.step-indicator__step--complete')
         end
 
@@ -39,7 +38,6 @@ describe 'shared/_step_indicator_step.html.erb' do
         it 'renders current step' do
           expect(rendered).to have_selector('.step-indicator__step')
           expect(rendered).to have_selector('.step-indicator__step--current')
-          expect(rendered).not_to have_selector('.step-indicator__step--pending')
           expect(rendered).not_to have_selector('.step-indicator__step--complete')
         end
 
@@ -53,7 +51,6 @@ describe 'shared/_step_indicator_step.html.erb' do
 
         it 'renders pending step' do
           expect(rendered).to have_selector('.step-indicator__step')
-          expect(rendered).to have_selector('.step-indicator__step--pending')
           expect(rendered).not_to have_selector('.step-indicator__step--current')
           expect(rendered).not_to have_selector('.step-indicator__step--complete')
         end
@@ -70,7 +67,6 @@ describe 'shared/_step_indicator_step.html.erb' do
           expect(rendered).to have_selector('.step-indicator__step')
           expect(rendered).to have_selector('.step-indicator__step--complete')
           expect(rendered).not_to have_selector('.step-indicator__step--current')
-          expect(rendered).not_to have_selector('.step-indicator__step--pending')
         end
 
         it 'renders accessible indicator' do


### PR DESCRIPTION
Related: #6846

**Why**: As a user, I want to see a step indicator at the top of the page that shows me moving forward in the flow, so that it's easy to understand that I'm making progress and what I still need to do.

**Screenshots:**

Step|Before|After
---|---|---
GPO Opt-in|![Screen Shot 2022-08-29 at 10 44 23 AM](https://user-images.githubusercontent.com/1779930/187235631-2638acc2-3e8a-4720-a113-1dcf683eea0c.png)|![Screen Shot 2022-08-29 at 10 44 23 AM](https://user-images.githubusercontent.com/1779930/187235631-2638acc2-3e8a-4720-a113-1dcf683eea0c.png)
Password confirm|![Screen Shot 2022-08-29 at 10 44 38 AM](https://user-images.githubusercontent.com/1779930/187235651-dfa81237-a45c-44cc-98ce-9c87ead32f94.png)|![Screen Shot 2022-08-29 at 10 42 28 AM](https://user-images.githubusercontent.com/1779930/187235574-52c959a2-70ee-440b-a083-bcc7b3fd49ef.png)
Personal key|![Screen Shot 2022-08-29 at 10 44 45 AM](https://user-images.githubusercontent.com/1779930/187235678-c0d9cdfe-9ada-4532-aa9f-f32dc92fc2d0.png)|![Screen Shot 2022-08-29 at 10 42 35 AM](https://user-images.githubusercontent.com/1779930/187235576-3c8e9e90-9f9c-4971-81b7-a26f27788b00.png)
Come back soon|![Screen Shot 2022-08-29 at 10 44 52 AM](https://user-images.githubusercontent.com/1779930/187235700-59fce474-4f1d-4a4e-be48-fc48b6f4fde7.png)|![Screen Shot 2022-08-29 at 10 42 42 AM](https://user-images.githubusercontent.com/1779930/187235587-ef4fad6a-337c-4ece-825d-d4c28192212a.png)
GPO Verification|![Screen Shot 2022-08-29 at 10 44 58 AM](https://user-images.githubusercontent.com/1779930/187235723-c7ea3ff9-4c1e-4eeb-ba01-4934db75f4f3.png)|![Screen Shot 2022-08-29 at 10 42 50 AM](https://user-images.githubusercontent.com/1779930/187235606-509bdb7b-b230-4990-ab40-f08deef9181c.png)