### PR TITLE
Improve speed of VerifySpAttributesConcern

### DIFF
--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -3,27 +3,15 @@ module VerifySpAttributesConcern
     return nil if sp_session[:issuer].blank?
     return nil if sp_session[:request_url].blank?
 
-    if @use_cache
-      @sp_session_identity = cached_sp_session_identity
-      if @sp_session_identity.nil?
-        :new_sp
-      elsif !cached_requested_attributes_verified?(@sp_session_identity)
-        :new_attributes
-      elsif cached_consent_has_expired?(@sp_session_identity)
-        :consent_expired
-      elsif cached_consent_was_revoked?(@sp_session_identity)
-        :consent_revoked
-      end
-    else
-      if sp_session_identity.nil?
-        :new_sp
-      elsif !requested_attributes_verified?
-        :new_attributes
-      elsif consent_has_expired?
-        :consent_expired
-      elsif consent_was_revoked?
-        :consent_revoked
-      end
+    sp_session_identity = find_sp_session_identity
+    if sp_session_identity.nil?
+      :new_sp
+    elsif !requested_attributes_verified?(sp_session_identity)
+      :new_attributes
+    elsif consent_has_expired?(sp_session_identity)
+      :consent_expired
+    elsif consent_was_revoked?(sp_session_identity)
+      :consent_revoked
     end
   end
 
@@ -39,7 +27,7 @@ module VerifySpAttributesConcern
     )
   end
 
-  def consent_has_expired?
+  def consent_has_expired?(sp_session_identity)
     return false unless sp_session_identity
     return false if sp_session_identity.deleted_at.present?
     last_estimated_consent = sp_session_identity.last_consented_at || sp_session_identity.created_at
@@ -48,21 +36,7 @@ module VerifySpAttributesConcern
       verified_after_consent?(last_estimated_consent)
   end
 
-  def cached_consent_has_expired?(sp_session_identity)
-    return false unless sp_session_identity
-    return false if sp_session_identity.deleted_at.present?
-    last_estimated_consent = sp_session_identity.last_consented_at || sp_session_identity.created_at
-    !last_estimated_consent ||
-      last_estimated_consent < ServiceProviderIdentity::CONSENT_EXPIRATION.ago ||
-      verified_after_consent?(last_estimated_consent)
-  end
-
-  def consent_was_revoked?
-    return false unless sp_session_identity
-    sp_session_identity.deleted_at.present?
-  end
-
-  def cached_consent_was_revoked?(sp_session_identity)
+  def consent_was_revoked?(sp_session_identity)
     return false unless sp_session_identity
     sp_session_identity.deleted_at.present?
   end
@@ -75,22 +49,11 @@ module VerifySpAttributesConcern
     verification_timestamp.present? && last_estimated_consent < verification_timestamp
   end
 
-  def sp_session_identity
-    @sp_session_identity =
-      current_user&.identities&.find_by(service_provider: sp_session[:issuer])
-  end
-
-  def cached_sp_session_identity
+  def find_sp_session_identity
     current_user&.identities&.find_by(service_provider: sp_session[:issuer])
   end
 
-  def requested_attributes_verified?
-    @sp_session_identity && (
-      Array(sp_session[:requested_attributes]) - @sp_session_identity.verified_attributes.to_a
-    ).empty?
-  end
-
-  def cached_requested_attributes_verified?(sp_session_identity)
+  def requested_attributes_verified?(sp_session_identity)
     sp_session_identity && (
       Array(sp_session[:requested_attributes]) - sp_session_identity.verified_attributes.to_a
     ).empty?

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -3,14 +3,27 @@ module VerifySpAttributesConcern
     return nil if sp_session[:issuer].blank?
     return nil if sp_session[:request_url].blank?
 
-    if sp_session_identity.nil?
-      :new_sp
-    elsif !requested_attributes_verified?
-      :new_attributes
-    elsif consent_has_expired?
-      :consent_expired
-    elsif consent_was_revoked?
-      :consent_revoked
+    if @use_cache
+      @sp_session_identity = cached_sp_session_identity
+      if @sp_session_identity.nil?
+        :new_sp
+      elsif !cached_requested_attributes_verified?(@sp_session_identity)
+        :new_attributes
+      elsif cached_consent_has_expired?(@sp_session_identity)
+        :consent_expired
+      elsif cached_consent_was_revoked?(@sp_session_identity)
+        :consent_revoked
+      end
+    else
+      if sp_session_identity.nil?
+        :new_sp
+      elsif !requested_attributes_verified?
+        :new_attributes
+      elsif consent_has_expired?
+        :consent_expired
+      elsif consent_was_revoked?
+        :consent_revoked
+      end
     end
   end
 
@@ -35,7 +48,21 @@ module VerifySpAttributesConcern
       verified_after_consent?(last_estimated_consent)
   end
 
