### PR TITLE
LG-7582: Add proofing components to IdV analytics events

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -50,7 +50,7 @@ module Idv
       irs_attempts_api_tracker.idv_gpo_letter_requested(resend: resend_requested?)
       create_user_event(:gpo_mail_sent, current_user)
 
-      ProofingComponent.create_or_find_by(user: current_user).update(address_check: 'gpo_letter')
+      ProofingComponent.find_or_create_by(user: current_user).update(address_check: 'gpo_letter')
     end
 
     def resend_requested?

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -43,7 +43,7 @@ module Idv
     end
 
     def add_proofing_component
-      ProofingComponent.create_or_find_by(user: current_user).update(verified_at: Time.zone.now)
+      ProofingComponent.find_or_create_by(user: current_user).update(verified_at: Time.zone.now)
     end
 
     def finish_idv_session

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -2,6 +2,9 @@
 
 class Analytics
   include AnalyticsEvents
+  include Idv::AnalyticsEventsEnhancer
+
+  attr_reader :user, :request, :sp, :ahoy
 
   def initialize(user:, request:, sp:, session:, ahoy: nil)
     @user = user
@@ -86,8 +89,6 @@ class Analytics
     )
     attributes[:success] ? 'success' : 'fail'
   end
-
-  attr_reader :user, :request, :sp, :ahoy
 
   def request_attributes
     attributes = {

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -480,12 +480,19 @@ module AnalyticsEvents
   # @param [String] step the step that the user was on when they clicked cancel
   # @param [String] request_came_from the controller and action from the
   #   source such as "users/sessions#new"
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user clicked cancel during IDV (presented with an option to go back or confirm)
-  def idv_cancellation_visited(step:, request_came_from:, **extra)
+  def idv_cancellation_visited(
+    step:,
+    request_came_from:,
+    proofing_components: nil,
+    **extra
+  )
     track_event(
       'IdV: cancellation visited',
       step: step,
       request_came_from: request_came_from,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -515,20 +522,37 @@ module AnalyticsEvents
   end
 
   # @param [String] step the step that the user was on when they clicked cancel
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user confirmed their choice to cancel going through IDV
-  def idv_cancellation_confirmed(step:, **extra)
-    track_event('IdV: cancellation confirmed', step: step, **extra)
+  def idv_cancellation_confirmed(step:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: cancellation confirmed',
+      step: step,
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [String] step the step that the user was on when they clicked cancel
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user chose to go back instead of cancel IDV
-  def idv_cancellation_go_back(step:, **extra)
-    track_event('IdV: cancellation go back', step: step, **extra)
+  def idv_cancellation_go_back(step:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: cancellation go back',
+      step: step,
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # The user visited the "come back later" page shown during the GPO mailing flow
-  def idv_come_back_later_visit
-    track_event('IdV: come back later visited')
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  def idv_come_back_later_visit(proofing_components: nil, **extra)
+    track_event(
+      'IdV: come back later visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
@@ -583,9 +607,14 @@ module AnalyticsEvents
     track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user visited the "ready to verify" page for the in person proofing flow
-  def idv_in_person_ready_to_verify_visit
-    track_event('IdV: in person ready to verify visited')
+  def idv_in_person_ready_to_verify_visit(proofing_components: nil, **extra)
+    track_event(
+      'IdV: in person ready to verify visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [String] step_name which step the user was on
@@ -724,34 +753,48 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited forgot password page
-  def idv_forgot_password
-    track_event('IdV: forgot password visited')
+  def idv_forgot_password(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User confirmed forgot password
-  def idv_forgot_password_confirmed
-    track_event('IdV: forgot password confirmed')
+  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password confirmed',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [DateTime] enqueued_at
   # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # GPO letter was enqueued and the time at which it was enqueued
-  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, **extra)
+  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, proofing_components: nil, **extra)
     track_event(
       'IdV: USPS address letter enqueued',
       enqueued_at: enqueued_at,
       resend: resend,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
   # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # GPO letter was requested
-  def idv_gpo_address_letter_requested(resend:, **extra)
+  def idv_gpo_address_letter_requested(resend:, proofing_components: nil, **extra)
     track_event(
       'IdV: USPS address letter requested',
       resend: resend,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -801,26 +844,39 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # Tracks the last step of IDV, indicates the user successfully prooved
   def idv_final(
     success:,
+    proofing_components: nil,
     **extra
   )
     track_event(
       'IdV: final resolution',
       success: success,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited IDV personal key page
-  def idv_personal_key_visited
-    track_event('IdV: personal key visited')
+  def idv_personal_key_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: personal key visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User submitted IDV personal key page
-  def idv_personal_key_submitted
-    track_event('IdV: personal key submitted')
+  def idv_personal_key_submitted(proofing_components: nil, **extra)
+    track_event(
+      'IdV: personal key submitted',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # A user has downloaded their backup codes
@@ -830,39 +886,62 @@ module AnalyticsEvents
 
   # A user has downloaded their personal key. This event is no longer emitted.
   # @identity.idp.previous_event_name IdV: download personal key
-  def idv_personal_key_downloaded
-    track_event('IdV: personal key downloaded')
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  def idv_personal_key_downloaded(proofing_components: nil, **extra)
+    track_event(
+      'IdV: personal key downloaded',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [Boolean] success
   # @param [Hash] errors
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user submitted their phone on the phone confirmation page
   def idv_phone_confirmation_form_submitted(
     success:,
     errors:,
+    proofing_components: nil,
     **extra
   )
     track_event(
       'IdV: phone confirmation form',
       success: success,
       errors: errors,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user was rate limited for submitting too many OTPs during the IDV phone step
-  def idv_phone_confirmation_otp_rate_limit_attempts
-    track_event('Idv: Phone OTP attempts rate limited')
+  def idv_phone_confirmation_otp_rate_limit_attempts(proofing_components: nil, **extra)
+    track_event(
+      'Idv: Phone OTP attempts rate limited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user was locked out for hitting the phone OTP rate limit during IDV
-  def idv_phone_confirmation_otp_rate_limit_locked_out
-    track_event('Idv: Phone OTP rate limited user')
+  def idv_phone_confirmation_otp_rate_limit_locked_out(proofing_components: nil, **extra)
+    track_event(
+      'Idv: Phone OTP rate limited user',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user was rate limited for requesting too many OTPs during the IDV phone step
-  def idv_phone_confirmation_otp_rate_limit_sends
-    track_event('Idv: Phone OTP sends rate limited')
+  def idv_phone_confirmation_otp_rate_limit_sends(proofing_components: nil, **extra)
+    track_event(
+      'Idv: Phone OTP sends rate limited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [Boolean] success
@@ -872,6 +951,7 @@ module AnalyticsEvents
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
   # @param [Hash] telephony_response response from Telephony gem
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user resent an OTP during the IDV phone step
   def idv_phone_confirmation_otp_resent(
     success:,
@@ -881,6 +961,7 @@ module AnalyticsEvents
     area_code:,
     rate_limit_exceeded:,
     telephony_response:,
+    proofing_components: nil,
     **extra
   )
     track_event(
@@ -892,6 +973,7 @@ module AnalyticsEvents
       area_code: area_code,
       rate_limit_exceeded: rate_limit_exceeded,
       telephony_response: telephony_response,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -904,6 +986,7 @@ module AnalyticsEvents
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # @param [Hash] telephony_response response from Telephony gem
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user requested an OTP to confirm their phone during the IDV phone step
   def idv_phone_confirmation_otp_sent(
     success:,
@@ -914,6 +997,7 @@ module AnalyticsEvents
     rate_limit_exceeded:,
     phone_fingerprint:,
     telephony_response:,
+    proofing_components: nil,
     **extra
   )
     track_event(
@@ -926,22 +1010,26 @@ module AnalyticsEvents
       rate_limit_exceeded: rate_limit_exceeded,
       phone_fingerprint: phone_fingerprint,
       telephony_response: telephony_response,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
   # @param [Boolean] success
   # @param [Hash] errors
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The vendor finished the process of confirming the users phone
   def idv_phone_confirmation_vendor_submitted(
     success:,
     errors:,
+    proofing_components: nil,
     **extra
   )
     track_event(
       'IdV: phone confirmation vendor',
       success: success,
       errors: errors,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -951,8 +1039,8 @@ module AnalyticsEvents
   # @param [Boolean] code_expired if the confirmation code expired
   # @param [Boolean] code_matches
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
-  # @param [Time, nil] second_factor_locked_at timestamp when the phone was
-  # locked out at
+  # @param [Time, nil] second_factor_locked_at timestamp when the phone was locked out
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # When a user attempts to confirm posession of a new phone number during the IDV process
   def idv_phone_confirmation_otp_submitted(
     success:,
@@ -961,6 +1049,7 @@ module AnalyticsEvents
     code_matches:,
     second_factor_attempts_count:,
     second_factor_locked_at:,
+    proofing_components: nil,
     **extra
   )
     track_event(
@@ -971,24 +1060,38 @@ module AnalyticsEvents
       code_matches: code_matches,
       second_factor_attempts_count: second_factor_attempts_count,
       second_factor_locked_at: second_factor_locked_at,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # When a user visits the page to confirm posession of a new phone number during the IDV process
-  def idv_phone_confirmation_otp_visit
-    track_event('IdV: phone confirmation otp visited')
+  def idv_phone_confirmation_otp_visit(proofing_components: nil, **extra)
+    track_event(
+      'IdV: phone confirmation otp visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param ['warning','jobfail','failure'] type
   # @param [Time] throttle_expires_at when the throttle expires
   # @param [Integer] remaining_attempts number of attempts remaining
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # When a user gets an error during the phone finder flow of IDV
-  def idv_phone_error_visited(type:, throttle_expires_at: nil, remaining_attempts: nil, **extra)
+  def idv_phone_error_visited(
+    type:,
+    proofing_components: nil,
+    throttle_expires_at: nil,
+    remaining_attempts: nil,
+    **extra
+  )
     track_event(
       'IdV: phone error visited',
       {
         type: type,
+        proofing_components: proofing_components,
         throttle_expires_at: throttle_expires_at,
         remaining_attempts: remaining_attempts,
         **extra,
@@ -1000,9 +1103,11 @@ module AnalyticsEvents
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [Hash] error_details
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   def idv_phone_otp_delivery_selection_submitted(
     success:,
     otp_delivery_preference:,
+    proofing_components: nil,
     errors: nil,
     error_details: nil,
     **extra
@@ -1014,63 +1119,91 @@ module AnalyticsEvents
         errors: errors,
         error_details: error_details,
         otp_delivery_preference: otp_delivery_preference,
+        proofing_components: proofing_components,
         **extra,
       }.compact,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited idv phone of record
-  def idv_phone_of_record_visited
-    track_event('IdV: phone of record visited')
-  end
-
-  # User visited idv phone OTP delivery selection
-  def idv_phone_otp_delivery_selection_visit
-    track_event('IdV: Phone OTP delivery Selection Visited')
-  end
-
-  # @param [String] step the step the user was on when they clicked use a different phone number
-  # User decided to use a different phone number in idv
-  def idv_phone_use_different(step:, **extra)
+  def idv_phone_of_record_visited(proofing_components: nil, **extra)
     track_event(
-      'IdV: use different phone number',
-      step: step,
+      'IdV: phone of record visited',
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User visited idv phone OTP delivery selection
+  def idv_phone_otp_delivery_selection_visit(proofing_components: nil, **extra)
+    track_event(
+      'IdV: Phone OTP delivery Selection Visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String] step the step the user was on when they clicked use a different phone number
+  # User decided to use a different phone number in idv
+  def idv_phone_use_different(step:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: use different phone number',
+      step: step,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The system encountered an error and the proofing results are missing
-  def idv_proofing_resolution_result_missing
-    track_event('Proofing Resolution Result Missing')
+  def idv_proofing_resolution_result_missing(proofing_components: nil, **extra)
+    track_event(
+      'Proofing Resolution Result Missing',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # User submitted IDV password confirm page
   # @param [Boolean] success
-  def idv_review_complete(success:, **extra)
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  def idv_review_complete(success:, proofing_components: nil, **extra)
     track_event(
       'IdV: review complete',
       success: success,
+      proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited IDV password confirm page
-  def idv_review_info_visited
-    track_event('IdV: review info visited')
+  def idv_review_info_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: review info visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [String] step
   # @param [String] location
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User started over idv
   def idv_start_over(
     step:,
     location:,
+    proofing_components: nil,
     **extra
   )
     track_event(
       'IdV: start over',
       step: step,
       location: location,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -2800,9 +2933,14 @@ module AnalyticsEvents
     track_event('Account Reset: Cancel Account Recovery Options')
   end
 
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # Tracks when the user reaches the verify setup errors page after failing proofing
-  def idv_setup_errors_visited
-    track_event('IdV: Verify setup errors visited')
+  def idv_setup_errors_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: Verify setup errors visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 
   # @param [String] redirect_url URL user was directed to
@@ -2829,10 +2967,16 @@ module AnalyticsEvents
 
   # Tracks if a user clicks the 'acknowledge' checkbox during personal
   # key creation
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [boolean] checked whether the user checked or un-checked
   #                  the box with this click
-  def idv_personal_key_acknowledgment_toggled(checked:, **extra)
-    track_event('IdV: personal key acknowledgment toggled', checked: checked, **extra)
+  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
+    track_event(
+      'IdV: personal key acknowledgment toggled',
+      checked: checked,
+      proofing_components: proofing_components,
+      **extra,
+    )
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/services/frontend_logger.rb
+++ b/app/services/frontend_logger.rb
@@ -8,7 +8,7 @@ class FrontendLogger
 
   def track_event(name, attributes)
     if (analytics_method = event_map[name])
-      analytics_method.bind_call(analytics, **hash_from_method_kwargs(attributes, analytics_method))
+      analytics.send(analytics_method.name, **hash_from_method_kwargs(attributes, analytics_method))
     else
       analytics.track_event("Frontend: #{name}", attributes)
     end

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -1,0 +1,62 @@
+module Idv
+  module AnalyticsEventsEnhancer
+    DECORATED_METHODS = %i[
+      idv_cancellation_confirmed
+      idv_cancellation_go_back
+      idv_cancellation_visited
+      idv_come_back_later_visit
+      idv_forgot_password
+      idv_forgot_password_confirmed
+      idv_final
+      idv_gpo_address_letter_enqueued
+      idv_gpo_address_letter_requested
+      idv_in_person_ready_to_verify_visit
+      idv_personal_key_acknowledgment_toggled
+      idv_personal_key_downloaded
+      idv_personal_key_submitted
+      idv_personal_key_visited
+      idv_phone_confirmation_form_submitted
+      idv_phone_confirmation_otp_rate_limit_attempts
+      idv_phone_confirmation_otp_rate_limit_locked_out
+      idv_phone_confirmation_otp_rate_limit_sends
+      idv_phone_confirmation_otp_resent
+      idv_phone_confirmation_otp_sent
+      idv_phone_confirmation_otp_submitted
+      idv_phone_confirmation_otp_visit
+      idv_phone_confirmation_vendor_submitted
+      idv_phone_error_visited
+      idv_phone_of_record_visited
+      idv_phone_otp_delivery_selection_visit
+      idv_phone_otp_delivery_selection_submitted
+      idv_proofing_resolution_result_missing
+      idv_review_complete
+      idv_review_info_visited
+      idv_setup_errors_visited
+      idv_start_over
+    ].freeze
+
+    extend ActiveSupport::Concern
+
+    included do
+      DECORATED_METHODS.each do |method_name|
+        alias_method "original_#{method_name}", method_name
+        define_method(method_name) do |**kwargs|
+          send("original_#{method_name}", **kwargs, **common_analytics_attributes)
+        end
+      end
+    end
+
+    private
+
+    def common_analytics_attributes
+      {
+        proofing_components: proofing_components,
+      }
+    end
+
+    def proofing_components
+      return if !user&.respond_to?(:proofing_component) || !user.proofing_component
+      ProofingComponentsLogging.new(user.proofing_component)
+    end
+  end
+end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -108,7 +108,7 @@ module Idv
       idv_session.vendor_phone_confirmation = true
       idv_session.user_phone_confirmation = false
 
-      ProofingComponent.create_or_find_by(user: idv_session.current_user).
+      ProofingComponent.find_or_create_by(user: idv_session.current_user).
         update(address_check: 'lexis_nexis_address')
     end
 

--- a/app/services/idv/proofing_components_logging.rb
+++ b/app/services/idv/proofing_components_logging.rb
@@ -1,0 +1,19 @@
+module Idv
+  ProofingComponentsLogging = Struct.new(:proofing_components) do
+    def as_json(*)
+      proofing_components.slice(
+        :document_check,
+        :document_type,
+        :source_check,
+        :resolution_check,
+        :address_check,
+        :liveness_check,
+        :device_fingerprinting_vendor,
+        :threatmetrix,
+        :threatmetrix_review_status,
+        :threatmetrix_risk_rating,
+        :threatmetrix_policy_score,
+      ).compact
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -249,9 +249,16 @@ describe ApplicationController do
         allow(controller).to receive(:analytics_user).and_return(user)
         allow(controller).to receive(:current_sp).and_return(sp)
 
+        analytics = instance_double(Analytics, decorate: nil)
         expect(Analytics).to receive(:new).
-          with(user: user, request: request, sp: sp.issuer, session: match_array({}),
-               ahoy: controller.ahoy)
+          with(
+            user: user,
+            request: request,
+            sp: sp.issuer,
+            session: match_array({}),
+            ahoy: controller.ahoy,
+          ).
+          and_return(analytics)
 
         controller.analytics
       end
@@ -264,9 +271,16 @@ describe ApplicationController do
         user = instance_double(AnonymousUser)
         allow(AnonymousUser).to receive(:new).and_return(user)
 
+        analytics = instance_double(Analytics, decorate: nil)
         expect(Analytics).to receive(:new).
-          with(user: user, request: request, sp: nil, session: match_array({}),
-               ahoy: controller.ahoy)
+          with(
+            user: user,
+            request: request,
+            sp: nil,
+            session: match_array({}),
+            ahoy: controller.ahoy,
+          ).
+          and_return(analytics)
 
         controller.analytics
       end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -249,16 +249,9 @@ describe ApplicationController do
         allow(controller).to receive(:analytics_user).and_return(user)
         allow(controller).to receive(:current_sp).and_return(sp)
 
-        analytics = instance_double(Analytics, decorate: nil)
         expect(Analytics).to receive(:new).
-          with(
-            user: user,
-            request: request,
-            sp: sp.issuer,
-            session: match_array({}),
-            ahoy: controller.ahoy,
-          ).
-          and_return(analytics)
+          with(user: user, request: request, sp: sp.issuer, session: match_array({}),
+               ahoy: controller.ahoy)
 
         controller.analytics
       end
@@ -271,16 +264,9 @@ describe ApplicationController do
         user = instance_double(AnonymousUser)
         allow(AnonymousUser).to receive(:new).and_return(user)
 
-        analytics = instance_double(Analytics, decorate: nil)
         expect(Analytics).to receive(:new).
-          with(
-            user: user,
-            request: request,
-            sp: nil,
-            session: match_array({}),
-            ahoy: controller.ahoy,
-          ).
-          and_return(analytics)
+          with(user: user, request: request, sp: nil, session: match_array({}),
+               ahoy: controller.ahoy)
 
         controller.analytics
       end

--- a/spec/controllers/concerns/idv/phone_otp_rate_limitable_spec.rb
+++ b/spec/controllers/concerns/idv/phone_otp_rate_limitable_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Idv::PhoneOtpRateLimitable, type: :controller do
 
       expect(@analytics).to have_received(:track_event).with(
         'Idv: Phone OTP sends rate limited',
+        proofing_components: nil,
       )
     end
 

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -17,9 +17,13 @@ describe Idv::CancellationsController do
     it 'tracks the event in analytics when referer is nil' do
       stub_sign_in
       stub_analytics
-      properties = { request_came_from: 'no referer', step: nil }
 
-      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: cancellation visited',
+        request_came_from: 'no referer',
+        step: nil,
+        proofing_components: nil,
+      )
 
       get :new
     end
@@ -28,9 +32,13 @@ describe Idv::CancellationsController do
       stub_sign_in
       stub_analytics
       request.env['HTTP_REFERER'] = 'http://example.com/'
-      properties = { request_came_from: 'users/sessions#new', step: nil }
 
-      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: cancellation visited',
+        request_came_from: 'users/sessions#new',
+        step: nil,
+        proofing_components: nil,
+      )
 
       get :new
     end
@@ -38,9 +46,13 @@ describe Idv::CancellationsController do
     it 'tracks the event in analytics when step param is present' do
       stub_sign_in
       stub_analytics
-      properties = { request_came_from: 'no referer', step: 'first' }
 
-      expect(@analytics).to receive(:track_event).with('IdV: cancellation visited', properties)
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: cancellation visited',
+        request_came_from: 'no referer',
+        step: 'first',
+        proofing_components: nil,
+      )
 
       get :new, params: { step: 'first' }
     end
@@ -100,6 +112,7 @@ describe Idv::CancellationsController do
       expect(@analytics).to receive(:track_event).with(
         'IdV: cancellation go back',
         step: 'first',
+        proofing_components: nil,
       )
 
       put :update, params: { step: 'first', cancel: 'true' }
@@ -136,6 +149,7 @@ describe Idv::CancellationsController do
       expect(@analytics).to receive(:track_event).with(
         'IdV: cancellation confirmed',
         step: 'first',
+        proofing_components: nil,
       )
 
       delete :destroy, params: { step: 'first' }

--- a/spec/controllers/idv/come_back_later_controller_spec.rb
+++ b/spec/controllers/idv/come_back_later_controller_spec.rb
@@ -16,7 +16,10 @@ describe Idv::ComeBackLaterController do
     it 'renders the show template' do
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with('IdV: come back later visited')
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: come back later visited',
+        proofing_components: nil,
+      )
 
       get :show
 

--- a/spec/controllers/idv/forgot_password_controller_spec.rb
+++ b/spec/controllers/idv/forgot_password_controller_spec.rb
@@ -18,7 +18,10 @@ describe Idv::ForgotPasswordController do
     it 'tracks the event in analytics when referer is nil' do
       get :new
 
-      expect(@analytics).to have_received(:track_event).with('IdV: forgot password visited')
+      expect(@analytics).to have_received(:track_event).with(
+        'IdV: forgot password visited',
+        proofing_components: nil,
+      )
     end
   end
 
@@ -39,7 +42,10 @@ describe Idv::ForgotPasswordController do
 
       post :update
 
-      expect(@analytics).to have_received(:track_event).with('IdV: forgot password confirmed')
+      expect(@analytics).to have_received(:track_event).with(
+        'IdV: forgot password confirmed',
+        proofing_components: nil,
+      )
     end
   end
 end

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -70,7 +70,7 @@ describe Idv::OtpDeliveryMethodController do
       get :new
 
       expect(@analytics).to have_received(:track_event).
-        with('IdV: Phone OTP delivery Selection Visited')
+        with('IdV: Phone OTP delivery Selection Visited', proofing_components: nil)
     end
   end
 
@@ -135,6 +135,7 @@ describe Idv::OtpDeliveryMethodController do
           success: true,
           errors: {},
           otp_delivery_preference: 'sms',
+          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -168,6 +169,7 @@ describe Idv::OtpDeliveryMethodController do
           success: true,
           errors: {},
           otp_delivery_preference: 'voice',
+          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -197,6 +199,7 @@ describe Idv::OtpDeliveryMethodController do
           errors: { otp_delivery_preference: ['is not included in the list'] },
           error_details: { otp_delivery_preference: [:inclusion] },
           otp_delivery_preference: '🎷',
+          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -135,7 +135,6 @@ describe Idv::OtpDeliveryMethodController do
           success: true,
           errors: {},
           otp_delivery_preference: 'sms',
-          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -169,7 +168,6 @@ describe Idv::OtpDeliveryMethodController do
           success: true,
           errors: {},
           otp_delivery_preference: 'voice',
-          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -199,7 +197,6 @@ describe Idv::OtpDeliveryMethodController do
           errors: { otp_delivery_preference: ['is not included in the list'] },
           error_details: { otp_delivery_preference: [:inclusion] },
           otp_delivery_preference: '🎷',
-          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -58,7 +58,10 @@ describe Idv::OtpVerificationController do
     it 'tracks an analytics event' do
       get :show
 
-      expect(@analytics).to have_received(:track_event).with('IdV: phone confirmation otp visited')
+      expect(@analytics).to have_received(:track_event).with(
+        'IdV: phone confirmation otp visited',
+        proofing_components: nil,
+      )
     end
   end
 
@@ -91,6 +94,7 @@ describe Idv::OtpVerificationController do
         code_matches: true,
         second_factor_attempts_count: 0,
         second_factor_locked_at: nil,
+        proofing_components: nil,
       }
 
       expect(@analytics).to have_received(:track_event).with(

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -90,8 +90,11 @@ describe Idv::PhoneController do
       it 'logs an event showing that the user wants to choose a different number' do
         get :new, params: params
 
-        expect(@analytics).to have_received(:track_event).
-          with('IdV: use different phone number', step: step)
+        expect(@analytics).to have_received(:track_event).with(
+          'IdV: use different phone number',
+          step: step,
+          proofing_components: nil,
+        )
       end
     end
 
@@ -180,6 +183,7 @@ describe Idv::PhoneController do
           carrier: 'Test Mobile Carrier',
           phone_type: :mobile,
           types: [],
+          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -217,6 +221,7 @@ describe Idv::PhoneController do
           carrier: 'Test Mobile Carrier',
           phone_type: :mobile,
           types: [:fixed_or_mobile],
+          proofing_components: nil,
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -329,6 +334,7 @@ describe Idv::PhoneController do
             transaction_id: 'address-mock-transaction-id-123',
             reference: '',
           },
+          proofing_components: nil,
         }
 
         expect(@analytics).to receive(:track_event).ordered.with(
@@ -384,6 +390,7 @@ describe Idv::PhoneController do
             transaction_id: 'address-mock-transaction-id-123',
             reference: '',
           },
+          proofing_components: nil,
         }
 
         expect(@analytics).to receive(:track_event).ordered.with(

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -80,7 +80,6 @@ describe Idv::PhoneErrorsController do
           'IdV: phone error visited',
           type: action,
           remaining_attempts: 4,
-          proofing_components: nil,
         )
       end
     end
@@ -133,7 +132,6 @@ describe Idv::PhoneErrorsController do
           'IdV: phone error visited',
           type: action,
           remaining_attempts: 4,
-          proofing_components: nil,
         )
       end
     end
@@ -172,7 +170,6 @@ describe Idv::PhoneErrorsController do
             'IdV: phone error visited',
             type: action,
             throttle_expires_at: attempted_at + throttle_window,
-            proofing_components: nil,
           )
         end
       end

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -74,12 +74,14 @@ describe Idv::PhoneErrorsController do
       end
 
       it 'logs an event' do
-        logged_attributes = { type: action, remaining_attempts: 4 }
-
         get action
 
-        expect(@analytics).to have_received(:track_event).
-          with('IdV: phone error visited', logged_attributes)
+        expect(@analytics).to have_received(:track_event).with(
+          'IdV: phone error visited',
+          type: action,
+          remaining_attempts: 4,
+          proofing_components: nil,
+        )
       end
     end
   end
@@ -125,12 +127,14 @@ describe Idv::PhoneErrorsController do
       end
 
       it 'logs an event' do
-        logged_attributes = { type: action, remaining_attempts: 4 }
-
         get action
 
-        expect(@analytics).to have_received(:track_event).
-          with('IdV: phone error visited', logged_attributes)
+        expect(@analytics).to have_received(:track_event).with(
+          'IdV: phone error visited',
+          type: action,
+          remaining_attempts: 4,
+          proofing_components: nil,
+        )
       end
     end
   end
@@ -161,15 +165,15 @@ describe Idv::PhoneErrorsController do
       it 'logs an event' do
         freeze_time do
           throttle_window = Throttle.attempt_window_in_minutes(:proof_address).minutes
-          logged_attributes = {
-            type: action,
-            throttle_expires_at: attempted_at + throttle_window,
-          }
 
           get action
 
-          expect(@analytics).to have_received(:track_event).
-            with('IdV: phone error visited', logged_attributes)
+          expect(@analytics).to have_received(:track_event).with(
+            'IdV: phone error visited',
+            type: action,
+            throttle_expires_at: attempted_at + throttle_window,
+            proofing_components: nil,
+          )
         end
       end
     end

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -61,6 +61,7 @@ describe Idv::ResendOtpController do
         area_code: '225',
         rate_limit_exceeded: false,
         telephony_response: instance_of(Telephony::Response),
+        proofing_components: nil,
       }
 
       expect(@analytics).to have_received(:track_event).with(

--- a/spec/controllers/idv/setup_errors_controller_spec.rb
+++ b/spec/controllers/idv/setup_errors_controller_spec.rb
@@ -10,7 +10,10 @@ describe Idv::SetupErrorsController do
   it 'renders the show template' do
     stub_analytics
 
-    expect(@analytics).to receive(:track_event).with('IdV: Verify setup errors visited')
+    expect(@analytics).to receive(:track_event).with(
+      'IdV: Verify setup errors visited',
+      proofing_components: nil,
+    )
 
     get :show
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -31,15 +31,20 @@ feature 'Analytics Regression', js: true do
       'IdV: doc auth verify submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'verify', step_count: 1 },
       'IdV: doc auth verify_wait visited' => { flow_path: 'standard', step: 'verify_wait', step_count: 1 },
       'IdV: doc auth optional verify_wait submitted' => { success: true, errors: {}, address_edited: false, proofing_results: { exception: nil, timed_out: false, context: { should_proof_state_id: true, stages: { resolution: { vendor_name: 'ResolutionMock', errors: {}, exception: nil, success: true, timed_out: false, transaction_id: 'resolution-mock-transaction-id-123', reference: 'aaa-bbb-ccc', can_pass_with_additional_verification: false, attributes_requiring_additional_verification: [] }, state_id: { vendor_name: 'StateIdMock', errors: {}, success: true, timed_out: false, exception: nil, transaction_id: 'state-id-mock-transaction-id-456', verified_attributes: [], state: 'MT', state_id_jurisdiction: 'ND' } } } }, ssn_is_unique: true, step: 'verify_wait_step_show' },
-      'IdV: phone of record visited' => {},
-      'IdV: phone confirmation form' => { success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202' },
-      'IdV: phone confirmation vendor' => { success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false },
-      'IdV: review info visited' => {},
-      'IdV: review complete' => { success: true },
-      'IdV: final resolution' => { success: true },
-      'IdV: personal key visited' => {},
-      'IdV: personal key submitted' => {},
-      'IdV: personal key acknowledgment toggled' => { checked: true },
+      'IdV: phone of record visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: phone confirmation form' => { success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: phone confirmation vendor' => { success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: Phone OTP delivery Selection Visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: Phone OTP Delivery Selection Submitted' => { success: true, otp_delivery_preference: 'sms', proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp sent' => { success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp submitted' => { success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: review info visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: review complete' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: final resolution' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key acknowledgment toggled' => { checked: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key submitted' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
     }
   end
   let(:gpo_path_events) do
@@ -66,15 +71,16 @@ feature 'Analytics Regression', js: true do
       'IdV: doc auth verify submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'verify', step_count: 1 },
       'IdV: doc auth verify_wait visited' => { flow_path: 'standard', step: 'verify_wait', step_count: 1 },
       'IdV: doc auth optional verify_wait submitted' => { success: true, errors: {}, address_edited: false, proofing_results: { exception: nil, timed_out: false, context: { should_proof_state_id: true, stages: { resolution: { vendor_name: 'ResolutionMock', errors: {}, exception: nil, success: true, timed_out: false, transaction_id: 'resolution-mock-transaction-id-123', reference: 'aaa-bbb-ccc', can_pass_with_additional_verification: false, attributes_requiring_additional_verification: [] }, state_id: { vendor_name: 'StateIdMock', errors: {}, success: true, timed_out: false, exception: nil, transaction_id: 'state-id-mock-transaction-id-456', verified_attributes: [], state: 'MT', state_id_jurisdiction: 'ND' } } } }, ssn_is_unique: true, step: 'verify_wait_step_show' },
-      'IdV: phone of record visited' => {},
-      'IdV: USPS address letter requested' => { resend: false },
-      'IdV: review info visited' => {},
-      'IdV: USPS address letter enqueued' => { enqueued_at: Time.zone.now, resend: false },
-      'IdV: review complete' => { success: true },
-      'IdV: final resolution' => { success: true },
-      'IdV: personal key visited' => {},
-      'IdV: personal key submitted' => {},
-      'IdV: come back later visited' => {},
+      'IdV: phone of record visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: USPS address letter requested' => { resend: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: review info visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: USPS address letter enqueued' => { enqueued_at: Time.zone.now, resend: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: review complete' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: final resolution' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: personal key visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: personal key acknowledgment toggled' => { checked: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: personal key submitted' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: come back later visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
     }
   end
   let(:in_person_path_events) do
@@ -108,20 +114,21 @@ feature 'Analytics Regression', js: true do
       'IdV: in person proofing verify submitted' => { success: true, step: 'verify', flow_path: 'standard', step_count: 1 },
       'IdV: in person proofing verify_wait visited' => { flow_path: 'standard', step: 'verify_wait', step_count: 1 },
       'IdV: in person proofing optional verify_wait submitted' => { success: true, step: 'verify_wait_step_show', address_edited: false, ssn_is_unique: true },
-      'IdV: phone of record visited' => {},
-      'IdV: phone confirmation form' => { success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202' },
-      'IdV: phone confirmation vendor' => { success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false },
-      'IdV: Phone OTP delivery Selection Visited' => {},
-      'IdV: Phone OTP Delivery Selection Submitted' => { success: true, otp_delivery_preference: 'sms' },
-      'IdV: phone confirmation otp sent' => { success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202' },
-      'IdV: phone confirmation otp visited' => {},
-      'IdV: phone confirmation otp submitted' => { success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil },
-      'IdV: review info visited' => {},
-      'IdV: review complete' => { success: true },
-      'IdV: final resolution' => { success: true },
-      'IdV: personal key visited' => {},
-      'IdV: personal key submitted' => {},
-      'IdV: in person ready to verify visited' => {},
+      'IdV: phone of record visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: phone confirmation form' => { success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
+      'IdV: phone confirmation vendor' => { success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: Phone OTP delivery Selection Visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: Phone OTP Delivery Selection Submitted' => { success: true, otp_delivery_preference: 'sms', proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp sent' => { success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: phone confirmation otp submitted' => { success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: review info visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: review complete' => { success: true, proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: final resolution' => { success: true, proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key acknowledgment toggled' => { checked: true, proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: personal key submitted' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
+      'IdV: in person ready to verify visited' => { proofing_components: { document_check: 'usps', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'lexis_nexis_address' } },
     }
   end
   # rubocop:enable Layout/LineLength
@@ -132,7 +139,10 @@ feature 'Analytics Regression', js: true do
   end
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    allow_any_instance_of(ApplicationController).to receive(:analytics) do |controller|
+      fake_analytics.user = controller.analytics_user
+      fake_analytics
+    end
     allow_any_instance_of(DocumentProofingJob).to receive(:build_analytics).
       and_return(fake_analytics)
   end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -74,7 +74,7 @@ feature 'Analytics Regression', js: true do
       'IdV: phone of record visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
       'IdV: USPS address letter requested' => { resend: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis' } },
       'IdV: review info visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
-      'IdV: USPS address letter enqueued' => { enqueued_at: Time.zone.now, resend: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
+      'IdV: USPS address letter enqueued' => { enqueued_at: Time.zone.now.utc, resend: false, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
       'IdV: review complete' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
       'IdV: final resolution' => { success: true, proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },
       'IdV: personal key visited' => { proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', address_check: 'gpo_letter' } },

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Idv::AnalyticsEventsEnhancer do
+  class ExampleAnalytics
+    include AnalyticsEvents
+
+    def idv_final(**kwargs)
+      @called_kwargs = kwargs
+    end
+
+    include Idv::AnalyticsEventsEnhancer
+
+    attr_reader :user, :called_kwargs
+
+    def initialize(user:)
+      @user = user
+    end
+  end
+
+  let(:user) { build(:user) }
+  let(:analytics) { ExampleAnalytics.new(user: user) }
+
+  it 'includes decorated methods' do
+    expect(analytics.methods).to include(*described_class::DECORATED_METHODS)
+    expect(
+      analytics.methods.
+        intersection(described_class::DECORATED_METHODS).
+        map { |method| analytics.method(method).source_location.first }.
+        uniq,
+    ).to eq([Idv::AnalyticsEventsEnhancer.const_source_location(:DECORATED_METHODS).first])
+  end
+
+  it 'calls analytics method with original and decorated attributes' do
+    analytics.idv_final(extra: true)
+
+    expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+  end
+
+  context 'with anonymous analytics user' do
+    let(:user) { AnonymousUser.new }
+
+    it 'calls analytics method with original and decorated attributes' do
+      analytics.idv_final(extra: true)
+
+      expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+    end
+  end
+
+  context 'with proofing component' do
+    let(:proofing_components) do
+      ProofingComponent.new(source_check: Idp::Constants::Vendors::AAMVA)
+    end
+
+    before do
+      user.proofing_component = proofing_components
+    end
+
+    it 'calls analytics method with original and decorated attributes' do
+      analytics.idv_final(extra: true)
+
+      expect(analytics.called_kwargs).to match(
+        extra: true,
+        proofing_components: kind_of(Idv::ProofingComponentsLogging),
+      )
+    end
+  end
+end

--- a/spec/services/idv/proofing_components_logging_spec.rb
+++ b/spec/services/idv/proofing_components_logging_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Idv::ProofingComponentsLogging do
+  describe '#as_json' do
+    it 'returns hash with nil values omitted' do
+      proofing_components = ProofingComponent.new(document_check: Idp::Constants::Vendors::AAMVA)
+      logging = described_class.new(proofing_components)
+
+      expect(logging.as_json).to eq('document_check' => Idp::Constants::Vendors::AAMVA)
+    end
+  end
+end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -81,7 +81,7 @@ class FakeAnalytics < Analytics
 
   def track_event(event, attributes = {})
     events[event] ||= []
-    events[event] << attributes.as_json
+    events[event] << attributes
     nil
   end
 
@@ -102,13 +102,12 @@ end
 
 RSpec::Matchers.define :have_logged_event do |event_name, attributes|
   attributes ||= {}
-  attributes = attributes.as_json
 
   match do |actual|
     if RSpec::Support.is_a_matcher?(attributes)
       expect(actual.events[event_name]).to include(attributes)
     else
-      expect(actual.events[event_name]).to(be_any { |event| attributes <= event })
+      expect(actual.events[event_name]).to(be_any { |event| attributes.as_json <= event.as_json })
     end
   end
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -1,7 +1,8 @@
-class FakeAnalytics
+class FakeAnalytics < Analytics
   PiiDetected = Class.new(StandardError)
 
   include AnalyticsEvents
+  include Idv::AnalyticsEventsEnhancer
 
   module PiiAlerter
     def track_event(event, original_attributes = {})
@@ -71,14 +72,16 @@ class FakeAnalytics
   prepend PiiAlerter
 
   attr_reader :events
+  attr_accessor :user
 
-  def initialize
+  def initialize(user: AnonymousUser.new)
     @events = Hash.new
+    @user = user
   end
 
   def track_event(event, attributes = {})
     events[event] ||= []
-    events[event] << attributes
+    events[event] << attributes.as_json
     nil
   end
 
@@ -99,10 +102,9 @@ end
 
 RSpec::Matchers.define :have_logged_event do |event_name, attributes|
   attributes ||= {}
+  attributes = attributes.as_json
 
   match do |actual|
-    expect(actual).to be_kind_of(FakeAnalytics)
-
     if RSpec::Support.is_a_matcher?(attributes)
       expect(actual.events[event_name]).to include(attributes)
     else


### PR DESCRIPTION
## 🎫 Ticket

[LG-7582](https://cm-jira.usa.gov/browse/LG-7582)

## 🛠 Summary of changes

To provide a means to disambiguate between in-person and unsupervised proofing events, it's proposed to add the user's proofing components to identity verification events, to allow for this and other similar filtering.

```
# Find IdV completion events for in-person proofing
filter name = 'IdV: review complete' and properties.event_properties.proofing_components.document_check = 'usps'
```

## 📜 Testing Plan

- [ ] Run updated analytics regression specs: `rspec spec/features/idv/analytics_spec.rb`