### PR TITLE
Enhance analytics linter to catch non-keyword arguments

### DIFF
--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -119,6 +119,21 @@ RSpec.describe AnalyticsEventsDocumenter do
       end
     end
 
+    context 'when a method includes a positional param' do
+      let(:source_code) { <<~RUBY }
+        class AnalyticsEvents
+          def some_event(success)
+            track_event('Some Event')
+          end
+        end
+      RUBY
+
+      it 'reports the invalid param' do
+        expect(documenter.missing_documentation.first).
+          to include('some_event unexpected positional parameters ["success"]')
+      end
+    end
+
     context 'when a method skips documenting an param, such as pii_like_keypaths' do
       let(:source_code) { <<~RUBY }
         class AnalyticsEvents


### PR DESCRIPTION
## 🛠 Summary of changes

Analytics methods are expected to contain only keyword arguments and an `**extra` splat, so we should enforce this through the existing lint tooling.

Related example: #7044

## 📜 Testing Plan

- [ ] `rspec spec/lib/analytics_events_documenter_spec.rb` passes
- [ ] `make lint_tracker_events` fails as expected (until after #7044 is merged)
