### PR TITLE
Shannon/lg 7663 email sent analytics

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -19,6 +19,15 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
+  def email_analytics_attributes(enrollment, delay_time)
+    {
+      timestamp: Time.zone.now,
+      user_id: enrollment.user_id,
+      service_provider: enrollment.issuer,
+      delay_time_amount: delay_time,
+    }
+  end
+
   def enrollment_analytics_attributes(enrollment, complete:)
     {
       enrollment_code: enrollment.enrollment_code,
@@ -220,8 +229,16 @@ class GetUspsProofingResultsJob < ApplicationJob
     enrollment.update(status: :failed)
     if response['fraudSuspected']
       send_failed_fraud_email(enrollment.user, enrollment)
+      analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
+        **email_analytics_attributes(enrollment, **mail_delivery_params),
+        email_version: 'Failed fraud suspected email version',
+      )
     else
       send_failed_email(enrollment.user, enrollment)
+      analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
+        **email_analytics_attributes(enrollment, **mail_delivery_params),
+        email_version: 'Failed email version',
+      )
     end
   end
 
@@ -233,6 +250,10 @@ class GetUspsProofingResultsJob < ApplicationJob
       fraud_suspected: response['fraudSuspected'],
       passed: true,
       reason: 'Successful status update',
+    )
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
+      **email_analytics_attributes(enrollment, **mail_delivery_params),
+      email_version: 'Success email version',
     )
     enrollment.profile.activate
     enrollment.update(status: :passed)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2766,6 +2766,19 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks emails that are initiated during GetUspsProofingResultsJob
+  # @param [String] email_version success, failed or failed fraud
+  def idv_in_person_usps_proofing_results_job_email_initiated(
+    email_version:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Success or failure email initiated',
+      email_version: email_version,
+      **extra,
+    )
+  end
+
   # Tracks users visiting the recovery options page
   def account_reset_recovery_options_visit
     track_event('Account Reset: Recovery Options Visited')

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -433,6 +433,36 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Enrollment status updated',
           )
+          expect(job_analytics).to have_logged_event(
+            'GetUspsProofingResultsJob: Success or failure email initiated',
+            email_version: 'Failed email version',
+          )
+        end
+      end
+
+      context 'when an enrollment fails and fraud is suspected' do
+        before(:each) do
+          stub_request_failed_suspected_fraud_proofing_results
+        end
+
+        it_behaves_like(
+          'enrollment with a status update',
+          passed: false,
+          status: 'failed',
+          response_json: UspsInPersonProofing::Mock::Fixtures.
+            request_failed_suspected_fraud_proofing_results_response,
+        )
+
+        it 'logs fraud failure details' do
+          job.perform(Time.zone.now)
+
+          expect(job_analytics).to have_logged_event(
+            'GetUspsProofingResultsJob: Enrollment status updated',
+          )
+          expect(job_analytics).to have_logged_event(
+            'GetUspsProofingResultsJob: Success or failure email initiated',
+            email_version: 'Failed fraud suspected email version',
+          )
         end
       end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
         timestamp: Time.zone.now,
         user_id: pending_enrollment.user_id,
         service_provider: pending_enrollment.issuer,
-        delay_time_amount: {wait: 1.hour}
+        delay_time_seconds: 3600
       )
     end
   end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -407,6 +407,10 @@ RSpec.describe GetUspsProofingResultsJob do
             'GetUspsProofingResultsJob: Enrollment status updated',
             reason: 'Successful status update',
           )
+          expect(job_analytics).to have_logged_event(
+            'GetUspsProofingResultsJob: Success or failure email initiated',
+            email_version: 'Success email version',
+          )
         end
       end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -38,6 +38,24 @@ RSpec.shared_examples 'enrollment with a status update' do |passed:, status:, re
     )
   end
 
+  context 'email_analytics_attributes' do
+    before(:each) do
+      stub_request_passed_proofing_results
+    end
+    it 'logs message with email analytics attributes' do
+      freeze_time do
+        job.perform(Time.zone.now)
+        expect(job_analytics).to have_logged_event(
+        'GetUspsProofingResultsJob: Success or failure email initiated',
+        timestamp: Time.zone.now,
+        user_id: pending_enrollment.user_id,
+        service_provider: pending_enrollment.issuer,
+        delay_time_amount: {wait: 1.hour}
+      )
+    end
+  end
+end
+
   it 'updates the status of the enrollment and profile appropriately' do
     freeze_time do
       pending_enrollment.update(


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7633](https://cm-jira.usa.gov/browse/LG-7663)

## 🛠 Summary of changes

This pr is to add analytics to Cloudwatch around the success and fail emails in the GetUspsProofingResultsJob. Because we are using a service to send the emails we cannot know for sure that they are sent, but we can know when we've initiated/queued the job. When we handle a failed or successful status we call the functions that send the appropriate emails, this pr adds an analytic's event for emails when we handle those statuses. The analytics event is called idv_in_person_usps_proofing_results_job_email_initiated and it accepts email_analytics_attributes. These attributes include: 
timestamp: time email was initiated,
user_id: user id attached to the enrollment,
service_provider: found in enrollment's issuer field,
delay_time_seconds: wait time for email to be sent,

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Comment out enrollment_outcomes[:enrollments_passed] += 1 on line 247
- [ ] Open a rails console
- [ ] Save user: u = User.last
- [ ] Save enrollment: e = u.in_person_enrollments.last
- [ ] Save json using a mock response: json = 
  UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_results_response
- [ ] Parse json: res = JSON.parse(json)
- [ ] Trigger successful update: GetUspsProofingResultsJob.new.send(:handle_successful_status_update, e, res)
- [ ] Go to local events.log file in repo
- [ ] Confirm that event named "GetUspsProofingResultsJob: Success or failure email initiated" was triggered with email version "Success email version".
- [ ]  Repeat steps from json to confirmation using mocked failed status and failed fraud status. Confirm appropriate email versions are shown. 


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>

## 🚀 Notes for Deployment

Include any special instructions for deployment.
