### PR TITLE
Clean up Phone Confirmation Events

### DIFF
--- a/app/controllers/idv/otp_delivery_method_controller.rb
+++ b/app/controllers/idv/otp_delivery_method_controller.rb
@@ -69,7 +69,7 @@ module Idv
       result = send_phone_confirmation_otp
       analytics.idv_phone_confirmation_otp_sent(**result.to_h)
 
-      irs_attempts_api_tracker.idv_phone_confirmation_otp_sent(
+      irs_attempts_api_tracker.idv_phone_otp_sent(
         phone_number: @idv_phone,
         success: result.success?,
         otp_delivery_method: params[:otp_delivery_preference],
@@ -84,7 +84,6 @@ module Idv
 
     def handle_send_phone_confirmation_otp_failure(result)
       if send_phone_confirmation_otp_rate_limited?
-        irs_attempts_api_tracker.idv_phone_confirmation_otp_sent_rate_limited
         handle_too_many_otp_sends
       else
         invalid_phone_number(result.extra[:telephony_response].error)

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -189,21 +189,13 @@ module IrsAttemptsApi
     # @param [String] otp_delivery_method - Either SMS or Voice
     # @param [Hash<Key, Array<String>>] failure_reason
     # Track when OTP is sent and what method chosen during idv flow.
-    def idv_phone_confirmation_otp_sent(success:, phone_number:,
-                                        otp_delivery_method:, failure_reason: nil)
+    def idv_phone_otp_sent(success:, phone_number:, otp_delivery_method:, failure_reason: nil)
       track_event(
-        :idv_phone_confirmation_otp_sent,
+        :idv_phone_otp_sent,
         success: success,
         phone_number: phone_number,
         otp_delivery_method: otp_delivery_method,
         failure_reason: failure_reason,
-      )
-    end
-
-    # Track when OTP phone sent is rate limited during idv flow
-    def idv_phone_confirmation_otp_sent_rate_limited
-      track_event(
-        :idv_phone_confirmation_otp_sent_rate_limited,
       )
     end
 

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Idv::OtpDeliveryMethodController do
   let(:user) { build(:user) }
+  let(:valid_phone_number) { '+1 (225) 555-5000' }
 
   before do
     stub_verify_steps_one_and_two(user)
@@ -9,7 +10,7 @@ describe Idv::OtpDeliveryMethodController do
     subject.idv_session.vendor_phone_confirmation = true
     subject.idv_session.user_phone_confirmation = false
     user_phone_confirmation_session = PhoneConfirmation::ConfirmationSession.start(
-      phone: '+1 (225) 555-5000',
+      phone: valid_phone_number,
       delivery_method: :sms,
     )
     subject.idv_session.user_phone_confirmation_session = user_phone_confirmation_session
@@ -75,6 +76,9 @@ describe Idv::OtpDeliveryMethodController do
 
   describe '#create' do
     let(:params) { { otp_delivery_preference: :sms } }
+    let(:valid_phone_parameter) { { phone_number: valid_phone_number } }
+    let(:success_parameters) { { failure_reason: {}, success: true } }
+    let(:defalut_parameters) { { **valid_phone_parameter, otp_delivery_method: 'sms' } }
 
     context 'user has not selected phone verification method' do
       before do
@@ -116,9 +120,14 @@ describe Idv::OtpDeliveryMethodController do
         expect(response).to redirect_to idv_otp_verification_path
       end
 
-      it 'tracks an analytics event' do
+      it 'tracks appropriate events' do
         stub_analytics
+        stub_attempts_tracker
         allow(@analytics).to receive(:track_event)
+
+        expect(@irs_attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+          { **success_parameters, **defalut_parameters },
+        )
 
         post :create, params: params
 
@@ -142,9 +151,16 @@ describe Idv::OtpDeliveryMethodController do
         expect(response).to redirect_to idv_otp_verification_path
       end
 
-      it 'tracks an analytics event' do
+      it 'tracks appropriate events' do
         stub_analytics
+        stub_attempts_tracker
         allow(@analytics).to receive(:track_event)
+
+        expect(@irs_attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+          { **success_parameters,
+            **valid_phone_parameter,
+            otp_delivery_method: 'voice' },
+        )
 
         post :create, params: params
 
@@ -167,9 +183,12 @@ describe Idv::OtpDeliveryMethodController do
         expect(response).to render_template :new
       end
 
-      it 'tracks an analytics event' do
+      it 'tracks appropriate events' do
         stub_analytics
+        stub_attempts_tracker
         allow(@analytics).to receive(:track_event)
+
+        expect(@irs_attempts_api_tracker).not_to receive(:idv_phone_otp_sent)
 
         post :create, params: params
 
@@ -226,10 +245,9 @@ describe Idv::OtpDeliveryMethodController do
           'Vendor Phone Validation failed', telephony_error_analytics_hash
         )
 
-        expect(@irs_attempts_api_tracker).to receive(:idv_phone_confirmation_otp_sent).with(
-          phone_number: '+1 (225) 555-5000',
+        expect(@irs_attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+          **defalut_parameters,
           success: false,
-          otp_delivery_method: 'sms',
           failure_reason: { telephony_error: I18n.t('telephony.error.friendly_message.generic') },
         )
 


### PR DESCRIPTION
Remove the `idv_phone_confirmation_otp_sent_rate_limited` event as it duplicates functionality of another event.

Since only one `idv_phone_otp` event contains the word `confirmation` now, remove the word `confirmation` to standardize the `idv_phone_otp` events (and seek to improve the associated unit tests).