### PR TITLE
LG-7123: Always use Pii::Attribute when creating enrollment

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -64,7 +64,7 @@ module Idv
       elsif in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           current_user,
-          applicant,
+          pii,
         )
       end
     end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -130,7 +130,7 @@ describe Idv::Session do
         it 'creates a USPS enrollment' do
           expect(UspsInPersonProofing::EnrollmentHelper).
             to receive(:schedule_in_person_enrollment).
-            with(user, subject.applicant.transform_keys(&:to_s))
+            with(user, Pii::Attributes.new_from_hash(subject.applicant))
 
           subject.create_profile_from_applicant_with_password(user.password)
 


### PR DESCRIPTION
**Why:**
- We were sometimes passing Pii::Attribute structs and other times
passing hashes to this function. While it wasn't causing a technical problem now
it is confusing

- The other two places where we use EnrollmentHelper#schedule_in_person_enrollment
we are already passing a Pii::Attributes struct (FSM v1 flow password confirmation page and
the GPO address verification + in-person proofing flow)

changelog: Upcoming Features, In-person proofing, Normalize arguments
for creating an enrollment