### PR TITLE
Remove JavaScript optimization from asset pipeline

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,6 @@ Rails.application.configure do
     # and request is nil during asset precompilation
     (IdentityConfig.store.asset_host.presence || IdentityConfig.store.domain_name) if request
   end
-  config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true
   config.assets.gzip = false


### PR DESCRIPTION
## 🛠 Summary of changes

These changes disable JavaScript compression as part of the asset pipeline, since the files are already expected to be compressed via the Webpack build, which infers `mode` of `production` as enabling default optimizations, including minification ([see related documentation](https://webpack.js.org/configuration/mode/), specifically reference to [TerserPlugin](https://webpack.js.org/plugins/terser-webpack-plugin/)).

https://github.com/18F/identity-idp/blob/68564bbca6fcebdc33e306bb1c0ab7d87ae43c7b/webpack.config.js#L8

https://github.com/18F/identity-idp/blob/68564bbca6fcebdc33e306bb1c0ab7d87ae43c7b/webpack.config.js#L13

https://github.com/18F/identity-idp/blob/68564bbca6fcebdc33e306bb1c0ab7d87ae43c7b/webpack.config.js#L20-L21

These changes also have an impact in...

- Likely improving build times
- Avoiding errors such as one which was observed with #7115 where `ActionCable` JavaScript included ES6 syntax, which is not compatible with the default `:uglifier` configuration value used previously.

## 📜 Testing Plan

Confirm that JavaScript assets are compressed when built for production:

1. `RAILS_ENV=production yarn build`
2. Inspect files in `public/packs/js`