### PR TITLE
changelog: Improvements, In-Person Proofing, uses correct error handling

### DIFF
--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -49,9 +49,12 @@ module ArcgisApi
 
     def parse_suggestions(response_body)
       if response_body['error']
-        if response_body['error']['code'] >= 400 && response_body['error']['code'] < 500
-          raise Faraday::ClientError.new(response_body)
-        end
+        error_code = response_body.dig('error', 'code')
+
+        raise Faraday::ClientError.new(
+          RuntimeError.new("received error code #{error_code}"),
+          response_body,
+        )
       end
 
       response_body['suggestions'].map do |suggestion|

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe ArcgisApi::Geocoder do
     it 'returns an error response body but with Status coded as 200' do
       stub_request_suggestions_error
 
-      expect { subject.suggest('100 Main') }.to raise_error(
-        an_instance_of(Faraday::ClientError),
-      )
+      expect { subject.suggest('100 Main') }.to raise_error do |error|
+        expect(error).to be_instance_of(Faraday::ClientError)
+        expect(error.message).to eq('received error code 400')
+        expect(error.response).to be_kind_of(Hash)
+      end
     end
 
     it 'returns an error with Status coded as 4** in HTML' do


### PR DESCRIPTION
## 🎫 Ticket

[Link to the relevant ticket.](https://cm-jira.usa.gov/browse/LG-7719)

## 🛠 Summary of changes

Implements [better error handling](https://www.rubydoc.info/gems/faraday/Faraday/Error#initialize-instance_method) by passing the correct args ([context](https://github.com/18F/identity-idp/pull/7186#discussion_r1002207549)).

## 📜 Testing Plan

Instead of "Faraday::ClientError: the server responded with status" we get a more help message:

>      # Faraday::ClientError:
>      #   received error code 400

