### PR TITLE
LG-7203: Use DB for service provider IPP feature enablement

### DIFF
--- a/app/services/idv/in_person_config.rb
+++ b/app/services/idv/in_person_config.rb
@@ -6,13 +6,7 @@ module Idv
       if issuer.nil?
         enabled_without_issuer?
       else
-        db_enabled = issuer_enabled_db?(issuer)
-
-        if db_enabled.nil?
-          enabled_issuers.include?(issuer)
-        else
-          db_enabled
-        end
+        ServiceProvider.find_by(issuer: issuer)&.in_person_proofing_enabled || false
       end
     end
 
@@ -22,14 +16,6 @@ module Idv
 
     def self.enabled?
       IdentityConfig.store.in_person_proofing_enabled
-    end
-
-    def self.enabled_issuers
-      IdentityConfig.store.in_person_proofing_enabled_issuers
-    end
-
-    def self.issuer_enabled_db?(issuer)
-      ServiceProvider.find_by(issuer: issuer)&.in_person_proofing_enabled
     end
   end
 end

--- a/app/services/idv/in_person_config.rb
+++ b/app/services/idv/in_person_config.rb
@@ -6,7 +6,13 @@ module Idv
       if issuer.nil?
         enabled_without_issuer?
       else
-        enabled_issuers.include?(issuer)
+        db_enabled = issuer_enabled_db?(issuer)
+
+        if db_enabled.nil?
+          enabled_issuers.include?(issuer)
+        else
+          db_enabled
+        end
       end
     end
 
@@ -20,6 +26,10 @@ module Idv
 
     def self.enabled_issuers
       IdentityConfig.store.in_person_proofing_enabled_issuers
+    end
+
+    def self.issuer_enabled_db?(issuer)
+      ServiceProvider.find_by(issuer: issuer)&.in_person_proofing_enabled
     end
   end
 end

--- a/app/services/idv/in_person_config.rb
+++ b/app/services/idv/in_person_config.rb
@@ -6,7 +6,10 @@ module Idv
       if issuer.nil?
         enabled_without_issuer?
       else
-        ServiceProvider.find_by(issuer: issuer)&.in_person_proofing_enabled || false
+        ServiceProvider.exists?(
+          issuer: issuer,
+          in_person_proofing_enabled: true,
+        )
       end
     end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -109,7 +109,6 @@ idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_sp_required: false
 in_person_proofing_enabled: false
-in_person_proofing_enabled_issuers: '[]'
 in_person_enrollment_validity_in_days: 30
 in_person_results_delay_in_hours: 1
 include_slo_in_saml_metadata: false

--- a/db/primary_migrate/20220909021833_add_in_person_proofing_enabled_to_service_provider.rb
+++ b/db/primary_migrate/20220909021833_add_in_person_proofing_enabled_to_service_provider.rb
@@ -1,5 +1,5 @@
 class AddInPersonProofingEnabledToServiceProvider < ActiveRecord::Migration[7.0]
   def change
-    add_column :service_providers, :in_person_proofing_enabled, :boolean, null: true
+    add_column :service_providers, :in_person_proofing_enabled, :boolean, default: false
   end
 end

--- a/db/primary_migrate/20220909021833_add_in_person_proofing_enabled_to_service_provider.rb
+++ b/db/primary_migrate/20220909021833_add_in_person_proofing_enabled_to_service_provider.rb
@@ -1,0 +1,5 @@
+class AddInPersonProofingEnabledToServiceProvider < ActiveRecord::Migration[7.0]
+  def change
+    add_column :service_providers, :in_person_proofing_enabled, :boolean, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_112214) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_09_021833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -555,6 +555,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_112214) do
     t.boolean "use_legacy_name_id_behavior", default: false
     t.boolean "irs_attempts_api_enabled"
     t.boolean "device_profiling_enabled", default: false
+    t.boolean "in_person_proofing_enabled"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -555,7 +555,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_021833) do
     t.boolean "use_legacy_name_id_behavior", default: false
     t.boolean "irs_attempts_api_enabled"
     t.boolean "device_profiling_enabled", default: false
