### PR TITLE
LG-7345: Generate a unique ID when creating enrollments

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -72,7 +72,9 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     enrollments.each do |enrollment|
       # Add a unique ID for enrollments that don't have one
-      enrollment.update(unique_id: enrollment.usps_unique_id) if enrollment.unique_id.blank?
+      if enrollment.unique_id.blank?
+        enrollment.update(unique_id: InPersonEnrollment.generate_unique_id)
+      end
 
       status_check_attempted_at = Time.zone.now
       enrollment_outcomes[:enrollments_checked] += 1

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -72,9 +72,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     enrollments.each do |enrollment|
       # Add a unique ID for enrollments that don't have one
-      if enrollment.unique_id.blank?
-        enrollment.update(unique_id: InPersonEnrollment.generate_unique_id)
-      end
+      enrollment.update(unique_id: enrollment.usps_unique_id) if enrollment.unique_id.blank?
 
       status_check_attempted_at = Time.zone.now
       enrollment_outcomes[:enrollments_checked] += 1

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -72,7 +72,7 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def set_unique_id
-    self.unique_id = InPersonEnrollment.generate_unique_id if self.unique_id.nil?
+    self.unique_id = InPersonEnrollment.generate_unique_id
   end
 
   def profile_belongs_to_user

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -72,7 +72,7 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def set_unique_id
-    self.unique_id = InPersonEnrollment.generate_unique_id
+    self.unique_id = self.class.generate_unique_id
   end
 
   def profile_belongs_to_user

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -20,6 +20,7 @@ class InPersonEnrollment < ApplicationRecord
   validate :profile_belongs_to_user
 
   before_save(:on_status_updated, if: :will_save_change_to_status?)
+  before_create(:set_unique_id, unless: :unique_id)
 
   # Find enrollments that need a status check via the USPS API
   def self.needs_usps_status_check(check_interval)
@@ -68,6 +69,10 @@ class InPersonEnrollment < ApplicationRecord
 
   def on_status_updated
     self.status_updated_at = Time.zone.now
+  end
+
+  def set_unique_id
+    self.unique_id = InPersonEnrollment.generate_unique_id if self.unique_id.nil?
   end
 
   def profile_belongs_to_user

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -35,10 +35,7 @@ module UspsInPersonProofing
         enrollment = user.establishing_in_person_enrollment
         return enrollment if enrollment.present?
 
-        InPersonEnrollment.create!(
-          user: user,
-          profile: nil,
-        )
+        InPersonEnrollment.create!(user: user, profile: nil)
       end
 
       def create_usps_enrollment(enrollment, pii)

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -35,7 +35,11 @@ module UspsInPersonProofing
         enrollment = user.establishing_in_person_enrollment
         return enrollment if enrollment.present?
 
