### PR TITLE
Include SP name in OIDC logout confirmation

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -61,7 +61,7 @@ module OpenidConnect
           post_logout_redirect_uri: logout_params[:post_logout_redirect_uri],
         }
         @params[:state] = logout_params[:state] if !logout_params[:state].nil?
-        @service_provider = @logout_form.service_provider&.friendly_name
+        @service_provider_name = @logout_form.service_provider&.friendly_name
         render :index
       else
         analytics.logout_initiated(**result.to_h.except(:redirect_uri))

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -61,6 +61,7 @@ module OpenidConnect
           post_logout_redirect_uri: logout_params[:post_logout_redirect_uri],
         }
         @params[:state] = logout_params[:state] if !logout_params[:state].nil?
+        @service_provider = @logout_form.service_provider&.friendly_name
         render :index
       else
         analytics.logout_initiated(**result.to_h.except(:redirect_uri))

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -52,6 +52,20 @@ class OpenidConnectLogoutForm
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
 
+  # Used by RedirectUriValidator
+  def service_provider
+    return @service_provider if defined?(@service_provider)
+    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
+
+    @service_provider = if reject_id_token_hint?
+                          sp_from_client_id
+    else
+      identity&.service_provider_record || sp_from_client_id
+    end
+
+    @service_provider
+  end
+
   private
 
   attr_reader :identity, :success
@@ -115,17 +129,6 @@ class OpenidConnectLogoutForm
         :id_token_hint, t('openid_connect.logout.errors.id_token_hint'),
         type: :id_token_hint
       )
-    end
-  end
-
-  # Used by RedirectUriValidator
-  def service_provider
-    sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
-
-    if reject_id_token_hint?
-      sp_from_client_id
-    else
-      identity&.service_provider_record || sp_from_client_id
     end
   end
 

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -57,11 +57,12 @@ class OpenidConnectLogoutForm
     return @service_provider if defined?(@service_provider)
     sp_from_client_id = ServiceProvider.find_by(issuer: client_id)
 
-    @service_provider = if reject_id_token_hint?
-                          sp_from_client_id
-    else
-      identity&.service_provider_record || sp_from_client_id
-    end
+    @service_provider =
+      if reject_id_token_hint?
+        sp_from_client_id
+      else
+        identity&.service_provider_record || sp_from_client_id
+      end
 
     @service_provider
   end

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -2,7 +2,11 @@
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
-  <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
+  <% if @service_provider %>
+    <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider: @service_provider)) %>
+  <% else %>
+    <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
+  <% end %>
 </div>
 
 <%= button_to(

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
-  <% if @service_provider %>
-    <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider: @service_provider)) %>
+  <% if @service_provider_name %>
+    <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>
   <% end %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
-  <% if @service_provider_name %>
+  <% if @service_provider_name.present? %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading', app_name: APP_NAME)) %>

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -29,6 +29,7 @@ en:
         no_client_id_or_id_token_hint: This application is misconfigured and must send
           either client_id or id_token_hint.
       heading: Do you want to sign out of %{app_name}?
+      heading_with_sp: Do you want to sign out of %{app_name} and return to %{service_provider}?
     token:
       errors:
         expired_code: is expired

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -29,7 +29,8 @@ en:
         no_client_id_or_id_token_hint: This application is misconfigured and must send
           either client_id or id_token_hint.
       heading: Do you want to sign out of %{app_name}?
-      heading_with_sp: Do you want to sign out of %{app_name} and return to %{service_provider}?
+      heading_with_sp: Do you want to sign out of %{app_name} and return to
+        %{service_provider_name}?
     token:
       errors:
         expired_code: is expired

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -29,6 +29,8 @@ es:
         no_client_id_or_id_token_hint: Esta aplicación está mal configurada y debe
           enviar client_id o id_token_hint.
       heading: ¿Quieres cerrar sesión en %{app_name}?
+      heading_with_sp: ¿Quiere cerrar sesión en %{app_name} y regresar a
+        %{service_provider_name}?
     token:
       errors:
         expired_code: ha expirado

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -29,6 +29,8 @@ fr:
         no_client_id_or_id_token_hint: Cette application est mal configurée et doit
           envoyer client_id ou id_token_hint.
       heading: Voulez-vous vous déconnecter de %{app_name}?
+      heading_with_sp: Souhaitez-vous vous déconnecter de %{app_name} et revenir à
+        %{service_provider_name}?
     token:
       errors:
         expired_code: est expiré

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe OpenidConnect::LogoutController do
   let(:state) { SecureRandom.hex }
   let(:code) { SecureRandom.uuid }
