### PR TITLE
LG-7442 Add Threatmetrix Costing

### DIFF
--- a/app/services/db/proofing_cost/add_user_proofing_cost.rb
+++ b/app/services/db/proofing_cost/add_user_proofing_cost.rb
@@ -13,6 +13,7 @@ module Db
         lexis_nexis_address
         gpo_letter
         phone_otp
+        threatmetrix
       ].freeze
 
       def self.call(user_id, token)

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -12,6 +12,7 @@ module Db
         lexis_nexis_resolution
         lexis_nexis_address
         gpo_letter
+        threatmetrix
       ].freeze
 
       def self.call(service_provider, ial, token, transaction_id: nil, user: nil)

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -49,8 +49,6 @@ module Idv
           if stage == :resolution
             # transaction_id comes from ConversationId
             add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
-            tmx_id = hash[:threatmetrix_request_id]
-            add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
           elsif stage == :state_id
             process_aamva(hash[:transaction_id])
           elsif stage == :threatmetrix

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -53,6 +53,10 @@ module Idv
             add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
           elsif stage == :state_id
             process_aamva(hash[:transaction_id])
+          elsif stage == :threatmetrix
+            # transaction_id comes from request_id
+            tmx_id = hash[:transaction_id]
+            add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
           end
         end
       end

--- a/db/primary_migrate/20220906112214_add_threatmetrix_to_proofing_cost.rb
+++ b/db/primary_migrate/20220906112214_add_threatmetrix_to_proofing_cost.rb
@@ -1,4 +1,6 @@
 class AddThreatmetrixToProofingCost < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def up
     add_column :proofing_costs, :threatmetrix_count, :integer
     change_column_default :proofing_costs, :threatmetrix_count, 0

--- a/db/primary_migrate/20220906112214_add_threatmetrix_to_proofing_cost.rb
+++ b/db/primary_migrate/20220906112214_add_threatmetrix_to_proofing_cost.rb
@@ -1,0 +1,10 @@
+class AddThreatmetrixToProofingCost < ActiveRecord::Migration[7.0]
+  def up
+    add_column :proofing_costs, :threatmetrix_count, :integer
+    change_column_default :proofing_costs, :threatmetrix_count, 0
+  end
+
+  def down
+    remove_column :proofing_costs, :threatmetrix_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_08_140030) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_06_112214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -476,6 +476,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_08_140030) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "acuant_result_count", default: 0
     t.integer "acuant_selfie_count", default: 0
+    t.integer "threatmetrix_count", default: 0
     t.index ["user_id"], name: "index_proofing_costs_on_user_id", unique: true
   end
 

--- a/spec/features/reports/proofing_costs_report_spec.rb
+++ b/spec/features/reports/proofing_costs_report_spec.rb
@@ -28,6 +28,7 @@ feature 'Proofing Costs report' do
       'gpo_letter_count_average' => 0.0,
       'lexis_nexis_address_count_average' => 0.0,
       'phone_otp_count_average' => 0.0,
+      'threatmetrix_count_average' => 0.0,
     }
   end
 

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -80,11 +80,10 @@ describe Idv::Steps::VerifyWaitStepShow do
 
       step.call
 
-      sp_costs = SpCost.where(issuer: issuer)
-      expect(sp_costs[0].cost_type).to eq('lexis_nexis_resolution')
+      sp_costs = SpCost.where(issuer: issuer, cost_type: 'lexis_nexis_resolution')
       expect(sp_costs[0].transaction_id).to eq(resolution_transaction_id)
-      expect(sp_costs[1].cost_type).to eq('threatmetrix')
-      expect(sp_costs[1].transaction_id).to eq(threatmetrix_transaction_id)
+      sp_costs = SpCost.where(issuer: issuer, cost_type: 'threatmetrix')
+      expect(sp_costs[0].transaction_id).to eq(threatmetrix_transaction_id)
 
       proofing_cost = ProofingCost.last
       expect(proofing_cost.user_id).to eq(user.id)

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -6,6 +6,8 @@ describe Idv::Steps::VerifyWaitStepShow do
   let(:user) { build(:user) }
   let(:issuer) { 'test_issuer' }
   let(:service_provider) { build(:service_provider, issuer: issuer) }
+  let(:resolution_transaction_id) { Proofing::Mock::ResolutionMockClient::TRANSACTION_ID }
+  let(:threatmetrix_transaction_id) { Proofing::Mock::DdpMockClient::TRANSACTION_ID }
 
   let(:request) { FakeRequest.new }
 
@@ -24,7 +26,8 @@ describe Idv::Steps::VerifyWaitStepShow do
 
   let(:idv_result) do
     {
-      context: { stages: { resolution: {} } },
+      context: { stages: { resolution: { transaction_id: resolution_transaction_id },
+                           threatmetrix: { transaction_id: threatmetrix_transaction_id } } },
       errors: {},
       exception: nil,
       success: true,
@@ -71,11 +74,17 @@ describe Idv::Steps::VerifyWaitStepShow do
     end
 
     it 'adds costs' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
+        and_return(true)
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
+
       step.call
 
-      expect(SpCost.where(issuer: issuer).map(&:cost_type)).to contain_exactly(
-        'lexis_nexis_resolution',
-      )
+      sp_costs = SpCost.where(issuer: issuer)
+      expect(sp_costs[0].cost_type).to eq('lexis_nexis_resolution')
+      expect(sp_costs[0].transaction_id).to eq(resolution_transaction_id)
+      expect(sp_costs[1].cost_type).to eq('threatmetrix')
+      expect(sp_costs[1].transaction_id).to eq(threatmetrix_transaction_id)
     end
 
     it 'clears pii from session' do

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -85,6 +85,11 @@ describe Idv::Steps::VerifyWaitStepShow do
       expect(sp_costs[0].transaction_id).to eq(resolution_transaction_id)
       expect(sp_costs[1].cost_type).to eq('threatmetrix')
       expect(sp_costs[1].transaction_id).to eq(threatmetrix_transaction_id)
+
+      proofing_cost = ProofingCost.last
+      expect(proofing_cost.user_id).to eq(user.id)
+      expect(proofing_cost.threatmetrix_count).to eq(1)
+      expect(proofing_cost.lexis_nexis_resolution_count).to eq(1)
     end
 
     it 'clears pii from session' do


### PR DESCRIPTION
**Why**: To track threatmetrix costs on a per user, per sp, and global basis.
**How**: Add threatmetrix symbol to the allow list for the generic costing routines, add a field in the db to store counts.  hookup calls.