### PR TITLE
LG-7686: Update address line 2 label for IPP address form

### DIFF
--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -24,7 +24,7 @@
   <%= render ValidatedFieldComponent.new(
         form: f,
         input_html: { value: pii[:address1] },
-        label: t('in_person_proofing.form.address.address1'),
+        label: t('idv.form.address1'),
         label_html: { class: 'usa-label' },
         maxlength: 255,
         name: :address1,
@@ -33,7 +33,7 @@
   <%= render ValidatedFieldComponent.new(
         form: f,
         input_html: { value: pii[:address2] },
-        label: t('in_person_proofing.form.address.address2'),
+        label: t('idv.form.address2_optional'),
         label_html: { class: 'usa-label' },
         maxlength: 255,
         name: :address2,
@@ -42,7 +42,7 @@
   <%= render ValidatedFieldComponent.new(
         form: f,
         input_html: { value: pii[:city] },
-        label: t('in_person_proofing.form.address.city'),
+        label: t('idv.form.city'),
         label_html: { class: 'usa-label' },
         maxlength: 255,
         name: :city,
@@ -51,7 +51,7 @@
   <%= render ValidatedFieldComponent.new(
         collection: us_states_territories,
         form: f,
-        label: t('in_person_proofing.form.address.state'),
+        label: t('idv.form.state'),
         label_html: { class: 'usa-label' },
         name: :state,
         prompt: t('in_person_proofing.form.address.state_prompt'),
@@ -66,7 +66,7 @@
           error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.zipcode') },
           form: f,
           input_html: { value: pii[:zipcode], class: 'zipcode' },
-          label: t('in_person_proofing.form.address.zipcode'),
+          label: t('idv.form.zipcode'),
           label_html: { class: 'usa-label' },
           name: :zipcode,
           pattern: '\d{5}([\-]\d{4})?',

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -57,16 +57,11 @@ en:
           ID in person.'
     form:
       address:
-        address1: Address
-        address2: Address (optional)
-        city: City
         same_address: 'Is this address displayed on the state-issued ID that you are
           bringing to the Post Office?'
         same_address_choice_no: I have a different address on my ID
         same_address_choice_yes: This address is on my state-issued ID
-        state: State
         state_prompt: '- Select -'
-        zipcode: ZIP Code
       state_id:
         dob: Date of birth
         dob_hint: 'Example: 4 28 1986'

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -63,16 +63,11 @@ es:
           información para confirmar que coincide con su cédula en persona.'
     form:
       address:
-        address1: Dirección
-        address2: Dirección (opcional)
-        city: Ciudad
         same_address: '¿Aparece esta dirección en la cédula de identidad emitido por el
           Estado que va a llevar a la oficina de Correos?'
         same_address_choice_no: Tengo una dirección diferente en mi cédula de identidad
         same_address_choice_yes: Esta dirección aparece en mi cédula de identidad emitida por el estado
-        state: Estado
         state_prompt: '- Seleccione -'
-        zipcode: Código postal
       state_id:
         dob: Fecha de nacimiento
         dob_hint: 'Ejemplo: 4 28 1986'

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -66,16 +66,11 @@ fr:
           d’identité en personne.'
     form:
       address:
-        address1: Adresse
-        address2: Adresse (facultatif)
-        city: Ville
         same_address: Cette adresse figure-t-elle sur la pièce d’identité délivrée par
           l’État que vous apportez au bureau de poste?
         same_address_choice_no: J’ai une adresse différente sur mon document d’identité
         same_address_choice_yes: Cette adresse figure sur mon document d’identité nationale
-        state: État
         state_prompt: '- Sélectionnez -'
-        zipcode: Code postal
       state_id:
         dob: Date de naissance
         dob_hint: 'Exemple: 4 28 1986'

--- a/spec/features/idv/steps/in_person/verify_step_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_step_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'doc auth IPP Verify Step', js: true do
     # click update address button
     click_button t('idv.buttons.change_address_label')
     expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    fill_in t('in_person_proofing.form.address.address1'), with: 'bad address'
+    fill_in t('idv.form.address1'), with: 'bad address'
     click_doc_auth_back_link
     expect(page).to have_content(t('headings.verify'))
     expect(page).to have_text(InPersonHelper::GOOD_ADDRESS1)

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -30,11 +30,11 @@ module InPersonHelper
   end
 
   def fill_out_address_form_ok
-    fill_in t('in_person_proofing.form.address.address1'), with: GOOD_ADDRESS1
-    fill_in t('in_person_proofing.form.address.address2'), with: GOOD_ADDRESS2
-    fill_in t('in_person_proofing.form.address.city'), with: GOOD_CITY
-    fill_in t('in_person_proofing.form.address.zipcode'), with: GOOD_ZIPCODE
-    select GOOD_STATE, from: t('in_person_proofing.form.address.state')
+    fill_in t('idv.form.address1'), with: GOOD_ADDRESS1
+    fill_in t('idv.form.address2_optional'), with: GOOD_ADDRESS2
+    fill_in t('idv.form.city'), with: GOOD_CITY
+    fill_in t('idv.form.zipcode'), with: GOOD_ZIPCODE
+    select GOOD_STATE, from: t('idv.form.state')
     choose t('in_person_proofing.form.address.same_address_choice_yes')
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-7686](https://cm-jira.usa.gov/browse/LG-7686)

## 🛠 Summary of changes

Updates "Address (optional)" to "Address line 2 (optional)" in the in-person proofing address form, for clarity and consistency with unsupervised flow step labels updated in #7180 ([LG-7669](https://cm-jira.usa.gov/browse/LG-7669)).

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete proofing flow up to document capture
5. Use [attention result test document](https://developers.login.gov/testing/#testing-identity-proofing) for front and back
6. Submit
7. Enter in-person proofing flow and complete up to address form
8. Observe that the label for second address line is "Address line 2 (optional)"

## 👀 Screenshots

Screen|Before|After
---|---|---
Form|![localhost_3000_verify_in_person_address](https://user-images.githubusercontent.com/1779930/198339516-a9cf0f0b-f94c-497f-a7a2-ce3949d94489.png)|![localhost_3000_verify_in_person_address (1)](https://user-images.githubusercontent.com/1779930/198339511-97b7eb70-d98f-4e6e-87da-29c181b769a3.png)
Verify step|![localhost_3000_verify_in_person_verify](https://user-images.githubusercontent.com/1779930/198339522-93ad4f11-a8e9-4b44-9070-0a7279a73508.png)|![localhost_3000_verify_in_person_verify](https://user-images.githubusercontent.com/1779930/198339522-93ad4f11-a8e9-4b44-9070-0a7279a73508.png)