### PR TITLE
LG-7602 Pull VA IP Data and Store It In Session (Form refactor)

### DIFF
--- a/app/forms/idv/inherited_proofing/base_form.rb
+++ b/app/forms/idv/inherited_proofing/base_form.rb
@@ -1,0 +1,139 @@
+module Idv
+  module InheritedProofing
+    class BaseForm
+      include ActiveModel::Model
+
+      class << self
+        def model_name
+          ActiveModel::Name.new(self, nil, namespaced_model_name)
+        end
+
+        def namespaced_model_name
+          self.to_s.gsub('::', '')
+        end
+
+        def fields
+          @fields ||= required_fields + optional_fields
+        end
+
+        def required_fields
+          raise NotImplementedError,
+                'Override this method and return an Array of required field names as Symbols'
+        end
+
+        def optional_fields
+          raise NotImplementedError,
+                'Override this method and return an Array of optional field names as Symbols'
+        end
+      end
+
+      private_class_method :namespaced_model_name, :required_fields, :optional_fields
+
+      attr_reader :payload_hash
+
+      def initialize(payload_hash:)
+        raise ArgumentError, 'payload_hash is blank?' if payload_hash.blank?
+        raise ArgumentError, 'payload_hash is not a Hash' unless payload_hash.is_a? Hash
+
+        self.class.attr_accessor(*self.class.fields)
+
+        @payload_hash = payload_hash.dup
+
+        populate_field_data
+      end
+
+      def submit
+        validate
+
+        FormResponse.new(
+          success: valid?,
+          errors: errors,
+          extra: {
+          },
+        )
+      end
+
+      # Perhaps overkill, but a mapper service of some kind, not bound to this class,
+      # that takes into consideration context, may be more suitable. In the meantime,
+      # simply return a Hash suitable to place into flow_session[:pii_from_user] in
+      # our inherited proofing flow steps.
+      def user_pii
+        raise NotImplementedError, 'Override this method and return a user PII Hash'
+      end
+
+      private
+
+      attr_writer :payload_hash
+
+      # Populates our field data from the payload hash.
+      def populate_field_data
+        payload_field_info.each do |field_name, field_info|
+          # Ignore fields we're not interested in.
+          next unless respond_to? field_name
+
+          value = payload_hash.dig(
+            *[field_info[:namespace],
+              field_info[:field_name]].flatten.compact,
+          )
+          public_send("#{field_name}=", value)
+        end
+      end
+
+      def payload_field_info
+        @payload_field_info ||= field_name_info_from payload_hash: payload_hash
+      end
+
+      # This method simply navigates the payload hash received and creates qualified
+      # hash key names that can be used to verify/map to our field names in this model.
+      # This can be used to qualify nested hash fields and saves us some headaches
+      # if there are nested field names with the same name:
+      #
+      # given:
+      #
+      # payload_hash = {
+      #   first_name: 'first_name',
+      #   ...
+      #   address: {
+      #     street: '',
+      #     ...
+      #   }
+      # }
+      #
+      # field_name_info_from(payload_hash: payload_hash) #=>
+      #
+      # {
+      #   :first_name=>{:field_name=>:first_name, :namespace=>[]},
+      #   ...
+      #   :address_street=>{:field_name=>:street, :namespace=>[:address]},
+      #   ...
+      # }
+      #
+      # The generated, qualified field names expected to map to our model, because we named
+      # them as such.
+      #
+      # :field_name is the actual, unqualified field name found in the payload hash sent.
+      # :namespace is the hash key by which :field_name can be found in the payload hash
+      # if need be.
+      def field_name_info_from(payload_hash:, namespace: [], field_name_info: {})
+        payload_hash.each do |key, value|
+          if value.is_a? Hash
+            field_name_info_from payload_hash: value, namespace: namespace << key,
+                                 field_name_info: field_name_info
+            namespace.pop
+            next
+          end
+
+          namespace = namespace.dup
+          if namespace.blank?
+            field_name_info[key] = { field_name: key, namespace: namespace }
+          else
+            field_name_info["#{namespace.split.join('_')}_#{key}".to_sym] =
+              { field_name: key, namespace: namespace }
+          end
+        end
+
+        field_name_info
+      end
+    end
+  end
+end

