### PR TITLE
LG-7602 Pull VA IP Data and Store It In Session (Controller and Flow State) 3 of 3

### DIFF
--- a/app/controllers/idv/inherited_proofing_controller.rb
+++ b/app/controllers/idv/inherited_proofing_controller.rb
@@ -1,6 +1,8 @@
 module Idv
   class InheritedProofingController < ApplicationController
     include Flow::FlowStateMachine
+    include IdvSession
+    include InheritedProofingConcern
 
     before_action :render_404_if_disabled
 

--- a/app/services/idv/flows/inherited_proofing_flow.rb
+++ b/app/services/idv/flows/inherited_proofing_flow.rb
@@ -22,6 +22,11 @@ module Idv
       def initialize(controller, session, name)
         @idv_session = self.class.session_idv(session)
         super(controller, STEPS, ACTIONS, session[name])
+
+        @flow_session ||= {}
+        @flow_session[:pii_from_user] ||= { uuid: current_user.uuid }
+        applicant = @idv_session['applicant'] || {}
+        @flow_session[:pii_from_user] = @flow_session[:pii_from_user].to_h.merge(applicant)
       end
 
       def self.session_idv(session)

--- a/app/services/idv/steps/inherited_proofing/agreement_step.rb
+++ b/app/services/idv/steps/inherited_proofing/agreement_step.rb
@@ -2,9 +2,13 @@ module Idv
   module Steps
     module InheritedProofing
       class AgreementStep < InheritedProofingBaseStep
+        include UserPiiManagable
+
         STEP_INDICATOR_STEP = :getting_started
 
         def call
+          inherited_proofing_save_user_pii_to_session!
+          inherited_proofing_form_response
         end
 
         def form_submit

--- a/app/services/idv/steps/inherited_proofing/user_pii_managable.rb
+++ b/app/services/idv/steps/inherited_proofing/user_pii_managable.rb
@@ -1,0 +1,37 @@
+module Idv
+  module Steps
+    module InheritedProofing
+      module UserPiiManagable
+        include UserPiiRetrievable
+
+        def inherited_proofing_save_user_pii_to_session!
+          inherited_proofing_save_session!
+          inherited_proofing_skip_steps!
+        end
+
+        private
+
+        def inherited_proofing_save_session!
+          return unless inherited_proofing_form_response.success?
+
+          flow_session[:pii_from_user] =
+            flow_session[:pii_from_user].to_h.merge(inherited_proofing_user_pii)
+          # This is unnecessary, but added for completeness. Any subsequent FLOWS we
+          # might splice into will pull from idv_session['applicant'] and merge into
+          # flow_session[:pii_from_user] anyhow in their #initialize(r); any subsequent
+          # STEP FLOWS we might splice into will populate idv_session['applicant'] and
+          # ultimately get merged in to flow_session[:pii_from_user] as well.
+          idv_session['applicant'] = flow_session[:pii_from_user]
+        end
+
+        def inherited_proofing_skip_steps!
+          idv_session['profile_confirmation'] = true
+          idv_session['vendor_phone_confirmation'] = false
+          idv_session['user_phone_confirmation'] = false
+          idv_session['address_verification_mechanism'] = 'phone'
+          idv_session['resolution_successful'] = 'phone'
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/inherited_proofing/user_pii_retrievable.rb
+++ b/app/services/idv/steps/inherited_proofing/user_pii_retrievable.rb
@@ -1,0 +1,43 @@
+module Idv
+  module Steps
+    module InheritedProofing
+      module UserPiiRetrievable
+        def inherited_proofing_user_pii
+          inherited_proofing_info[0]
+        end
+
+        def inherited_proofing_form_response
+          inherited_proofing_info[1]
+        end
+
+        private
+
+        # This needs error handling.
+        def inherited_proofing_info
+          return @inherited_proofing_info if defined? @inherited_proofing_info
+
+          payload_hash = inherited_proofing_service.execute.dup
+          form = inherited_proofing_form(payload_hash)
+          form_response = form.submit
+
+          user_pii = {}
+          user_pii = form.user_pii if form_response.success?
+
+          @inherited_proofing_info = [user_pii, form_response]
+        end
+
+        def inherited_proofing_service
+          controller.inherited_proofing_service
+        end
+
+        def inherited_proofing_form(payload_hash)
+          controller.inherited_proofing_form payload_hash
+        end
+
+        def inherited_proofing_service_provider_data
+          controller.inherited_proofing_service_provider_data
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/inherited_proofing/user_pii_retrievable.rb
+++ b/app/services/idv/steps/inherited_proofing/user_pii_retrievable.rb
@@ -33,10 +33,6 @@ module Idv
         def inherited_proofing_form(payload_hash)
           controller.inherited_proofing_form payload_hash
         end
