### PR TITLE
Make sign-in page buttons big to improve button style consistency

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,14 +34,14 @@
       ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: @request_id } %>
   <div class='margin-bottom-4'>
-    <%= f.submit t('links.next'), full_width: true, big: false, wide: false %>
+    <%= f.submit t('links.next'), full_width: true, big: true, wide: false %>
     <h2 class='separator-text'>
       <%= t('headings.create_account_with_sp.cta', app_name: APP_NAME) %>
     </h2>
     <%= link_to(
           t('links.create_account'),
           sign_up_email_url(request_id: @request_id),
-          class: 'text-no-underline usa-button usa-button--outline usa-button--full-width margin-top-1',
+          class: 'text-no-underline usa-button usa-button--big usa-button--outline usa-button--full-width margin-top-1',
         ) %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -41,7 +41,7 @@
     <%= link_to(
           t('links.create_account'),
           sign_up_email_url(request_id: @request_id),
-          class: 'text-no-underline usa-button usa-button--big usa-button--outline usa-button--full-width margin-top-1',
+          class: 'usa-button usa-button--big usa-button--outline usa-button--full-width margin-top-1',
         ) %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,7 +34,7 @@
       ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: @request_id } %>
   <div class='margin-bottom-4'>
-    <%= f.submit t('links.next'), full_width: true, big: true, wide: false %>
+    <%= f.submit t('links.next'), full_width: true, wide: false %>
     <h2 class='separator-text'>
       <%= t('headings.create_account_with_sp.cta', app_name: APP_NAME) %>
     </h2>


### PR DESCRIPTION
## 🛠 Summary of changes

While working with @anniehirshman-gsa on #7017, she suggested that the sign-in page buttons could be updated to match other buttons.  This PR is a small style change to make sign-in page buttons use the "big" style to match buttons elsewhere on the site.

## 👀 Screenshots

| Before | After |
|:------:|:-----:|
|   ![image](https://user-images.githubusercontent.com/1430443/192386358-b28fa289-e391-4984-96c4-81c2625702af.png)     |    ![image](https://user-images.githubusercontent.com/1430443/192386329-35133c6c-0bab-4e85-93a8-2502a575d91d.png)   |