--- a/app/forms/idv/inherited_proofing/va/form.rb
+++ b/app/forms/idv/inherited_proofing/va/form.rb
@@ -1,163 +1,34 @@
 module Idv
   module InheritedProofing
     module Va
-      class Form
-        include ActiveModel::Model
-
+      class Form < Idv::InheritedProofing::BaseForm
         class << self
-          def model_name
-            ActiveModel::Name.new(self, nil, namespaced_model_name)
-          end
-
-          def namespaced_model_name
-            self.to_s.gsub('::', '')
-          end
-
-          # Returns the field names based on the validators we've set up.
-          def field_names
-            @field_names ||= fields.keys
-          end
-
-          def fields
-            @fields ||= {
-              first_name: { required: true },
-              last_name: { required: true },
-              phone: { required: false },
-              birth_date: { required: true },
-              ssn: { required: true },
-              address_street: { required: true },
-              address_street2: { required: false },
-              address_city: { required: false },
-              address_state: { required: false },
-              address_country: { required: false },
-              address_zip: { required: true },
-            }
-          end
-
           def required_fields
-            @required_fields ||= fields.filter_map do |field_name, options|
-              field_name if options[:required]
-            end
+            @required_fields ||= %i[first_name last_name birth_date ssn address_street address_zip]
           end
 
           def optional_fields
-            @optional_fields ||= fields.filter_map do |field_name, options|
-              field_name unless options[:required]
-            end
+            @optional_fields ||= %i[phone address_street2 address_city address_state
+                                    address_country]
           end
         end
 
-        private_class_method :namespaced_model_name, :required_fields, :optional_fields
+        validates(*required_fields, presence: true)
 
-        attr_reader :payload_hash
+        def user_pii
+          raise 'User PII is invalid' unless valid?
 
-        validate :validate_field_names
-
-        required_fields.each { |required_field| validates(required_field, presence: true) }
-
-        # This must be performed after our validators are defined.
-        attr_accessor(*self.field_names)
-
-        def initialize(payload_hash:)
-          raise ArgumentError, 'payload_hash is blank?' if payload_hash.blank?
-          raise ArgumentError, 'payload_hash is not a Hash' unless payload_hash.is_a? Hash
-
-          @payload_hash = payload_hash.dup
-
-          populate_field_data
-        end
-
-        def submit
-          validate
-
-          FormResponse.new(
-            success: valid?,
-            errors: errors,
-            extra: {
-            },
-          )
-        end
-
-        private
-
-        attr_writer :payload_hash
-
-        # Populates our field data from the payload hash.
-        def populate_field_data
-          payload_field_info.each do |field_name, field_info|
-            # Ignore fields we're not interested in.
-            next unless respond_to? field_name
-
-            value = payload_hash.dig(
-              *[field_info[:namespace],
-                field_info[:field_name]].flatten.compact,
-            )
-            public_send("#{field_name}=", value)
-          end
-        end
-
-        # Validator for field names. All fields (not the presence of data) are required.
-        def validate_field_names
-          self.class.field_names.each do |field_name|
-            next if payload_field_info.key? field_name
-            errors.add(field_name, 'field is missing', type: :missing_required_field)
-          end
-        end
-
-        def payload_field_info
-          @payload_field_info ||= field_name_info_from payload_hash: payload_hash
-        end
-
-        # This method simply navigates the payload hash received and creates qualified
-        # hash key names that can be used to verify/map to our field names in this model.
-        # This can be used to qualify nested hash fields and saves us some headaches
-        # if there are nested field names with the same name:
-        #
-        # given:
-        #
-        # payload_hash = {
-        #   first_name: 'first_name',
-        #   ...
-        #   address: {
-        #     street: '',
-        #     ...
-        #   }
-        # }
-        #
-        # field_name_info_from(payload_hash: payload_hash) #=>
-        #
-        # {
-        #   :first_name=>{:field_name=>:first_name, :namespace=>[]},
-        #   ...
-        #   :address_street=>{:field_name=>:street, :namespace=>[:address]},
-        #   ...
-        # }
-        #
-        # The generated, qualified field names expected to map to our model, because we named
-        # them as such.
-        #
-        # :field_name is the actual, unqualified field name found in the payload hash sent.
-        # :namespace is the hash key by which :field_name can be found in the payload hash
-        # if need be.
-        def field_name_info_from(payload_hash:, namespace: [], field_name_info: {})
-          payload_hash.each do |key, value|
-            if value.is_a? Hash
-              field_name_info_from payload_hash: value, namespace: namespace << key,
-                                   field_name_info: field_name_info
-              namespace.pop
-              next
-            end
-
-            namespace = namespace.dup
-            if namespace.blank?
-              field_name_info[key] = { field_name: key, namespace: namespace }
-            else
-              field_name_info["#{namespace.split.join('_')}_#{key}".to_sym] =
-                { field_name: key, namespace: namespace }
-            end
-          end
-
-          field_name_info
+          user_pii = {}
+          user_pii[:first_name] = first_name
+          user_pii[:last_name] = last_name
+          user_pii[:dob] = birth_date
+          user_pii[:ssn] = ssn
+          user_pii[:phone] = phone
+          user_pii[:address1] = address_street
+          user_pii[:city] = address_city
+          user_pii[:state] = address_state
+          user_pii[:zipcode] = address_zip
+          user_pii
         end
       end
     end

