### PR TITLE
Confirm OIDC logout when using client_id parameter (LG-7629)

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -20,7 +20,7 @@ module OpenidConnect
       )
 
       if result.success? && (redirect_uri = result.extra[:redirect_uri])
-        handle_successful_logout_request(params, redirect_uri)
+        handle_successful_logout_request(redirect_uri)
       else
         render :error
       end
@@ -44,7 +44,7 @@ module OpenidConnect
     end
 
     def handle_successful_logout_request(redirect_uri)
-      if logout_params[:client_id] && logout_params[:id_token_hint].nil?
+      if logout_params[:client_id] && logout_params[:id_token_hint].nil? && current_user
         @client_id = logout_params[:client_id]
         @state = logout_params[:state]
         @post_logout_redirect_uri = logout_params[:post_logout_redirect_uri]

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -12,10 +12,7 @@ module OpenidConnect
     before_action :confirm_two_factor_authenticated, only: [:delete]
 
     def index
-      @logout_form = OpenidConnectLogoutForm.new(
-        params: logout_params,
-        current_user: current_user,
-      )
+      @logout_form = build_logout_form
 
       result = @logout_form.submit
 
@@ -32,10 +29,7 @@ module OpenidConnect
     end
 
     def delete
-      @logout_form = OpenidConnectLogoutForm.new(
-        params: logout_params,
-        current_user: current_user,
-      )
+      @logout_form = build_logout_form
       result = @logout_form.submit
       if result.success? && (redirect_uri = result.extra[:redirect_uri])
         sign_out
@@ -46,6 +40,15 @@ module OpenidConnect
       else
         render :error
       end
+    end
+
+    private
+
+    def build_logout_form
+      OpenidConnectLogoutForm.new(
+        params: logout_params,
+        current_user: current_user,
+      )
     end
 
     def handle_successful_logout_request(redirect_uri)

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -43,7 +43,7 @@ module OpenidConnect
       end
     end
 
-    def handle_successful_logout_request(params, redirect_uri)
+    def handle_successful_logout_request(redirect_uri)
       if logout_params[:client_id] && logout_params[:id_token_hint].nil?
         @client_id = logout_params[:client_id]
         @state = logout_params[:state]
@@ -73,7 +73,9 @@ module OpenidConnect
     end
 
     def render_404_if_disabled
-      render_not_found unless IdentityConfig.store.accept_client_id_in_oidc_logout || IdentityConfig.store.reject_id_token_hint_in_logout
+      unless IdentityConfig.store.accept_client_id_in_oidc_logout || IdentityConfig.store.reject_id_token_hint_in_logout
+        render_not_found
+      end
     end
   end
 end

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -15,14 +15,10 @@ module OpenidConnect
       @logout_form = build_logout_form
 
       result = @logout_form.submit
+      analytics.oidc_logout_requested(**result.to_h.except(:redirect_uri))
 
-      analytics.logout_initiated(**result.to_h.except(:redirect_uri))
-      irs_attempts_api_tracker.logout_initiated(
-        success: result.success?,
-      )
-
-      if result.success? && (redirect_uri = result.extra[:redirect_uri])
-        handle_successful_logout_request(redirect_uri)
+      if result.success? && result.extra[:redirect_uri]
+        handle_successful_logout_request(result, result.extra[:redirect_uri])
       else
         render :error
       end
@@ -31,7 +27,13 @@ module OpenidConnect
     def delete
       @logout_form = build_logout_form
       result = @logout_form.submit
+
+      analytics.oidc_logout_submitted(**result.to_h.except(:redirect_uri))
+
       if result.success? && (redirect_uri = result.extra[:redirect_uri])
