### PR TITLE
Prepare to drop unused registration_logs columns (LG-6317)

### DIFF
--- a/app/models/registration_log.rb
+++ b/app/models/registration_log.rb
@@ -1,3 +1,12 @@
 class RegistrationLog < ApplicationRecord
+  self.ignored_columns = %w[
+    submitted_at
+    confirmed_at
+    password_at
+    first_mfa
+    first_mfa_at
+    second_mfa
+  ]
+
   belongs_to :user
 end

--- a/app/services/funnel/registration/add_mfa.rb
+++ b/app/services/funnel/registration/add_mfa.rb
@@ -2,8 +2,7 @@ module Funnel
   module Registration
     class AddMfa
       def self.call(user_id, mfa_method, analytics)
-        now = Time.zone.now
-        funnel = RegistrationLog.where(user_id: user_id).first_or_create(submitted_at: now)
+        funnel = RegistrationLog.create_or_find_by(user_id: user.id)
         return if funnel.registered_at.present?
 
         analytics.user_registration_user_fully_registered(mfa_method: mfa_method)

--- a/app/services/funnel/registration/add_mfa.rb
+++ b/app/services/funnel/registration/add_mfa.rb
@@ -2,6 +2,7 @@ module Funnel
   module Registration
     class AddMfa
       def self.call(user_id, mfa_method, analytics)
+        now = Time.zone.now
         funnel = RegistrationLog.create_or_find_by(user_id: user_id)
         return if funnel.registered_at.present?
 

--- a/app/services/funnel/registration/add_mfa.rb
+++ b/app/services/funnel/registration/add_mfa.rb
@@ -2,7 +2,7 @@ module Funnel
   module Registration
     class AddMfa
       def self.call(user_id, mfa_method, analytics)
-        funnel = RegistrationLog.create_or_find_by(user_id: user.id)
+        funnel = RegistrationLog.create_or_find_by(user_id: user_id)
         return if funnel.registered_at.present?
 
         analytics.user_registration_user_fully_registered(mfa_method: mfa_method)

--- a/db/primary_migrate/20221012172457_alter_registration_logs_nullable_submitted_at.rb
+++ b/db/primary_migrate/20221012172457_alter_registration_logs_nullable_submitted_at.rb
@@ -1,0 +1,13 @@
+class AlterRegistrationLogsNullableSubmittedAt < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      execute 'ALTER TABLE "registration_logs" ALTER COLUMN submitted_at DROP NOT NULL'
+    end
+  end
+
+  def down
+    safety_assured do
+      execute 'ALTER TABLE "registration_logs" ALTER COLUMN submitted_at SET NOT NULL'
+    end
+  end
+end

--- a/db/primary_migrate/20221012172457_alter_registration_logs_nullable_submitted_at.rb
+++ b/db/primary_migrate/20221012172457_alter_registration_logs_nullable_submitted_at.rb
@@ -1,13 +1,7 @@
 class AlterRegistrationLogsNullableSubmittedAt < ActiveRecord::Migration[7.0]
-  def up
+  def change
     safety_assured do
-      execute 'ALTER TABLE "registration_logs" ALTER COLUMN submitted_at DROP NOT NULL'
-    end
-  end
-
-  def down
-    safety_assured do
-      execute 'ALTER TABLE "registration_logs" ALTER COLUMN submitted_at SET NOT NULL'
+      change_column_null :registration_logs, :submitted_at, true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_21_233413) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_12_172457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -483,7 +483,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_233413) do
 
   create_table "registration_logs", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.datetime "submitted_at", precision: nil, null: false
+    t.datetime "submitted_at", precision: nil
     t.datetime "confirmed_at", precision: nil
     t.datetime "password_at", precision: nil
     t.string "first_mfa"


### PR DESCRIPTION
## 🎫 Ticket

[LG-6317](https://cm-jira.usa.gov/browse/LG-6317)

## 🛠 Summary of changes

- Make registration_logs.submitted_at nullable, stop writing it
- Ignore other columns
- **Next steps**: drop these columns entirely

## 🚀 Notes for Deployment

Must be merged *after* https://github.com/18F/identity-idp/pull/7107 has deployed
