### PR TITLE
First pass refactor

### DIFF
--- a/app/controllers/concerns/inherited_proofing_concern.rb
+++ b/app/controllers/concerns/inherited_proofing_concern.rb
@@ -4,6 +4,8 @@
 # Login.gov account.
 module InheritedProofingConcern
   extend ActiveSupport::Concern
+  include Idv::InheritedProofing::ServiceProviderForms
+  include Idv::InheritedProofing::ServiceProviderServices
 
   # Department of Veterans Affairs (VA) methods.
   # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Inherited%20Proofing/MHV%20Inherited%20Proofing/inherited-proofing-interface.md
@@ -26,39 +28,5 @@ module InheritedProofingConcern
 
   def va_inherited_proofing_auth_code_params_key
     'inherited_proofing_auth'
-  end
-
-  # Service Provider-agnostic members for now.
-  # Think about putting this in a factory(ies).
-
-  def inherited_proofing_service
-    inherited_proofing_service_class.new inherited_proofing_service_provider_data
-  end
-
-  def inherited_proofing_service_class
-    raise 'Inherited Proofing is not enabled' unless IdentityConfig.store.inherited_proofing_enabled
-
-    if va_inherited_proofing?
-      if IdentityConfig.store.va_inherited_proofing_mock_enabled
-        return Idv::InheritedProofing::Va::Mocks::Service
-      end
-      return Idv::InheritedProofing::Va::Service
-    end
-
-    raise 'Inherited proofing service class could not be identified'
-  end
-
-  def inherited_proofing_form(payload_hash)
-    return Idv::InheritedProofing::Va::Form.new payload_hash: payload_hash if va_inherited_proofing?
-
-    raise 'Inherited proofing form could not be identified'
-  end
-
-  def inherited_proofing_service_provider_data
-    if va_inherited_proofing?
-      { auth_code: va_inherited_proofing_auth_code }
-    else
-      {}
-    end
   end
 end

--- a/app/services/idv/inherited_proofing/service_provider_form_factory.rb
+++ b/app/services/idv/inherited_proofing/service_provider_form_factory.rb
@@ -1,0 +1,34 @@
+module Idv
+  module InheritedProofing
+    module ServiceProviderFormFactory
+      class << self
+        # Returns the form for the service provider
+        def form(service_provider:, payload_hash:)
+          Factory.new(service_provider: service_provider, payload_hash: payload_hash).form
+        end
+      end
+
+      private
+
+      class Factory
+        include ServiceProviders
+        include ServiceProviderForms
+
+        attr_reader :service_provider, :payload_hash
+
+        def initialize(service_provider:, payload_hash:)
+          @service_provider = service_provider
+          @payload_hash = payload_hash
+        end
+
+        def form
+          inherited_proofing_form(payload_hash)
+        end
+
+        def va_inherited_proofing?
+          service_provider == VA
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/inherited_proofing/service_provider_forms.rb
+++ b/app/services/idv/inherited_proofing/service_provider_forms.rb
@@ -1,0 +1,13 @@
+module Idv
+  module InheritedProofing
+    module ServiceProviderForms
+      def inherited_proofing_form(payload_hash)
+        if va_inherited_proofing?
+          return Idv::InheritedProofing::Va::Form.new payload_hash: payload_hash
+          end
+
+        raise 'Inherited proofing form could not be identified'
+      end
+      end
+    end
+  end

