### PR TITLE
Revert strscan version upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -648,7 +648,7 @@ GEM
     stringex (2.8.5)
     strong_migrations (0.8.0)
       activerecord (>= 5.2)
-    strscan (3.0.4)
+    strscan (3.0.1)
     subprocess (1.5.5)
     systemu (2.6.5)
     terminal-table (3.0.2)


### PR DESCRIPTION
#7000 included an update to `strscan`, a default gem which has weird interactions with our deployed bundler version (2.20.0) and caused deploys to fail.  This PR reverts the version to the previous version until we update bundler