+        analytics.logout_initiated(**result.to_h.except(:redirect_uri))
+        irs_attempts_api_tracker.logout_initiated(success: result.success?)
+
         sign_out
         redirect_to(
           redirect_uri,
@@ -44,6 +46,12 @@ module OpenidConnect
 
     private
 
+    def require_logout_confirmation?
+      (logout_params[:id_token_hint].nil? || IdentityConfig.store.reject_id_token_hint_in_logout) &&
+        logout_params[:client_id] &&
+        current_user
+    end
+
     def build_logout_form
       OpenidConnectLogoutForm.new(
         params: logout_params,
@@ -51,13 +59,17 @@ module OpenidConnect
       )
     end
 
-    def handle_successful_logout_request(redirect_uri)
-      if logout_params[:client_id] && logout_params[:id_token_hint].nil? && current_user
+    def handle_successful_logout_request(result, redirect_uri)
+      if require_logout_confirmation?
+        analytics.oidc_logout_visited(**result.to_h.except(:redirect_uri))
         @client_id = logout_params[:client_id]
         @state = logout_params[:state]
         @post_logout_redirect_uri = logout_params[:post_logout_redirect_uri]
         render :index
       else
+        analytics.logout_initiated(**result.to_h.except(:redirect_uri))
+        irs_attempts_api_tracker.logout_initiated(success: result.success?)
+
         sign_out
         redirect_to(
           redirect_uri,

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -53,17 +53,6 @@ class OpenidConnectLogoutForm
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
 
-  # Used by RedirectUriValidator
-  def service_provider
-    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
-
-    if reject_id_token_hint?
-      sp_from_client_id
-    else
-      identity&.service_provider_record || sp_from_client_id
-    end
-  end
-
   private
 
   attr_reader :identity, :success
@@ -131,6 +120,17 @@ class OpenidConnectLogoutForm
         :id_token_hint, t('openid_connect.logout.errors.id_token_hint'),
         type: :id_token_hint
       )
+    end
+  end
+
+  # Used by RedirectUriValidator
+  def service_provider
+    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
+
+    if reject_id_token_hint?
+      sp_from_client_id
+    else
+      identity&.service_provider_record || sp_from_client_id
     end
   end
 

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -53,6 +53,17 @@ class OpenidConnectLogoutForm
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
 
+  # Used by RedirectUriValidator
+  def service_provider
+    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
+
+    if reject_id_token_hint?
+      sp_from_client_id
+    else
+      identity&.service_provider_record || sp_from_client_id
+    end
+  end
+
   private
 
   attr_reader :identity, :success
@@ -120,17 +131,6 @@ class OpenidConnectLogoutForm
         :id_token_hint, t('openid_connect.logout.errors.id_token_hint'),
         type: :id_token_hint
       )
-    end
-  end
-
-  # Used by RedirectUriValidator
-  def service_provider
-    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
-
-    if reject_id_token_hint?
-      sp_from_client_id
-    else
-      identity&.service_provider_record || sp_from_client_id
     end
   end
 

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -136,6 +136,8 @@ class OpenidConnectLogoutForm
 
   def extra_analytics_attributes
     {
+      client_id_parameter_present: client_id.present?,
+      id_token_hint_parameter_present: id_token_hint.present?,
       client_id: service_provider&.issuer,
       redirect_uri: redirect_uri,
       sp_initiated: true,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1135,6 +1135,8 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
   # @param [Boolean] sp_initiated
   # @param [Boolean] oidc
   # @param [Boolean] saml_request_valid
@@ -1147,6 +1149,8 @@ module AnalyticsEvents
     client_id: nil,
     sp_initiated: nil,
     oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
     saml_request_valid: nil,
     errors: nil,
     error_details: nil,
@@ -1157,6 +1161,128 @@ module AnalyticsEvents
       'Logout Initiated',
       success: success,
       client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Requested
+  def oidc_logout_requested(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Requested',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Visited
+  def oidc_logout_visited(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Page Visited',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Submitted
+  def oidc_logout_submitted(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Submitted',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
       errors: errors,
       error_details: error_details,
       sp_initiated: sp_initiated,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
 
 <% if decorated_session.sp_name %>
   <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>
+    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '91') %>
 
     <%= render decorated_session.registration_heading %>
   </div>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -5,20 +5,15 @@
   <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
 </div>
 
-<div class='sm-left-align'>
-  <div class='margin-top-5 text-center'>
-    <%= button_to(
-          openid_connect_logout_path,
-          params: {
-            client_id: @client_id,
-            state: @state,
-            post_logout_redirect_uri: @post_logout_redirect_uri,
-          },
-          method: :delete,
-          class: 'usa-button usa-button--big usa-button usa-button--full-width',
-        ) { t('openid_connect.logout.confirm', app_name: APP_NAME) } %>
-  </div>
-  <div class='margin-top-2 text-center'>
-    <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>
-  </div>
-</div>
+<%= button_to(
+      openid_connect_logout_path,
+      params: {
+        client_id: @client_id,
+        state: @state,
+        post_logout_redirect_uri: @post_logout_redirect_uri,
+      },
+      method: :delete,
+      form_class: 'margin-top-5 margin-bottom-2',
+      class: 'usa-button usa-button--big usa-button usa-button--full-width',
+    ) { t('openid_connect.logout.confirm', app_name: APP_NAME) } %>
+<%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -8,15 +8,15 @@
 <div class='sm-left-align'>
   <div class='margin-top-5 text-center'>
     <%= button_to(
-      openid_connect_logout_path,
-      params: {
-        client_id: @client_id,
-        state: @state,
-        post_logout_redirect_uri: @post_logout_redirect_uri,
-      },
-      method: :delete,
-      class: 'usa-button usa-button--big usa-button usa-button--full-width'
-    ) { t('openid_connect.logout.confirm') } %>
+          openid_connect_logout_path,
+          params: {
+            client_id: @client_id,
+            state: @state,
+            post_logout_redirect_uri: @post_logout_redirect_uri,
+          },
+          method: :delete,
+          class: 'usa-button usa-button--big usa-button usa-button--full-width',
+        ) { t('openid_connect.logout.confirm') } %>
   </div>
   <div class='margin-top-2 text-center'>
     <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,8 +1,8 @@
-<% title t('openid_connect.logout.heading') %>
+<% title t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>
-  <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading')) %>
+  <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
 </div>
 
 <div class='sm-left-align'>
@@ -16,7 +16,7 @@
           },
           method: :delete,
           class: 'usa-button usa-button--big usa-button usa-button--full-width',
-        ) { t('openid_connect.logout.confirm') } %>
+        ) { t('openid_connect.logout.confirm', app_name: APP_NAME) } %>
   </div>
   <div class='margin-top-2 text-center'>
     <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,0 +1,24 @@
