### PR TITLE
LG-7891 Protect against nil state id numbers in mock proofer

### DIFF
--- a/app/services/proofing/mock/state_id_mock_client.rb
+++ b/app/services/proofing/mock/state_id_mock_client.rb
@@ -12,7 +12,7 @@ module Proofing
       TRIGGER_MVA_TIMEOUT = 'mvatimeout'
 
       def proof(applicant)
-        return mva_timeout_result if applicant[:state_id_number].downcase == TRIGGER_MVA_TIMEOUT
+        return mva_timeout_result if mva_timeout?(applicant[:state_id_number])
 
         errors = {}
         if state_not_supported?(applicant[:state_id_jurisdiction])
@@ -56,6 +56,11 @@ module Proofing
           vendor_name: 'StateIdMock',
           transaction_id: TRANSACTION_ID,
         )
+      end
+
+      def mva_timeout?(state_id_number)
+        return false if state_id_number.blank?
+        state_id_number.downcase == TRIGGER_MVA_TIMEOUT
       end
 
       def state_not_supported?(state_id_jurisdiction)

--- a/spec/services/proofing/mock/state_id_mock_client_spec.rb
+++ b/spec/services/proofing/mock/state_id_mock_client_spec.rb
@@ -69,5 +69,16 @@ RSpec.describe Proofing::Mock::StateIdMockClient do
         )
       end
     end
+
+    context 'with a nil state id number' do
+      it 'returns a good result' do
+        applicant[:state_id_number] = nil
+
+        result = subject.proof(applicant)
+
+        expect(result.success?).to eq(true)
+        expect(result.errors).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
Our dev docs have a sample YAML file which does not include a state ID number. As a result when partners change the jurisdiction to a supported jurisdiction it causes failures when calling downcase on the nil value.

This commit fixes this bug by protecting against a nil value there. We should also add a state id number and type to the example YAML on the dev docs.

[skip changelog]
