### PR TITLE
Update add_email to build its URL once and re-use it

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -173,8 +173,10 @@ class UserMailer < ActionMailer::Base
       presenter = ConfirmationEmailPresenter.new(user, view_context)
       @first_sentence = presenter.first_sentence
       @confirmation_period = presenter.confirmation_period
-      @locale = locale_url_param
-      @token = token
+      @add_email_url = add_email_confirmation_url(
+        confirmation_token: token,
+        locale: locale_url_param,
+      )
       mail(to: email, subject: t('user_mailer.add_email.subject'))
     end
   end

--- a/app/views/user_mailer/add_email.html.erb
+++ b/app/views/user_mailer/add_email.html.erb
@@ -13,11 +13,7 @@
               <td>
                 <center>
                   <%= link_to t('user_mailer.email_confirmation_instructions.link_text'),
-                              add_email_confirmation_url(
-                                _request_id: @request_id,
-                                confirmation_token: @token,
-                                locale: @locale,
-                              ),
+                              @add_email_url,
                               target: '_blank',
                               class: 'float-center',
                               align: 'center',
@@ -35,12 +31,8 @@
 </table>
 
 <p>
-  <%= link_to add_email_confirmation_url(_request_id: @request_id, confirmation_token: @token, locale: @locale),
-              add_email_confirmation_url(
-                _request_id: @request_id,
-                confirmation_token: @token,
-                locale: @locale,
-              ),
+  <%= link_to @add_email_url,
+              @add_email_url,
               target: '_blank',
               rel: 'noopener' %>
 </p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,6 +5,21 @@ describe UserMailer, type: :mailer do
   let(:email_address) { user.email_addresses.first }
   let(:banned_email) { 'banned_email+123abc@gmail.com' }
 
+  describe '#add_email' do
+    let(:token) { SecureRandom.hex }
+    let(:mail) { UserMailer.add_email(user, email_address, token) }
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'renders the add_email_confirmation_url' do
+      add_email_url = add_email_confirmation_url(confirmation_token: token)
+
+      expect(mail.html_part.body).to have_content(add_email_url)
+      expect(mail.html_part.body).to_not have_content(sign_up_create_email_confirmation_url)
+    end
+  end
+
   describe '#email_deleted' do
     let(:mail) { UserMailer.email_deleted(user, 'old@email.com') }
 


### PR DESCRIPTION
- Follow-up to #7019 to prevent similar bugs in the future

[skip changelog]