### PR TITLE
Avoid importing design system utilities into email CSS

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -2,7 +2,6 @@
 @import 'variables/email';
 @import 'foundation-emails/scss/foundation-emails';
 @import 'identity-style-guide/dist/assets/scss/packages/required';
-@import 'identity-style-guide/dist/assets/scss/packages/utilities';
 
 .gray {
   &:active,
@@ -155,4 +154,83 @@ h4 {
   line-height: 1;
   padding-top: units(0.5);
   margin-right: units(1.5);
+}
+
+// Design system utility classes are duplicated here as a compromise to allow for consistent usage
+// while avoiding performance cost of importing the full design system. Feel free to add as needed.
+
+.border-1px {
+  @include u-border(1px);
+}
+
+.border-primary-light {
+  @include u-border('primary-light');
+}
+
+.font-heading-lg {
+  @include u-font('heading', 'lg');
+}
+
+.font-heading-md {
+  @include u-font('heading', 'md');
+}
+
+.font-sans-md {
+  @include u-font('sans', 'md');
+}
+
+.margin-bottom-0 {
+  @include u-margin-bottom(0);
+}
+
+.margin-bottom-1 {
+  @include u-margin-bottom(1);
+}
+
+.margin-bottom-105 {
+  @include u-margin-bottom(1.5);
+}
+
+.margin-bottom-2 {
+  @include u-margin-bottom(2);
+}
+
+.margin-bottom-4 {
+  @include u-margin-bottom(4);
+}
+
+.margin-top-0 {
+  @include u-margin-top(0);
+}
+
+.margin-top-5 {
+  @include u-margin-top(5);
+}
+
+.margin-y-105 {
+  @include u-margin-y(1.5);
+}
+
+.margin-y-4 {
+  @include u-margin-y(4);
+}
+
+.padding-4 {
+  @include u-padding(4);
+}
+
+.padding-bottom-4 {
+  @include u-padding-bottom(4);
+}
+
+.text-bold {
+  @include u-text('bold');
+}
+
+.usa-list {
+  @extend %usa-list;
+
+  li {
+    @extend %usa-list-item;
+  }
 }

--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -167,6 +167,14 @@ h4 {
   @include u-border('primary-light');
 }
 
+.display-inline-block {
+  @include u-display('inline-block');
+}
+
+.display-block {
+  @include u-display('block');
+}
+
 .font-heading-lg {
   @include u-font('heading', 'lg');
 }
@@ -225,6 +233,10 @@ h4 {
 
 .text-bold {
   @include u-text('bold');
+}
+
+.text-center {
+  @include u-text('center');
 }
 
 .usa-list {

--- a/app/components/barcode_component.rb
+++ b/app/components/barcode_component.rb
@@ -34,7 +34,7 @@ class BarcodeComponent < BaseComponent
   end
 
   def css_class
-    [*tag_options[:class], 'display-inline-block margin-0']
+    [*tag_options[:class], 'display-inline-block']
   end
 
   private

--- a/app/views/user_mailer/in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/in_person_ready_to_verify.html.erb
@@ -76,7 +76,7 @@
 
 <% if @presenter.selected_location_details.present? %>
   <div class="margin-y-4">
-    <h2 class="font-sans-md margin-bottom-1 text-normal text-bold"><%= @presenter.selected_location_details['name'] %></h2>
+    <h2 class="font-sans-md margin-bottom-1 text-bold"><%= @presenter.selected_location_details['name'] %></h2>
     <div class="margin-bottom-1">
       <%= @presenter.selected_location_details['street_address'] %><br>
       <%= @presenter.selected_location_details['formatted_city_state_zip'] %>

--- a/app/views/user_mailer/in_person_verified.html.erb
+++ b/app/views/user_mailer/in_person_verified.html.erb
@@ -14,7 +14,7 @@
         date: @presenter.formatted_verified_date,
       ) %>
 </p>
-<p class="s16">
+<p>
   <% if @presenter.service_provider.present? %>
     <% if @presenter.show_cta? %>
       <%= t('user_mailer.in_person_verified.next_sign_in.with_sp.with_cta', sp_name: @presenter.service_provider.friendly_name) %>


### PR DESCRIPTION
## 🛠 Summary of changes

This pull request seeks to improve performance of email sends (and the delivered email itself?) by avoiding the inclusion of the full set of design system utility classes. As discovered by @mitchellhenke, email delivery is quite slow, due to how the [premailer gem](https://github.com/premailer/premailer) iterates and detects matches for each selector of the email stylesheet. Thus, we should be careful to limit the size of the email stylesheet as much as possible.

The approach here aims to try to continue usage of the design system utility classes for developer convenience and consistency, but opting-in piecemeal.

This should only be relevant for templates added or updated since July (c8a185b8cf7e3ab2a84bb50b8a6ab7f9c42aabe8), as this is when the utilities were initially introduced.

A combination of techniques were used to try to discover classes currently in use (e.g. `ag class app/views/user_mailer/in_person*`).

### Impact

`NODE_ENV=production yarn build:css && du -h app/assets/builds/email.css`

**Before:** 140kb
**After:** 28kb
**Diff%:** -81.4%

## 📜 Testing Plan

- [ ] Spot check email previews at http://localhost:3000/rails/mailers/user_mailer
- [ ] Review whether any other classes would need to be included