### PR TITLE
7683 Revert IPP CTA change (while preserving troubleshooting-options refactor)

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -49,22 +49,6 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
-      {hasErrors && inPersonURL && showInPersonOption && (
-        <TroubleshootingOptions
-          isNewFeatures
-          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
-            wbr: 'wbr',
-          })}
-          divider={false}
-          options={[
-            {
-              url: '#location',
-              text: t('idv.troubleshooting.options.verify_in_person'),
-              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
-            },
-          ]}
-        />
-      )}
       <TroubleshootingOptions
         heading={heading}
         options={
@@ -95,6 +79,22 @@ function DocumentCaptureTroubleshootingOptions({
           ].filter(Boolean) as TroubleshootingOption[]
         }
       />
+      {hasErrors && inPersonURL && showInPersonOption && (
+        <TroubleshootingOptions
+          isNewFeatures
+          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
+            wbr: 'wbr',
+          })}
+          divider={false}
+          options={[
+            {
+              url: '#location',
+              text: t('idv.troubleshooting.options.verify_in_person'),
+              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
+            },
+          ]}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.

https://github.com/18F/identity-idp/pull/7129
https://cm-jira.usa.gov/browse/LG-7683

## 🛠 Summary of changes

~This reverts commit feb84afa58e049a1c2bdbbee083eb048cedb04a2. I was supposed to leave this as an open PR until designers were ready to merge this.~

This change reverts some of feb84afa58e049a1c2bdbbee083eb048cedb04a2. We will keep changes to troubleshooting-options, but hold off on moving up the IPP CTA.

## 👀 Screenshots


<details>
<summary>Before:</summary>

<img width="611" alt="Screen Shot 2022-10-12 at 10 25 53 AM" src="https://user-images.githubusercontent.com/5004319/195370104-b9b7436e-ad6b-4dc4-8d20-f650db3b8826.png">

</details>

<details>
<summary>After:</summary>

<img width="738" alt="Screen Shot 2022-10-12 at 3 31 20 PM" src="https://user-images.githubusercontent.com/5004319/195432711-97a40189-9a2b-4d14-a0bf-693c06a1e3b2.png">

</details>
