### PR TITLE
Lg-7033: change hint text element from span to div

### DIFF
--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -1,9 +1,9 @@
 <label class="usa-label">     
     <%= label %>
 </label>
-<span class="usa-hint">
+<div class="usa-hint">
     <%= hint %>
-</span>
+</div>
   <%= content_tag :'lg-memorable-date', min: min, max: max, **tag_options do -%>
     <div class="usa-memorable-date">
       <%= content_tag(


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7033](https://cm-jira.usa.gov/browse/LG-7033)

## 🛠 Summary of changes

This pr addresses the hint text for the date of birth portion of the state_id form. The text is being read by the VoiceOver and NVDA screen readers - but the latter does not highlight the element that displays that text (it's not focusable). This was happening because that text is within a span. This pr changes the span to a div so that the element is not focusable when the NVDA screen reader reaches it. 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
Tested this using AssistivLabs
- [ ] Follow the instructions on the AssistivLab's dashboard to enable a tunnel 
- [ ] Start a new session by clicking "Start Testing"
- [ ] Open the finder on the bottom left hand screen by clicking "start"
- [ ] Create a new error.yml file and save in downloads ( can accomplish by opening an existing document in notepad then clicking new under the file tab) 
- [ ] Navigate to localhost:3000/
- [ ] Create an account and navigate to /verify
- [ ] Choose upload from phone and upload yml file you just created
- [ ] Navigate through screens until you reach state id form
- [ ] Use `shift` + `option` + `down-arrow` to navigate through form
- [ ] Screen reader should read out hint text under Date of Birth and it should be outlined with a red box

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="1221" alt="Screen Shot 2022-09-26 at 5 42 03 PM" src="https://user-images.githubusercontent.com/20867088/192393381-6a95dec9-2a60-464b-8d15-a4fe0fd3ee4b.png">

</details>

<details>
<summary>After:</summary>
<img width="998" alt="Screen Shot 2022-09-26 at 5 43 08 PM" src="https://user-images.githubusercontent.com/20867088/192393401-1b28bb78-c499-445e-bbba-7c6bb76c8c48.png">

</details>

## 🚀 Notes for Deployment

Include any special instructions for deployment.

changelog: Improvements, Accessibility, Change hint text from span to div