### PR TITLE
Update total-monthly-auths report to pull from the raw table

### DIFF
--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
@@ -2,14 +2,28 @@ module Db
   module MonthlySpAuthCount
     class TotalMonthlyAuthCounts
       def self.call
-        sql = <<~SQL
-          SELECT monthly_sp_auth_counts.issuer,monthly_sp_auth_counts.ial,year_month,
-                 SUM(auth_count) AS total, MAX(app_id) AS app_id
-          FROM monthly_sp_auth_counts, service_providers
-          WHERE monthly_sp_auth_counts.issuer = service_providers.issuer
-          GROUP BY monthly_sp_auth_counts.issuer, monthly_sp_auth_counts.ial, year_month
-          ORDER BY issuer, ial, year_month
+        sql = <<-SQL
+          SELECT
+              sp_return_logs.issuer
+            , sp_return_logs.ial
+            , to_char(sp_return_logs.requested_at, 'YYYYMM') AS year_month
+            , COUNT(sp_return_logs.id) AS total
+            , MAX(service_providers.app_id) AS app_id
+          FROM sp_return_logs
+          JOIN service_providers ON service_providers.issuer = sp_return_logs.issuer
+          WHERE
+                sp_return_logs.returned_at IS NOT NULL
+            AND sp_return_logs.billable = true
+          GROUP BY
+              sp_return_logs.issuer
+            , sp_return_logs.ial
+            , year_month
+          ORDER BY
+              sp_return_logs.issuer
+            , sp_return_logs.ial
+            , year_month
         SQL
+
         ActiveRecord::Base.connection.execute(sql)
       end
     end

--- a/spec/jobs/reports/total_monthly_auths_report_spec.rb
+++ b/spec/jobs/reports/total_monthly_auths_report_spec.rb
@@ -13,14 +13,23 @@ describe Reports::TotalMonthlyAuthsReport do
 
   it 'returns the total monthly auths' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    MonthlySpAuthCount.create(
-      issuer: 'foo', ial: 1, year_month: '201901', user_id: 2,
-      auth_count: 7
-    )
-    MonthlySpAuthCount.create(
-      issuer: 'foo', ial: 1, year_month: '201901', user_id: 3,
-      auth_count: 3
-    )
+    [
+      { user_id: 2, count: 7 },
+      { user_id: 3, count: 3 },
+    ].each do |config|
+      config[:count].times do
+        create(
+          :sp_return_log,
+          user_id: config[:user_id],
+          issuer: issuer,
+          ial: 1,
+          billable: true,
+          returned_at: Time.zone.now,
+          requested_at: Date.new(2019, 1, 15).to_date,
+        )
+      end
+    end
+
     result = [{ issuer: 'foo', ial: 1, year_month: '201901', total: 10, app_id: app_id }].to_json
 
     expect(subject.perform(Time.zone.today)).to eq(result)

--- a/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
+++ b/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
@@ -13,14 +13,28 @@ describe Db::MonthlySpAuthCount::TotalMonthlyAuthCounts do
 
   it 'returns the total auth counts' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer, app_id: app_id)
-    MonthlySpAuthCount.create(
-      issuer: issuer, ial: 1, year_month: year_month, user_id: 2,
-      auth_count: 7
-    )
-    MonthlySpAuthCount.create(
-      issuer: issuer, ial: 1, year_month: year_month, user_id: 3,
-      auth_count: 3
-    )
+    7.times do
+      create(
+        :sp_return_log,
+        issuer: issuer,
+        ial: 1,
+        user_id: 2,
+        requested_at: Date.new(2019, 1, 15),
+        returned_at: Date.new(2019, 1, 15),
+        billable: true,
+      )
+    end
+    3.times do
+      create(
+        :sp_return_log,
+        issuer: issuer,
+        ial: 1,
+        user_id: 3,
+        requested_at: Date.new(2019, 1, 15),
+        returned_at: Date.new(2019, 1, 15),
+        billable: true,
+      )
+    end
     result = { issuer: issuer, ial: 1, year_month: year_month, total: 10, app_id: app_id }.to_json
 
     expect(subject.call.ntuples).to eq(1)


### PR DESCRIPTION
**Why**: We've found some discrepancies with the aggregated monthly table so this helps us have more precise reports

(this is just the monthly auths report part of https://github.com/18F/identity-idp/pull/6935, so it doesn't need a new DB index)