### PR TITLE
Update IPP flow to include CSP for ThreatMetrix

### DIFF
--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -9,8 +9,10 @@ module Idv
 
     include IdvSession
     include Flow::FlowStateMachine
+    include Idv::ThreatMetrixConcern
 
     before_action :redirect_if_flow_completed
+    before_action :override_csp_for_threat_metrix
 
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_in_person_step_url,

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -12,6 +12,7 @@ describe Idv::DocAuthController do
         :confirm_two_factor_authenticated,
         :fsm_initialize,
         :ensure_correct_step,
+        :override_csp_for_threat_metrix,
       )
     end
 

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -22,6 +22,7 @@ describe Idv::InPersonController do
         :confirm_two_factor_authenticated,
         :fsm_initialize,
         :ensure_correct_step,
+        :override_csp_for_threat_metrix,
       )
     end
   end


### PR DESCRIPTION
This is a follow-on to #6877, just ensuring that CSP headers are set properly on the SSN page for the In-Person Proofing flow to allow the ThreatMetrix javascript to run (when enabled).

[skip changelog]