### PR TITLE
Log digest of OIDC "code" param (LG-7440)

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -25,7 +25,7 @@ module OpenidConnect
       link_identity_to_service_provider
 
       result = @authorize_form.submit
-      # track successful formsm see pre_validate_authorize_form for unsuccessful
+      # track successful forms, see pre_validate_authorize_form for unsuccessful
       # this needs to be after link_identity_to_service_provider so that "code" is present
       track_authorize_analytics(result)
 

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -17,7 +17,7 @@ class OpenidConnectAuthorizeForm
 
   ATTRS = [:unauthorized_scope, :acr_values, :scope, :verified_within, *SIMPLE_ATTRS].freeze
 
-  attr_reader(:code, *ATTRS)
+  attr_reader(*ATTRS)
 
   RANDOM_VALUE_MINIMUM_LENGTH = 22
   MINIMUM_REPROOF_VERIFIED_WITHIN_DAYS = 30
@@ -82,7 +82,6 @@ class OpenidConnectAuthorizeForm
 
   def success_redirect_uri
     uri = redirect_uri unless errors.include?(:redirect_uri)
-    @code = identity&.session_uuid
 
     UriService.add_params(uri, code: code, state: state) if code
   end
@@ -111,6 +110,10 @@ class OpenidConnectAuthorizeForm
   private
 
   attr_reader :identity, :success
+
+  def code
+    identity&.session_uuid
+  end
 
   def check_for_unauthorized_scope(params)
     param_value = params[:scope]

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -17,7 +17,7 @@ class OpenidConnectAuthorizeForm
 
   ATTRS = [:unauthorized_scope, :acr_values, :scope, :verified_within, *SIMPLE_ATTRS].freeze
 
-  attr_reader(*ATTRS)
+  attr_reader(:code, *ATTRS)
 
   RANDOM_VALUE_MINIMUM_LENGTH = 22
   MINIMUM_REPROOF_VERIFIED_WITHIN_DAYS = 30
@@ -82,7 +82,7 @@ class OpenidConnectAuthorizeForm
 
   def success_redirect_uri
     uri = redirect_uri unless errors.include?(:redirect_uri)
-    code = identity&.session_uuid
+    @code = identity&.session_uuid
 
     UriService.add_params(uri, code: code, state: state) if code
   end
@@ -206,6 +206,7 @@ class OpenidConnectAuthorizeForm
       scope: scope&.sort&.join(' '),
       acr_values: acr_values&.sort&.join(' '),
       unauthorized_scope: @unauthorized_scope,
+      code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
     }
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -195,6 +195,7 @@ class OpenidConnectTokenForm
     {
       client_id: client_id,
       user_id: identity&.user&.uuid,
+      code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
     }
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1460,12 +1460,14 @@ module AnalyticsEvents
   # @param [Array] acr_values
   # @param [Boolean] unauthorized_scope
   # @param [Boolean] user_fully_authenticated
+  # @param [String] hash of returned "code" param
   def openid_connect_request_authorization(
     client_id:,
     scope:,
     acr_values:,
     unauthorized_scope:,
     user_fully_authenticated:,
+    code_digest:,
     **extra
   )
     track_event(
@@ -1475,6 +1477,7 @@ module AnalyticsEvents
       acr_values: acr_values,
       unauthorized_scope: unauthorized_scope,
       user_fully_authenticated: user_fully_authenticated,
+      code_digest: code_digest,
       **extra,
     )
   end
@@ -1482,11 +1485,13 @@ module AnalyticsEvents
   # Tracks when an openid connect token request is made
   # @param [String] client_id
   # @param [String] user_id
-  def openid_connect_token(client_id:, user_id:, **extra)
+  # @param [String] hash of "code" param
+  def openid_connect_token(client_id:, user_id:, code_digest:, **extra)
     track_event(
       'OpenID Connect: token',
       client_id: client_id,
       user_id: user_id,
+      code_digest: code_digest,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1460,7 +1460,7 @@ module AnalyticsEvents
   # @param [Array] acr_values
   # @param [Boolean] unauthorized_scope
   # @param [Boolean] user_fully_authenticated
-  # @param [String] hash of returned "code" param
+  # @param [String] code_digest hash of returned "code" param
   def openid_connect_request_authorization(
     client_id:,
     scope:,
@@ -1485,7 +1485,7 @@ module AnalyticsEvents
   # Tracks when an openid connect token request is made
   # @param [String] client_id
   # @param [String] user_id
-  # @param [String] hash of "code" param
+  # @param [String] code_digest hash of "code" param
   def openid_connect_token(client_id:, user_id:, code_digest:, **extra)
     track_event(
       'OpenID Connect: token',

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  unauthorized_scope: true,
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid')
+                 scope: 'openid',
+                 code_digest: anything)
           expect(@analytics).to receive(:track_event).
             with(
               'SP redirect initiated',
@@ -116,7 +117,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      unauthorized_scope: false,
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
-                     scope: 'openid profile')
+                     scope: 'openid profile',
+                     code_digest: anything)
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -215,7 +217,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      unauthorized_scope: false,
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile')
+                     scope: 'openid profile',
+                     code_digest: anything)
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -256,7 +259,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      unauthorized_scope: false,
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile')
+                     scope: 'openid profile',
+                     code_digest: anything)
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -298,7 +302,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      unauthorized_scope: false,
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile')
+                     scope: 'openid profile',
+                     code_digest: anything)
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -376,7 +381,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  error_details: hash_including(:prompt),
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid')
+                 scope: 'openid',
+                 code_digest: nil)
           expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
 
           action
