### PR TITLE
Switch Idv::AnalyticsEventsEnhancer to use prepend

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -2,7 +2,7 @@
 
 class Analytics
   include AnalyticsEvents
-  include Idv::AnalyticsEventsEnhancer
+  prepend Idv::AnalyticsEventsEnhancer
 
   attr_reader :user, :request, :sp, :ahoy
 

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -41,7 +41,7 @@ module Idv
       end
     end
 
-    def self.included(mod)
+    def self.included(_mod)
       raise 'this mixin is intended to be prepended, not included'
     end
 

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -35,15 +35,14 @@ module Idv
       idv_start_over
     ].freeze
 
-    extend ActiveSupport::Concern
-
-    included do
-      DECORATED_METHODS.each do |method_name|
-        alias_method "original_#{method_name}", method_name
-        define_method(method_name) do |**kwargs|
-          send("original_#{method_name}", **kwargs, **common_analytics_attributes)
-        end
+    DECORATED_METHODS.each do |method_name|
+      define_method(method_name) do |**kwargs|
+        super(**kwargs, **common_analytics_attributes)
       end
+    end
+
+    def self.included(mod)
+      raise 'this mixin is intended to be prepended, not included'
     end
 
     private

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 describe Idv::AnalyticsEventsEnhancer do
   class ExampleAnalytics
     include AnalyticsEvents
+    prepend Idv::AnalyticsEventsEnhancer
 
     def idv_final(**kwargs)
       @called_kwargs = kwargs
     end
-
-    include Idv::AnalyticsEventsEnhancer
 
     attr_reader :user, :called_kwargs
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -2,7 +2,7 @@ class FakeAnalytics < Analytics
   PiiDetected = Class.new(StandardError)
 
   include AnalyticsEvents
-  include Idv::AnalyticsEventsEnhancer
+  prepend Idv::AnalyticsEventsEnhancer
 
   module PiiAlerter
     def track_event(event, original_attributes = {})


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Followup to https://github.com/18F/identity-idp/pull/7111#discussion_r998555203

**Why**: We can avoid creating extra methods via alias_method, avoid a few dynamic #send as well


