### PR TITLE
LG-7449, Add first error page for inherited proofing when no information is received from API call.

### DIFF
--- a/app/controllers/idv/inherited_proofing_controller.rb
+++ b/app/controllers/idv/inherited_proofing_controller.rb
@@ -1,5 +1,7 @@
 module Idv
   class InheritedProofingController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
     include Flow::FlowStateMachine
     include IdvSession
     include InheritedProofing404Concern
@@ -14,6 +16,10 @@ module Idv
 
     def return_to_sp
       redirect_to return_to_sp_failure_to_proof_url(step: next_step, location: params[:location])
+    end
+
+    # for errors/no_information
+    def no_information
     end
   end
 end

--- a/app/views/idv/inherited_proofing/no_information.html.erb
+++ b/app/views/idv/inherited_proofing/no_information.html.erb
@@ -11,15 +11,15 @@
   <%= link_to t('inherited_proofing.buttons.try_again'), root_url, class: 'usa-button usa-button--big usa-button--wide' %>
 
   <%= render(
-      'shared/troubleshooting_options',
-      heading_tag: :h3,
-      heading: t('components.troubleshooting_options.default_heading'),
-      options: [
-        {
-          url: 'https://www.va.gov/resources/managing-your-vagov-profile/',
-          text: t('inherited_proofing.troubleshooting.options.get_va_help'),
-          new_tab: true,
-        },
-      ].select(&:present?),
-    ) %>
+        'shared/troubleshooting_options',
+        heading_tag: :h3,
+        heading: t('components.troubleshooting_options.default_heading'),
+        options: [
+          {
+            url: 'https://www.va.gov/resources/managing-your-vagov-profile/',
+            text: t('inherited_proofing.troubleshooting.options.get_va_help'),
+            new_tab: true,
+          },
+        ].select(&:present?),
+      ) %>
 <% end %>

