### PR TITLE
Lg 7738 - mock errors for inherited proofing mock proofer

### DIFF
--- a/app/forms/idv/inherited_proofing/base_form.rb
+++ b/app/forms/idv/inherited_proofing/base_form.rb
@@ -48,8 +48,7 @@ module Idv
         FormResponse.new(
           success: valid?,
           errors: errors,
-          extra: {
-          },
+          extra: {},
         )
       end
 

--- a/app/services/idv/inherited_proofing/va/mocks/service.rb
+++ b/app/services/idv/inherited_proofing/va/mocks/service.rb
@@ -44,13 +44,13 @@ module Idv
           end
 
           def execute
-            valid_auth_code ? PAYLOAD_HASH : ERROR_HASH
+            invalid_auth_code ? ERROR_HASH : PAYLOAD_HASH
           end
 
           private
 
-          def valid_auth_code
-            @auth_code == VALID_AUTH_CODE
+          def invalid_auth_code
+            @auth_code != VALID_AUTH_CODE
           end
         end
       end

--- a/app/services/idv/inherited_proofing/va/mocks/service.rb
+++ b/app/services/idv/inherited_proofing/va/mocks/service.rb
@@ -35,17 +35,22 @@ module Idv
             },
           }.freeze
 
+          ERROR_HASH = {
+            errors: 'InheritedProofing::Errors::MHVIdentityDataNotFoundError',
+          }.freeze
+
           def initialize(service_provider_data)
             @auth_code = service_provider_data[:auth_code]
           end
 
           def execute
-            if (@auth_code != VALID_AUTH_CODE)
-              raise TypeError,
-                    "auth_code is invalid: #{@auth_code}"
-            end
+            valid_auth_code ? PAYLOAD_HASH : ERROR_HASH
+          end
 
-            PAYLOAD_HASH
+          private
+
+          def valid_auth_code
+            @auth_code == VALID_AUTH_CODE
           end
         end
       end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -99,8 +99,7 @@ class SessionEncryptor
   # We use #reduce to build the nested empty hash if needed. If Hash#bury
   # (https://bugs.ruby-lang.org/issues/11747) existed, we could use that instead.
   def kms_encrypt_sensitive_paths!(session, sensitive_paths)
-    sensitive_data = {
-    }
+    sensitive_data = {}
 
     sensitive_paths.each do |path|
       all_but_last_key = path[0..-2]

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -183,8 +183,7 @@ describe Users::MfaSelectionController do
       context 'with no active MFA' do
         it 'redirects to the index page with a flash error' do
           patch :update, params: {
-            two_factor_options_form: {
-            },
+            two_factor_options_form: {},
           }
 
           expect(response).to redirect_to two_factor_options_path

--- a/spec/services/idv/inherited_proofing/va/mocks/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/mocks/service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Idv::InheritedProofing::Va::Mocks::Service do
       let(:auth_code) { "invalid-#{described_class::VALID_AUTH_CODE}" }
 
       it 'returns an error' do
-        expect { subject.execute }.to raise_error(/auth_code is invalid/)
+        expect(subject.execute).to eq(described_class::ERROR_HASH)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7738](https://cm-jira.usa.gov/browse/LG-7738)

## 🛠 Summary of changes

Returns an error in the Inherited Proofing mock proofer when the incorrect auth code is provided
