### PR TITLE
Create DownloadButtonComponent for download button

### DIFF
--- a/app/components/download_button_component.rb
+++ b/app/components/download_button_component.rb
@@ -1,0 +1,29 @@
+class DownloadButtonComponent < ButtonComponent
+  attr_reader :data, :file_name, :tag_options
+
+  def initialize(data:, file_name:, **tag_options)
+    super(
+      icon: :file_download,
+      action: ->(**tag_options, &block) do
+        link_to(
+          "data:text/plain;charset=utf-8,#{CGI.escape(data)}",
+          download: file_name,
+          **tag_options,
+          &block
+        )
+      end,
+      **tag_options,
+    )
+
+    @data = data
+    @file_name = file_name
+  end
+
+  def call
+    content_tag(:'lg-download-button', super)
+  end
+
+  def content
+    t('components.download_button.label')
+  end
+end

--- a/app/components/download_button_component.rb
+++ b/app/components/download_button_component.rb
@@ -1,12 +1,12 @@
 class DownloadButtonComponent < ButtonComponent
-  attr_reader :data, :file_name, :tag_options
+  attr_reader :file_data, :file_name, :tag_options
 
-  def initialize(data:, file_name:, **tag_options)
+  def initialize(file_data:, file_name:, **tag_options)
     super(
       icon: :file_download,
       action: ->(**tag_options, &block) do
         link_to(
-          "data:text/plain;charset=utf-8,#{CGI.escape(data)}",
+          "data:text/plain;charset=utf-8,#{CGI.escape(file_data)}",
           download: file_name,
           **tag_options,
           &block
@@ -15,7 +15,7 @@ class DownloadButtonComponent < ButtonComponent
       **tag_options,
     )
 
-    @data = data
+    @file_data = file_data
     @file_name = file_name
   end
 

--- a/app/components/download_button_component.rb
+++ b/app/components/download_button_component.rb
@@ -24,6 +24,6 @@ class DownloadButtonComponent < ButtonComponent
   end
 
   def content
-    t('components.download_button.label')
+    super || t('components.download_button.label')
   end
 end

--- a/app/components/download_button_component.ts
+++ b/app/components/download_button_component.ts
@@ -1,0 +1,1 @@
+import '@18f/identity-download-button/download-button-element';

--- a/app/javascript/packages/download-button/README.md
+++ b/app/javascript/packages/download-button/README.md
@@ -1,0 +1,19 @@
+# `@18f/identity-download-button`
+
+Custom element for a download button component.
+
+## Usage
+
+Importing the element will register the `<lg-download-button>` custom element:
+
+```ts
+import '@18f/identity-download-button/download-button-element';
+```
+
+The custom element will implement the copying behavior, but all markup must already exist.
+
+```html
+<lg-download-button>
+  <a href="data:text/plain;charset=utf-8,hello%20world" download="filename.txt">Download</a>
+</lg-download-button>
+```

--- a/app/javascript/packages/download-button/download-button-element.spec.ts
+++ b/app/javascript/packages/download-button/download-button-element.spec.ts
@@ -1,0 +1,71 @@
+import sinon from 'sinon';
+import { screen, fireEvent } from '@testing-library/dom';
+import { useDefineProperty } from '@18f/identity-test-helpers';
+import { dataURIToBlob } from './download-button-element';
+
+describe('dataURIToBlob', () => {
+  it('converts a data URI to equivalent Blob', async () => {
+    const blob = dataURIToBlob('data:text/plain;charset=utf-8,hello%20world');
+
+    const result = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.addEventListener('load', () => resolve(reader.result as string));
+      reader.readAsText(blob);
+    });
+
+    expect(result).to.equal('hello world');
+  });
+});
+
+describe('DownloadButtonElement', () => {
+  it('does not interfere with the click event', () => {
+    document.body.innerHTML = `
+      <lg-download-button>
+        <a href="data:text/plain;charset=utf-8,hello%20world" download="filename.txt">Download</a>
+      </lg-download-button>
+    `;
+
+    const link = screen.getByRole('link', { name: 'Download' });
+
+    const onClick = sinon.stub().callsFake((event: MouseEvent) => {
+      expect(event.defaultPrevented).to.be.false();
+
+      // Prevent default behavior, since JSDOM will otherwise throw an error on navigation.
+      event.preventDefault();
+    });
+    window.addEventListener('click', onClick);
+    fireEvent.click(link);
+    window.removeEventListener('click', onClick);
+
+    expect(onClick).to.have.been.called();
+  });
+
+  context('with legacy Microsoft proprietary download', () => {
+    const defineProperty = useDefineProperty();
+
+    it('prevents default and calls msSaveBlob', () => {
+      defineProperty(window.navigator, 'msSaveBlob', { value: sinon.stub(), configurable: true });
+
+      document.body.innerHTML = `
+        <lg-download-button>
+          <a href="data:text/plain;charset=utf-8,hello%20world" download="filename.txt">Download</a>
+        </lg-download-button>
+      `;
+
+      const link = screen.getByRole('link', { name: 'Download' });
+
+      const onClick = sinon.stub().callsFake((event: MouseEvent) => {
+        expect(event.defaultPrevented).to.be.true();
+
+        // Prevent default behavior, since JSDOM will otherwise throw an error on navigation.
+        event.preventDefault();
+      });
+      window.addEventListener('click', onClick);
+      fireEvent.click(link);
+      window.removeEventListener('click', onClick);
+
+      expect(onClick).to.have.been.called();
+      expect(window.navigator.msSaveBlob).to.have.been.called();
+    });
+  });
+});

