### PR TITLE
Update long-running report queries to reset connection

### DIFF
--- a/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
+++ b/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
@@ -16,7 +16,6 @@ module Reports
           issuers: iaa.issuers,
           start_date: iaa.start_date,
           end_date: iaa.end_date,
-          &method(:transaction_with_timeout)
         )
       end
 

--- a/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
+++ b/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
@@ -11,14 +11,13 @@ module Reports
 
     def perform(_date)
       raw_results = IaaReportingHelper.iaas.flat_map do |iaa|
-        transaction_with_timeout do
-          Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(
-            key: iaa.key,
-            issuers: iaa.issuers,
-            start_date: iaa.start_date,
-            end_date: iaa.end_date,
-          )
-        end
+        Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(
+          key: iaa.key,
+          issuers: iaa.issuers,
+          start_date: iaa.start_date,
+          end_date: iaa.end_date,
+          &method(:transaction_with_timeout)
+        )
       end
 
       results = combine_by_iaa_month(raw_results)

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -7,6 +7,20 @@ module Reports
     # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
     discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
+    def self.transaction_with_timeout(rails_env = Rails.env)
+      # rspec-rails's use_transactional_tests does not seem to act as expected when switching
+      # connections mid-test, so we just skip for now :[
+      return yield if rails_env.test?
+
+      ActiveRecord::Base.connected_to(role: :reading, shard: :read_replica) do
+        ActiveRecord::Base.transaction do
+          quoted_timeout = ActiveRecord::Base.connection.quote(IdentityConfig.store.report_timeout)
+          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")
+          yield
+        end
+      end
+    end
+
     private
 
     def public_bucket_name
@@ -27,22 +41,8 @@ module Reports
       Time.zone.now.end_of_day
     end
 
-    def report_timeout
-      IdentityConfig.store.report_timeout
-    end
-
-    def transaction_with_timeout(rails_env = Rails.env)
-      # rspec-rails's use_transactional_tests does not seem to act as expected when switching
-      # connections mid-test, so we just skip for now :[
-      return yield if rails_env.test?
-
-      ActiveRecord::Base.connected_to(role: :reading, shard: :read_replica) do
-        ActiveRecord::Base.transaction do
-          quoted_timeout = ActiveRecord::Base.connection.quote(report_timeout)
-          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")
-          yield
-        end
-      end
+    def transaction_with_timeout(...)
+      self.class.transaction_with_timeout(...)
     end
 
     def save_report(report_name, body, extension:)

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -15,26 +15,24 @@ module Reports
       iaas = IaaReportingHelper.iaas
 
       by_iaa_results = iaas.flat_map do |iaa|
-        transaction_with_timeout do
-          Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(
-            key: iaa.key,
-            issuers: iaa.issuers,
-            start_date: iaa.start_date,
-            end_date: iaa.end_date,
-          )
-        end
+        Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(
+          key: iaa.key,
+          issuers: iaa.issuers,
+          start_date: iaa.start_date,
+          end_date: iaa.end_date,
+          &method(:transaction_with_timeout)
+        )
       end
 
       by_issuer_results = iaas.flat_map do |iaa|
         iaa.issuers.flat_map do |issuer|
-          transaction_with_timeout do
-            Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow.call(
-              issuer: issuer,
-              iaa_start_date: iaa.start_date,
-              iaa_end_date: iaa.end_date,
-              iaa: iaa.key,
-            )
-          end
+          Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow.call(
+            issuer: issuer,
+            iaa_start_date: iaa.start_date,
+            iaa_end_date: iaa.end_date,
+            iaa: iaa.key,
+            &method(:transaction_with_timeout)
+          )
         end
       end
 

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -20,7 +20,6 @@ module Reports
           issuers: iaa.issuers,
           start_date: iaa.start_date,
           end_date: iaa.end_date,
-          &method(:transaction_with_timeout)
         )
       end
 
@@ -31,7 +30,6 @@ module Reports
             iaa_start_date: iaa.start_date,
             iaa_end_date: iaa.end_date,
             iaa: iaa.key,
-            &method(:transaction_with_timeout)
           )
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

(none)

## 🛠 Summary of changes

**Why**: Occasionally we see PG::UnableToSend errors at which point the connection stops receiving queries. [NewRelic link](https://onenr.io/0vjAX7omDRP)

In an attempt to recover the job and continue, we call #reconnect! on the connection. However, this would reset our session-specific timeouts, so there's a big of rejiggering to allow the connection timeout stuff from the reports to be called in to the db query classes

## 📜 Testing Plan

- [ ] Try patching these changes in a Rails console and see if they work
