### PR TITLE
Make analytics event matcher show a diff

### DIFF
--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -151,9 +151,9 @@ RSpec::Matchers.define :have_logged_event do |event_name, attributes|
 
   def differ
     RSpec::Support::Differ.new(
-      object_preparer: lambda { |object|
+      object_preparer: lambda do |object|
                          RSpec::Matchers::Composable.surface_descriptions_in(object)
-                       },
+                       end,
       color: RSpec::Matchers.configuration.color?,
     )
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates our `have_logged_event` custom matcher to show diffs of unexpected analytics events

I only implemented diffs when we can tell that the expected event occurred exactly once but the attributes are different than expected. This will show diffs for cases when we do a direct comparison of the event's attributes to a hash ([example](https://github.com/18F/identity-idp/blob/73c4379eb613565eaa787b90958706fa4b82162b/spec/jobs/get_usps_proofing_results_job_spec.rb#L16-L38)) and when we use an `include` matcher ([example](https://github.com/18F/identity-idp/blob/73c4379eb613565eaa787b90958706fa4b82162b/spec/jobs/get_usps_proofing_results_job_spec.rb#L89-L99)). Other scenarios will fall back to the existing failure message

This is just a change to our tests. No changes to application code

## 👀 Screenshots

<details>
<summary>Example of rspec's built-in diff for hashes:</summary>

![Screen Shot 2022-10-28 at 3 34 14 PM](https://user-images.githubusercontent.com/9039672/198734591-b6375d77-8031-4a46-87da-a1a8dd332d67.png)

</details>

<details>
<summary>Current way that have_logged_event displays diffs:</summary>

![Screen Shot 2022-10-28 at 3 55 45 PM](https://user-images.githubusercontent.com/9039672/198735130-f1314274-b320-4280-ba82-976c7793e158.png)

</details>

<details>
<summary>Updated diff for hash comparison:</summary>

![Screen Shot 2022-10-28 at 3 45 51 PM](https://user-images.githubusercontent.com/9039672/198734963-3f620fe8-f8c1-4376-8e13-bcde17b61683.png)

</details>

<details>
<summary>Updated diff for comparing to an include matcher:</summary>

![Screen Shot 2022-10-28 at 3 47 00 PM](https://user-images.githubusercontent.com/9039672/198734882-c8be91b2-5f2e-4c2c-94a9-1a3d2f88f16a.png)

</details>

[skip changelog]