### PR TITLE
Make AAMVA response `verified_attributes` an array instead of a set

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -86,7 +86,7 @@ module Proofing
           attributes.add attribute if verified
         end
 
-        attributes
+        attributes.to_a
       end
 
       def address_verified?(results)


### PR DESCRIPTION
This commit fixes a bug where the AAMVA response was using a Set instead of the expected array to set verified attribute on its response.