--- a/app/services/idv/inherited_proofing/service_provider_service_factory.rb
+++ b/app/services/idv/inherited_proofing/service_provider_service_factory.rb
@@ -1,0 +1,46 @@
+module Idv
+  module InheritedProofing
+    module ServiceProviderServiceFactory
+      class << self
+        # Returns the service for the service provider
+        def service(service_provider:, service_provider_data: {})
+          Factory.new(
+            service_provider: service_provider,
+            service_provider_data: service_provider_data,
+          ).inherited_proofing_service
+        end
+
+        def execute(service_provider:, service_provider_data: {})
+          service(
+            service_provider: service_provider,
+            service_provider_data: service_provider_data,
+          ).execute
+        end
+      end
+
+      private
+
+      class Factory
+        include ServiceProviders
+        include ServiceProviderServices
+
+        attr_reader :service_provider, :service_provider_data
+
+        def initialize(service_provider:, service_provider_data: {})
+          @service_provider = service_provider
+          @service_provider_data = service_provider_data
+        end
+
+        # ServiceProviderServices overrides
+
+        def va_inherited_proofing?
+          service_provider == VA
+        end
+
+        def inherited_proofing_service_provider_data
+          service_provider_data
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/inherited_proofing/service_provider_services.rb
+++ b/app/services/idv/inherited_proofing/service_provider_services.rb
@@ -1,0 +1,44 @@
+module Idv
+  module InheritedProofing
+    module ServiceProviderServices
+      include Idv::InheritedProofing::ServiceProviders
+
+      # Not sure I like the naming here because it might imply the ServiceProvider#id.
+      # However, we're using it here as the Inherited Proofing-specific Service
+      # Provider (SP) identification, because we're currently identifying the SP
+      # identify (in the case of the VA anyhow) by what is in Session.
+      def inherited_proofing_service_provider_id
+        return VA if va_inherited_proofing?
+
+        raise 'Inherited proofing service id could not be identified'
+      end
+
+      def inherited_proofing_service
+        inherited_proofing_service_class.new inherited_proofing_service_provider_data
+      end
+
+      def inherited_proofing_service_class
+        unless IdentityConfig.store.inherited_proofing_enabled
+          raise 'Inherited Proofing is not enabled'
+        end
+
+        if va_inherited_proofing?
+          if IdentityConfig.store.va_inherited_proofing_mock_enabled
+            return Idv::InheritedProofing::Va::Mocks::Service
+          end
+          return Idv::InheritedProofing::Va::Service
+        end
+
+        raise 'Inherited proofing service class could not be identified'
+      end
+
+      def inherited_proofing_service_provider_data
+        if va_inherited_proofing?
+          { auth_code: va_inherited_proofing_auth_code }
+        else
+          {}
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/inherited_proofing/service_providers.rb
+++ b/app/services/idv/inherited_proofing/service_providers.rb
@@ -1,0 +1,11 @@
+module Idv
+  module InheritedProofing
+    # This module is temporary until InheritedProofing has a viable way
+    # of identifying/communicating identifying Service Providers
+    # modules
+    module ServiceProviders
+      VA = :va
+      SERVICE_PROVIDERS = %i[VA]
+    end
+  end
+end

--- a/spec/controllers/concerns/inherited_proofing_concern_spec.rb
+++ b/spec/controllers/concerns/inherited_proofing_concern_spec.rb
@@ -15,6 +15,26 @@ RSpec.describe InheritedProofingConcern do
   let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
   let(:payload_hash) { Idv::InheritedProofing::Va::Mocks::Service::PAYLOAD_HASH }
 
+  describe '#inherited_proofing_service_provider_id' do
+    context 'when the service provider id can be identified' do
+      it 'returns the service provider id as a Symbol' do
+        expect(subject.inherited_proofing_service_provider_id).to eq \
+          Idv::InheritedProofing::ServiceProviders::VA
+      end
+    end
+
+    context 'when the service provider id cannot be identified' do
+      before do
+        allow(subject).to receive(:va_inherited_proofing_auth_code).and_return nil
+      end
+
+      it 'raises an error' do
+        expected_error = 'Inherited proofing service id could not be identified'
+        expect { subject.inherited_proofing_service_provider_id }.to raise_error expected_error
+      end
+    end
+  end
+
   describe '#va_inherited_proofing?' do
     context 'when the va auth code is present' do
       it 'returns true' do


### PR DESCRIPTION
changelog: Upcoming Features, Inherited Proofing, LG-7255 sample refactoring

...so that we can obtain Service Provider-agnostic Inherited Proofing services in request/response-related code and in other code that does not have direct access to Session.

## Example usage

```ruby
include Idv::InheritedProofing::ServiceProviderForms
include Idv::InheritedProofing::ServiceProviderServices
...

# You can get <service_provider> below from your controller: controller.inherited_proofing_service_provider_id
service_provider = Idv::InheritedProofing::ServiceProviders::VA

# You can get <service_provider_data> below from your controller: controller.inherited_proofing_service_provider_data
service_provider_data = { auth_code: Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
payload_hash = Idv::InheritedProofing::ServiceProviderServiceFactory.execute(service_provider: service_provider, service_provider_data: service_provider_data)

form = Idv::InheritedProofing::ServiceProviderFormFactory.form(service_provider: service_provider, payload_hash: payload_hash)
user_pii = form.user_pii
form_response = form.submit
```

## 🎫 Ticket

Link to the relevant ticket.

## 🛠 Summary of changes

Write a brief description of what you changed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>

## 🚀 Notes for Deployment

Include any special instructions for deployment.
