### PR TITLE
Remove liveness check from ApiDocumentVerification

### DIFF
--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -7,7 +7,6 @@ module Api
       def create
         result = Idv::ApiDocumentVerificationForm.new(
           verify_params,
-          liveness_checking_enabled: false,
           analytics: analytics,
           irs_attempts_api_tracker: irs_attempts_api_tracker,
           flow_path: params[:flow_path],

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -73,10 +73,6 @@ module Idv
       params[:back_image_iv]
     end
 
-    def selfie_image_iv
-      params[:selfie_image_iv]
-    end
-
     def valid_url?(key)
       uri = params[key]
       parsed_uri = URI.parse(uri)

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -8,19 +8,16 @@ module Idv
     validates_presence_of :document_capture_session
     validates_presence_of :front_image_iv
     validates_presence_of :back_image_iv
-    validates_presence_of :selfie_image_iv, if: :liveness_checking_enabled?
 
     validate :throttle_if_rate_limited
 
     def initialize(
       params,
-      liveness_checking_enabled:,
       analytics:,
       irs_attempts_api_tracker:,
       flow_path: nil
     )
       @params = params
-      @liveness_checking_enabled = liveness_checking_enabled
       @analytics = analytics
       @irs_attempts_api_tracker = irs_attempts_api_tracker
       @flow_path = flow_path
@@ -48,10 +45,6 @@ module Idv
     def remaining_attempts
       return unless document_capture_session
       throttle.remaining_count
-    end
-
-    def liveness_checking_enabled?
-      @liveness_checking_enabled
     end
 
     def document_capture_session_uuid
@@ -121,13 +114,6 @@ module Idv
       unless valid_url?(:back_image_url)
         errors.add(
           :back_image_url, invalid_link,
-          type: :invalid_link
-        )
-      end
-      return if valid_url?(:selfie_image_url)
-      if liveness_checking_enabled?
-        errors.add(
-          :selfie_image_url, invalid_link,
           type: :invalid_link
         )
       end

--- a/spec/forms/idv/api_document_verification_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_form_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
         selfie_image_iv: selfie_image_iv,
         document_capture_session_uuid: document_capture_session_uuid,
       },
-      liveness_checking_enabled: liveness_checking_enabled?,
       analytics: analytics,
       irs_attempts_api_tracker: irs_attempts_api_tracker,
     )
@@ -30,36 +29,12 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:analytics) { FakeAnalytics.new }
   let(:irs_attempts_api_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
-  let(:liveness_checking_enabled?) { true }
 
   describe '#valid?' do
     context 'with all valid images' do
       it 'is valid' do
         expect(form.valid?).to eq(true)
         expect(form.errors).to be_blank
-      end
-    end
-
-    context 'with valid front and back but no selfie' do
-      let(:selfie_image_url) { nil }
-
-      context 'with liveness required' do
-        let(:liveness_checking_enabled?) { true }
-
-        it 'is not valid' do
-          expect(form.valid?).to eq(false)
-          expect(form.errors.attribute_names).to eq([:selfie_image_url])
-          expect(form.errors[:selfie_image_url]).to eq([t('doc_auth.errors.not_a_file')])
-        end
-      end
-
-      context 'without liveness require' do
-        let(:liveness_checking_enabled?) { false }
-
-        it 'is valid' do
-          expect(form.valid?).to eq(true)
-          expect(form.errors).to be_blank
-        end
       end
     end
 

--- a/spec/forms/idv/api_document_verification_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_form_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
         front_image_iv: front_image_iv,
         back_image_url: back_image_url,
         back_image_iv: back_image_iv,
-        selfie_image_url: selfie_image_url,
-        selfie_image_iv: selfie_image_iv,
         document_capture_session_uuid: document_capture_session_uuid,
       },
       analytics: analytics,
@@ -23,8 +21,6 @@ RSpec.describe Idv::ApiDocumentVerificationForm do
   let(:front_image_iv) { 'front-iv' }
   let(:back_image_url) { 'http://example.com/back' }
   let(:back_image_iv) { 'back-iv' }
-  let(:selfie_image_url) { 'http://example.com/selfie' }
-  let(:selfie_image_iv) { 'selfie-iv' }
   let!(:document_capture_session) { DocumentCaptureSession.create!(user: create(:user)) }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:analytics) { FakeAnalytics.new }


### PR DESCRIPTION
## 🛠 Summary of changes

Removed the liveness check from the ApiDocumentVerification form. The liveness check is a part of selfie verification which is being removed from IdV.

