### PR TITLE
LG-4258: Changing Default phone number should require multiple numbers associated with account

### DIFF
--- a/app/forms/edit_phone_form.rb
+++ b/app/forms/edit_phone_form.rb
@@ -33,6 +33,10 @@ class EditPhoneForm
     phone_configuration == user.default_phone_configuration
   end
 
+  def one_phone_configured?
+    user.phone_configurations.count == 1
+  end
+
   private
 
   attr_writer :delivery_preference, :make_default_number

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -10,7 +10,7 @@
       <div class="grid-row grid-gap-2">
         <div class="grid-col-fill">
           <%= PhoneFormatter.format(phone_configuration.phone) %>
-          <% if current_user.default_phone_configuration == phone_configuration %>
+          <% if current_user.default_phone_configuration == phone_configuration && MfaContext.new(current_user).phone_configurations.count > 1 %>
             (<%= I18n.t('account.index.default') %>)
           <% end %>
         </div>

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -1,20 +1,19 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
-  <% if @edit_phone_form.one_phone_configured? %>
     <legend class="margin-bottom-1">
-      <%= t('two_factor_authentication.otp_make_default_number.one_number_title') %>
+      <% if @edit_phone_form.one_phone_configured? %>
+        <%= t('two_factor_authentication.otp_make_default_number.one_number_title') %>
+      <% else %>
+        <%= t('two_factor_authentication.otp_make_default_number.title') %>
+      <% end %>
     </legend>
-    <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">
-      <%= t('two_factor_authentication.otp_make_default_number.one_number_instruction') %>
+    <p class="margin-top-0 margin-bottom-2">
+      <% if @edit_phone_form.one_phone_configured? %>
+        <%= t('two_factor_authentication.otp_make_default_number.one_number_instruction') %>
+      <% else %>
+        <%= t('two_factor_authentication.otp_make_default_number.instruction') %>
+      <% end %>
     </p>