+<% title t('titles.logout') %>
+
+<div class='text-center'>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>
+  <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading')) %>
+</div>
+
+<div class='sm-left-align'>
+  <div class='margin-top-5 text-center'>
+    <%= button_to(
+      openid_connect_logout_path,
+      params: {
+        client_id: @client_id,
+        state: @state,
+        post_logout_redirect_uri: @post_logout_redirect_uri,
+      },
+      method: :delete,
+      class: 'usa-button usa-button--big usa-button usa-button--full-width'
+    ) { t('openid_connect.logout.confirm') } %>
+  </div>
+  <div class='margin-top-2 text-center'>
+    <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>
+  </div>
+</div>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,7 +1,7 @@
 <% title t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
-  <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
   <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
 </div>
 

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.logout') %>
+<% title t('openid_connect.logout.heading') %>
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -2,7 +2,7 @@
 
 <% if decorated_session.sp_name %>
   <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '') %>
+    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '91') %>
 
     <%= render decorated_session.registration_heading %>
   </div>

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -18,6 +18,10 @@ en:
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
         unauthorized_scope: Unauthorized scope
     logout:
+      description: Testing
+      heading: Do you want to sign out of Login.gov?
+      confirm: Yes, sign out of Login.gov
+      deny: No, go to my account page
       errors:
         client_id_invalid: client_id was not recognized
         client_id_missing: client_id is missing

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -18,8 +18,6 @@ en:
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
         unauthorized_scope: Unauthorized scope
     logout:
-      description: Testing
-      heading: Do you want to sign out of Login.gov?
       confirm: Yes, sign out of Login.gov
       deny: No, go to my account page
       errors:
@@ -30,6 +28,7 @@ en:
           sending id_token_hint. Please send client_id instead.
         no_client_id_or_id_token_hint: This application is misconfigured and must send
           either client_id or id_token_hint.
+      heading: Do you want to sign out of Login.gov?
     token:
       errors:
         expired_code: is expired

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -18,7 +18,7 @@ en:
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
         unauthorized_scope: Unauthorized scope
     logout:
-      confirm: Yes, sign out of Login.gov
+      confirm: Yes, sign out of %{app_name}
       deny: No, go to my account page
       errors:
         client_id_invalid: client_id was not recognized
@@ -28,7 +28,7 @@ en:
           sending id_token_hint. Please send client_id instead.
         no_client_id_or_id_token_hint: This application is misconfigured and must send
           either client_id or id_token_hint.
-      heading: Do you want to sign out of Login.gov?
+      heading: Do you want to sign out of %{app_name}?
     token:
       errors:
         expired_code: is expired

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -18,7 +18,7 @@ es:
         redirect_uri_no_match: Redirect_uri no coincide con redirect_uri registrado
         unauthorized_scope: Alcance no autorizado
     logout:
-      confirm: Sí, cerrar sesión en Login.gov
+      confirm: Sí, cerrar sesión en %{app_name}
       deny: No, ir a la página de mi cuenta
       errors:
         client_id_invalid: client_id no fue reconocido
@@ -28,7 +28,7 @@ es:
           id_token_hint. Por favor, envíe client_id en su lugar.
         no_client_id_or_id_token_hint: Esta aplicación está mal configurada y debe
           enviar client_id o id_token_hint.
-      heading: ¿Quieres cerrar sesión en Login.gov?
+      heading: ¿Quieres cerrar sesión en %{app_name}?
     token:
       errors:
         expired_code: ha expirado

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -18,6 +18,8 @@ es:
         redirect_uri_no_match: Redirect_uri no coincide con redirect_uri registrado
         unauthorized_scope: Alcance no autorizado
     logout:
+      confirm: Sí, cerrar sesión en Login.gov
+      deny: No, ir a la página de mi cuenta
       errors:
         client_id_invalid: client_id no fue reconocido
         client_id_missing: falta client_id
@@ -26,6 +28,7 @@ es:
           id_token_hint. Por favor, envíe client_id en su lugar.
         no_client_id_or_id_token_hint: Esta aplicación está mal configurada y debe
           enviar client_id o id_token_hint.
