### PR TITLE
LG-7446 Create "Cancel" Links and Supporting Cancellation Code for Identity Proofing Process (3 of n)

### DIFF
--- a/app/views/idv/inherited_proofing/_cancel.html.erb
+++ b/app/views/idv/inherited_proofing/_cancel.html.erb
@@ -1,0 +1,7 @@
+<%#
+locals:
+* step: Current step, used in analytics logging.
+%>
+<%= render PageFooterComponent.new do %>
+  <%= link_to cancel_link_text, idv_inherited_proofing_cancel_path(step: local_assigns[:step]) %>
+<% end %>

--- a/app/views/idv/inherited_proofing/agreement.html.erb
+++ b/app/views/idv/inherited_proofing/agreement.html.erb
@@ -38,3 +38,5 @@
       ) %>
   <%= f.submit t('inherited_proofing.buttons.continue'), class: 'margin-top-4' %>
 <% end %>
+
+<%= render 'idv/inherited_proofing/cancel', step: 'agreement' %>

--- a/app/views/idv/inherited_proofing/get_started.html.erb
+++ b/app/views/idv/inherited_proofing/get_started.html.erb
@@ -59,4 +59,6 @@
           ),
         ) %>
   </p>
+
+  <%= render 'shared/cancel', link: idv_inherited_proofing_cancel_path(step: 'get_started') %>
 <% end %>

--- a/app/views/idv/inherited_proofing/verify_info.html.erb
+++ b/app/views/idv/inherited_proofing/verify_info.html.erb
@@ -7,7 +7,6 @@
     <%= f.submit t('inherited_proofing.buttons.continue') %>
 <% end %>
 
-
 <%= render(
       'shared/troubleshooting_options',
       heading_tag: :h3,
@@ -20,3 +19,5 @@
         },
       ].select(&:present?),
     ) %>
+
+<%= render 'idv/inherited_proofing/cancel', step: 'verify_info' %>

--- a/app/views/idv/inherited_proofing_cancellations/new.html.erb
+++ b/app/views/idv/inherited_proofing_cancellations/new.html.erb
@@ -8,7 +8,7 @@
   <p><%= t('inherited_proofing.cancel.description.start_over') %></p>
 
   <div class="margin-top-4">
-    NOTE: Render "Start Over" button here, but first have to create an IP-specific SessionController.
+    <%# NOTE: Render "Start Over" button here, but first have to create an IP-specific SessionController. %>
     <%#= render ButtonComponent.new(
           action: ->(**tag_options, &block) do
             button_to(idv_session_path(step: @flow_step), **tag_options, &block)

--- a/spec/features/idv/inherited_proofing/agreement_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/agreement_step_spec.rb
@@ -41,6 +41,13 @@ feature 'inherited proofing agreement' do
 
       expect_ip_verify_info_step
     end
+
+    context 'when clicking on the Cancel link' do
+      it 'redirects to the Cancellation UI' do
+        click_link t('links.cancel')
+        expect(page).to have_current_path(idv_inherited_proofing_cancel_path(step: :agreement))
+      end
+    end
   end
 
   context 'when JS is disabled' do
@@ -62,6 +69,13 @@ feature 'inherited proofing agreement' do
       click_continue
 
       expect_ip_verify_info_step
+    end
+
+    context 'when clicking on the Cancel link' do
+      it 'redirects to the Cancellation UI' do
+        click_link t('links.cancel')
+        expect(page).to have_current_path(idv_inherited_proofing_cancel_path(step: :agreement))
+      end
     end
   end
 end

