### PR TITLE
Add explicit alg: param to JWE encryption

### DIFF
--- a/app/services/irs_attempts_api/attempt_event.rb
+++ b/app/services/irs_attempts_api/attempt_event.rb
@@ -24,6 +24,7 @@ module IrsAttemptsApi
         event_data_encryption_key,
         typ: 'secevent+jwe',
         zip: 'DEF',
+        alg: 'RSA-OAEP',
         enc: 'A256GCM',
       )
     end

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -32,7 +32,13 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
     it 'returns a JWE for the event' do
       jwe = subject.to_jwe
 
+      header_str, *_rest = JWE::Serialization::Compact.decode(jwe)
+      headers = JSON.parse(header_str)
+
+      expect(headers['alg']).to eq('RSA-OAEP')
+
       decrypted_jwe_payload = JWE.decrypt(jwe, irs_attempt_api_private_key)
+
       token = JSON.parse(decrypted_jwe_payload)
 
       expect(token['iss']).to eq('http://www.example.com/')


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

**Why**: This was implicitly the default already, and making it explicit helps clarify that this is asymmetric encryption (because the enc: is symmetric)

