### PR TITLE
Include account_drivers_license_type, alternate way to get state

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -21,7 +21,8 @@ module Proofing
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
             account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
-            account_drivers_license_issuer: applicant[:state_id_jurisdiction].to_s.strip,
+            account_drivers_license_type: "us_dl",
+            account_drivers_license_issuer: applicant[:state_id_jurisdiction] || applicant[:state],
             event_type: 'ACCOUNT_CREATION',
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -21,8 +21,8 @@ module Proofing
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
             account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
-            account_drivers_license_type: "us_dl",
-            account_drivers_license_issuer: applicant[:state_id_jurisdiction] || applicant[:state],
+            account_drivers_license_type: 'us_dl',
+            account_drivers_license_issuer: applicant[:state_id_jurisdiction].to_s.strip,
             event_type: 'ACCOUNT_CREATION',
             policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
             service_type: 'all',

--- a/spec/fixtures/proofing/lexis_nexis/ddp/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/request.json
@@ -13,6 +13,7 @@
   "account_last_name": "McTesterson",
   "account_telephone": "",
   "account_drivers_license_number": "12345678",
+  "account_drivers_license_type": "us_dl",
   "account_drivers_license_issuer" : "LA",
   "event_type": "ACCOUNT_CREATION",
   "policy": "test-policy",


### PR DESCRIPTION
LexisNexis advised that we should correct the keys:
- `account_drivers_license_type`
- `account_drivers_license_issuer `

I've hard-coded the first. For the second, we weren't seeing a `state_id_jurisdiction` in the data so I wonder if others feel that `state` is a good fallback?

UPDATE: Per a comment from @zachmargolis I have removed the state fallback. I propose we should verify `state_id_jurisdiction` is working correctly, if we're relying on it.

changelog: Include account_drivers_license_type, alternate way to get state