--- a/spec/forms/idv/inherited_proofing/base_form_spec.rb
+++ b/spec/forms/idv/inherited_proofing/base_form_spec.rb
@@ -1,0 +1,231 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'the hash is blank?' do
+  it 'raises an error' do
+    expect { subject }.to raise_error 'payload_hash is blank?'
+  end
+end
+
+RSpec.describe Idv::InheritedProofing::BaseForm do
+  subject { form_object }
+
+  let(:form_class) do
+    Class.new(Idv::InheritedProofing::BaseForm) do
+      class << self
+        def required_fields; [] end
+
+        def optional_fields; [] end
+      end
+
+      def user_pii; {} end
+    end
+  end
+
+  let(:form_object) do
+    form_class.new(payload_hash: payload_hash)
+  end
+
+  let(:payload_hash) do
+    {
+      first_name: 'Henry',
+      last_name: 'Ford',
+      phone: '12222222222',
+      birth_date: '2000-01-01',
+      ssn: '111223333',
+      address: {
+        street: '1234 Model Street',
+        street2: 'Suite A',
+        city: 'Detroit',
+        state: 'MI',
+        country: 'United States',
+        zip: '12345',
+      },
+    }
+  end
+
+  describe '#initialize' do
+    subject { form_class }
+
+    context 'when .required_fields is not overridden' do
+      it 'raises an error' do
+        subject.singleton_class.send(:remove_method, :required_fields)
+        expected_error = 'Override this method and return ' \
+          'an Array of required field names as Symbols'
+        expect { subject.new(payload_hash: payload_hash) }.to raise_error(expected_error)
+      end
+    end
+
+    context 'when .optional_fields is not overridden' do
+      it 'raises an error' do
+        subject.singleton_class.send(:remove_method, :optional_fields)
+        expected_error = 'Override this method and return ' \
+          'an Array of optional field names as Symbols'
+        expect { subject.new(payload_hash: payload_hash) }.to raise_error(expected_error)
+      end
+    end
+
+    context 'when .user_pii is not overridden' do
+      subject do
+        Class.new(Idv::InheritedProofing::BaseForm) do
+          class << self
+            def required_fields; [] end
+
+            def optional_fields; [] end
+          end
+        end
+      end
+
+      it 'raises an error' do
+        expected_error = 'Override this method and return a user PII Hash'
+        expect { subject.new(payload_hash: payload_hash).user_pii }.to raise_error(expected_error)
+      end
+    end
+  end
+
+  describe 'class methods' do
+    describe '.model_name' do
+      it 'returns the right model name' do
+        expect(described_class.model_name).to eq 'IdvInheritedProofingBaseForm'
+      end
+    end
+
+    describe '.fields' do
+      subject do
+        Class.new(Idv::InheritedProofing::BaseForm) do
+          class << self
+            def required_fields; %i[required] end
+
+            def optional_fields; %i[optional] end
+          end
+
+          def user_pii; {} end
+        end
+      end
+
+      let(:expected_field_names) do
+        [
+          :required,
+          :optional,
+        ].sort
+      end
+
+      it 'returns the right field names' do
+        expect(subject.fields).to match_array expected_field_names
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'when passing an invalid payload hash' do
+      context 'when not a Hash' do
+        let(:payload_hash) { :x }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error 'payload_hash is not a Hash'
+        end
+      end
+
+      context 'when nil?' do
+        let(:payload_hash) { nil }
+
+        it_behaves_like 'the hash is blank?'
+      end
+
+      context 'when empty?' do
+        let(:payload_hash) { {} }
+
+        it_behaves_like 'the hash is blank?'
+      end
+    end
+
+    context 'when passing a valid payload hash' do
+      it 'raises no errors' do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+
+  describe '#validate' do
+    subject do
+      Class.new(Idv::InheritedProofing::BaseForm) do
+        class << self
+          def required_fields; %i[required] end
+
+          def optional_fields; %i[optional] end
+        end
+
+        def user_pii; {} end
+      end.new(payload_hash: payload_hash)
+    end
+
+    let(:payload_hash) do
+      {
+        required: 'Required',
+        optional: 'Optional',
+      }
+    end
+
+    context 'with valid payload data' do
+      it 'returns true' do
+        expect(subject.validate).to eq true
+      end
+    end
+
+    context 'with invalid payload data' do
+      context 'when the payload has unrecognized fields' do
+        let(:payload_hash) do
+          {
+            xrequired: 'xRequired',
+            xoptional: 'xOptional',
+          }
+        end
+
+        let(:expected_error_messages) do
+          [
+            # Required field presence
+            'Required field is missing',
+            'Optional field is missing',
+          ]
+        end
+
+        it 'returns true' do
+          expect(subject.validate).to eq true
+        end
+      end
+
+      context 'when the payload has missing required field data' do
+        let(:payload_hash) do
+          {
+            required: nil,
+            optional: '',
+          }
+        end
+
+        it 'returns true' do
+          expect(subject.validate).to eq true
+        end
+
+        it 'returns no errors because no data validations take place by default' do
+          subject.validate
+          expect(subject.errors.full_messages).to eq []
+        end
+      end
+    end
+  end
+
+  describe '#submit' do
+    it 'returns a FormResponse object' do
+      expect(subject.submit).to be_kind_of FormResponse
+    end
+
+    describe 'before returning' do
+      after do
+        subject.submit
+      end
+
+      it 'calls #validate' do
+        expect(subject).to receive(:validate).once
+      end
+    end
+  end
+end

