### PR TITLE
LG-6497: Set min date for State ID page to January 1, 1900

### DIFF
--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -47,7 +47,7 @@
         month: parsed_dob&.month,
         year: parsed_dob&.year,
         required: true,
-        min: Time.zone.today - 200.years,
+        min: '1900-01-01',
         max: Time.zone.today,
         hint: t('in_person_proofing.form.state_id.dob_hint'),
         label: t('in_person_proofing.form.state_id.dob'),

--- a/config/locales/time/en.yml
+++ b/config/locales/time/en.yml
@@ -10,7 +10,7 @@ en:
       - Saturday
       - Sunday
     formats:
-      long: '%B %d, %Y'
+      long: '%B %-d, %Y'
     month_names:
       - null
       - January


### PR DESCRIPTION
- Set min date for State ID page to January 1, 1900
- Remove leading zero from day (English translation)
  - Displays **January 1, 1900**