+  def cached_consent_has_expired?(sp_session_identity)
+    return false unless sp_session_identity
+    return false if sp_session_identity.deleted_at.present?
+    last_estimated_consent = sp_session_identity.last_consented_at || sp_session_identity.created_at
+    !last_estimated_consent ||
+      last_estimated_consent < ServiceProviderIdentity::CONSENT_EXPIRATION.ago ||
+      verified_after_consent?(last_estimated_consent)
+  end
+
   def consent_was_revoked?
+    return false unless sp_session_identity
+    sp_session_identity.deleted_at.present?
+  end
+
+  def cached_consent_was_revoked?(sp_session_identity)
     return false unless sp_session_identity
     sp_session_identity.deleted_at.present?
   end
@@ -53,9 +80,19 @@ module VerifySpAttributesConcern
       current_user&.identities&.find_by(service_provider: sp_session[:issuer])
   end
 
+  def cached_sp_session_identity
+    current_user&.identities&.find_by(service_provider: sp_session[:issuer])
+  end
+
   def requested_attributes_verified?
     @sp_session_identity && (
       Array(sp_session[:requested_attributes]) - @sp_session_identity.verified_attributes.to_a
+    ).empty?
+  end
+
+  def cached_requested_attributes_verified?(sp_session_identity)
+    sp_session_identity && (
+      Array(sp_session[:requested_attributes]) - sp_session_identity.verified_attributes.to_a
     ).empty?
   end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -1,4 +1,3 @@
-require 'benchmark/ips'
 module OpenidConnect
   class AuthorizationController < ApplicationController
     include FullyAuthenticatable
@@ -21,41 +20,13 @@ module OpenidConnect
     before_action :bump_auth_count, only: [:index]
 
     def index
-      # StackProf.run(mode: :cpu, raw: true, interval: 50, out: 'tmp/stackprof-cpu-myapp.dump') do
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
-
-# Warming up --------------------------------------
-#             no cache     8.000  i/100ms
-#                cache    50.000  i/100ms
-# Calculating -------------------------------------
-#             no cache     79.407  (±12.6%) i/s -      2.328k in  30.055220s
-#                cache    449.444  (±10.9%) i/s -     13.300k in  30.030989s
-
-# Comparison:
-#                cache:      449.4 i/s
-#             no cache:       79.4 i/s - 5.66x  (± 0.00) slower
-
-      j = Benchmark.ips do |x|
-        x.time = 30
-        x.report("no cache") do
-          @use_cache = false
-          return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
-        end
-
-        x.report("cache") do
-          @use_cache = true
-          return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
-        end
-
-        x.compare!
-      end
-      binding.pry
+      return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
       link_identity_to_service_provider
       if auth_count == 1 && first_visit_for_sp?
         return redirect_to(user_authorization_confirmation_url)
       end
       handle_successful_handoff
-      render plain: "O"
     end
 
     private
@@ -98,7 +69,7 @@ module OpenidConnect
     def handle_successful_handoff
       track_events
       SpHandoffBounce::AddHandoffTimeToSession.call(sp_session)
-      # redirect_to @authorize_form.success_redirect_uri, allow_other_host: true
+      redirect_to @authorize_form.success_redirect_uri, allow_other_host: true
       delete_branded_experience
     end
 

--- a/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
+++ b/spec/controllers/concerns/verify_sp_attributes_concern_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe VerifySpAttributesConcern do
       allow(controller).to receive(:sp_session_identity).and_return(sp_session_identity)
     end
 
-    subject(:consent_has_expired?) { controller.consent_has_expired? }
+    subject(:consent_has_expired?) { controller.consent_has_expired?(sp_session_identity) }
 
     context 'when there is no sp_session_identity' do
       let(:sp_session_identity) { nil }
@@ -113,7 +113,7 @@ RSpec.describe VerifySpAttributesConcern do
       allow(controller).to receive(:sp_session_identity).and_return(sp_session_identity)
     end
 
-    subject(:consent_was_revoked?) { controller.consent_was_revoked? }
+    subject(:consent_was_revoked?) { controller.consent_was_revoked?(sp_session_identity) }
 
     context 'when there is no sp_session_identity' do
       let(:sp_session_identity) { nil }


### PR DESCRIPTION
Currently, `VerifySpAttributesConcern` makes repeated calls to `sp_session_identity`.  The database call is cached after the first call, but there is still a noticeable amount of overhead in doing that.

This PR cleans up the behavior to only maybe hit the database once and passes the result to the functions that follow.

Performance benchmark available in commit https://github.com/18F/identity-idp/commit/b924b5a96b0a5126c1d3f23fbf13fa4679375d52
```
# Warming up --------------------------------------
#             no cache     8.000  i/100ms
#                cache    50.000  i/100ms
# Calculating -------------------------------------
#             no cache     79.407  (±12.6%) i/s -      2.328k in  30.055220s
#                cache    449.444  (±10.9%) i/s -     13.300k in  30.030989s

# Comparison:
#                cache:      449.4 i/s
#             no cache:       79.4 i/s - 5.66x  (± 0.00) slower
```