--- a/app/javascript/packages/download-button/download-button-element.ts
+++ b/app/javascript/packages/download-button/download-button-element.ts
@@ -14,7 +14,7 @@ declare global {
  */
 export function dataURIToBlob(uri: string) {
   const data = decodeURIComponent(uri.split(',')[1]);
-  const bytes = Uint8Array.from(data.split('').map((char) => char.charCodeAt(0)));
+  const bytes = Uint8Array.from(data, (char) => char.charCodeAt(0));
   return new Blob([bytes], { type: 'text/plain' });
 }
 

--- a/app/javascript/packages/download-button/download-button-element.ts
+++ b/app/javascript/packages/download-button/download-button-element.ts
@@ -1,0 +1,56 @@
+declare global {
+  interface Navigator {
+    msSaveBlob?: (blob: Blob, filename: string) => void;
+  }
+}
+
+/**
+ * Converts a data URI to a Blob. The given URI data must be URI-encoded and have a MIME type of
+ * `text/plain`.
+ *
+ * @param uri URI string to convert.
+ *
+ * @return Blob instance.
+ */
+export function dataURIToBlob(uri: string) {
+  const data = decodeURIComponent(uri.split(',')[1]);
+  const bytes = Uint8Array.from(data.split('').map((char) => char.charCodeAt(0)));
+  return new Blob([bytes], { type: 'text/plain' });
+}
+
+class DownloadButtonElement extends HTMLElement {
+  link: HTMLAnchorElement;
+
+  connectedCallback() {
+    this.link = this.querySelector('a')!;
+
+    if (window.navigator.msSaveBlob) {
+      this.link.addEventListener('click', this.triggerInternetExplorerDownload);
+    }
+  }
+
+  /**
+   * Click handler to trigger download for legacy Microsoft proprietary download.
+   */
+  triggerInternetExplorerDownload = (event: MouseEvent) => {
+    event.preventDefault();
+
+    const filename = this.link.getAttribute('download')!;
+    const uri = this.link.getAttribute('href')!;
+    const blob = new Blob([dataURIToBlob(uri)], { type: 'text/plain' });
+
+    window.navigator.msSaveBlob?.(blob, filename);
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lg-download-button': DownloadButtonElement;
+  }
+}
+
+if (!customElements.get('lg-download-button')) {
+  customElements.define('lg-download-button', DownloadButtonElement);
+}
+
+export default DownloadButtonElement;

--- a/app/javascript/packages/download-button/package.json
+++ b/app/javascript/packages/download-button/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@18f/identity-download-button",
+  "version": "1.0.0",
+  "private": true
+}

