### PR TITLE
Render language picker as collapsed by default in markup

### DIFF
--- a/app/components/language_picker_component.html.erb
+++ b/app/components/language_picker_component.html.erb
@@ -1,18 +1,23 @@
 <%= content_tag(:div, **tag_options, class: css_class) do %>
-  <button
-    aria-controls="language-picker-<%= unique_id %>"
-    class="usa-accordion__button language-picker__label"
-  >
+  <%= content_tag(
+        :button,
+        class: 'usa-accordion__button language-picker__label',
+        aria: {
+          controls: "language-picker-#{unique_id}",
+          expanded: false,
+        },
+      ) do %>
     <%= image_tag(asset_url('globe-blue.svg'), width: 12, height: 12, alt: '', class: 'tablet:display-none') %>
     <%= image_tag(asset_url('globe-white.svg'), width: 12, height: 12, alt: '', class: 'display-none tablet:display-inline') %>
     <span id="language-picker-description-<%= unique_id %>">
       <%= t('i18n.language') %>
     </span>
-  </button>
+  <% end %>
   <ul
     id="language-picker-<%= unique_id %>"
     aria-describedby="language-picker-description-<%= unique_id %>"
     class="usa-accordion__content language-picker__list"
+    hidden
   >
     <% I18n.available_locales.each do |locale| %>
       <li>

--- a/spec/components/language_picker_component_spec.rb
+++ b/spec/components/language_picker_component_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe LanguagePickerComponent, type: :component do
     with_request_url('/') { example.run }
   end
 
-  it 'renders language picker accordion element' do
+  it 'renders collapsed language picker accordion element' do
     rendered = render_inline LanguagePickerComponent.new
 
     expect(rendered).to have_css('.language-picker.usa-accordion')
+    expect(rendered).to have_css('.usa-accordion__button[aria-expanded="false"]')
+    expect(rendered).to have_css('.usa-accordion__content', visible: false)
   end
 
   context 'with tag options' do

--- a/spec/components/language_picker_component_spec.rb
+++ b/spec/components/language_picker_component_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe LanguagePickerComponent, type: :component do
     expect(button_controls).to eq(list)
   end
 
+  it 'renders language options in their native locale' do
+    rendered = render_inline LanguagePickerComponent.new
+
+    I18n.available_locales.each do |locale|
+      expect(rendered).to have_xpath(
+        ".//a[text()='#{t("i18n.locale.#{locale}", locale: locale)}'][@lang='#{locale}']",
+        visible: false,
+      )
+    end
+  end
+
   context 'with tag options' do
     it 'renders with attributes' do
       rendered = render_inline LanguagePickerComponent.new(class: 'example', data: { foo: 'bar' })

--- a/spec/components/language_picker_component_spec.rb
+++ b/spec/components/language_picker_component_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe LanguagePickerComponent, type: :component do
     expect(rendered).to have_css('.usa-accordion__content', visible: false)
   end
 
+  it 'renders with accessible relationships' do
+    rendered = render_inline LanguagePickerComponent.new
+
+    list = rendered.at_css('ul')
+    list_description = rendered.at_css("##{list['aria-describedby']}").text.strip
+    button_controls = rendered.at_css("##{rendered.at_css('[aria-controls]')['aria-controls']}")
+
+    expect(list_description).to eq(t('i18n.language'))
+    expect(button_controls).to eq(list)
+  end
+
   context 'with tag options' do
     it 'renders with attributes' do
       rendered = render_inline LanguagePickerComponent.new(class: 'example', data: { foo: 'bar' })


### PR DESCRIPTION
## 🛠 Summary of changes

As a follow-on improvement (minor regression fix) to #7188, this updates the language picker component to render as collapsed by default in the initial markup.

While previously the language picker would become collapsed by default, it wouldn't occur until JavaScript had initialized, which could result in some brief flickering of the language picker while the page is loading.

It could be argued that the collapsing _should_ occur in JavaScript in order to support no-JavaScript browsers, however (a) this is not how it behaved prior to #7188 and the changes here seek to restore the original behavior, and (b) due to the styling of the language picker, it's possible for the options to overlap page content in such a way that may worsen the experience for no-JavaScript users. Future work could explore improvements to the no-JavaScript language picker experience.

This also resolves a styling issue where the arrow caret would rely on the presence of `aria-expanded` attribute to display the correct icon, which was not assigned previously in markup and would display incorrectly both for no-JavaScript users and until initialization occurred.

## 📜 Testing Plan

- [ ] Ensure no regressions in the behavior of the language picker

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2022-10-27 at 11 13 14 AM](https://user-images.githubusercontent.com/1779930/198328977-6ead5dbc-8e5c-48d6-91ae-87469914a5ee.png)|![Screen Shot 2022-10-27 at 11 13 05 AM](https://user-images.githubusercontent.com/1779930/198328946-71e33828-84ed-4ba7-a4d7-154ebdb514cc.png)
