### PR TITLE
Fix logging for password visibility toggle

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -26,7 +26,7 @@ class FrontendLogController < ApplicationController
     'IdV: download personal key' => :idv_personal_key_downloaded,
     'IdV: Native camera forced after failed attempts' => :idv_native_camera_forced,
     'Multi-Factor Authentication: download backup code' => :multi_factor_auth_backup_code_download,
-    'Show Password Button Clicked' => :show_password_button_clicked,
+    'Show Password button clicked' => :show_password_button_clicked,
   }.transform_values do |method|
     method.is_a?(Proc) ? method : AnalyticsEvents.instance_method(method)
   end.freeze

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2672,8 +2672,9 @@ module AnalyticsEvents
   end
 
   # Tracks if a user clicks the "Show Password button"
-  def show_password_button_clicked
-    track_event('Show Password Button Clicked')
+  # @param [String] path URL path where the click occurred
+  def show_password_button_clicked(path:)
+    track_event('Show Password Button Clicked', path: path)
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2673,8 +2673,8 @@ module AnalyticsEvents
 
   # Tracks if a user clicks the "Show Password button"
   # @param [String] path URL path where the click occurred
-  def show_password_button_clicked(path:)
-    track_event('Show Password Button Clicked', path: path)
+  def show_password_button_clicked(path:, **extra)
+    track_event('Show Password Button Clicked', path: path, **extra)
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -224,7 +224,10 @@ feature 'Sign in' do
     check t('components.password_toggle.toggle_label')
 
     expect(page).to have_css('input.password[type="text"]')
-    expect(fake_analytics).to have_logged_event('Show Password Button Clicked', path: root_path)
+    expect(fake_analytics).to have_logged_event(
+      'Show Password Button Clicked',
+      path: new_user_session_path,
+    )
   end
 
   scenario 'user session expires in amount of time specified by Devise config' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Sign in' do
+  include JavascriptDriverHelper
+
   before(:all) do
     @original_capyabara_wait = Capybara.default_max_wait_time
     Capybara.default_max_wait_time = 5
@@ -221,7 +223,9 @@ feature 'Sign in' do
 
     visit new_user_session_path
 
-    check t('components.password_toggle.toggle_label')
+    with_awaited_fetch do
+      check t('components.password_toggle.toggle_label')
+    end
 
     expect(page).to have_css('input.password[type="text"]')
     expect(fake_analytics).to have_logged_event(

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -216,11 +216,15 @@ feature 'Sign in' do
   end
 
   scenario 'user can see and use password visibility toggle', js: true do
+    fake_analytics = FakeAnalytics.new
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+
     visit new_user_session_path
 
     check t('components.password_toggle.toggle_label')
 
     expect(page).to have_css('input.password[type="text"]')
+    expect(fake_analytics).to have_logged_event('Show Password Button Clicked', path: root_path)
   end
 
   scenario 'user session expires in amount of time specified by Devise config' do

--- a/spec/support/features/javascript_driver_helper.rb
+++ b/spec/support/features/javascript_driver_helper.rb
@@ -2,4 +2,24 @@ module JavascriptDriverHelper
   def javascript_enabled?
     %i[headless_chrome headless_chrome_mobile].include?(Capybara.current_driver)
   end
+
+  def with_awaited_fetch
+    setup_js = <<~JS
+      window._fetch = window.fetch;
+      window.fetch = async (...args) => {
+        window.isFetching = true;
+        const result = await window._fetch.call(window, ...args);
+        window.isFetching = false;
+        return result;
+      };
+    JS
+    teardown_js = 'window.fetch = window._fetch; delete window._fetch;'
+
+    page.execute_script(setup_js)
+    yield
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop if page.evaluate_script('window.isFetching')
+    end
+    page.execute_script(teardown_js)
+  end
 end

--- a/spec/support/features/javascript_driver_helper.rb
+++ b/spec/support/features/javascript_driver_helper.rb
@@ -20,6 +20,7 @@ module JavascriptDriverHelper
     Timeout.timeout(Capybara.default_max_wait_time) do
       loop if page.evaluate_script('window.isFetching')
     end
+  ensure
     page.execute_script(teardown_js)
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

LG-6143

## 🛠 Summary of changes

Context: https://github.com/18F/identity-idp/pull/6946#discussion_r976534843

The intention with the changes in #6946 was to omit the default "Frontend" prefix by defining a corresponding analytics event in `FrontendLogController::EVENT_MAP`. However, since this map is case-sensitive, the matching was not happening as expected, so the event was still logged with the "Frontend" prefix. Additionally, the `path` argument would only be included in the payload if explicitly listed in the keyword arguments of the event method, as of #6927.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] `rspec spec/features/users/sign_in_spec.rb:218` passes
- [ ] `tail log/events.log` shows the expected event after toggling the checkbox

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A