### PR TITLE
LG-7620: Update IPP CTA language to include Baltimore option

### DIFF
--- a/app/assets/stylesheets/components/_troubleshooting-options.scss
+++ b/app/assets/stylesheets/components/_troubleshooting-options.scss
@@ -22,7 +22,6 @@
 .troubleshooting-options__heading {
   @include u-margin-y(1.5);
   @extend %h3;
-  white-space: pre;
 }
 
 .troubleshooting-options__options {

--- a/app/javascript/packages/components/troubleshooting-options.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.tsx
@@ -14,7 +14,7 @@ export type TroubleshootingOption = Omit<BlockLinkProps, 'href'> & {
 interface TroubleshootingOptionsProps {
   headingTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-  heading?: string;
+  heading?: ReactNode;
 
   options: TroubleshootingOption[];
 

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { TroubleshootingOptions } from '@18f/identity-components';
-import { useI18n } from '@18f/identity-react-i18n';
+import { useI18n, formatHTML } from '@18f/identity-react-i18n';
 import type { TroubleshootingOption } from '@18f/identity-components/troubleshooting-options';
 import ServiceProviderContext from '../context/service-provider';
 import MarketingSiteContext from '../context/marketing-site';
@@ -82,7 +82,9 @@ function DocumentCaptureTroubleshootingOptions({
       {hasErrors && inPersonURL && showInPersonOption && (
         <TroubleshootingOptions
           isNewFeatures
-          heading={t('idv.troubleshooting.headings.are_you_near')}
+          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
+            br: 'br',
+          })}
           options={[
             {
               url: '#location',

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -185,7 +185,7 @@ en:
         review: Re-enter your %{app_name} password to protect your data
     troubleshooting:
       headings:
-        are_you_near: 'Are you located near Washington, D.C.<wbr/>or Baltimore, MD?'
+        are_you_near: 'Are you located near Washington, D.C. <br/>or Baltimore, MD?'
         missing_required_items: Are you missing one of these items?
         need_assistance: 'Need immediate assistance? Here’s how to get help:'
         still_having_trouble: Still having trouble?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -193,7 +193,7 @@ es:
         review: Vuelve a ingresar tu contraseña de %{app_name} para encriptar tus datos
     troubleshooting:
       headings:
-        are_you_near: '¿Reside cerca de Washington, D.C.<wbr/>o Baltimore, MD?'
+        are_you_near: '¿Reside cerca de Washington, D.C. <br/>o Baltimore, MD?'
         missing_required_items: '¿Le falta alguno de estos puntos?'
         need_assistance: '¿Necesita ayuda inmediata? Así es como puede obtener ayuda:'
         still_having_trouble: '¿Sigue teniendo dificultades?'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -205,7 +205,7 @@ fr:
         review: Entrez à nouveau votre mot de passe %{app_name} pour crypter vos données
     troubleshooting:
       headings:
-        are_you_near: 'Êtes-vous situé près de Washington, D.C.<wbr/>ou Baltimore, MD?'
+        are_you_near: 'Êtes-vous situé près de Washington, D.C. <br/>ou Baltimore, MD?'
         missing_required_items: Est-ce qu’il vous manque un de ces éléments?
         need_assistance: 'Avez-vous besoin d’une assistance immédiate? Voici comment
           obtenir de l’aide:'


### PR DESCRIPTION
Update FR, ES, and EN IPP CTA language to include Baltimore option.

Ran these changes through `make normalize_yaml`

Follow up should include updates to: https://github.com/18F/identity-site/blob/20e3e81cd7ff94491f8709e4b1d2b52efd18bfa8/content/_help/verify-your-identity/verify-your-identity-in-person._en.md.

## 🎫 Ticket

[Link to the relevant ticket.](https://cm-jira.usa.gov/browse/LG-7620)

## 🛠 Summary of changes

Change IPP CTA language to include Baltimore, MD. Note the intentional newline after "or".

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Check that CI passes
- [x] Visual check after local setup?

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="577" alt="image" src="https://user-images.githubusercontent.com/5004319/192629575-b4ed4c44-e5db-49a2-b205-7adc9128dc6a.png">

</details>

<details>
<summary>After:</summary>

<img width="551" alt="image" src="https://user-images.githubusercontent.com/5004319/192877815-22b735ea-614c-4a67-a70e-bbe74eee628a.png">

</details>
