### PR TITLE
Stop distinuishing between liveness and no liveness general errors

### DIFF
--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -72,7 +72,7 @@ module DocAuth
           response_info: response_info,
         )
 
-        error = self.class.general_error(liveness_enabled)
+        error = Errors::GENERAL_ERROR
         side = ID
       elsif alert_error_count == 1
         error = alert_errors.values[0].to_a.pop
@@ -84,19 +84,14 @@ module DocAuth
           side = error_fields.first
           case side
           when ID
-            error = self.class.general_error(false)
+            error = Errors::GENERAL_ERROR
           when FRONT
             error = Errors::MULTIPLE_FRONT_ID_FAILURES
           when BACK
             error = Errors::MULTIPLE_BACK_ID_FAILURES
           end
         elsif error_fields.length > 1
-          if error_fields.include?(SELFIE)
-            error = self.class.general_error(liveness_enabled)
-          else
-            # If we don't have a selfie error don't give the message suggesting retaking selfie.
-            error = self.class.general_error(false)
-          end
+          error = Errors::GENERAL_ERROR
           side = ID
         end
       end
@@ -199,12 +194,8 @@ module DocAuth
       unknown_fail_count
     end
 
-    def self.general_error(liveness_enabled)
-      liveness_enabled ? Errors::GENERAL_ERROR_LIVENESS : Errors::GENERAL_ERROR_NO_LIVENESS
-    end
-
-    def self.wrapped_general_error(liveness_enabled)
-      { general: [ErrorGenerator.general_error(liveness_enabled)], hints: true }
+    def self.wrapped_general_error
+      { general: [Errors::GENERAL_ERROR], hints: true }
     end
   end
 end

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -14,8 +14,7 @@ module DocAuth
     DOCUMENT_EXPIRED_CHECK = 'doc_expired_check' # document has expired
     EXPIRATION_CHECKS = 'expiration_checks' # expiration date valid, expiration crosscheck
     FULL_NAME_CHECK = 'full_name_check'
-    GENERAL_ERROR_LIVENESS = 'general_error_liveness'
-    GENERAL_ERROR_NO_LIVENESS = 'general_error_no_liveness'
+    GENERAL_ERROR = 'general_error'
     ID_NOT_RECOGNIZED = 'id_not_recognized'
     ID_NOT_VERIFIED = 'id_not_verified'
     ISSUE_DATE_CHECKS = 'issue_date_checks'
@@ -52,8 +51,7 @@ module DocAuth
       DOC_NUMBER_CHECKS,
       EXPIRATION_CHECKS,
       FULL_NAME_CHECK,
-      GENERAL_ERROR_LIVENESS,
-      GENERAL_ERROR_NO_LIVENESS,
+      GENERAL_ERROR,
       ID_NOT_RECOGNIZED,
       ID_NOT_VERIFIED,
       ISSUE_DATE_CHECKS,
@@ -109,8 +107,7 @@ module DocAuth
       # Multiple Errors
       MULTIPLE_FRONT_ID_FAILURES => { long_msg: MULTIPLE_FRONT_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       MULTIPLE_BACK_ID_FAILURES => { long_msg: MULTIPLE_BACK_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
-      GENERAL_ERROR_LIVENESS => { long_msg: GENERAL_ERROR_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
-      GENERAL_ERROR_NO_LIVENESS => { long_msg: GENERAL_ERROR_NO_LIVENESS, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
+      GENERAL_ERROR => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       # Liveness
       SELFIE_FAILURE => { long_msg: SELFIE_FAILURE, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
     }

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -62,7 +62,7 @@ module DocAuth
           if true_id_product&.dig(:AUTHENTICATION_RESULT).present?
             ErrorGenerator.new(config).generate_doc_auth_errors(response_info)
           elsif true_id_product.present?
-            ErrorGenerator.wrapped_general_error(false)
+            ErrorGenerator.wrapped_general_error
           else
             { network: true } # return a generic technical difficulties error to user
           end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -28,11 +28,8 @@ module DocAuthRouter
     # i18n-tasks-use t('doc_auth.errors.alerts.full_name_check')
     DocAuth::Errors::FULL_NAME_CHECK =>
       'doc_auth.errors.alerts.full_name_check',
-    # i18n-tasks-use t('doc_auth.errors.general.liveness')
-    DocAuth::Errors::GENERAL_ERROR_LIVENESS =>
-      'doc_auth.errors.general.liveness',
     # i18n-tasks-use t('doc_auth.errors.general.no_liveness')
-    DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS =>
+    DocAuth::Errors::GENERAL_ERROR =>
       'doc_auth.errors.general.no_liveness',
     # i18n-tasks-use t('doc_auth.errors.alerts.id_not_recognized')
     DocAuth::Errors::ID_NOT_RECOGNIZED =>

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
       it 'only returns one copy of the each error' do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
-          general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+          general: [DocAuth::Errors::GENERAL_ERROR],
           front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
           back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
           hints: true,

--- a/spec/services/doc_auth/error_generator_spec.rb
+++ b/spec/services/doc_auth/error_generator_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe DocAuth::ErrorGenerator do
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
       expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
-      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR)
       expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:hints]).to eq(true)
@@ -107,7 +107,7 @@ RSpec.describe DocAuth::ErrorGenerator do
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
       expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
-      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR)
       expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:hints]).to eq(true)
