### PR TITLE
[LG-7244] Translate the getting started page

### DIFF
--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -2,15 +2,19 @@
 es:
   inherited_proofing:
     buttons:
-      continue: replaceme
+      continue: Continuar
     headings:
-      welcome: replaceme
+      welcome: Empiece con la verificación de su identidad
     info:
-      no_sp_name: replaceme
-      privacy_html: replaceme %{app_name} %{link}
-      welcome_html: replaceme %{sp_name}
+      no_sp_name: La agencia a la que está intentando acceder
+      privacy_html: '%{app_name} es un sitio web gubernamental seguro que cumple con
+        las normas más estrictas de protección de datos. Solo utilizamos sus
+        datos para verificar su identidad. %{link} sobre nuestras medidas de
+        privacidad y seguridad.'
+      welcome_html: '%{sp_name} necesita asegurarse de que sea usted y no alguien que
+        se haga pasar por usted.'
     instructions:
-      bullet1: replaceme
-      learn_more: replaceme
-      privacy: replaceme
-      welcome: replaceme
+      bullet1: Un número de teléfono con un plan tarifario vinculado a su nombre.
+      learn_more: Obtenga más información
+      privacy: Nuestras normas de privacidad y seguridad
+      welcome: 'Deberá contar con lo siguiente para verificar su identidad:'

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -2,15 +2,19 @@
 fr:
   inherited_proofing:
     buttons:
-      continue: replaceme
+      continue: Continuer
     headings:
-      welcome: replaceme
+      welcome: Commencez à vérifier votre identité
     info:
-      no_sp_name: replaceme
-      privacy_html: replaceme %{app_name} %{link}
-      welcome_html: replaceme %{sp_name}
+      no_sp_name: L’agence à laquelle vous essayez d’accéder
+      privacy_html: '%{app_name} est un site gouvernemental sécurisé qui respecte les
+        normes les plus strictes en matière de protection des données. Nous
+        n’utilisons vos données uniquement pour vérifier votre identité. %{link}
+        sur nos mesures de confidentialité et de sécurité.'
+      welcome_html: '%{sp_name} doit s’assurer que vous êtes bien vous, et non
+        quelqu’un qui se fait passer pour vous.'
     instructions:
-      bullet1: replaceme
-      learn_more: replaceme
-      privacy: replaceme
-      welcome: replaceme
+      bullet1: Un numéro de téléphone associé à un forfait téléphonique à votre nom.
+      learn_more: En savoir plus
+      privacy: Nos normes de confidentialité et de sécurité
+      welcome: 'Pour vérifier votre identité, vous aurez besoin de:'

--- a/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
+++ b/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'idv/inherited_proofing/get_started.html.erb' do
   let(:flow_session) { {} }
   let(:sp_name) { nil }
+  let(:locale) { nil }
 
   before do
     @decorated_session = instance_double(ServiceProviderSessionDecorator)
@@ -16,5 +17,37 @@ describe 'idv/inherited_proofing/get_started.html.erb' do
     render template: 'idv/inherited_proofing/get_started'
 
     expect(rendered).to have_button(t('inherited_proofing.buttons.continue'))
+  end
+
+  describe 'I18n' do
+    before do
+      view.locale = locale
+
+      render template: 'idv/inherited_proofing/get_started'
+    end
+
+    context 'when rendered using the default locale' do
+      let(:locale) { nil }
+
+      it 'renders the correct language' do
+        expect(rendered).to have_content('Get started verifying your identity')
+      end
+    end
+
+    context 'when rendered using the French (:fr) locale' do
+      let(:locale) { :fr }
+
+      it 'renders the correct language' do
+        expect(rendered).to have_content('Commencez à vérifier votre identité')
+      end
+    end
+
+    context 'when rendered using the Spanish (:es) locale' do
+      let(:locale) { :es }
+
+      it 'renders using the correct locale' do
+        expect(rendered).to have_content('Empiece con la verificación de su identidad')
+      end
+    end
   end
 end


### PR DESCRIPTION
[LG-7244](https://cm-jira.usa.gov/browse/LG-7244)

The Inherited Proofing "Getting Started" page needs (in addition to English), Spanish and French as well. This adds the translation (.yml) files for fr and es (Spanish and French respectfully).