### PR TITLE
LG-7704 Add a controller for the user to land on when they start reproofing

### DIFF
--- a/app/controllers/idv/reproofing_started_controller.rb
+++ b/app/controllers/idv/reproofing_started_controller.rb
@@ -1,0 +1,7 @@
+module Idv
+  class ReproofingStartedController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    def new; end
+  end
+end

--- a/app/views/idv/reproofing_started/new.html.erb
+++ b/app/views/idv/reproofing_started/new.html.erb
@@ -1,0 +1,1 @@
+Hello world!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,7 @@ Rails.application.routes.draw do
     end
     scope '/verify', module: 'idv', as: 'idv' do
       get '/come_back_later' => 'come_back_later#show'
+      get '/reproofing_started' => 'reproofing_started#new'
       get '/personal_key' => 'personal_key#show'
       post '/personal_key' => 'personal_key#update'
       get '/forgot_password' => 'forgot_password#new'


### PR DESCRIPTION
IRS users will need to re-proof to use login.gov. This commit adds a page to display to users so they have context for why they are going through this flow again.

[skip changelog]

This is a draft for now and is WIP while we wait for designs for what this screen should look like