### PR TITLE
Remove unused FSMv2 analytics event mapping

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -13,23 +13,11 @@ class FrontendLogController < ApplicationController
     'IdV: prepare submitted' => :idv_in_person_prepare_submitted,
     'IdV: switch_back visited' => :idv_in_person_switch_back_visited,
     'IdV: switch_back submitted' => :idv_in_person_switch_back_submitted,
-    'IdV: forgot password visited' => :idv_forgot_password,
-    'IdV: password confirm visited' => :idv_review_info_visited,
-    'IdV: password confirm submitted' => proc do |analytics|
-      analytics.idv_review_complete(success: true)
-      analytics.idv_final(success: true)
-    end,
-    'IdV: personal key visited' => :idv_personal_key_visited,
-    'IdV: personal key submitted' => :idv_personal_key_submitted,
-    'IdV: personal key confirm visited' => :idv_personal_key_confirm_visited,
-    'IdV: personal key confirm submitted' => :idv_personal_key_confirm_submitted,
     'IdV: download personal key' => :idv_personal_key_downloaded,
     'IdV: Native camera forced after failed attempts' => :idv_native_camera_forced,
     'Multi-Factor Authentication: download backup code' => :multi_factor_auth_backup_code_download,
     'Show Password button clicked' => :show_password_button_clicked,
-  }.transform_values do |method|
-    method.is_a?(Proc) ? method : AnalyticsEvents.instance_method(method)
-  end.freeze
+  }.transform_values { |method| AnalyticsEvents.instance_method(method) }.freeze
   # rubocop:enable Layout/LineLength
 
   def create

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -28,12 +28,12 @@ describe FrontendLogController do
       end
 
       context 'allowlisted analytics event' do
-        let(:event) { 'IdV: personal key visited' }
+        let(:event) { 'IdV: download personal key' }
 
         it 'succeeds' do
           action
 
-          expect(fake_analytics).to have_logged_event('IdV: personal key visited')
+          expect(fake_analytics).to have_logged_event('IdV: personal key downloaded')
           expect(response).to have_http_status(:ok)
           expect(json[:success]).to eq(true)
         end
@@ -68,19 +68,6 @@ describe FrontendLogController do
               )
             end
           end
-        end
-      end
-
-      context 'allowlisted analytics event with compound proc' do
-        let(:event) { 'IdV: password confirm submitted' }
-
-        it 'succeeds' do
-          action
-
-          expect(fake_analytics).to have_logged_event('IdV: review complete')
-          expect(fake_analytics).to have_logged_event('IdV: final resolution', success: true)
-          expect(response).to have_http_status(:ok)
-          expect(json[:success]).to eq(true)
         end
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Follow-up to #7051

These event mappings existed to support FSMv2 frontend analytics event logging, removed as of #7051. Since they are no longer called, they should be removed.

## 📜 Testing Plan

- [ ] `rspec spec/controllers/frontend_log_controller_spec.rb`
- [ ] Expected analytics events are logged: `rspec spec/features/idv/analytics_spec.rb`