### PR TITLE
Set va_inherited_proofing_mock_enabled true for development environments

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -337,7 +337,7 @@ development:
   identity_pki_local_dev: true
   in_person_proofing_enabled: true
   inherited_proofing_enabled: true
-  va_inherited_proofing_mock_enabled: false
+  va_inherited_proofing_mock_enabled: true
   kantara_2fa_phone_restricted: true
   kantara_2fa_phone_existing_user_restriction: true
   kantara_restriction_enforcement_date: '2022-07-01'


### PR DESCRIPTION
changelog: Internal, Inherited Proofing, Set va_inherited_proofing_mock_enabled true for development environments

This is so that developers do not have to specifically enable this switch - we should not be attempting to make live calls in our development environments by default.

## 🎫 Ticket

N/A

## 🛠 Summary of changes

Set va_inherited_proofing_mock_enabled to true in development environments.

This is so that developers do not have to specifically enable this switch - we should not be attempting to make live calls in our development environments by default.

## 📜 Testing Plan

- [x] Local development environment test.

## 👀 Screenshots

N/A

## 🚀 Notes for Deployment

N/A
