### PR TITLE
LG-7411 Analytics event for TM Proofing Failure Page

### DIFF
--- a/app/controllers/idv/setup_errors_controller.rb
+++ b/app/controllers/idv/setup_errors_controller.rb
@@ -3,6 +3,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
 
     def show
+      analytics.idv_setup_errors_visited
     end
   end
 end

--- a/app/controllers/redirect/contact_controller.rb
+++ b/app/controllers/redirect/contact_controller.rb
@@ -1,7 +1,10 @@
 module Redirect
   class ContactController < RedirectController
     def show
-      redirect_to_and_log IdentityConfig.store.idv_contact_url
+      redirect_to_and_log(
+        IdentityConfig.store.idv_contact_url,
+        tracker_method: analytics.method(:contact_redirect),
+      )
     end
   end
 end

--- a/app/controllers/redirect/contact_controller.rb
+++ b/app/controllers/redirect/contact_controller.rb
@@ -1,0 +1,7 @@
+module Redirect
+  class ContactController < RedirectController
+    def show
+      redirect_to_and_log IdentityConfig.store.idv_contact_url
+    end
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2572,5 +2572,21 @@ module AnalyticsEvents
   def idv_setup_errors_visited
     track_event('IdV: Verify setup errors visited')
   end
+
+  # @param [String] redirect_url URL user was directed to
+  # @param [String, nil] step which step
+  # @param [String, nil] location which part of a step, if applicable
+  # @param ["idv", String, nil] flow which flow
+  # User was redirected to the login.gov contact page
+  def contact_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
+    track_event(
+      'Contact Page Redirect',
+      redirect_url: redirect_url,
+      step: step,
+      location: location,
+      flow: flow,
+      **extra,
+    )
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2567,5 +2567,10 @@ module AnalyticsEvents
   def cancel_account_reset_recovery
     track_event('Account Reset: Cancel Account Recovery Options')
   end
+
+  # Tracks when the user reaches the verify setup errors page after failing proofing
+  def idv_setup_errors_visited
+    track_event('IdV: Verify setup errors visited')
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/views/idv/setup_errors/show.html.erb
+++ b/app/views/idv/setup_errors/show.html.erb
@@ -12,6 +12,6 @@
       heading: t('idv.failure.setup.heading'),
     ) do %>
   <p>
-    <%= t('idv.failure.setup.fail_html', contact_form_link: link_to(t('idv.failure.setup.link_text'), IdentityConfig.store.idv_contact_url), support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
+    <%= t('idv.failure.setup.fail_html', contact_form_link: link_to(t('idv.failure.setup.link_text'), contact_redirect_url), support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
   </p>
 <% end %>

--- a/app/views/idv/setup_errors/show.html.erb
+++ b/app/views/idv/setup_errors/show.html.erb
@@ -12,6 +12,6 @@
       heading: t('idv.failure.setup.heading'),
     ) do %>
   <p>
-    <%= t('idv.failure.setup.fail_html', contact_form_link: link_to(t('idv.failure.setup.link_text'), contact_redirect_url), support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
+    <%= t('idv.failure.setup.fail_html', contact_form_link: link_to(t('idv.failure.setup.link_text'), contact_redirect_url(flow: :idv, step: :secure_account)), support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
   </p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,7 @@ Rails.application.routes.draw do
     get '/redirect/return_to_sp/cancel' => 'redirect/return_to_sp#cancel', as: :return_to_sp_cancel
     get '/redirect/return_to_sp/failure_to_proof' => 'redirect/return_to_sp#failure_to_proof', as: :return_to_sp_failure_to_proof
     get '/redirect/help_center' => 'redirect/help_center#show', as: :help_center_redirect
+    get '/redirect/contact/' => 'redirect/contact#show', as: :contact_redirect
 
     match '/sign_out' => 'sign_out#destroy', via: %i[get post delete]
 

--- a/spec/controllers/idv/setup_errors_controller_spec.rb
+++ b/spec/controllers/idv/setup_errors_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Idv::SetupErrorsController do
+  let(:user) { build_stubbed(:user, :signed_up) }
+
+  before do
+    stub_sign_in(user)
+  end
+
+  it 'renders the show template' do
+    stub_analytics
+
+    expect(@analytics).to receive(:track_event).with('IdV: Verify setup errors visited')
+
+    get :show
+
+    expect(response).to render_template :show
+  end
+end

--- a/spec/controllers/redirect/contact_controller_spec.rb
+++ b/spec/controllers/redirect/contact_controller_spec.rb
@@ -6,15 +6,18 @@ describe Redirect::ContactController do
   end
 
   describe '#show' do
+    let(:location_params) { { flow: 'flow', step: 'step', location: 'location', foo: 'bar' } }
     it 'redirects to contact page' do
       redirect_url = IdentityConfig.store.idv_contact_url
 
-      get :show
+      get :show, params: { **location_params }
 
       expect(response).to redirect_to redirect_url
       expect(@analytics).to have_logged_event(
-        'External Redirect',
+        'Contact Page Redirect',
         redirect_url: redirect_url,
+        flow: 'flow',
+        step: 'step',
       )
     end
   end

--- a/spec/controllers/redirect/contact_controller_spec.rb
+++ b/spec/controllers/redirect/contact_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Redirect::ContactController do
+  before do
+    stub_analytics
+  end
+
+  describe '#show' do
+    it 'redirects to contact page' do
+      redirect_url = IdentityConfig.store.idv_contact_url
+
+      get :show
+
+      expect(response).to redirect_to redirect_url
+      expect(@analytics).to have_logged_event(
+        'External Redirect',
+        redirect_url: redirect_url,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Why? Tracking analytics for ThreatMetrix failure proofing page. Also tracking whenever a user accesses the contact page.