### PR TITLE
LG-6959 IDV verify redirects to inherited proofing

### DIFF
--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -37,11 +37,8 @@ class IdvController < ApplicationController
 
   def verify_identity
     analytics.idv_intro_visit
-    if va_inherited_proofing?
-      redirect_to idv_inherited_proofing_url
-    else
-      redirect_to idv_doc_auth_url
-    end
+    return redirect_to idv_inherited_proofing_url if va_inherited_proofing?
+    redirect_to idv_doc_auth_url
   end
 
   def profile_needs_reactivation?

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -1,6 +1,7 @@
 class IdvController < ApplicationController
   include IdvSession
   include AccountReactivationConcern
+  include InheritedProofingConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :profile_needs_reactivation?, only: [:index]
@@ -36,7 +37,11 @@ class IdvController < ApplicationController
 
   def verify_identity
     analytics.idv_intro_visit
-    redirect_to idv_doc_auth_url
+    if va_inherited_proofing?
+      redirect_to idv_inherited_proofing_url
+    else
+      redirect_to idv_doc_auth_url
+    end
   end
 
   def profile_needs_reactivation?

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -55,6 +55,21 @@ describe IdvController do
       expect(response).to redirect_to idv_doc_auth_path
     end
 
+    it 'redirects to inherited proofing if an auth code parameter is included in request URL' do
+      session_service_provider = create(:service_provider)
+      users_auth_code = 'any_auth_code'
+      request_url = "https://login.gov/openid_connect/authorize?inherited_proofing_auth=#{users_auth_code}"
+
+      allow_any_instance_of(ApplicationController).to receive(:current_sp).
+        and_return(session_service_provider)
+      stub_sign_in
+      session[:sp] = { request_url: request_url }
+
+      get :index
+
+      expect(response).to redirect_to idv_inherited_proofing_path
+    end
+
     context 'sp has reached quota limit' do
       let(:issuer) { 'foo' }
 

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -55,19 +55,16 @@ describe IdvController do
       expect(response).to redirect_to idv_doc_auth_path
     end
 
-    it 'redirects to inherited proofing if an auth code parameter is included in request URL' do
-      session_service_provider = create(:service_provider)
-      users_auth_code = 'any_auth_code'
-      request_url = "https://login.gov/openid_connect/authorize?inherited_proofing_auth=#{users_auth_code}"
+    context 'with a VA inherited proofing session' do
+      before do
+        stub_sign_in
+        allow(controller).to receive(:va_inherited_proofing?).and_return(true)
+      end
 
-      allow_any_instance_of(ApplicationController).to receive(:current_sp).
-        and_return(session_service_provider)
-      stub_sign_in
-      session[:sp] = { request_url: request_url }
-
-      get :index
-
-      expect(response).to redirect_to idv_inherited_proofing_path
+      it 'redirects to inherited proofing' do
+        get :index
+        expect(response).to redirect_to idv_inherited_proofing_path
+      end
     end
 
     context 'sp has reached quota limit' do


### PR DESCRIPTION
When a VA user completes authorization through openid_connect, they are redirected to inherited proofing verification.

changelog: Upcoming Features, Inherited proofing, verification step redirects to inherited proofing

Refer to the upper-right portion of this diagram: https://www.figma.com/file/Lj6tqLhohJMTR4IvvoU2BI/VA-Inherited-Proofing-Architecture-Diagram