### PR TITLE
LG-7602 Pull VA IP Data and Store It In Session (InheritedProofingConcern refactor) 2 of 3

### DIFF
--- a/app/controllers/concerns/inherited_proofing_concern.rb
+++ b/app/controllers/concerns/inherited_proofing_concern.rb
@@ -27,4 +27,38 @@ module InheritedProofingConcern
   def va_inherited_proofing_auth_code_params_key
     'inherited_proofing_auth'
   end
+
+  # Service Provider-agnostic members for now.
+  # Think about putting this in a factory(ies).
+
+  def inherited_proofing_service
+    inherited_proofing_service_class.new inherited_proofing_service_provider_data
+  end
+
+  def inherited_proofing_service_class
+    raise 'Inherited Proofing is not enabled' unless IdentityConfig.store.inherited_proofing_enabled
+
+    if va_inherited_proofing?
+      if IdentityConfig.store.va_inherited_proofing_mock_enabled
+        return Idv::InheritedProofing::Va::Mocks::Service
+      end
+      return Idv::InheritedProofing::Va::Service
+    end
+
+    raise 'Inherited proofing service class could not be identified'
+  end
+
+  def inherited_proofing_form(payload_hash)
+    return Idv::InheritedProofing::Va::Form.new payload_hash: payload_hash if va_inherited_proofing?
+
+    raise 'Inherited proofing form could not be identified'
+  end
+
+  def inherited_proofing_service_provider_data
+    if va_inherited_proofing?
+      { auth_code: va_inherited_proofing_auth_code }
+    else
+      {}
+    end
+  end
 end

--- a/app/services/idv/inherited_proofing/va/mocks/service.rb
+++ b/app/services/idv/inherited_proofing/va/mocks/service.rb
@@ -35,8 +35,8 @@ module Idv
             },
           }.freeze
 
-          def initialize(auth_code)
-            @auth_code = auth_code
+          def initialize(service_provider_data)
+            @auth_code = service_provider_data[:auth_code]
           end
 
           def execute

--- a/app/services/idv/inherited_proofing/va/service.rb
+++ b/app/services/idv/inherited_proofing/va/service.rb
@@ -9,8 +9,8 @@ module Idv
 
         attr_reader :auth_code
 
-        def initialize(auth_code)
-          @auth_code = auth_code
+        def initialize(service_provider_data)
+          @auth_code = service_provider_data[:auth_code]
         end
 
         # Calls the endpoint and returns the decrypted response.

--- a/scripts/inherited_proofing/va/user_attributes/test_server.rb
+++ b/scripts/inherited_proofing/va/user_attributes/test_server.rb
@@ -10,7 +10,7 @@ module Scripts
           attr_reader :base_uri
 
           def initialize(auth_code:, private_key_file: nil, base_uri: nil)
-            super auth_code
+            super({ auth_code: auth_code })
 
             if private_key_file.present?
               @private_key_file = force_tmp_private_key_file_name(private_key_file)

