### PR TITLE
Log 2FA Setup Complete Event when skipping adding additional MFA

### DIFF
--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -11,6 +11,12 @@ class MfaConfirmationController < ApplicationController
     user_session.delete(:mfa_selections)
     user_session.delete(:next_mfa_selection_choice)
     analytics.user_registration_suggest_another_mfa_notice_skipped
+    analytics.user_registration_mfa_setup_complete(
+      mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
+      enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+      pii_like_keypaths: [[:mfa_method_counts, :phone]],
+      success: true,
+    )
     redirect_to after_mfa_setup_path
   end
 
@@ -63,5 +69,9 @@ class MfaConfirmationController < ApplicationController
     irs_attempts_api_tracker.logged_in_profile_change_reauthentication_rate_limited
     sign_out
     redirect_to root_url, flash: { error: t('errors.max_password_attempts_reached') }
+  end
+
+  def mfa_context
+    @mfa_context ||= MfaContext.new(current_user)
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

The 2FA Registration Complete event wasn't being logged when people finish 2FA Registration by skipping the suggestion to add another, so this PR adds it.