@@ -404,7 +410,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  error_details: hash_including(:client_id),
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid')
+                 scope: 'openid',
+                 code_digest: nil)
           expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
 
           action

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
                  scope: 'openid',
-                 code_digest: anything)
+                 code_digest: kind_of(String))
           expect(@analytics).to receive(:track_event).
             with(
               'SP redirect initiated',
@@ -118,7 +118,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
                      scope: 'openid profile',
-                     code_digest: anything)
+                     code_digest: kind_of(String))
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -218,7 +218,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
                      scope: 'openid profile',
-                     code_digest: anything)
+                     code_digest: kind_of(String))
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -260,7 +260,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
                      scope: 'openid profile',
-                     code_digest: anything)
+                     code_digest: kind_of(String))
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',
@@ -303,7 +303,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                      user_fully_authenticated: true,
                      acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
                      scope: 'openid profile',
-                     code_digest: anything)
+                     code_digest: kind_of(String))
               expect(@analytics).to receive(:track_event).
                 with(
                   'SP redirect initiated',

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe OpenidConnect::TokenController do
             client_id: client_id,
             user_id: user.uuid,
             errors: {},
+            code_digest: kind_of(String),
           })
         action
       end
@@ -83,6 +84,7 @@ RSpec.describe OpenidConnect::TokenController do
             client_id: client_id,
             user_id: user.uuid,
             errors: hash_including(:grant_type),
+            code_digest: kind_of(String),
             error_details: hash_including(:grant_type),
           })
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -464,8 +464,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
 
       it 'logs a hash of the code in the analytics params' do
-        identity = user.identities.where(service_provider: client_id).first
-
         code = UriService.params(form.success_redirect_uri)[:code]
 
         expect(form.submit.extra[:code_digest]).to eq(Digest::SHA256.hexdigest(code))

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           unauthorized_scope: true,
           acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
           scope: 'openid',
+          code_digest: nil,
         )
       end
     end
@@ -66,6 +67,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
             unauthorized_scope: true,
             acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
             scope: 'openid',
+            code_digest: nil,
           )
         end
       end
@@ -450,12 +452,23 @@ RSpec.describe OpenidConnectAuthorizeForm do
     let(:rails_session_id) { SecureRandom.hex }
 
     context 'when the identity has been linked' do
-      it 'returns a redirect URI with the code from the identity session_uuid' do
+      before do
         form.link_identity_to_service_provider(user, rails_session_id)
+      end
+
+      it 'returns a redirect URI with the code from the identity session_uuid' do
         identity = user.identities.where(service_provider: client_id).first
 
         expect(form.success_redirect_uri).
           to eq "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}"
+      end
+
+      it 'logs a hash of the code in the analytics params' do
+        identity = user.identities.where(service_provider: client_id).first
+
+        code = UriService.params(form.success_redirect_uri)[:code]
+
+        expect(form.submit.extra[:code_digest]).to eq(Digest::SHA256.hexdigest(code))
       end
     end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -387,6 +387,7 @@ RSpec.describe OpenidConnectTokenForm do
           errors: {},
           client_id: client_id,
           user_id: user.uuid,
+          code_digest: Digest::SHA256.hexdigest(code),
         )
       end
     end
@@ -403,6 +404,7 @@ RSpec.describe OpenidConnectTokenForm do
           error_details: hash_including(*form.errors.attribute_names),
           client_id: nil,
           user_id: nil,
+          code_digest: nil,
         )
       end
     end


### PR DESCRIPTION
**Why**: to assist with debugging requests from partners

changelog: Internal, Logging, Log hash of OpenID Connect "code" param