### PR TITLE
LG-7716: adds Mock IRS to sample SPs

### DIFF
--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -433,6 +433,19 @@ development:
       - 'sp_sinatra_demo'
     friendly_name: 'Example Sinatra App'
 
+  'urn:gov:gsa:openidconnect:sp:mock_irs':
+    agency_id: 1
+    ial: 2
+    irs_attempts_api_enabled: true
+    push_notification_url: http://localhost:9292/api/push_notifications
+    redirect_uris:
+      - 'http://localhost:9292/'
+      - 'http://localhost:9292/auth/result'
+      - 'http://localhost:9292/logout'
+    certs:
+      - 'sp_sinatra_demo'
+    friendly_name: 'Login Mock IRS'
+
   'urn:gov:gsa:openidconnect:sp:expressjs':
     agency: 'GSA'
     certs:


### PR DESCRIPTION
[skip changelog]

## 🎫 Ticket

[LG-7716: Sample apps support IRS reproofing](https://cm-jira.usa.gov/browse/LG-7716)

## 🛠 Summary of changes

Adds a Mock IRS SP for testing IRS reproofing.

## 📜 Testing Plan

Paired with [this OIDC Sample App PR](https://github.com/18F/identity-oidc-sinatra/pull/125), for which enabling Attempts API in your request will redirect the auth request to this new mock SP.