--- a/app/javascript/packages/form-link/form-link-element.spec.ts
+++ b/app/javascript/packages/form-link/form-link-element.spec.ts
@@ -20,8 +20,8 @@ describe('FormLinkElement', () => {
 
     const onSubmit = sinon.stub().callsFake((event) => event.preventDefault());
     window.addEventListener('submit', onSubmit);
-
     const didPreventDefault = !fireEvent.click(link);
+    window.removeEventListener('submit', onSubmit);
 
     expect(onSubmit).to.have.been.called();
     expect(didPreventDefault).to.be.true();

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -1,28 +1,7 @@
 import { trackEvent } from '@18f/identity-analytics';
 
-const personalKeyWords = [].slice.call(document.querySelectorAll('[data-personal-key]'));
 const downloadLink = document.querySelector('a[download]');
 const acknowledgmentCheckbox = document.getElementById('acknowledgment');
-
-function scrapePersonalKey() {
-  const keywords = [];
-
-  personalKeyWords.forEach((keyword) => {
-    keywords.push(keyword.innerHTML);
-  });
-
-  return keywords.join('-').toUpperCase();
-}
-
-function downloadForIE(event) {
-  event.preventDefault();
-
-  const filename = downloadLink.getAttribute('download');
-  const data = scrapePersonalKey();
-  const blob = new Blob([data], { type: 'text/plain' });
-
-  window.navigator.msSaveBlob(blob, filename);
-}
 
 function trackAcknowledgment(clickEvent) {
   trackEvent('IdV: personal key acknowledgment toggled', { checked: clickEvent.target.checked });
@@ -34,7 +13,3 @@ function trackDownload() {
 
 downloadLink.addEventListener('click', trackDownload);
 acknowledgmentCheckbox.addEventListener('click', trackAcknowledgment);
-
-if (window.navigator.msSaveBlob) {
-  downloadLink.addEventListener('click', downloadForIE);
-}

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -12,31 +12,12 @@
           date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
         ) %>
   </p>
-
-  <%= render ClipboardButtonComponent.new(
-        clipboard_text: code,
-        unstyled: true,
-      ) %>
-
-  <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          link_to(
-            "data:text/plain;charset=utf-8,#{CGI.escape(code)}",
-            download: 'personal_key.txt',
-            **tag_options,
-            &block
-          )
-        end,
-        icon: :file_download,
+  <%= render ClipboardButtonComponent.new(clipboard_text: code, unstyled: true) %>
+  <%= render DownloadButtonComponent.new(
+        data: code,
+        file_name: 'personal_key.txt',
         unstyled: true,
         class: 'margin-x-2 display-inline-block',
-      ).with_content(t('forms.personal_key.download')) %>
-
-  <%= render PrintButtonComponent.new(
-        icon: :print,
-        unstyled: true,
-        type: :button,
-        class: 'margin-right-2 margin-bottom-2 tablet:margin-bottom-0',
       ) %>
-
+  <%= render PrintButtonComponent.new(unstyled: true) %>
 </div>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -18,6 +18,6 @@
         file_name: 'personal_key.txt',
         unstyled: true,
         class: 'margin-x-2 display-inline-block',
-      ) %>
+      ).with_content(t('forms.personal_key.download')) %>
   <%= render PrintButtonComponent.new(unstyled: true) %>
 </div>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -14,7 +14,7 @@
   </p>
   <%= render ClipboardButtonComponent.new(clipboard_text: code, unstyled: true) %>
   <%= render DownloadButtonComponent.new(
-        data: code,
+        file_data: code,
         file_name: 'personal_key.txt',
         unstyled: true,
         class: 'margin-x-2 display-inline-block',

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -29,18 +29,11 @@
   </div>
   <div class="margin-top-1">
     <% if desktop_device? %>
-      <%= render ButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              link_to(
-                "data:text/plain;charset=utf-8,#{CGI.escape(@codes.join("\n"))}",
-                download: 'backup_codes.txt',
-                **tag_options,
-                &block
-              )
-            end,
+      <%= render DownloadButtonComponent.new(
+            data: @codes.join("\n"),
+            file_name: 'backup_codes.txt',
             outline: true,
-            icon: :file_download,
-          ).with_content(t('forms.backup_code.download')) %>
+          ) %>
     <% end %>
     <%= render PrintButtonComponent.new(
           icon: :print,

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -30,7 +30,7 @@
   <div class="margin-top-1">
     <% if desktop_device? %>
       <%= render DownloadButtonComponent.new(
-            data: @codes.join("\n"),
+            file_data: @codes.join("\n"),
             file_name: 'backup_codes.txt',
             outline: true,
           ) %>

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -5,6 +5,8 @@ en:
       image_alt: Barcode
     clipboard_button:
       label: Copy
+    download_button:
+      label: Download
     javascript_required:
       browser_instructions: 'Follow the instructions for your browser to enable JavaScript:'
       enabled_alert: You have enabled JavaScript in your browser.

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -5,6 +5,8 @@ es:
       image_alt: Código de barras
     clipboard_button:
       label: Copiar
+    download_button:
+      label: Descargar
     javascript_required:
       browser_instructions: 'Siga las instrucciones para habilitar JavaScript en su navegador:'
       enabled_alert: YHabilitó el JavaScript en su navegador.

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -5,6 +5,8 @@ fr:
       image_alt: Code-barres
     clipboard_button:
       label: Copier
+    download_button:
+      label: Télécharger
     javascript_required:
       browser_instructions: 'Suivez les instructions de votre navigateur pour activer JavaScript:'
       enabled_alert: Vous avez activé JavaScript dans votre navigateur.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -13,7 +13,6 @@ en:
       caution_delete: If you delete your backup codes you will no longer be able to
         use them to sign in.
       confirm_delete: Are you sure you want to delete your backup codes?
-      download: Download
       generate: Get codes
       last_code: You used your last backup code. Please print, copy or download the
         codes below. You can use these new codes the next time you sign in.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -14,7 +14,6 @@ es:
       caution_delete: Si elimina sus códigos de respaldo, ya no podrá usarlos para
         iniciar sesión.
       confirm_delete: '¿Estás seguro de que deseas eliminar tus códigos de respaldo?'
-      download: Descargar
       generate: Obtener códigos
       last_code: Usted utilizó el último código de seguridad. Imprima, copie o
         descargue los códigos que aparecen a continuación. Puede introducir

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -15,7 +15,6 @@ fr:
       caution_delete: Si vous supprimez vos codes de sauvegarde, vous ne pourrez plus
         les utiliser pour vous connecter.
       confirm_delete: Êtes-vous sûr de vouloir supprimer vos codes de sauvegarde?
-      download: Télécharger
       generate: Obtenir des codes
       last_code: Vous avez utilisé votre dernier code de sauvegarde. Veuillez
         imprimer, copier ou télécharger les codes ci-dessous. Vous pourrez

--- a/spec/components/download_button_component_spec.rb
+++ b/spec/components/download_button_component_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe DownloadButtonComponent, type: :component do
   let(:file_data) { 'Downloaded Text' }
   let(:file_name) { 'file.txt' }
   let(:tag_options) { {} }
-
-  subject(:rendered) do
-    render_inline DownloadButtonComponent.new(
+  let(:instance) do
+    DownloadButtonComponent.new(
       file_data: file_data,
       file_name: file_name,
       **tag_options,
     )
   end
 
+  subject(:rendered) { render_inline instance }
+
   it 'renders link with data and file name' do
     expect(rendered).to have_css(
       "lg-download-button a[href*='#{CGI.escape(file_data)}'][download='#{file_name}']",
+      text: t('components.download_button.label'),
     )
   end
 
@@ -24,6 +26,15 @@ RSpec.describe DownloadButtonComponent, type: :component do
 
     it 'renders button given the tag options' do
       expect(rendered).to have_css('.usa-button.usa-button--outline[data-foo="bar"]')
+    end
+  end
+
+  context 'with content' do
+    let(:content) { 'Download File' }
+    let(:instance) { super().with_content(content) }
+
+    it 'renders with the given content' do
+      expect(rendered).to have_content(content)
     end
   end
 end

--- a/spec/components/download_button_component_spec.rb
+++ b/spec/components/download_button_component_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DownloadButtonComponent, type: :component do
+  let(:file_data) { 'Downloaded Text' }
+  let(:file_name) { 'file.txt' }
+  let(:tag_options) { {} }
+
+  subject(:rendered) do
+    render_inline DownloadButtonComponent.new(
+      file_data: file_data,
+      file_name: file_name,
+      **tag_options,
+    )
+  end
+
+  it 'renders link with data and file name' do
+    expect(rendered).to have_css(
+      "lg-download-button a[href*='#{CGI.escape(file_data)}'][download='#{file_name}']",
+    )
+  end
+
+  context 'with tag options' do
+    let(:tag_options) { { outline: true, data: { foo: 'bar' } } }
+
+    it 'renders button given the tag options' do
+      expect(rendered).to have_css('.usa-button.usa-button--outline[data-foo="bar"]')
+    end
+  end
+end

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -10,7 +10,7 @@ feature 'sign up with backup code' do
       have_content t('two_factor_authentication.login_options.backup_code_info')
     select_2fa_option('backup_code')
 
-    expect(page).to have_link(t('forms.backup_code.download'))
+    expect(page).to have_link(t('components.download_button.label'))
     expect(current_path).to eq backup_code_setup_path
 
     click_on 'Continue'
@@ -28,7 +28,7 @@ feature 'sign up with backup code' do
 
     select_2fa_option('backup_code')
 
-    expect(page).to_not have_link(t('forms.backup_code.download'))
+    expect(page).to_not have_link(t('components.download_button.label'))
   end
 
   it 'works for each code and refreshes the codes on the last one' do

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -32,7 +32,7 @@ feature 'Multi Two Factor Authentication' do
 
       click_continue
 
-      expect(page).to have_link(t('forms.backup_code.download'))
+      expect(page).to have_link(t('components.download_button.label'))
 
       click_continue
 
@@ -93,7 +93,7 @@ feature 'Multi Two Factor Authentication' do
 
       click_continue
 
-      expect(page).to have_link(t('forms.backup_code.download'))
+      expect(page).to have_link(t('components.download_button.label'))
 
       click_continue
 
@@ -121,7 +121,7 @@ feature 'Multi Two Factor Authentication' do
 
       click_continue
 
-      expect(page).to have_link(t('forms.backup_code.download'))
+      expect(page).to have_link(t('components.download_button.label'))
 
       click_continue
 

--- a/spec/views/users/backup_code_setup/create.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/create.html.erb_spec.rb
@@ -29,7 +29,7 @@ describe 'users/backup_code_setup/create.html.erb' do
     download_link = doc.at_css('a[download]')
     data_uri = URI::Data.new(download_link[:href])
 
-    expect(rendered).to have_content((t('forms.backup_code.download')))
+    expect(rendered).to have_content((t('components.download_button.label')))
     expect(data_uri.content_type).to eq('text/plain')
     expect(data_uri.data).to eq(@codes.join("\n"))
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a new `DownloadButtonComponent` component to contain the behaviors associated with rendering a button which downloads some content once clicked. This also fixes an issue where backup code downloads would not work in Internet Explorer. While Internet Explorer support will be discontinued before long, the component would still be valuable to simplify and standardize common behaviors.

Between this, #7109, and #7103, I expect we'll also be able to remove `personal-key-page-controller.js` pack altogether and rely exclusively on component-contained behaviors.

## 📜 Testing Plan

- [ ] Try backup code and personal key download in Internet Explorer and in your preferred browser

## 👀 Screenshots

Demo screenshots in Internet Explorer:

![Screen Shot 2022-10-14 at 10 44 40 AM](https://user-images.githubusercontent.com/1779930/195887690-054345eb-98df-4e82-9944-9286dc23e02a.png)

![Screen Shot 2022-10-14 at 10 44 49 AM](https://user-images.githubusercontent.com/1779930/195887701-d0fd96db-4373-4d4f-b495-6ab891210afc.png)