+      heading: ¿Quieres cerrar sesión en Login.gov?
     token:
       errors:
         expired_code: ha expirado

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -18,6 +18,8 @@ fr:
         redirect_uri_no_match: redirect_uri ne correspond pas au redirect_uri enregistré
         unauthorized_scope: Portée non autorisée
     logout:
+      confirm: Oui, déconnectez-vous de Login.gov
+      deny: Non, allez sur la page de mon compte
       errors:
         client_id_invalid: client_id n’a pas été reconnu
         client_id_missing: client_id est manquant
@@ -26,6 +28,7 @@ fr:
           envoyer id_token_hint. Veuillez envoyer client_id à la place.
         no_client_id_or_id_token_hint: Cette application est mal configurée et doit
           envoyer client_id ou id_token_hint.
+      heading: Voulez-vous vous déconnecter de Login.gov?
     token:
       errors:
         expired_code: est expiré

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -18,7 +18,7 @@ fr:
         redirect_uri_no_match: redirect_uri ne correspond pas au redirect_uri enregistré
         unauthorized_scope: Portée non autorisée
     logout:
-      confirm: Oui, déconnectez-vous de Login.gov
+      confirm: Oui, déconnectez-vous de %{app_name}
       deny: Non, allez sur la page de mon compte
       errors:
         client_id_invalid: client_id n’a pas été reconnu
@@ -28,7 +28,7 @@ fr:
           envoyer id_token_hint. Veuillez envoyer client_id à la place.
         no_client_id_or_id_token_hint: Cette application est mal configurée et doit
           envoyer client_id ou id_token_hint.
-      heading: Voulez-vous vous déconnecter de Login.gov?
+      heading: Voulez-vous vous déconnecter de %{app_name}?
     token:
       errors:
         expired_code: est expiré

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -47,7 +47,6 @@ en:
     no_auth_option: No sign-in method found
     openid_connect:
       authorization: OpenID Connect Authorization
-      logout: OpenID Connect Logout
     passwords:
       change: Change the password for your account
       confirm: Confirm the password for your account

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -40,13 +40,13 @@ en:
       reset_password: Reset Password
       review: Re-enter your password
       verify_info: Verify your information
-    logout: Sign out
     mfa_setup:
       suggest_second_mfa: You’ve added your first authentication method! Add a second
         method as a backup.
     no_auth_option: No sign-in method found
     openid_connect:
       authorization: OpenID Connect Authorization
+      logout: OpenID Connect Logout
     passwords:
       change: Change the password for your account
       confirm: Confirm the password for your account

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -40,6 +40,7 @@ en:
       reset_password: Reset Password
       review: Re-enter your password
       verify_info: Verify your information
+    logout: Sign out
     mfa_setup:
       suggest_second_mfa: You’ve added your first authentication method! Add a second
         method as a backup.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   get '/openid_connect/logout' => 'openid_connect/logout#index'
+  delete '/openid_connect/logout' => 'openid_connect/logout#delete'
 
   get '/no_js/detect.css' => 'no_js#index', as: :no_js_detect_css
 
@@ -192,8 +193,6 @@ Rails.application.routes.draw do
 
     get '/rules_of_use' => 'users/rules_of_use#new'
     post '/rules_of_use' => 'users/rules_of_use#create'
-
-    delete '/openid_connect/logout' => 'openid_connect/logout#delete'
 
     get '/piv_cac' => 'users/piv_cac_authentication_setup#new', as: :setup_piv_cac
     get '/piv_cac_error' => 'users/piv_cac_authentication_setup#error', as: :setup_piv_cac_error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,6 +193,8 @@ Rails.application.routes.draw do
     get '/rules_of_use' => 'users/rules_of_use#new'
     post '/rules_of_use' => 'users/rules_of_use#create'
 
+    delete '/openid_connect/logout' => 'openid_connect/logout#delete'
+
     get '/piv_cac' => 'users/piv_cac_authentication_setup#new', as: :setup_piv_cac
     get '/piv_cac_error' => 'users/piv_cac_authentication_setup#error', as: :setup_piv_cac_error
     delete '/piv_cac' => 'users/piv_cac_authentication_setup#delete', as: :disable_piv_cac

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -199,20 +199,22 @@ RSpec.describe OpenidConnect::LogoutController do
                  state: state,
                }
       end
-      context 'returns 404' do
-        before { sign_in user }
-        it 'destroys the session' do
-          action
+      context 'when sending client_id' do
+        context 'user is signed in' do
+          before { sign_in user }
+          it 'returns 404' do
+            action
 
-          expect(response).to be_not_found
+            expect(response).to be_not_found
+          end
         end
-      end
 
-      context 'returns 404' do
-        it 'destroys the session' do
-          action
+        context 'user is not signed in' do
+          it 'returns 404' do
+            action
 