-  <% else %>
-    <legend class="margin-bottom-1">
-      <%= t('two_factor_authentication.otp_make_default_number.title') %>
-    </legend>
-    <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">
-      <%= t('two_factor_authentication.otp_make_default_number.instruction') %>
-    </p>
-  <% end %>
     <%= check_box_tag(
           'edit_phone_form[make_default_number]',
           :otp_make_default_number,

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -1,11 +1,20 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
+  <% if @edit_phone_form.one_phone_configured? %>
+    <legend class="margin-bottom-1">
+      <%= t('two_factor_authentication.otp_make_default_number.one_number_title') %>
+    </legend>
+    <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">
+      <%= t('two_factor_authentication.otp_make_default_number.one_number_instruction') %>
+    </p>
+  <% else %>
     <legend class="margin-bottom-1">
       <%= t('two_factor_authentication.otp_make_default_number.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">
       <%= t('two_factor_authentication.otp_make_default_number.instruction') %>
     </p>
+  <% end %>
     <%= check_box_tag(
           'edit_phone_form[make_default_number]',
           :otp_make_default_number,

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -11,6 +11,7 @@
           :otp_make_default_number,
           @edit_phone_form.default_phone_configuration?,
           class: 'usa-checkbox__input usa-checkbox__input--bordered',
+          disabled: @edit_phone_form.one_phone_configured?,
         ) %>
     <label
       class="usa-checkbox__label"

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -88,9 +88,12 @@ en:
       voice: Phone call
       voice_unsupported: We are unable to call phone numbers in %{location}.
     otp_make_default_number:
-      instruction: Please check the box below if you want this to be the default phone
-        number you receive text messages or phone calls.
+      instruction: Make this phone number the default number where you receive text
+        message or phone calls.
       label: Default phone number
+      one_number_instruction: You must have more than one phone number added to select
+        a default phone number.
+      one_number_title: This is your default number
       title: Make this your default phone number?
     personal_key_fallback:
       question: Don’t have your personal key?

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -95,10 +95,12 @@ es:
       voice: Llamada telefónica
       voice_unsupported: No podemos llamar a números de teléfono en %{location}.
     otp_make_default_number:
-      instruction: Marque la casilla a continuación si desea que este sea el teléfono
-        predeterminado número que recibe mensajes de texto o llamadas
-        telefónicas.
+      instruction: Establece este número de teléfono como predeterminado para que
+        recibas en él mensajes de texto o llamadas telefónicas.
       label: Número de teléfono predeterminado
+      one_number_instruction: Debes tener más de un número de teléfono agregado para
+        seleccionar un número de teléfono predeterminado.
+      one_number_title: Este es tu número predeterminado
       title: '¿Es este tu número de teléfono predeterminado?'
     personal_key_fallback:
       question: '¿No tiene su clave personal?'

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -99,10 +99,12 @@ fr:
       voice_unsupported: Il nous est impossible d’appeler des numéros de téléphone
         dans le %{location}.
     otp_make_default_number:
-      instruction: Veuillez cocher la case ci-dessous si vous voulez que ce soit le
-        téléphone par défaut. numéro que vous recevez des messages texte ou des
-        appels téléphoniques.
+      instruction: Faites de ce numéro de téléphone le numéro par défaut où vous
+        recevez des messages texte ou des appels téléphoniques.
       label: Numéro de téléphone par défaut
+      one_number_instruction: Vous devez avoir ajouté plus d’un numéro de téléphone
+        pour pouvoir sélectionner un numéro de téléphone par défaut.
+      one_number_title: Il s’agit de votre numéro par défaut
       title: Faites-en votre numéro de téléphone par défaut?
     personal_key_fallback:
       question: Vous n’avez pas votre clé personnelle?

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -21,7 +21,7 @@ describe 'default phone selection' do
         )
       end
 
-      it 'does not indicate that it is the default text ' do
+      it 'does not indicate that it is the default number on the account page ' do
         sign_in_before_2fa(user)
         expect(page).not_to have_content t('account.index.default')
       end
@@ -53,12 +53,6 @@ describe 'default phone selection' do
           number: '(***) ***-3434',
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
-      end
-
-      it 'shows a disabled checkbox' do
-        sign_in_visit_add_phone_path(user, phone_config2)
-
-        expect(rendered).to have_field('two_factor_options_form[selection][]', disabled: true)
       end
     end
 

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -54,6 +54,12 @@ describe 'default phone selection' do
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
+
+      it 'shows a disabled checkbox' do
+        sign_in_visit_add_phone_path(user, phone_config2)
+
+        expect(rendered).to have_field('two_factor_options_form[selection][]', disabled: true)
+      end
     end
 
     context 'when the user edits exiting phone and sets it as default' do

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -20,6 +20,11 @@ describe 'default phone selection' do
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
+
+      it 'does not indicate that it is the default text ' do
+        sign_in_before_2fa(user)
+        expect(page).not_to have_content t('account.index.default')
+      end
     end
 
     context 'when the user creates a new default phone number' do

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -12,6 +12,9 @@ describe 'editing a phone' do
     expect(current_path).to eq(manage_phone_path(id: phone_configuration.id))
   end
 
+  it 'allows a user to select a default number' do
+  end
+
   it "does not allow a user to edit another user's phone number" do
     user = create(:user, :signed_up)
     sign_in_and_2fa_user(user)
@@ -19,5 +22,16 @@ describe 'editing a phone' do
     visit(manage_phone_path(id: create(:phone_configuration).id))
 
     expect(page).to have_content('The page you were looking for doesn’t exist')
+  end
+
+  context "with only one phone number" do
+    it "does not allow you to check default phone number if only one number is set up" do
+      user = create(:user, :signed_up)
+      phone_configuration = user.phone_configurations.first
+      sign_in_and_2fa_user(user)
+  
+      visit(manage_phone_path(id: phone_configuration.id))
+      expect(page).to have_field('edit_phone_form[make_default_number]', disabled: true)
+    end
   end
 end

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -21,12 +21,12 @@ describe 'editing a phone' do
     expect(page).to have_content('The page you were looking for doesn’t exist')
   end
 
-  context "with only one phone number" do
-    it "does not allow you to check default phone number if only one number is set up" do
+  context 'with only one phone number' do
+    it 'does not allow you to check default phone number if only one number is set up' do
       user = create(:user, :signed_up)
       phone_configuration = user.phone_configurations.first
       sign_in_and_2fa_user(user)
-  
+
       visit(manage_phone_path(id: phone_configuration.id))
       expect(page).to have_field('edit_phone_form[make_default_number]', disabled: true)
     end

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -28,7 +28,10 @@ describe 'editing a phone' do
       sign_in_and_2fa_user(user)
 
       visit(manage_phone_path(id: phone_configuration.id))
-      expect(page).to have_field('edit_phone_form[make_default_number]', disabled: true)
+      expect(page).to have_field(
+        t('two_factor_authentication.otp_make_default_number.label'),
+        disabled: true,
+      )
     end
   end
 end

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -12,9 +12,6 @@ describe 'editing a phone' do
     expect(current_path).to eq(manage_phone_path(id: phone_configuration.id))
   end
 
-  it 'allows a user to select a default number' do
-  end
-
   it "does not allow a user to edit another user's phone number" do
     user = create(:user, :signed_up)
     sign_in_and_2fa_user(user)

--- a/spec/forms/edit_phone_form_spec.rb
+++ b/spec/forms/edit_phone_form_spec.rb
@@ -11,7 +11,7 @@ describe EditPhoneForm do
     }
   end
 
