### PR TITLE
Add FakeABTestBucket#assign_all

### DIFF
--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -25,13 +25,4 @@ module AbTests
       key_pair_group: IdentityConfig.store.key_pair_generation_percent,
     },
   )
-
-  def self.reload_ab_test_initializer!
-    # To be used in specs to undefine the AB tests instances so we can re-initialize them
-    # with different config values
-    AbTests.constants.each do |const_name|
-      AbTests.class_eval { remove_const(const_name) }
-    end
-    load Rails.root.join('config', 'initializers', 'ab_tests.rb').to_s
-  end
 end

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe AbTests do
+  def reload_ab_test_initializer!
+    # undefine the AB tests instances so we can re-initialize them with different config values
+    AbTests.constants.each do |const_name|
+      AbTests.class_eval { remove_const(const_name) }
+    end
+    load Rails.root.join('config', 'initializers', 'ab_tests.rb').to_s
+  end
+
   describe '::NATIVE_CAMERA' do
     let(:percent) { 30 }
 
@@ -10,7 +18,7 @@ describe AbTests do
       allow(IdentityConfig.store).to receive(:idv_native_camera_a_b_testing_percent).
         and_return(percent)
 
-      described_class.reload_ab_test_initializer!
+      reload_ab_test_initializer!
     end
 
     after do
@@ -19,7 +27,7 @@ describe AbTests do
       allow(IdentityConfig.store).to receive(:idv_native_camera_a_b_testing_percent).
         and_call_original
 
-      described_class.reload_ab_test_initializer!
+      reload_ab_test_initializer!
     end
 
     context 'configured with buckets adding up to less than 100 percent' do

--- a/spec/features/users/key_pair_generation_spec.rb
+++ b/spec/features/users/key_pair_generation_spec.rb
@@ -1,19 +1,15 @@
 require 'rails_helper'
 
 feature 'Generate key pair on Sign in' do
-  let(:percentage) { 0 }
-
   before do
-    allow(IdentityConfig.store).to receive(:key_pair_generation_percent).and_return(percentage)
-    AbTests.reload_ab_test_initializer!
-  end
-
-  after do
-    allow(IdentityConfig.store).to receive(:key_pair_generation_percent).and_call_original
-    AbTests.reload_ab_test_initializer!
+    stub_const('AbTests::KEY_PAIR_GENERATION', FakeAbTestBucket.new)
   end
 
   context 'key pair generation disabled' do
+    before do
+      AbTests::KEY_PAIR_GENERATION.assign_all(:default)
+    end
+
     it 'does not include a key pair generator on the page' do
       visit '/'
       expect(page).not_to have_css('lg-key-pair-generator')
@@ -21,7 +17,9 @@ feature 'Generate key pair on Sign in' do
   end
 
   context 'key pair generation enabled' do
-    let(:percentage) { 100 }
+    before do
+      AbTests::KEY_PAIR_GENERATION.assign_all(:key_pair_group)
+    end
 
     it 'includes a key pair generator on the page' do
       visit '/'

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe DocAuthRouter do
   end
 
   describe '.doc_auth_vendor' do
+    def reload_ab_test_initializer!
+      # undefine the AB tests instances so we can re-initialize them with different config values
+      AbTests.constants.each do |const_name|
+        AbTests.class_eval { remove_const(const_name) }
+      end
+      load Rails.root.join('config', 'initializers', 'ab_tests.rb').to_s
+    end
+
     let(:doc_auth_vendor) { 'test1' }
     let(:doc_auth_vendor_randomize_alternate_vendor) { 'test2' }
     let(:discriminator) { SecureRandom.uuid }
@@ -51,7 +59,7 @@ RSpec.describe DocAuthRouter do
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_randomize).
         and_return(doc_auth_vendor_randomize)
 
-      AbTests.reload_ab_test_initializer!
+      reload_ab_test_initializer!
     end
 
     after do
@@ -60,7 +68,7 @@ RSpec.describe DocAuthRouter do
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_randomize).
         and_call_original
 
-      AbTests.reload_ab_test_initializer!
+      reload_ab_test_initializer!
     end
 
     context 'with a nil discriminator' do

--- a/spec/services/idv/steps/document_capture_step_spec.rb
+++ b/spec/services/idv/steps/document_capture_step_spec.rb
@@ -66,7 +66,7 @@ describe Idv::Steps::DocumentCaptureStep do
 
         stub_const(
           'AbTests::NATIVE_CAMERA',
-          FakeAbTestBucket.new(session_uuid => :native_camera_only),
+          FakeAbTestBucket.new.tap { |ab| ab.assign(session_uuid => :native_camera_only) },
         )
       end
 

--- a/spec/support/fake_ab_test_bucket.rb
+++ b/spec/support/fake_ab_test_bucket.rb
@@ -13,7 +13,7 @@ class FakeAbTestBucket
   # @example
   #   ab.assign('aaa' => :default, 'bbb' => :experiment)
   def assign(discriminator_to_bucket)
-    @discriminator_to_bucket = discriminator_to_bucket
+    @discriminator_to_bucket.merge!(discriminator_to_bucket)
   end
 
   def assign_all(bucket)

--- a/spec/support/fake_ab_test_bucket.rb
+++ b/spec/support/fake_ab_test_bucket.rb
@@ -1,14 +1,22 @@
 # Mock version of AbTestBucket, used to pre-assign items to buckets for deterministic tests
 class FakeAbTestBucket
-  attr_reader :discriminator_to_bucket
+  attr_reader :discriminator_to_bucket, :all_result
 
-  # @example
-  #   FakeAbTestBucket.new('aaa' => :default, 'bbb' => :experiment)
-  def initialize(discriminator_to_bucket)
-    @discriminator_to_bucket = discriminator_to_bucket
+  def initialize
+    @discriminator_to_bucket = {}
   end
 
   def bucket(discriminator)
-    discriminator_to_bucket.fetch(discriminator, :default)
+    all_result || discriminator_to_bucket.fetch(discriminator, :default)
+  end
+
+  # @example
+  #   ab.assign('aaa' => :default, 'bbb' => :experiment)
+  def assign(discriminator_to_bucket)
+    @discriminator_to_bucket = discriminator_to_bucket
+  end
+
+  def assign_all(bucket)
+    @all_result = bucket
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

So in the PR that moved AB test bucket creation to an initializer (#6994) I added a duplicated method `reload_ab_test_initializer` as a hacky workaround that let us test logic inside an initializer (because for those two existing tests, we have multiple feature flags)

However, I think reloading initializers is a bad pattern, so I'd like to move as many instances of that as possible to `stub_const` and use the `FakeAbTestBucket` class

It looks like in this case, we were reloading to assign to 100% because we don't know the user ID *a priori* so I think the missing piece was an `#assign_all` method which I added

Anyways this is probably minor but I expect we'll continue to add more AB tests over time so I'd like to start encouraging cleaner ways to have determinism in specs that are less likely to risk test pollution

## 📜 Testing Plan

- [x] Specs still work

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A