-          expect(response).to be_not_found
+            expect(response).to be_not_found
+          end
         end
       end
     end
@@ -457,7 +459,7 @@ RSpec.describe OpenidConnect::LogoutController do
     end
 
     describe '#delete' do
-      context 'when sending id_token_hint' do
+      context 'when sending client_id' do
         subject(:action) do
           delete :delete,
                  params: {
@@ -466,12 +468,13 @@ RSpec.describe OpenidConnect::LogoutController do
                    state: state,
                  }
         end
+
         context 'user is signed in' do
           before { stub_sign_in(user) }
           it 'destroys the session' do
             action
 
-            expect(response).to be_not_found
+            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
         end
 
@@ -479,7 +482,36 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'destroys the session' do
             action
 
-            expect(response).to be_not_found
+            expect(response).to redirect_to(new_user_session_path)
+          end
+        end
+      end
+
+      context 'when sending id_token_hint' do
+        let(:id_token_hint) { valid_id_token_hint }
+        subject(:action) do
+          delete :delete,
+                 params: {
+                   id_token_hint: id_token_hint,
+                   post_logout_redirect_uri: post_logout_redirect_uri,
+                   state: state,
+                 }
+        end
+
+        context 'user is signed in' do
+          before { stub_sign_in(user) }
+          it 'destroys the session' do
+            action
+
+            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+          end
+        end
+
+        context 'user is not signed in' do
+          it 'destroys the session' do
+            action
+
+            expect(response).to redirect_to(new_user_session_path)
           end
         end
       end
@@ -635,6 +667,65 @@ RSpec.describe OpenidConnect::LogoutController do
           action
 
           expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+        end
+      end
+    end
+
+    describe '#delete' do
+      context 'when sending client_id' do
+        subject(:action) do
+          delete :delete,
+                 params: {
+                   client_id: service_provider,
+                   post_logout_redirect_uri: post_logout_redirect_uri,
+                   state: state,
+                 }
+        end
+
+        context 'user is signed in' do
+          before { stub_sign_in(user) }
+          it 'destroys the session' do
+            action
+
+            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+          end
+        end
+
+        context 'user is not signed in' do
+          it 'destroys the session' do
+            action
+
+            expect(response).to redirect_to(new_user_session_path)
+          end
+        end
+      end
+
+      context 'when sending id_token_hint' do
+        let(:id_token_hint) { valid_id_token_hint }
+        subject(:action) do
+          delete :delete,
+                 params: {
+                   id_token_hint: id_token_hint,
+                   post_logout_redirect_uri: post_logout_redirect_uri,
+                   state: state,
+                 }
+        end
+
+        context 'user is signed in' do
+          before { stub_sign_in(user) }
+          it 'destroys the session' do
+            action
+
+            expect(response).to render_template(:error)
+          end
+        end
+
+        context 'user is not signed in' do
+          it 'destroys the session' do
+            action
+
+            expect(response).to redirect_to(new_user_session_path)
+          end
         end
       end
     end

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is not signed in' do
-        it 'redirects back with an error' do
+        it 'redirects back to the client' do
           action
 
           expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -449,7 +449,7 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is not signed in' do
-          it 'redirects back with an error' do
+          it 'redirects back to client' do
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -663,7 +663,7 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is not signed in' do
-        it 'redirects back with an error' do
+        it 'redirects back to client' do
           action
 
           expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -193,11 +193,11 @@ RSpec.describe OpenidConnect::LogoutController do
     describe '#delete' do
       subject(:action) do
         delete :delete,
-            params: {
-              client_id: service_provider,
-              post_logout_redirect_uri: post_logout_redirect_uri,
-              state: state,
-            }
+               params: {
+                 client_id: service_provider,
+                 post_logout_redirect_uri: post_logout_redirect_uri,
+                 state: state,
+               }
       end
       context 'returns 404' do
         before { sign_in user }
@@ -460,11 +460,11 @@ RSpec.describe OpenidConnect::LogoutController do
       context 'when sending id_token_hint' do
         subject(:action) do
           delete :delete,
-            params: {
-              client_id: service_provider,
-              post_logout_redirect_uri: post_logout_redirect_uri,
-              state: state,
-            }
+                 params: {
+                   client_id: service_provider,
+                   post_logout_redirect_uri: post_logout_redirect_uri,
+                   state: state,
+                 }
         end
         context 'user is signed in' do
           before { stub_sign_in(user) }

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is signed in' do
-        before { sign_in user }
+        before { stub_sign_in(user) }
 
         context 'with valid params' do
           it 'destroys the session' do
