### PR TITLE
LG-7362: Add copy for digital forms of IPP proof of address

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -91,15 +91,15 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
 
         <IconListItem
           icon="check_circle"
-          title={t('in_person_proofing.body.prepare.bring_proof_header')}
+          title={t('in_person_proofing.process.proof_of_address.heading')}
         >
-          <p>{t('in_person_proofing.body.prepare.bring_proof_info_acceptable')}</p>
+          <p>{t('in_person_proofing.process.proof_of_address.info')}</p>
           <ul>
-            <li>{t('in_person_proofing.body.prepare.bring_proof_info_lease')}</li>
-            <li>{t('in_person_proofing.body.prepare.bring_proof_info_registration')}</li>
-            <li>{t('in_person_proofing.body.prepare.bring_proof_info_card')}</li>
-            <li>{t('in_person_proofing.body.prepare.bring_proof_info_policy')}</li>
+            {t(['in_person_proofing.process.proof_of_address.acceptable_proof']).map((proof) => (
+              <li key={proof}>{proof}</li>
+            ))}
           </ul>
+          <p>{t('in_person_proofing.process.proof_of_address.physical_or_digital_copy')}</p>
         </IconListItem>
       </IconList>
       {flowPath === 'hybrid' && <FormStepsButton.Continue />}

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -55,6 +55,7 @@
             <li><%= proof %></li>
           <% end %>
         </ul>
+        <p><%= t('in_person_proofing.process.proof_of_address.physical_or_digital_copy') %></p>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -57,6 +57,7 @@
               <li><%= proof %></li>
             <% end %>
           </ul>
+          <p><%= t('in_person_proofing.process.proof_of_address.physical_or_digital_copy') %></p>
         </td>
       </tr>
     <% end %>

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -42,14 +42,6 @@ en:
         bring_id_info_id_card: 'State Non-Driver’s Identification Card'
         bring_id_info_no_other_forms: We do not currently accept any other forms of
           Identification, such as passports and military IDs
-        bring_proof_header: Proof of your current address
-        bring_proof_info_acceptable: 'You need a proof of address if your current
-          address is different than the address on your ID. Acceptable forms of
-          proof of address are:'
-        bring_proof_info_card: Vehicle Registration Card
-        bring_proof_info_lease: Lease, Mortgage, or Deed of Trust
-        bring_proof_info_policy: Home or Vehicle Insurance Policy
-        bring_proof_info_registration: Voter Registration
         bring_title: 'When you go to the Post Office, please bring:'
         privacy_disclaimer: '%{app_name} is a secure, government website. We and the
           U.S. Postal Service use your data to verify your identity.'
@@ -115,6 +107,9 @@ en:
         heading: Proof of your current address
         info: 'You need a proof of address if your current address is different than the
           address on your ID. Acceptable forms of proof of address are:'
+        physical_or_digital_copy: You can bring a physical copy or show a digital copy
+          of the document. You cannot show a photo or screenshot of the
+          document.
       state_id:
         acceptable_documents:
           - State Driver’s License

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -45,14 +45,6 @@ es:
         bring_id_info_id_card: 'Tarjeta de identificación estatal para no conductores'
         bring_id_info_no_other_forms: Actualmente no aceptamos otras formas de
           identificación, como pasaportes y cartillas militares.
-        bring_proof_header: Prueba de su dirección actual
-        bring_proof_info_acceptable: 'Necesita un justificante de domicilio si su
-          dirección actual es diferente a la que figura en su cédula de
-          identidad. Los comprobantes de domicilio aceptables son:'
-        bring_proof_info_card: Tarjeta de registro del vehículo
-        bring_proof_info_lease: Arrendamiento, hipoteca o escritura de fideicomiso
-        bring_proof_info_policy: Póliza de seguro del hogar o del vehículo
-        bring_proof_info_registration: Registro de votantes
         bring_title: 'Cuando vaya a la oficina de correos, lleve:'
         privacy_disclaimer: '%{app_name} es un sitio web seguro del gobierno. Nosotros y
           el Servicio Postal de los Estados Unidos utilizamos sus datos para
