### PR TITLE
Add spec/ directory to Rails/Output cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -841,6 +841,15 @@ Rails/MatchRoute:
 Rails/NegateInclude:
   Enabled: false
 
+Rails/Output:
+  Enabled: true
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
+    - spec/**/*.rb # in addition to default
+
 Rails/Pluck:
   Enabled: true
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,9 +61,11 @@ RSpec.configure do |config|
     begin
       REDIS_POOL.with { |namespaced| namespaced.redis.info }
     rescue RuntimeError => error
+      # rubocop:disable Rails/Output
       puts error
       puts 'It appears Redis is not running, but it is required for (some) specs to run'
       exit 1
+      # rubocop:enable Rails/Output
     end
   end
 
@@ -73,10 +75,12 @@ RSpec.configure do |config|
       next if defined?($ran_asset_build)
       $ran_asset_build = true
       # rubocop:enable Style/GlobalVars
+      # rubocop:disable Rails/Output
       print '                       Bundling JavaScript and stylesheets... '
       system 'WEBPACK_PORT= yarn build > /dev/null 2>&1'
       system 'yarn build:css > /dev/null 2>&1'
       puts '✨ Done!'
+      # rubocop:enable Rails/Output
     end
   end
 

--- a/spec/support/private_key_file_helper.rb
+++ b/spec/support/private_key_file_helper.rb
@@ -6,7 +6,7 @@ module PrivateKeyFileHelper
     file_name = force_tmp_private_key_file_name file_name: file_name
 
     if Rails.env.test? && !File.exist?(file_name)
-      puts "WARNING: Private key file '#{file_name}' not found!"
+      puts "WARNING: Private key file '#{file_name}' not found!" # rubocop:disable Rails/Output
     end
 
     if File.exist?(file_name)


### PR DESCRIPTION
**Why**: would have caught the slip that lead to #7119

**How**: the spec/ directory is not included by default as part of the cop