@@ -73,10 +73,25 @@ RSpec.describe OpenidConnect::LogoutController do
             stub_analytics
             expect(@analytics).to receive(:track_event).
               with(
+                'OIDC Logout Requested',
+                hash_including(
+                  success: true,
+                  client_id: service_provider,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
+                  errors: {},
+                  sp_initiated: true,
+                  oidc: true,
+                ),
+              )
+            expect(@analytics).to receive(:track_event).
+              with(
                 'Logout Initiated',
                 hash_including(
                   success: true,
                   client_id: service_provider,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
                   errors: {},
                   sp_initiated: true,
                   oidc: true,
@@ -130,22 +145,20 @@ RSpec.describe OpenidConnect::LogoutController do
             errors = {
               redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
             }
+
             expect(@analytics).to receive(:track_event).
               with(
-                'Logout Initiated',
+                'OIDC Logout Requested',
                 success: false,
                 client_id: service_provider,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
                 errors: errors,
                 error_details: hash_including(*errors.keys),
                 sp_initiated: true,
                 oidc: true,
                 method: nil,
                 saml_request_valid: nil,
-              )
-            stub_attempts_tracker
-            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-              with(
-                success: false,
               )
 
             action
@@ -160,20 +173,17 @@ RSpec.describe OpenidConnect::LogoutController do
 
             expect(@analytics).to receive(:track_event).
               with(
-                'Logout Initiated',
+                'OIDC Logout Requested',
                 success: false,
                 client_id: nil,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
                 errors: hash_including(*errors_keys),
                 error_details: hash_including(*errors_keys),
                 sp_initiated: true,
                 oidc: true,
                 method: nil,
                 saml_request_valid: nil,
-              )
-            stub_attempts_tracker
-            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-              with(
-                success: false,
               )
 
             action
@@ -201,7 +211,7 @@ RSpec.describe OpenidConnect::LogoutController do
       end
       context 'when sending client_id' do
         context 'user is signed in' do
-          before { sign_in user }
+          before { stub_sign_in(user) }
           it 'returns 404' do
             action
 
@@ -242,7 +252,7 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is signed in' do
-          before { sign_in user }
+          before { stub_sign_in(user) }
 
           context 'with valid params' do
             it 'destroys the session' do
@@ -261,10 +271,25 @@ RSpec.describe OpenidConnect::LogoutController do
               stub_analytics
               expect(@analytics).to receive(:track_event).
                 with(
+                  'OIDC Logout Requested',
+                  hash_including(
+                    success: true,
+                    client_id: service_provider,
+                    client_id_parameter_present: false,
+                    id_token_hint_parameter_present: true,
+                    errors: {},
+                    sp_initiated: true,
+                    oidc: true,
+                  ),
+                )
+              expect(@analytics).to receive(:track_event).
+                with(
                   'Logout Initiated',
                   hash_including(
                     success: true,
                     client_id: service_provider,
+                    client_id_parameter_present: false,
+                    id_token_hint_parameter_present: true,
                     errors: {},
                     sp_initiated: true,
                     oidc: true,
@@ -303,20 +328,17 @@ RSpec.describe OpenidConnect::LogoutController do
               }
               expect(@analytics).to receive(:track_event).
                 with(
-                  'Logout Initiated',
+                  'OIDC Logout Requested',
                   success: false,
                   client_id: service_provider,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
                   errors: errors,
                   error_details: hash_including(*errors.keys),
                   sp_initiated: true,
                   oidc: true,
                   method: nil,
                   saml_request_valid: nil,
-                )
-              stub_attempts_tracker
-              expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-                with(
-                  success: false,
                 )
 
               action
@@ -331,20 +353,17 @@ RSpec.describe OpenidConnect::LogoutController do
 
               expect(@analytics).to receive(:track_event).
                 with(
-                  'Logout Initiated',
+                  'OIDC Logout Requested',
                   success: false,
                   client_id: nil,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
                   errors: hash_including(*errors_keys),
                   error_details: hash_including(*errors_keys),
                   sp_initiated: true,
                   oidc: true,
                   method: nil,
                   saml_request_valid: nil,
-                )
-              stub_attempts_tracker
-              expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-                with(
-                  success: false,
                 )
 
               action
@@ -385,21 +404,31 @@ RSpec.describe OpenidConnect::LogoutController do
               stub_analytics
               expect(@analytics).to receive(:track_event).
                 with(
-                  'Logout Initiated',
+                  'OIDC Logout Requested',
                   hash_including(
                     success: true,
                     client_id: service_provider,
+                    client_id_parameter_present: true,
+                    id_token_hint_parameter_present: false,
+                    errors: {},
+                    sp_initiated: true,
+                    oidc: true,
+                  ),
+                )
+              expect(@analytics).to receive(:track_event).
+                with(
+                  'OIDC Logout Page Visited',
+                  hash_including(
+                    success: true,
+                    client_id: service_provider,
+                    client_id_parameter_present: true,
+                    id_token_hint_parameter_present: false,
                     errors: {},
                     sp_initiated: true,
                     oidc: true,
                   ),
                 )
 
-              stub_attempts_tracker
-              expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-                with(
-                  success: true,
-                )
               action
             end
           end
@@ -427,20 +456,19 @@ RSpec.describe OpenidConnect::LogoutController do
               }
               expect(@analytics).to receive(:track_event).
                 with(
-                  'Logout Initiated',
-                  success: false,
-                  client_id: service_provider,
-                  errors: errors,
-                  error_details: hash_including(*errors.keys),
-                  sp_initiated: true,
-                  oidc: true,
-                  method: nil,
-                  saml_request_valid: nil,
-                )
-              stub_attempts_tracker
-              expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-                with(
-                  success: false,
+                  'OIDC Logout Requested',
+                  hash_including(
+                    success: false,
+                    client_id: service_provider,
+                    client_id_parameter_present: true,
+                    id_token_hint_parameter_present: false,
+                    errors: errors,
+                    error_details: hash_including(*errors.keys),
+                    sp_initiated: true,
+                    oidc: true,
+                    method: nil,
+                    saml_request_valid: nil,
+                  ),
                 )
 
               action
@@ -537,40 +565,45 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is signed in' do
-        before { sign_in user }
+        before { stub_sign_in(user) }
 
         context 'with valid params' do
-          it 'destroys the session' do
-            expect(controller).to receive(:sign_out).and_call_original
-
-            action
-          end
-
-          it 'redirects back to the client' do
+          it 'renders logout confirmation page' do
             action
 
-            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+            expect(response).to render_template(:index)
           end
 
           it 'tracks events' do
             stub_analytics
             expect(@analytics).to receive(:track_event).
               with(
-                'Logout Initiated',
+                'OIDC Logout Requested',
                 hash_including(
                   success: true,
                   client_id: service_provider,
+                  client_id_parameter_present: true,
+                  id_token_hint_parameter_present: false,
                   errors: {},
                   sp_initiated: true,
                   oidc: true,
                 ),
               )
 
-            stub_attempts_tracker
-            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
+            expect(@analytics).to receive(:track_event).
               with(
-                success: true,
+                'OIDC Logout Page Visited',
+                hash_including(
+                  success: true,
+                  client_id: service_provider,
+                  client_id_parameter_present: true,
+                  id_token_hint_parameter_present: false,
+                  errors: {},
+                  sp_initiated: true,
+                  oidc: true,
+                ),
               )
+
             action
           end
         end
@@ -598,20 +631,17 @@ RSpec.describe OpenidConnect::LogoutController do
             }
             expect(@analytics).to receive(:track_event).
               with(
-                'Logout Initiated',
+                'OIDC Logout Requested',
                 success: false,
                 client_id: service_provider,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: true,
                 errors: errors,
                 error_details: hash_including(*errors.keys),
                 sp_initiated: true,
                 oidc: true,
                 method: nil,
                 saml_request_valid: nil,
-              )
-            stub_attempts_tracker
-            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-              with(
-                success: false,
               )
 
             action
@@ -641,20 +671,17 @@ RSpec.describe OpenidConnect::LogoutController do
             }
             expect(@analytics).to receive(:track_event).
               with(
-                'Logout Initiated',
+                'OIDC Logout Requested',
                 success: false,
                 client_id: service_provider,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
                 errors: errors,
                 error_details: hash_including(*errors.keys),
                 sp_initiated: true,
                 oidc: true,
                 method: nil,
                 saml_request_valid: nil,
-              )
-            stub_attempts_tracker
-            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
-              with(
-                success: false,
               )
 
             action
