### PR TITLE
Improve changelog tool flexibility for commit messages

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?changelog: (?<category>[\w -/]{2,}), (?<subcategory>[\w -]{2,}), (?<change>.+)$}
+  %r{^(?:\* )?[cC]hangelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}
 CATEGORIES = [
   'Improvements',
   'Bug Fixes',

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -79,3 +79,27 @@ squashed_commit_invalid:
     DELIMITER
   title: 'LG-5629 account buttons part 2 (#5945)'
   commit_messages: []
+commit_changelog_capitalized:
+  commit_log: |
+    title: Improve changelog tool flexibility for commit messages (#7000)
+    body:Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages
+    DELIMITER
+  title: Improve changelog tool flexibility for commit messages (#7000)
+  category: Internal
+  subcategory: Changelog
+  change: Improve changelog tool flexibility for commit messages
+  pr_number: '7000'
+  commit_messages:
+    - 'Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages'
+commit_changelog_whitespace:
+  commit_log: |
+    title: Improve changelog tool flexibility for commit messages (#7000)
+    body:changelog:Internal,Changelog,Improve changelog tool flexibility for commit messages
+    DELIMITER
+  title: Improve changelog tool flexibility for commit messages (#7000)
+  category: Internal
+  subcategory: Changelog
+  change: Improve changelog tool flexibility for commit messages
+  pr_number: '7000'
+  commit_messages:
+    - 'changelog:Internal,Changelog,Improve changelog tool flexibility for commit messages'

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'scripts/changelog_check' do
     it 'builds a git log into structured changelog objects' do
       git_log = git_fixtures.values.pluck('commit_log').join("\n")
       changelog_entries = generate_changelog(git_log)
-      expect(changelog_entries.length).to eq 4
+      expect(changelog_entries.length).to eq 6
       fixture_and_changelog = git_fixtures.values.filter do |x|
         x['category'].present?
       end.zip(changelog_entries)
@@ -34,6 +34,32 @@ RSpec.describe 'scripts/changelog_check' do
       expect(commits.first['subcategory']).to eq changelog.first.subcategory
       expect(commits.first['pr_number']).to eq changelog.first.pr_number
       expect(commits.first['change']).to eq changelog.first.change
+    end
+
+    it 'detects changelog regardless of capitalization' do
+      commit = git_fixtures['commit_changelog_capitalized']
+      git_log = commit['commit_log']
+
+      changelog = generate_changelog(git_log)
+
+      expect(changelog).not_to be_empty
+      expect(commit['category']).to eq changelog.first.category
+      expect(commit['subcategory']).to eq changelog.first.subcategory
+      expect(commit['pr_number']).to eq changelog.first.pr_number
+      expect(commit['change']).to eq changelog.first.change
+    end
+
+    it 'detects changelog regardless of whitespace' do
+      commit = git_fixtures['commit_changelog_whitespace']
+      git_log = commit['commit_log']
+
+      changelog = generate_changelog(git_log)
+
+      expect(changelog).not_to be_empty
+      expect(commit['category']).to eq changelog.first.category
+      expect(commit['subcategory']).to eq changelog.first.subcategory
+      expect(commit['pr_number']).to eq changelog.first.pr_number
+      expect(commit['change']).to eq changelog.first.change
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Allows case- and whitespace-insensitivity for commit messages, to help avoid developer toil associated with crafting commit messages.

Examples:

- 238f6745af1c4497964cade45210b1d43d4aaa70
- 8dbcf928c52d50e406e5bb6941d7a9ca76593ca7

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Observe that build on this pull request passes, despite irregular case and whitespace in the changelog commit message

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A