### PR TITLE
Add ESLint enforcement of awaited userEvent interaction

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,10 @@
       {
         "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
         "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
+      },
+      {
+        "selector": "ExpressionStatement[expression.callee.object.name='userEvent']",
+        "message": "Await the promised result of a userEvent interaction"
       }
     ]
   },

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -18,19 +18,8 @@ describe('PasswordResetButton', () => {
   });
 
   it('triggers password reset API call and redirects', async () => {
-    let resolve: (value?: any) => void;
-    let reject: (error: Error) => void;
+    const onComplete = sandbox.stub() as FlowContextValue['onComplete'];
 
-    function onComplete({ completionURL }) {
-      let error;
-
-      try {
-        expect(completionURL).to.equal(REDIRECT_URL);
-        resolve();
-      } catch (assertionError) {
-        reject(error);
-      }
-    }
     const { getByRole } = render(
       <FlowContext.Provider value={{ onComplete } as FlowContextValue}>
         <PasswordResetButton />
@@ -39,11 +28,8 @@ describe('PasswordResetButton', () => {
 
     const button = getByRole('button');
     await Promise.all([
-      new Promise((_resolve, _reject) => {
-        resolve = _resolve;
-        reject = _reject;
-      }),
       userEvent.click(button),
+      expect(onComplete).to.eventually.be.calledWith({ completionURL: REDIRECT_URL }),
     ]);
   });
 });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -17,17 +17,19 @@ describe('PasswordResetButton', () => {
       .resolves({ redirect_url: REDIRECT_URL });
   });
 
-  it('triggers password reset API call and redirects', async (done) => {
+  it('triggers password reset API call and redirects', async () => {
+    let resolve: (value?: any) => void;
+    let reject: (error: Error) => void;
+
     function onComplete({ completionURL }) {
       let error;
 
       try {
         expect(completionURL).to.equal(REDIRECT_URL);
+        resolve();
       } catch (assertionError) {
-        error = assertionError;
+        reject(error);
       }
-
-      done(error);
     }
     const { getByRole } = render(
       <FlowContext.Provider value={{ onComplete } as FlowContextValue}>
@@ -36,6 +38,12 @@ describe('PasswordResetButton', () => {
     );
 
     const button = getByRole('button');
-    await userEvent.click(button);
+    await Promise.all([
+      new Promise((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
+      }),
+      userEvent.click(button),
+    ]);
   });
 });

--- a/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
+++ b/app/javascript/packages/verify-flow/steps/password-confirm/password-reset-button.spec.tsx
@@ -17,7 +17,7 @@ describe('PasswordResetButton', () => {
       .resolves({ redirect_url: REDIRECT_URL });
   });
 
-  it('triggers password reset API call and redirects', (done) => {
+  it('triggers password reset API call and redirects', async (done) => {
     function onComplete({ completionURL }) {
       let error;
 
@@ -36,6 +36,6 @@ describe('PasswordResetButton', () => {
     );
 
     const button = getByRole('button');
-    userEvent.click(button);
+    await userEvent.click(button);
   });
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@testing-library/react-hooks": "^3.7.0",
     "@testing-library/user-event": "^14.1.1",
     "@types/chai": "^4.3.0",
+    "@types/chai-as-promised": "^7.1.5",
     "@types/cleave.js": "^1.4.6",
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^9.1.0",

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -158,6 +158,7 @@ describe('document-capture/components/document-capture', () => {
 
     await new Promise((resolve) => {
       onSubmit.callsFake(resolve);
+      // eslint-disable-next-line no-restricted-syntax
       userEvent.click(submitButton);
     });
 
@@ -426,6 +427,7 @@ describe('document-capture/components/document-capture', () => {
         resolve();
       });
 
+      // eslint-disable-next-line no-restricted-syntax
       userEvent.click(submitButton);
     });
   });
@@ -617,6 +619,8 @@ describe('document-capture/components/document-capture', () => {
 
       await new Promise((resolve) => {
         onSubmit.callsFake(resolve);
+
+        // eslint-disable-next-line no-restricted-syntax
         userEvent.click(getByText('forms.buttons.submit.default'));
       });
     });

--- a/spec/javascripts/support/sinon.ts
+++ b/spec/javascripts/support/sinon.ts
@@ -1,3 +1,12 @@
+declare global {
+  export namespace Chai {
+    export interface PromisedAssertion {
+      called(): PromisedAssertion;
+      calledWith(...args: any[]): PromisedAssertion;
+    }
+  }
+}
+
 /**
  * Chai plugin which allows a combination of `calledWith` and `eventually` to expect an eventual
  * spy (stub) call.
@@ -28,7 +37,7 @@ export function sinonChaiAsPromised({ Assertion }, utils) {
   Assertion.overwriteProperty(
     'called',
     ifEventually(function () {
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         if (this._obj.called) {
           resolve();
         } else {
@@ -41,7 +50,7 @@ export function sinonChaiAsPromised({ Assertion }, utils) {
   Assertion.overwriteMethod(
     'calledWith',
     ifEventually(function (...args) {
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         if (this._obj.calledWith(...args)) {
           resolve();
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,6 +1297,13 @@
   dependencies:
     "@types/chai" "*"
 
+"@types/chai-as-promised@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai@*", "@types/chai@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"


### PR DESCRIPTION
**Why**: Avoid developer confusion associated with race conditions caused by not properly awaiting the completion of a userEvent interaction.

It's not obvious by the changes themselves (especially in the exceptions being ignored), but this has tripped me up on several occasions, resulting in much wasted time for what turns out to be a very simple fix. There are exceptions to this rule and the ESLint selector isn't perfect, but I expect this should have a net positive impact on test authoring.