### PR TITLE
Scope the NativeCameraABTest to the Idv module

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -245,7 +245,7 @@ module Idv
     def native_camera_ab_test_data
       return {} unless IdentityConfig.store.idv_native_camera_a_b_testing_enabled
 
-      ab_test = NativeCameraABTest.new
+      ab_test = Idv::NativeCameraABTest.new
       discriminator = document_capture_session.uuid
       {
         native_camera_ab_test_bucket: ab_test.bucket(discriminator),

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -100,7 +100,7 @@ class DocumentProofingJob < ApplicationJob
   def native_camera_ab_test_data(document_capture_session)
     return {} unless IdentityConfig.store.idv_native_camera_a_b_testing_enabled
 
-    ab_test = NativeCameraABTest.new
+    ab_test = Idv::NativeCameraABTest.new
     discriminator = document_capture_session.uuid
     {
       native_camera_ab_test_bucket: ab_test.bucket(discriminator),

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -31,7 +31,7 @@ module Idv
       private
 
       def native_camera_ab_testing_variables
-        ab_test = NativeCameraABTest.new
+        ab_test = Idv::NativeCameraABTest.new
         discriminator = flow_session[:document_capture_session_uuid]
         skip_sdk = ab_test.bucket(discriminator) == :native_camera_only
 


### PR DESCRIPTION
PR #6915 added in A/B testing on skipping the Acuant SDK. It appears in testing against `dev` that the class was not properly scoped to the module.

[skip changelog]