### PR TITLE
Ensure email belongs to account when resending email confirmation email

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -13,6 +13,7 @@ module Users
       @add_user_email_form = AddUserEmailForm.new
 
       result = @add_user_email_form.submit(current_user, permitted_params)
+      analytics.add_email_request(**result.to_h)
 
       if result.success?
         process_successful_creation
@@ -28,10 +29,12 @@ module Users
       email_address = EmailAddress.where(user_id: current_user.id).find_with_email(session_email)
 
       if email_address && !email_address.confirmed?
+        analytics.resend_add_email_request(success: true)
         SendAddEmailConfirmation.new(current_user).call(email_address)
         flash[:success] = t('notices.resend_confirmation_email.success')
         redirect_to add_email_verify_email_url
       else
+        analytics.resend_add_email_request(success: false)
         flash[:error] = t('errors.general')
         redirect_to add_email_url
       end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -25,7 +25,7 @@ module Users
     end
 
     def resend
-      email_address = EmailAddress.find_with_email(session_email)
+      email_address = EmailAddress.where(user_id: current_user.id).find_with_email(session_email)
 
       if email_address && !email_address.confirmed?
         SendAddEmailConfirmation.new(current_user).call(email_address)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -266,6 +266,28 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # Tracks request for adding new emails to an account
+  def add_email_request(success:, errors:, **extra)
+    track_event(
+      'Add Email Requested',
+      success: success,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # Tracks request for resending confirmation for new emails to an account
+  def resend_add_email_request(success:, **extra)
+    track_event(
+      'Resend Add Email Requested',
+      success: success,
+      **extra,
+    )
+  end
+
   # Tracks if Email Language is visited
   def email_language_visited
     track_event('Email Language: Visited')


### PR DESCRIPTION
## 🛠 Summary of changes
Follow on to #7106 (and #7162) that addresses some user/email address mismatch issues around email resending.  This PR ensures that the email address record we are using belongs to the current user. It is difficult to write a regression test for this since it depends partially on the database returning the incorrect record, which only happens some of the time.

This PR also adds analytics to the add email/resend email actions which did not exist previously.