### PR TITLE
Improve rendering speed of phone input component

### DIFF
--- a/app/components/phone_input_component.rb
+++ b/app/components/phone_input_component.rb
@@ -36,9 +36,10 @@ class PhoneInputComponent < BaseComponent
   end
 
   def international_phone_codes
+    translated_international_codes = PhoneNumberCapabilities.translated_international_codes
     supported_country_codes.
       map do |code_key|
-        code_data = PhoneNumberCapabilities.translated_international_codes[code_key]
+        code_data = translated_international_codes[code_key]
 
         [
           international_phone_code_label(code_data),

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -10,24 +10,17 @@ class PhoneNumberCapabilities
   attr_reader :phone, :phone_confirmed
 
   def self.translated_international_codes
-    if Rails.env.development?
-      translated_international_codes_data = {}
+    @translated_intl_codes_data = nil if Rails.env.development?
+    return @translated_intl_codes_data[I18n.locale] if @translated_intl_codes_data
+
+    @translated_intl_codes_data = Hash.new { |h, k| h[k] = {} }
+    I18n.available_locales.each do |locale|
       INTERNATIONAL_CODES.each do |k, value|
-        translated_international_codes_data[k] =
-          value.merge('name' => I18n.t("countries.#{k.downcase}"))
+        @translated_intl_codes_data[locale][k] =
+          value.merge('name' => I18n.t("countries.#{k.downcase}", locale: locale))
       end
-      translated_international_codes_data
-    else
-      return @translated_intl_codes_data[I18n.locale] if defined?(@translated_intl_codes_data)
-      @translated_intl_codes_data = Hash.new { |h, k| h[k] = {} }
-      I18n.available_locales.each do |locale|
-        INTERNATIONAL_CODES.each do |k, value|
-          @translated_intl_codes_data[locale][k] =
-            value.merge('name' => I18n.t("countries.#{k.downcase}", locale: locale))
-        end
-      end
-      @translated_intl_codes_data[I18n.locale]
     end
+    @translated_intl_codes_data[I18n.locale]
   end
 
   def initialize(phone, phone_confirmed:)

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -19,10 +19,9 @@ class PhoneNumberCapabilities
       translated_international_codes_data
     else
       return @translated_intl_codes_data[I18n.locale] if defined?(@translated_intl_codes_data)
-      @translated_intl_codes_data = {}
+      @translated_intl_codes_data = Hash.new { |h, k| h[k] = {} }
       I18n.available_locales.each do |locale|
         INTERNATIONAL_CODES.each do |k, value|
-          @translated_intl_codes_data[locale] ||= {}
           @translated_intl_codes_data[locale][k] =
             value.merge('name' => I18n.t("countries.#{k.downcase}", locale: locale))
         end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -10,12 +10,25 @@ class PhoneNumberCapabilities
   attr_reader :phone, :phone_confirmed
 
   def self.translated_international_codes
-    translated_international_codes_data = {}
-    INTERNATIONAL_CODES.each do |k, value|
-      translated_international_codes_data[k] =
-        value.merge('name' => I18n.t("countries.#{k.downcase}"))
+    if Rails.env.development?
+      translated_international_codes_data = {}
+      INTERNATIONAL_CODES.each do |k, value|
+        translated_international_codes_data[k] =
+          value.merge('name' => I18n.t("countries.#{k.downcase}"))
+      end
+      translated_international_codes_data
+    else
+      return @translated_intl_codes_data[I18n.locale] if defined?(@translated_intl_codes_data)
+      @translated_intl_codes_data = {}
+      I18n.available_locales.each do |locale|
+        INTERNATIONAL_CODES.each do |k, value|
+          @translated_intl_codes_data[locale] ||= {}
+          @translated_intl_codes_data[locale][k] =
+            value.merge('name' => I18n.t("countries.#{k.downcase}", locale: locale))
+        end
+      end
+      @translated_intl_codes_data[I18n.locale]
     end
-    translated_international_codes_data
   end
 
   def initialize(phone, phone_confirmed:)

--- a/spec/components/phone_input_component_spec.rb
+++ b/spec/components/phone_input_component_spec.rb
@@ -136,10 +136,11 @@ RSpec.describe PhoneInputComponent, type: :component do
 
   context 'with delivery unsupported country' do
     before do
-      stub_const(
-        'PhoneNumberCapabilities::INTERNATIONAL_CODES',
-        PhoneNumberCapabilities::INTERNATIONAL_CODES.merge(
-          'US' => PhoneNumberCapabilities::INTERNATIONAL_CODES['US'].merge('supports_sms' => false),
+      allow(PhoneNumberCapabilities).to receive(:translated_international_codes).and_return(
+        PhoneNumberCapabilities.translated_international_codes.merge(
+          'US' => PhoneNumberCapabilities.translated_international_codes['US'].merge(
+            'supports_sms' => false,
+          ),
         ),
       )
     end
@@ -159,10 +160,9 @@ RSpec.describe PhoneInputComponent, type: :component do
 
   context 'with delivery unsupported unconfirmed country' do
     before do
-      stub_const(
-        'PhoneNumberCapabilities::INTERNATIONAL_CODES',
-        PhoneNumberCapabilities::INTERNATIONAL_CODES.merge(
-          'US' => PhoneNumberCapabilities::INTERNATIONAL_CODES['US'].merge(
+      allow(PhoneNumberCapabilities).to receive(:translated_international_codes).and_return(
+        PhoneNumberCapabilities.translated_international_codes.merge(
+          'US' => PhoneNumberCapabilities.translated_international_codes['US'].merge(
             'supports_sms_unconfirmed' => false,
           ),
         ),


### PR DESCRIPTION
I noticed we spend a disproportionate amount of time rendering templates on phone input pages in [NewRelic](https://one.newrelic.com/nr1-core/apm-features/transactions/MTM3NjM3MHxBUE18QVBQTElDQVRJT058MTA0NDEwMDY1?account=1376370&begin=1661966100000&end=1661966280000&state=0c2819b1-c4d7-4897-760b-525cba76bd61)

Ex:
![image](https://user-images.githubusercontent.com/1430443/187747369-e2f74337-9c61-41ae-964a-52b642712e80.png)

I did a bit of profiling and it looks like it is in large part due to many calls to `PhoneNumberCapabilities.translated_international_codes`.  It is not clear that it is an expensive operation that iterates over all of the country codes (currently 220) and translates them.  `PhoneInputComponent#international_phone_codes` calls it for every country code (up to a total of 220^2 times).

I tried two approaches.  The first being caching the results of `PhoneNumberCapabilities.translated_international_codes` and the second to skip recalculating `PhoneNumberCapabilities.translated_international_codes` in the component.

The caching did provide a ~25% improvement on top of the ~4500% improvement of simply not recalculating every time.  However, I wasn't sure whether it was worth it since it's additional complexity and would require some more work to disable it in dev to avoid causing issues with updating translated content.  If others think it's worth it, I can bring it in.

Both the [caching code](https://github.com/18F/identity-idp/compare/mitchellhenke/phone-index-rendering-performance-tests?expand=1#diff-5dbff90afb428a07ab595ee2263832c9fabd560d14819cdec2ef472925da7fedR24-R33) and [benchmark code](https://github.com/18F/identity-idp/compare/mitchellhenke/phone-index-rendering-performance-tests?expand=1#diff-d87d02472882eb050b0aceb5c085e286bf7baf7db9585258923b2a855f5f8d0dR20-R50) are on the `mitchellhenke/phone-index-rendering-performance-tests` branch.

```
Warming up --------------------------------------
no cache and recalculate
                         1.000  i/100ms
cache and recalculate
                         6.000  i/100ms
no cache and no recalculate
                         4.000  i/100ms
cache and no recalculate
                         6.000  i/100ms
Calculating -------------------------------------
no cache and recalculate
                          1.008  (± 0.0%) i/s -     31.000  in  30.760540s
cache and recalculate
                         59.919  (±13.4%) i/s -      1.734k in  30.023267s
no cache and no recalculate
                         45.959  (±10.9%) i/s -      1.352k in  30.056932s
cache and no recalculate
                         59.156  (±11.8%) i/s -      1.728k in  30.086327s

Comparison:
cache and recalculate:       59.9 i/s
cache and no recalculate:       59.2 i/s - same-ish: difference falls within error
no cache and no recalculate:       46.0 i/s - 1.30x  (± 0.00) slower
no cache and recalculate:        1.0 i/s - 59.42x  (± 0.00) slower

------------------------------------------------------------------------------


Warming up --------------------------------------
no cache and no recalculate
                         4.000  i/100ms
cache and no recalculate
                         6.000  i/100ms
Calculating -------------------------------------
no cache and no recalculate
                         47.595  (± 8.4%) i/s -      1.404k in  30.051126s
cache and no recalculate
                         59.313  (±10.1%) i/s -      1.740k in  30.005606s

Comparison:
cache and no recalculate:       59.3 i/s
no cache and no recalculate:       47.6 i/s - 1.25x  (± 0.00) slower
```