### PR TITLE
[LG-7878] Fully remove SP session during unconfirmed OIDC logout

### DIFF
--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -1,6 +1,8 @@
 module FullyAuthenticatable
-  def delete_branded_experience
+  def delete_branded_experience(logout: false)
     ServiceProviderRequestProxy.delete(request_id)
+    session[:sp] = {} if logout
+    nil
   end
 
   def request_id

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -1,6 +1,7 @@
 module OpenidConnect
   class LogoutController < ApplicationController
     include SecureHeadersConcern
+    include FullyAuthenticatable
 
     before_action :apply_secure_headers_override, only: [:index, :delete]
     before_action :confirm_two_factor_authenticated, only: [:delete]
@@ -62,6 +63,8 @@ module OpenidConnect
         }
         @params[:state] = logout_params[:state] if !logout_params[:state].nil?
         @service_provider_name = @logout_form.service_provider&.friendly_name
+        delete_branded_experience(logout: true)
+
         render :index
       else
         analytics.logout_initiated(**result.to_h.except(:redirect_uri))

--- a/app/controllers/users/service_provider_inactive_controller.rb
+++ b/app/controllers/users/service_provider_inactive_controller.rb
@@ -8,8 +8,7 @@ module Users
       @sp_name = sp_from_sp_session&.friendly_name ||
                  I18n.t('service_providers.errors.generic_sp_name')
 
-      delete_branded_experience
-      session[:sp] = {}
+      delete_branded_experience(logout: true)
     end
   end
 end


### PR DESCRIPTION
Resolves LG-7878

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-7878

## 🛠 Summary of changes

Add an option for `delete_branded_experience` to remove the SP session and use it during OIDC logout to ensure that users that elect not to terminate their Login.gov session don't end up being prompted to return to the SP that logged them out.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Visit [OIDC sample app](https://int-identity-oidc-sinatra.app.cloud.gov/)
- [ ] Sign in
- [ ] Sign out
- [ ] On confirmation page, choose not to sign out from Login.gov and visit account page

**Expected:** There will be no alert prompting the user to return to the SP