### PR TITLE
LG-7669 Added address line 2 under verify your information

### DIFF
--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -28,7 +28,7 @@
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :address2,
-        label: t('idv.form.address2'),
+        label: t('idv.form.address2_optional'),
         required: false,
         maxlength: 255,
         input_html: { value: @pii['address2'] },

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -46,6 +46,12 @@ locals:
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:address1] %> </dd>
       </div>
+      <% if pii[:address2].present? %>
+        <div>
+          <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
+          <dd class="display-inline margin-left-0"> <%= pii[:address2] %> </dd>
+        </div>
+      <% end %>
       <div>
         <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:city] %> </dd>
@@ -70,7 +76,7 @@ locals:
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">
     <div class='grid-col-fill'>
-      <%= t('idv.form.ssn') %>: 
+      <%= t('idv.form.ssn') %>:
       <%= render(
             'shared/masked_text',
             text: SsnFormatter.format(pii[:ssn]),

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -101,7 +101,8 @@ en:
           state-issued ID, etc.
     form:
       address1: Address
-      address2: Address (optional)
+      address2: Address line 2
+      address2_optional: Address line 2 (optional)
       city: City
       dob: Date of birth
       first_name: First name

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -106,7 +106,8 @@ es:
           documento de identidad emitido por el estado, etc.
     form:
       address1: Dirección
-      address2: Dirección (opcional)
+      address2: Línea de dirección 2
+      address2_optional: Línea de dirección 2 (opcional)
       city: Ciudad
       dob: Fecha de nacimiento
       first_name: Nombre de pila

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -111,7 +111,8 @@ fr:
           pièce d’identité officielle, etc.
     form:
       address1: Adresse
-      address2: Adresse (optional)
+      address2: Adresse Ligne 2
+      address2_optional: Adresse Ligne 2 (optional)
       city: Ville
       dob: Date de naissance
       first_name: Prénom


### PR DESCRIPTION
Changelog: Features, IdV, Added address line 2 under verify your information

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-7669

## 🛠 Summary of changes

Under "Verify your information" in the IdV flow, if a user has a line 2 to their address it is now shown.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV flow and add a 2nd line to your address
- [ ] Check to see if Address line 2 is on the Verify your information step


## 👀 Screenshots
Old:

<img width="617" alt="Screen Shot 2022-10-20 at 10 48 43 AM" src="https://user-images.githubusercontent.com/1034049/196984094-2887e33c-3cbc-463d-8cea-02df3fe9de1f.png">

New:

<img width="617" alt="Screen Shot 2022-10-20 at 10 49 21 AM" src="https://user-images.githubusercontent.com/1034049/196984152-f5ce4668-ed05-4311-9d9d-164e4599b84a.png">

New Update Mailing Address Screen:

<img width="615" alt="Screen Shot 2022-10-20 at 10 49 09 AM" src="https://user-images.githubusercontent.com/1034049/196984423-5640ae37-b7cc-4c8b-8a47-c2ff40b5f70f.png">



<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
