### PR TITLE
Remove unused analytics events

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -812,17 +812,6 @@ module AnalyticsEvents
     track_event('IdV: personal key downloaded')
   end
 
-  # @identity.idp.previous_event_name IdV: show personal key modal
-  # User opened IDV personal key confirmation modal
-  def idv_personal_key_confirm_visited
-    track_event('IdV: personal key confirm visited')
-  end
-
-  # User submitted IDV personal key confirmation modal
-  def idv_personal_key_confirm_submitted
-    track_event('IdV: personal key confirm submitted')
-  end
-
   # @param [Boolean] success
   # @param [Hash] errors
   # The user submitted their phone on the phone confirmation page


### PR DESCRIPTION
## 🛠 Summary of changes

Removes analytics events which are no longer used. These were last referenced prior to #7110.

I put together a small script to try to find any other unused, these were the only ones.

```bash
cat app/services/analytics_events.rb | perl -n -e '/def ([a-z_]+)/ && print "$1\n"' | while read LINE; do
  count=$(grep --recursive -o $LINE app | wc -l)
  if [ "$count" -eq "1" ]; then
    echo $LINE
  fi
done
```

## 📜 Testing Plan

Automated tests should pass.