@@ -688,6 +715,46 @@ RSpec.describe OpenidConnect::LogoutController do
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+          end
+
+          it 'tracks events' do
+            stub_analytics
+
+            expect(@analytics).to receive(:track_event).
+              with(
+                'OIDC Logout Submitted',
+                success: true,
+                client_id: service_provider,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: {},
+                error_details: nil,
+                sp_initiated: true,
+                oidc: true,
+                method: nil,
+                saml_request_valid: nil,
+              )
+            expect(@analytics).to receive(:track_event).
+              with(
+                'Logout Initiated',
+                success: true,
+                client_id: service_provider,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: {},
+                error_details: nil,
+                sp_initiated: true,
+                oidc: true,
+                method: nil,
+                saml_request_valid: nil,
+              )
+            stub_attempts_tracker
+            expect(@irs_attempts_api_tracker).to receive(:logout_initiated).
+              with(
+                success: true,
+              )
+
+            action
           end
         end
 

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -189,6 +189,33 @@ RSpec.describe OpenidConnect::LogoutController do
         end
       end
     end
+
+    describe '#delete' do
+      subject(:action) do
+        delete :delete,
+            params: {
+              client_id: service_provider,
+              post_logout_redirect_uri: post_logout_redirect_uri,
+              state: state,
+            }
+      end
+      context 'returns 404' do
+        before { sign_in user }
+        it 'destroys the session' do
+          action
+
+          expect(response).to be_not_found
+        end
+      end
+
+      context 'returns 404' do
+        it 'destroys the session' do
+          action
+
+          expect(response).to be_not_found
+        end
+      end
+    end
   end
 
   context 'when accepting id_token_hint and client_id' do
