### PR TITLE
Fix flakey local test failures for in-person proofing feature specs

### DIFF
--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -63,9 +63,7 @@ module InPersonHelper
 
   def complete_state_id_step(_user = nil)
     # Wait for page to load before attempting to fill out form
-    expect(page).to have_current_path(
-      idv_in_person_step_path(step: :state_id),
-    )
+    expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
     fill_out_state_id_form_ok
     click_idv_continue
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Allows a longer wait delay for in-person feature specs to avoid flakey test failures when run locally. Clicking "Continue" from the "prepare" step will wait for a client-side logging event before continuing to the "State ID" step, which often cannot complete before the 0.5 second tolerance allowed by default in local development environments.

Related discussion: https://github.com/18F/identity-idp/pull/7046#discussion_r983867979

Source for client-side awaited logging:

https://github.com/18F/identity-idp/blob/2a6bc17e50bb3bc23097d9e1aa1d9a82bb85e00f/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx#L39-L40

Example failure:

```
Failures:

  1) Analytics Regression in person path records all of the events
     Failure/Error:
       expect(page).to have_current_path(
         idv_in_person_step_path(step: :state_id),
       )
     
       expected "/verify/doc_auth/document_capture" to equal "/verify/in_person/state_id"
     # ./spec/support/features/in_person_helper.rb:66:in `complete_state_id_step'
     # ./spec/support/features/in_person_helper.rb:90:in `complete_all_in_person_proofing_steps'
     # ./spec/features/idv/analytics_spec.rb:196:in `block (3 levels) in <top (required)>'
     # ./spec/features/idv/analytics_spec.rb:133:in `block (3 levels) in <top (required)>'
     # ./spec/features/idv/analytics_spec.rb:133:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
```

## 📜 Testing Plan

Running a feature spec which uses this helper should pass.

For example: `rspec spec/features/idv/analytics_spec.rb`