### PR TITLE
LG-7155: Add delay between polling requests to USPS

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -69,7 +69,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   DEFAULT_EMAIL_DELAY_IN_HOURS = 1
 
   def check_enrollments(enrollments)
-    request_delay_ms = IdentityConfig.store.
+    request_delay_seconds = IdentityConfig.store.
       get_usps_proofing_results_job_request_delay_milliseconds / MILLISECONDS_PER_SECOND
     proofer = UspsInPersonProofing::Proofer.new
 
@@ -99,7 +99,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       enrollment.update(status_check_attempted_at: status_check_attempted_at)
 
       # Sleep for a while before we attempt to make another call to USPS
-      sleep request_delay_ms if idx < enrollments.length - 1
+      sleep request_delay_seconds if idx < enrollments.length - 1
     end
   end
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -1,4 +1,5 @@
 class GetUspsProofingResultsJob < ApplicationJob
+  MILLISECONDS_IN_SECONDS = 1000.0 # Specify float value to use floating point math
   IPP_STATUS_PASSED = 'In-person passed'
   IPP_STATUS_FAILED = 'In-person failed'
   IPP_INCOMPLETE_ERROR_MESSAGE = 'Customer has not been to a post office to complete IPP'
@@ -68,7 +69,8 @@ class GetUspsProofingResultsJob < ApplicationJob
   DEFAULT_EMAIL_DELAY_IN_HOURS = 1
 
   def check_enrollments(enrollments)
-    request_delay_ms = IdentityConfig.store.get_usps_proofing_results_job_request_delay_milliseconds
+    request_delay_ms = IdentityConfig.store.
+      get_usps_proofing_results_job_request_delay_milliseconds / MILLISECONDS_IN_SECONDS
     proofer = UspsInPersonProofing::Proofer.new
 
     enrollments.each_with_index do |enrollment, idx|

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -68,6 +68,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   DEFAULT_EMAIL_DELAY_IN_HOURS = 1
 
   def check_enrollments(enrollments)
+    request_delay_ms = IdentityConfig.store.get_usps_proofing_results_job_request_delay_milliseconds
     proofer = UspsInPersonProofing::Proofer.new
 
     enrollments.each_with_index do |enrollment, idx|
@@ -96,8 +97,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       enrollment.update(status_check_attempted_at: status_check_attempted_at)
 
       # Sleep for a while before we attempt to make another call to USPS
-      request_delay = IdentityConfig.store.get_usps_proofing_results_job_request_delay_seconds
-      sleep request_delay if idx < enrollments.length - 1
+      sleep request_delay_ms if idx < enrollments.length - 1
     end
   end
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -69,7 +69,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   DEFAULT_EMAIL_DELAY_IN_HOURS = 1
 
   def check_enrollments(enrollments)
-    request_delay_seconds = IdentityConfig.store.
+    request_delay_in_seconds = IdentityConfig.store.
       get_usps_proofing_results_job_request_delay_milliseconds / MILLISECONDS_PER_SECOND
     proofer = UspsInPersonProofing::Proofer.new
 
@@ -99,7 +99,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       enrollment.update(status_check_attempted_at: status_check_attempted_at)
 
       # Sleep for a while before we attempt to make another call to USPS
-      sleep request_delay_seconds if idx < enrollments.length - 1
+      sleep request_delay_in_seconds if idx < enrollments.length - 1
     end
   end
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -1,5 +1,5 @@
 class GetUspsProofingResultsJob < ApplicationJob
-  MILLISECONDS_IN_SECONDS = 1000.0 # Specify float value to use floating point math
+  MILLISECONDS_PER_SECOND = 1000.0 # Specify float value to use floating point math
   IPP_STATUS_PASSED = 'In-person passed'
   IPP_STATUS_FAILED = 'In-person failed'
   IPP_INCOMPLETE_ERROR_MESSAGE = 'Customer has not been to a post office to complete IPP'
@@ -70,7 +70,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   def check_enrollments(enrollments)
     request_delay_ms = IdentityConfig.store.
-      get_usps_proofing_results_job_request_delay_milliseconds / MILLISECONDS_IN_SECONDS
+      get_usps_proofing_results_job_request_delay_milliseconds / MILLISECONDS_PER_SECOND
     proofer = UspsInPersonProofing::Proofer.new
 
     enrollments.each_with_index do |enrollment, idx|

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -70,7 +70,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   def check_enrollments(enrollments)
     proofer = UspsInPersonProofing::Proofer.new
 
-    enrollments.each do |enrollment|
+    enrollments.each_with_index do |enrollment, idx|
       # Add a unique ID for enrollments that don't have one
       enrollment.update(unique_id: enrollment.usps_unique_id) if enrollment.unique_id.blank?
 
@@ -94,6 +94,10 @@ class GetUspsProofingResultsJob < ApplicationJob
 
       # Record the attempt to update the enrollment
       enrollment.update(status_check_attempted_at: status_check_attempted_at)
+
+      # Sleep for a while before we attempt to make another call to USPS
+      request_delay = IdentityConfig.store.get_usps_proofing_results_job_request_delay_seconds
+      sleep request_delay if idx < enrollments.length - 1
     end
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -289,6 +289,7 @@ usps_ipp_username: ''
 usps_mock_fallback: true
 get_usps_proofing_results_job_cron: '0/10 * * * *'
 get_usps_proofing_results_job_reprocess_delay_minutes: 5
