### PR TITLE
changelog: Improvements, Authentication, Update from cancel to skip for now

### DIFF
--- a/app/views/users/mfa_selection/index.html.erb
+++ b/app/views/users/mfa_selection/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 
 <%= render PageFooterComponent.new do %>
-  <%= link_to t('mfa.skip'), @after_setup_path, method: :get, class: 'usa-button usa-button--unstyled' %>
+  <%= link_to t('mfa.skip'), @after_setup_path, method: :get %>
 <% end %>
 
 <%= javascript_packs_tag_once('webauthn-unhide') %>

--- a/app/views/users/mfa_selection/index.html.erb
+++ b/app/views/users/mfa_selection/index.html.erb
@@ -24,6 +24,8 @@
   <%= f.submit t('forms.buttons.continue'), class: 'margin-bottom-1' %>
 <% end %>
 
-<%= render 'shared/cancel', link: @after_setup_path %>
+<%= render PageFooterComponent.new do %>
+  <%= link_to t('mfa.skip'), @after_setup_path, method: :get, class: 'usa-button usa-button--unstyled' %>
+<% end %>
 
 <%= javascript_packs_tag_once('webauthn-unhide') %>

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -108,7 +108,7 @@ feature 'Multi Two Factor Authentication' do
       expect(current_path).to eq account_path
     end
 
-    scenario 'user can select 1 MFA methods and cancels selecting second mfa' do
+    scenario 'user can select 1 MFA methods and skips selecting second mfa' do
       sign_in_before_2fa
 
       expect(current_path).to eq authentication_methods_setup_path
@@ -135,7 +135,7 @@ feature 'Multi Two Factor Authentication' do
 
       expect(page).to have_current_path(second_mfa_setup_path)
 
-      click_link t('links.cancel')
+      click_link t('mfa.skip')
 
       expect(page).to have_current_path(account_path)
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-6918: Authentication update CTA](https://cm-jira.usa.gov/browse/LG-6918)

## 🛠 Summary of changes

This will change the language of the link at the secondary MFA page to "Skip for now" 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.


## 👀 Screenshots
What it will look like after change. 
![Screen Shot 2022-09-26 at 10 11 04 AM](https://user-images.githubusercontent.com/23225522/192298717-3c0fedd1-68b3-434a-8be6-0dd30bf3e235.png)




