### PR TITLE
Sync Rubocop target platform versions to current versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,8 +24,8 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'public/**/*'
-  TargetRubyVersion: 2.7
-  TargetRailsVersion: 6.0
+  TargetRubyVersion: 3.0.4
+  TargetRailsVersion: 7.0
   UseCache: true
   DisabledByDefault: true
   SuggestExtensions: false

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -216,7 +216,7 @@ module Users
       ).call
     end
 
-    LETTERS_AND_DASHES = /\A[a-z0-9\-]+\Z/i.freeze
+    LETTERS_AND_DASHES = /\A[a-z0-9\-]+\Z/i
 
     def request_id_if_valid
       request_id = (params[:request_id] || sp_session[:request_id]).to_s

--- a/app/services/date_parser.rb
+++ b/app/services/date_parser.rb
@@ -1,5 +1,5 @@
 module DateParser
-  AMERICAN_REGEX = %r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}.freeze
+  AMERICAN_REGEX = %r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}
 
   # Date parsing with a fallback for american-style Month/Day/Year
   # since we have legacy data in PII bundles that may be stored this way

--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -35,7 +35,7 @@ module DocAuth
         hash
       end
 
-      ACUANT_TIMESTAMP_FORMAT = %r{/Date\((?<milliseconds>-?\d+)\)/}.freeze
+      ACUANT_TIMESTAMP_FORMAT = %r{/Date\((?<milliseconds>-?\d+)\)/}
 
       # @api private
       def convert_date(date)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Rubocop target versions to our current targeted support.

https://github.com/18F/identity-idp/blob/062ac12ce6d70ab711ecd019fd8916dc6e759b7c/.ruby-version#L1

https://github.com/18F/identity-idp/blob/062ac12ce6d70ab711ecd019fd8916dc6e759b7c/Gemfile#L6