### PR TITLE
Include U.S. territories in allowed countries for IdV phone

### DIFF
--- a/app/components/phone_input_component.rb
+++ b/app/components/phone_input_component.rb
@@ -57,7 +57,6 @@ class PhoneInputComponent < BaseComponent
     {
       country_code_label: t('components.phone_input.country_code_label'),
       invalid_phone: t('errors.messages.invalid_phone_number'),
-      country_constraint_usa: t('errors.messages.phone_country_constraint_usa'),
       unsupported_country: unsupported_country_string,
     }
   end

--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -29,7 +29,14 @@ module Idv
     attr_reader :idv_phone
 
     def phone_number_capabilities
-      @phone_number_capabilities ||= PhoneNumberCapabilities.new(idv_phone, phone_confirmed: false)
+      @phone_number_capabilities ||= PhoneNumberCapabilities.new(
+        idv_phone,
+        phone_confirmed: user_phone?,
+      )
+    end
+
+    def user_phone?
+      MfaContext.new(current_user).phone_configurations.any? { |config| config.phone == idv_phone }
     end
 
     def confirm_phone_step_complete

--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -12,8 +12,7 @@ module Idv
 
     def new
       analytics.idv_phone_otp_delivery_selection_visit
-      @phone_number_capabilities = phone_number_capabilities
-      render :new, locals: { gpo_letter_available: gpo_letter_available }
+      render :new, locals: view_locals
     end
 
     def create
@@ -27,6 +26,13 @@ module Idv
     private
 
     attr_reader :idv_phone
+
+    def view_locals
+      {
+        gpo_letter_available: gpo_letter_available,
+        phone_number_capabilities: phone_number_capabilities,
+      }
+    end
 
     def phone_number_capabilities
       PhoneNumberCapabilities.new(idv_phone, phone_confirmed: user_phone?)
@@ -55,7 +61,7 @@ module Idv
 
     def render_new_with_error_message
       flash[:error] = t('idv.errors.unsupported_otp_delivery_method')
-      render :new, locals: { gpo_letter_available: gpo_letter_available }
+      render :new, locals: view_locals
     end
 
     def send_phone_confirmation_otp_and_handle_result

--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -12,6 +12,7 @@ module Idv
 
     def new
       analytics.idv_phone_otp_delivery_selection_visit
+      @phone_number_capabilities = phone_number_capabilities
       render :new, locals: { gpo_letter_available: gpo_letter_available }
     end
 
@@ -24,6 +25,12 @@ module Idv
     end
 
     private
+
+    attr_reader :idv_phone
+
+    def phone_number_capabilities
+      @phone_number_capabilities ||= PhoneNumberCapabilities.new(idv_phone, phone_confirmed: false)
+    end
 
     def confirm_phone_step_complete
       redirect_to idv_phone_url if idv_session.vendor_phone_confirmation != true

--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -29,10 +29,7 @@ module Idv
     attr_reader :idv_phone
 
     def phone_number_capabilities
-      @phone_number_capabilities ||= PhoneNumberCapabilities.new(
-        idv_phone,
-        phone_confirmed: user_phone?,
-      )
+      PhoneNumberCapabilities.new(idv_phone, phone_confirmed: user_phone?)
     end
 
     def user_phone?

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -100,7 +100,8 @@ module Idv
       @idv_form = Idv::PhoneForm.new(
         user: current_user,
         previous_params: idv_session.previous_phone_step_params,
-        allowed_countries: PhoneNumberCapabilities::US_AND_US_TERRITORY_CODES,
+        allowed_countries:
+          PhoneNumberCapabilities::ADDRESS_IDENTITY_PROOFING_SUPPORTED_COUNTRY_CODES,
       )
     end
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -100,7 +100,7 @@ module Idv
       @idv_form = Idv::PhoneForm.new(
         user: current_user,
         previous_params: idv_session.previous_phone_step_params,
-        allowed_countries: PhoneCountryCodes::US_AND_US_TERRITORY_CODES,
+        allowed_countries: PhoneNumberCapabilities::US_AND_US_TERRITORY_CODES,
       )
     end
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -100,7 +100,7 @@ module Idv
       @idv_form = Idv::PhoneForm.new(
         user: current_user,
         previous_params: idv_session.previous_phone_step_params,
-        allowed_countries: ['US'],
+        allowed_countries: PhoneCountryCodes::US_AND_US_TERRITORY_CODES,
       )
     end
 

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -54,12 +54,7 @@ module Idv
 
     def validate_valid_phone_for_allowed_countries
       return if valid_phone_for_allowed_countries?(phone)