+  let(:valid_post_logout_redirect_uri) { 'gov.gsa.openidconnect.test://result/signout' }
   let(:post_logout_redirect_uri) { 'gov.gsa.openidconnect.test://result/signout' }
 
   let(:user) { build(:user) }
@@ -10,7 +11,7 @@ RSpec.describe OpenidConnect::LogoutController do
   let(:service_provider) do
     create(
       :service_provider, issuer: 'test', redirect_uris: [
-        post_logout_redirect_uri,
+        valid_post_logout_redirect_uri,
       ]
     )
   end
@@ -257,7 +258,7 @@ RSpec.describe OpenidConnect::LogoutController do
                   'OIDC Logout Requested',
                   hash_including(
                     success: false,
-                    client_id: service_provider,
+                    client_id: service_provider.issuer,
                     client_id_parameter_present: true,
                     id_token_hint_parameter_present: false,
                     errors: errors,
@@ -289,7 +290,7 @@ RSpec.describe OpenidConnect::LogoutController do
         subject(:action) do
           delete :delete,
                  params: {
-                   client_id: service_provider,
+                   client_id: service_provider.issuer,
                    post_logout_redirect_uri: post_logout_redirect_uri,
                    state: state,
                  }
@@ -355,7 +356,7 @@ RSpec.describe OpenidConnect::LogoutController do
       subject(:action) do
         get :index,
             params: {
-              client_id: service_provider,
+              client_id: service_provider.issuer,
               id_token_hint: id_token_hint,
               post_logout_redirect_uri: post_logout_redirect_uri,
               state: state,
@@ -379,7 +380,7 @@ RSpec.describe OpenidConnect::LogoutController do
                 'OIDC Logout Requested',
                 hash_including(
                   success: true,
-                  client_id: service_provider,
+                  client_id: service_provider.issuer,
                   client_id_parameter_present: true,
                   id_token_hint_parameter_present: false,
                   errors: {},
@@ -393,7 +394,7 @@ RSpec.describe OpenidConnect::LogoutController do
                 'OIDC Logout Page Visited',
                 hash_including(
                   success: true,
-                  client_id: service_provider,
+                  client_id: service_provider.issuer,
                   client_id_parameter_present: true,
                   id_token_hint_parameter_present: false,
                   errors: {},
@@ -431,7 +432,7 @@ RSpec.describe OpenidConnect::LogoutController do
               with(
                 'OIDC Logout Requested',
                 success: false,
-                client_id: service_provider,
+                client_id: service_provider.issuer,
                 client_id_parameter_present: true,
                 id_token_hint_parameter_present: true,
                 errors: errors,
@@ -471,7 +472,7 @@ RSpec.describe OpenidConnect::LogoutController do
               with(
                 'OIDC Logout Requested',
                 success: false,
-                client_id: service_provider,
+                client_id: service_provider.issuer,
                 client_id_parameter_present: true,
                 id_token_hint_parameter_present: false,
                 errors: errors,
@@ -501,7 +502,7 @@ RSpec.describe OpenidConnect::LogoutController do
         subject(:action) do
           delete :delete,
                  params: {
-                   client_id: service_provider,
+                   client_id: service_provider.issuer,
                    post_logout_redirect_uri: post_logout_redirect_uri,
                    state: state,
                  }
@@ -522,7 +523,7 @@ RSpec.describe OpenidConnect::LogoutController do
               with(
                 'OIDC Logout Submitted',
                 success: true,
-                client_id: service_provider,
+                client_id: service_provider.issuer,
                 client_id_parameter_present: true,
                 id_token_hint_parameter_present: false,
                 errors: {},
@@ -536,7 +537,7 @@ RSpec.describe OpenidConnect::LogoutController do
               with(
                 'Logout Initiated',
                 success: true,
-                client_id: service_provider,
+                client_id: service_provider.issuer,
                 client_id_parameter_present: true,
                 id_token_hint_parameter_present: false,
                 errors: {},
@@ -599,7 +600,7 @@ RSpec.describe OpenidConnect::LogoutController do
   def add_sp_session_request_url
     params = {
       acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      client_id: service_provider,
+      client_id: service_provider.issuer,
       nonce: SecureRandom.hex,
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       response_type: 'code',

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -175,17 +175,23 @@ describe 'OpenID Connect' do
 
     context 'when sending client_id' do
       it 'logout destroys the session when confirming logout' do
-        client_id = 'urn:gov:gsa:openidconnect:test'
-        sign_in_get_id_token(client_id: client_id)
+        service_provider = ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:test')
+        sign_in_get_id_token(client_id: service_provider.issuer)
 
         state = SecureRandom.hex
 
         visit openid_connect_logout_path(
-          client_id: client_id,
+          client_id: service_provider.issuer,
           post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
           state: state,
         )
-        expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+        expect(page).to have_content(
+          t(
+            'openid_connect.logout.heading_with_sp',
+            app_name: APP_NAME,
+            service_provider_name: service_provider.friendly_name,
+          ),
+        )
         click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
         visit account_path
@@ -194,14 +200,20 @@ describe 'OpenID Connect' do
       end
 
       it 'logout does not require state' do
-        client_id = 'urn:gov:gsa:openidconnect:test'
-        sign_in_get_id_token(client_id: client_id)
+        service_provider = ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:test')
+        sign_in_get_id_token(client_id: service_provider.issuer)
 
         visit openid_connect_logout_path(
-          client_id: client_id,
+          client_id: service_provider.issuer,
           post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
         )
-        expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+        expect(page).to have_content(
+          t(
+            'openid_connect.logout.heading_with_sp',
+            app_name: APP_NAME,
+            service_provider_name: service_provider.friendly_name,
+          ),
+        )
         click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
         visit account_path
@@ -210,17 +222,23 @@ describe 'OpenID Connect' do
       end
 
       it 'does not destroy the session and redirects to account page when denying logout' do
-        client_id = 'urn:gov:gsa:openidconnect:test'
-        sign_in_get_id_token(client_id: client_id)
+        service_provider = ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:test')
+        sign_in_get_id_token(client_id: service_provider.issuer)
 
         state = SecureRandom.hex
 
         visit openid_connect_logout_path(
-          client_id: client_id,
+          client_id: service_provider.issuer,
           post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
           state: state,
         )
-        expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+        expect(page).to have_content(
+          t(
+            'openid_connect.logout.heading_with_sp',
+            app_name: APP_NAME,
+            service_provider_name: service_provider.friendly_name,
+          ),
+        )
         click_link t('openid_connect.logout.deny')
 
         expect(page).to have_content(t('headings.account.login_info'))
@@ -235,17 +253,23 @@ describe 'OpenID Connect' do
     end
 
     it 'logout destroys the session when confirming logout' do
-      client_id = 'urn:gov:gsa:openidconnect:test'
-      sign_in_get_id_token(client_id: client_id)
+      service_provider = ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:test')
+      sign_in_get_id_token(client_id: service_provider.issuer)
 
       state = SecureRandom.hex
 
       visit openid_connect_logout_path(
-        client_id: client_id,
+        client_id: service_provider.issuer,
         post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
         state: state,
       )
-      expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+      expect(page).to have_content(
+        t(
+          'openid_connect.logout.heading_with_sp',
+          app_name: APP_NAME,
+          service_provider_name: service_provider.friendly_name,
+        ),
+      )
       click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
       visit account_path
@@ -254,14 +278,20 @@ describe 'OpenID Connect' do
     end
 
     it 'logout does not require state' do
-      client_id = 'urn:gov:gsa:openidconnect:test'
-      sign_in_get_id_token(client_id: client_id)
+      service_provider = ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:test')
+      sign_in_get_id_token(client_id: service_provider.issuer)
 
       visit openid_connect_logout_path(
-        client_id: client_id,
+        client_id: service_provider.issuer,
         post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/signout',
       )
-      expect(page).to have_content(t('openid_connect.logout.heading', app_name: APP_NAME))
+      expect(page).to have_content(
+        t(
+          'openid_connect.logout.heading_with_sp',
+          app_name: APP_NAME,
+          service_provider_name: service_provider.friendly_name,
+        ),
+      )
       click_button t('openid_connect.logout.confirm', app_name: APP_NAME)
 
       visit account_path


### PR DESCRIPTION
## 🛠 Summary of changes

To make RP-initiated OIDC Logout clearer for users, we should be explicit that they will return to the SP.  This PR intends to add content to clarify this.

## 👀 Screenshots

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/1430443/193920995-a79b857a-bca4-49aa-82f3-913ae17a3e6e.png)  | ![image](https://user-images.githubusercontent.com/1430443/193920712-40ff2a44-3b61-41b5-b800-1ee7f0c9014b.png) | 