### PR TITLE
Fix error from personal key validation unexpected characters

### DIFF
--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -30,8 +30,12 @@ function resetForm() {
 }
 
 function validateInput() {
-  const value = encodeInput(input.value);
-  const isValid = value === personalKey;
+  let isValid = false;
+  try {
+    const value = encodeInput(input.value);
+    isValid = value === personalKey;
+  } catch {}
+
   input.setCustomValidity(isValid ? '' : t('users.personal_key.confirmation_error'));
 }
 

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -50,7 +50,7 @@ shared_examples_for 'personal key page' do |address_verification_mechanism|
       input = page.find(':focus')
 
       # Validate as incorrect
-      input.fill_in with: 'wrong'
+      input.fill_in with: 'wrong!'
       within('[role=dialog]') { click_on t('forms.buttons.continue') }
       expect(page).to have_content(t('users.personal_key.confirmation_error'))
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error which occurs when the user enters an invalid (non-alphanumeric) character in the personal key step of the identity verification flow.

The [`base32-decode` library](https://github.com/LinusU/base32-decode/) [used in `@18f/identity-personal-key-input`](https://github.com/18F/identity-idp/blob/b1361b41aade947d2a728758afff8541116f70ad/app/javascript/packages/personal-key-input/index.js#L14) [throws an error when encountering an unexpected character](https://github.com/LinusU/base32-decode/blob/fa61c01bc0bbd963a1abcf86cc519f09d70b09e0/index.js#L9). Rather than letting these errors throw unhandled, catch them and treat them as equivalent to an invalid entry.

NewRelic: https://onenr.io/0bRmopb8BQy

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] `rspec './spec/features/idv/steps/confirmation_step_spec.rb[1:1:2:2]'` passes (fails on `main` with changes to spec)
