### PR TITLE
LG-7691 Fixing alert icon badge positioning

### DIFF
--- a/app/assets/stylesheets/components/_alert-icon.scss
+++ b/app/assets/stylesheets/components/_alert-icon.scss
@@ -7,6 +7,7 @@
 // For displaying icons as "badges"
 // at the top of modals
 .iconic-modal-badge {
+  position: relative;
   &::before {
     background-repeat: no-repeat;
     background-size: contain;
@@ -26,5 +27,5 @@
   position: absolute;
   left: 50%;
   top: 0px;
-  transform: translateX(-50%) translateY(-50%);
+  transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
## 🎫 Ticket
[LG-7691](https://cm-jira.usa.gov/browse/LG-7691)

## 🛠 Summary of changes

Updated the alert icon "badge" mode styling to have the correct position attribute, so pseudo-element displays in the correct position across browsers.

## 📜 Testing Plan

- [ ] Clone, install, and run the local idp if you do not have a test instance to work from
- [ ] Create and proof an account
- [ ] Logout
- [ ] At the login screen, select forgot password
- [ ] Follow the steps and create a new password
- [ ] At the profile screen, select reactivate your account
- [ ] Select that you _do_ have your personal key
- [ ] The personal key re-entry screen you see here should be the one affected (see before and after screens below)

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
  
![icon-before](https://user-images.githubusercontent.com/105373963/193132384-460a4839-7ed6-4656-90af-02b4d91b5128.png)

</details>

<details>
<summary>After:</summary>
  
![Screen Shot 2022-09-29 at 4 02 18 PM](https://user-images.githubusercontent.com/105373963/193132418-a78bc2d8-97a2-401a-8a3f-a8258201ac6e.png)

</details>

## 🚀 Notes for Deployment

No special notes.