-  subject { described_class.new(user, phone_configuration) }
+  subject { EditPhoneForm.new(user, phone_configuration) }
 
   describe '#submit' do
     context 'when delivery_preference is not voice or sms' do
@@ -108,12 +108,24 @@ describe EditPhoneForm do
     end
   end
 
-  describe 'user has one number' do
-    let(:user) { create(:user, :signed_up) }
-    let(:phone_configuration) { user.phone_configurations.first }
+  describe '#one_phone_configured?' do
+    context 'when editing a form with only one number set up' do
+      let(:user) { create(:user, :signed_up) }
+      let(:phone_configuration) { user.phone_configurations.first }
 
-    it 'recognizes it as the only method set up' do
-      expect(user.default_phone_configuration).to eq(phone_configuration)
+      it 'recognizes it as the only method set up' do
+        expect(subject.one_phone_configured?).to eq(true)
+      end
+    end
+
+    context 'when editing a form with multiple numbers set up' do
+      before do
+        create(:phone_configuration, user: user, made_default_at: Time.zone.now)
+      end
+
+      it 'recognizes that there are multiple phone methods set up' do
+        expect(user.phone_configurations.count).to eq(2)
+      end
     end
   end
 end

--- a/spec/forms/edit_phone_form_spec.rb
+++ b/spec/forms/edit_phone_form_spec.rb
@@ -107,4 +107,13 @@ describe EditPhoneForm do
       end
     end
   end
+
+  describe 'user has one number' do
+    let(:user) { create(:user, :signed_up) }
+    let(:phone_configuration) { user.phone_configurations.first }
+
+    it 'recognizes it as the only method set up' do
+      expect(user.default_phone_configuration).to eq(phone_configuration)
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-4258](https://cm-jira.usa.gov/browse/LG-4258)

## 🛠 Summary of changes

If a user has only one phone number set up on their account, they should not be able to select or deselect the "Make default number" checkbox. With this change, the checkbox will be disabled when there is one number associated with an account as well as a messaging that lays out why they cannot change their default number.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
- [x] Unit tests pass

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

|   Before  |   After  |
|--------- | ------- |
|  ![Image of manage phone number before checkbox change is made](https://user-images.githubusercontent.com/17969963/194144174-a6f9217e-4c95-4985-b7d0-996cfe3cdcce.png)   | ![image of change with checkbox disabled](https://user-images.githubusercontent.com/17969963/194143784-0f4017bc-da34-49b8-b9ee-673f53e059fc.png) |  



## 🚀 Notes for Deployment

N/A
