### PR TITLE
LG-7814: Cache USPS auth token as class member

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,7 +1,6 @@
 module UspsInPersonProofing
   class Proofer
-    mattr_reader :token
-    mattr_reader :token_expires_at
+    mattr_reader :token, :token_expires_at
     attr_reader :token, :token_expires_at
 
     # Makes HTTP request to get nearby in-person proofing facilities

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -113,7 +113,7 @@ module UspsInPersonProofing
     end
 
     def token_valid?
-      @@token.present? && @@token_expires_at.present? && @@token_expires_at.future?
+      token.present? && token_expires_at.present? && token_expires_at.future?
     end
 
     private

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -114,9 +114,7 @@ module UspsInPersonProofing
     end
 
     def token_valid?
-      @@token.present? &&
-        @@token_expires_at.present? &&
-        (@@token_expires_at - 1.second).future?
+      @@token.present? && @@token_expires_at.present? && @@token_expires_at.future?
     end
 
     private

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -112,7 +112,9 @@ module UspsInPersonProofing
     end
 
     def token_valid?
-      @@token.present? && @@token_expires_at.present? && @@token_expires_at.future?
+      @@token.present? &&
+        @@token_expires_at.present? &&
+        (@@token_expires_at - 1.second).future?
     end
 
     private

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -148,7 +148,7 @@ module UspsInPersonProofing
       retrieve_token! unless token_valid?
 
       {
-        'Authorization' => @@token,
+        'Authorization' => token,
         'RequestID' => request_id,
       }
     end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,5 +1,7 @@
 module UspsInPersonProofing
   class Proofer
+    @@token = nil
+    @@token_expires_at = nil
     attr_reader :token, :token_expires_at
 
     # Makes HTTP request to get nearby in-person proofing facilities

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -18,13 +18,8 @@ module UspsInPersonProofing
         zipCode: location.zip_code,
       }.to_json
 
-      headers = request_headers.merge(
-        'Authorization' => @token,
-        'RequestID' => request_id,
-      )
-
       parse_facilities(
-        faraday.post(url, body, headers) do |req|
+        faraday.post(url, body, dynamic_headers) do |req|
           req.options.context = { service_name: 'usps_facilities' }
         end.body,
       )
@@ -112,12 +107,12 @@ module UspsInPersonProofing
     # @return [String] the token
     def retrieve_token!
       body = request_token
-      @token_expires_at = Time.zone.now + body['expires_in']
-      @token = "#{body['token_type']} #{body['access_token']}"
+      @@token_expires_at = Time.zone.now + body['expires_in']
+      @@token = "#{body['token_type']} #{body['access_token']}"
     end
 
     def token_valid?
-      @token.present? && @token_expires_at.present? && @token_expires_at.future?
+      @@token.present? && @@token_expires_at.present? && @@token_expires_at.future?
     end
 
     private
@@ -152,7 +147,7 @@ module UspsInPersonProofing
       retrieve_token! unless token_valid?
 
       {
-        'Authorization' => @token,
+        'Authorization' => @@token,
         'RequestID' => request_id,
       }
     end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,7 +1,7 @@
 module UspsInPersonProofing
   class Proofer
-    @@token = nil
-    @@token_expires_at = nil
+    mattr_reader :token
+    mattr_reader :token_expires_at
     attr_reader :token, :token_expires_at
 
     # Makes HTTP request to get nearby in-person proofing facilities

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe UspsInPersonProofing::Proofer do
       stub_request_token
       subject.retrieve_token!
 
-      expect(subject.token).to be_present
-      expect(subject.token_expires_at).to be_present
+      expect(subject.class.token).to be_present
+      expect(subject.class.token_expires_at).to be_present
     end
 
     it 'calls the endpoint with the expected params' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-7814](https://cm-jira.usa.gov/browse/LG-7814)

## 🛠 Summary of changes

* Cache the USPS API authorization token as a class variable instead of an instance variable