### PR TITLE
7683 Make divider explicit and configurable

### DIFF
--- a/app/assets/stylesheets/components/_troubleshooting-options.scss
+++ b/app/assets/stylesheets/components/_troubleshooting-options.scss
@@ -5,7 +5,7 @@
     margin-bottom: 0;
   }
 
-  &.troubleshooting-options--bar::before {
+  &.troubleshooting-options--divider::before {
     @include u-margin-bottom(4);
     background-color: color('secondary');
     content: '';

--- a/app/assets/stylesheets/components/_troubleshooting-options.scss
+++ b/app/assets/stylesheets/components/_troubleshooting-options.scss
@@ -5,17 +5,13 @@
     margin-bottom: 0;
   }
 
-  &::before {
+  &.troubleshooting-options--bar::before {
     @include u-margin-bottom(4);
     background-color: color('secondary');
     content: '';
     display: block;
     height: 4px;
     width: 5rem;
-  }
-
-  & + &::before {
-    content: none;
   }
 }
 

--- a/app/javascript/packages/components/troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.tsx
@@ -81,4 +81,24 @@ describe('TroubleshootingOptions', () => {
     const tag = getByText('components.troubleshooting_options.new_feature');
     expect(tag.classList.contains('text-uppercase')).to.eq(true);
   });
+
+  it('renders with expected classes', () => {
+    const { container } = render(<TroubleshootingOptions {...DEFAULT_PROPS} />);
+
+    const element = container.firstElementChild!;
+
+    expect(element.classList.contains('troubleshooting-options')).to.be.true();
+    expect(element.classList.contains('troubleshooting-options--divider')).to.be.true();
+  });
+
+  context('with divider disabled', () => {
+    it('renders with expected classes', () => {
+      const { container } = render(<TroubleshootingOptions {...DEFAULT_PROPS} divider={false} />);
+
+      const element = container.firstElementChild!;
+
+      expect(element.classList.contains('troubleshooting-options')).to.be.true();
+      expect(element.classList.contains('troubleshooting-options--divider')).to.be.false();
+    });
+  });
 });

--- a/app/javascript/packages/components/troubleshooting-options.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.tsx
@@ -19,6 +19,8 @@ interface TroubleshootingOptionsProps {
   options: TroubleshootingOption[];
 
   isNewFeatures?: boolean;
+
+  divider?: boolean;
 }
 
 function TroubleshootingOptions({
@@ -26,6 +28,7 @@ function TroubleshootingOptions({
   heading,
   options,
   isNewFeatures,
+  divider = true,
 }: TroubleshootingOptionsProps) {
   const { t } = useI18n();
 
@@ -36,7 +39,7 @@ function TroubleshootingOptions({
   const HeadingTag = headingTag;
 
   return (
-    <section className="troubleshooting-options">
+    <section className={`troubleshooting-options ${divider && 'troubleshooting-options--bar'}`}>
       {isNewFeatures && (
         <span className="usa-tag bg-accent-cool-darker text-uppercase display-inline-block">
           {t('components.troubleshooting_options.new_feature')}

--- a/app/javascript/packages/components/troubleshooting-options.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.tsx
@@ -36,10 +36,13 @@ function TroubleshootingOptions({
     return null;
   }
 
+  const classes = ['troubleshooting-options', divider && 'troubleshooting-options--divider']
+    .filter(Boolean)
+    .join(' ');
   const HeadingTag = headingTag;
 
   return (
-    <section className={`troubleshooting-options ${divider && 'troubleshooting-options--bar'}`}>
+    <section className={classes}>
       {isNewFeatures && (
         <span className="usa-tag bg-accent-cool-darker text-uppercase display-inline-block">
           {t('components.troubleshooting_options.new_feature')}

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -49,6 +49,22 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
+      {hasErrors && inPersonURL && showInPersonOption && (
+        <TroubleshootingOptions
+          isNewFeatures
+          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
+            wbr: 'wbr',
+          })}
+          divider={false}
+          options={[
+            {
+              url: '#location',
+              text: t('idv.troubleshooting.options.verify_in_person'),
+              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
+            },
+          ]}
+        />
+      )}
       <TroubleshootingOptions
         heading={heading}
         options={
@@ -79,21 +95,6 @@ function DocumentCaptureTroubleshootingOptions({
           ].filter(Boolean) as TroubleshootingOption[]
         }
       />
-      {hasErrors && inPersonURL && showInPersonOption && (
-        <TroubleshootingOptions
-          isNewFeatures
-          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
-            wbr: 'wbr',
-          })}
-          options={[
-            {
-              url: '#location',
-              text: t('idv.troubleshooting.options.verify_in_person'),
-              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
-            },
-          ]}
-        />
-      )}
     </>
   );
 }


### PR DESCRIPTION
## 🎫 Ticket

[Link to the relevant ticket.](https://cm-jira.usa.gov/browse/LG-7683)

## 🛠 Summary of changes

Previously, troubleshooting options relied on implicit logic for dealing with the red divider, specifically with multiple invocations of the component. Now the divider is explicitly added, default to appearing. IPP view uses this to show the divider in the middle.

## 📜 Testing Plan

- [x] Manual visual check locally
- [ ] Visual check/diff in other areas of the app
- [ ] CI checks pass

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="505" alt="Screen Shot 2022-10-12 at 10 29 10 AM" src="https://user-images.githubusercontent.com/5004319/195370456-1778023c-8804-4aeb-bfe5-4f61245b67ea.png">

</details>

<details>
<summary>After:</summary>

<img width="611" alt="Screen Shot 2022-10-12 at 10 25 53 AM" src="https://user-images.githubusercontent.com/5004319/195370104-b9b7436e-ad6b-4dc4-8d20-f650db3b8826.png">

</details>

