### PR TITLE
LG-7277 Acuant Not Working for iPads

### DIFF
--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -5,6 +5,15 @@
  * @return {boolean}
  */
 export function isLikelyMobile() {
+  /**
+   * iPadOS devices no longer list the correct user agent.
+   * As a proxy, we check for the incorrect one (Macintosh)
+   * then test the number of touchpoints, which for iPads will
+   * be 5.
+   */
+  if (/macintosh/i.test(window.navigator.userAgent) && window.navigator.maxTouchPoints == 5) {
+    return true;
+  }
   return /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);
 }
 

--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -11,7 +11,7 @@ export function isLikelyMobile() {
    * then test the number of touchpoints, which for iPads will
    * be 5.
    */
-  if (/macintosh/i.test(window.navigator.userAgent) && window.navigator.maxTouchPoints == 5) {
+  if (/macintosh/i.test(window.navigator.userAgent) && window.navigator.maxTouchPoints === 5) {
     return true;
   }
   return /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);

--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -5,16 +5,20 @@
  * @return {boolean}
  */
 export function isLikelyMobile() {
-  /**
-   * iPadOS devices no longer list the correct user agent.
-   * As a proxy, we check for the incorrect one (Macintosh)
-   * then test the number of touchpoints, which for iPads will
-   * be 5.
-   */
-  if (/macintosh/i.test(window.navigator.userAgent) && window.navigator.maxTouchPoints === 5) {
-    return true;
-  }
-  return /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);
+  return isIPad() || /iphone|android/i.test(window.navigator.userAgent);
+}
+
+/**
+ * Returns true if the device is an iPad, or false otherwise.
+ * 
+ * iPadOS devices no longer list the correct user agent. As a proxy, we check for the incorrect
+ * one (Macintosh) then test the number of touchpoints, which for iPads will be 5.
+ *
+ * @return {boolean}
+ */
+export function isIPad() {
+  const { userAgent, maxTouchPoints } = window.navigator;
+  return /ipad/i.test(userAgent) || (/macintosh/i.test(userAgent) && maxTouchPoints === 5);
 }
 
 /**

--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -1,16 +1,6 @@
 /**
- * Returns true if the device is likely a mobile device, or false otherwise. This is a rough
- * approximation, using device user agent sniffing.
- *
- * @return {boolean}
- */
-export function isLikelyMobile() {
-  return isIPad() || /iphone|android/i.test(window.navigator.userAgent);
-}
-
-/**
  * Returns true if the device is an iPad, or false otherwise.
- * 
+ *
  * iPadOS devices no longer list the correct user agent. As a proxy, we check for the incorrect
  * one (Macintosh) then test the number of touchpoints, which for iPads will be 5.
  *
@@ -19,6 +9,16 @@ export function isLikelyMobile() {
 export function isIPad() {
   const { userAgent, maxTouchPoints } = window.navigator;
   return /ipad/i.test(userAgent) || (/macintosh/i.test(userAgent) && maxTouchPoints === 5);
+}
+
+/**
+ * Returns true if the device is likely a mobile device, or false otherwise. This is a rough
+ * approximation, using device user agent sniffing.
+ *
+ * @return {boolean}
+ */
+export function isLikelyMobile() {
+  return isIPad() || /iphone|android/i.test(window.navigator.userAgent);
 }
 
 /**

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -65,7 +65,11 @@ module Idv
       end
 
       def mobile_device?
-        BrowserCache.parse(request.user_agent).mobile?
+        if not flow_session[:skip_upload_step]
+          BrowserCache.parse(request.user_agent).mobile?
+        else
+          true
+        end
       end
 
       def form_response(destination:)

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -65,11 +65,9 @@ module Idv
       end
 
       def mobile_device?
-        if !flow_session[:skip_upload_step]
-          BrowserCache.parse(request.user_agent).mobile?
-        else
-          true
-        end
+        # See app/javascript/packs/document-capture-welcome.js
+        # And app/services/idv/steps/agreement_step.rb
+        !!flow_session[:skip_upload_step]
       end
 
       def form_response(destination:)

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -65,7 +65,7 @@ module Idv
       end
 
       def mobile_device?
-        if not flow_session[:skip_upload_step]
+        if !flow_session[:skip_upload_step]
           BrowserCache.parse(request.user_agent).mobile?
         else
           true

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -6,6 +6,8 @@ module Idv
       def call
         @flow.irs_attempts_api_tracker.document_upload_method_selected(upload_method: params[:type])
 
+        # See the simple_form_for in
+        # app/views/idv/doc_auth/upload.html.erb
         if params[:type] == 'desktop'
           handle_desktop_selection
         else

--- a/spec/features/idv/doc_auth/email_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/email_sent_step_spec.rb
@@ -5,6 +5,7 @@ feature 'doc auth email sent step' do
   include DocAuthHelper
 
   before do
+    allow_any_instance_of(Idv::Steps::UploadStep).to receive(:mobile_device?).and_return(true)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_email_sent_step
   end

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -56,6 +56,10 @@ feature 'doc auth upload step' do
   end
 
   context 'on a desktop device' do
+    before do
+      allow_any_instance_of(Idv::Steps::UploadStep).to receive(:mobile_device?).and_return(false)
+    end
+    
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -9,6 +9,7 @@ feature 'doc auth upload step' do
 
   before do
     sign_in_and_2fa_user
+    allow_any_instance_of(Idv::Steps::UploadStep).to receive(:mobile_device?).and_return(true)
     complete_doc_auth_steps_before_upload_step
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -59,7 +59,7 @@ feature 'doc auth upload step' do
     before do
       allow_any_instance_of(Idv::Steps::UploadStep).to receive(:mobile_device?).and_return(false)
     end
-    
+
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_upload_step)
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -4,118 +4,110 @@ import {
   isCameraCapableMobile,
   isIPad,
 } from '@18f/identity-device';
+import { useDefineProperty } from '@18f/identity-test-helpers';
 
 describe('isIPad', () => {
-  let originalUserAgent;
-  beforeEach(() => {
-    originalUserAgent = navigator.userAgent;
-    navigator.maxTouchPoints = 0;
-    Object.defineProperty(navigator, 'userAgent', {
-      configurable: true,
-      writable: true,
-    });
-    Object.defineProperty(navigator, 'maxTouchPoints', {
-      writable: true,
-    });
+  const defineProperty = useDefineProperty();
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    writable: true,
   });
-
-  afterEach(() => {
-    navigator.userAgent = originalUserAgent;
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    writable: true,
   });
 
   it('returns true if ipad is in the user agent string (old format)', () => {
-    navigator.userAgent =
-      'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10';
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
+    });
 
     expect(isIPad()).to.be.true();
   });
 
   it('returns false if the user agent is Macintosh but with 0 maxTouchPoints', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    });
 
     expect(isIPad()).to.be.false();
   });
 
   it('returns true if the user agent is Macintosh but with 5 maxTouchPoints', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
-    navigator.maxTouchPoints = 5;
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    });
+    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
 
     expect(isIPad()).to.be.true();
   });
 
-  it('returns false for non-Apple userAgent, even with 5 macTouchPoints', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36';
-    navigator.maxTouchPoints = 5;
+  it('returns false for non-Apple userAgent, even with 5 maxTouchPoints', () => {
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36',
+    });
+    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
 
     expect(isIPad()).to.be.false();
   });
 });
 
 describe('isLikelyMobile', () => {
-  let originalUserAgent;
-  beforeEach(() => {
-    originalUserAgent = navigator.userAgent;
-    navigator.maxTouchPoints = 0;
-    Object.defineProperty(navigator, 'userAgent', {
-      configurable: true,
-      writable: true,
-    });
-    Object.defineProperty(navigator, 'maxTouchPoints', {
-      writable: true,
-    });
+  const defineProperty = useDefineProperty();
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    writable: true,
   });
-
-  afterEach(() => {
-    navigator.userAgent = originalUserAgent;
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    writable: true,
   });
 
   it('returns false if not mobile and has no touchpoints', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
-    navigator.maxTouchPoints = 0;
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    });
+    defineProperty(navigator, 'maxTouchPoints', { value: 0 });
 
     expect(isLikelyMobile()).to.be.false();
   });
 
   it('returns true if there is an Apple user agent and 5 maxTouchPoints', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
-    navigator.maxTouchPoints = 5;
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    });
+    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
 
     expect(isLikelyMobile()).to.be.true();
   });
 
   it('returns true if likely mobile', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+    });
 
     expect(isLikelyMobile()).to.be.true();
   });
 });
 
 describe('hasMediaAccess', () => {
-  let originalMediaDevices;
+  const defineProperty = useDefineProperty();
   beforeEach(() => {
-    originalMediaDevices = navigator.mediaDevices;
     Object.defineProperty(navigator, 'mediaDevices', {
       configurable: true,
       writable: true,
     });
   });
 
-  afterEach(() => {
-    if (originalMediaDevices === undefined) {
-      delete navigator.mediaDevices;
-    } else {
-      navigator.mediaDevices = originalMediaDevices;
-    }
-  });
-
   it('returns false if no media device API access', () => {
-    delete navigator.mediaDevices;
+    defineProperty(navigator, 'mediaDevices', { value: undefined });
 
     expect(hasMediaAccess()).to.be.false();
   });
@@ -128,11 +120,8 @@ describe('hasMediaAccess', () => {
 });
 
 describe('isCameraCapableMobile', () => {
-  let originalUserAgent;
-  let originalMediaDevices;
+  const defineProperty = useDefineProperty();
   beforeEach(() => {
-    originalUserAgent = navigator.userAgent;
-    originalMediaDevices = navigator.mediaDevices;
     Object.defineProperty(navigator, 'userAgent', {
       configurable: true,
       writable: true,
@@ -143,35 +132,32 @@ describe('isCameraCapableMobile', () => {
     });
   });
 
-  afterEach(() => {
-    navigator.userAgent = originalUserAgent;
-    if (originalMediaDevices === undefined) {
-      delete navigator.mediaDevices;
-    } else {
-      navigator.mediaDevices = originalMediaDevices;
-    }
-  });
-
   it('returns false if not mobile', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
-    navigator.mediaDevices = {};
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    });
+    defineProperty(navigator, 'mediaDevices', { value: {} });
 
     expect(isCameraCapableMobile()).to.be.false();
   });
 
   it('returns false if no media device API access', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
-    delete navigator.mediaDevices;
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+    });
+    defineProperty(navigator, 'mediaDevices', { value: undefined });
 
     expect(isCameraCapableMobile()).to.be.false();
   });
 
   it('returns true if likely mobile and media device API access', () => {
-    navigator.userAgent =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
-    navigator.mediaDevices = {};
+    defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+    });
+    defineProperty(navigator, 'mediaDevices', {});
 
     expect(isCameraCapableMobile()).to.be.true();
   });

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -1,11 +1,20 @@
-import { isLikelyMobile, hasMediaAccess, isCameraCapableMobile } from '@18f/identity-device';
+import {
+  isLikelyMobile,
+  hasMediaAccess,
+  isCameraCapableMobile,
+  isIPad,
+} from '@18f/identity-device';
 
-describe('isLikelyMobile', () => {
+describe('isIPad', () => {
   let originalUserAgent;
   beforeEach(() => {
     originalUserAgent = navigator.userAgent;
+    navigator.maxTouchPoints = 0;
     Object.defineProperty(navigator, 'userAgent', {
       configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
       writable: true,
     });
   });
@@ -14,11 +23,69 @@ describe('isLikelyMobile', () => {
     navigator.userAgent = originalUserAgent;
   });
 
-  it('returns false if not mobile', () => {
+  it('returns true if ipad is in the user agent string (old format)', () => {
+    navigator.userAgent =
+      'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10';
+
+    expect(isIPad()).to.be.true();
+  });
+
+  it('returns false if the user agent is Macintosh but with 0 maxTouchPoints', () => {
     navigator.userAgent =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
 
+    expect(isIPad()).to.be.false();
+  });
+
+  it('returns true if the user agent is Macintosh but with 5 maxTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isIPad()).to.be.true();
+  });
+
+  it('returns false for non-Apple userAgent, even with 5 macTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isIPad()).to.be.false();
+  });
+});
+
+describe('isLikelyMobile', () => {
+  let originalUserAgent;
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    navigator.maxTouchPoints = 0;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+  });
+
+  it('returns false if not mobile and has no touchpoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 0;
+
     expect(isLikelyMobile()).to.be.false();
+  });
+
+  it('returns true if there is an Apple user agent and 5 maxTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isLikelyMobile()).to.be.true();
   });
 
   it('returns true if likely mobile', () => {

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -4,161 +4,195 @@ import {
   isCameraCapableMobile,
   isIPad,
 } from '@18f/identity-device';
+
 import { useDefineProperty } from '@18f/identity-test-helpers';
+
+Object.defineProperty(navigator, 'userAgent', {
+  configurable: true,
+  writable: true,
+});
+Object.defineProperty(navigator, 'maxTouchPoints', {
+  writable: true,
+  configurable: true,
+});
+
+Object.defineProperty(navigator, 'mediaDevices', {
+  writable: true,
+  configurable: true,
+});
 
 describe('isIPad', () => {
   const defineProperty = useDefineProperty();
-  Object.defineProperty(navigator, 'userAgent', {
-    configurable: true,
-    writable: true,
-  });
-  Object.defineProperty(navigator, 'maxTouchPoints', {
-    configurable: true,
-    writable: true,
-  });
 
-  it('returns true if ipad is in the user agent string (old format)', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
+  context('iPad is in the user agent string (old format)', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
+      });
     });
 
-    expect(isIPad()).to.be.true();
+    it('returns true', () => {
+      expect(isIPad()).to.be.true();
+    });
   });
 
-  it('returns false if the user agent is Macintosh but with 0 maxTouchPoints', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+  context('The user agent is Macintosh but with 0 maxTouchPoints', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+      });
     });
 
-    expect(isIPad()).to.be.false();
+    it('returns false', () => {
+      expect(isIPad()).to.be.false();
+    });
   });
 
-  it('returns true if the user agent is Macintosh but with 5 maxTouchPoints', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+  context('The user agent is Macintosh but with 5 maxTouchPoints', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+      });
+      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
     });
-    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
 
-    expect(isIPad()).to.be.true();
+    it('returns true', () => {
+      expect(isIPad()).to.be.true();
+    });
   });
 
-  it('returns false for non-Apple userAgent, even with 5 maxTouchPoints', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36',
+  context('Non-Apple userAgent, even with 5 maxTouchPoints', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36',
+      });
+      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
     });
-    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
-
-    expect(isIPad()).to.be.false();
+    it('returns false', () => {
+      expect(isIPad()).to.be.false();
+    });
   });
 });
 
 describe('isLikelyMobile', () => {
   const defineProperty = useDefineProperty();
-  Object.defineProperty(navigator, 'userAgent', {
-    configurable: true,
-    writable: true,
-  });
-  Object.defineProperty(navigator, 'maxTouchPoints', {
-    configurable: true,
-    writable: true,
-  });
 
-  it('returns false if not mobile and has no touchpoints', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+  context('Is not mobile and has no touchpoints', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+        writable: true,
+        configurable: true,
+      });
+      defineProperty(navigator, 'maxTouchPoints', { value: 0 });
     });
-    defineProperty(navigator, 'maxTouchPoints', { value: 0 });
 
-    expect(isLikelyMobile()).to.be.false();
-  });
-
-  it('returns true if there is an Apple user agent and 5 maxTouchPoints', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+    it('returns false', () => {
+      expect(isLikelyMobile()).to.be.false();
     });
-    defineProperty(navigator, 'maxTouchPoints', { value: 5 });
-
-    expect(isLikelyMobile()).to.be.true();
   });
 
-  it('returns true if likely mobile', () => {
+  context('There is an Apple user agent and 5 maxTouchPoints', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+      });
+      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
+    });
+
+    it('returns true', () => {
+      expect(isLikelyMobile()).to.be.true();
+    });
+  });
+
+  context('There is an explicit iPhone user agent', () => {
     defineProperty(navigator, 'userAgent', {
       value:
         'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
     });
 
-    expect(isLikelyMobile()).to.be.true();
+    it('returns true', () => {
+      expect(isLikelyMobile()).to.be.true();
+    });
   });
 });
 
 describe('hasMediaAccess', () => {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    writable: true,
+    configurable: true,
+  });
   const defineProperty = useDefineProperty();
-  beforeEach(() => {
-    Object.defineProperty(navigator, 'mediaDevices', {
-      configurable: true,
-      writable: true,
+
+  context('No media device API access', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'mediaDevices', { value: undefined });
+    });
+
+    it('returns false', () => {
+      expect(hasMediaAccess()).to.be.false();
     });
   });
 
-  it('returns false if no media device API access', () => {
-    defineProperty(navigator, 'mediaDevices', { value: undefined });
+  it('Has media device API access', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'mediaDevices', { value: {} });
+    });
 
-    expect(hasMediaAccess()).to.be.false();
-  });
-
-  it('returns true if media device API access', () => {
-    navigator.mediaDevices = {};
-
-    expect(hasMediaAccess()).to.be.true();
+    it('returns true', () => {
+      expect(hasMediaAccess()).to.be.true();
+    });
   });
 });
 
 describe('isCameraCapableMobile', () => {
   const defineProperty = useDefineProperty();
-  beforeEach(() => {
-    Object.defineProperty(navigator, 'userAgent', {
-      configurable: true,
-      writable: true,
+
+  context('Is not mobile', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+      });
+      defineProperty(navigator, 'mediaDevices', { value: {} });
     });
-    Object.defineProperty(navigator, 'mediaDevices', {
-      configurable: true,
-      writable: true,
+
+    it('returns false', () => {
+      expect(isCameraCapableMobile()).to.be.false();
     });
   });
 
-  it('returns false if not mobile', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
+  context('No media device API access', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      });
+      defineProperty(navigator, 'mediaDevices', { value: undefined });
     });
-    defineProperty(navigator, 'mediaDevices', { value: {} });
 
-    expect(isCameraCapableMobile()).to.be.false();
+    it('returns false', () => {
+      expect(isCameraCapableMobile()).to.be.false();
+    });
   });
 
-  it('returns false if no media device API access', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  context('Is likely mobile and media device API access', () => {
+    beforeEach(() => {
+      defineProperty(navigator, 'userAgent', {
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      });
+      defineProperty(navigator, 'mediaDevices', {});
     });
-    defineProperty(navigator, 'mediaDevices', { value: undefined });
 
-    expect(isCameraCapableMobile()).to.be.false();
-  });
-
-  it('returns true if likely mobile and media device API access', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+    it('returns true', () => {
+      expect(isCameraCapableMobile()).to.be.true();
     });
-    defineProperty(navigator, 'mediaDevices', {});
-
-    expect(isCameraCapableMobile()).to.be.true();
   });
 });

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -5,194 +5,182 @@ import {
   isIPad,
 } from '@18f/identity-device';
 
-import { useDefineProperty } from '@18f/identity-test-helpers';
-
-Object.defineProperty(navigator, 'userAgent', {
-  configurable: true,
-  writable: true,
-});
-Object.defineProperty(navigator, 'maxTouchPoints', {
-  writable: true,
-  configurable: true,
-});
-
-Object.defineProperty(navigator, 'mediaDevices', {
-  writable: true,
-  configurable: true,
-});
-
 describe('isIPad', () => {
-  const defineProperty = useDefineProperty();
+  let originalUserAgent;
+  let originalTouchPoints;
 
-  context('iPad is in the user agent string (old format)', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
-      });
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    originalTouchPoints = navigator.maxTouchPoints;
+    navigator.maxTouchPoints = 0;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
     });
-
-    it('returns true', () => {
-      expect(isIPad()).to.be.true();
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      writable: true,
     });
   });
 
-  context('The user agent is Macintosh but with 0 maxTouchPoints', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
-      });
-    });
-
-    it('returns false', () => {
-      expect(isIPad()).to.be.false();
-    });
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+    navigator.maxTouchPoints = originalTouchPoints;
   });
 
-  context('The user agent is Macintosh but with 5 maxTouchPoints', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
-      });
-      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
-    });
+  it('returns true if ipad is in the user agent string (old format)', () => {
+    navigator.userAgent =
+      'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10';
 
-    it('returns true', () => {
-      expect(isIPad()).to.be.true();
-    });
+    expect(isIPad()).to.be.true();
   });
 
-  context('Non-Apple userAgent, even with 5 maxTouchPoints', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36',
-      });
-      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
-    });
-    it('returns false', () => {
-      expect(isIPad()).to.be.false();
-    });
+  it('returns false if the user agent is Macintosh but with 0 maxTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+
+    expect(isIPad()).to.be.false();
+  });
+
+  it('returns true if the user agent is Macintosh but with 5 maxTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isIPad()).to.be.true();
+  });
+
+  it('returns false for non-Apple userAgent, even with 5 macTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.58 Mobile Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isIPad()).to.be.false();
   });
 });
 
 describe('isLikelyMobile', () => {
-  const defineProperty = useDefineProperty();
+  let originalUserAgent;
+  let originalTouchPoints;
 
-  context('Is not mobile and has no touchpoints', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
-        writable: true,
-        configurable: true,
-      });
-      defineProperty(navigator, 'maxTouchPoints', { value: 0 });
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    originalTouchPoints = navigator.maxTouchPoints;
+    navigator.maxTouchPoints = 0;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
     });
-
-    it('returns false', () => {
-      expect(isLikelyMobile()).to.be.false();
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      writable: true,
     });
   });
 
-  context('There is an Apple user agent and 5 maxTouchPoints', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
-      });
-      defineProperty(navigator, 'maxTouchPoints', { value: 5 });
-    });
-
-    it('returns true', () => {
-      expect(isLikelyMobile()).to.be.true();
-    });
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+    navigator.maxTouchPoints = originalTouchPoints;
   });
 
-  context('There is an explicit iPhone user agent', () => {
-    defineProperty(navigator, 'userAgent', {
-      value:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
-    });
+  it('returns false if not mobile and has no touchpoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 0;
 
-    it('returns true', () => {
-      expect(isLikelyMobile()).to.be.true();
-    });
+    expect(isLikelyMobile()).to.be.false();
+  });
+
+  it('returns true if there is an Apple user agent and 5 maxTouchPoints', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.maxTouchPoints = 5;
+
+    expect(isLikelyMobile()).to.be.true();
+  });
+
+  it('returns true if likely mobile', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+
+    expect(isLikelyMobile()).to.be.true();
   });
 });
 
 describe('hasMediaAccess', () => {
-  Object.defineProperty(navigator, 'mediaDevices', {
-    writable: true,
-    configurable: true,
-  });
-  const defineProperty = useDefineProperty();
-
-  context('No media device API access', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'mediaDevices', { value: undefined });
-    });
-
-    it('returns false', () => {
-      expect(hasMediaAccess()).to.be.false();
+  let originalMediaDevices;
+  beforeEach(() => {
+    originalMediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
     });
   });
 
-  it('Has media device API access', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'mediaDevices', { value: {} });
-    });
+  afterEach(() => {
+    if (originalMediaDevices === undefined) {
+      delete navigator.mediaDevices;
+    } else {
+      navigator.mediaDevices = originalMediaDevices;
+    }
+  });
 
-    it('returns true', () => {
-      expect(hasMediaAccess()).to.be.true();
-    });
+  it('returns false if no media device API access', () => {
+    delete navigator.mediaDevices;
+
+    expect(hasMediaAccess()).to.be.false();
+  });
+
+  it('returns true if media device API access', () => {
+    navigator.mediaDevices = {};
+
+    expect(hasMediaAccess()).to.be.true();
   });
 });
 
 describe('isCameraCapableMobile', () => {
-  const defineProperty = useDefineProperty();
-
-  context('Is not mobile', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36',
-      });
-      defineProperty(navigator, 'mediaDevices', { value: {} });
+  let originalUserAgent;
+  let originalMediaDevices;
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    originalMediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
     });
-
-    it('returns false', () => {
-      expect(isCameraCapableMobile()).to.be.false();
-    });
-  });
-
-  context('No media device API access', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
-      });
-      defineProperty(navigator, 'mediaDevices', { value: undefined });
-    });
-
-    it('returns false', () => {
-      expect(isCameraCapableMobile()).to.be.false();
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
     });
   });
 
-  context('Is likely mobile and media device API access', () => {
-    beforeEach(() => {
-      defineProperty(navigator, 'userAgent', {
-        value:
-          'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
-      });
-      defineProperty(navigator, 'mediaDevices', {});
-    });
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+    if (originalMediaDevices === undefined) {
+      delete navigator.mediaDevices;
+    } else {
+      navigator.mediaDevices = originalMediaDevices;
+    }
+  });
 
-    it('returns true', () => {
-      expect(isCameraCapableMobile()).to.be.true();
-    });
+  it('returns false if not mobile', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.mediaDevices = {};
+
+    expect(isCameraCapableMobile()).to.be.false();
+  });
+
+  it('returns false if no media device API access', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    delete navigator.mediaDevices;
+
+    expect(isCameraCapableMobile()).to.be.false();
+  });
+
+  it('returns true if likely mobile and media device API access', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    navigator.mediaDevices = {};
+
+    expect(isCameraCapableMobile()).to.be.true();
   });
 });


### PR DESCRIPTION
## What ##
This PR deals with [LG-7277](https://cm-jira.usa.gov/browse/LG-7277), for which it was discovered that the Acuant SDK was not being loaded on iPads or Android tablets.
  
## Notes ##
It turns out that Apple has changed the User Agent header for Safari on iPadOS, such that the result indicates a Macintosh running Safari. The workaround that many people have been using is to detect, on the frontend, the `window.navigator.maxTouchPoints`, which on a tablet like the iPad, will be 5 (and usually 0 on a laptop or desktop).
  
After [updating the checks](https://github.com/18F/identity-idp/commit/8ec1b127f64895fc0442a73077bdbd668b9ccb11#diff-9815e80bb77c594216dcb42905c8df514f096d953b02b5e0db3fb162a26a4895) we use to indicate mobile on the frontend, I found that the frontend sets a hidden input with a "skip_upload" value if the device is mobile, and that the Rails application will set the `flow_session[:skip_upload_step]` based on this value.
  
With that in mind, I've [updated the controller's](https://github.com/18F/identity-idp/commit/5d0f4407573ed603a23639dfff0c32caed85d858#diff-92cdbc2be14eb42a04b4b84c20016825efc82516be4a1fe4051a85a9ef477b5f) `mobile_device?` method to also take this into consideration. 