### PR TITLE
Fix flaky spec for awaited fetch request

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -223,9 +223,8 @@ feature 'Sign in' do
 
     visit new_user_session_path
 
-    with_awaited_fetch do
-      check t('components.password_toggle.toggle_label')
-    end
+    check t('components.password_toggle.toggle_label')
+    Capybara.current_session.server.wait_for_pending_requests
 
     expect(page).to have_css('input.password[type="text"]')
     expect(fake_analytics).to have_logged_event(

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -224,6 +224,9 @@ feature 'Sign in' do
     visit new_user_session_path
 
     check t('components.password_toggle.toggle_label')
+
+    # Clicking the checkbox triggers a frontend event logging request. Wait for network requests to
+    # settle before continuing to avoid a race condition.
     Capybara.current_session.server.wait_for_pending_requests
 
     expect(page).to have_css('input.password[type="text"]')

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 feature 'Sign in' do
-  include JavascriptDriverHelper
-
   before(:all) do
     @original_capyabara_wait = Capybara.default_max_wait_time
     Capybara.default_max_wait_time = 5

--- a/spec/support/features/javascript_driver_helper.rb
+++ b/spec/support/features/javascript_driver_helper.rb
@@ -2,25 +2,4 @@ module JavascriptDriverHelper
   def javascript_enabled?
     %i[headless_chrome headless_chrome_mobile].include?(Capybara.current_driver)
   end
-
-  def with_awaited_fetch
-    setup_js = <<~JS
-      window._fetch = window.fetch;
-      window.fetch = async (...args) => {
-        window.isFetching = true;
-        const result = await window._fetch.call(window, ...args);
-        window.isFetching = false;
-        return result;
-      };
-    JS
-    teardown_js = 'window.fetch = window._fetch; delete window._fetch;'
-
-    page.execute_script(setup_js)
-    yield
-    Timeout.timeout(Capybara.default_max_wait_time) do
-      loop if page.evaluate_script('window.isFetching')
-    end
-  ensure
-    page.execute_script(teardown_js)
-  end
 end


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Resolves intermittent test failures caused by a race condition between user interaction in the feature spec and the JavaScript `fetch` request being settled.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1664317848054629

There _should_ be a way to have the test helper work as expected, but this appears to work as a simpler alternative. The issue with the test helper appears to be that the `Timeout.timeout` loop only loops once and does not actually wait for `window.isFetching` to become `false`.

## 📜 Testing Plan

- [ ] `rspec spec/features/users/sign_in_spec.rb:220`

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A