### PR TITLE
Use design system utility classes for IPP location elements

### DIFF
--- a/app/assets/stylesheets/components/_location-collection-item.scss
+++ b/app/assets/stylesheets/components/_location-collection-item.scss
@@ -11,28 +11,3 @@
   padding-bottom: 1rem;
   border-color: $border-color;
 }
-
-@media screen {
-  .wrap-name {
-    overflow-wrap: break-word;
-  }
-}
-
-@media screen and (min-width: 320px) {
-  .usa-button-mobile {
-    width: -webkit-fill-available;
-    margin-top: 8px;
-  }
-}
-
-@media screen and (max-width: 480px) {
-  .usa-button-mobile-hidden {
-    display: none;
-  }
-}
-
-@media screen and (min-width: 481px) {
-  .usa-button-desktop-hidden {
-    display: none;
-  }
-}

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -48,7 +48,7 @@ function LocationCollectionItem({
         <div>{`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}</div>
         <Button
           id={`location_button_mobile_${selectId}`}
-          className="tablet:display-none margin-top-2"
+          className="tablet:display-none margin-top-2 width-full"
           onClick={(event) => handleSelect(event, selectId)}
           type="submit"
         >

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -28,7 +28,7 @@ function LocationCollectionItem({
     <li className="location-collection-item">
       <div className="usa-collection__body">
         <div className="display-flex flex-justify">
-          <h3 className="usa-collection__heading break-word">{name}</h3>
+          <h3 className="usa-collection__heading">{name}</h3>
           <Button
             id={`location_button_desktop_${selectId}`}
             className="display-none tablet:display-inline-block"

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -48,7 +48,7 @@ function LocationCollectionItem({
         <div>{`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}</div>
         <Button
           id={`location_button_mobile_${selectId}`}
-          className="tablet:display-none margin-top-1"
+          className="tablet:display-none margin-top-2"
           onClick={(event) => handleSelect(event, selectId)}
           type="submit"
         >

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -28,10 +28,10 @@ function LocationCollectionItem({
     <li className="location-collection-item">
       <div className="usa-collection__body">
         <div className="display-flex flex-justify">
-          <h3 className="usa-collection__heading wrap-name">{name}</h3>
+          <h3 className="usa-collection__heading break-word">{name}</h3>
           <Button
             id={`location_button_desktop_${selectId}`}
-            className="usa-button-mobile-hidden"
+            className="display-none tablet:display-inline-block"
             onClick={(event) => {
               handleSelect(event, selectId);
             }}
@@ -48,7 +48,7 @@ function LocationCollectionItem({
         <div>{`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}</div>
         <Button
           id={`location_button_mobile_${selectId}`}
-          className="usa-button-mobile usa-button-desktop-hidden"
+          className="tablet:display-none margin-top-1"
           onClick={(event) => handleSelect(event, selectId)}
           type="submit"
         >


### PR DESCRIPTION
## 🛠 Summary of changes

This pull request removes custom styles which had been implemented for the in-person proofing locations screen. Largely this should be visually identical to how it was previously, with the exception of a minor margin correction for the mobile button placement (based on Figma references).

Rationale:

* They can be achieved with existing design system utility classes
* Align class naming for component stylesheets to be consistent with file name
* Avoid ambiguity between design system classes and IdP-specific ad hoc style classes caused by similar naming
* Use standard breakpoints ("tablet")
* Improve performance by reducing CSS stylesheet size

Context:
* https://github.com/18F/identity-idp/pull/6624#discussion_r931016013
* https://github.com/18F/identity-idp/pull/6624#discussion_r931017636
* https://github.com/18F/identity-idp/pull/6624#discussion_r931019749
* https://github.com/18F/identity-idp/pull/6624#discussion_r931021285
* https://github.com/18F/identity-idp/pull/6624#discussion_r931022904

## 📜 Testing Plan

- [ ] Confirm that the IPP locations step looks and behaves same as it had

## 👀 Screenshots

**Desktop:**

<details>
<summary>Before:</summary>
<img src="https://user-images.githubusercontent.com/1779930/192621804-e5dce82e-de8f-4279-ba10-b4a4a1637e15.png" alt="before">
</details>

<details>
<summary>After:</summary>
<img src="https://user-images.githubusercontent.com/1779930/192621804-e5dce82e-de8f-4279-ba10-b4a4a1637e15.png" alt="after">
</details>

**Mobile:**

<details>
<summary>Before:</summary>
<img src="https://user-images.githubusercontent.com/1779930/192621260-76df06cd-911d-40f1-b1c1-4e14d64cc462.png" alt="before">
</details>

<details>
<summary>After:</summary>
<img src="https://user-images.githubusercontent.com/1779930/192621258-a4cc439d-ed47-4502-ba38-8156c1773570.png" alt="after">
</details>