### PR TITLE
update ready to verify presenter to use enrollment_established_at

### DIFF
--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -32,8 +32,8 @@ module Idv
       attr_reader :enrollment
 
       def due_date
-        enrollment.enrollment_established_at ? enrollment.enrollment_established_at + IdentityConfig.store.in_person_enrollment_validity_in_days.days :
-        enrollment.created_at + IdentityConfig.store.in_person_enrollment_validity_in_days.days
+        start_date = enrollment.enrollment_established_at.presence || enrollment.created_at
+        start_date + IdentityConfig.store.in_person_enrollment_validity_in_days.days
       end
 
       def localized_hours(hours)

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -32,6 +32,7 @@ module Idv
       attr_reader :enrollment
 
       def due_date
+        enrollment.enrollment_established_at ? enrollment.enrollment_established_at + IdentityConfig.store.in_person_enrollment_validity_in_days.days :
         enrollment.created_at + IdentityConfig.store.in_person_enrollment_validity_in_days.days
       end
 

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
   let(:enrollment_code) { '2048702198804358' }
   let(:current_address_matches_id) { true }
   let(:created_at) { described_class::USPS_SERVER_TIMEZONE.parse('2022-07-14T00:00:00Z') }
-  let(:enrollment_established_at) { described_class::USPS_SERVER_TIMEZONE.parse('2022-08-14T00:00:00Z') }
+  let(:enrollment_established_at) do
+    described_class::USPS_SERVER_TIMEZONE.parse('2022-08-14T00:00:00Z')
+  end
   let(:enrollment_selected_location_details) do
     JSON.parse(UspsInPersonProofing::Mock::Fixtures.enrollment_selected_location_details)
   end
@@ -17,7 +19,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       enrollment_code: enrollment_code,
       unique_id: InPersonEnrollment.generate_unique_id,
       created_at: created_at,
-      enrollment_established_at:  enrollment_established_at,
+      enrollment_established_at: enrollment_established_at,
       current_address_matches_id: current_address_matches_id,
       selected_location_details: enrollment_selected_location_details,
     )
@@ -38,7 +40,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
     context 'there is no enrollment_established_at' do
       let(:enrollment_established_at) { nil }
       it 'returns formatted due date when no enrollment_established_at' do
-        expect(formatted_due_date). to eq 'August 12, 2022'
+        expect(formatted_due_date).to eq 'August 12, 2022'
       end
     end
   end

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -16,22 +16,16 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       profile: profile,
       enrollment_code: enrollment_code,
       unique_id: InPersonEnrollment.generate_unique_id,
+      created_at: created_at,
       enrollment_established_at:  enrollment_established_at,
       current_address_matches_id: current_address_matches_id,
       selected_location_details: enrollment_selected_location_details,
     )
   end
-  let(:enrollment2) do
-    InPersonEnrollment.new(
-      created_at: created_at
-    )
-  end
   subject(:presenter) { described_class.new(enrollment: enrollment) }
-  subject(:presenter2) {described_class.new(enrollment: enrollment2)}
 
   describe '#formatted_due_date' do
     subject(:formatted_due_date) { presenter.formatted_due_date }
-    subject(:formatted_due_date_two) {presenter2.formatted_due_date}
 
     around do |example|
       Time.use_zone('UTC') { example.run }
@@ -41,8 +35,11 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       expect(formatted_due_date).to eq 'September 12, 2022'
     end
 
-    it 'returns formatted due date when no enrollment_established_at' do
-      expect(formatted_due_date_two). to eq 'August 12, 2022'
+    context 'there is no enrollment_established_at' do
+      let(:enrollment_established_at) { nil }
+      it 'returns formatted due date when no enrollment_established_at' do
+        expect(formatted_due_date). to eq 'August 12, 2022'
+      end
     end
   end
 

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
   let(:enrollment_code) { '2048702198804358' }
   let(:current_address_matches_id) { true }
   let(:created_at) { described_class::USPS_SERVER_TIMEZONE.parse('2022-07-14T00:00:00Z') }
+  let(:enrollment_established_at) { described_class::USPS_SERVER_TIMEZONE.parse('2022-08-14T00:00:00Z') }
   let(:enrollment_selected_location_details) do
     JSON.parse(UspsInPersonProofing::Mock::Fixtures.enrollment_selected_location_details)
   end
@@ -15,23 +16,33 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       profile: profile,
       enrollment_code: enrollment_code,
       unique_id: InPersonEnrollment.generate_unique_id,
-      created_at: created_at,
+      enrollment_established_at:  enrollment_established_at,
       current_address_matches_id: current_address_matches_id,
       selected_location_details: enrollment_selected_location_details,
     )
   end
-
+  let(:enrollment2) do
+    InPersonEnrollment.new(
+      created_at: created_at
+    )
+  end
   subject(:presenter) { described_class.new(enrollment: enrollment) }
+  subject(:presenter2) {described_class.new(enrollment: enrollment2)}
 
   describe '#formatted_due_date' do
     subject(:formatted_due_date) { presenter.formatted_due_date }
+    subject(:formatted_due_date_two) {presenter2.formatted_due_date}
 
     around do |example|
       Time.use_zone('UTC') { example.run }
     end
 
     it 'returns a formatted due date' do
-      expect(formatted_due_date).to eq 'August 12, 2022'
+      expect(formatted_due_date).to eq 'September 12, 2022'
+    end
+
+    it 'returns formatted due date when no enrollment_established_at' do
+      expect(formatted_due_date_two). to eq 'August 12, 2022'
     end
   end
 


### PR DESCRIPTION
[Ticket](https://cm-jira.usa.gov/browse/LG-7344)

What
This pr updates the ReadyToVerifyPresenter so that it uses the enrollment_established_at date to create the due date that is presented to the user. If there is no enrollment_established_at date attached to the enrollment then the created_at date is used instead. 

Why
This update will ensure that if a user chooses to receive confirmation in the mail the 30 day period they have to complete their in person verification will start AFTER inputting the code they get in the mail rather than starting when they began the process online. This will give such users the full 30 days. 

Here we can see that the enrollment_established_at property is the one used to format the date:
<img width="421" alt="Screen Shot 2022-09-13 at 11 30 18 AM" src="https://user-images.githubusercontent.com/20867088/189946584-47073bd1-e3f6-4f3c-aa67-ffb408e161e6.png">

<img width="1048" alt="Screen Shot 2022-09-13 at 11 30 49 AM" src="https://user-images.githubusercontent.com/20867088/189946587-adfed32c-6512-436e-a090-6773784deb9e.png">
