### PR TITLE
Try to fix intermittent failure for in-person feature spec

### DIFF
--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe 'In Person Proofing', js: true do
     click_button t('forms.buttons.back')
 
     expect(page).to have_content(t('in_person_proofing.headings.location'))
+    expect(page).to have_css('.location-collection-item', wait: 10)
     click_button t('forms.buttons.back')
 
     # Note: This is specifically for failed barcodes. Other cases may use


### PR DESCRIPTION
**Why**: So that our builds pass reliably.

Example: https://gitlab.login.gov/lg/identity-idp/-/jobs/68130

```
  1) In Person Proofing allows the user to go back to document capture from prepare step
     Failure/Error: expect(page).to have_button(t('doc_auth.buttons.add_new_photos'))
       expected to find button "Add new photos" that is not disabled but there were no matches
     # ./spec/features/idv/in_person_spec.rb:163:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:126:in `block (2 levels) in <top (required)>'
```

The operating hypothesis is that the "< Back" link on the Location selection screen can shift position on the page as the locations become loaded which may cause some issues with the accuracy of the click interaction, so the changes here waits for the locations to finish loading before proceeding to click "< Back".