### PR TITLE
Only check email for sensitive info when async

### DIFF
--- a/config/initializers/ext_action_mailer.rb
+++ b/config/initializers/ext_action_mailer.rb
@@ -12,7 +12,6 @@ module ActionMailer
     prepend DeliverLaterArgumentChecker
 
     def deliver_now_or_later(opts = {})
-      MailerSensitiveInformationChecker.check_for_sensitive_pii!(@params, @args, @action)
       if IdentityConfig.store.deliver_mail_async
         deliver_later(opts)
       else


### PR DESCRIPTION
## 🛠 Summary of changes

We only wanted to check in the `perform_later` case because that's when we store it in the database.