--- a/spec/controllers/concerns/inherited_proofing_concern_spec.rb
+++ b/spec/controllers/concerns/inherited_proofing_concern_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe InheritedProofingConcern do
+  subject do
+    Class.new do
+      include InheritedProofingConcern
+    end.new
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:inherited_proofing_enabled).and_return(true)
+    allow(subject).to receive(:va_inherited_proofing_auth_code).and_return auth_code
+  end
+
+  let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
+  let(:payload_hash) { Idv::InheritedProofing::Va::Mocks::Service::PAYLOAD_HASH }
+
+  describe '#va_inherited_proofing?' do
+    context 'when the va auth code is present' do
+      it 'returns true' do
+        expect(subject.va_inherited_proofing?).to eq true
+      end
+    end
+
+    context 'when the va auth code is not present' do
+      let(:auth_code) { nil }
+
+      it 'returns false' do
+        expect(subject.va_inherited_proofing?).to eq false
+      end
+    end
+  end
+
+  describe '#va_inherited_proofing_auth_code_params_key' do
+    it 'returns the correct va auth code url query param key' do
+      expect(subject.va_inherited_proofing_auth_code_params_key).to eq 'inherited_proofing_auth'
+    end
+  end
+
+  describe '#inherited_proofing_service_class' do
+    context 'when va inherited proofing is disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:inherited_proofing_enabled).and_return(false)
+      end
+
+      it 'raises an error' do
+        expect do
+          subject.inherited_proofing_service_class
+        end.to raise_error 'Inherited Proofing is not enabled'
+      end
+    end
+
+    context 'when there is a va inherited proofing request' do
+      context 'when va mock proofing is turned on' do
+        before do
+          allow(IdentityConfig.store).to \
+            receive(:va_inherited_proofing_mock_enabled).and_return(true)
+        end
+
+        it 'returns the correct service provider service class' do
+          expect(subject.inherited_proofing_service_class).to \
+            eq Idv::InheritedProofing::Va::Mocks::Service
+        end
+      end
+
+      context 'when va mock proofing is turned off' do
+        before do
+          allow(IdentityConfig.store).to \
+            receive(:va_inherited_proofing_mock_enabled).and_return(false)
+        end
+
+        it 'returns the correct service provider service class' do
+          expect(subject.inherited_proofing_service_class).to eq Idv::InheritedProofing::Va::Service
+        end
+      end
+    end
+
+    context 'when the inherited proofing request cannot be identified' do
+      let(:auth_code) { nil }
+
+      it 'raises an error' do
+        expect do
+          subject.inherited_proofing_service_class
+        end.to raise_error 'Inherited proofing service class could not be identified'
+      end
+    end
+  end
+
+  describe '#inherited_proofing_service' do
+    context 'when there is a va inherited proofing request' do
+      context 'when va mock proofing is turned on' do
+        before do
+          allow(IdentityConfig.store).to \
+            receive(:va_inherited_proofing_mock_enabled).and_return(true)
+        end
+
+        it 'returns the correct service provider service class' do
+          expect(subject.inherited_proofing_service).to \
+            be_kind_of Idv::InheritedProofing::Va::Mocks::Service
+        end
+      end
+
+      context 'when va mock proofing is turned off' do
+        before do
+          allow(IdentityConfig.store).to \
+            receive(:va_inherited_proofing_mock_enabled).and_return(false)
+        end
+
+        it 'returns the correct service provider service class' do
+          expect(subject.inherited_proofing_service).to \
+            be_kind_of Idv::InheritedProofing::Va::Service
+        end
+      end
+    end
+  end
+
+  describe '#inherited_proofing_form' do
+    context 'when there is a va inherited proofing request' do
+      it 'returns the correct form' do
+        expect(subject.inherited_proofing_form(payload_hash)).to \
+          be_kind_of Idv::InheritedProofing::Va::Form
+      end
+    end
+
+    context 'when the inherited proofing request cannot be identified' do
+      let(:auth_code) { nil }
+
+      it 'raises an error' do
+        expect { subject.inherited_proofing_form(payload_hash) }.to \
+          raise_error 'Inherited proofing form could not be identified'
+      end
+    end
+  end
+
+  describe '#inherited_proofing_service_provider_data' do
+    context 'when there is a va inherited proofing request' do
+      it 'returns the correct service provider-specific data' do
+        expect(subject.inherited_proofing_service_provider_data).to \
+          eq({ auth_code: auth_code })
+      end
+    end
+
+    context 'when the inherited proofing request cannot be identified' do
+      let(:auth_code) { nil }
+
+      it 'returns an empty hash' do
+        expect(subject.inherited_proofing_service_provider_data).to eq({})
+      end
+    end
+  end
+end

--- a/spec/features/services/idv/inherited_proofing/va/mocks/service_spec.rb
+++ b/spec/features/services/idv/inherited_proofing/va/mocks/service_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe 'Inherited Proofing VA API Proofer Service' do
   subject(:form) { Idv::InheritedProofing::Va::Form.new(payload_hash: proofer_results) }
 
-  let(:proofer_results) { Idv::InheritedProofing::Va::Mocks::Service.new(auth_code).execute }
+  let(:proofer_results) do
+    Idv::InheritedProofing::Va::Mocks::Service.new({ auth_code: auth_code }).execute
+  end
   let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
 
   context 'when used with the VA Inherited Proofing Response Form' do

--- a/spec/services/idv/inherited_proofing/va/mocks/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/mocks/service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Idv::InheritedProofing::Va::Mocks::Service do
-  subject { described_class.new(auth_code) }
+  subject { described_class.new({ auth_code: auth_code }) }
   let(:auth_code) { described_class::VALID_AUTH_CODE }
 
   describe '#initialize' do

--- a/spec/services/idv/inherited_proofing/va/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Idv::InheritedProofing::Va::Service do
   include_context 'va_api_context'
   include_context 'va_user_context'
 
-  subject(:service) { described_class.new auth_code }
+  subject(:service) { described_class.new(auth_code: auth_code) }
 
   before do
     allow(service).to receive(:private_key).and_return(private_key)


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-7602

2 of 3.

This is a supporting change for the LG-7602 feature for Inherited Proofing (IP).

The user's PII needs to be obtained from the Service Provider in our Inherited Proofing process Flow Steps. Identifying whether or not an Inherited Proofing SP request is in progress, needs access to the decorated_session, which currently takes place in the InheritedProofingConcern. It makes sense (for how), to serve up the Service Provider Services and Forms in this concern, since we can easily identify the Service Provider here also; we can think about placing this code in a SP Service and Form factory or something similar later.

changelog: Upcoming Features, Inherited Proofing, Pull VA IP Data and Store It In Session (LG-7602)