### PR TITLE
LG-7110 added new event for idv_phone_send_link_rate_limitted

### DIFF
--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -34,6 +34,11 @@ module Idv
             except: :seconds,
           ),
         )
+
+        @flow.irs_attempts_api_tracker.idv_phone_send_link_rate_limited(
+          phone_number: formatted_destination_phone,
+        )
+
         failure(message)
       end
 

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -245,6 +245,15 @@ module IrsAttemptsApi
       )
     end
 
+    # Tracks when sending a link to a phone is rate limited during idv flow
+    # @param [String] phone_number
+    def idv_phone_send_link_rate_limited(phone_number:)
+      track_event(
+        :idv_phone_send_link_rate_limited,
+        phone_number: phone_number,
+      )
+    end
+
     # Tracks when the user submits their idv phone number
     # @param [String] phone_number
     # param [Boolean] success

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -16,6 +16,7 @@ feature 'doc auth send link step' do
   end
   let(:document_capture_session) { DocumentCaptureSession.create! }
   let(:fake_analytics) { FakeAnalytics.new }
+  let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
   it 'is on the correct page' do
     expect(page).to have_current_path(idv_doc_auth_send_link_step)
@@ -105,12 +106,21 @@ feature 'doc auth send link step' do
 
   it 'throttles sending the link' do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    allow_any_instance_of(ApplicationController).to receive(
+      :irs_attempts_api_tracker,
+    ).and_return(fake_attempts_tracker)
+
     user = user_with_2fa
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_send_link_step
     timeout = distance_of_time_in_words(
       Throttle.attempt_window_in_minutes(:idv_send_link).minutes,
     )
+
+    expect(fake_attempts_tracker).to receive(
+      :idv_phone_send_link_rate_limited,
+    ).with({ phone_number: '+1 415-555-0199' })
+
     freeze_time do
       idv_send_link_max_attempts.times do
         expect(page).to_not have_content(


### PR DESCRIPTION
# Summary

1. Added a new event that is tracked whenever the user is locked out by exceeding the rate limit for submitting their phone number repeatedly for instruction links during idv workflow. 
2. The event was renamed from `idv_phone_submitted_rate_limited` to `idv_phone_send_link_rate_limited` as `idv_phone_submitted_rate_limited` is covered already by `idv_phone_otp_submitted_rate_limited`, everywhere else. 

changelog: Internal, Attempts API, Track additional events