-        InPersonEnrollment.create!(user: user, profile: nil)
+        InPersonEnrollment.create!(
+          unique_id: InPersonEnrollment.generate_unique_id,
+          user: user,
+          profile: nil,
+        )
       end
 
       def create_usps_enrollment(enrollment, pii)

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -42,7 +42,7 @@ module UspsInPersonProofing
         address = [pii['address1'], pii['address2']].select(&:present?).join(' ')
         applicant = UspsInPersonProofing::Applicant.new(
           {
-            unique_id: enrollment.usps_unique_id,
+            unique_id: enrollment.unique_id || enrollment.usps_unique_id,
             first_name: pii['first_name'],
             last_name: pii['last_name'],
             address: address,

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -36,7 +36,6 @@ module UspsInPersonProofing
         return enrollment if enrollment.present?
 
         InPersonEnrollment.create!(
-          unique_id: InPersonEnrollment.generate_unique_id,
           user: user,
           profile: nil,
         )

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -39,10 +39,14 @@ module UspsInPersonProofing
       end
 
       def create_usps_enrollment(enrollment, pii)
+        # Use the enrollment's unique_id value if it exists, otherwise use the deprecated
+        # #usps_unique_id value in order to remain backwards-compatible. LG-7024 will remove this
+        unique_id = enrollment.unique_id || enrollment.usps_unique_id
         address = [pii['address1'], pii['address2']].select(&:present?).join(' ')
+
         applicant = UspsInPersonProofing::Applicant.new(
           {
-            unique_id: enrollment.unique_id || enrollment.usps_unique_id,
+            unique_id: unique_id,
             first_name: pii['first_name'],
             last_name: pii['last_name'],
             address: address,

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :in_person_enrollment do
     user { association :user, :signed_up }
     profile { association :profile, user: user }
-    unique_id { Faker::Number.hexadecimal(digits: 18) }
     current_address_matches_id { true }
     selected_location_details { { name: 'BALTIMORE' } }
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -206,10 +206,10 @@ RSpec.describe GetUspsProofingResultsJob do
       end
 
       context 'when an enrollment does not have a unique ID' do
-        it 'generates a secure unique ID' do
+        it 'generates a backwards-compatible unique ID' do
           pending_enrollment.update(unique_id: nil)
           stub_request_passed_proofing_results
-          expect(InPersonEnrollment).to receive(:generate_unique_id).and_call_original
+          expect(pending_enrollment).to receive(:usps_unique_id).and_call_original
 
           job.perform(Time.zone.now)
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -205,6 +205,17 @@ RSpec.describe GetUspsProofingResultsJob do
         ).to be >= 0.0
       end
 
+      context 'when an enrollment does not have a unique ID' do
+        it 'generates a secure unique ID' do
+          pending_enrollment.update(unique_id: nil)
+          stub_request_passed_proofing_results
+          expect(InPersonEnrollment).to receive(:generate_unique_id).and_call_original
+          job.perform(Time.zone.now)
+
+          expect(pending_enrollment.unique_id).not_to be_nil
+        end
+      end
+
       describe 'sending emails' do
         it 'sends proofing failed email on response with failed status' do
           stub_request_failed_proofing_results

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe GetUspsProofingResultsJob do
           pending_enrollment.update(unique_id: nil)
           stub_request_passed_proofing_results
           expect(InPersonEnrollment).to receive(:generate_unique_id).and_call_original
+
           job.perform(Time.zone.now)
 
           expect(pending_enrollment.unique_id).not_to be_nil

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -66,6 +66,31 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
   end
 
+  describe 'Triggers' do
+    it 'generates a unique ID if one is not provided' do
+      user = create(:user)
+      profile = create(:profile, :gpo_verification_pending, user: user)
+      expect(InPersonEnrollment).to receive(:generate_unique_id).and_call_original
+
+      enrollment = create(:in_person_enrollment, user: user, profile: profile, status: :pending)
+
+      expect(enrollment.unique_id).not_to be_nil
+    end
+
+    it 'does not generated a unique ID if one is provided' do
+      user = create(:user)
+      profile = create(:profile, :gpo_verification_pending, user: user)
+      expect(InPersonEnrollment).not_to receive(:generate_unique_id)
+
+      enrollment = create(
+        :in_person_enrollment, user: user, profile: profile, status: :pending,
+                               unique_id: '1234'
+      )
+
+      expect(enrollment.unique_id).to eq('1234')
+    end
+  end
+
   describe 'needs_usps_status_check' do
     let(:check_interval) { ...1.hour.ago }
     let!(:passed_enrollment) { create(:in_person_enrollment, :passed) }

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe InPersonEnrollment, type: :model do
       profile = create(:profile, :gpo_verification_pending, user: user)
       expect(InPersonEnrollment).to receive(:generate_unique_id).and_call_original
 
-      enrollment = create(:in_person_enrollment, user: user, profile: profile, status: :pending)
+      enrollment = create(:in_person_enrollment, user: user, profile: profile)
 
       expect(enrollment.unique_id).not_to be_nil
     end
@@ -82,10 +82,7 @@ RSpec.describe InPersonEnrollment, type: :model do
       profile = create(:profile, :gpo_verification_pending, user: user)
       expect(InPersonEnrollment).not_to receive(:generate_unique_id)
 
-      enrollment = create(
-        :in_person_enrollment, user: user, profile: profile, status: :pending,
-                               unique_id: '1234'
-      )
+      enrollment = create(:in_person_enrollment, user: user, profile: profile, unique_id: '1234')
 
       expect(enrollment.unique_id).to eq('1234')
     end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -68,11 +68,12 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
         subject.schedule_in_person_enrollment(user, pii)
       end
 
-      it 'sets enrollment status to pending and sets enrollment established at date' do
+      it 'sets enrollment status to pending and sets established at date and unique id' do
         subject.schedule_in_person_enrollment(user, pii)
 
         expect(user.in_person_enrollments.first.status).to eq('pending')
         expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
+        expect(user.in_person_enrollments.first.unique_id).to_not be_nil
       end
 
       it 'sends verification emails' do

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -60,12 +60,29 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
           expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
           expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
           expect(applicant.email).to eq('no-reply@login.gov')
-          expect(applicant.unique_id).to be_a(String)
+          expect(applicant.unique_id).to eq(enrollment.unique_id)
 
           proofer.request_enroll(applicant)
         end
 
         subject.schedule_in_person_enrollment(user, pii)
+      end
+
+      context 'when the enrollment does not have a unique ID' do
+        it 'uses the deprecated InPersonEnrollment#usps_unique_id value to create the enrollment' do
+          enrollment.update(unique_id: nil)
+          proofer = UspsInPersonProofing::Mock::Proofer.new
+          mock = double
+
+          expect(UspsInPersonProofing::Proofer).to receive(:new).and_return(mock)
+          expect(mock).to receive(:request_enroll) do |applicant|
+            expect(applicant.unique_id).to eq(enrollment.usps_unique_id)
+
+            proofer.request_enroll(applicant)
+          end
+
+          subject.schedule_in_person_enrollment(user, pii)
+        end
       end
 
       it 'sets enrollment status to pending and sets established at date and unique id' do


### PR DESCRIPTION
## 🔮 Context

The USPS API requires us to specify a unique ID when we create an enrollment. Initially we did not store that value in the database and instead just grabbed 18 digits of the user's UUID -- this was a temporary workaround until we fleshed out the unique ID generation better

Since that initial workaround we've added a `unique_id` database column on the InPersonEnrollment model. The polling job sets that value and uses it once it's set, but it isn't used when we actually create the enrollment in the USPS API

### Current sequence of actions

1. When the user visits the location page we generate an enrollment with status == `establishing`. No unique ID is generated and the field is left empty
2. When the user confirms their password we create an enrollment in the USPS API. For the unique ID we use `InPersonEnrollment#usps_unique_id`, which uses 18 digits of the user's UUID
3. We change the status of the enrollment to `pending`
4. Later the polling job runs queries for each `pending` enrollment. If the enrollment does not have a unique ID value saved then we set it to `InPersonEnrollment#usps_unique_id` (which would've been used to create the enrollment in the USPS API)
5. The polling job polls the USPS API for updates to the enrollment using the value of `enrollment.unique_id`, which was just set in the previous step

### What this PR implements

**changes in bold**
*context in italics*

1. When the user visits the location page we generate an enrollment with status == `establishing`. **When the enrollment is created we generate and save a unique ID using `InPersonEnrollment.generate_unique_id`**
2. When the user confirms their password we create an enrollment in the USPS API. For the unique ID we use:
    1. **`enrollment.unique_id` if it exists**
    2. Otherwise `InPersonEnrollment#usps_unique_id`, which uses 18 digits of the user's UUID
3. We change the status of the enrollment to `pending`
4. Later the polling job queries for each `pending` enrollment. If the enrollment does not have a unique ID value saved then we set it to `InPersonEnrollment#usps_unique_id` (which would've been used to create the enrollment in the USPS API)
5. The polling job polls the USPS API for updates to the enrollment using the value of `enrollment.unique_id`. *For enrollments created before this PR these values would have been set in the previous step. For enrollments created after this PR this value would have been set when the enrollment was first created at step 1*

### Future work

Eventually we'll set the `unique_id` field to be a required field. Then we can simplify step 2 above to always use `enrollment.unique_id` and we can remove step 4 above. This is captured in LG-7024

## 🚧 Changes

* Adds a hook on the `InPersonEnrollment` model to generate a unique ID automatically if one isn't provided
* Adds a few tests so that regressions will be detected