### PR TITLE
Enable Rubocop Style/MethodDefParentheses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1055,6 +1055,9 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: true
   IgnoredMethods: []
 
+Style/MethodDefParentheses:
+  Enabled: true
+
 Style/MissingRespondToMissing:
   Enabled: true
 


### PR DESCRIPTION
Context: https://github.com/18F/identity-idp/pull/6713#discussion_r964884841

**Why**: For consistency, and to reduce toil in code review.

Documentation: https://docs.rubocop.org/rubocop/cops_style.html#stylemethoddefparentheses