-    t.boolean "in_person_proofing_enabled"
+    t.boolean "in_person_proofing_enabled", default: false
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -188,7 +188,6 @@ class IdentityConfig
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
     config.add(:in_person_proofing_enabled, type: :boolean)
-    config.add(:in_person_proofing_enabled_issuers, type: :json)
     config.add(:in_person_enrollment_validity_in_days, type: :integer)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:include_slo_in_saml_metadata, type: :boolean)

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -2,15 +2,12 @@ require 'rails_helper'
 
 describe Idv::InPersonController do
   let(:in_person_proofing_enabled) { false }
-  let(:in_person_proofing_enabled_issuers) { [] }
   let(:sp) { nil }
   let(:user) { nil }
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
       and_return(in_person_proofing_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
-      and_return(in_person_proofing_enabled_issuers)
     allow(controller).to receive(:current_sp).and_return(sp)
     stub_sign_in(user) if user
   end
@@ -64,7 +61,7 @@ describe Idv::InPersonController do
           end
 
           context 'with associated service provider' do
-            let(:sp) { build(:service_provider) }
+            let(:sp) { create(:service_provider, in_person_proofing_enabled: false) }
 
             it 'renders 404 not found' do
               get :index
@@ -73,7 +70,10 @@ describe Idv::InPersonController do
             end
 
             context 'with in person proofing enabled for service provider' do
-              let(:in_person_proofing_enabled_issuers) { [sp.issuer] }
+              before do
+                ServiceProvider.find_by(issuer: sp.issuer).
+                  update(in_person_proofing_enabled: true)
+              end
 
               it 'redirects to the first step' do
                 get :index

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe 'idv/shared/_document_capture.html.erb' do
   let(:flow_path) { 'standard' }
   let(:failure_to_proof_url) { return_to_sp_failure_to_proof_path }
   let(:in_person_proofing_enabled) { false }
-  let(:in_person_proofing_enabled_issuers) { [] }
+  let(:in_person_proofing_enabled_issuer) { nil }
   let(:front_image_upload_url) { nil }
   let(:back_image_upload_url) { nil }
   let(:selfie_image_upload_url) { nil }
@@ -26,10 +26,13 @@ describe 'idv/shared/_document_capture.html.erb' do
 
     allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
       and_return(async_uploads_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
-      and_return(in_person_proofing_enabled)
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled_issuers).
-      and_return(in_person_proofing_enabled_issuers)
+    allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?) do |issuer|
+      if issuer.nil?
+        in_person_proofing_enabled
+      else
+        issuer == in_person_proofing_enabled_issuer
+      end
+    end
 
     assign(:step_url, :idv_doc_auth_step_url)
   end
@@ -110,7 +113,7 @@ describe 'idv/shared/_document_capture.html.erb' do
         end
 
         context 'when in person proofing is enabled for issuer' do
-          let(:in_person_proofing_enabled_issuers) { [sp_issuer] }
+          let(:in_person_proofing_enabled_issuer) { sp_issuer }
 
           it 'initializes with in person url' do
             render_partial


### PR DESCRIPTION
This supplants the config key `in_person_proofing_enabled_issuers` with a new database field `in_person_proofing_enabled` on each `ServiceProvider` record. This field will be managed elsewhere.

## Testing

1. Run the migrations in this repo, then start the IDP
2. Setup and run [the Sinatra app](https://github.com/18f/identity-oidc-sinatra)
3. Open the Sinatra app - default local stack URL is http://127.0.0.1:9292
4. Select "IAL2" in the options under the sign-in button, then click "Sign in"
5. Proceed through to the doc auth step of IPP
6. Trigger a non-terminal failure of doc auth, e.g. image resolution error
7.  You should not initially see the option to verify at a post office
8. Run the Rails console in the IDP repo folder via a terminal:
    ```sh
    rails console
    ```
9. Run this Ruby code in the console:
    ```ruby
    ServiceProvider.find_by(issuer: "urn:gov:gsa:openidconnect:sp:sinatra").update(in_person_proofing_enabled: true)
    ```
10. Refresh the doc auth page
11. Trigger a non-terminal failure of doc auth again
12. You should see the option to verify at a post office displayed