### PR TITLE
Fix 500 error when displaying IDV session error

### DIFF
--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -12,7 +12,7 @@
 
   <% c.troubleshooting_options do |tc| %>
     <% tc.header { t('components.troubleshooting_options.default_heading') } %>
-    <% if user_session.dig(:'idv/doc_auth', :had_barcode_read_failure) %>
+    <% if user_session&.dig(:'idv/doc_auth', :had_barcode_read_failure) %>
       <% tc.option(
            url: idv_doc_auth_step_path(step: :redo_document_capture),
            action: FormLinkComponent.method(:new),

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -52,4 +52,17 @@ describe 'idv/session_errors/warning.html.erb' do
       )
     end
   end
+
+  context 'with a nil user_session' do
+    let(:user_session) { nil }
+
+    it 'does not render troubleshooting option to retake photos' do
+      expect(rendered).to have_link(t('idv.failure.button.warning'), href: try_again_path)
+      expect(rendered).to_not have_content(t('components.troubleshooting_options.default_heading'))
+      expect(rendered).to_not have_link(
+        t('idv.troubleshooting.options.add_new_photos'),
+        href: idv_doc_auth_step_path(step: :redo_document_capture),
+      )
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Came across a 500 in [NewRelic](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=c38c7388-c40d-b0f3-e548-323f96874398) caused by  `user_session` being nil.  I'm not 100% sure this is the _best_ way to fix it, but it is a way.