### PR TITLE
lg-7150 add login icon alt text

### DIFF
--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -46,7 +46,7 @@
                                           attachments['logo.png'].url,
                                           size: '142x19',
                                           style: 'width: 142px; height: 19px;',
-                                          alt: 'Login.gov logo',
+                                          alt: "#{APP_NAME} logo",
                                         ) %>
                                   </th>
                                   <th class="expander"></th>

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -46,7 +46,7 @@
                                           attachments['logo.png'].url,
                                           size: '142x19',
                                           style: 'width: 142px; height: 19px;',
-                                          alt: "#{APP_NAME} logo",
+                                          alt: t('mailer.logo', app_name: APP_NAME),
                                         ) %>
                                   </th>
                                   <th class="expander"></th>

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -46,6 +46,7 @@
                                           attachments['logo.png'].url,
                                           size: '142x19',
                                           style: 'width: 142px; height: 19px;',
+                                          alt: 'Login.gov logo',
                                         ) %>
                                   </th>
                                   <th class="expander"></th>

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -5,5 +5,6 @@ en:
     email_reuse_notice:
       subject: This email address is already associated with an account.
     help: If you need help, visit %{link}
+    logo: '%{app_name} logo'
     no_reply: Please do not reply to this message.
     privacy_policy: Privacy policy

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -5,5 +5,6 @@ es:
     email_reuse_notice:
       subject: Este email ya está asociado a una cuenta.
     help: Si necesita ayuda, visite %{link}
+    logo: '%{app_name} logo'
     no_reply: Por favor, no responda a este mensaje.
     privacy_policy: Póliza de privacidad

--- a/config/locales/mailer/fr.yml
+++ b/config/locales/mailer/fr.yml
@@ -5,5 +5,6 @@ fr:
     email_reuse_notice:
       subject: Cette adresse courriel est déjà associée à un compte.
     help: Si vous avez besoin d’aide, visitez le site %{link}
+    logo: '%{app_name} logo'
     no_reply: Veuillez ne pas répondre à ce message.
     privacy_policy: Politique de confidentialité

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -29,6 +29,7 @@ module I18n
         { key: 'time.pm' }, # "PM" is "PM" in French and Spanish
         { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
+        { key: 'mailer.logo' }, # "logo is logo" in English, French and Spanish
       ].freeze
       # rubocop:enable Layout/LineLength
 

--- a/spec/views/layouts/user_mailer.html.erb_spec.rb
+++ b/spec/views/layouts/user_mailer.html.erb_spec.rb
@@ -20,7 +20,7 @@ describe 'layouts/user_mailer.html.erb' do
   end
 
   it 'includes alt text for app logo that reads Login.gov logo' do
-    expect(rendered).to have_css("img[alt='Login.gov logo']")
+    expect(rendered).to have_css("img[alt='#{t('mailer.logo', app_name: APP_NAME)}']")
   end
 
   it 'includes the message subject in the body' do

--- a/spec/views/layouts/user_mailer.html.erb_spec.rb
+++ b/spec/views/layouts/user_mailer.html.erb_spec.rb
@@ -19,6 +19,10 @@ describe 'layouts/user_mailer.html.erb' do
     expect(rendered).to have_css("img[src*='.mail']")
   end
 
+  it 'includes alt text for app logo that reads Login.gov logo' do
+    expect(rendered).to have_css("img[alt='Login.gov logo']")
+  end
+
   it 'includes the message subject in the body' do
     expect(rendered).to have_content @mail.subject
   end


### PR DESCRIPTION
[Ticket](https://cm-jira.usa.gov/browse/LG-7150)

**What:** This pr adds alt text to the Login.gov logo in order to allow screen reader users to hear text that describes the logo image in emails. 

**How:** Alt tag added to image_tag in the base email used by other emails. 
Note: Did not add this text to the i18l files as the text is the same in the 3 languages we support. 

**Testing:**
* Go to one of the emails, can use ready to verify email for example. `http://localhost:3000/rails/mailers/user_mailer/in_person_verified.html?locale=en`
* Open finder
* Navigate to VoiceOver and enable
* Navigate the email using VoiceOver to ensure that "Login.gov logo" is read out when highlighting the logo

<details>
<summary>Screenshot</summary>

<img width="833" alt="Screen Shot 2022-09-22 at 4 56 42 PM" src="https://user-images.githubusercontent.com/20867088/191965748-d3878f73-5db4-4560-9657-b2dcb7bbae84.png">
</details>

changelog: Improvement, Accessibility, add alt text for login.gov logo