### PR TITLE
Refactored UserSession context functions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,7 +126,7 @@ class ApplicationController < ActionController::Base
   end
 
   def context
-    user_session[:context] || UserSessionContext::DEFAULT_CONTEXT
+    user_session[:context] || UserSessionContext::AUTHENTICATION_CONTEXT
   end
 
   def current_sp

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -14,7 +14,7 @@ module RememberDeviceConcern
   end
 
   def check_remember_device_preference
-    return unless UserSessionContext.authentication_context?(context)
+    return unless UserSessionContext.authentication_or_reauthentication_context?(context)
     return if remember_device_cookie.nil?
     return unless remember_device_cookie.valid_for_user?(
       user: current_user,

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -23,7 +23,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     PushNotification::HttpPush.deliver(event)
 
     if context && type
-      if UserSessionContext.authentication_context?(context)
+      if UserSessionContext.authentication_or_reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_rate_limited(mfa_device_type: type)
       elsif UserSessionContext.confirmation_context?(context)
         irs_attempts_api_tracker.mfa_enroll_rate_limited(mfa_device_type: type)
@@ -37,7 +37,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     analytics.multi_factor_auth_max_sends
 
     if context && phone
-      if UserSessionContext.authentication_context?(context)
+      if UserSessionContext.authentication_or_reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_sent_rate_limited(
           phone_number: phone,
         )
@@ -69,7 +69,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def check_already_authenticated
-    return unless UserSessionContext.initial_authentication_context?(context)
+    return unless UserSessionContext.authentication_context?(context)
     return unless user_fully_authenticated?
     return if remember_device_expired_for_sp?
     return if service_provider_mfa_policy.user_needs_sp_auth_method_verification?
@@ -112,7 +112,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def handle_valid_otp_for_context
-    if UserSessionContext.authentication_context?(context)
+    if UserSessionContext.authentication_or_reauthentication_context?(context)
       handle_valid_otp_for_authentication_context
     elsif UserSessionContext.confirmation_context?(context)
       handle_valid_otp_for_confirmation_context
@@ -313,7 +313,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def display_phone_to_deliver_to
-    if UserSessionContext.authentication_context?(context)
+    if UserSessionContext.authentication_or_reauthentication_context?(context)
       phone_configuration.masked_phone
     else
       user_session[:unconfirmed_phone]
@@ -321,7 +321,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def voice_otp_delivery_unsupported?
-    if UserSessionContext.authentication_context?(context)
+    if UserSessionContext.authentication_or_reauthentication_context?(context)
       PhoneNumberCapabilities.new(phone_configuration&.phone, phone_confirmed: true).supports_voice?
     else
       phone = user_session[:unconfirmed_phone]

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -55,7 +55,7 @@ module TwoFactorAuthentication
     def confirm_voice_capability
       return if two_factor_authentication_method == 'sms'
 
-      phone_is_confirmed = UserSessionContext.authentication_context?(context)
+      phone_is_confirmed = UserSessionContext.authentication_or_reauthentication_context?(context)
 
       capabilities = PhoneNumberCapabilities.new(phone, phone_confirmed: phone_is_confirmed)
 
@@ -98,7 +98,7 @@ module TwoFactorAuthentication
           reauthentication: true,
           success: properties[:success],
         )
