### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,7 +206,9 @@ coverage:
     - mv coverage/coverage/* coverage/
   artifacts:
     reports:
-      cobertura: coverage/coverage.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/coverage.xml
     name: coverage
     expire_in: 31d
     paths:


### PR DESCRIPTION
Gitlab 15.0 removed the `cobertura` keyword in favor of a new syntax.

Detail: https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscoverage_report

[skip changelog]