@@ -122,6 +114,9 @@ es:
         info: 'Necesita un justificante de domicilio si su dirección actual es diferente
           a la que figura en su cédula de identidad. Los comprobantes de
           domicilio aceptables son:'
+        physical_or_digital_copy: Puede traer una copia física o mostrar una copia
+          digital del documento. No puede mostrar una foto o una captura de
+          pantalla del documento.
       state_id:
         acceptable_documents:
           - Licencia de conducir estatal

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -47,15 +47,6 @@ fr:
         bring_id_info_no_other_forms: Nous n’acceptons actuellement aucune autre forme
           d’identification, comme les passeports et les documents d’identité
           militaires.
-        bring_proof_header: Preuve de votre adresse actuelle
-        bring_proof_info_acceptable: 'Vous avez besoin d’un justificatif de domicile si
-          votre adresse actuelle est différente de l’adresse figurant sur votre
-          document d’identité. Les justificatifs d’adresse acceptés sont les
-          suivants:'
-        bring_proof_info_card: Carte d’immatriculation du véhicule
-        bring_proof_info_lease: Bail, hypothèque ou acte de fiducie
-        bring_proof_info_policy: Police d’assurance habitation ou véhicule
-        bring_proof_info_registration: Inscription sur les listes électorales
         bring_title: 'Lorsque vous allez au bureau de poste, veuillez apporter:'
         privacy_disclaimer: '%{app_name} est un site gouvernemental sécurisé. Nous et le
           service postal américain utilisons vos données pour vérifier votre
@@ -126,6 +117,9 @@ fr:
         info: 'Vous avez besoin d’un justificatif de domicile si votre adresse actuelle
           est différente de l’adresse figurant sur votre document d’identité.
           Les justificatifs d’adresse acceptés sont les suivants:'
+        physical_or_digital_copy: Vous pouvez apporter une copie physique ou montrer une
+          copie numérique du document. Vous ne pouvez pas montrer une photo ou
+          une capture d’écran du document.
       state_id:
         acceptable_documents:
           - Permis de conduire d’État

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -181,7 +181,7 @@ class UserMailerPreview < ActionMailer::Preview
         enrollment_code: '2048702198804358',
         created_at: Time.zone.now - 2.hours,
         status_updated_at: Time.zone.now - 1.hour,
-        current_address_matches_id: true,
+        current_address_matches_id: params['current_address_matches_id'] == 'true',
         selected_location_details: {
           'name' => 'BALTIMORE',
           'street_address' => '900 E FAYETTE ST RM 118',


### PR DESCRIPTION
**Why**: As I user I want to know if it's ok for me to bring a physical copy or digital of my secondary ID if my current address is not the same as the one printed on my physical address.

**Screenshots:**

Screen|Before|After
---|---|---
Prepare|![lg-7362-prepare-before](https://user-images.githubusercontent.com/1779930/190671240-56e336f9-2769-4eae-9122-2110ce61f423.png)|![lg-7362-prepare-after](https://user-images.githubusercontent.com/1779930/190671237-bf3293a1-7ae8-4d8e-a07e-21797e19b187.png)
Barcode|![lg-7362-barcode-before](https://user-images.githubusercontent.com/1779930/190671224-a1a5c75f-b641-486f-95fd-f916c67217f0.png)|![lg-7362-barcode-after](https://user-images.githubusercontent.com/1779930/190671218-ac878fb5-f725-42c1-bd71-e73e0c2f320b.png)
Email|![lg-7362-email-before](https://user-images.githubusercontent.com/1779930/190671236-d7811a94-edcc-4216-b1c1-e157d3bb901e.png)|![lg-7362-email-after](https://user-images.githubusercontent.com/1779930/190671227-b0d8d602-ae9a-48f8-a80f-7bfffd7be1de.png)