### PR TITLE
Remove the last few selfie references in the error generator

### DIFF
--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -21,7 +21,6 @@ module DocAuth
     MULTIPLE_BACK_ID_FAILURES = 'multiple_back_id_failures'
     MULTIPLE_FRONT_ID_FAILURES = 'multiple_front_id_failures'
     REF_CONTROL_NUMBER_CHECK = 'ref_control_number_check'
-    SELFIE_FAILURE = 'selfie_failure'
     SEX_CHECK = 'sex_check'
     VISIBLE_COLOR_CHECK = 'visible_color_check'
     VISIBLE_PHOTO_CHECK = 'visible_photo_check'
@@ -58,7 +57,6 @@ module DocAuth
       MULTIPLE_BACK_ID_FAILURES,
       MULTIPLE_FRONT_ID_FAILURES,
       REF_CONTROL_NUMBER_CHECK,
-      SELFIE_FAILURE,
       SEX_CHECK,
       VISIBLE_COLOR_CHECK,
       VISIBLE_PHOTO_CHECK,
@@ -108,8 +106,6 @@ module DocAuth
       MULTIPLE_FRONT_ID_FAILURES => { long_msg: MULTIPLE_FRONT_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       MULTIPLE_BACK_ID_FAILURES => { long_msg: MULTIPLE_BACK_ID_FAILURES, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
       GENERAL_ERROR => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: true },
-      # Liveness
-      SELFIE_FAILURE => { long_msg: SELFIE_FAILURE, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
     }
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -49,8 +49,6 @@ module DocAuthRouter
     # i18n-tasks-use t('doc_auth.errors.alerts.ref_control_number_check')
     DocAuth::Errors::REF_CONTROL_NUMBER_CHECK =>
       'doc_auth.errors.alerts.ref_control_number_check',
-    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_failure')
-    DocAuth::Errors::SELFIE_FAILURE => 'doc_auth.errors.alerts.selfie_failure',
     # i18n-tasks-use t('doc_auth.errors.alerts.sex_check')
     DocAuth::Errors::SEX_CHECK => 'doc_auth.errors.alerts.sex_check',
     # i18n-tasks-use t('doc_auth.errors.alerts.visible_color_check')
@@ -116,9 +114,7 @@ module DocAuthRouter
     end
 
     def translate_doc_auth_errors!(response)
-      # acuant selfie errors are handled in translate_generic_errors!
       error_keys = DocAuth::ErrorGenerator::ERROR_KEYS.dup
-      error_keys.delete(:selfie) if @client.is_a?(DocAuth::Acuant::AcuantClient)
 
       error_keys.each do |category|
         response.errors[category]&.map! do |plain_error|
@@ -127,7 +123,6 @@ module DocAuthRouter
             I18n.t(error_key)
           else
             Rails.logger.warn("unknown DocAuth error=#{plain_error}")
-            # This isn't right, this should depend on the liveness setting
             I18n.t('doc_auth.errors.general.no_liveness')
           end
         end
@@ -137,11 +132,6 @@ module DocAuthRouter
     def translate_generic_errors!(response)
       if response.errors[:network] == true
         response.errors[:network] = I18n.t('doc_auth.errors.general.network_error')
-      end
-
-      # this is only relevant to acuant code path
-      if response.errors[:selfie] == true
-        response.errors[:selfie] = I18n.t('doc_auth.errors.general.liveness')
       end
     end
   end

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -65,8 +65,6 @@ en:
         invalid: This file type is not accepted, please choose a JPG or PNG file.
       general:
         fallback_field_level: Please add a new image
-        liveness: We couldn’t verify your ID and photo of yourself. Try taking new
-          pictures.
         multiple_back_id_failures: We couldn’t verify the back of your ID. Try taking a new picture.
         multiple_front_id_failures: We couldn’t verify the front of your ID. Try taking a new picture.
         network_error: We are having technical difficulties on our end. Please try to

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -38,8 +38,6 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_failure: We couldn’t match the photo of you to your ID. Try taking a new
-          picture of yourself or the front of your ID.
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -46,9 +46,6 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_failure: No pudimos hacer coincidir su foto con su documento de
-          identidad. Intente tomarse una nueva foto de usted o de la parte
-          delantera de su documento de identidad.
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
           nuevas fotos.
         visible_color_check: No pudimos verificar su documento de identidad. Puede que

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -80,8 +80,6 @@ es:
         invalid: Ese formato no es admitido, por favor elija un archivo JPG o PNG.
       general:
         fallback_field_level: Agregue una imagen nueva
-        liveness: No pudimos verificar su documento de identidad y su foto. Intente
-          tomar nuevas fotografías.
         multiple_back_id_failures: No pudimos verificar la parte trasera de su documento
           de identidad. Intente tomar una nueva foto.
         multiple_front_id_failures: No pudimos verificar la parte delantera de su

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -49,9 +49,6 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_failure: Nous n’avons pas pu associer votre photo à votre pièce
-          d’identité. Essayez de prendre une nouvelle photo de vous-même ou du
-          recto de votre carte d’identité.
         sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
         visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité. Elle a

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -85,8 +85,6 @@ fr:
           ou PNG.
       general:
         fallback_field_level: Veuillez ajouter une nouvelle image
-        liveness: Nous n’avons pas pu vérifier votre pièce d’identité et votre photo.
-          Essayez de prendre de nouvelles photos.
         multiple_back_id_failures: Nous n’avons pas pu vérifier le verso de votre pièce
           d’identité. Essayez de prendre une nouvelle photo.
         multiple_front_id_failures: Nous n’avons pas pu vérifier le recto de votre pièce

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe DocAuthRouter do
         ),
       )
 
