### PR TITLE
Remove puts in UserMailer spec

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -587,7 +587,6 @@ describe UserMailer, type: :mailer do
     end
 
     let(:mail) do
-      p enrollment
       UserMailer.in_person_failed_fraud(
         user,
         user.email_addresses.first,


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a `puts` that snuck into a spec