### PR TITLE
Remove selfie and liveness check from mock doc_auth client

### DIFF
--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -11,7 +11,6 @@ module DocAuth
         attr_reader :response_mocks
         attr_accessor :last_uploaded_front_image
         attr_accessor :last_uploaded_back_image
-        attr_accessor :last_uploaded_selfie_image
       end
 
       def self.mock_response!(method:, response:)
@@ -23,7 +22,6 @@ module DocAuth
         @response_mocks = {}
         @last_uploaded_front_image = nil
         @last_uploaded_back_image = nil
-        @last_uploaded_selfie_image = nil
       end
 
       def create_document
@@ -48,18 +46,14 @@ module DocAuth
         DocAuth::Response.new(success: true)
       end
 
-      def post_selfie(image:, instance_id:)
-        return mocked_response_for_method(__method__) if method_mocked?(__method__)
-
-        self.class.last_uploaded_selfie_image = image
-        DocAuth::Response.new(success: true)
+      def post_selfie
+        raise NotImplementedError,
+                'This method should be removed when one of the same name is removed from AcuantClient'
       end
 
       def post_images(
         front_image:,
         back_image:,
-        selfie_image:,
-        liveness_checking_enabled: nil,
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil
@@ -77,10 +71,10 @@ module DocAuth
         back_image_response = post_back_image(image: back_image, instance_id: instance_id)
         return back_image_response unless back_image_response.success?
 
-        process_results(instance_id, liveness_checking_enabled, selfie_image)
+        process_results(instance_id)
       end
 
-      def get_results(instance_id:, liveness_enabled:)
+      def get_results(instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
         overriden_config = config.dup.tap do |c|
@@ -92,25 +86,14 @@ module DocAuth
         ResultResponse.new(
           self.class.last_uploaded_back_image,
           overriden_config,
-          liveness_enabled,
         )
       end
       # rubocop:enable Lint/UnusedMethodArgument
 
       private
 
-      def process_results(instance_id, liveness_checking_enabled, selfie_image)
-        results_response = get_results(
-          instance_id: instance_id,
-          liveness_enabled: liveness_checking_enabled,
-        )
-        return results_response unless results_response.success?
-
-        if liveness_checking_enabled
-          post_selfie(image: selfie_image, instance_id: instance_id).merge(results_response)
-        else
-          results_response
-        end
+      def process_results(instance_id)
+        get_results(instance_id: instance_id)
       end
 
       def method_mocked?(method_name)

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -1,12 +1,11 @@
 module DocAuth
   module Mock
     class ResultResponse < DocAuth::Response
-      attr_reader :uploaded_file, :config, :liveness_enabled
+      attr_reader :uploaded_file, :config
 
-      def initialize(uploaded_file, config, liveness_enabled)
+      def initialize(uploaded_file, config)
         @uploaded_file = uploaded_file.to_s
         @config = config
-        @liveness_enabled = liveness_enabled
         super(
           success: success?,
           errors: errors,
@@ -163,7 +162,6 @@ module DocAuth
           },
           alert_failure_count: failed&.count.to_i,
           image_metrics: merged_image_metrics,
-          liveness_enabled: liveness_enabled,
           portrait_match_results: { FaceMatchResult: liveness_result },
         }
       end

--- a/spec/services/doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -22,12 +22,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       instance_id: instance_id,
       image: DocAuthImageFixtures.document_back_image,
     )
-    get_results_response = client.get_results(instance_id: instance_id, liveness_enabled: false)
-
-    selfie_response = client.post_selfie(
-      instance_id: instance_id,
-      image: DocAuthImageFixtures.selfie_image,
-    )
+    get_results_response = client.get_results(instance_id: instance_id)
 
     expect(create_document_response.success?).to eq(true)
     expect(create_document_response.instance_id).to_not be_blank
@@ -54,8 +49,6 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       phone: nil,
     )
 
-    expect(selfie_response.success?).to eq(true)
-    expect(selfie_response.attention_with_barcode?).to eq(false)
   end
 
   it 'if the document is a YAML file it returns the PII from the YAML file' do
@@ -86,8 +79,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       image: yaml,
     )
     get_results_response = client.get_results(
-      instance_id: create_document_response.instance_id,
-      liveness_enabled: false,
+      instance_id: create_document_response.instance_id
     )
 
     expect(get_results_response.pii_from_doc).to eq(
@@ -132,7 +124,6 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       post_images_response = client.post_images(
         front_image: DocAuthImageFixtures.document_front_image,
         back_image: DocAuthImageFixtures.document_back_image,
-        selfie_image: nil,
       )
 
       expect(post_images_response.success?).to eq(false)
@@ -145,7 +136,6 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     post_images_response = client.post_images(
       front_image: DocAuthImageFixtures.document_front_image,
       back_image: DocAuthImageFixtures.document_back_image,
-      selfie_image: nil,
       image_source: DocAuth::ImageSources::UNKNOWN,
     )
 

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       glare_threshold: 40,
       warn_notifier: warn_notifier,
     )
-    described_class.new(input, config, false)
+    described_class.new(input, config)
   end
 
   context 'with an image file' do
@@ -254,22 +254,22 @@ RSpec.describe DocAuth::Mock::ResultResponse do
           glare_threshold: 40,
         },
       )
-      described_class.new(input, config, true)
+      described_class.new(input, config)
     end
 
     let(:input) do
       <<~YAML
         doc_auth_result: Passed
-        liveness_result: Fail
       YAML
     end
 
     it 'returns a passed result' do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(
-        general: [DocAuth::Errors::SELFIE_FAILURE],
-        selfie: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
-        hints: false,
+        back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+        front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+        general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+        hints: true,
       )
       expect(response.exception).to eq(nil)
       expect(response.pii_from_doc).to eq({})


### PR DESCRIPTION
## 🎫 Ticket

[LG-7711](https://cm-jira.usa.gov/browse/LG-7711)

## 🛠 Summary of changes

- Remove selfie and liveness check from mock doc_auth client and relevant specs.
- Put a NotImplementedError to a function that's needed when spec compares to mock client to Acuant client



