### PR TITLE
Export information about source code for event documentation

### DIFF
--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'optparse'
 require 'stringio'
 require 'active_support/core_ext/object/blank'
+require_relative './identity_config'
 
 # Parses YARD output for AnalyticsEvents methods
 class AnalyticsEventsDocumenter
@@ -137,6 +138,10 @@ class AnalyticsEventsDocumenter
         previous_event_names: method_object.tags(PREVIOUS_EVENT_NAME_TAG).map(&:text),
         description: method_object.docstring.presence,
         attributes: attributes,
+        method_name: method_object.name,
+        source_line: method_object.line,
+        source_file: method_object.file,
+        source_sha: IdentityConfig::GIT_SHA,
       }
     end
 

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -217,6 +217,10 @@ RSpec.describe AnalyticsEventsDocumenter do
               { name: 'success', types: ['Boolean'], description: nil },
               { name: 'count', types: ['Integer'], description: 'number of attempts' },
             ],
+            method_name: :some_event,
+            source_file: '(stdin)',
+            source_line: 5,
+            source_sha: kind_of(String),
           },
           {
             event_name: 'Other Event',
@@ -226,6 +230,10 @@ RSpec.describe AnalyticsEventsDocumenter do
             ],
             description: nil,
             attributes: [],
+            method_name: :other_event,
+            source_file: '(stdin)',
+            source_line: 11,
+            source_sha: kind_of(String),
           },
         ],
       )
@@ -246,7 +254,7 @@ RSpec.describe AnalyticsEventsDocumenter do
       RUBY
 
       it 'still finds events' do
-        expect(documenter.as_json[:events]).to eq(
+        expect(documenter.as_json[:events]).to match_array(
           [
             {
               event_name: 'some_event',
@@ -255,6 +263,10 @@ RSpec.describe AnalyticsEventsDocumenter do
               attributes: [
                 { name: 'success', types: ['Boolean'], description: nil },
               ],
+              method_name: :some_event,
+              source_file: '(stdin)',
+              source_line: 4,
+              source_sha: kind_of(String),
             },
           ],
         )


### PR DESCRIPTION
## 🛠 Summary of changes

**Why**: Lets us link to specific definition of code, as well as link to searching for usages of where it's called

Corresponding handbook PR: https://github.com/18F/identity-handbook/pull/337