### PR TITLE
LG-7706: Log unexpected bad request errors to new relic

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -146,6 +146,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     when IPP_EXPIRED_ERROR_MESSAGE
       handle_expired_status_update(enrollment, err.response)
     else
+      NewRelic::Agent.notice_error(err)
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_exception(
         **enrollment_analytics_attributes(enrollment, complete: false),
         **response_analytics_attributes(response),

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -586,7 +586,8 @@ RSpec.describe GetUspsProofingResultsJob do
         )
 
         it 'logs the error to NewRelic' do
-          expect(NewRelic::Agent).to receive(:notice_error).with(instance_of(Faraday::BadRequestError))
+          expect(NewRelic::Agent).to receive(:notice_error).
+            with(instance_of(Faraday::BadRequestError))
           job.perform(Time.zone.now)
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7706](https://cm-jira.usa.gov/browse/LG-7706?filter=-1)

## 🛠 Summary of changes

When the USPS polling job encounters an unexpected bad request error begin logging it to NewRelic