-      response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
+      response = proxy.post_images(front_image: 'a', back_image: 'b')
 
       expect(response.errors[:network]).to eq(I18n.t('doc_auth.errors.general.network_error'))
     end
@@ -193,20 +193,18 @@ RSpec.describe DocAuthRouter do
             id: [DocAuth::Errors::EXPIRATION_CHECKS],
             front: [DocAuth::Errors::VISIBLE_PHOTO_CHECK],
             back: [DocAuth::Errors::REF_CONTROL_NUMBER_CHECK],
-            selfie: [DocAuth::Errors::SELFIE_FAILURE],
             general: [DocAuth::Errors::GENERAL_ERROR],
             not_translated: true,
           },
         ),
       )
 
-      response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
+      response = proxy.post_images(front_image: 'a', back_image: 'b')
 
       expect(response.errors).to eq(
         id: [I18n.t('doc_auth.errors.alerts.expiration_checks')],
         front: [I18n.t('doc_auth.errors.alerts.visible_photo_check')],
         back: [I18n.t('doc_auth.errors.alerts.ref_control_number_check')],
-        selfie: [I18n.t('doc_auth.errors.alerts.selfie_failure')],
         general: [I18n.t('doc_auth.errors.general.no_liveness')],
         not_translated: true,
       )
@@ -225,7 +223,7 @@ RSpec.describe DocAuthRouter do
 
       expect(Rails.logger).to receive(:warn).with('unknown DocAuth error=some_obscure_error')
 
-      response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
+      response = proxy.post_images(front_image: 'a', back_image: 'b')
 
       expect(response.errors).to eq(
         id: [I18n.t('doc_auth.errors.general.no_liveness')],
@@ -244,7 +242,7 @@ RSpec.describe DocAuthRouter do
         ),
       )
 
-      response = proxy.post_images(front_image: 'a', back_image: 'b', selfie_image: 'c')
+      response = proxy.post_images(front_image: 'a', back_image: 'b')
 
       expect(response.errors).to eq(general: [I18n.t('doc_auth.errors.http.image_load')])
       expect(response.exception.message).to eq('Test 438 HTTP failure')


### PR DESCRIPTION
We are removing IAL2 strict and selfie match functionality. This commit cleans up the last references to the selfie match portions of the `ErrorGenerator`.

The `ErrorGenerator` produces a takes the reponse and ultimately generates an errors hash data structure which can be used to render errors to the user on specific images (e.g. the front, back, selfie, or entire ID). This commit removes the code that covered special cases for selfie failures.
