### PR TITLE
Remove Faraday request logging

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -136,9 +136,6 @@ module UspsInPersonProofing
         # Note: The order of this matters for parsing the error response body.
         conn.response :raise_error
 
-        # Log request method and URL, excluding headers and body
-        conn.response :logger, nil, { headers: false, bodies: false }
-
         # Convert body to JSON
         conn.request :json
 


### PR DESCRIPTION
**Why**: It's noisy in development, and STDOUT is ignored in prod

(see [Slack thread for context](https://gsa-tts.slack.com/archives/CUG1ETRKR/p1663257242357579))