### PR TITLE
LG-7255 - Adds proofing session 

### DIFF
--- a/app/services/idv/steps/inherited_proofing/agreement_step.rb
+++ b/app/services/idv/steps/inherited_proofing/agreement_step.rb
@@ -24,7 +24,6 @@ module Idv
             inherited_proofing_verify_step_document_capture_session_uuid_key,
           )
 
-          doc_capture_session.create_doc_auth_session
           doc_capture_session.create_proofing_session
 
           InheritedProofingJob.perform_later(

--- a/app/services/idv/steps/inherited_proofing/agreement_step.rb
+++ b/app/services/idv/steps/inherited_proofing/agreement_step.rb
@@ -25,6 +25,7 @@ module Idv
           )
 
           doc_capture_session.create_doc_auth_session
+          doc_capture_session.create_proofing_session
 
           InheritedProofingJob.perform_later(
             controller.inherited_proofing_service_provider,


### PR DESCRIPTION
Why:
Need to track asyn proofing session to accurately track proofing process

changelog: Internal, Inherited Proofing, We are Retrieving API call

## 🎫 Ticket

[LG-7255](https://cm-jira.usa.gov/browse/LG-7255)

## 🛠 Summary of changes

Added a proofing session to accurately capture the proofing process. This copies other similar processes in the app.