--- a/spec/forms/idv/inherited_proofing/va/form_spec.rb
+++ b/spec/forms/idv/inherited_proofing/va/form_spec.rb
@@ -9,6 +9,9 @@ end
 RSpec.describe Idv::InheritedProofing::Va::Form do
   subject(:form) { described_class.new payload_hash: payload_hash }
 
+  let(:required_fields) { %i[first_name last_name birth_date ssn address_street address_zip] }
+  let(:optional_fields) { %i[phone address_street2 address_city address_state address_country] }
+
   let(:payload_hash) do
     {
       first_name: 'Henry',
@@ -34,25 +37,21 @@ RSpec.describe Idv::InheritedProofing::Va::Form do
       end
     end
 
-    describe '.field_names' do
-      let(:expected_field_names) do
-        [
-          :address_city,
-          :address_country,
-          :address_state,
-          :address_street,
-          :address_street2,
-          :address_zip,
-          :birth_date,
-          :first_name,
-          :last_name,
-          :phone,
-          :ssn,
-        ].sort
+    describe '.fields' do
+      it 'returns all the fields' do
+        expect(described_class.fields).to match_array required_fields + optional_fields
       end
+    end
 
-      it 'returns the right model name' do
-        expect(described_class.field_names).to match_array expected_field_names
+    describe '.required_fields' do
+      it 'returns the required fields' do
+        expect(described_class.required_fields).to match_array required_fields
+      end
+    end
+
+    describe '.optional_fields' do
+      it 'returns the optional fields' do
+        expect(described_class.optional_fields).to match_array optional_fields
       end
     end
   end
@@ -116,18 +115,12 @@ RSpec.describe Idv::InheritedProofing::Va::Form do
 
         let(:expected_error_messages) do
           [
-            # Required field presence
-            'First name field is missing',
-            'Last name field is missing',
-            'Phone field is missing',
-            'Birth date field is missing',
-            'Ssn field is missing',
-            'Address street field is missing',
-            'Address street2 field is missing',
-            'Address city field is missing',
-            'Address state field is missing',
-            'Address country field is missing',
-            'Address zip field is missing',
+            'First name Please fill in this field.',
+            'Last name Please fill in this field.',
+            'Birth date Please fill in this field.',
+            'Ssn Please fill in this field.',
+            'Address street Please fill in this field.',
+            'Address zip Please fill in this field.',
           ]
         end
 
@@ -137,11 +130,7 @@ RSpec.describe Idv::InheritedProofing::Va::Form do
 
         it 'adds the correct error messages for missing fields' do
           subject.validate
-          expect(
-            expected_error_messages.all? do |error_message|
-              subject.errors.full_messages.include? error_message
-            end,
-          ).to eq true
+          expect(subject.errors.full_messages).to match_array expected_error_messages
         end
       end
 
@@ -185,32 +174,91 @@ RSpec.describe Idv::InheritedProofing::Va::Form do
           expect(subject.errors.full_messages).to match_array expected_error_messages
         end
       end
+
+      context 'when the payload has missing optional field data' do
+        let(:payload_hash) do
+          {
+            first_name: 'x',
+            last_name: 'x',
+            phone: nil,
+            birth_date: '01/01/2022',
+            ssn: '123456789',
+            address: {
+              street: 'x',
+              street2: nil,
+              city: '',
+              state: nil,
+              country: '',
+              zip: '12345',
+            },
+          }
+        end
+
+        it 'returns true' do
+          expect(subject.validate).to eq true
+        end
+      end
     end
   end
 
   describe '#submit' do
-    it 'returns a FormResponse object' do
-      expect(subject.submit).to be_kind_of FormResponse
-    end
-
-    describe 'before returning' do
-      after do
-        subject.submit
-      end
-
-      it 'calls #validate' do
-        expect(subject).to receive(:validate).once
-      end
-    end
-
     context 'with an invalid payload' do
-      context 'when the payload has missing fields' do
-        it 'returns a FormResponse indicating errors'
-      end
-
       context 'when the payload has invalid field data' do
-        it 'returns a FormResponse indicating errors'
+        let(:payload_hash) do
+          {
+            first_name: nil,
+            last_name: '',
+            phone: nil,
+            birth_date: '',
+            ssn: nil,
+            address: {
+              street: '',
+              street2: nil,
+              city: '',
+              state: nil,
+              country: '',
+              zip: nil,
+            },
+          }
+        end
+
+        let(:expected_errors) do
+          {
+            # Required field data presence
+            first_name: ['Please fill in this field.'],
+            last_name: ['Please fill in this field.'],
+            birth_date: ['Please fill in this field.'],
+            ssn: ['Please fill in this field.'],
+            address_street: ['Please fill in this field.'],
+            address_zip: ['Please fill in this field.'],
+          }
+        end
+
+        it 'returns a FormResponse indicating the correct errors and status' do
+          form_response = subject.submit
+          expect(form_response.success?).to eq false
+          expect(form_response.errors).to match_array expected_errors
+        end
       end
+    end
+  end
+
+  describe '#user_pii' do
+    let(:expected_user_pii) do
+      {
+        first_name: subject.first_name,
+        last_name: subject.last_name,
+        dob: subject.birth_date,
+        ssn: subject.ssn,
+        phone: subject.phone,
+        address1: subject.address_street,
+        city: subject.address_city,
+        state: subject.address_state,
+        zipcode: subject.address_zip,
+      }
+    end
+    it 'returns the correct user pii' do
+      expect(subject.user_pii).to eq expected_user_pii
     end
   end
 end


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-7602

1 of n.

This is simply an existing Form refactor that splits off a FormBase class.

This is a supporting change for the LG-7602 feature for Inherited Proofing (IP) where user PII needs to be stored in session for IP flow steps and subsequent IDV workflow flow steps that need this information for (example) Lexis Phone Finder look ups.

This change exposes a #user_pii method that retuns a Hash suitable to be stored in the idv_session and flow_session[:pii_from_user] (minus :uuid). The data mapped  to the user PII returned from this method is Service Provider (SP)-specific in that the SP API returning the user PII may be returned having data keys that differ from what we need; consequently, create a mapper service for this, but that would disconnect what the SP service returns hash-wise. The Form knows about this, so it may be better suited "as is".

changelog: Upcoming Features, Inherited Proofing, Pull VA IP Data and Store It In Session (LG-7602)