### PR TITLE
Add missing email CSS class

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -231,6 +231,10 @@ h4 {
   @include u-padding-bottom(4);
 }
 
+.radius-lg {
+  @include u-radius('lg');
+}
+
 .text-bold {
   @include u-text('bold');
 }


### PR DESCRIPTION
## 🛠 Summary of changes

As a follow-on to #7224, adds a missing CSS class `radius-lg` currently used in email templates.

https://github.com/18F/identity-idp/blob/08b0a7cdab4c0dfdb2b776af9779f8786b092e1e/app/views/user_mailer/in_person_ready_to_verify.html.erb#L18

It may have been missed in part since `.radius` is a class provided by [`foundation-emails`](https://www.npmjs.com/package/foundation-emails) so it may have been assumed the same for `.radius-lg`, but in-fact this is implemented as a design system utility.