### PR TITLE
Jskinne3 lg 7653 intermittent tests 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,6 @@ end
 group :test do
   gem 'axe-core-rspec', '~> 4.2'
   gem 'bundler-audit', require: false
-  gem 'capybara-selenium', '>= 0.0.6'
   gem 'simplecov', '~> 0.21.0', require: false
   gem 'simplecov-cobertura'
   gem 'simplecov_json_formatter'

--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,6 @@ group :test do
   gem 'rack-test', '>= 1.1.0'
   gem 'rails-controller-testing', '>= 1.0.4'
   gem 'rspec-retry'
-  gem 'sassc-rails'
   gem 'shoulda-matchers', '~> 4.0', require: false
   gem 'webdrivers', '~> 5.2.0'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :test do
   gem 'rack-test', '>= 1.1.0'
   gem 'rails-controller-testing', '>= 1.0.4'
   gem 'rspec-retry'
+  gem 'sassc-rails'
   gem 'shoulda-matchers', '~> 4.0', require: false
   gem 'webdrivers', '~> 5.2.0'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,9 +210,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-selenium (0.0.6)
-      capybara
-      selenium-webdriver
     cbor (0.5.9.6)
     childprocess (4.1.0)
     choice (0.2.0)
@@ -742,7 +739,6 @@ DEPENDENCIES
   browser
   bullet (~> 7.0)
   bundler-audit
