### PR TITLE
LG-7640 review_status should be a top-level key

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -97,6 +97,7 @@ class ResolutionProofingJob < ApplicationJob
       success: threatmetrix_result.success?,
       timed_out: threatmetrix_result.timed_out?,
       transaction_id: threatmetrix_result.transaction_id,
+      review_status: threatmetrix_result.review_status,
       response_body: response_h,
     }
   end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "workspaces": [
     "app/javascript/packages/*"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "workspaces": [
     "app/javascript/packages/*"

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           expect(result_context_stages_threatmetrix[:success]).to eq(true)
           expect(result_context_stages_threatmetrix[:timed_out]).to eq(false)
           expect(result_context_stages_threatmetrix[:transaction_id]).to eq(threatmetrix_request_id)
+          expect(result_context_stages_threatmetrix[:review_status]).to eq('pass')
           expect(result_context_stages_threatmetrix[:response_body]).to eq(ddp_response_body)
 
           proofing_component = user.proofing_component


### PR DESCRIPTION
## 🎫 Ticket

[LG-7640](https://cm-jira.usa.gov/browse/LG-7640)

## 🛠 Summary of changes

Add the review status to the top level of the threatmetrix logging results for the following event:

"IdV: in person proofing optional verify_wait submitted"

from here:
properties.event_properties.proofing_results.context.stages.threatmetrix.response_body.review_status

to also here:
properties.event_properties.proofing_results.context.stages.threatmetrix.review_status

because cloudwatch has difficulty parsing large packets at depth

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IDV flow and continue to just after 'verify your information'
- [ ] Locally check the events.log for the event "IdV: in person proofing optional verify_wait submitted"
- [ ] Verify that review_status is also at the top level of the json body for threatmetrix

## 👀 Screenshots

![Screen Shot 2022-09-27 at 11 05 40 AM](https://user-images.githubusercontent.com/34244063/193074179-426fa147-d1d3-4f1d-b520-6bb4943541b0.png)

## 🚀 Notes for Deployment

None
