### PR TITLE
Remove sleep delay from JavaScript tests

### DIFF
--- a/app/javascript/packages/memorable-date/index.spec.ts
+++ b/app/javascript/packages/memorable-date/index.spec.ts
@@ -204,16 +204,11 @@ describe('MemorableDateElement', () => {
           'user has entered a day and year, then clicks an element outside the memorable date fields',
           () => {
             beforeEach(async function () {
-              this.timeout(8000);
-
               await userEvent.click(dayInput);
               await userEvent.type(dayInput, '1');
               await userEvent.click(yearInput);
               await userEvent.type(yearInput, '19');
               await userEvent.click(otherClickableElement);
-
-              // Issue seems to happen after a 5 or more second delay in this state
-              await new Promise((resolve) => setTimeout(resolve, 6000));
             });
 
             it('does not hang when the user modifies the day', async () => {


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unnecessary sleep delay from JavaScript tests, to avoid prolonging runtime of the tests. Ideally we should never have a realtime delay in any spec.

Impact should be at least 12 seconds faster test runtime (2x 6 second delay). Assuming an average of 1m30s test runtime in GitLab, should hopefully equate to ~13% faster completion.

Per the inline code comment, I tested to confirm that the tests would fail as expected before and after the removal of the delay with a reversion of the fix in #6938.

I'd like to remove this test group `itIsUnaffectedByNewRelicEventBug ` altogether at some point after this and #7246 are merged, since we ideally shouldn't have to build-in assumed hostile third-party script handling to our specs.

## 📜 Testing Plan

- [ ] `yarn test` passes on the branch
- [ ] `yarn test` fails when reverting fix from #6938

Revert patch:

```diff
diff --git a/app/javascript/packages/memorable-date/index.ts b/app/javascript/packages/memorable-date/index.ts
index ced471a93..02ce0e931 100644
--- a/app/javascript/packages/memorable-date/index.ts
+++ b/app/javascript/packages/memorable-date/index.ts
@@ -108,11 +108,6 @@ class MemorableDateElement extends HTMLElement {
     this.validate();
 
     const inputListener = (event: Event) => {
-      // Don't process the event if this function generated it
-      if (event instanceof CustomEvent && event.detail?.flag === CUSTOM_INPUT_EVENT_DETAIL_FLAG) {
-        return;
-      }
-
       this.validate();
 
       // Artificially trigger input events on all inputs
@@ -122,16 +117,15 @@ class MemorableDateElement extends HTMLElement {
       // message (instead of only the selected field).
       const otherInputs = allInputs.filter((input) => input !== event.target);
 
-      otherInputs.forEach((input) => {
-        input.dispatchEvent(
-          new CustomEvent('input', {
-            bubbles: true,
-            detail: {
-              flag: CUSTOM_INPUT_EVENT_DETAIL_FLAG,
-            },
-          }),
-        );
-      });
+      try {
+        this.removeEventListener('input', inputListener);
+        otherInputs.forEach((input) => {
+          // Prevent recursion by removing listener temporarily
+          input.dispatchEvent(new CustomEvent('input', { bubbles: true }));
+        });
+      } finally {
+        this.addEventListener('input', inputListener);
+      }
     };
 
     this.addEventListener('input', inputListener);
```