### PR TITLE
Remove class-level puts statement from Attempts API rake task

### DIFF
--- a/lib/tasks/attempts.rake
+++ b/lib/tasks/attempts.rake
@@ -1,10 +1,10 @@
 namespace :attempts do
-  auth_token = IdentityConfig.store.irs_attempt_api_auth_tokens.sample
-  puts 'There are no configured irs_attempt_api_auth_tokens' if auth_token.nil?
-  private_key_path = 'keys/attempts_api_private_key.key'
-
   desc 'Retrieve events via the API'
   task fetch_events: :environment do
+    auth_token = IdentityConfig.store.irs_attempt_api_auth_tokens.sample
+    puts 'There are no configured irs_attempt_api_auth_tokens' if auth_token.nil?
+    private_key_path = 'keys/attempts_api_private_key.key'
+
     conn = Faraday.new(url: 'http://localhost:3000')
     body = "timestamp=#{Time.zone.now.iso8601}"
 


### PR DESCRIPTION

[skip changelog]

## 🎫 Ticket

n/a

## 🛠 Summary of changes

In production, running one rake task causes them all to be loaded so this puts statement got executed from an unrelated task, because it was at the class level

## 📜 Testing Plan

- [ ] Override `irs_attempt_api_auth_tokens: ''` locally
- [ ] Run `bundle exec rake -T` (list tasks)
- [ ] Make sure error message does not print

```
> bundle exec rake -T
There are no configured irs_attempt_api_auth_tokens
```