+get_usps_proofing_results_job_request_delay_seconds: 1
 gpo_allowed_for_strict_ial2: true
 voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -289,7 +289,7 @@ usps_ipp_username: ''
 usps_mock_fallback: true
 get_usps_proofing_results_job_cron: '0/10 * * * *'
 get_usps_proofing_results_job_reprocess_delay_minutes: 5
-get_usps_proofing_results_job_request_delay_seconds: 1
+get_usps_proofing_results_job_request_delay_milliseconds: 1000
 gpo_allowed_for_strict_ial2: true
 voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -376,7 +376,7 @@ class IdentityConfig
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:get_usps_proofing_results_job_cron, type: :string)
     config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)
-    config.add(:get_usps_proofing_results_job_request_delay_seconds, type: :integer)
+    config.add(:get_usps_proofing_results_job_request_delay_milliseconds, type: :integer)
     config.add(:gpo_allowed_for_strict_ial2, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)
     config.add(:usps_upload_sftp_host, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -376,6 +376,7 @@ class IdentityConfig
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:get_usps_proofing_results_job_cron, type: :string)
     config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)
+    config.add(:get_usps_proofing_results_job_request_delay_seconds, type: :integer)
     config.add(:gpo_allowed_for_strict_ial2, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)
     config.add(:usps_upload_sftp_host, type: :string)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe GetUspsProofingResultsJob do
   include UspsIppHelper
 
   let(:reprocess_delay_minutes) { 2.0 }
-  let(:request_delay_seconds) { 0 }
+  let(:request_delay_ms) { 0 }
   let(:job) { GetUspsProofingResultsJob.new }
   let(:job_analytics) { FakeAnalytics.new }
 
@@ -88,8 +88,9 @@ RSpec.describe GetUspsProofingResultsJob do
     allow(job).to receive(:analytics).and_return(job_analytics)
     allow(IdentityConfig.store).to receive(:get_usps_proofing_results_job_reprocess_delay_minutes).
       and_return(reprocess_delay_minutes)
-    allow(IdentityConfig.store).to receive(:get_usps_proofing_results_job_request_delay_seconds).
-      and_return(request_delay_seconds)
+    allow(IdentityConfig.store).
+      to receive(:get_usps_proofing_results_job_request_delay_milliseconds).
+      and_return(request_delay_ms)
     stub_request_token
   end
 
@@ -213,7 +214,7 @@ RSpec.describe GetUspsProofingResultsJob do
           and_return(pending_enrollments)
         stub_request_passed_proofing_results
         expect(job).to receive(:sleep).exactly(pending_enrollments.length - 1).times.
-          with(request_delay_seconds)
+          with(request_delay_ms)
 
         job.perform(Time.zone.now)
       end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -209,14 +209,18 @@ RSpec.describe GetUspsProofingResultsJob do
         ).to be >= 0.0
       end
 
-      it 'adds a delay between requests to USPS' do
-        allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-          and_return(pending_enrollments)
-        stub_request_passed_proofing_results
-        expect(job).to receive(:sleep).exactly(pending_enrollments.length - 1).times.
-          with(request_delay_ms)
+      context 'with a request delay in ms' do
+        let(:request_delay_ms) { 750 }
 
-        job.perform(Time.zone.now)
+        it 'adds a delay between requests to USPS' do
+          allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+            and_return(pending_enrollments)
+          stub_request_passed_proofing_results
+          expect(job).to receive(:sleep).exactly(pending_enrollments.length - 1).times.
+            with(0.75)
+
+          job.perform(Time.zone.now)
+        end
       end
 
       context 'when an enrollment does not have a unique ID' do

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe GetUspsProofingResultsJob do
   include UspsIppHelper
 
   let(:reprocess_delay_minutes) { 2.0 }
+  let(:request_delay_seconds) { 0 }
   let(:job) { GetUspsProofingResultsJob.new }
   let(:job_analytics) { FakeAnalytics.new }
 
@@ -87,6 +88,8 @@ RSpec.describe GetUspsProofingResultsJob do
     allow(job).to receive(:analytics).and_return(job_analytics)
     allow(IdentityConfig.store).to receive(:get_usps_proofing_results_job_reprocess_delay_minutes).
       and_return(reprocess_delay_minutes)
+    allow(IdentityConfig.store).to receive(:get_usps_proofing_results_job_request_delay_seconds).
+      and_return(request_delay_seconds)
     stub_request_token
   end
 
@@ -203,6 +206,16 @@ RSpec.describe GetUspsProofingResultsJob do
           job_analytics.events['GetUspsProofingResultsJob: Job completed'].
             first[:duration_seconds],
         ).to be >= 0.0
+      end
+
+      it 'adds a delay between requests to USPS' do
+        allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+          and_return(pending_enrollments)
+        stub_request_passed_proofing_results
+        expect(job).to receive(:sleep).exactly(pending_enrollments.length - 1).times.
+          with(request_delay_seconds)
+
+        job.perform(Time.zone.now)
       end
 
       context 'when an enrollment does not have a unique ID' do


### PR DESCRIPTION
Adds a configurable delay, in milliseconds, between requests to the USPS API when we are polling for enrollment status updates. The default value is 1 second