### PR TITLE
Flip idv_personal_key_confirmation_enabled to false by default

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -107,7 +107,7 @@ idv_max_attempts: 5
 idv_min_age_years: 13
 idv_native_camera_a_b_testing_enabled: false
 idv_native_camera_a_b_testing_percent: 10
-idv_personal_key_confirmation_enabled: true
+idv_personal_key_confirmation_enabled: false
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_sp_required: false


### PR DESCRIPTION
**Why**: This will effectively remove the confirmation modal. This is a change that will need follow-up to remove the code for the modal