### PR TITLE
Add kid "key id" header claim to Attempts API JWEs

### DIFF
--- a/app/services/irs_attempts_api/attempt_event.rb
+++ b/app/services/irs_attempts_api/attempt_event.rb
@@ -26,6 +26,7 @@ module IrsAttemptsApi
         zip: 'DEF',
         alg: 'RSA-OAEP',
         enc: 'A256GCM',
+        kid: JWT::JWK.new(event_data_encryption_key).kid,
       )
     end
 
@@ -83,8 +84,10 @@ module IrsAttemptsApi
     end
 
     def event_data_encryption_key
-      decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
-      OpenSSL::PKey::RSA.new(decoded_key_der)
+      @event_data_encryption_key ||= begin
+        decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
+        OpenSSL::PKey::RSA.new(decoded_key_der)
+      end
     end
   end
 end

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
       headers = JSON.parse(header_str)
 
       expect(headers['alg']).to eq('RSA-OAEP')
+      expect(headers['kid']).to eq(JWT::JWK.new(irs_attempt_api_public_key).kid)
 
       decrypted_jwe_payload = JWE.decrypt(jwe, irs_attempt_api_private_key)
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

Adds a Key ID header claim that is in plaintext in the resulting JWE, so it can assist in future key rotations


## 🚀 Notes for Deployment

Include any special instructions for deployment.
