### PR TITLE
LG-7814: Fix issue where USPS API token wasn't being used

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,7 +1,6 @@
 module UspsInPersonProofing
   class Proofer
     mattr_reader :token, :token_expires_at
-    attr_reader :token, :token_expires_at
 
     # Makes HTTP request to get nearby in-person proofing facilities
     # Requires address, city, state and zip code.

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe UspsInPersonProofing::Proofer do
       stub_request_token
       subject.retrieve_token!
 
-      expect(subject.class.token).to be_present
-      expect(subject.class.token_expires_at).to be_present
+      expect(subject.token).to be_present
+      expect(subject.token_expires_at).to be_present
     end
 
     it 'calls the endpoint with the expected params' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-7814](https://cm-jira.usa.gov/browse/LG-7836)

## 🛠 Summary of changes

* Removes the unused instance variable accessors which were overwriting the class variable accessors