### PR TITLE
Speed up feature_management_spec.rb by removing use of browser

### DIFF
--- a/knapsack_rspec_report.json
+++ b/knapsack_rspec_report.json
@@ -27,7 +27,6 @@
   "spec/presenters/setup_presenter_spec.rb": 0.05804999999963911,
   "spec/features/remember_device/session_expiration_spec.rb": 5.3716609999974025,
   "spec/requests/redirects_spec.rb": 0.12476699999388075,
-  "spec/lib/feature_management_spec.rb": 158.021550999998,
   "spec/forms/idv/doc_pii_form_spec.rb": 0.023514000000432134,
   "spec/controllers/users/personal_keys_controller_spec.rb": 0.22581699999864213,
   "spec/services/encryption/uak_password_verifier_spec.rb": 0.21799900000041816,

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'FeatureManagement', type: :feature do
+describe 'FeatureManagement' do
   describe '#prefill_otp_codes?' do
     context 'when SMS sending is disabled' do
       before { allow(FeatureManagement).to receive(:telephony_test_adapter?).and_return(true) }


### PR DESCRIPTION
```
bundle exec rspec spec/lib/feature_management_spec.rb
# BEFORE
Finished in 2 minutes 38.5 seconds (files took 3.96 seconds to load)
# AFTER
Finished in 0.76372 seconds (files took 7.82 seconds to load)
```
about a 200x speedup
