### PR TITLE
Remove first name from "Ready to Verify" email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -235,14 +235,13 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def in_person_ready_to_verify(user, email_address, first_name:, enrollment:)
+  def in_person_ready_to_verify(user, email_address, enrollment:)
     attachments.inline['barcode.png'] = BarcodeOutputter.new(
       code: enrollment.enrollment_code,
     ).image_data
 
     with_user_locale(user) do
       @header = t('in_person_proofing.headings.barcode')
-      @first_name = first_name
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,
         barcode_image_url: attachments['barcode.png'].url,

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -17,15 +17,14 @@ module UspsInPersonProofing
         enrollment.enrollment_established_at = Time.zone.now
         enrollment.save!
 
-        send_ready_to_verify_email(user, pii, enrollment)
+        send_ready_to_verify_email(user, enrollment)
       end
 
-      def send_ready_to_verify_email(user, pii, enrollment)
+      def send_ready_to_verify_email(user, enrollment)
         user.confirmed_email_addresses.each do |email_address|
           UserMailer.in_person_ready_to_verify(
             user,
             email_address,
-            first_name: pii['first_name'],
             enrollment: enrollment,
           ).deliver_now_or_later
         end

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= t('user_mailer.in_person_ready_to_verify.greeting', name: @first_name) %><br>
+  <%= t('user_mailer.in_person_ready_to_verify.greeting') %><br>
   <%= t('user_mailer.in_person_ready_to_verify.intro') %>
 </p>
 

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -136,7 +136,7 @@ en:
       greeting: Hello,
       subject: Your identity could not be verified in person
     in_person_ready_to_verify:
-      greeting: Hi %{name},
+      greeting: Hello,
       intro: Here are the details to verify your identity in person at a United States
         Post Office near you.
       subject: You’re ready to verify your identity with %{app_name} in person

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -144,7 +144,7 @@ es:
       greeting: Hola,
       subject: No se pudo verificar su identidad en persona
     in_person_ready_to_verify:
-      greeting: 'Hola, %{name}:'
+      greeting: Hola,
       intro: Estos son los detalles para verificar su identidad en persona en una
         oficina de correos de los Estados Unidos cercana a usted.
       subject: Está listo para verificar su identidad con %{app_name} en persona

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -147,7 +147,7 @@ fr:
       greeting: Bonjour,
       subject: Votre identité n’a pas pu être vérifiée en personne
     in_person_ready_to_verify:
-      greeting: Bonjour %{name},
+      greeting: Bonjour,
       intro: Voici les détails pour vérifier votre identité en personne dans un bureau
         de poste des États-Unis près de chez vous.
       subject: Vous êtes prêt à vérifier votre identité avec %{app_name} en personne

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -442,7 +442,6 @@ describe Idv::ReviewController do
                   user,
                   email_address,
                   enrollment: instance_of(InPersonEnrollment),
-                  first_name: kind_of(String),
                 ).
                 and_return(mailer)
             end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -141,7 +141,6 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.in_person_ready_to_verify(
       user,
       email_address_record,
-      first_name: 'Michael',
       enrollment: in_person_enrollment,
     )
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -512,7 +512,6 @@ describe UserMailer, type: :mailer do
   end
 
   describe '#in_person_ready_to_verify' do
-    let(:first_name) { 'Michael' }
     let!(:enrollment) do
       create(
         :in_person_enrollment,
@@ -526,7 +525,6 @@ describe UserMailer, type: :mailer do
       UserMailer.in_person_ready_to_verify(
         user,
         user.email_addresses.first,
-        first_name: first_name,
         enrollment: enrollment,
       )
     end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
               user,
               email_address,
               enrollment: instance_of(InPersonEnrollment),
-              first_name: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:first_name],
             ).
             and_return(mailer)
         end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7650](https://cm-jira.usa.gov/browse/LG-7650)

## 🛠 Summary of changes

For consistency with other in-person proofing emails and to avoid potentially storing PII, this PR removes the `first_name` variable from the content.

## 👀 Screenshots

| Before | After |
|-------|-----|
| ![image](https://user-images.githubusercontent.com/1430443/194612681-e7e1105c-8003-44b3-8610-a99f2154a148.png)  |  ![image](https://user-images.githubusercontent.com/1430443/194612293-f1326d14-6d38-4389-b5b8-d01b337672cb.png)  |
