### PR TITLE
Remove the selfie args from the `Idv::Agent`

### DIFF
--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -37,7 +37,6 @@ module Api
         }
         Idv::Agent.new(applicant).proof_document(
           verify_document_capture_session,
-          liveness_checking_enabled: false,
           trace_id: amzn_trace_id,
           image_metadata: image_metadata,
           analytics_data: {

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -9,7 +9,6 @@ class DocumentProofingJob < ApplicationJob
     result_id:,
     encrypted_arguments:,
     trace_id:,
-    liveness_checking_enabled:,
     image_metadata:,
     analytics_data:,
     flow_path:
@@ -32,10 +31,8 @@ class DocumentProofingJob < ApplicationJob
     encryption_key = Base64.decode64(document_args[:encryption_key].to_s)
     front_image_iv = Base64.decode64(document_args[:front_image_iv].to_s)
     back_image_iv = Base64.decode64(document_args[:back_image_iv].to_s)
-    selfie_image_iv = Base64.decode64(document_args[:selfie_image_iv].to_s)
     front_image_url = document_args[:front_image_url]
     back_image_url = document_args[:back_image_url]
-    selfie_image_url = document_args[:selfie_image_url]
 
     front_image = decrypt_image_from_s3(
       timer: timer, name: :front, url: front_image_url, iv: front_image_iv, key: encryption_key,
@@ -43,12 +40,6 @@ class DocumentProofingJob < ApplicationJob
     back_image = decrypt_image_from_s3(
       timer: timer, name: :back, url: back_image_url, iv: back_image_iv, key: encryption_key,
     )
-    if liveness_checking_enabled
-      selfie_image = decrypt_image_from_s3(
-        timer: timer, name: :selfie, url: selfie_image_url, iv: selfie_image_iv,
-        key: encryption_key
-      )
-    end
 
     analytics = build_analytics(dcs)
     doc_auth_client = build_doc_auth_client(analytics, dcs)
@@ -57,9 +48,9 @@ class DocumentProofingJob < ApplicationJob
       doc_auth_client.post_images(
         front_image: front_image,
         back_image: back_image,
-        selfie_image: selfie_image || '',
+        selfie_image: nil,
         image_source: image_source(image_metadata),
-        liveness_checking_enabled: liveness_checking_enabled,
+        liveness_checking_enabled: false,
         user_uuid: user_uuid,
         uuid_prefix: uuid_prefix,
       )

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -5,13 +5,15 @@ class DocumentProofingJob < ApplicationJob
 
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 
+  # rubocop:disable Lint/UnusedMethodArgument
   def perform(
     result_id:,
     encrypted_arguments:,
     trace_id:,
     image_metadata:,
     analytics_data:,
-    flow_path:
+    flow_path:,
+    liveness_checking_enabled: nil
   )
     timer = JobHelpers::Timer.new
 
@@ -85,6 +87,7 @@ class DocumentProofingJob < ApplicationJob
       }.to_json,
     )
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   private
 

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -61,7 +61,6 @@ module Idv
 
     def proof_document(
       document_capture_session,
-      liveness_checking_enabled:,
       trace_id:,
       image_metadata:,
       analytics_data:,
@@ -73,7 +72,6 @@ module Idv
 
       DocumentProofingJob.perform_later(
         encrypted_arguments: encrypted_arguments,
-        liveness_checking_enabled: liveness_checking_enabled,
         result_id: document_capture_session.result_id,
         trace_id: trace_id,
         image_metadata: image_metadata,

--- a/spec/controllers/api/verify/document_capture_controller_spec.rb
+++ b/spec/controllers/api/verify/document_capture_controller_spec.rb
@@ -9,8 +9,6 @@ describe Api::Verify::DocumentCaptureController do
   let(:front_image_iv) { 'front-iv' }
   let(:back_image_url) { 'http://example.com/back' }
   let(:back_image_iv) { 'back-iv' }
-  let(:selfie_image_url) { 'http://example.com/selfie' }
-  let(:selfie_image_iv) { 'selfie-iv' }
   let(:front_image_metadata) do
     { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }
   end
@@ -81,17 +79,14 @@ describe Api::Verify::DocumentCaptureController do
               'encryption_key' => encryption_key,
               'front_image_iv' => front_image_iv,
               'back_image_iv' => back_image_iv,
-              'selfie_image_iv' => selfie_image_iv,
               'front_image_url' => front_image_url,
               'back_image_url' => back_image_url,
-              'selfie_image_url' => selfie_image_url,
             },
           },
         ).and_return(agent)
 
         expect(agent).to receive(:proof_document).with(
           document_capture_session,
-          liveness_checking_enabled: false,
           trace_id: nil,
           image_metadata: image_metadata,
           analytics_data: analytics_data,
@@ -102,10 +97,8 @@ describe Api::Verify::DocumentCaptureController do
           encryption_key: encryption_key,
           front_image_iv: front_image_iv,
           back_image_iv: back_image_iv,
-          selfie_image_iv: selfie_image_iv,
           front_image_url: front_image_url,
           back_image_url: back_image_url,
-          selfie_image_url: selfie_image_url,
           front_image_metadata: front_image_metadata.to_json,
           back_image_metadata: back_image_metadata.to_json,
           document_capture_session_uuid: document_capture_session_uuid,
@@ -128,10 +121,8 @@ describe Api::Verify::DocumentCaptureController do
             encryption_key: encryption_key,
             front_image_iv: nil,
             back_image_iv: back_image_iv,
-            selfie_image_iv: selfie_image_iv,
             front_image_url: front_image_url,
             back_image_url: back_image_url,
-            selfie_image_url: selfie_image_url,
             document_capture_session_uuid: document_capture_session_uuid,
           }
 


### PR DESCRIPTION
The selfie is used to support strict IAL2. The strict IAL2 flow is being retired so we will not be matching selfies here in the near term. This commit retires the code that passes the selfie through the IdV agent to the document proofing job and to the SDK adapter since it is no longer an active code path.
