### PR TITLE
Fix a typo in the step indicator constants for inherited proofing

### DIFF
--- a/app/services/idv/steps/inherited_proofing/phone_step.rb
+++ b/app/services/idv/steps/inherited_proofing/phone_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     module InheritedProofing
       class PhoneStep < InheritedProofingBaseStep
-        STEP_INDICATOR_STEP = :verify_info
+        STEP_INDICATOR_STEP = :verify_phone
         def call
         end
       end

--- a/app/services/idv/steps/inherited_proofing/verify_info_step.rb
+++ b/app/services/idv/steps/inherited_proofing/verify_info_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     module InheritedProofing
       class VerifyInfoStep < InheritedProofingBaseStep
-        STEP_INDICATOR_STEP = :verify_phone
+        STEP_INDICATOR_STEP = :verify_info
         def call
         end
       end


### PR DESCRIPTION
This is a quick fix I noticed looking at this code earlier