### PR TITLE
7683 IPP CTA moved up (wait before merging)

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -49,6 +49,22 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
+      {hasErrors && inPersonURL && showInPersonOption && (
+        <TroubleshootingOptions
+          isNewFeatures
+          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
+            wbr: 'wbr',
+          })}
+          divider={false}
+          options={[
+            {
+              url: '#location',
+              text: t('idv.troubleshooting.options.verify_in_person'),
+              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
+            },
+          ]}
+        />
+      )}
       <TroubleshootingOptions
         heading={heading}
         options={
@@ -79,22 +95,6 @@ function DocumentCaptureTroubleshootingOptions({
           ].filter(Boolean) as TroubleshootingOption[]
         }
       />
-      {hasErrors && inPersonURL && showInPersonOption && (
-        <TroubleshootingOptions
-          isNewFeatures
-          heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {
-            wbr: 'wbr',
-          })}
-          divider={false}
-          options={[
-            {
-              url: '#location',
-              text: t('idv.troubleshooting.options.verify_in_person'),
-              onClick: () => trackEvent('IdV: verify in person troubleshooting option clicked'),
-            },
-          ]}
-        />
-      )}
     </>
   );
 }


### PR DESCRIPTION
## 🎫 Ticket

[Link to the relevant ticket.](https://cm-jira.usa.gov/browse/LG-7683)

## 🛠 Summary of changes

Moves IPP CTA further up in the view.

Note this change was accidentally [merged](https://github.com/18F/identity-idp/pull/7129) then later [reverted](https://github.com/18F/identity-idp/pull/7134). Waiting for the go-ahead before merging.

## 📜 Testing Plan

- [x] Manual visual check locally
- [x] Visual check/diff in other areas of the app
- [x] CI checks pass

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="505" alt="Screen Shot 2022-10-12 at 10 29 10 AM" src="https://user-images.githubusercontent.com/5004319/195370456-1778023c-8804-4aeb-bfe5-4f61245b67ea.png">

</details>

<details>
<summary>After:</summary>

<img width="611" alt="Screen Shot 2022-10-12 at 10 25 53 AM" src="https://user-images.githubusercontent.com/5004319/195370104-b9b7436e-ad6b-4dc4-8d20-f650db3b8826.png">

</details>
