### PR TITLE
Limit selection of sign in events to 2 when fetching second_last_signed_in_at

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -113,7 +113,7 @@ class UserDecorator
 
   def second_last_signed_in_at
     user.events.where(event_type: 'sign_in_after_2fa').
-      order(created_at: :desc).pluck(:created_at).second
+      order(created_at: :desc).limit(2).pluck(:created_at).second
   end
 
   def connected_apps

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -338,4 +338,15 @@ describe UserDecorator do
       expect(user_decorator.connected_apps).to eq([app])
     end
   end
+
+  describe '#second_last_signed_in_at' do
+    it 'returns second most recent full authentication event' do
+      user = create(:user)
+      _event1 = create(:event, user: user, event_type: 'sign_in_after_2fa')
+      event2 = create(:event, user: user, event_type: 'sign_in_after_2fa')
+      _event3 = create(:event, user: user, event_type: 'sign_in_after_2fa')
+
+      expect(user.decorate.second_last_signed_in_at).to eq(event2.reload.created_at)
+    end
+  end
 end


### PR DESCRIPTION
Currently selects all and only takes the second.  This is a small change to only select up to 2