--- a/app/views/idv/inherited_proofing/no_information.html.erb
+++ b/app/views/idv/inherited_proofing/no_information.html.erb
@@ -12,7 +12,6 @@
 
   <%= render(
         'shared/troubleshooting_options',
-        heading_tag: :h3,
         heading: t('components.troubleshooting_options.default_heading'),
         options: [
           {

--- a/app/views/idv/inherited_proofing/no_information.html.erb
+++ b/app/views/idv/inherited_proofing/no_information.html.erb
@@ -1,0 +1,25 @@
+<%= render(
+      'idv/shared/error',
+      type: :warning,
+      title: t('inherited_proofing.errors.cannot_retrieve.title'),
+      heading: t('inherited_proofing.errors.cannot_retrieve.heading'),
+    ) do %>
+  <p>
+     <%= t('inherited_proofing.errors.cannot_retrieve.info') %>
+  </p>
+
+  <%= link_to t('inherited_proofing.buttons.try_again'), root_url, class: 'usa-button usa-button--big usa-button--wide' %>
+
+  <%= render(
+      'shared/troubleshooting_options',
+      heading_tag: :h3,
+      heading: t('components.troubleshooting_options.default_heading'),
+      options: [
+        {
+          url: 'https://www.va.gov/resources/managing-your-vagov-profile/',
+          text: t('inherited_proofing.troubleshooting.options.get_va_help'),
+          new_tab: true,
+        },
+      ].select(&:present?),
+    ) %>
+<% end %>

--- a/app/views/idv/inherited_proofing/phone.html.erb
+++ b/app/views/idv/inherited_proofing/phone.html.erb
@@ -1,2 +1,0 @@
-Hello
-<% t('step_indicator.flows.idv.verify_phone') %>

--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -20,6 +20,12 @@ en:
       instructions:
         switch_back: Switch back to your computer to finish verifying your identity.
         switch_back_image: Arrow pointing from phone to computer
+    errors:
+      cannot_retrieve:
+        heading: We could not retrieve your information from My HealtheVet
+        info: We are temporarily having trouble retrieving your information. Please try
+          again.
+        title: Couldn’t retrieve information
     headings:
       lets_go: How verifying your identity works
       retrieval: We are retrieving your information from My HealtheVet
@@ -60,8 +66,3 @@ en:
       options:
         get_va_help: Get help at VA.gov
         learn_more_phone_or_mail: Learn more about verifying by phone or mail
-    errors:
-      cannot_retrieve:
-        info: We are temporarily having trouble retrieving your information. Please try again.
-        heading: We could not retrieve your information from My HealtheVet
-        title: Couldn't retrieve information

--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -3,6 +3,7 @@ en:
   inherited_proofing:
     buttons:
       continue: Continue
+      try_again: Try again
     cancel:
       actions:
         keep_going: No, keep going
@@ -59,3 +60,8 @@ en:
       options:
         get_va_help: Get help at VA.gov
         learn_more_phone_or_mail: Learn more about verifying by phone or mail
+    errors:
+      cannot_retrieve:
+        info: We are temporarily having trouble retrieving your information. Please try again.
+        heading: We could not retrieve your information from My HealtheVet
+        title: Couldn't retrieve information

--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -21,6 +21,12 @@ es:
         switch_back: Regrese a su computadora para continuar con la verificación de su
           identidad.
         switch_back_image: Flecha que apunta del teléfono a la computadora
+    errors:
+      cannot_retrieve:
+        heading: No hemos podido obtener su información de My HealtheVet
+        info: Estamos teniendo problemas temporalmente para obtener su información.
+          Inténtelo de nuevo.
+        title: to be implemented
     headings:
       lets_go: to be implemented
       retrieval: Estamos recuperando su información de My HealtheVet
@@ -56,8 +62,3 @@ es:
       options:
         get_va_help: to be implemented
         learn_more_phone_or_mail: to be implemented
-    errors:
-      cannot_retrieve:
-        info: Estamos teniendo problemas temporalmente para obtener su información. Inténtelo de nuevo.
-        heading: No hemos podido obtener su información de My HealtheVet
-        title: to be implemented

--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -3,6 +3,7 @@ es:
   inherited_proofing:
     buttons:
       continue: Continuar
+      try_again: Inténtelo de nuevo
     cancel:
       actions:
         keep_going: No, continuar
@@ -55,3 +56,8 @@ es:
       options:
         get_va_help: to be implemented
         learn_more_phone_or_mail: to be implemented
+    errors:
+      cannot_retrieve:
+        info: Estamos teniendo problemas temporalmente para obtener su información. Inténtelo de nuevo.
+        heading: No hemos podido obtener su información de My HealtheVet
+        title: to be implemented

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -22,6 +22,12 @@ fr:
         switch_back: Retournez sur votre ordinateur pour continuer à vérifier votre
           identité.
         switch_back_image: Flèche pointant du téléphone vers l’ordinateur
+    errors:
+      cannot_retrieve:
+        heading: Nous n’avons pas pu récupérer vos informations dans My HealtheVet
+        info: Nous avons temporairement des difficultés à récupérer vos informations.
+          Veuillez réessayer.
+        title: to be implemented
     headings:
       lets_go: to be implemented
       retrieval: Nous récupérons vos informations depuis My HealtheVet.
@@ -57,8 +63,3 @@ fr:
       options:
         get_va_help: to be implemented
         learn_more_phone_or_mail: to be implemented
-    errors:
-      cannot_retrieve:
-        info: Nous avons temporairement des difficultés à récupérer vos informations. Veuillez réessayer.
-        heading: Nous n'avons pas pu récupérer vos informations dans My HealtheVet
-        title: to be implemented

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -3,6 +3,7 @@ fr:
   inherited_proofing:
     buttons:
       continue: Continuer
+      try_again: Réessayez
     cancel:
       actions:
         keep_going: Non, continuer
@@ -56,3 +57,8 @@ fr:
       options:
         get_va_help: to be implemented
         learn_more_phone_or_mail: to be implemented
+    errors:
+      cannot_retrieve:
+        info: Nous avons temporairement des difficultés à récupérer vos informations. Veuillez réessayer.
+        heading: Nous n'avons pas pu récupérer vos informations dans My HealtheVet
+        title: to be implemented

--- a/config/locales/step_indicator/en.yml
+++ b/config/locales/step_indicator/en.yml
@@ -11,7 +11,6 @@ en:
         secure_account: Secure your account
         verify_id: Verify your ID
         verify_info: Verify your personal details
-        verify_phone: Verify phone
         verify_phone_or_address: Verify phone or address
     status:
       complete: Completed

--- a/config/locales/step_indicator/es.yml
+++ b/config/locales/step_indicator/es.yml
@@ -11,7 +11,6 @@ es:
         secure_account: Proteje tu cuenta
         verify_id: Verifica tu identificación
         verify_info: Verifica tus datos personales
-        verify_phone: to implement
         verify_phone_or_address: Verifica el teléfono o dirección
     status:
       complete: Completo

--- a/config/locales/step_indicator/fr.yml
+++ b/config/locales/step_indicator/fr.yml
@@ -11,7 +11,6 @@ fr:
         secure_account: Sécurisez votre compte
         verify_id: Vérifier votre identité
         verify_info: Vérifier vos données personnelles
-        verify_phone: to implement
         verify_phone_or_address: Vérifier le téléphone ou l’adresse
     status:
       complete: Terminé

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -364,6 +364,7 @@ Rails.application.routes.draw do
       get '/:step' => 'inherited_proofing#show', as: :step
       put '/:step' => 'inherited_proofing#update'
       get '/return_to_sp' => 'inherited_proofing#return_to_sp'
+      get '/errors/no_information' => 'inherited_proofing#no_information'
     end
 
     namespace :api do


### PR DESCRIPTION
## 🎫 Ticket
[LG-7449](https://cm-jira.usa.gov/browse/LG-7449)
Link to the relevant ticket.

## 🛠 Summary of changes

1. Add first error page for inherited proofing when no information is received from API call for any reason
2. Removed unused phone html page and relevant translations.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>

## 🚀 Notes for Deployment

Include any special instructions for deployment.
