### PR TITLE
Generate report in spec with the stubbed date

### DIFF
--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -34,7 +34,7 @@ describe Reports::SpActiveUsersReport do
     result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json
 
-    expect(subject.perform(Time.zone.today)).to eq(result)
+    expect(subject.perform(job_date)).to eq(result)
   end
 
   it 'when Oct 1, returns total active user counts per sp by ial1 and ial2 for last fiscal year' do


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes build failures occurring for branches created after October 1 (new fiscal year). The job uses the passed date for the reporting range, so it should correspond to the date used in stubbing data, like what's done in other test cases in the file.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] `rspec spec/jobs/reports/sp_active_users_report_spec.rb:14`