### PR TITLE
LG-7410: Add ThreatMetrix back to In-Person Proofing flow

### DIFF
--- a/app/services/idv/steps/ipp/ssn_step.rb
+++ b/app/services/idv/steps/ipp/ssn_step.rb
@@ -18,7 +18,7 @@ module Idv
         def extra_view_variables
           {
             updating_ssn: updating_ssn,
-            threatmetrix_session_id: generate_threatmetrix_session_id,            
+            threatmetrix_session_id: generate_threatmetrix_session_id,
           }
         end
 

--- a/app/services/idv/steps/ipp/ssn_step.rb
+++ b/app/services/idv/steps/ipp/ssn_step.rb
@@ -18,6 +18,7 @@ module Idv
         def extra_view_variables
           {
             updating_ssn: updating_ssn,
+            threatmetrix_session_id: generate_threatmetrix_session_id,            
           }
         end
 
@@ -25,6 +26,12 @@ module Idv
 
         def form_submit
           Idv::SsnFormatForm.new(current_user).submit(permit(:ssn))
+        end
+
+        def generate_threatmetrix_session_id
+          return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
+          flow_session[:threatmetrix_session_id] = SecureRandom.uuid if !updating_ssn
+          flow_session[:threatmetrix_session_id]
         end
 
         def ssn

--- a/app/services/idv/steps/ipp/ssn_step.rb
+++ b/app/services/idv/steps/ipp/ssn_step.rb
@@ -23,12 +23,12 @@ module Idv
 
         private
 
-        def ssn
-          flow_params[:ssn]
-        end
-
         def form_submit
           Idv::SsnFormatForm.new(current_user).submit(permit(:ssn))
+        end
+
+        def ssn
+          flow_params[:ssn]
         end
 
         def updating_ssn

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -7,6 +7,7 @@ module Idv
         return invalid_state_response if invalid_state?
 
         flow_session[:pii_from_doc][:ssn] = ssn
+
         @flow.irs_attempts_api_tracker.idv_ssn_submitted(
           success: true,
           ssn: ssn,
@@ -28,6 +29,17 @@ module Idv
         Idv::SsnFormatForm.new(current_user).submit(permit(:ssn))
       end
 
+      def invalid_state_response
+        mark_step_incomplete(:document_capture)
+        FormResponse.new(success: false)
+      end
+
+      def generate_threatmetrix_session_id
+        return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
+        flow_session[:threatmetrix_session_id] = SecureRandom.uuid if !updating_ssn
+        flow_session[:threatmetrix_session_id]
+      end
+
       def ssn
         flow_params[:ssn]
       end
@@ -38,17 +50,6 @@ module Idv
 
       def updating_ssn
         flow_session.dig(:pii_from_doc, :ssn).present?
-      end
-
-      def invalid_state_response
-        mark_step_incomplete(:document_capture)
-        FormResponse.new(success: false)
-      end
-
-      def generate_threatmetrix_session_id
-        return unless IdentityConfig.store.proofing_device_profiling_collecting_enabled
-        flow_session[:threatmetrix_session_id] = SecureRandom.uuid if !updating_ssn
-        flow_session[:threatmetrix_session_id]
       end
     end
   end

--- a/app/views/idv/in_person/ssn.html.erb
+++ b/app/views/idv/in_person/ssn.html.erb
@@ -1,1 +1,1 @@
-<%= render 'idv/shared/ssn', flow_session: flow_session, success_alert_enabled: false, updating_ssn: updating_ssn %>
+<%= render 'idv/shared/ssn', flow_session: flow_session, success_alert_enabled: false, updating_ssn: updating_ssn, threatmetrix_session_id: threatmetrix_session_id %>

--- a/app/views/idv/shared/_ssn.html.erb
+++ b/app/views/idv/shared/_ssn.html.erb
@@ -30,10 +30,10 @@ locals:
 
 <% if IdentityConfig.store.proofing_device_profiling_collecting_enabled %>
   <% unless IdentityConfig.store.lexisnexis_threatmetrix_org_id.empty? %>
-    <% if flow_session[:threatmetrix_session_id].present? %>
-      <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{flow_session[:threatmetrix_session_id]}", nonce: true %>
+    <% if threatmetrix_session_id.present? %>
+      <%= javascript_include_tag "https://h.online-metrix.net/fp/tags.js?org_id=#{IdentityConfig.store.lexisnexis_threatmetrix_org_id}&session_id=#{threatmetrix_session_id}", nonce: true %>
       <noscript>
-        <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= flow_session[:threatmetrix_session_id] %>">
+        <iframe style="width: 100px; height: 100px; border: 0; position: absolute; top: -5000px;" src="https://h.online-metrix.net/fp/tags?org_id=<%= IdentityConfig.store.lexisnexis_threatmetrix_org_id %>&session_id=<%= threatmetrix_session_id %>">
         </iframe>
       </noscript>
     <% end %>

--- a/spec/services/idv/steps/ipp/ssn_step_spec.rb
+++ b/spec/services/idv/steps/ipp/ssn_step_spec.rb
@@ -49,13 +49,13 @@ describe Idv::Steps::Ipp::SsnStep do
     end
 
     context 'with proofing device profiling collecting enabled' do
-      it 'does not add a threatmetrix session id to flow session' do
+      it 'adds a session id to flow session' do
         allow(IdentityConfig.store).
           to receive(:proofing_device_profiling_collecting_enabled).
           and_return(true)
         step.extra_view_variables
 
-        expect(flow.flow_session[:threatmetrix_session_id]).to eq(nil)
+        expect(flow.flow_session[:threatmetrix_session_id]).to_not eq(nil)
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
@@ -66,6 +66,16 @@ describe Idv::Steps::Ipp::SsnStep do
         session_id = flow.flow_session[:threatmetrix_session_id]
         step.extra_view_variables
         expect(flow.flow_session[:threatmetrix_session_id]).to eq(session_id)
+      end
+    end
+
+    context 'with proofing device profiling collecting disabled' do
+      it 'does not add a session id to flow session' do
+        allow(IdentityConfig.store).
+          to receive(:proofing_device_profiling_collecting_enabled).
+          and_return(false)
+        step.extra_view_variables
+        expect(flow.flow_session[:threatmetrix_session_id]).to eq(nil)
       end
     end
   end

--- a/spec/views/idv/shared/_ssn.html.erb_spec.rb
+++ b/spec/views/idv/shared/_ssn.html.erb_spec.rb
@@ -27,10 +27,9 @@ describe 'idv/shared/_ssn.html.erb' do
       to receive(:lexisnexis_threatmetrix_org_id).and_return(lexisnexis_threatmetrix_org_id)
 
     render partial: 'idv/shared/ssn', locals: {
-      flow_session: {
-        threatmetrix_session_id: session_id,
-      },
+      flow_session: {},
       success_alert_enabled: false,
+      threatmetrix_session_id: session_id,
       updating_ssn: updating_ssn,
     }
   end


### PR DESCRIPTION
**Why?** ThreatMetrix usage will be tied more closely to IPP partners initially.

**How?** Mostly update `ipp/ssn_step.rb` to generate a `threatmetrix_session_id`, and pass that to the front end to ensure the resulting `<script>` tag is generated. There's some DRY work that could be done in a future PR to get the two `SsnStep` classes to share a little more code.

changelog: Upcoming Features, ThreatMetrix, Add ThreatMetrix to In-Person Proofing flow