### PR TITLE
Remove integration_hub_results from threatmetrix response (redact)

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
+++ b/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
@@ -92,7 +92,6 @@ module Proofing
           fraudpoint.synthetic_identity_index
           fraudpoint.transaction_status
           fraudpoint.vulnerable_victim_index
-          integration_hub_results
           org_id
           policy
           policy_details_api


### PR DESCRIPTION
**Why**: It is echoing the request data which contains PII.
**How**: Remove it from the allowed fields in the response with ResponseRedacter via this PR: https://github.com/18F/identity-idp/pull/6857