### PR TITLE
Fix flakey spec failures in SessionController

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -47,23 +47,23 @@ describe Users::SessionsController, devise: true do
         expect(json['live']).to eq true
       end
 
-      it 'includes the timeout key' do
-        timeout =  Time.zone.now + 10
+      it 'includes the timeout key', freeze_time: true do
+        timeout = Time.zone.now + 10
         controller.session[:session_expires_at] = timeout
         get :active
 
         json ||= JSON.parse(response.body)
 
-        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(timeout.to_i)
+        expect(json['timeout'].to_datetime.to_i).to eq(timeout.to_i)
       end
 
-      it 'includes the remaining key' do
+      it 'includes the remaining key', freeze_time: true do
         controller.session[:session_expires_at] = Time.zone.now + 10
         get :active
 
         json ||= JSON.parse(response.body)
 
-        expect(json['remaining']).to be_within(1).of(10)
+        expect(json['remaining']).to eq(10)
       end
     end
 
@@ -76,15 +76,15 @@ describe Users::SessionsController, devise: true do
         expect(json['live']).to eq false
       end
 
-      it 'includes session_expires_at' do
+      it 'includes session_expires_at', freeze_time: true do
         get :active
 
         json ||= JSON.parse(response.body)
 
-        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(Time.zone.now.to_i - 1)
+        expect(json['timeout'].to_datetime.to_i).to eq(Time.zone.now.to_i - 1)
       end
 
-      it 'includes the remaining time' do
+      it 'includes the remaining time', freeze_time: true do
         get :active
 
         json ||= JSON.parse(response.body)
@@ -98,11 +98,11 @@ describe Users::SessionsController, devise: true do
         expected_time = now + 10
         session[:pinged_at] = now
 
-        travel_to(Time.zone.now + 10) do
+        travel_to(expected_time) do
           get :active
         end
 
-        expect(session[:pinged_at].to_i).to be_within(1).of(expected_time.to_i)
+        expect(session[:pinged_at].to_i).to eq(expected_time.to_i)
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -128,6 +128,10 @@ RSpec.configure do |config|
     Bullet.enable = false
   end
 
+  config.around(:each, freeze_time: true) do |example|
+    freeze_time { example.run }
+  end
+
   config.after(:each, type: :feature, js: true) do |spec|
     next unless page.driver.browser.respond_to?(:manage)
 


### PR DESCRIPTION
## 🛠 Summary of changes

Improves reliability of SessionController specs by avoiding race conditions associated with assumed near-instant responses by using [`freeze_time` helper](https://api.rubyonrails.org/v5.2.6/classes/ActiveSupport/Testing/TimeHelpers.html).

Example: https://gitlab.login.gov/lg/identity-idp/-/jobs/92662

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Spec passes: `rspec spec/controllers/users/sessions_controller_spec.rb`