@@ -159,7 +159,7 @@ RSpec.describe DocAuth::ErrorGenerator do
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
       expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
-      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR)
       expect(output[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:hints]).to eq(true)
@@ -232,7 +232,7 @@ RSpec.describe DocAuth::ErrorGenerator do
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
       expect(output.keys).to contain_exactly(:general, :front, :back, :hints)
-      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_LIVENESS)
+      expect(output[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR)
       expect(output[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(output[:hints]).to eq(true)
     end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       )
       expect(output[:success]).to eq(false)
       expect(errors.keys).to contain_exactly(:general, :front, :back, :hints)
-      expect(errors[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS)
+      expect(errors[:general]).to contain_exactly(DocAuth::Errors::GENERAL_ERROR)
       expect(errors[:front]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(errors[:hints]).to eq(true)
@@ -199,7 +199,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         success: false,
         exception: nil,
         errors: {
-          general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+          general: [DocAuth::Errors::GENERAL_ERROR],
           front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
           back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
           hints: true,
@@ -258,7 +258,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(
-        general: [DocAuth::Errors::GENERAL_ERROR_NO_LIVENESS],
+        general: [DocAuth::Errors::GENERAL_ERROR],
         hints: true,
       )
       expect(output).to include(:lexis_nexis_status, :lexis_nexis_info, :exception)

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -168,22 +168,6 @@ RSpec.describe DocAuthRouter do
       expect(response.errors[:network]).to eq(I18n.t('doc_auth.errors.general.network_error'))
     end
 
-    it 'translates generic selfie errors' do
-      DocAuth::Mock::DocAuthMockClient.mock_response!(
-        method: :get_results,
-        response: DocAuth::Response.new(
-          success: false,
-          errors: {
-            selfie: [DocAuth::Errors::SELFIE_FAILURE],
-          },
-        ),
-      )
-
-      response = proxy.get_results(instance_id: 'abcdef')
-
-      expect(response.errors[:selfie]).to eq([I18n.t('doc_auth.errors.alerts.selfie_failure')])
-    end
-
     it 'translates generic network errors' do
       DocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_images,
@@ -223,7 +207,7 @@ RSpec.describe DocAuthRouter do
         front: [I18n.t('doc_auth.errors.alerts.visible_photo_check')],
         back: [I18n.t('doc_auth.errors.alerts.ref_control_number_check')],
         selfie: [I18n.t('doc_auth.errors.alerts.selfie_failure')],
-        general: [I18n.t('doc_auth.errors.general.liveness')],
+        general: [I18n.t('doc_auth.errors.general.no_liveness')],
         not_translated: true,
       )
     end

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe DocAuthRouter do
             front: [DocAuth::Errors::VISIBLE_PHOTO_CHECK],
             back: [DocAuth::Errors::REF_CONTROL_NUMBER_CHECK],
             selfie: [DocAuth::Errors::SELFIE_FAILURE],
-            general: [DocAuth::Errors::GENERAL_ERROR_LIVENESS],
+            general: [DocAuth::Errors::GENERAL_ERROR],
             not_translated: true,
           },
         ),


### PR DESCRIPTION
We are removing the selfie and strict IAL2 tooling 🙅. This commit moves us in that direction ➡️ by removing the distinction between selfie and no selfie general errors in the doc auth error generator.
