### PR TITLE
Add safeguard tests to ensure IRS events are not stored in plaintext

### DIFF
--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Api::IrsAttemptsApiController do
         event_type: :test_event,
         session_id: 'test-session-id',
         occurred_at: time,
-        event_metadata: {},
+        event_metadata: {
+          first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+        },
       )
       jti = event.jti
       jwe = event.to_jwe

--- a/spec/services/irs_attempts_api/envelope_encryptor_spec.rb
+++ b/spec/services/irs_attempts_api/envelope_encryptor_spec.rb
@@ -4,17 +4,19 @@ RSpec.describe IrsAttemptsApi::EnvelopeEncryptor do
   let(:public_key) { private_key.public_key }
   describe '.encrypt' do
     it 'returns encrypted result' do
-      text = 'test'
+      text = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
         data: text, timestamp: time, public_key: public_key,
       )
 
       expect(result.encrypted_data).to_not eq text
+      expect(result.encrypted_data).to_not include(text)
+      expect(Base64.decode64(result.encrypted_data)).to_not include(text)
     end
 
     it 'filename includes digest and truncated timestamp' do
-      text = 'test'
+      text = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
         data: text, timestamp: time,
@@ -31,7 +33,7 @@ RSpec.describe IrsAttemptsApi::EnvelopeEncryptor do
 
   describe '.decrypt' do
     it 'returns decrypted text' do
-      text = 'test'
+      text = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
         data: text, timestamp: time,

--- a/spec/services/irs_attempts_api/redis_client_spec.rb
+++ b/spec/services/irs_attempts_api/redis_client_spec.rb
@@ -9,7 +9,9 @@ describe IrsAttemptsApi::RedisClient do
           event_type: 'test_event',
           session_id: 'test-session-id',
           occurred_at: Time.zone.now,
-          event_metadata: { 'foo' => 'bar' },
+          event_metadata: {
+            first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+          },
         )
         event_key = event.event_key
         jwe = event.to_jwe
@@ -34,7 +36,9 @@ describe IrsAttemptsApi::RedisClient do
             event_type: 'test_event',
             session_id: 'test-session-id',
             occurred_at: now,
-            event_metadata: { 'foo' => 'bar' },
+            event_metadata: {
+              first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+            },
           )
           event_key = event.event_key
           jwe = event.to_jwe
@@ -57,13 +61,17 @@ describe IrsAttemptsApi::RedisClient do
         event_type: 'test_event',
         session_id: 'test-session-id',
         occurred_at: time1,
-        event_metadata: { 'foo' => 'bar' },
+        event_metadata: {
+          first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+        },
       )
       event2 = IrsAttemptsApi::AttemptEvent.new(
         event_type: 'test_event',
         session_id: 'test-session-id',
         occurred_at: time2,
-        event_metadata: { 'foo' => 'bar' },
+        event_metadata: {
+          first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+        },
       )
       jwe1 = event1.to_jwe
       jwe2 = event2.to_jwe

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe IrsAttemptsApi::Tracker do
       end
     end
 
+    it 'does not store events in plaintext in redis' do
+      freeze_time do
+        subject.track_event(:event, first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+
+        events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: Time.zone.now)
+
+        expect(events.keys.first).to_not include('first_name')
+        expect(events.values.first).to_not include(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+      end
+    end
+
     context 'the current session is not an IRS attempt API session' do
       let(:enabled_for_session) { false }
 


### PR DESCRIPTION
This adds a small additional layer to safeguard against future changes to the API to alert us if we are ever storing events in plaintext in Redis.  It also changes some of the event metadata in tests to be PII to be slightly more precise about the type of data stored.  Using PII also helps in the controller specs since the session class will automatically fail [if it detects plaintext PII](https://github.com/18F/identity-idp/blob/fd71f6babd37a6f2e7d9f082eb7c6a1ff2534cf1/lib/session_encryptor.rb#L54)