### PR TITLE
Stop requesting selfies from the frontend

### DIFF
--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -7,7 +7,7 @@ module Api
       def create
         result = Idv::ApiDocumentVerificationForm.new(
           verify_params,
-          liveness_checking_enabled: liveness_checking_enabled?,
+          liveness_checking_enabled: false,
           analytics: analytics,
           irs_attempts_api_tracker: irs_attempts_api_tracker,
           flow_path: params[:flow_path],
@@ -37,7 +37,7 @@ module Api
         }
         Idv::Agent.new(applicant).proof_document(
           verify_document_capture_session,
-          liveness_checking_enabled: liveness_checking_enabled?,
+          liveness_checking_enabled: false,
           trace_id: amzn_trace_id,
           image_metadata: image_metadata,
           analytics_data: {

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -20,7 +20,7 @@ module Idv
     def image_upload_form
       @image_upload_form ||= Idv::ApiImageUploadForm.new(
         params,
-        liveness_checking_enabled: liveness_checking_enabled?,
+        liveness_checking_enabled: false,
         service_provider: current_sp,
         analytics: analytics,
         uuid_prefix: current_sp&.app_id,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -12,7 +12,7 @@
 %>
 <%= tag.div id: 'document-capture-form', data: {
       app_name: APP_NAME,
-      liveness_required: false,
+      liveness_required: nil,
       mock_client: (DocAuthRouter.doc_auth_vendor(discriminator: session_id) == 'mock').presence,
       help_center_redirect_url: help_center_redirect_url(
         flow: :idv,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -12,7 +12,7 @@
 %>
 <%= tag.div id: 'document-capture-form', data: {
       app_name: APP_NAME,
-      liveness_required: liveness_checking_enabled?.presence,
+      liveness_required: false,
       mock_client: (DocAuthRouter.doc_auth_vendor(discriminator: session_id) == 'mock').presence,
       help_center_redirect_url: help_center_redirect_url(
         flow: :idv,

--- a/spec/controllers/api/verify/document_capture_controller_spec.rb
+++ b/spec/controllers/api/verify/document_capture_controller_spec.rb
@@ -23,7 +23,6 @@ describe Api::Verify::DocumentCaptureController do
   let(:password) { 'iambatman' }
   let(:user) { create(:user, :signed_up) }
   let(:flow_path) { 'standard' }
-  let(:liveness_checking_enabled) { false }
   let(:analytics_data) do
     { browser_attributes:
       { browser_bot: false,
@@ -92,7 +91,7 @@ describe Api::Verify::DocumentCaptureController do
 
         expect(agent).to receive(:proof_document).with(
           document_capture_session,
-          liveness_checking_enabled: liveness_checking_enabled,
+          liveness_checking_enabled: false,
           trace_id: nil,
           image_metadata: image_metadata,
           analytics_data: analytics_data,

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -7,14 +7,10 @@ feature 'doc capture document capture step', js: true do
 
   let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
   let(:user) { user_with_2fa }
-  let(:liveness_enabled) { true }
   let(:doc_auth_enable_presigned_s3_urls) { false }
-  let(:sp_requests_ial2_strict) { true }
   let(:fake_analytics) { FakeAnalytics.new }
   let(:sp_name) { 'Test SP' }
   before do
-    allow(IdentityConfig.store).to receive(:liveness_checking_enabled).
-      and_return(liveness_enabled)
     allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).
       and_return(doc_auth_enable_presigned_s3_urls)
     allow(Identity::Hostdata::EC2).to receive(:load).
@@ -23,12 +19,38 @@ feature 'doc capture document capture step', js: true do
     allow_any_instance_of(DocumentProofingJob).to receive(:build_analytics).
       and_return(fake_analytics)
     allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).and_return(sp_name)
-    if sp_requests_ial2_strict && liveness_enabled
-      visit_idp_from_oidc_sp_with_ial2_strict
-    else
-      visit_idp_from_oidc_sp_with_ial2
-    end
+
+    visit_idp_from_oidc_sp_with_ial2
+
     allow_any_instance_of(Browser).to receive(:mobile?).and_return(true)
+  end
+
+  it 'is on the correct page and shows the document upload options' do
+    complete_doc_capture_steps_before_first_step(user)
+
+    expect(current_path).to eq(idv_capture_doc_document_capture_step)
+    expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
+    expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+    # Document capture tips
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
+    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
+
+    # No selfie option, evidenced by "Submit" button instead of "Continue"
+    expect(page).to have_content(t('forms.buttons.submit.default'))
+  end
+
+  it 'proceeds to the next page with valid info' do
+    complete_doc_capture_steps_before_first_step(user)
+
+    attach_and_submit_images
+
+    expect(page).to have_current_path(next_step)
   end
 
   it 'offers the user the option to cancel and return to desktop' do
@@ -106,7 +128,7 @@ feature 'doc capture document capture step', js: true do
             pii_from_doc: {},
           },
         )
-        click_idv_continue
+        click_submit_default
       end
 
       click_idv_continue
@@ -124,7 +146,7 @@ feature 'doc capture document capture step', js: true do
             pii_from_doc: {},
           },
         )
-        click_idv_continue
+        click_submit_default
       end
 
       click_idv_continue
@@ -199,107 +221,23 @@ feature 'doc capture document capture step', js: true do
     end
   end
 
-  context 'when liveness checking is enabled' do
-    let(:liveness_enabled) { true }
+  it 'logs a warning event when there are unknown errors in the response', :allow_browser_log do
+    complete_doc_capture_steps_before_first_step(user)
 
-    before do
-      complete_doc_capture_steps_before_first_step(user)
+    Tempfile.create(['ia2_mock', '.yml']) do |yml_file|
+      yml_file.rewind
+      yml_file.puts <<~YAML
+        failed_alerts:
+        - name: Some Made Up Error
+      YAML
+      yml_file.close
+
+      attach_images(yml_file.path)
+      click_submit_default
     end
 
-    context 'when the SP does not request strict IAL2' do
-      let(:sp_requests_ial2_strict) { false }
-
-      it 'is on the correct page and shows the document upload options' do
-        expect(current_path).to eq(idv_capture_doc_document_capture_step)
-        expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
-        expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-
-        # Doc capture tips
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
-        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-
-        # No selfie option, evidenced by "Submit" button instead of "Continue"
-        expect(page).to have_content(t('forms.buttons.submit.default'))
-      end
-    end
-
-    it 'is on the correct page and shows the document upload options' do
-      expect(current_path).to eq(idv_capture_doc_document_capture_step)
-      expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
-      expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-
-      # Doc capture tips
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-
-      # Selfie option, evidenced by "Continue" button instead of "Submit"
-      expect(page).to have_content(t('forms.buttons.continue'))
-    end
-
-    it 'logs a warning event when there are unknown errors in the response', :allow_browser_log do
-      Tempfile.create(['ia2_mock', '.yml']) do |yml_file|
-        yml_file.rewind
-        yml_file.puts <<~YAML
-          failed_alerts:
-          - name: Some Made Up Error
-        YAML
-        yml_file.close
-
-        attach_images(yml_file.path)
-        click_submit_default
-      end
-
-      expect(page).to have_content(t('errors.doc_auth.throttled_heading'), wait: 5)
-      expect(fake_analytics).to have_logged_event('Doc Auth Warning', {})
-    end
-
-    it 'does not proceed to the next page with invalid info', allow_browser_log: true do
-      mock_general_doc_auth_client_error(:create_document)
-      attach_and_submit_images
-
-      expect(page).to have_current_path(idv_capture_doc_document_capture_step)
-    end
-  end
-
-  context 'when liveness checking is not enabled' do
-    let(:liveness_enabled) { false }
-
-    before do
-      complete_doc_capture_steps_before_first_step(user)
-    end
-
-    it 'is on the correct page and shows the document upload options' do
-      expect(current_path).to eq(idv_capture_doc_document_capture_step)
-      expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
-      expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-
-      # Document capture tips
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
-      expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-
-      # No selfie option, evidenced by "Submit" button instead of "Continue"
-      expect(page).to have_content(t('forms.buttons.submit.default'))
-    end
-
-    it 'proceeds to the next page with valid info' do
-      attach_and_submit_images
-
-      expect(page).to have_current_path(next_step)
-    end
+    expect(page).to have_content(t('errors.doc_auth.throttled_heading'), wait: 5)
+    expect(fake_analytics).to have_logged_event('Doc Auth Warning', {})
   end
 
   def next_step

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -48,33 +48,4 @@ RSpec.describe 'proofing components' do
       end
     end
   end
-
-  it 'clears liveness enabled proofing component when user re-proofs without liveness', js: true do
-    allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true)
-    user = user_with_totp_2fa
-    sign_in_and_2fa_user(user)
-    visit_idp_from_oidc_sp_with_ial2_strict
-    complete_proofing_steps
-
-    expect(user.active_profile.includes_liveness_check?).to be_truthy
-
-    visit account_path
-    first(:link, t('links.sign_out')).click
-
-    trigger_reset_password_and_click_email_link(user.email)
-    reset_password_and_sign_back_in(user, user.password)
-    fill_in_code_with_last_totp(user)
-    click_submit_default
-
-    expect(user.reload.profiles.where(active: true)).to be_empty
-
-    visit_idp_from_oidc_sp_with_ial2
-    click_on t('links.account.reactivate.without_key')
-    click_on t('forms.buttons.continue')
-
-    complete_proofing_steps
-
-    user = User.find(user.id)
-    expect(user.active_profile.includes_liveness_check?).to be_falsy
-  end
 end

--- a/spec/features/idv/strict_ial2/upgrade_spec.rb
+++ b/spec/features/idv/strict_ial2/upgrade_spec.rb
@@ -8,29 +8,6 @@ feature 'Strict IAL2 upgrade', js: true do
 
   before { allow(IdentityConfig.store).to receive(:liveness_checking_enabled).and_return(true) }
 
-  scenario 'an IAL2 strict request for a user with no liveness triggers an upgrade' do
-    user = create(
-      :profile, :active, :verified,
-      pii: { first_name: 'John', ssn: '111223333' }
-    ).user
-    visit_idp_from_oidc_sp_with_ial2_strict
-    sign_in_user(user)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    click_agree_and_continue_optional
-
-    expect(page.current_path).to eq(idv_doc_auth_welcome_step)
-
-    complete_all_doc_auth_steps_before_password_step
-    fill_in 'Password', with: user.password
-    click_continue
-    acknowledge_and_confirm_personal_key
-    click_agree_and_continue
-
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
-    expect(user.active_profile.strict_ial2_proofed?).to be_truthy
-  end
-
   context 'strict IAL2 does not allow a phone check' do
     before do
       allow(IdentityConfig.store).to receive(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,20 +69,21 @@ RSpec.configure do |config|
     end
   end
 
-  if !ENV['CI']
-    config.before(js: true) do
-      # rubocop:disable Style/GlobalVars
-      next if defined?($ran_asset_build)
-      $ran_asset_build = true
-      # rubocop:enable Style/GlobalVars
-      # rubocop:disable Rails/Output
-      print '                       Bundling JavaScript and stylesheets... '
-      system 'WEBPACK_PORT= yarn build > /dev/null 2>&1'
-      system 'yarn build:css > /dev/null 2>&1'
-      puts '✨ Done!'
-      # rubocop:enable Rails/Output
-    end
-  end
+  # TODO: PUT THIS BACK!!!
+  # if !ENV['CI']
+  #   config.before(js: true) do
+  #     # rubocop:disable Style/GlobalVars
+  #     next if defined?($ran_asset_build)
+  #     $ran_asset_build = true
+  #     # rubocop:enable Style/GlobalVars
+  #     # rubocop:disable Rails/Output
+  #     print '                       Bundling JavaScript and stylesheets... '
+  #     system 'WEBPACK_PORT= yarn build > /dev/null 2>&1'
+  #     system 'yarn build:css > /dev/null 2>&1'
+  #     puts '✨ Done!'
+  #     # rubocop:enable Rails/Output
+  #   end
+  # end
 
   config.before(:each) do
     I18n.locale = :en

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,21 +69,20 @@ RSpec.configure do |config|
     end
   end
 
-  # TODO: PUT THIS BACK!!!
-  # if !ENV['CI']
-  #   config.before(js: true) do
-  #     # rubocop:disable Style/GlobalVars
-  #     next if defined?($ran_asset_build)
-  #     $ran_asset_build = true
-  #     # rubocop:enable Style/GlobalVars
-  #     # rubocop:disable Rails/Output
-  #     print '                       Bundling JavaScript and stylesheets... '
-  #     system 'WEBPACK_PORT= yarn build > /dev/null 2>&1'
-  #     system 'yarn build:css > /dev/null 2>&1'
-  #     puts '✨ Done!'
-  #     # rubocop:enable Rails/Output
-  #   end
-  # end
+  if !ENV['CI']
+    config.before(js: true) do
+      # rubocop:disable Style/GlobalVars
+      next if defined?($ran_asset_build)
+      $ran_asset_build = true
+      # rubocop:enable Style/GlobalVars
+      # rubocop:disable Rails/Output
+      print '                       Bundling JavaScript and stylesheets... '
+      system 'WEBPACK_PORT= yarn build > /dev/null 2>&1'
+      system 'yarn build:css > /dev/null 2>&1'
+      puts '✨ Done!'
+      # rubocop:enable Rails/Output
+    end
+  end
 
   config.before(:each) do
     I18n.locale = :en


### PR DESCRIPTION
We are retiring IAL2-strict which means we will no longer be asking the React app to collect selfies from the user. This commit sets the flags to be permanently false so we can start working back and removing code to remove the request for selfies.

[skip changelog]
