### PR TITLE
Guard defining ComponentPreviewController on feature flag

### DIFF
--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -6,4 +6,4 @@ class ComponentPreviewController < ViewComponentsController
 
   helper_method :enqueue_component_scripts
   alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
-end
+end if IdentityConfig.store.component_previews_enabled

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -1,9 +1,15 @@
-class ComponentPreviewController < ViewComponentsController
-  include ActionView::Helpers::AssetTagHelper
-  helper Lookbook::PreviewHelper
-  include Lookbook::PreviewController
-  include ScriptHelper
+if IdentityConfig.store.component_previews_enabled
+  # Define a stub class, in cases where this file is eager loaded but the
+  # dependencies have not been loaded
+  class ComponentPreviewController < ApplicationController; end
+else
+  class ComponentPreviewController < ViewComponentsController
+    include ActionView::Helpers::AssetTagHelper
+    helper Lookbook::PreviewHelper
+    include Lookbook::PreviewController
+    include ScriptHelper
 
-  helper_method :enqueue_component_scripts
-  alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
-end if IdentityConfig.store.component_previews_enabled # only define the class conditionally
+    helper_method :enqueue_component_scripts
+    alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
+  end
+end

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -4,8 +4,8 @@ class ComponentPreviewController < ViewComponentsController
     helper Lookbook::PreviewHelper
     include Lookbook::PreviewController
     include ScriptHelper
-  end
 
-  helper_method :enqueue_component_scripts
-  alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
+    helper_method :enqueue_component_scripts
+    alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
+  end
 end

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -1,15 +1,10 @@
-if IdentityConfig.store.component_previews_enabled
-  # Define a stub class, in cases where this file is eager loaded but the
-  # dependencies have not been loaded
-  class ComponentPreviewController < ApplicationController; end
-else
-  class ComponentPreviewController < ViewComponentsController
+class ComponentPreviewController < ViewComponentsController
+  if IdentityConfig.store.component_previews_enabled
     include ActionView::Helpers::AssetTagHelper
     helper Lookbook::PreviewHelper
     include Lookbook::PreviewController
     include ScriptHelper
 
-    helper_method :enqueue_component_scripts
-    alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
-  end
+  helper_method :enqueue_component_scripts
+  alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
 end

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -4,6 +4,7 @@ class ComponentPreviewController < ViewComponentsController
     helper Lookbook::PreviewHelper
     include Lookbook::PreviewController
     include ScriptHelper
+  end
 
   helper_method :enqueue_component_scripts
   alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -6,4 +6,4 @@ class ComponentPreviewController < ViewComponentsController
 
   helper_method :enqueue_component_scripts
   alias_method :enqueue_component_scripts, :render_javascript_pack_once_tags
-end if IdentityConfig.store.component_previews_enabled
+end if IdentityConfig.store.component_previews_enabled # only define the class conditionally


### PR DESCRIPTION
## 🎫 Ticket

[slack discussion of error](https://gsa-tts.slack.com/archives/C0NGESUN5/p1666632258318099?thread_ts=1666632234.792629&cid=C0NGESUN5)

## 🛠 Summary of changes

**Why**: we avoid loading lookbook gem unless the feature flag is on, so the classes to subclass and the mixins will fail due to load errors

**How**: I went with the sneaky trailing if to minimize diff noise


## 📜 Testing Plan

- Deploy to a lower env with the feature disabled (int)

