### PR TITLE
Deploy RC 206.1 to Production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,7 +206,9 @@ coverage:
     - mv coverage/coverage/* coverage/
   artifacts:
     reports:
-      cobertura: coverage/coverage.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/coverage.xml
     name: coverage
     expire_in: 31d
     paths:

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -10,7 +10,12 @@ class AccessTokenVerifier
   end
 
   def submit
-    FormResponse.new(success: valid?, errors: errors)
+    FormResponse.new(
+      success: valid?, errors: errors, extra: {
+        client_id: identity&.service_provider,
+        ial: identity&.ial,
+      }
+    )
   end
 
   def identity

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1381,11 +1381,15 @@ module AnalyticsEvents
 
   # Tracks when an openid connect bearer token authentication request is made
   # @param [Boolean] success
+  # @param [Integer] ial
+  # @param [String] client_id Service Provider issuer
   # @param [Hash] errors
-  def openid_connect_bearer_token(success:, errors:, **extra)
+  def openid_connect_bearer_token(success:, ial:, client_id:, errors:, **extra)
     track_event(
       'OpenID Connect: bearer token authentication',
       success: success,
+      ial: ial,
+      client_id: client_id,
       errors: errors,
       **extra,
     )


### PR DESCRIPTION
## Internal
- Logging: Log service provider and IAL for userinfo access token ([#6899](https://github.com/18F/identity-idp/pull/6899))
