### PR TITLE
Recompile Sass after exception when watching files

### DIFF
--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -43,7 +43,7 @@ function watchOnce(paths, callback) {
  *
  * @return {error is SassException}
  */
-const isSassException = (error) => !!(/** @type {SassException} */ (error).span);
+const isSassException = (error) => 'span' in /** @type {SassException} */ (error);
 
 /**
  * @param {string[]} files


### PR DESCRIPTION
**Why**: So that a developer has an opportunity to fix a compilation error, and so that they're not confused when their changes are not reflected in the running application process.

Currently, if a developer is running `make run` and introduces a syntax error to a stylesheet, the stylesheet build process will crash and never recover. The application will continue to run, however, causing confusion for the developer.

**Testing Instructions:**

- Try adding an intentional syntax error to a stylesheet while `make run` is running, observe the error in the console, and observe that the files are recompiled when the syntax error is fixed.
   - Note: There is (currently) no feedback for rebuilds in the terminal process, but you should notice changes being reflected in the application after refresh shortly after the file is saved.
- Ensure that syntax errors continue to exit with a non-zero status code when _not_ watching.

```diff
diff --git a/app/assets/stylesheets/utilities/_typography.scss b/app/assets/stylesheets/utilities/_typography.scss
index 9b8678f5b..c8a122482 100644
--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -99,3 +99,11 @@ h6,
 .h6 {
   @extend %h6;
 }
+
+.example {
+  background: $broken;
+}
+
+h1 {
+  color: red !important;
+}
```

```bash
yarn build:css
echo $?
# 1
```