### PR TITLE
Update ThreatMetrixJsVerificationJob

### DIFF
--- a/app/jobs/threat_metrix_js_verification_job.rb
+++ b/app/jobs/threat_metrix_js_verification_job.rb
@@ -24,6 +24,7 @@ class ThreatMetrixJsVerificationJob < ApplicationJob
     js = content if !valid
   rescue => err
     error = err
+    raise err
   ensure
     logger.info(
       {

--- a/app/jobs/threat_metrix_js_verification_job.rb
+++ b/app/jobs/threat_metrix_js_verification_job.rb
@@ -36,7 +36,7 @@ class ThreatMetrixJsVerificationJob < ApplicationJob
         js: js,
         valid: valid,
         error_class: error&.class,
-        error_message: error&.message
+        error_message: error&.message,
       }.compact.to_json,
     )
   end

--- a/app/jobs/threat_metrix_js_verification_job.rb
+++ b/app/jobs/threat_metrix_js_verification_job.rb
@@ -18,14 +18,10 @@ class ThreatMetrixJsVerificationJob < ApplicationJob
     resp = build_faraday.get(url)
     content, signature = parse_js(resp.body)
 
-    if js_verified?(content, signature, cert)
-      valid = true
-    else
-      # When signature validation fails, we include the JS payload in the
-      # log message for future analysis
-      valid = false
-      js = content
-    end
+    valid = js_verified?(content, signature, cert)
+    # When signature validation fails, we include the JS payload in the
+    # log message for future analysis
+    js = content if !valid
   rescue => err
     error = err
   ensure

--- a/spec/jobs/threat_metrix_js_verification_job_spec.rb
+++ b/spec/jobs/threat_metrix_js_verification_job_spec.rb
@@ -80,27 +80,29 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
 
     context 'when certificate is not configured' do
       let(:threatmetrix_signing_certificate) { '' }
-      it 'logs an error_message' do
+      it 'logs an error_message, and raises' do
         expect(instance.logger).to receive(:info) do |message|
           expect(JSON.parse(message, symbolize_names: true)).to include(
             name: 'ThreatMetrixJsVerification',
             error_message: 'JS signing certificate is missing',
           )
         end
-        perform
+
+        expect { perform }.to raise_error(RuntimeError,  'JS signing certificate is missing')
       end
     end
 
     context 'when certificate is expired' do
       let(:threatmetrix_signing_cert_expiry) { Time.zone.now - 3600 }
-      it 'logs an error_message' do
+      it 'logs an error_message, and raises' do
         expect(instance.logger).to receive(:info) do |message|
           expect(JSON.parse(message, symbolize_names: true)).to include(
             name: 'ThreatMetrixJsVerification',
             error_message: 'JS signing certificate is expired',
           )
         end
-        perform
+
+        expect { perform }.to raise_error(RuntimeError,  'JS signing certificate is expired')
       end
     end
 

--- a/spec/jobs/threat_metrix_js_verification_job_spec.rb
+++ b/spec/jobs/threat_metrix_js_verification_job_spec.rb
@@ -78,33 +78,28 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
         )
     end
 
-    context 'when collecting is disabled' do
-      let(:proofing_device_profiling_collecting_enabled) { false }
-      it 'does not run' do
-        expect(instance.logger).not_to receive(:info)
-        perform
-      end
-    end
-
     context 'when certificate is not configured' do
       let(:threatmetrix_signing_certificate) { '' }
-      it 'does not run' do
-        expect(instance.logger).not_to receive(:info)
+      it 'logs an error_message' do
+        expect(instance.logger).to receive(:info) do |message|
+          expect(JSON.parse(message, symbolize_names: true)).to include(
+            name: 'ThreatMetrixJsVerification',
+            error_message: 'JS signing certificate is missing',
+          )
+        end
         perform
       end
     end
 
     context 'when certificate is expired' do
       let(:threatmetrix_signing_cert_expiry) { Time.zone.now - 3600 }
-      it 'raises an error' do
-        expect { perform }.to raise_error
-      end
-    end
-
-    context 'when org id is not configured' do
-      let(:threatmetrix_org_id) { nil }
-      it 'does not run' do
-        expect(instance.logger).not_to receive(:info)
+      it 'logs an error_message' do
+        expect(instance.logger).to receive(:info) do |message|
+          expect(JSON.parse(message, symbolize_names: true)).to include(
+            name: 'ThreatMetrixJsVerification',
+            error_message: 'JS signing certificate is expired',
+          )
+        end
         perform
       end
     end

--- a/spec/jobs/threat_metrix_js_verification_job_spec.rb
+++ b/spec/jobs/threat_metrix_js_verification_job_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
           )
         end
 
-        expect { perform }.to raise_error(RuntimeError,  'JS signing certificate is missing')
+        expect { perform }.to raise_error(RuntimeError, 'JS signing certificate is missing')
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
           )
         end
 
-        expect { perform }.to raise_error(RuntimeError,  'JS signing certificate is expired')
+        expect { perform }.to raise_error(RuntimeError, 'JS signing certificate is expired')
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Currently the job will early return and log nothing in a bunch of cases where it could be misconfigured. This updates the job to always logs something after each run, so that we can get better info on why it bails early, if it does.

Related: https://github.com/18F/identity-devops/pull/5320

I updated it to remove the `valid` key unless we had an explicit result, so that hopefully misconfigured runs would not trip the alert above.

## 📜 Testing Plan

- [ ] Run specs, deploy to a sandbox
