### PR TITLE
Remove unused support for proc methods in frontend logger

### DIFF
--- a/app/services/frontend_logger.rb
+++ b/app/services/frontend_logger.rb
@@ -8,14 +8,7 @@ class FrontendLogger
 
   def track_event(name, attributes)
     if (analytics_method = event_map[name])
-      if analytics_method.is_a?(Proc)
-        analytics_method.call(analytics, **attributes)
-      else
-        analytics_method.bind_call(
-          analytics,
-          **hash_from_method_kwargs(attributes, analytics_method),
-        )
-      end
+      analytics_method.bind_call(analytics, **hash_from_method_kwargs(attributes, analytics_method))
     else
       analytics.track_event("Frontend: #{name}", attributes)
     end

--- a/spec/services/frontend_logger_spec.rb
+++ b/spec/services/frontend_logger_spec.rb
@@ -12,10 +12,8 @@ describe FrontendLogger do
   end
 
   let(:analytics) { ExampleAnalytics.new }
-  let(:proc_handler) { proc {} }
   let(:event_map) do
     {
-      'proc' => proc_handler,
       'method' => ExampleAnalyticsEvents.instance_method(:example_method_handler),
     }
   end
@@ -34,16 +32,6 @@ describe FrontendLogger do
         call
 
         expect(analytics).to have_logged_event('Frontend: unknown', attributes)
-      end
-    end
-
-    context 'with proc event handler' do
-      let(:name) { 'proc' }
-
-      it 'calls proc with analytics instance' do
-        expect(proc_handler).to receive(:call).with(analytics, attributes)
-
-        call
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes support for proc methods in `FrontendLogger#track_event`, since we're no longer handling any frontend events as proc methods as of #7110.

## 📜 Testing Plan

Automated tests should pass.