### PR TITLE
LG-7305 Make sure ThreatMetrix failure disables profile Part 2

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -74,6 +74,8 @@ module Idv
         :gpo_verification_pending
       elsif in_person_enrollment?
         :in_person_verification_pending
+      elsif threatmetrix_failed_and_needs_review?
+        :threatmetrix_review_pending
       end
     end
 
@@ -165,6 +167,14 @@ module Idv
 
     def in_person_enrollment?
       ProofingComponent.find_by(user: current_user)&.document_check == Idp::Constants::Vendors::USPS
+    end
+
+    def threatmetrix_failed_and_needs_review?
+      return unless IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
+      return unless IdentityConfig.store.lexisnexis_threatmetrix_enabled
+      component = ProofingComponent.find_by(user: @current_user)
+      return true unless component
+      !(component.threatmetrix && component.threatmetrix_review_status == 'pass')
     end
   end
 end


### PR DESCRIPTION
**Why**: Code was added to password_controller but the password screen is actually called review_controller (another spot where a profile is created)
**How**: Follow up to
 https://github.com/18F/identity-idp/pull/6817
