### PR TITLE
LG-7943: Avoid showing in-person option for field validation errors

### DIFF
--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
@@ -60,7 +60,7 @@ function BarcodeAttentionWarning({ onDismiss, pii }: BarcodeAttentionWarningProp
         <DocumentCaptureTroubleshootingOptions
           location="post_submission_warning"
           showDocumentTips={false}
-          hasErrors
+          showAlternativeProofingOptions
         />
       }
     >

--- a/app/javascript/packages/document-capture/components/capture-advice.jsx
+++ b/app/javascript/packages/document-capture/components/capture-advice.jsx
@@ -29,7 +29,7 @@ function CaptureAdvice({ onTryAgain, isAssessedAsGlare, isAssessedAsBlurry }) {
         <DocumentCaptureTroubleshootingOptions
           heading={t('idv.troubleshooting.headings.still_having_trouble')}
           location="capture_tips"
-          hasErrors
+          showAlternativeProofingOptions
         />
       }
     >

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -125,75 +125,69 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
   });
 
   context('in person proofing links', () => {
-    context('no errors and no inPersonURL', () => {
+    context('without inPersonURL', () => {
       it('has no IPP information', () => {
         const { queryByText } = render(<DocumentCaptureTroubleshootingOptions />);
 
         expect(queryByText('components.troubleshooting_options.new_feature')).to.not.exist();
       });
+
+      context('with showAlternativeProofingOptions', () => {
+        it('has no IPP information', () => {
+          const { queryByText } = render(
+            <DocumentCaptureTroubleshootingOptions showAlternativeProofingOptions />,
+          );
+
+          expect(queryByText('components.troubleshooting_options.new_feature')).to.not.exist();
+        });
+      });
     });
 
-    context('hasErrors but no inPersonURL', () => {
+    context('with inPersonURL', () => {
+      const wrapper: ComponentType = ({ children }) => (
+        <FlowContext.Provider value={{ inPersonURL } as FlowContextValue}>
+          {children}
+        </FlowContext.Provider>
+      );
+
       it('has no IPP information', () => {
-        const { queryByText } = render(<DocumentCaptureTroubleshootingOptions hasErrors />);
+        const { queryByText } = render(<DocumentCaptureTroubleshootingOptions />);
 
         expect(queryByText('components.troubleshooting_options.new_feature')).to.not.exist();
       });
-    });
 
-    context('hasErrors and inPersonURL', () => {
-      const wrapper: ComponentType = ({ children }) => (
-        <FlowContext.Provider value={{ inPersonURL } as FlowContextValue}>
-          {children}
-        </FlowContext.Provider>
-      );
+      context('with showAlternativeProofingOptions', () => {
+        it('has link to IPP flow', () => {
+          const { getByText, getByRole } = render(
+            <DocumentCaptureTroubleshootingOptions showAlternativeProofingOptions />,
+            {
+              wrapper,
+            },
+          );
 
-      it('has link to IPP flow', () => {
-        const { getByText, getByRole } = render(
-          <DocumentCaptureTroubleshootingOptions hasErrors />,
-          { wrapper },
-        );
+          expect(getByText('components.troubleshooting_options.new_feature')).to.exist();
 
-        expect(getByText('components.troubleshooting_options.new_feature')).to.exist();
+          const link = getByRole('link', { name: 'idv.troubleshooting.options.verify_in_person' });
 
-        const link = getByRole('link', { name: 'idv.troubleshooting.options.verify_in_person' });
+          expect(link).to.exist();
+        });
 
-        expect(link).to.exist();
-      });
+        it('logs an event when clicking the troubleshooting option', async () => {
+          const trackEvent = sinon.stub();
+          const { getByRole } = render(
+            <AnalyticsContextProvider trackEvent={trackEvent}>
+              <DocumentCaptureTroubleshootingOptions showAlternativeProofingOptions />
+            </AnalyticsContextProvider>,
+            { wrapper },
+          );
 
-      it('logs an event when clicking the troubleshooting option', async () => {
-        const trackEvent = sinon.stub();
-        const { getByRole } = render(
-          <AnalyticsContextProvider trackEvent={trackEvent}>
-            <DocumentCaptureTroubleshootingOptions hasErrors />
-          </AnalyticsContextProvider>,
-          { wrapper },
-        );
+          const link = getByRole('link', { name: 'idv.troubleshooting.options.verify_in_person' });
+          await userEvent.click(link);
 
-        const link = getByRole('link', { name: 'idv.troubleshooting.options.verify_in_person' });
-        await userEvent.click(link);
-
-        expect(trackEvent).to.have.been.calledWith(
-          'IdV: verify in person troubleshooting option clicked',
-        );
-      });
-    });
-
-    context('hasErrors and inPersonURL but showInPersonOption is false', () => {
-      const wrapper: ComponentType = ({ children }) => (
-        <FlowContext.Provider value={{ inPersonURL } as FlowContextValue}>
-          {children}
-        </FlowContext.Provider>
-      );
-
-      it('does not have link to IPP flow', () => {
-        const { queryAllByText, queryAllByRole } = render(
-          <DocumentCaptureTroubleshootingOptions hasErrors showInPersonOption={false} />,
-          { wrapper },
-        );
-
-        expect(queryAllByText('components.troubleshooting_options.new_feature').length).to.equal(0);
-        expect(queryAllByRole('button').length).to.equal(0);
+          expect(trackEvent).to.have.been.calledWith(
+            'IdV: verify in person troubleshooting option clicked',
+          );
+        });
       });
     });
   });

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -24,22 +24,16 @@ interface DocumentCaptureTroubleshootingOptionsProps {
   showDocumentTips?: boolean;
 
   /**
-   * Whether to include option to verify in person.
+   * Whether to display alternative options for verifying.
    */
-  showInPersonOption?: boolean;
-
-  /**
-   * If there are any errors (toggles whether or not to show in person proofing option)
-   */
-  hasErrors?: boolean;
+  showAlternativeProofingOptions?: boolean;
 }
 
 function DocumentCaptureTroubleshootingOptions({
   heading,
   location = 'document_capture_troubleshooting_options',
   showDocumentTips = true,
-  showInPersonOption = true,
-  hasErrors,
+  showAlternativeProofingOptions,
 }: DocumentCaptureTroubleshootingOptionsProps) {
   const { t } = useI18n();
   const { inPersonURL } = useContext(FlowContext);
@@ -49,7 +43,7 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
-      {hasErrors && inPersonURL && showInPersonOption && (
+      {showAlternativeProofingOptions && inPersonURL && (
         <TroubleshootingOptions
           isNewFeatures
           heading={formatHTML(t('idv.troubleshooting.headings.are_you_near'), {

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -66,7 +66,7 @@ function DocumentsStep({
         />
       ))}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
-      <DocumentCaptureTroubleshootingOptions hasErrors={!!errors.length} />
+      <DocumentCaptureTroubleshootingOptions />
       <Cancel />
     </CaptureTroubleshooting>
   );

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -102,8 +102,7 @@ function ReviewIssuesStep({
         troubleshootingOptions={
           <DocumentCaptureTroubleshootingOptions
             location="post_submission_warning"
-            hasErrors={!!errors?.length}
-            showInPersonOption={!isFailedResult}
+            showAlternativeProofingOptions={!isFailedResult}
           />
         }
       >

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -488,7 +488,7 @@ describe('document-capture/components/document-capture', () => {
     context('in person steps', () => {
       it('renders the step indicator', async () => {
         const endpoint = '/upload';
-        const { getByLabelText, getByText, findByText } = render(
+        const { getByLabelText, getByText, queryByText, findByText } = render(
           <UploadContextProvider upload={httpUpload} endpoint={endpoint}>
             <ServiceProviderContextProvider value={{ isLivenessRequired: false }}>
               <FlowContext.Provider
@@ -513,6 +513,10 @@ describe('document-capture/components/document-capture', () => {
             url: endpoint,
             json: () => ({ success: false, remaining_attempts: 1, errors: [{}] }),
           });
+
+        expect(queryByText('idv.troubleshooting.options.verify_in_person')).not.to.exist();
+        await userEvent.click(getByText('forms.buttons.submit.default'));
+        expect(queryByText('idv.troubleshooting.options.verify_in_person')).not.to.exist();
 
         const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
         const backImage = getByLabelText('doc_auth.headings.document_capture_back');


### PR DESCRIPTION
## 🎫 Ticket

[LG-7943](https://cm-jira.usa.gov/browse/LG-7943)

## 🛠 Summary of changes

Updates display of document capture troubleshooting option to avoid rendering in-person call-to-action when field validation errors exist.

## 📜 Testing Plan

- [ ] `yarn test` passes
- [ ] Attempting to submit with field validation errors (e.g. empty fields, images with blur or glare) does not present in-person option

## 👀 Screenshots

<details>
<summary>Before:</summary>
<img src="https://user-images.githubusercontent.com/1779930/199016683-61f2f072-1fe2-4914-9143-4cc568629038.png" alt="screenshot before">
</details>

<details>
<summary>After:</summary>
<img src="https://user-images.githubusercontent.com/1779930/199016564-d74a4f46-a9d0-4f01-8fea-5a6f31700185.png" alt="screenshot after">
</details>
