### PR TITLE
Enable accepting client_id parameter by default in OIDC Logout

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -22,7 +22,7 @@ aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","H
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url
 all_redirect_uris_cache_duration_minutes: 2
-accept_client_id_in_oidc_logout: false
+accept_client_id_in_oidc_logout: true
 account_reset_token_valid_for_days: 1
 account_reset_wait_period_days: 1
 acuant_maintenance_window_start:


### PR DESCRIPTION
## 🛠 Summary of changes

This will be enabled in prod today, so we should enable it everywhere by default!
Prompted by https://github.com/18F/identity-oidc-sinatra/pull/120#issuecomment-1262212781

## 🚀 Notes for Deployment

This should not be merged until prod is done