### PR TITLE
Fix undefined method transaction_id when LexisNexis PhoneFinder raises an exception

### DIFF
--- a/app/services/proofing/lexis_nexis/result_with_exception.rb
+++ b/app/services/proofing/lexis_nexis/result_with_exception.rb
@@ -16,6 +16,10 @@ module Proofing
         {}
       end
 
+      def transaction_id
+        nil
+      end
+
       def timed_out?
         exception.is_a?(Proofing::TimeoutError)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Based on a failed job from [New Relic](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=259200000&state=972082af-b8a1-364e-a868-f50e94985730), it appears to be an unintentional breakage from #6920, which introduced a new shape for proofing results.

```
undefined method `transaction_id' for #<Proofing::LexisNexis::ResultWithException
```

This PR adds a nil `transaction_id` to ResultWithException so the results have closer behavior.  The `AddressMockClient` [doesn't use ResultWithException](https://github.com/18F/identity-idp/blob/440ba52acff0253384e63edb2f3d17cb5049de34/app/services/proofing/mock/address_mock_client.rb#L30-L41) so it's not straightforward to test.