--- a/spec/features/idv/inherited_proofing/get_started_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/get_started_step_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+feature 'inherited proofing get started' do
+  include IdvHelper
+  include DocAuthHelper
+
+  before do
+    allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return true
+    allow_any_instance_of(Idv::InheritedProofingController).to \
+      receive(:va_inherited_proofing?).and_return true
+    allow_any_instance_of(Idv::InheritedProofingController).to \
+      receive(:va_inherited_proofing_auth_code).and_return auth_code
+  end
+
+  let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
+
+  def expect_ip_get_started_step
+    expect(page).to have_current_path(idv_ip_get_started_step)
+  end
+
+  def expect_inherited_proofing_get_started_step
+    expect(page).to have_current_path(idv_ip_get_started_step)
+  end
+
+  context 'when JS is enabled', :js do
+    before do
+      sign_in_and_2fa_user
+      complete_inherited_proofing_steps_before_get_started_step
+    end
+
+    context 'when clicking on the Cancel link' do
+      it 'redirects to the Cancellation UI' do
+        click_link t('links.cancel')
+        expect(page).to have_current_path(idv_inherited_proofing_cancel_path(step: :get_started))
+      end
+    end
+  end
+
+  context 'when JS is disabled' do
+    before do
+      sign_in_and_2fa_user
+      complete_inherited_proofing_steps_before_get_started_step
+    end
+
+    context 'when clicking on the Cancel link' do
+      it 'redirects to the Cancellation UI' do
+        click_link t('links.cancel')
+        expect(page).to have_current_path(idv_inherited_proofing_cancel_path(step: :get_started))
+      end
+    end
+  end
+end

--- a/spec/views/idv/inherited_proofing/agreement.html.erb_spec.rb
+++ b/spec/views/idv/inherited_proofing/agreement.html.erb_spec.rb
@@ -1,20 +1,28 @@
 require 'rails_helper'
 
 describe 'idv/inherited_proofing/agreement.html.erb' do
+  include Devise::Test::ControllerHelpers
+
   let(:flow_session) { {} }
-  let(:sp_name) { nil }
-  let(:locale) { nil }
+  let(:sp_name) { 'test' }
 
   before do
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
     allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:url_for).and_return('https://www.example.com/')
+    allow(view).to receive(:user_signing_up?).and_return(true)
   end
 
   it 'renders the Continue button' do
     render template: 'idv/inherited_proofing/agreement'
 
     expect(rendered).to have_button(t('inherited_proofing.buttons.continue'))
+  end
+
+  it 'renders the Cancel link' do
+    render template: 'idv/inherited_proofing/agreement'
+
+    expect(rendered).to have_link(t('links.cancel_account_creation'))
   end
 
   context 'with or without service provider' do

--- a/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
+++ b/spec/views/idv/inherited_proofing/get_started.html.erb_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 describe 'idv/inherited_proofing/get_started.html.erb' do
+  include Devise::Test::ControllerHelpers
+
   let(:flow_session) { {} }
-  let(:sp_name) { nil }
-  let(:locale) { nil }
+  let(:sp_name) { 'test' }
 
   before do
     @decorated_session = instance_double(ServiceProviderSessionDecorator)
@@ -11,6 +12,8 @@ describe 'idv/inherited_proofing/get_started.html.erb' do
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
     allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:url_for).and_return('https://www.example.com/')
+    allow(view).to receive(:user_fully_authenticated?).and_return(true)
+    allow(view).to receive(:user_signing_up?).and_return(true)
   end
 
   it 'renders the Continue button' do
@@ -19,30 +22,28 @@ describe 'idv/inherited_proofing/get_started.html.erb' do
     expect(rendered).to have_button(t('inherited_proofing.buttons.continue'))
   end
 
-  describe 'I18n' do
-    before do
-      view.locale = locale
+  it 'renders the Cancel link' do
+    render template: 'idv/inherited_proofing/get_started'
 
+    expect(rendered).to have_link(t('links.cancel_account_creation'))
+  end
+
+  context 'with or without service provider' do
+    it 'renders troubleshooting options' do
       render template: 'idv/inherited_proofing/get_started'
-    end
 
