### PR TITLE
LG-6925: Move client_id field for USPS API from hardcoded value to config

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -170,7 +170,7 @@ module UspsInPersonProofing
         password: IdentityConfig.store.usps_ipp_password,
         grant_type: 'implicit',
         response_type: 'token',
-        client_id: '424ada78-62ae-4c53-8e3a-0b737708a9db',
+        client_id: IdentityConfig.store.usps_ipp_client_id,
         scope: 'ivs.ippaas.apis',
       }
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -282,6 +282,7 @@ use_dashboard_service_providers: false
 use_kms: false
 usps_confirmation_max_days: 10
 usps_ipp_password: ''
+usps_ipp_client_id: ''
 usps_ipp_root_url: ''
 usps_ipp_request_timeout: 10
 usps_ipp_sponsor_id: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -369,6 +369,7 @@ class IdentityConfig
     config.add(:usps_mock_fallback, type: :boolean)
     config.add(:usps_confirmation_max_days, type: :integer)
     config.add(:usps_ipp_password, type: :string)
+    config.add(:usps_ipp_client_id, type: :string)
     config.add(:usps_ipp_root_url, type: :string)
     config.add(:usps_ipp_sponsor_id, type: :string)
     config.add(:usps_ipp_username, type: :string)


### PR DESCRIPTION
This pull request sources the `client_id` value from the config instead of hardcoding it. See [LG-6925](https://cm-jira.usa.gov/browse/LG-6925) for more details.

I plan to have the config deployed with the `client_id` to each environment before or during the deployment of this code (and will coordinate w/ others before merging to make sure that happens).