### PR TITLE
Fix personal key block display

### DIFF
--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -1,8 +1,15 @@
-.key-badge {
-  position: relative;
+.personal-key-block {
+  background-image: url('personal-key/pkey-block.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+
+  @include at-media('tablet') {
+    @include u-padding-x(1);
+    @include u-padding-y(2);
+  }
 }
 
-.separator-text__code {
+.personal-key-block__code {
   @include u-font-family('mono');
   font-size: 1.5rem;
 
@@ -17,19 +24,8 @@
   }
 }
 
-@include at-media('tablet') {
-  .separator-text > div {
-    &::after {
-      color: #000;
-      padding: 0 0.5rem;
-    }
-  }
-}
-
-.bg-pk-box {
-  background-image: url('personal-key/pkey-block.svg');
-  background-position: center;
-  background-repeat: no-repeat;
+.key-badge {
+  position: relative;
 }
 
 .bg-personal-key {

--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -24,10 +24,6 @@
   }
 }
 
-.key-badge {
-  position: relative;
-}
-
 .bg-personal-key {
   height: 145px;
   background-image: url('personal-key/shield.svg');

--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -1,11 +1,11 @@
 .personal-key-block {
+  @include u-padding-y(2);
   background-image: url('personal-key/pkey-block.svg');
   background-position: center;
   background-repeat: no-repeat;
 
   @include at-media('tablet') {
     @include u-padding-x(1);
-    @include u-padding-y(2);
   }
 }
 

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -3,9 +3,9 @@
     <%= t('users.personal_key.header') %>
   </h2>
   <div class="bg-personal-key padding-top-4 margin-y-2">
-    <div class="padding-x-0 tablet:padding-x-1 padding-y-2 separator-text bg-pk-box">
+    <div class="personal-key-block">
       <% code.split('-').each do |word| %>
-        <% concat(content_tag(:strong, word, class: 'separator-text__code', data: { personal_key: '' })) %>
+        <% concat(content_tag(:strong, word, class: 'personal-key-block__code', data: { personal_key: '' })) %>
       <% end %>
     </div>
   </div>

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -28,6 +28,6 @@ module PersonalKeyHelper
   end
 
   def scrape_personal_key
-    page.all('.separator-text__code').map(&:text).join('-')
+    page.all('.personal-key-block__code').map(&:text).join('-')
   end
 end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -242,7 +242,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
           fill_in_credentials_and_submit(user.email, user.password)
 
           expect(page).to have_content(t('account.personal_key.needs_new'))
-          code = page.all('.separator-text__code').map(&:text).join(' ')
+          code = page.all('.personal-key-block__code').map(&:text).join(' ')
           acknowledge_and_confirm_personal_key
 
           expect(user.reload.valid_personal_key?(code)).to eq(true)
@@ -265,7 +265,7 @@ shared_examples 'signing in as proofed account with broken personal key' do |pro
           click_button t('forms.buttons.submit.default')
 
           expect(page).to have_content(t('account.personal_key.needs_new'))
-          code = page.all('.separator-text__code').map(&:text).join(' ')
+          code = page.all('.personal-key-block__code').map(&:text).join(' ')
           acknowledge_and_confirm_personal_key
 
           expect(user.reload.valid_personal_key?(code)).to eq(true)


### PR DESCRIPTION
## 🛠 Summary of changes

This fixes an issue where the personal key page layout was malformed, as an unintended regression of #6986 due to accidental name collision of the `.separator-text` class added there.

## 📜 Testing Plan

- [ ] Confirm that the identity verification "Personal key" page appears as expected

## 👀 Screenshots

**Desktop:**

Before|After
---|---
![localhost_3000_manage_personal_key (2)](https://user-images.githubusercontent.com/1779930/193135684-4d0101f2-feff-4699-aa3f-965d677c7a30.png)|![localhost_3000_manage_personal_key (1)](https://user-images.githubusercontent.com/1779930/193135696-ba5f24cf-f4ac-49f0-81b7-75ccf962e228.png)

**Mobile:**

Before|After
---|---
![localhost_3000_manage_personal_key(iPhone XR)](https://user-images.githubusercontent.com/1779930/193136548-58046e79-ef0c-4c27-948c-2b01911da4b3.png)|![localhost_3000_manage_personal_key(iPhone XR) (1)](https://user-images.githubusercontent.com/1779930/193136562-d4f446d6-815a-4327-8ba5-83152527ee03.png)
