### PR TITLE
Improve changelog tool sorting and capitalization

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -150,13 +150,14 @@ end
 # Entries with the same category and change are grouped into one changelog line so that we can
 # support multi-PR changes.
 def format_changelog(changelog_entries)
-  changelog_entries = changelog_entries.group_by { |entry| [entry.category, entry.change] }
+  changelog_entries = changelog_entries.
+    sort_by { |entry| entry.subcategory }.
+    group_by { |entry| [entry.category, entry.change] }
 
   changelog = ''
   CATEGORIES.each do |category|
     category_changes = changelog_entries.
-      filter { |(changelog_category, _change), _changes| changelog_category == category }.
-      sort_by { |(_category, change), _changes| change }
+      filter { |(changelog_category, _change), _changes| changelog_category == category }
 
     next if category_changes.empty?
     changelog.concat("## #{category}\n")

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -134,7 +134,7 @@ def generate_changelog(git_log)
 
     changelog_entry = ChangelogEntry.new(
       category: category,
-      subcategory: change[:subcategory].capitalize,
+      subcategory: change[:subcategory].upcase_first,
       pr_number: pr_number&.named_captures&.fetch('pr'),
       change: change[:change].sub(/./, &:upcase),
     )

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -152,7 +152,7 @@ end
 # support multi-PR changes.
 def format_changelog(changelog_entries)
   changelog_entries = changelog_entries.
-    sort_by { |entry| entry.subcategory }.
+    sort_by(&:subcategory).
     group_by { |entry| [entry.category, entry.change] }
 
   changelog = ''

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'open3'
 require 'optparse'
+require 'active_support/inflector'
 
 CHANGELOG_REGEX =
   %r{^(?:\* )?changelog: (?<category>[\w -/]{2,}), (?<subcategory>[\w -]{2,}), (?<change>.+)$}

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -86,6 +86,22 @@ RSpec.describe 'scripts/changelog_check' do
         - Security: Upgrade Rails to patch vulnerability ([#6041](https://github.com/18F/identity-idp/pull/6041), [#6042](https://github.com/18F/identity-idp/pull/6042))
       CHANGELOG
     end
+
+    it 'sorts changelog by subcategory' do
+      commits = [
+        git_fixtures['squashed_commit_with_one_commit'],
+        git_fixtures['squashed_commit_2'],
+      ]
+      git_log = commits.pluck('commit_log').join("\n")
+      changelogs = generate_changelog(git_log)
+      formatted_changelog = format_changelog(changelogs)
+
+      expect(formatted_changelog).to eq <<~CHANGELOG.chomp
+        ## Internal
+        - Logging: Update logging flow ([#9999](https://github.com/18F/identity-idp/pull/9999))
+        - Security: Upgrade Rails to patch vulnerability ([#6041](https://github.com/18F/identity-idp/pull/6041))
+      CHANGELOG
+    end
   end
 
   describe '#generate_changelog' do

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe 'scripts/changelog_check' do
         body:- Lets us set log level to minimize STDOUT output
           from Identity::Hostdata (downloading files from S3, etc)
 
-        * changelog: Improvements, authentication, provide better authentication (LG-4515)
+        * changelog: Improvements, authentication API, provide better authentication (LG-4515)
         DELIMITER
       COMMIT
 
       changelogs = generate_changelog(git_log)
 
-      expect(changelogs.first.subcategory).to eq('Authentication')
+      expect(changelogs.first.subcategory).to eq('Authentication API')
       expect(changelogs.first.change).to start_with('P')
     end
   end


### PR DESCRIPTION
* Use `upcase_first` to capitalize changelog subcategory
   * **Why**: Avoids affecting intentional capitalization elsewhere in the changelog (e.g. "API" -> "api")
* Sort changelog by subcategory
   * **Why**: So that subcategories entries are grouped together in the output.
