### PR TITLE
Add the DOB year only arg back to the resolution proofer job call

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -21,6 +21,7 @@ module Idv
       job_arguments = {
         encrypted_arguments: encrypted_arguments,
         should_proof_state_id: should_proof_state_id,
+        dob_year_only: false,
         trace_id: trace_id,
         result_id: document_capture_session.result_id,
         user_id: user_id,


### PR DESCRIPTION
This was a slip up that led to errors in int. The new instances will call without the arg and the old instance will not default to nil. This leads to an argument error.

This commit fixes that

[skip changelog]