### PR TITLE
Fix typo for user mailer validation error class

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -37,7 +37,7 @@ class UserMailer < ActionMailer::Base
     @user = params.fetch(:user)
     @email_address = params.fetch(:email_address)
     if @user.id != @email_address.user_id
-      raise UserEmailAddressMisMatchError.new(
+      raise UserEmailAddressMismatchError.new(
         "User ID #{@user.id} does not match EmailAddress ID #{@email_address.id}",
       )
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,6 +6,25 @@ describe UserMailer, type: :mailer do
   let(:banned_email) { 'banned_email+123abc@gmail.com' }
   let(:banned_email_address) { create(:email_address, email: banned_email, user: user) }
 
+  describe '#validate_user_and_email_address' do
+    let(:mail) { UserMailer.with(user: user, email_address: email_address).signup_with_your_email }
+
+    context 'with user and email address match' do
+      it 'does not raise an error' do
+        expect { mail.body }.not_to raise_error
+      end
+    end
+
+    context 'with user and email address mismatch' do
+      let(:user) { create(:user) }
+      let(:email_address) { EmailAddress.new }
+
+      it 'raises an error' do
+        expect { mail.body }.to raise_error(UserMailer::UserEmailAddressMismatchError)
+      end
+    end
+  end
+
   describe '#add_email' do
     let(:token) { SecureRandom.hex }
     let(:mail) { UserMailer.with(user: user, email_address: email_address).add_email(token) }


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a typo currently causing unhandled exceptions.

https://github.com/18F/identity-idp/blob/77adb3a7553057b45b76e64537e051ce2a84962c/app/mailers/user_mailer.rb#L19

Slack context: https://gsa-tts.slack.com/archives/C0NGESUN5/p1666063910385719

## 📜 Testing Plan

- [ ] `rspec spec/mailers/user_mailer_spec.rb`