### PR TITLE
Aggregate failures for flakey mailer specs

### DIFF
--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -17,14 +17,16 @@ module MailerHelper
 
   def expect_delivered_email(index, hash)
     mail = ActionMailer::Base.deliveries[index]
-    expect(mail.to).to eq hash[:to] if hash[:to]
 
-    expect(mail.subject).to eq hash[:subject] if hash[:subject]
+    aggregate_failures do
+      expect(mail.to).to eq hash[:to] if hash[:to]
+      expect(mail.subject).to eq hash[:subject] if hash[:subject]
 
-    if hash[:body]
-      delivered_body = mail.text_part.decoded.gsub("\r\n", ' ')
-      hash[:body].to_a.each do |expected_body|
-        expect(delivered_body).to include(expected_body)
+      if hash[:body]
+        delivered_body = mail.text_part.decoded.gsub("\r\n", ' ')
+        hash[:body].to_a.each do |expected_body|
+          expect(delivered_body).to include(expected_body)
+        end
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Implements [RSpec failure aggregation](https://relishapp.com/rspec/rspec-core/docs/expectation-framework-integration/aggregating-failures) to run all assertions against expected email message before failing.

There are some flakey mailer specs ([example](https://gitlab.login.gov/lg/identity-idp/-/jobs/111536)) which are difficult to debug currently since it fails at the first assertion. It's hypothesized that the emails may be sent out of order, and it'd be helpful to have a fuller picture of the actual and expected results.

Easiest to review with whitespace hidden: https://github.com/18F/identity-idp/pull/7251/files?w=1

## 📜 Testing Plan

- [ ] `rspec`