-
-      if allowed_countries == ['US']
-        errors.add(:phone, :must_have_us_country_code, type: :must_have_us_country_code)
-      else
-        errors.add(:phone, :improbable_phone, type: :improbable_phone)
-      end
+      errors.add(:phone, :improbable_phone, type: :improbable_phone)
     end
 
     def validate_phone_delivery_methods

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -80,7 +80,7 @@ module Idv
 
     def valid_phone_for_allowed_countries?(phone)
       if allowed_countries.present?
-        allowed_countries.all? { |country| Phonelib.valid_for_country?(phone, country) }
+        allowed_countries.any? { |country| Phonelib.valid_for_country?(phone, country) }
       else
         Phonelib.valid?(phone)
       end

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -66,7 +66,9 @@ module Idv
       return unless valid_phone_for_allowed_countries?(phone)
 
       capabilities = PhoneNumberCapabilities.new(phone, phone_confirmed: user_phone?(phone))
-      unsupported_delivery_methods(capabilities).each do |delivery_method|
+      unsupported_methods = unsupported_delivery_methods(capabilities)
+      return if unsupported_methods.count != delivery_methods.count
+      unsupported_methods.each do |delivery_method|
         errors.add(
           :phone,
           I18n.t(

--- a/app/javascript/packages/phone-input/index.js
+++ b/app/javascript/packages/phone-input/index.js
@@ -10,7 +10,6 @@ import { replaceVariables } from '@18f/identity-i18n';
  *
  * @prop {string=} country_code_label
  * @prop {string=} invalid_phone
- * @prop {string=} country_constraint_usa
  * @prop {string=} unsupported_country
  */
 
@@ -176,11 +175,7 @@ export class PhoneInput extends HTMLElement {
     const isInvalidCountry =
       supportedCountryCodes?.length === 1 && !isValidNumberForRegion(phoneNumber, countryCode);
     if (isInvalidCountry) {
-      if (countryCode === 'US') {
-        textInput.setCustomValidity(this.strings.country_constraint_usa || '');
-      } else {
-        textInput.setCustomValidity(this.strings.invalid_phone || '');
-      }
+      textInput.setCustomValidity(this.strings.invalid_phone || '');
     }
 
     const isInvalidPhoneNumber = !isPhoneValid(phoneNumber, countryCode);

--- a/app/javascript/packages/phone-input/index.js
+++ b/app/javascript/packages/phone-input/index.js
@@ -45,32 +45,34 @@ export class PhoneInput extends HTMLElement {
   countryCodePairs = {};
 
   connectedCallback() {
-    /** @type {HTMLInputElement?} */
-    this.textInput = this.querySelector('.phone-input__number');
-    /** @type {HTMLSelectElement?} */
-    this.codeInput = this.querySelector('.phone-input__international-code');
-    this.codeWrapper = this.querySelector('.phone-input__international-code-wrapper');
-    this.exampleText = this.querySelector('.phone-input__example');
+    if (this.isConnected) {
+      /** @type {HTMLInputElement?} */
+      this.textInput = this.querySelector('.phone-input__number');
+      /** @type {HTMLSelectElement?} */
+      this.codeInput = this.querySelector('.phone-input__international-code');
+      this.codeWrapper = this.querySelector('.phone-input__international-code-wrapper');
+      this.exampleText = this.querySelector('.phone-input__example');
 
-    try {
-      this.deliveryMethods = JSON.parse(this.dataset.deliveryMethods || '');
-      this.countryCodePairs = JSON.parse(this.dataset.translatedCountryCodeNames || '');
-    } catch {}
+      try {
+        this.deliveryMethods = JSON.parse(this.dataset.deliveryMethods || '');
+        this.countryCodePairs = JSON.parse(this.dataset.translatedCountryCodeNames || '');
+      } catch {}
 
-    if (!this.textInput || !this.codeInput) {
-      return;
+      if (!this.textInput || !this.codeInput) {
+        return;
+      }
+
+      this.iti = this.initializeIntlTelInput();
+
+      this.textInput.addEventListener('countrychange', () => this.syncCountryChangeToCodeInput());
+      this.textInput.addEventListener('input', () => this.validate());
+      this.codeInput.addEventListener('change', () => this.formatTextInput());
+      this.codeInput.addEventListener('change', () => this.setExampleNumber());
+      this.codeInput.addEventListener('change', () => this.validate());
+
+      this.setExampleNumber();
+      this.validate();
     }
-
-    this.iti = this.initializeIntlTelInput();
-
-    this.textInput.addEventListener('countrychange', () => this.syncCountryChangeToCodeInput());
-    this.textInput.addEventListener('input', () => this.validate());
-    this.codeInput.addEventListener('change', () => this.formatTextInput());
-    this.codeInput.addEventListener('change', () => this.setExampleNumber());
-    this.codeInput.addEventListener('change', () => this.validate());
-
-    this.setExampleNumber();
-    this.validate();
   }
 
   get selectedOption() {

--- a/app/javascript/packages/phone-input/index.js
+++ b/app/javascript/packages/phone-input/index.js
@@ -159,7 +159,7 @@ export class PhoneInput extends HTMLElement {
   }
 
   validate() {
-    const { textInput, codeInput, supportedCountryCodes, selectedOption } = this;
+    const { textInput, codeInput, selectedOption } = this;
     if (!textInput || !codeInput || !selectedOption) {
       return;
     }
@@ -172,8 +172,7 @@ export class PhoneInput extends HTMLElement {
       return;
     }
 
-    const isInvalidCountry =
-      supportedCountryCodes?.length === 1 && !isValidNumberForRegion(phoneNumber, countryCode);
+    const isInvalidCountry = !isValidNumberForRegion(phoneNumber, countryCode);
     if (isInvalidCountry) {
       textInput.setCustomValidity(this.strings.invalid_phone || '');
     }

--- a/app/javascript/packages/phone-input/index.spec.js
+++ b/app/javascript/packages/phone-input/index.spec.js
@@ -43,7 +43,6 @@ describe('PhoneInput', () => {
         {
           "country_code_label": "Country code",
           "invalid_phone": "Phone number is not valid",
-          "country_constraint_usa": "Must be a U.S. phone number",
           "unsupported_country": "We are unable to verify phone numbers from %{location}"
         }
       </script>
@@ -133,25 +132,13 @@ describe('PhoneInput', () => {
     });
 
     it('validates phone from region', async () => {
-      const input = createAndConnectElement({ isSingleOption: true });
+      const input = createAndConnectElement({ isNonUSSingleOption: true });
 
       /** @type {HTMLInputElement} */
       const phoneNumber = getByLabelText(input, 'Phone number');
 
-      await userEvent.type(phoneNumber, '306-555-1234');
-      expect(phoneNumber.validationMessage).to.equal('Must be a U.S. phone number');
-    });
-
-    context('with non-U.S. single option', () => {
-      it('validates phone from region', async () => {
-        const input = createAndConnectElement({ isNonUSSingleOption: true });
-
-        /** @type {HTMLInputElement} */
-        const phoneNumber = getByLabelText(input, 'Phone number');
-
-        await userEvent.type(phoneNumber, '513-555-1234');
-        expect(phoneNumber.validationMessage).to.equal('Phone number is not valid');
-      });
+      await userEvent.type(phoneNumber, '513-555-1234');
+      expect(phoneNumber.validationMessage).to.equal('Phone number is not valid');
     });
   });
 

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -120,8 +120,13 @@ module Idv
     end
 
     def extra_analytics_attributes
+      parsed_phone = Phonelib.parse(applicant[:phone])
+
       {
         vendor: idv_result.except(:errors, :success),
+        area_code: parsed_phone.area_code,
+        country_code: parsed_phone.country,
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
       }
     end
 

--- a/app/services/phone_country_codes.rb
+++ b/app/services/phone_country_codes.rb
@@ -1,0 +1,3 @@
+class PhoneCountryCodes
+  US_AND_US_TERRITORY_CODES = ['AS', 'GU', 'MP', 'PR', 'US', 'VI']
+end

--- a/app/services/phone_country_codes.rb
+++ b/app/services/phone_country_codes.rb
@@ -1,3 +1,0 @@
-class PhoneCountryCodes
-  US_AND_US_TERRITORY_CODES = ['AS', 'GU', 'MP', 'PR', 'US', 'VI']
-end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -6,6 +6,7 @@ class PhoneNumberCapabilities
   end
 
   INTERNATIONAL_CODES = load_config.freeze
+  US_AND_US_TERRITORY_CODES = ['AS', 'GU', 'MP', 'PR', 'US', 'VI']
 
   attr_reader :phone, :phone_confirmed
 

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -6,7 +6,8 @@ class PhoneNumberCapabilities
   end
 
   INTERNATIONAL_CODES = load_config.freeze
-  US_AND_US_TERRITORY_CODES = ['AS', 'GU', 'MP', 'PR', 'US', 'VI']
+  ADDRESS_IDENTITY_PROOFING_SUPPORTED_COUNTRY_CODES =
+    IdentityConfig.store.address_identity_proofing_supported_country_codes
 
   attr_reader :phone, :phone_confirmed
 

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -24,7 +24,7 @@
     ) do |f| %>
 
   <fieldset class="margin-bottom-4 padding-0 border-0">
-    <% if @phone_number_capabilities.supports_sms? %>
+    <% if phone_number_capabilities.supports_sms? %>
       <%= radio_button_tag(
             'otp_delivery_preference',
             :sms,
@@ -40,7 +40,7 @@
       </label>
     <% end %>
 
-    <% if @phone_number_capabilities.supports_voice? %>
+    <% if phone_number_capabilities.supports_voice? %>
       <%= radio_button_tag(
             'otp_delivery_preference',
             :voice,

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -24,7 +24,7 @@
     ) do |f| %>
 
   <fieldset class="margin-bottom-4 padding-0 border-0">
-    <% if @phone_number_capabilities.supports?(:sms) %>
+    <% if @phone_number_capabilities.supports_sms? %>
       <%= radio_button_tag(
             'otp_delivery_preference',
             :sms,
@@ -40,7 +40,7 @@
       </label>
     <% end %>
 
-    <% if @phone_number_capabilities.supports?(:voice) %>
+    <% if @phone_number_capabilities.supports_voice? %>
       <%= radio_button_tag(
             'otp_delivery_preference',
             :voice,

--- a/app/views/idv/otp_delivery_method/new.html.erb
+++ b/app/views/idv/otp_delivery_method/new.html.erb
@@ -24,33 +24,37 @@
     ) do |f| %>
 
   <fieldset class="margin-bottom-4 padding-0 border-0">
-    <%= radio_button_tag(
-          'otp_delivery_preference',
-          :sms,
-          false,
-          disabled: VendorStatus.new.vendor_outage?(:sms),
-          class: 'usa-radio__input usa-radio__input--tile',
-        ) %>
-    <label for="otp_delivery_preference_sms" class="usa-radio__label">
-      <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
-      <span class="usa-radio__label-description">
-        <%= t('two_factor_authentication.two_factor_choice_options.sms_info') %>
-      </span>
-    </label>
+    <% if @phone_number_capabilities.supports?(:sms) %>
+      <%= radio_button_tag(
+            'otp_delivery_preference',
+            :sms,
+            false,
+            disabled: VendorStatus.new.vendor_outage?(:sms),
+            class: 'usa-radio__input usa-radio__input--tile',
+          ) %>
+      <label for="otp_delivery_preference_sms" class="usa-radio__label">
+        <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
+        <span class="usa-radio__label-description">
+          <%= t('two_factor_authentication.two_factor_choice_options.sms_info') %>
+        </span>
+      </label>
+    <% end %>
 
-    <%= radio_button_tag(
-          'otp_delivery_preference',
-          :voice,
-          false,
-          disabled: VendorStatus.new.vendor_outage?(:voice),
-          class: 'usa-radio__input usa-radio__input--tile',
-        ) %>
-    <label for="otp_delivery_preference_voice" class="usa-radio__label">
-      <%= t('two_factor_authentication.otp_delivery_preference.voice') %>
-      <span class="usa-radio__label-description">
-        <%= t('two_factor_authentication.two_factor_choice_options.voice_info') %>
-      </span>
-    </label>
+    <% if @phone_number_capabilities.supports?(:voice) %>
+      <%= radio_button_tag(
+            'otp_delivery_preference',
+            :voice,
+            false,
+            disabled: VendorStatus.new.vendor_outage?(:voice),
+            class: 'usa-radio__input usa-radio__input--tile',
+          ) %>
+      <label for="otp_delivery_preference_voice" class="usa-radio__label">
+        <%= t('two_factor_authentication.otp_delivery_preference.voice') %>
+        <span class="usa-radio__label-description">
+          <%= t('two_factor_authentication.two_factor_choice_options.voice_info') %>
+        </span>
+      </label>
+    <% end %>
   </fieldset>
   <div class="margin-y-5">
     <%= submit_tag(t('idv.buttons.send_confirmation_code'), class: 'usa-button usa-button--big usa-button--wide') %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -56,7 +56,7 @@
     ) do |f| %>
   <%= render PhoneInputComponent.new(
         form: f,
-        allowed_countries: ['US'],
+        allowed_countries: @idv_form.allowed_countries,
         required: true,
         class: 'margin-bottom-4',
       ) %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,6 +41,7 @@ acuant_upload_image_timeout: 1.0
 acuant_get_results_timeout: 1.0
 acuant_create_document_timeout: 1.0
 add_email_link_valid_for_hours: 24
+address_identity_proofing_supported_country_codes: '["AS", "GU", "MP", "PR", "US", "VI"]'
 asset_host: ''
 async_wait_timeout_seconds: 60
 async_stale_job_timeout_seconds: 300

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -75,7 +75,6 @@ en:
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
       phone_confirmation_throttled: You tried too many times, please try again in %{timeout}.
-      phone_country_constraint_usa: Must be a U.S. phone number
       phone_duplicate: This account is already using the phone number you entered as
         an authenticator. Please use a different phone number.
       phone_required: Phone number is required

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -67,8 +67,6 @@ en:
       invalid_voice_number: Invalid phone number. Check that you’ve entered the
         correct country code or area code.
       missing_field: Please fill in this field.
-      must_have_us_country_code: Invalid phone number. Please make sure you enter a
-        phone number with a U.S. country code.
       no_pending_profile: No profile is waiting for verification
       not_a_number: is not a number
       otp_failed: Your security code failed to send.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -69,8 +69,6 @@ es:
       invalid_voice_number: Numero de telefono invalido. Verifique que haya ingresado
         el código de país o de área correcto.
       missing_field: Por favor, rellene este campo.
-      must_have_us_country_code: Número de teléfono no válido. Asegúrate de introducir
-        un número de teléfono con un código país de EE. UU.
       no_pending_profile: Ningún perfil está esperando verificación
       not_a_number: no es un número
       otp_failed: Se produjo un error al enviar el código de seguridad.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -77,7 +77,6 @@ es:
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
       phone_confirmation_throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
-      phone_country_constraint_usa: Debe ser un número telefónico de los Estados Unidos
       phone_duplicate: Esta cuenta ya está utilizando el número de teléfono que
         ingresó como autenticador. Por favor, use un número de teléfono
         diferente.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -76,8 +76,6 @@ fr:
       invalid_voice_number: Numéro de téléphone invalide. Vérifiez que vous avez entré
         le bon indicatif international ou régional.
       missing_field: Veuillez remplir ce champ.
-      must_have_us_country_code: Numéro de téléphone non valide. Veuillez vous assurer
-        de saisir un numéro de téléphone avec un code pays des États-Unis.
       no_pending_profile: Aucun profil en attente de vérification
       not_a_number: N’est pas un nombre
       otp_failed: Échec de l’envoi de votre code de sécurité.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -84,7 +84,6 @@ fr:
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
       phone_confirmation_throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
-      phone_country_constraint_usa: Dois être un numéro de téléphone américain
       phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez
         entré en tant qu’authentificateur. Veuillez utiliser un numéro de
         téléphone différent.

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -100,6 +100,7 @@ class IdentityConfig
     config.add(:acuant_get_results_timeout, type: :float)
     config.add(:acuant_create_document_timeout, type: :float)
     config.add(:add_email_link_valid_for_hours, type: :integer)
+    config.add(:address_identity_proofing_supported_country_codes, type: :json)
     config.add(:asset_host, type: :string)
     config.add(:async_wait_timeout_seconds, type: :integer)
     config.add(:async_stale_job_timeout_seconds, type: :integer)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -314,6 +314,7 @@ describe Idv::PhoneController do
       end
 
       it 'tracks event with valid phone' do
+        proofing_phone = Phonelib.parse(good_phone)
         user = build(:user, with: { phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now })
         stub_verify_steps_one_and_two(user)
 
@@ -324,6 +325,9 @@ describe Idv::PhoneController do
           success: true,
           new_phone_added: true,
           errors: {},
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+          country_code: proofing_phone.country,
+          area_code: proofing_phone.area_code,
           pii_like_keypaths: [[:errors, :phone], [:context, :stages, :address]],
           vendor: {
             vendor_name: 'AddressMock',
@@ -362,6 +366,7 @@ describe Idv::PhoneController do
       end
 
       it 'tracks event with invalid phone' do
+        proofing_phone = Phonelib.parse(bad_phone)
         user = build(:user, with: { phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now })
         stub_verify_steps_one_and_two(user)
 
@@ -371,6 +376,9 @@ describe Idv::PhoneController do
         result = {
           success: false,
           new_phone_added: true,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+          country_code: proofing_phone.country,
+          area_code: proofing_phone.area_code,
           errors: {
             phone: ['The phone number could not be verified.'],
           },

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -143,14 +143,14 @@ describe Idv::PhoneController do
       it 'renders #new' do
         put :create, params: { idv_phone_form: { phone: '703' } }
 
-        expect(flash[:error]).to eq t('errors.messages.must_have_us_country_code')
+        expect(flash[:error]).to eq t('errors.messages.improbable_phone')
         expect(response).to render_template(:new)
       end
 
       it 'disallows non-US numbers' do
         put :create, params: { idv_phone_form: { phone: international_phone } }
 
-        expect(flash[:error]).to eq t('errors.messages.must_have_us_country_code')
+        expect(flash[:error]).to eq t('errors.messages.improbable_phone')
         expect(response).to render_template(:new)
       end
 
@@ -162,10 +162,10 @@ describe Idv::PhoneController do
         result = {
           success: false,
           errors: {
-            phone: [t('errors.messages.must_have_us_country_code')],
+            phone: [t('errors.messages.improbable_phone')],
           },
           error_details: {
-            phone: [:must_have_us_country_code],
+            phone: [:improbable_phone],
           },
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
           country_code: nil,
@@ -189,7 +189,7 @@ describe Idv::PhoneController do
           success: false,
           phone_number: '703',
           failure_reason: {
-            phone: [t('errors.messages.must_have_us_country_code')],
+            phone: [t('errors.messages.improbable_phone')],
           },
         )
       end

--- a/spec/features/idv/steps/phone_otp_delivery_selection_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_delivery_selection_step_spec.rb
@@ -71,7 +71,7 @@ feature 'IdV phone OTP delivery method selection', :js do
 
     it 'displays an error message' do
       expect(Telephony).to_not receive(:send_confirmation_otp)
-      expect(page).to have_content(t('errors.messages.phone_country_constraint_usa'))
+      expect(page).to have_content(t('errors.messages.invalid_phone_number'))
       expect(current_path).to eq(idv_phone_path)
     end
   end

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -169,7 +169,7 @@ describe Idv::PhoneForm do
 
         it 'is valid' do
           expect(result.success?).to eq(true)
-          expect(result.errors).to eq([])
+          expect(result.errors).to eq({})
         end
       end
 

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -89,7 +89,7 @@ describe Idv::PhoneForm do
     end
 
     context 'with specific allowed countries' do
-      let(:allowed_countries) { ['MP'] }
+      let(:allowed_countries) { ['MP', 'US'] }
 
       it 'validates to only allow numbers from permitted countries' do
         invalid_phones = ['+81 54 354 3643', '+12423270143']

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -116,7 +116,7 @@ describe Idv::PhoneForm do
             result = subject.submit(phone: phone)
 
             expect(result.success?).to eq(false)
-            expect(result.errors[:phone]).to include(t('errors.messages.must_have_us_country_code'))
+            expect(result.errors[:phone]).to include(t('errors.messages.improbable_phone'))
           end
           valid_phones = ['7035551234']
           valid_phones.each do |phone|

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -154,5 +154,44 @@ describe Idv::PhoneForm do
         end
       end
     end
+
+    context 'with unsupported delivery method' do
+      let(:unsupported_delivery_methods) { [] }
+      let(:result) { subject.submit(params) }
+
+      before do
+        allow(subject).to receive(:unsupported_delivery_methods).
+          and_return(unsupported_delivery_methods)
+      end
+
+      context 'with one unsupported delivery method' do
+        let(:unsupported_delivery_methods) { [:sms] }
+
+        it 'is valid' do
+          expect(result.success?).to eq(true)
+          expect(result.errors).to eq([])
+        end
+      end
+
+      context 'with all delivery methods unsupported' do
+        let(:unsupported_delivery_methods) { [:sms, :voice] }
+
+        it 'is invalid' do
+          expect(result.success?).to eq(false)
+          expect(result.errors).to eq(
+            phone: [
+              t(
+                'two_factor_authentication.otp_delivery_preference.sms_unsupported',
+                location: 'United States',
+              ),
+              t(
+                'two_factor_authentication.otp_delivery_preference.voice_unsupported',
+                location: 'United States',
+              ),
+            ],
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -49,7 +49,11 @@ describe Idv::PhoneStep do
     let(:throttle) { Throttle.new(throttle_type: :proof_address, user: user) }
 
     it 'succeeds with good params' do
+      proofing_phone = Phonelib.parse(good_phone)
       extra = {
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+        country_code: proofing_phone.country,
+        area_code: proofing_phone.area_code,
         vendor: {
           vendor_name: 'AddressMock',
           exception: nil,
@@ -78,7 +82,11 @@ describe Idv::PhoneStep do
     end
 
     it 'fails with bad params' do
+      proofing_phone = Phonelib.parse(bad_phone)
       extra = {
+        phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+        country_code: proofing_phone.country,
+        area_code: proofing_phone.area_code,
         vendor: {
           vendor_name: 'AddressMock',
           exception: nil,

--- a/spec/views/idv/otp_delivery_method/new.html.erb_spec.rb
+++ b/spec/views/idv/otp_delivery_method/new.html.erb_spec.rb
@@ -3,12 +3,20 @@ require 'rails_helper'
 describe 'idv/otp_delivery_method/new.html.erb' do
   let(:gpo_letter_available) { false }
   let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS }
+  let(:supports_sms) { true }
+  let(:supports_voice) { true }
 
   before do
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
     allow(view).to receive(:gpo_letter_available).and_return(gpo_letter_available)
     allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
+
+    @phone_number_capabilities = instance_double(
+      PhoneNumberCapabilities,
+      supports_sms?: supports_sms,
+      supports_voice?: supports_voice,
+    )
   end
 
   subject(:rendered) { render template: 'idv/otp_delivery_method/new' }
@@ -44,6 +52,29 @@ describe 'idv/otp_delivery_method/new.html.erb' do
     it 'disables problematic vendor option' do
       expect(rendered).to have_field('otp_delivery_preference', with: :voice, disabled: false)
       expect(rendered).to have_field('otp_delivery_preference', with: :sms, disabled: true)
+    end
+  end
+
+  it 'renders sms and voice options' do
+    expect(rendered).to have_field('otp_delivery_preference', with: :voice)
+    expect(rendered).to have_field('otp_delivery_preference', with: :sms)
+  end
+
+  context 'without sms support' do
+    let(:supports_sms) { false }
+
+    it 'renders voice option' do
+      expect(rendered).to have_field('otp_delivery_preference', with: :voice)
+      expect(rendered).not_to have_field('otp_delivery_preference', with: :sms)
+    end
+  end
+
+  context 'without voice support' do
+    let(:supports_voice) { false }
+
+    it 'renders sms option' do
+      expect(rendered).not_to have_field('otp_delivery_preference', with: :voice)
+      expect(rendered).to have_field('otp_delivery_preference', with: :sms)
     end
   end
 end

--- a/spec/views/idv/otp_delivery_method/new.html.erb_spec.rb
+++ b/spec/views/idv/otp_delivery_method/new.html.erb_spec.rb
@@ -7,16 +7,17 @@ describe 'idv/otp_delivery_method/new.html.erb' do
   let(:supports_voice) { true }
 
   before do
-    allow(view).to receive(:user_signing_up?).and_return(false)
-    allow(view).to receive(:user_fully_authenticated?).and_return(true)
-    allow(view).to receive(:gpo_letter_available).and_return(gpo_letter_available)
-    allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
-
-    @phone_number_capabilities = instance_double(
+    phone_number_capabilities = instance_double(
       PhoneNumberCapabilities,
       supports_sms?: supports_sms,
       supports_voice?: supports_voice,
     )
+
+    allow(view).to receive(:phone_number_capabilities).and_return(phone_number_capabilities)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    allow(view).to receive(:user_fully_authenticated?).and_return(true)
+    allow(view).to receive(:gpo_letter_available).and_return(gpo_letter_available)
+    allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
   end
 
   subject(:rendered) { render template: 'idv/otp_delivery_method/new' }


### PR DESCRIPTION
**Why:** Since the restriction for phone step is based on the assumption that address verification is only supported for U.S. numbers, and U.S. numbers should include U.S. territories.

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/191830598-2c00deab-0241-4ccc-b3ed-44149103e205.png)|![image](https://user-images.githubusercontent.com/1779930/191830380-30a3f3cc-80c3-4c5e-b758-04ce26334e2c.png)

**Testing Instructions:**

Confirm that you can use a U.S. mainland phone number or a U.S. territory phone number at the "Phone" step of the identity verification flow, and not another international phone number.

Sample phone numbers:

- U.S. mainland: `5135551234`
- Puerto Rico: `9395550137`
- Canada: `3065551234`

Steps:

1. Navigate to http://localhost:3000
2. Sign in or create an account
3. Navigate to http://localhost:3000/verify
4. Complete proofing process up to "Enter a phone number with your name on the plan"
5. Enter a phone number and click Continue
6. Observe there is no validation preventing you from continuing to delivery method selection, unless using a non-U.S. number
7. Observe that only applicable delivery methods are shown for delivery method selection (i.e. only SMS for Puerto Rico)

**Context:**

- https://gsa-tts.slack.com/archives/C20J64X6V/p1663859825583259
- https://gsa-tts.slack.com/archives/CNCGEHG1G/p1663859909800979