-
-        def inherited_proofing_service_provider_data
-          controller.inherited_proofing_service_provider_data
-        end
       end
     end
   end

--- a/app/services/idv/steps/inherited_proofing_base_step.rb
+++ b/app/services/idv/steps/inherited_proofing_base_step.rb
@@ -1,6 +1,8 @@
 module Idv
   module Steps
     class InheritedProofingBaseStep < Flow::BaseStep
+      delegate :controller, :idv_session, to: :@flow
+
       def initialize(flow)
         super(flow, :inherited_proofing)
       end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -14,6 +14,7 @@ class SessionEncryptor
   # personal keys are generated and stored in the session between requests, but are used
   # to decrypt PII bundles, so we treat them similarly to the PII itself.
   SENSITIVE_PATHS = [
+    ['warden.user.user.session', 'idv/inherited_proofing'],
     ['warden.user.user.session', 'idv/doc_auth'],
     ['warden.user.user.session', 'idv/in_person'],
     ['warden.user.user.session', 'idv'],

--- a/spec/controllers/idv/inherited_proofing_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Idv::InheritedProofingController do
+shared_examples 'the flow steps work correctly' do
   describe '#index' do
     it 'redirects to the first step' do
       get :index
@@ -50,8 +50,34 @@ describe Idv::InheritedProofingController do
       expect(response).to redirect_to idv_inherited_proofing_step_url(step: :get_started)
     end
   end
+end
 
-  def mock_next_step(step)
-    allow_any_instance_of(Idv::Flows::InheritedProofingFlow).to receive(:next_step).and_return(step)
+def mock_next_step(step)
+  allow_any_instance_of(Idv::Flows::InheritedProofingFlow).to receive(:next_step).and_return(step)
+end
+
+describe Idv::InheritedProofingController do
+  let(:sp) { nil }
+  let(:user) { build(:user) }
+
+  before do
+    allow(controller).to receive(:current_sp).and_return(sp)
+    stub_sign_in(user)
+  end
+
+  context 'when VA inherited proofing mock is enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return(true)
+    end
+
+    it_behaves_like 'the flow steps work correctly'
+  end
+
+  context 'when VA inherited proofing mock is not enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return(false)
+    end
+
+    it_behaves_like 'the flow steps work correctly'
   end
 end

--- a/spec/features/idv/inherited_proofing/agreement_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/agreement_step_spec.rb
@@ -4,6 +4,16 @@ feature 'inherited proofing agreement' do
   include IdvHelper
   include DocAuthHelper
 
+  before do
+    allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return true
+    allow_any_instance_of(Idv::InheritedProofingController).to \
+      receive(:va_inherited_proofing?).and_return true
+    allow_any_instance_of(Idv::InheritedProofingController).to \
+      receive(:va_inherited_proofing_auth_code).and_return auth_code
+  end
+
+  let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
+
   def expect_ip_verify_info_step
     expect(page).to have_current_path(idv_ip_verify_info_step)
   end


### PR DESCRIPTION
ATTENTION: This branch is blocked/will fail until [this PR is approved/merged](https://github.com/18F/identity-idp/pull/7012)

[https://cm-jira.usa.gov/browse/LG-7602](https://github.com/18F/identity-idp/pull/7012/commits/c2aab30425b422d4602c4a42c50ba6f9f4d080f0)

3 of 3.

This is a supporting change for the LG-7602 feature for Inherited Proofing (IP).

The user's PII needs to be obtained from the Service Provider in our Inherited
Proofing process Flow Steps so that we can process the data and put it into session in such a way so that we can hand the rest of the proofing process to the current IDV workflow in a seamless manner. 

These changes ensure we can do the following in both our IP controller _and/or_ IP Flow Steps: 
1) Know if we are entertaining an Inherited Proofing (IP) request.
2) Identify the Service Provider (SP) making the IP request.
3) Determine the correct SP-specific Service to call in order to get the user PII and the SP-specific FormResponse class needed to consume the aforementioned SP Service API response for user PII.
