### PR TITLE
Remove query streaming for big reports

### DIFF
--- a/app/jobs/reports/query_helpers.rb
+++ b/app/jobs/reports/query_helpers.rb
@@ -7,20 +7,5 @@ module Reports
         ActiveRecord::Base.connection.quote(value)
       end
     end
-
-    # Wrapper around PG::Result#stream_each, runs a query and yields each row to the block
-    # as it is returned from the DB
-    # @param [String] SQL query
-    # @yieldparam [Hash] row
-    def stream_query(query)
-      ActiveRecord::Base.logger.debug(query) # using send_query skips ActiveRecord logging
-      connection = ActiveRecord::Base.connection.raw_connection
-      connection.send_query(query)
-      connection.set_single_row_mode
-      connection.get_result.stream_each do |row|
-        yield row
-      end
-      connection.get_result
-    end
   end
 end

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -33,14 +33,18 @@ module Db
 
           with_retries(
             max_tries: 3,
-            rescue: [PG::TRSerializationFailure, PG::UnableToSend],
+            rescue: [
+              ActiveRecord::SerializationFailure,
+              PG::TRSerializationFailure,
+              PG::UnableToSend,
+            ],
             handler: proc do
               ial_to_year_month_to_users = temp_copy
               ActiveRecord::Base.connection.reconnect!
             end,
           ) do
             Reports::BaseReport.transaction_with_timeout do
-              stream_query(query) do |row|
+              ActiveRecord::Base.connection.execute(query).each do |row|
                 user_id = row['user_id']
                 year_month = row['year_month']
                 auth_count = row['auth_count']
@@ -115,10 +119,6 @@ module Db
             , sp_return_logs.ial
           SQL
         end
-      end
-
-      def default_call
-        yield
       end
     end
   end

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window.rb
@@ -35,6 +35,7 @@ module Db
             max_tries: 3,
             rescue: [
               ActiveRecord::SerializationFailure,
+              PG::ConnectionBad,
               PG::TRSerializationFailure,
               PG::UnableToSend,
             ],

--- a/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
+++ b/app/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa.rb
@@ -31,6 +31,7 @@ module Db
             max_tries: 3,
             rescue: [
               ActiveRecord::SerializationFailure,
+              PG::ConnectionBad,
               PG::TRSerializationFailure,
               PG::UnableToSend,
             ],

--- a/spec/jobs/reports/query_helpers_spec.rb
+++ b/spec/jobs/reports/query_helpers_spec.rb
@@ -17,25 +17,4 @@ RSpec.describe Reports::QueryHelpers do
       expect(quote([1, 2, 3])).to eq('(1, 2, 3)')
     end
   end
-
-  describe '#stream_query' do
-    let!(:users) do
-      3.times.map { create(:user) }
-    end
-
-    it 'streams responses to a block' do
-      query = <<-SQL
-        SELECT id
-        FROM users
-      SQL
-
-      ids = []
-
-      stream_query(query) do |row|
-        ids << row['id']
-      end
-
-      expect(ids).to match_array(users.map(&:id))
-    end
-  end
 end


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Following up to https://github.com/18F/identity-idp/pull/7104#pullrequestreview-1133689290

**Why**: It may not be helping the reports run faster, and it may be making the pg connections more fragile/stateful

## 📜 Testing Plan

- [x] Patch these changes in and try them in a Rails console to make sure they work

