### PR TITLE
LG-7630 update enrollment attributes to include service provider

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -26,6 +26,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       minutes_since_last_status_check: enrollment.minutes_since_last_status_check,
       minutes_since_last_status_update: enrollment.minutes_since_last_status_update,
       minutes_to_completion: complete ? enrollment.minutes_since_established : nil,
+      issuer: enrollment.issuer,
     }
   end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -7,7 +7,6 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
         enrollment_established_at: Time.zone.now - 3.days,
         status_check_attempted_at: Time.zone.now - 15.minutes,
         status_updated_at: Time.zone.now - 2.days,
-        issuer: ServiceProvider.find_by(issuer: 'http://localhost:3000').issuer,
       )
 
       job.perform(Time.zone.now)
@@ -35,7 +34,7 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
       status: response['status'],
       transaction_end_date_time: response['transactionEndDateTime'],
       transaction_start_date_time: response['transactionStartDateTime'],
-      issuer: 'http://localhost:3000',
+      issuer: pending_enrollment.issuer,
     )
   end
 
@@ -130,7 +129,11 @@ RSpec.describe GetUspsProofingResultsJob do
     describe 'IPP enabled' do
       let!(:pending_enrollments) do
         [
-          create(:in_person_enrollment, :pending, selected_location_details: { name: 'BALTIMORE' }),
+          create(
+            :in_person_enrollment, :pending,
+            selected_location_details: { name: 'BALTIMORE' },
+            issuer: 'http://localhost:3000'
+          ),
           create(
             :in_person_enrollment, :pending,
             selected_location_details: { name: 'FRIENDSHIP' }

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
         enrollment_established_at: Time.zone.now - 3.days,
         status_check_attempted_at: Time.zone.now - 15.minutes,
         status_updated_at: Time.zone.now - 2.days,
+        issuer: ServiceProvider.find_by(issuer: 'http://localhost:3000').issuer,
       )
 
       job.perform(Time.zone.now)
@@ -34,6 +35,7 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
       status: response['status'],
       transaction_end_date_time: response['transactionEndDateTime'],
       transaction_start_date_time: response['transactionStartDateTime'],
+      issuer: 'http://localhost:3000',
     )
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-7630](https://cm-jira.usa.gov/browse/LG-7630)

## 🛠 Summary of changes

Added enrollment.issuer  to enrollment_analytic_attributes in order to allow service_provider to be tracked in CloudWatch.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Open a rails console
- [ ] Start an enrollment by walking through the ipp process
- [ ] In the rails console save the last user:
       `u = User.last`
- [ ] Save the user's last enrollment 
       `e = u.in_person_enrollments.last`
- [ ] `GetUspsProofingResultsJob.new.send(:enrollment_analytics_attributes, e, complete: true)`
- [ ] Confirm that issuer field is included

## 👀 Screenshots

<details>
<summary>Console</summary>
<img width="950" alt="Screen Shot 2022-10-07 at 8 23 26 AM" src="https://user-images.githubusercontent.com/20867088/194552543-998460ae-af33-4385-a47a-e0d22af2cbd0.png">

</details>

