### PR TITLE
Change fsm_ to _flow_state_machine to eliminate the acronym

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -3,7 +3,7 @@ module Flow
     extend ActiveSupport::Concern
 
     included do
-      before_action :flow_state_machine_initialize
+      before_action :initialize_flow_state_machine
       before_action :ensure_correct_step, only: :show
     end
 
@@ -69,7 +69,7 @@ module Flow
       sp_session[:issuer]
     end
 
-    def flow_state_machine_initialize
+    def initialize_flow_state_machine
       klass = self.class
       flow = klass::FLOW_STATE_MACHINE_SETTINGS[:flow]
       @name = klass.name.underscore.gsub('_controller', '')

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -9,7 +9,7 @@ describe Idv::CaptureDocController do
       expect(subject).to have_actions(
         :before,
         :ensure_user_id_in_session,
-        :flow_state_machine_initialize,
+        :initialize_flow_state_machine,
         :ensure_correct_step,
       )
     end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -10,7 +10,7 @@ describe Idv::DocAuthController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :flow_state_machine_initialize,
+        :initialize_flow_state_machine,
         :ensure_correct_step,
         :override_csp_for_threat_metrix,
       )

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -17,7 +17,7 @@ describe Idv::InPersonController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :flow_state_machine_initialize,
+        :initialize_flow_state_machine,
         :ensure_correct_step,
         :override_csp_for_threat_metrix,
       )


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Change fsm_ to _flow_state_machine to eliminate the cryptic acronyms.

## 📜 Testing Plan

- All existing tests should pass.

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A
