### PR TITLE
Make sure that `selfie_image` and `liveness_checking_enabled` args aren't used and have default values in images clients

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -66,8 +66,6 @@ module Idv
       response = doc_auth_client.post_images(
         front_image: front.read,
         back_image: back.read,
-        selfie_image: nil,
-        liveness_checking_enabled: false,
         image_source: image_source,
         user_uuid: user_uuid,
         uuid_prefix: uuid_prefix,

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -50,9 +50,7 @@ class DocumentProofingJob < ApplicationJob
       doc_auth_client.post_images(
         front_image: front_image,
         back_image: back_image,
-        selfie_image: nil,
         image_source: image_source(image_metadata),
-        liveness_checking_enabled: false,
         user_uuid: user_uuid,
         uuid_prefix: uuid_prefix,
       )

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -57,8 +57,8 @@ module DocAuth
       def post_images(
         front_image:,
         back_image:,
-        selfie_image:,
         image_source:,
+        selfie_image: nil,
         liveness_checking_enabled: nil,
         user_uuid: nil,
         uuid_prefix: nil

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -45,6 +45,7 @@ module DocAuth
           image_source: image_source,
         ).fetch
       end
+      # rubocop:enable Lint/UnusedMethodArgument
     end
   end
 end

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -24,9 +24,14 @@ module DocAuth
         raise NotImplementedError
       end
 
+      # The unused selfie_image and liveness_checking_enabled should be removed once the calls to
+      # these no longer have those args
+      # rubocop:disable Lint/UnusedMethodArgument
       def post_images(
         front_image:,
         back_image:,
+        selfie_image: nil,
+        liveness_checking_enabled: nil,
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil


### PR DESCRIPTION


This commit gives us some safety and assurance that things won't break when we start deploying the changes to remove IAL2 strict.

All of the clients _should_ have a default arg for `selfie_image` and `liveness_checking_enabled` and none of the callers should be passing those args. We can follow this up with a commit to configure the clients to stop supporting those args.
