### PR TITLE
Drivers' license as unhashed params

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -21,7 +21,7 @@ module Proofing
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
             account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
-            account_drivers_license_issuer: applicant[:state_id_issued].to_s.strip,
+            account_drivers_license_issuer: applicant[:state_id_jurisdiction].to_s.strip,
             event_type: 'ACCOUNT_CREATION',
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -21,6 +21,7 @@ module Proofing
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
             account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
+            account_drivers_license_issuer: applicant[:state_id_issued].to_s.strip,
             event_type: 'ACCOUNT_CREATION',
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -20,8 +20,7 @@ module Proofing
             account_first_name: applicant[:first_name],
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
-            drivers_license_number_hash: applicant[:state_id_number] ?
-              OpenSSL::Digest::SHA256.hexdigest(applicant[:state_id_number].gsub(/\W/, '')) : '',
+            account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
             event_type: 'ACCOUNT_CREATION',
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -12,7 +12,7 @@
   "account_first_name": "Testy",
   "account_last_name": "McTesterson",
   "account_telephone": "",
-  "drivers_license_number_hash": "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f",
+  "account_drivers_license_number": "12345678",
   "event_type": "ACCOUNT_CREATION",
   "policy": "test-policy",
   "service_type": "all",

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -13,6 +13,7 @@
   "account_last_name": "McTesterson",
   "account_telephone": "",
   "account_drivers_license_number": "12345678",
+  "account_drivers_license_issuer" : "LA",
   "event_type": "ACCOUNT_CREATION",
   "policy": "test-policy",
   "service_type": "all",

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -13,7 +13,7 @@ describe Proofing::LexisNexis::Ddp::Proofer do
       state: 'LA',
       zipcode: '70802-12345',
       state_id_number: '12345678',
-      state_id_issued: 'LA',
+      state_id_jurisdiction: 'LA',
       threatmetrix_session_id: '123456',
       phone: '5551231234',
       email: 'test@example.com',

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -13,6 +13,7 @@ describe Proofing::LexisNexis::Ddp::Proofer do
       state: 'LA',
       zipcode: '70802-12345',
       state_id_number: '12345678',
+      state_id_issued: 'LA',
       threatmetrix_session_id: '123456',
       phone: '5551231234',
       email: 'test@example.com',

--- a/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
@@ -14,7 +14,7 @@ describe Proofing::LexisNexis::Ddp::VerificationRequest do
       state: 'LA',
       zipcode: '70802-12345',
       state_id_number: '12345678',
-      state_id_issued: 'LA',
+      state_id_jurisdiction: 'LA',
       threatmetrix_session_id: 'UNIQUE_SESSION_ID',
       phone: '5551231234',
       email: 'test@example.com',

--- a/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
@@ -14,6 +14,7 @@ describe Proofing::LexisNexis::Ddp::VerificationRequest do
       state: 'LA',
       zipcode: '70802-12345',
       state_id_number: '12345678',
+      state_id_issued: 'LA',
       threatmetrix_session_id: 'UNIQUE_SESSION_ID',
       phone: '5551231234',
       email: 'test@example.com',


### PR DESCRIPTION
LG-7384

**Why:** Per LexisNexis email on 29 August 2022, these three params should be used to transmit drivers' license details:

- `account_drivers_license_issuer`
- `account_drivers_license_number`
- `account_drivers_license_type`

We should replace the `drivers_license_number_hash` which LN FraudPoint cannot process

**How:** I have replaced the params in the VerificationRequest and fixture file, and added `state_id_jurisdiction` to tests

changelog: Internal, ThreatMetrix API, Use non-hashed param