@@ -343,19 +370,13 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is signed in' do
-          before { sign_in user }
+          before { stub_sign_in(user) }
 
           context 'with valid params' do
-            it 'destroys the session' do
-              expect(controller).to receive(:sign_out).and_call_original
-
-              action
-            end
-
-            it 'redirects back to the client' do
+            it 'renders logout confirmation page' do
               action
 
-              expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+              expect(response).to render_template(:index)
             end
 
             it 'tracks events' do
@@ -430,6 +451,35 @@ RSpec.describe OpenidConnect::LogoutController do
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+          end
+        end
+      end
+    end
+
+    describe '#delete' do
+      context 'when sending id_token_hint' do
+        subject(:action) do
+          delete :delete,
+            params: {
+              client_id: service_provider,
+              post_logout_redirect_uri: post_logout_redirect_uri,
+              state: state,
+            }
+        end
+        context 'user is signed in' do
+          before { stub_sign_in(user) }
+          it 'destroys the session' do
+            action
+
+            expect(response).to be_not_found
+          end
+        end
+
+        context 'user is not signed in' do
+          it 'destroys the session' do
+            action
+
+            expect(response).to be_not_found
           end
         end
       end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -167,7 +167,7 @@ describe 'OpenID Connect' do
       end
 
       context 'when sending client_id' do
-        it 'logout destroys the session' do
+        it 'logout destroys the session when confirming logout' do
           client_id = 'urn:gov:gsa:openidconnect:test'
           sign_in_get_id_token(client_id: client_id)
 
@@ -178,10 +178,29 @@ describe 'OpenID Connect' do
             post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
             state: state,
           )
+          expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+          click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
           visit account_path
           expect(page).to_not have_content(t('headings.account.login_info'))
           expect(page).to have_content(t('headings.sign_in_without_sp'))
+        end
+
+        it 'does not destroy the session and redirects to account page when denying logout' do
+          client_id = 'urn:gov:gsa:openidconnect:test'
+          sign_in_get_id_token(client_id: client_id)
+
+          state = SecureRandom.hex
+
+          visit openid_connect_logout_path(
+            client_id: client_id,
+            post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
+            state: state,
+          )
+          expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+          click_link t('openid_connect.logout.deny')
+
+          expect(page).to have_content(t('headings.account.login_info'))
         end
       end
     end
@@ -221,7 +240,7 @@ describe 'OpenID Connect' do
         and_return(true)
     end
 
-    it 'logout destroys the session' do
+    it 'logout destroys the session when confirming logout' do
       client_id = 'urn:gov:gsa:openidconnect:test'
       sign_in_get_id_token(client_id: client_id)
 
@@ -232,6 +251,8 @@ describe 'OpenID Connect' do
         post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
         state: state,
       )
+      expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+      click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
       visit account_path
       expect(page).to_not have_content(t('headings.account.login_info'))


### PR DESCRIPTION
## 🎫 Ticket


[LG-7629](https://cm-jira.usa.gov/browse/LG-7629)

## 🛠 Summary of changes

This is a follow-on to PR #6936 which added support for the `client_id` parameter in OIDC Logout.  Per the [OpenID Connect RP-Initiated Logout 1.0 specification](https://openid.net/specs/openid-connect-rpinitiated-1_0.html):

>At the Logout Endpoint, the OP SHOULD ask the End-User whether to log out of the OP as well. Furthermore, the OP MUST ask the End-User this question if an id_token_hint was not provided or if the supplied ID Token does not belong to the current OP session with the RP and/or currently logged in End-User. If the End-User says "yes", then the OP MUST log out the End-User.

>Logout requests without a valid id_token_hint value are a potential means of denial of service; therefore, OPs should obtain explicit confirmation from the End-User before acting upon them. 

Based on the spec, this PR adds a confirmation page when using OIDC logout with the `client_id` parameter.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Log in to [https://idp.int.identitysandbox.gov](https://idp.int.identitysandbox.gov)
- [ ] Go to https://idp.int.identitysandbox.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:login-gov:identity-oidc-sinatra&post_logout_redirect_uri=https://int-identity-oidc-sinatra.app.cloud.gov/logout&state=83BF994909787E73437DAD097F15BC7a
- [ ] You should be given the option to confirm logging out of Login.gov

## 👀 Screenshots
![image](https://user-images.githubusercontent.com/1430443/192830327-9ab28933-418f-4ebb-8768-af3a096238a4.png)