-  capybara-selenium (>= 0.0.6)
   capybara-webmock!
   connection_pool
   cssbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,6 +611,14 @@ GEM
       errbase (>= 0.1.1)
     safety_net_attestation (0.4.0)
       jwt (~> 2.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -655,6 +663,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
     thread_safe (0.3.6)
+    tilt (2.0.11)
     timeout (0.3.0)
     tpm-key_attestation (0.10.0)
       bindata (~> 2.4)
@@ -816,6 +825,7 @@ DEPENDENCIES
   ruby-saml
   safe_target_blank (>= 1.0.2)
   saml_idp!
+  sassc-rails
   scrypt
   shoulda-matchers (~> 4.0)
   simple_form (>= 5.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,14 +611,6 @@ GEM
       errbase (>= 0.1.1)
     safety_net_attestation (0.4.0)
       jwt (~> 2.0)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -663,7 +655,6 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
     thread_safe (0.3.6)
-    tilt (2.0.11)
     timeout (0.3.0)
     tpm-key_attestation (0.10.0)
       bindata (~> 2.4)
@@ -825,7 +816,6 @@ DEPENDENCIES
   ruby-saml
   safe_target_blank (>= 1.0.2)
   saml_idp!
-  sassc-rails
   scrypt
   shoulda-matchers (~> 4.0)
   simple_form (>= 5.0.2)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ $ yarn install
 #### I am receiving errors related to Capybara in feature tests
 You may need to install _chromedriver_ or your chromedriver may be the wrong version (`$ which chromedriver && chromedriver --version`).
 
-chromedriver can be installed using [Homebrew](https://formulae.brew.sh/cask/chromedriver) or [direct download](https://chromedriver.chromium.org/downloads). The version of chromedriver should correspond to the version of Chrome you have installed `(Chrome > About Google Chrome)`; if installing via Homebrew, make sure the versions match up.
+chromedriver can be installed using [Homebrew](https://formulae.brew.sh/cask/chromedriver) or [direct download](https://chromedriver.chromium.org/downloads). The version of chromedriver should correspond to the version of Chrome you have installed `(Chrome > About Google Chrome)`; if installing via Homebrew, make sure the versions match up. After your system recieves an automatic Chrome browser update you may have to upgrade (or reinstall) chromedriver.
+
+If `chromedriver -v` does not work you may have to [allow it](https://stackoverflow.com/questions/60362018/macos-catalinav-10-15-3-error-chromedriver-cannot-be-opened-because-the-de) with `xattr`.
 
 #### I am receiving errors when creating the development and test databases
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,11 @@ To set this _permanently_, add the following to your `~/.zshrc` or `~/.bash_prof
 ulimit -Sn 65536
 ```
 
-If you are running MacOS, you may find it is not taking your revised ulimit seriously. [Insist by](https://medium.com/mindful-technology/too-many-open-files-limit-ulimit-on-mac-os-x-add0f1bfddde) adding the following file at `/Library/LaunchDaemons/limit.maxfiles.plist` and set it to be owned by root:
-
+If you are running MacOS, you may find it is not taking your revised ulimit seriously. [You must insist.](https://medium.com/mindful-technology/too-many-open-files-limit-ulimit-on-mac-os-x-add0f1bfddde) Run this command to edit a property list file:
+```
+sudo nano /Library/LaunchDaemons/limit.maxfiles.plist
+```
+Paste the following contents into the text editor:
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -266,5 +269,8 @@ If you are running MacOS, you may find it is not taking your revised ulimit seri
     <false/>
   </dict>
 </plist>
+
 ```
+Use Control+X to save the file.
+
 Restart your Mac to cause the .plist to take effect. Check the limits again and you should see both `ulimit -n` and `launchctl limit maxfiles` return a limit of 524288.

--- a/README.md
+++ b/README.md
@@ -198,13 +198,6 @@ $ bundle install
 $ yarn install
 ```
 
-#### I am receiving errors related to Capybara in feature tests
-You may need to install _chromedriver_ or your chromedriver may be the wrong version (`$ which chromedriver && chromedriver --version`).
-
-chromedriver can be installed using [Homebrew](https://formulae.brew.sh/cask/chromedriver) or [direct download](https://chromedriver.chromium.org/downloads). The version of chromedriver should correspond to the version of Chrome you have installed `(Chrome > About Google Chrome)`; if installing via Homebrew, make sure the versions match up. After your system recieves an automatic Chrome browser update you may have to upgrade (or reinstall) chromedriver.
-
-If `chromedriver -v` does not work you may have to [allow it](https://stackoverflow.com/questions/60362018/macos-catalinav-10-15-3-error-chromedriver-cannot-be-opened-because-the-de) with `xattr`.
-
 #### I am receiving errors when creating the development and test databases
 
 If you receive the following error (where _whoami_ == _your username_):
@@ -224,7 +217,14 @@ $ createdb `whoami`
 $ make test_serial
 ```
 
-##### Errors related to too many _open files_
+##### Errors related to Capybara in feature tests
+You may need to install _chromedriver_ or your chromedriver may be the wrong version (`$ which chromedriver && chromedriver --version`).
+
+chromedriver can be installed using [Homebrew](https://formulae.brew.sh/cask/chromedriver) or [direct download](https://chromedriver.chromium.org/downloads). The version of chromedriver should correspond to the version of Chrome you have installed `(Chrome > About Google Chrome)`; if installing via Homebrew, make sure the versions match up. After your system recieves an automatic Chrome browser update you may have to upgrade (or reinstall) chromedriver.
+
+If `chromedriver -v` does not work you may have to [allow it](https://stackoverflow.com/questions/60362018/macos-catalinav-10-15-3-error-chromedriver-cannot-be-opened-because-the-de) with `xattr`.
+
+##### Errors related to _too many open files_
 You may receive connection errors similar to the following:
 
 `Failed to open TCP connection to 127.0.0.1:9515 (Too many open files - socket(2) for "127.0.0.1" port 9515)`


### PR DESCRIPTION
## 🎫 Ticket

LG-7653
https://cm-jira.usa.gov/browse/LG-7653

changelog: Added, README, increase file descriptor limit

## 🛠 Summary of changes

I added to the README some instructions for increasing limit of MacOS file descriptors. This resolves "too many open files" errors.

This is does not fix all intermittent test failures I'm experiencing -- this is just the only one I was able to conclusively fix. I suspect there is an underlying issue, like a connection which is failing to close and is not relinquishing its file descriptors.

References:

1. [Maximum limits (in macOS file descriptors)](https://wilsonmar.github.io/maximum-limits/) by Wilson Mar
2. [El Capitan ulimit shenanigans](https://web.archive.org/web/20161223195250/https://blog.dekstroza.io/ulimit-shenanigans-on-osx-el-capitan/) by Dejan Kitic
3. ["Too many open files" limit/ulimit on Mac OS X](https://medium.com/mindful-technology/too-many-open-files-limit-ulimit-on-mac-os-x-add0f1bfddde) by Thomas Jung
4. [Ruby 2.7.1 - Errno::EMFILE: Failed to open TCP connection to 127.0.0.1:9*** (Too many open files - socket(2) for "127.0.0.1" port 9***)](https://bytemeta.vip/repo/teamcapybara/capybara/issues/2414) by ndbroadbent

## 📜 Testing Plan

Confirm if you are among the MacBooks experiencing intermittent "too many open files" errors. If you are, follow the instructions to create a limit.maxfiles.plist file. Reboot your laptop and see if the errors go away. 

## 🚀 Notes for Deployment

None because it is just a README change
