### PR TITLE
Remove unused method render_404_if_disabled

### DIFF
--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -23,10 +23,6 @@ module Idv
 
     private
 
-    def render_404_if_disabled
-      render_not_found unless InPersonConfig.enabled_for_issuer?(current_sp&.issuer)
-    end
-
     def redirect_unless_enrollment
       redirect_to idv_url unless current_user.establishing_in_person_enrollment
     end


### PR DESCRIPTION
**Why**: Because it's unused. This behavior is enforced via the `check_or_render_not_found` defined at the top of the controller:

https://github.com/18F/identity-idp/blob/71f3bd29473eed75af02fcf59920099f3871dcc5/app/controllers/idv/in_person_controller.rb#L5