### PR TITLE
 LG-7623 Add Feature Flag to Conditionally Call VA Mock API

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -117,6 +117,7 @@ in_person_results_delay_in_hours: 1
 include_slo_in_saml_metadata: false
 inherited_proofing_enabled: false
 inherited_proofing_va_base_url: 'https://staging-api.va.gov'
+va_inherited_proofing_mock_enabled: true
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''
 irs_attempt_api_csp_id: 'LOGIN.gov'
@@ -334,6 +335,7 @@ development:
   identity_pki_local_dev: true
   in_person_proofing_enabled: true
   inherited_proofing_enabled: true
+  va_inherited_proofing_mock_enabled: true
   kantara_2fa_phone_restricted: true
   kantara_2fa_phone_existing_user_restriction: true
   kantara_restriction_enforcement_date: '2022-07-01'
@@ -489,6 +491,7 @@ test:
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
   inherited_proofing_enabled: true
+  va_inherited_proofing_mock_enabled: false
   irs_attempt_api_auth_tokens: 'test-token-1,test-token-2'
   irs_attempt_api_public_key: MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyut9Uio5XxsIUVrXARqCoHvcMVYT0p6WyU1BnbhxLRW4Q60p+4Bn32vVOt9nzeih7qvauYM5M0PZdKEmwOHflqPP+ABfKhL+6jxBhykN5P5UY375wTFBJZ20Fx8jOJbRhJD02oUQ49YKlDu3MG5Y0ApyD4ER4WKgxuB2OdyQKd9vg2ZZa+P2pw1HkFPEin0h8KBUFBeLGDZni8PIJdHBP6dA+xbayGBxSM/8xQC0JIg6KlGTcLql37QJIhP2oSv0nAJNb6idFPAz0uMCQDQWKKWV5FUDCsFVH7VuQz8xUCwnPn/SdaratB+29bwUpVhgHXrHdJ0i8vjBEX7smD7pI8CcFHuVgACt86NMlBnNCVkwumQgZNAAxe2mJoYcotEWOnhCuMc6MwSj985bj8XEdFlbf4ny9QO9rETd5aYcwXBiV/T6vd637uvHb0KenghNmlb1Tv9LMj2b9ZwNc9C6oeCnbN2YAfxSDrb8Ik+yq4hRewOvIK7f0CcpZYDXK25aHXnHm306Uu53KIwMGf1mha5T5LWTNaYy5XFoMWHJ9E+AnU/MUJSrwCAITH/S0JFcna5Oatn70aTE9pISATsqB5Iz1c46MvdrxD8hPoDjT7x6/EO316DZrxQfJhjbWsCB+R0QxYLkXPHczhB2Z0HPna9xB6RbJHzph7ifDizhZoMCAwEAAQ==
   irs_attempt_api_public_key_id: key1

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -196,6 +196,7 @@ class IdentityConfig
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:inherited_proofing_enabled, type: :boolean)
     config.add(:inherited_proofing_va_base_url, type: :string)
+    config.add(:va_inherited_proofing_mock_enabled, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)
     config.add(:irs_attempt_api_csp_id)


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-7623

This change allows us to control whether or not we call the VA API mock proofer or a live VA API endpoint.

changelog: Upcoming Features, Inherited Proofing, Add Feature Flag to Conditionally Call Mock API for VA User Data (LG-7623)