### PR TITLE
Qualify script rails executable properly with bin/

### DIFF
--- a/scripts/inherited_proofing/va/lexis_nexis/test_script.rb
+++ b/scripts/inherited_proofing/va/lexis_nexis/test_script.rb
@@ -8,14 +8,14 @@
 #    will default to a base uri of: IdentityConfig.store.inherited_proofing_va_base_url
 #    and a private key using: AppArtifacts.store.oidc_private_key
 #
-# $ rails r scripts/inherited_proofing/va/lexis_nexis/test_script.rb
+# $ bin/rails r scripts/inherited_proofing/va/lexis_nexis/test_script.rb
 #
 # 2) To override BASE_URI in the Idv::InheritedProofing::Va::Service class
 #    and/or use a private key file, and/or force an error return.
 #    Where -u|-t|-f forces proofing to fail
 #
 # NOTE: Private key files are forced to be located at "#{Rails.root}/tmp".
-# $ rails r scripts/inherited_proofing/va/lexis_nexis/test_script.rb https://staging-api.va.gov private.key -u|-t|-f
+# $ bin/rails r scripts/inherited_proofing/va/lexis_nexis/test_script.rb https://staging-api.va.gov private.key -u|-t|-f
 
 require_relative '../user_attributes/test_server'
 require_relative './phone_finder'

--- a/scripts/inherited_proofing/va/user_attributes/test_script.rb
+++ b/scripts/inherited_proofing/va/user_attributes/test_script.rb
@@ -6,14 +6,14 @@
 #    will default to a base uri of: IdentityConfig.store.inherited_proofing_va_base_url
 #    and a private key using: AppArtifacts.store.oidc_private_key
 #
-# $ rails r scripts/inherited_proofing/va/user_attributes/test_script.rb
+# $ bin/rails r scripts/inherited_proofing/va/user_attributes/test_script.rb
 #
 # 2) To override BASE_URI in the Idv::InheritedProofing::Va::Service class
 #    and/or use a private key file:
 #
 # rubocop:disable Layout/LineLength
 # NOTE: Private key files are forced to be located at "#{Rails.root}/tmp".
-# $ rails r scripts/inherited_proofing/va/user_attributes/test_script.rb https://staging-api.va.gov private.key
+# $ bin/rails r scripts/inherited_proofing/va/user_attributes/test_script.rb https://staging-api.va.gov private.key
 # rubocop:enable Layout/LineLength
 
 require_relative '../../../../app/services/idv/inherited_proofing/va/service'


### PR DESCRIPTION
Qualify script rails executable properly with bin/ which is necessary to run in environments other than local.