-      elsif UserSessionContext.authentication_context?(context)
+      elsif UserSessionContext.authentication_or_reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_submitted(
           reauthentication: false,
           success: properties[:success],

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -304,7 +304,9 @@ module Users
     end
 
     def phone_to_deliver_to
-      return phone_configuration&.phone if UserSessionContext.authentication_or_reauthentication_context?(context)
+      if UserSessionContext.authentication_or_reauthentication_context?(context)
+        return phone_configuration&.phone
+      end
 
       user_session[:unconfirmed_phone]
     end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -74,7 +74,7 @@ module Users
     def validate_otp_delivery_preference_and_send_code
       result = otp_delivery_selection_form.submit(otp_delivery_preference: delivery_preference)
       analytics.otp_delivery_selection(**result.to_h)
-      phone_is_confirmed = UserSessionContext.authentication_context?(context)
+      phone_is_confirmed = UserSessionContext.authentication_or_reauthentication_context?(context)
       phone_capabilities = PhoneNumberCapabilities.new(
         parsed_phone,
         phone_confirmed: phone_is_confirmed,
@@ -230,7 +230,7 @@ module Users
           phone_number: parsed_phone.e164,
           otp_delivery_method: otp_delivery_preference,
         )
-      elsif UserSessionContext.authentication_context?(context)
+      elsif UserSessionContext.authentication_or_reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_sent(
           success: @telephony_result.success?,
           reauthentication: false,
@@ -280,7 +280,7 @@ module Users
         country_code: parsed_phone.country,
       }
 
-      if UserSessionContext.authentication_context?(context)
+      if UserSessionContext.authentication_or_reauthentication_context?(context)
         Telephony.send_authentication_otp(**params)
       else
         Telephony.send_confirmation_otp(**params)
@@ -304,7 +304,7 @@ module Users
     end
 
     def phone_to_deliver_to
-      return phone_configuration&.phone if UserSessionContext.authentication_context?(context)
+      return phone_configuration&.phone if UserSessionContext.authentication_or_reauthentication_context?(context)
 
       user_session[:unconfirmed_phone]
     end
@@ -313,7 +313,7 @@ module Users
       @otp_rate_limiter ||= OtpRateLimiter.new(
         phone: phone_to_deliver_to,
         user: current_user,
-        phone_confirmed: UserSessionContext.authentication_context?(context),
+        phone_confirmed: UserSessionContext.authentication_or_reauthentication_context?(context),
       )
     end
 

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -53,6 +53,6 @@ class OtpDeliverySelectionForm
   end
 
   def confirmed_phone?
-    UserSessionContext.authentication_context?(context)
+    UserSessionContext.authentication_or_reauthentication_context?(context)
   end
 end

--- a/app/services/user_session_context.rb
+++ b/app/services/user_session_context.rb
@@ -1,5 +1,4 @@
 class UserSessionContext
-  DEFAULT_CONTEXT = 'authentication'.freeze
   AUTHENTICATION_CONTEXT = 'authentication'.freeze
   REAUTHENTICATION_CONTEXT = 'reauthentication'.freeze
   CONFIRMATION_CONTEXT = 'confirmation'.freeze

--- a/app/services/user_session_context.rb
+++ b/app/services/user_session_context.rb
@@ -1,18 +1,19 @@
 class UserSessionContext
   DEFAULT_CONTEXT = 'authentication'.freeze
+  AUTHENTICATION_CONTEXT = 'authentication'.freeze
   REAUTHENTICATION_CONTEXT = 'reauthentication'.freeze
   CONFIRMATION_CONTEXT = 'confirmation'.freeze
 
-  def self.initial_authentication_context?(context)
-    context == DEFAULT_CONTEXT
+  def self.authentication_context?(context)
+    context == AUTHENTICATION_CONTEXT
   end
 
   def self.reauthentication_context?(context)
     context == REAUTHENTICATION_CONTEXT
   end
 
-  def self.authentication_context?(context)
-    initial_authentication_context?(context) || reauthentication_context?(context)
+  def self.authentication_or_reauthentication_context?(context)
+    authentication_context?(context) || reauthentication_context?(context)
   end
 
   def self.confirmation_context?(context)

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -7,7 +7,7 @@ describe TwoFactorLoginOptionsPresenter do
   let(:view) { ActionController::Base.new.view_context }
   let(:phishing_resistant_required) { false }
   let(:piv_cac_required) { false }
-  let(:user_session_context) { UserSessionContext::DEFAULT_CONTEXT }
+  let(:user_session_context) { UserSessionContext::AUTHENTICATION_CONTEXT }
 
   subject(:presenter) do
     TwoFactorLoginOptionsPresenter.new(
@@ -96,7 +96,7 @@ describe TwoFactorLoginOptionsPresenter do
     subject(:cancel_link) { presenter.cancel_link }
 
     context 'default user session context' do
-      let(:user_session_context) { UserSessionContext::DEFAULT_CONTEXT }
+      let(:user_session_context) { UserSessionContext::AUTHENTICATION_CONTEXT }
 
       it { should eq sign_out_path }
     end

--- a/spec/services/user_session_context_spec.rb
+++ b/spec/services/user_session_context_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 describe UserSessionContext do
   let(:confirmation) { { context: 'confirmation' } }
 
-  describe '.initial_authentication_context?' do
+  describe '.authentication_context?' do
     it 'returns true when context is default context' do
       expect(
-        UserSessionContext.initial_authentication_context?(UserSessionContext::DEFAULT_CONTEXT),
+        UserSessionContext.authentication_context?(UserSessionContext::AUTHENTICATION_CONTEXT),
       ).to eq true
     end
 
     it 'returns false when context is not default context' do
       expect(
-        UserSessionContext.initial_authentication_context?(
+        UserSessionContext.authentication_context?(
           UserSessionContext::CONFIRMATION_CONTEXT,
         ),
       ).to eq false
 
       expect(
-        UserSessionContext.initial_authentication_context?(
+        UserSessionContext.authentication_context?(
           UserSessionContext::REAUTHENTICATION_CONTEXT,
         ),
       ).to eq false
@@ -34,25 +34,25 @@ describe UserSessionContext do
 
     it 'returns false when context is default context' do
       expect(
-        UserSessionContext.reauthentication_context?(UserSessionContext::DEFAULT_CONTEXT),
+        UserSessionContext.reauthentication_context?(UserSessionContext::AUTHENTICATION_CONTEXT),
       ).to eq false
     end
   end
 
-  describe '.authentication_context?' do
+  describe '.authentication_or_reauthentication_context?' do
     it 'returns true when context is default or reauth context' do
       expect(
-        UserSessionContext.authentication_context?(UserSessionContext::DEFAULT_CONTEXT),
+        UserSessionContext.authentication_or_reauthentication_context?(UserSessionContext::AUTHENTICATION_CONTEXT),
       ).to eq true
 
       expect(
-        UserSessionContext.authentication_context?(UserSessionContext::REAUTHENTICATION_CONTEXT),
+        UserSessionContext.authentication_or_reauthentication_context?(UserSessionContext::REAUTHENTICATION_CONTEXT),
       ).to eq true
     end
 
     it 'returns false when context is confirmation context' do
       expect(
-        UserSessionContext.initial_authentication_context?(
+        UserSessionContext.authentication_context?(
           UserSessionContext::CONFIRMATION_CONTEXT,
         ),
       ).to eq false
@@ -68,7 +68,7 @@ describe UserSessionContext do
 
     it 'returns false when context is default or reauth context' do
       expect(
-        UserSessionContext.confirmation_context?(UserSessionContext::DEFAULT_CONTEXT),
+        UserSessionContext.confirmation_context?(UserSessionContext::AUTHENTICATION_CONTEXT),
       ).to eq false
 
       expect(

--- a/spec/services/user_session_context_spec.rb
+++ b/spec/services/user_session_context_spec.rb
@@ -42,11 +42,15 @@ describe UserSessionContext do
   describe '.authentication_or_reauthentication_context?' do
     it 'returns true when context is default or reauth context' do
       expect(
-        UserSessionContext.authentication_or_reauthentication_context?(UserSessionContext::AUTHENTICATION_CONTEXT),
+        UserSessionContext.authentication_or_reauthentication_context?(
+          UserSessionContext::AUTHENTICATION_CONTEXT,
+        ),
       ).to eq true
 
       expect(
-        UserSessionContext.authentication_or_reauthentication_context?(UserSessionContext::REAUTHENTICATION_CONTEXT),
+        UserSessionContext.authentication_or_reauthentication_context?(
+          UserSessionContext::REAUTHENTICATION_CONTEXT,
+        ),
       ).to eq true
     end
 

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'two_factor_authentication/options/index.html.erb' do
     @presenter = TwoFactorLoginOptionsPresenter.new(
       user: user,
       view: view,
-      user_session_context: UserSessionContext::DEFAULT_CONTEXT,
+      user_session_context: UserSessionContext::AUTHENTICATION_CONTEXT,
       service_provider: nil,
       phishing_resistant_required: false,
       piv_cac_required: false,


### PR DESCRIPTION
changelog: Internal, General, Refactored inconsistent function names

## 🎫 Ticket
[LG-7324](https://cm-jira.usa.gov/browse/LG-7324)

## 🛠 Summary of changes
Refactored function names in user_session_context.rb that were a bit confusing. `reauthentication_context?` and `confirmation_context?` both check explicitly for the respective contexts. Intuitively, one would expect `authentication_context?` to do the same, but it was checking either authentication or reauthentication. This renames `authentication_context?` and `intiial_authentication_context?` to more accurately describe what they are doing.