-    context 'with or without service provider' do
-      it 'renders troubleshooting options' do
-        render template: 'idv/inherited_proofing/get_started'
-
-        expect(rendered).to have_link(t('inherited_proofing.troubleshooting.options.get_va_help'))
-        expect(rendered).to have_link(
-          t('inherited_proofing.troubleshooting.options.learn_more_phone_or_mail'),
-        )
-        expect(rendered).not_to have_link(nil, href: idv_inherited_proofing_return_to_sp_path)
-        expect(rendered).to have_link(t('inherited_proofing.troubleshooting.options.get_va_help'))
-        expect(rendered).to have_link(
-          t('inherited_proofing.troubleshooting.options.learn_more_phone_or_mail'),
-        )
-        expect(rendered).to have_link(
-          t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        )
-      end
+      expect(rendered).to have_link(t('inherited_proofing.troubleshooting.options.get_va_help'))
+      expect(rendered).to have_link(
+        t('inherited_proofing.troubleshooting.options.learn_more_phone_or_mail'),
+      )
+      expect(rendered).not_to have_link(nil, href: idv_inherited_proofing_return_to_sp_path)
+      expect(rendered).to have_link(t('inherited_proofing.troubleshooting.options.get_va_help'))
+      expect(rendered).to have_link(
+        t('inherited_proofing.troubleshooting.options.learn_more_phone_or_mail'),
+      )
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+      )
     end
   end
 end


### PR DESCRIPTION
**NOTE: Ignore the first 3 commits, as they are part of the **lg-7446-create-cancel-links-2-of-n** branch _this_ branch was branched off of, and will go away once that branch is merged into main, and this branch is rebased on top if it**

See also PR [LG-7446 Create "Cancel" Links and Supporting Cancellation Code for Identity Proofing Process (1 of n)](https://github.com/18F/identity-idp/pull/7124)
See also PR [LG-7446 Create "Cancel" Links and Supporting Cancellation Code for Identity Proofing Process (2 of n)](https://github.com/18F/identity-idp/pull/7144)

## 🎫 Ticket

[LG-7446](https://cm-jira.usa.gov/browse/LG-7446)

## 🛠 Summary of changes

NOTE: This is feature branch 3 of what most likely be (at most) several feature branches.

In _this_ feature branch:

- Implement "Cancel" links on :agreement and :get_started step views to initiate the cancellation process in **app/views/idv/inherited_proofing_cancellations/new.html.erb** view.
- Create **InheritedProofingSessionsController** controller to handle Inherited Proofing (IP) session clean up for cancellation process "Start Over" logic.
- - Create routes for **InheritedProofingSessionsController** controller actions.
- Create specs and feature specs for all of the aforementioned.

In _subsequent_ feature branch(es):

- Implement "Cancel" links on all other IP step views besides the :agreement and :get_started step views, to initiate the cancellation process in **app/views/idv/inherited_proofing_cancellations/new.html.erb** view
The "Start Over" cancellation logic that involves the **InheritedProofingSessionsController** controller and associated specs and feature specs will be in a subsequent (and final) feature branch.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Automated tests.
- [x] Manual testing via Sinatra app (when feature branch that includes "Cancel" links in appropriate views are completed).

## 👀 Screenshots

<details>
<summary>Before:</summary>
![get_started_before](https://user-images.githubusercontent.com/346917/196483550-d8bd13f6-cb9d-449f-b21f-2b1e6baec456.png)
![agreement_before](https://user-images.githubusercontent.com/346917/196483614-5b9b6960-4924-4dfb-99f0-0f7e0357b142.png)
</details>

<details>
<summary>After:</summary>
![get_started_after](https://user-images.githubusercontent.com/346917/196483694-9a830097-8baf-41a5-9075-c830d702fbd6.png)
![agreement_after](https://user-images.githubusercontent.com/346917/196483713-60c57c88-8656-49cf-b9f8-2e745930e07a.png)
![cancel](https://user-images.githubusercontent.com/346917/196483737-877b7dd3-fc5c-41b0-bbf2-4708381898e7.png)
</details>

## 🚀 Notes for Deployment

See PR [LG-7446 Create "Cancel" Links and Supporting Cancellation Code for Identity Proofing Process (1 of n)](https://github.com/18F/identity-idp/pull/7124)
