### PR TITLE
Ensure job class defines warning_error_classes before calling it to prevent logging failures

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -196,7 +196,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def should_error?(job, ex)
-    if job.class.respond_to?(:warning_error_classes)
+    if job.is_a?(ApplicationJob)
       job.class.warning_error_classes.none? { |warning_class| ex.is_a?(warning_class) }
     else
       true

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -196,7 +196,11 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def should_error?(job, ex)
-    job.class.warning_error_classes.none? { |warning_class| ex.is_a?(warning_class) }
+    if job.class.respond_to?(:warning_error_classes)
+      job.class.warning_error_classes.none? { |warning_class| ex.is_a?(warning_class) }
+    else
+      true
+    end
   end
 end
 

--- a/spec/lib/identity_job_log_subscriber_spec.rb
+++ b/spec/lib/identity_job_log_subscriber_spec.rb
@@ -302,6 +302,25 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
       subscriber.enqueue_at(event)
     end
 
+    it 'is compatible with job classes that do not inherit from ApplicationJob' do
+      # rubocop:disable Rails/ApplicationJob
+      class SampleJob < ActiveJob::Base; def perform(_); end; end
+      # rubocop:enable Rails/ApplicationJob
+
+      job = SampleJob.new
+
+      event = ActiveSupport::Notifications::Event.new(
+        'enqueue.active_job',
+        now,
+        now,
+        event_uuid,
+        job: job,
+        exception_object: Errno::ECONNREFUSED.new,
+      )
+
+      subscriber.enqueue_at(event)
+    end
+
     it 'halts' do
       job = RiscDeliveryJob.new
 


### PR DESCRIPTION
## 🛠 Summary of changes

The `ActionMailer` job class does not implement `warning_error_classes` and this can cause issues when sending emails asynchronously. This isn't ideal, so I'm open to other approaches.