### PR TITLE
Protect against a missing items hash in the LN failure mapper

### DIFF
--- a/app/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper.rb
@@ -20,7 +20,8 @@ module Proofing
         }.freeze
 
         def initialize(instant_verify_errors)
-          if instant_verify_errors.present?
+          items = instant_verify_errors&.dig('Items')
+          if items.present?
             @instant_verify_checks = instant_verify_errors['Items'].map do |item|
               InstantVerifyCheck.new(name: item['ItemName'], status: item['ItemStatus'])
             end

--- a/spec/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper_spec.rb
@@ -92,5 +92,15 @@ RSpec.describe Proofing::LexisNexis::InstantVerify::CheckToAttributeMapper do
         expect(result).to eq([:dob])
       end
     end
+
+    context 'when the checks does not include any items' do
+      let(:instant_verify_errors) { {} }
+
+      it 'returns an empty array' do
+        result = subject.map_failed_checks_to_attributes
+
+        expect(result).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
We had a nil check in here for when the instant verify errors was nil, but not for when 'Items' was nil. This commit adds that protection

[skip changelog]
