### PR TITLE
Improve display of Process List in email notifications

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -152,6 +152,7 @@ h4 {
   font-size: units(2);
   font-weight: 700;
   text-align: center;
+  line-height: 1;
   padding-top: units(0.5);
   margin-right: units(1.5);
 }


### PR DESCRIPTION
**Why**: So that the Process List as displayed in email messages is consistent with the design system reference implementation.

It's assumed this is a side-effect of the revisions in #6736, where an increase in default email line-height of 1.3 to 1.5 caused an offset of the appearance of the text of the list item number. Explicitly assigning the line-height ensures correct math.

**Screenshots:**

Before|After
---|---
![process-list-before](https://user-images.githubusercontent.com/1779930/190672252-a741017c-8fcc-4200-8d92-4c101c325924.png)|![process-list-after](https://user-images.githubusercontent.com/1779930/190672248-704e471c-e9c3-4c57-9db6-cf9140506ff3.png)

