### PR TITLE
Standardization clean-up (naming, alphabetizing)

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -47,7 +47,7 @@ module Idv
 
     def update_tracking
       analytics.idv_gpo_address_letter_requested(resend: resend_requested?)
-      irs_attempts_api_tracker.idv_letter_requested(success: true, resend: resend_requested?)
+      irs_attempts_api_tracker.idv_gpo_letter_requested(success: true, resend: resend_requested?)
       create_user_event(:gpo_mail_sent, current_user)
 
       ProofingComponent.create_or_find_by(user: current_user).update(address_check: 'gpo_letter')

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -22,7 +22,7 @@ module Users
 
     def create
       if throttle.throttled_else_increment?
-        irs_attempts_api_tracker.personal_key_reactivation_rate_limited(success: false)
+        irs_attempts_api_tracker.personal_key_reactivation_rate_limited
         render_throttled
       else
         result = personal_key_form.submit

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -605,7 +605,6 @@ module IrsAttemptsApi
     end
 
     # Tracks when User personal key has been rate limited by too many attempts
-    # @param [Boolean] success
     def personal_key_reactivation_rate_limited
       track_event(
         :personal_key_reactivation_rate_limited,

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -138,13 +138,13 @@ module IrsAttemptsApi
     end
 
     # @param [Boolean] success
-    # @param [Hash<Key, Array<String>>] failure_reason displays GPO submission failed
-    # GPO verification submitted from Letter sent to verify address
-    def idv_gpo_verification_submitted(success:, failure_reason: nil)
+    # @param [String] resend
+    # The Address validation letter has been requested by user
+    def idv_gpo_letter_requested(success:, resend:)
       track_event(
-        :idv_gpo_verification_submitted,
+        :idv_gpo_letter_requested,
         success: success,
-        failure_reason: failure_reason,
+        resend: resend,
       )
     end
 
@@ -156,13 +156,13 @@ module IrsAttemptsApi
     end
 
     # @param [Boolean] success
-    # @param [String] resend
-    # The Address validation letter has been requested by user
-    def idv_letter_requested(success:, resend:)
+    # @param [Hash<Key, Array<String>>] failure_reason displays GPO submission failed
+    # GPO verification submitted from Letter sent to verify address
+    def idv_gpo_verification_submitted(success:, failure_reason: nil)
       track_event(
-        :idv_letter_requested,
+        :idv_gpo_verification_submitted,
         success: success,
-        resend: resend,
+        failure_reason: failure_reason,
       )
     end
 
@@ -604,6 +604,14 @@ module IrsAttemptsApi
       )
     end
 
+    # Tracks when User personal key has been rate limited by too many attempts
+    # @param [Boolean] success
+    def personal_key_reactivation_rate_limited
+      track_event(
+        :personal_key_reactivation_rate_limited,
+      )
+    end
+
     # Tracks when user has entered personal key after forgot password steps
     # @param [Boolean] success
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
@@ -612,15 +620,6 @@ module IrsAttemptsApi
         :personal_key_reactivation_submitted,
         success: success,
         failure_reason: failure_reason,
-      )
-    end
-
-    # Tracks when User personal key has been rate limited by too many attempts
-    # @param [Boolean] success
-    def personal_key_reactivation_rate_limited(success:)
-      track_event(
-        :personal_key_reactivation_rate_limited,
-        success: success,
       )
     end
 

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 describe Idv::GpoController do
   let(:user) { create(:user) }
 
-  before { stub_analytics }
-  before { stub_attempts_tracker }
+  before do
+    stub_analytics
+    stub_attempts_tracker
+  end
 
   describe 'before_actions' do
     it 'includes authentication before_action' do
@@ -102,7 +104,7 @@ describe Idv::GpoController do
       end
 
       it 'logs attempts api tracking' do
-        expect(@irs_attempts_api_tracker).to receive(:idv_letter_requested).
+        expect(@irs_attempts_api_tracker).to receive(:idv_gpo_letter_requested).
           with(success: true, resend: false)
 
         put :create
@@ -129,7 +131,7 @@ describe Idv::GpoController do
       end
 
       it 'logs attempts api tracking' do
-        expect(@irs_attempts_api_tracker).to receive(:idv_letter_requested).
+        expect(@irs_attempts_api_tracker).to receive(:idv_gpo_letter_requested).
           with(success: true, resend: true)
 
         put :create


### PR DESCRIPTION
Add `gpo` to standardize letter based events.  Re-alphabetize tracker events that are now out of order.  Remove an unnecessary parameter.