### PR TITLE
Fix height and alt attribute on images

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
 
 <% if decorated_session.sp_name %>
   <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '91') %>
+    <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
 
     <%= render decorated_session.registration_heading %>
   </div>

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -2,7 +2,7 @@
 
 <% if decorated_session.sp_name %>
   <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', alt: '91') %>
+    <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
 
     <%= render decorated_session.registration_heading %>
   </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes bugs introduced in #7017 where the `alt` attribute was replaced with the `height` value.  Mentioned in https://github.com/18F/identity-idp/pull/7017#discussion_r982997675