### PR TITLE
LG-7397 - Bugfix: Moved rate_limited events to be called before sign out.

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -24,9 +24,9 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
     if context && type
       if UserSessionContext.authentication_context?(context)
-        irs_attempts_api_tracker.mfa_login_rate_limited(type: type)
+        irs_attempts_api_tracker.mfa_login_rate_limited(mfa_device_type: type)
       elsif UserSessionContext.confirmation_context?(context)
-        irs_attempts_api_tracker.mfa_enroll_rate_limited(type: type)
+        irs_attempts_api_tracker.mfa_enroll_rate_limited(mfa_device_type: type)
       end
     end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -21,34 +21,34 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     analytics.multi_factor_auth_max_attempts
     event = PushNotification::MfaLimitAccountLockedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)
-    handle_max_attempts(type + '_login_attempts')
 
-    if context
+    if context && type
       if UserSessionContext.authentication_context?(context)
         irs_attempts_api_tracker.mfa_login_rate_limited(type: type)
       elsif UserSessionContext.confirmation_context?(context)
         irs_attempts_api_tracker.mfa_enroll_rate_limited(type: type)
       end
     end
+
+    handle_max_attempts(type + '_login_attempts')
   end
 
   def handle_too_many_otp_sends(phone: nil, context: nil)
     analytics.multi_factor_auth_max_sends
-    handle_max_attempts('otp_requests')
 
     if context && phone
       if UserSessionContext.authentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_sent_rate_limited(
           phone_number: phone,
-          success: true,
         )
       elsif UserSessionContext.confirmation_context?(context)
         irs_attempts_api_tracker.mfa_enroll_phone_otp_sent_rate_limited(
           phone_number: phone,
-          success: true,
         )
       end
     end
+
+    handle_max_attempts('otp_requests')
   end
 
   def handle_max_attempts(type)

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -198,11 +198,10 @@ module IrsAttemptsApi
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
     # @param [Boolean] success - True if the user was locked out
     # The user has exceeded the rate limit for SMS OTP sends.
-    def mfa_enroll_phone_otp_sent_rate_limited(phone_number:, success:)
+    def mfa_enroll_phone_otp_sent_rate_limited(phone_number:)
       track_event(
         :mfa_enroll_phone_otp_sent_rate_limited,
         phone_number: phone_number,
-        success: success,
       )
     end
 
@@ -295,11 +294,10 @@ module IrsAttemptsApi
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
     # @param [Boolean] success - True if the user was locked out
     # The user has exceeded the rate limit for SMS OTP sends.
-    def mfa_login_phone_otp_sent_rate_limited(phone_number:, success:)
+    def mfa_login_phone_otp_sent_rate_limited(phone_number:)
       track_event(
         :mfa_login_phone_otp_sent_rate_limited,
         phone_number: phone_number,
-        success: success,
       )
     end
 

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -196,7 +196,6 @@ module IrsAttemptsApi
     end
 
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
-    # @param [Boolean] success - True if the user was locked out
     # The user has exceeded the rate limit for SMS OTP sends.
     def mfa_enroll_phone_otp_sent_rate_limited(phone_number:)
       track_event(
@@ -292,7 +291,6 @@ module IrsAttemptsApi
     end
 
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
-    # @param [Boolean] success - True if the user was locked out
     # The user has exceeded the rate limit for SMS OTP sends.
     def mfa_login_phone_otp_sent_rate_limited(phone_number:)
       track_event(

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -232,13 +232,13 @@ module IrsAttemptsApi
       )
     end
 
-    # @param [String] type - the type of multi-factor authentication used
+    # @param [String] mfa_device_type - the type of multi-factor authentication used
     # The user has exceeded the rate limit during enrollment
     # and account has been locked
-    def mfa_enroll_rate_limited(type:)
+    def mfa_enroll_rate_limited(mfa_device_type:)
       track_event(
         :mfa_enroll_rate_limited,
-        type: type,
+        mfa_device_type: mfa_device_type,
       )
     end
 
@@ -329,13 +329,13 @@ module IrsAttemptsApi
       )
     end
 
-    # @param [String] type - the type of multi-factor authentication used
+    # @param [String] mfa_device_type - the type of multi-factor authentication used
     # The user has exceeded the rate limit during verification
     # and account has been locked
-    def mfa_login_rate_limited(type:)
+    def mfa_login_rate_limited(mfa_device_type:)
       track_event(
         :mfa_login_rate_limited,
-        type: type,
+        mfa_device_type: mfa_device_type,
       )
     end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -143,7 +143,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with('Multi-Factor Authentication: max attempts reached')
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
-          with(type: 'backup_code')
+          with(mfa_device_type: 'backup_code')
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -180,7 +180,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           with({ reauthentication: false, success: false })
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
-          with(type: 'otp')
+          with(mfa_device_type: 'otp')
 
         post :create, params:
         { code: '12345',

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -486,7 +486,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
               stub_attempts_tracker
               expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_rate_limited).
-                with(type: 'otp')
+                with(mfa_device_type: 'otp')
 
               post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
             end

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -160,7 +160,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
           with('Multi-Factor Authentication: max attempts reached')
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
-          with(type: 'personal_key')
+          with(mfa_device_type: 'personal_key')
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -193,7 +193,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
           with('Multi-Factor Authentication: enter PIV CAC visited', attributes)
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
-          with(type: 'piv_cac')
+          with(mfa_device_type: 'piv_cac')
 
         submit_attributes = {
           success: false,

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -99,7 +99,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
           with(:mfa_login_totp, success: false)
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
-          with(type: 'totp')
+          with(mfa_device_type: 'totp')
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -365,7 +365,7 @@ describe Users::TwoFactorAuthenticationController do
 
         stub_attempts_tracker
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_sent_rate_limited).
-          with(phone_number: '+12025551212', success: true)
+          with(phone_number: '+12025551212')
 
         freeze_time do
           (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
@@ -575,7 +575,7 @@ describe Users::TwoFactorAuthenticationController do
 
         stub_attempts_tracker
         expect(@irs_attempts_api_tracker).to receive(:mfa_enroll_phone_otp_sent_rate_limited).
-          with(phone_number: '+12025551213', success: true)
+          with(phone_number: '+12025551213')
 
         freeze_time do
           (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do


### PR DESCRIPTION
# Summary of changes
1. Moved rate_limited events to be fired before sign out happens, so that session remains valid and they get stored in redis properly by the tracker.
2. Removed the `success` attribute from `mfa_login_phone_otp_sent_rate_limited` and `mfa_enroll_phone_otp_sent_rate_limited` for consistency with other rate_limited events.
3. Changed parameter `type` to `mfa_device_type` to match schema and for consistency between events

changelog: Internal, Attempts API, Bugfix events