### PR TITLE
Better Account Deleted Icon Centering

### DIFF
--- a/app/assets/stylesheets/components/_alert-icon.scss
+++ b/app/assets/stylesheets/components/_alert-icon.scss
@@ -22,3 +22,9 @@
     background-image: url('status/personal-key.svg');
   }
 }
+.alert-icon-centered-top {
+  position: absolute;
+  left: 50%;
+  top: 0px;
+  transform: translateX(-50%) translateY(-50%);
+}

--- a/app/assets/stylesheets/components/_alert-icon.scss
+++ b/app/assets/stylesheets/components/_alert-icon.scss
@@ -22,7 +22,7 @@
     background-image: url('status/personal-key.svg');
   }
 }
-.alert-icon-centered-top {
+.alert-icon--centered-top {
   position: absolute;
   left: 50%;
   top: 0px;

--- a/app/views/account_reset/confirm_delete_account/show.html.erb
+++ b/app/views/account_reset/confirm_delete_account/show.html.erb
@@ -2,7 +2,7 @@
 <div class="margin-y-2 padding-y-6 padding-x-4 tablet:padding-x-6 border border-error rounded-xl position-relative">
   <%= render AlertIconComponent.new(
         icon_name: :delete,
-        class: 'alert-icon-centered-top',
+        class: 'alert-icon--centered-top',
       ) %>
   <%= render PageHeadingComponent.new.with_content(t('account_reset.confirm_delete_account.title')) %>
   <p><%= t('account_reset.confirm_delete_account.info_html', email: email) %></p>

--- a/app/views/account_reset/confirm_delete_account/show.html.erb
+++ b/app/views/account_reset/confirm_delete_account/show.html.erb
@@ -2,7 +2,7 @@
 <div class="margin-y-2 padding-y-6 padding-x-4 tablet:padding-x-6 border border-error rounded-xl position-relative">
   <%= render AlertIconComponent.new(
         icon_name: :delete,
-        class: 'pin-top pin-x margin-top-neg-5 margin-x-auto',
+        class: 'alert-icon-centered-top',
       ) %>
   <%= render PageHeadingComponent.new.with_content(t('account_reset.confirm_delete_account.title')) %>
   <p><%= t('account_reset.confirm_delete_account.info_html', email: email) %></p>


### PR DESCRIPTION
changelog: Internal, Accessibility, adjusting icon position

## 🛠 Summary of changes

Updated the alert-icon component sass to include a new convenience class.

Updated the account confirm deleted view to use the new class, which better centers the icon vertically

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Clone locally and setup
- [ ] change the value of `email` in `app/controllers/account_reset/confirm_delete_account_controller.rb` to be any string
- [ ] `make run`
- [ ] Create an account. Then manually navigate to `http://localhost:3000/account_reset/confirm_delete_account` to see the result

## 👀 Screenshots

<details>
<summary>Before:</summary>

</details>
  
![191615553-b2e5dd0a-aedb-402e-9ff6-8f89e454d1b2](https://user-images.githubusercontent.com/105373963/192639767-62966ed0-ca2b-4960-82df-7fc80b5fbb67.png)


<details>
<summary>After:</summary>

</details>
  
![Screen Shot 2022-09-27 at 5 25 28 PM](https://user-images.githubusercontent.com/105373963/192639292-265178f5-b020-469b-8cf1-0e06982a6d40.png)


## 🚀 Notes for Deployment

Include any special instructions for deployment.
