### PR TITLE
[LG-7676] Add logging of matching certificate for SAML AuthnRequests

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -119,6 +119,7 @@ class SamlIdpController < ApplicationController
       idv: identity_needs_verification?,
       finish_profile: profile_needs_verification?,
       requested_ial: requested_ial,
+      matching_cert_serial: saml_request.service_provider.matching_cert&.serial&.to_s,
     )
     analytics.saml_auth(**analytics_payload)
   end

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -3,6 +3,10 @@ class FakeSamlRequest
     self
   end
 
+  def matching_cert
+    nil
+  end
+
   def identifier
     'http://localhost:3000'
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -46,6 +46,10 @@ module SamlAuthHelper
     @saml_test_sp_cert ||= File.read(Rails.root.join('certs', 'sp', 'saml_test_sp.crt'))
   end
 
+  def saml_test_sp_cert_serial
+    OpenSSL::X509::Certificate.new(saml_test_sp_cert).serial.to_s
+  end
+
   def idp_fingerprint
     @idp_fingerprint ||= Fingerprinter.fingerprint_cert(
       OpenSSL::X509::Certificate.new(saml_test_idp_cert),


### PR DESCRIPTION
Resolves LG-7676


changelog: Improvements, Authentication, Add logging of matching certificate for SAML AuthnRequests

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-7676

## 🛠 Summary of changes

Adds a new attribute to successful `SAML Auth` events to track the serial number of the matching cert identified through signature validation. If the signature validation fails, this attribute will be `nil`, indicating that none of the configured SP public certificates could be used to validate the signature in the SAML AuthnRequest.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Send signed SAML AuthnRequest with corresponding public cert in the IdP SP record
- [ ] Check event logs in CloudWatch
- [ ] Expect `SAML Auth` event to include `matching_cert_serial` property with corresponding cert serial number

## 🚀 Notes for Deployment

N/A