### PR TITLE
Adding attempt events packaging batch job.

### DIFF
--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -1,0 +1,59 @@
+class IrsAttemptsEventsBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(subject_timestamp = Time.zone.now - 1.hour)
+    return nil unless IdentityConfig.store.irs_attempt_api_enabled
+
+    puts "#################### Performing IrsAttemptsEventBatchJob at formatted timestamp: #{subject_timestamp}"
+
+    # THe array of encrypted events
+    events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: subject_timestamp)
+
+    event_values = events.values.join("\r\n")
+
+    # Run events through envelope_encryptor - returns
+    # Result.new(
+    #    filename: filename,
+    #    iv: iv,
+    #    encrypted_key: encrypted_key,
+    #    encrypted_data: encrypted_data,
+    #  )
+   
+    decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
+    pub_key = OpenSSL::PKey::RSA.new(decoded_key_der)
+
+    result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
+      data: event_values, timestamp: subject_timestamp, public_key: pub_key,
+    )
+    
+    # write this a temp file until S3
+    begin
+      dir_path = "./attempts_api_output"
+      Dir.mkdir(dir_path) unless File.exists?(dir_path)
+
+      file = File.open("#{dir_path}/#{result.filename}", 'wb')
+      file.write(result.encrypted_data) 
+    rescue IOError => e
+      puts e
+    ensure
+      file.close unless file.nil?
+    end
+    puts "Wrote to file: #{file.path}"
+
+
+    # REMOVE THE FOLLOWING BEFORE MERGING 
+
+    #file = File.open("#{dir_path}/#{result.filename}", 'rb')
+    
+    #private_key_path = 'keys/attempts_api_private_key.key'
+    #private_key = OpenSSL::PKey::RSA.new(File.read(private_key_path))
+    #final_key = private_key.private_decrypt(result.encrypted_key)
+
+    #puts "@@@@@@@@@@@@@@@@@@@@@@@@@@ DECRYPTING THE FILE @@@@@@@@@@@@@@@@@@@@@@"
+    #puts IrsAttemptsApi::EnvelopeEncryptor.decrypt(encrypted_data: file.read, key: final_key, iv: result.iv)
+
+    
+    # Write the file to S3 instead of whatever dir_path winds up being
+
+  end
+end

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -18,12 +18,9 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     begin
       Dir.mkdir(dir_path) unless File.exist?(dir_path)
 
-      file = File.open("#{dir_path}/#{result.filename}", 'wb')
-      file.write(result.encrypted_data)
-    rescue IOError => e
-      Rails.logger.debug e
-    ensure
-      file&.close
+     File.open("#{dir_path}/#{result.filename}", 'wb') do |file|
+       file.write(result.encrypted_data) 
+     end
     end
     return file.path
 

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -22,7 +22,6 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
         file.write(result.encrypted_data)
       end
     end
-    return file.path
 
     # Write the file to S3 instead of whatever dir_path winds up being
   end

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -1,33 +1,32 @@
 class IrsAttemptsEventsBatchJob < ApplicationJob
   queue_as :default
 
-  def perform(subject_timestamp = Time.zone.now - 1.hour, dir_path = "./attempts_api_output")
+  def perform(subject_timestamp = Time.zone.now - 1.hour, dir_path = './attempts_api_output')
     return nil unless IdentityConfig.store.irs_attempt_api_enabled
-    
+
     events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: subject_timestamp)
     event_values = events.values.join("\r\n")
-   
+
     decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
     pub_key = OpenSSL::PKey::RSA.new(decoded_key_der)
 
     result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
       data: event_values, timestamp: subject_timestamp, public_key: pub_key,
     )
-    
+
     # write to a file and store on the disk until S3 is setup
     begin
-      Dir.mkdir(dir_path) unless File.exists?(dir_path)
+      Dir.mkdir(dir_path) unless File.exist?(dir_path)
 
       file = File.open("#{dir_path}/#{result.filename}", 'wb')
-      file.write(result.encrypted_data) 
+      file.write(result.encrypted_data)
     rescue IOError => e
-      puts e
+      Rails.logger.debug e
     ensure
-      file.close unless file.nil?
+      file&.close
     end
     return file.path
 
     # Write the file to S3 instead of whatever dir_path winds up being
-
   end
 end

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -16,7 +16,7 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
 
     # write to a file and store on the disk until S3 is setup
     begin
-      Dir.mkdir(dir_path) unless File.exist?(dir_path)
+      FileUtils.mkdir_p(dir_path)
 
      File.open("#{dir_path}/#{result.filename}", 'wb') do |file|
        file.write(result.encrypted_data) 

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -18,9 +18,9 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     begin
       FileUtils.mkdir_p(dir_path)
 
-     File.open("#{dir_path}/#{result.filename}", 'wb') do |file|
-       file.write(result.encrypted_data) 
-     end
+      File.open("#{dir_path}/#{result.filename}", 'wb') do |file|
+        file.write(result.encrypted_data)
+      end
     end
     return file.path
 

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -1,23 +1,11 @@
 class IrsAttemptsEventsBatchJob < ApplicationJob
   queue_as :default
 
-  def perform(subject_timestamp = Time.zone.now - 1.hour)
+  def perform(subject_timestamp = Time.zone.now - 1.hour, dir_path = "./attempts_api_output")
     return nil unless IdentityConfig.store.irs_attempt_api_enabled
-
-    puts "#################### Performing IrsAttemptsEventBatchJob at formatted timestamp: #{subject_timestamp}"
-
-    # THe array of encrypted events
+    
     events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: subject_timestamp)
-
     event_values = events.values.join("\r\n")
-
-    # Run events through envelope_encryptor - returns
-    # Result.new(
-    #    filename: filename,
-    #    iv: iv,
-    #    encrypted_key: encrypted_key,
-    #    encrypted_data: encrypted_data,
-    #  )
    
     decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
     pub_key = OpenSSL::PKey::RSA.new(decoded_key_der)
@@ -26,9 +14,8 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
       data: event_values, timestamp: subject_timestamp, public_key: pub_key,
     )
     
-    # write this a temp file until S3
+    # write to a file and store on the disk until S3 is setup
     begin
-      dir_path = "./attempts_api_output"
       Dir.mkdir(dir_path) unless File.exists?(dir_path)
 
       file = File.open("#{dir_path}/#{result.filename}", 'wb')
@@ -38,21 +25,9 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     ensure
       file.close unless file.nil?
     end
-    puts "Wrote to file: #{file.path}"
+    #puts "Wrote to file: #{file.path}"
+    return file.path
 
-
-    # REMOVE THE FOLLOWING BEFORE MERGING 
-
-    #file = File.open("#{dir_path}/#{result.filename}", 'rb')
-    
-    #private_key_path = 'keys/attempts_api_private_key.key'
-    #private_key = OpenSSL::PKey::RSA.new(File.read(private_key_path))
-    #final_key = private_key.private_decrypt(result.encrypted_key)
-
-    #puts "@@@@@@@@@@@@@@@@@@@@@@@@@@ DECRYPTING THE FILE @@@@@@@@@@@@@@@@@@@@@@"
-    #puts IrsAttemptsApi::EnvelopeEncryptor.decrypt(encrypted_data: file.read, key: final_key, iv: result.iv)
-
-    
     # Write the file to S3 instead of whatever dir_path winds up being
 
   end

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -25,7 +25,6 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     ensure
       file.close unless file.nil?
     end
-    #puts "Wrote to file: #{file.path}"
     return file.path
 
     # Write the file to S3 instead of whatever dir_path winds up being

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -1,27 +1,29 @@
 class IrsAttemptsEventsBatchJob < ApplicationJob
   queue_as :default
 
-  def perform(subject_timestamp = Time.zone.now - 1.hour, dir_path = './attempts_api_output')
+  def perform(timestamp: Time.zone.now - 1.hour, dir_path: './attempts_api_output')
     return nil unless IdentityConfig.store.irs_attempt_api_enabled
 
-    events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: subject_timestamp)
+    events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: timestamp)
     event_values = events.values.join("\r\n")
 
     decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
     pub_key = OpenSSL::PKey::RSA.new(decoded_key_der)
 
     result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-      data: event_values, timestamp: subject_timestamp, public_key: pub_key,
+      data: event_values, timestamp: timestamp, public_key: pub_key,
     )
 
     # write to a file and store on the disk until S3 is setup
-    begin
-      FileUtils.mkdir_p(dir_path)
+    FileUtils.mkdir_p(dir_path)
 
-      File.open("#{dir_path}/#{result.filename}", 'wb') do |file|
-        file.write(result.encrypted_data)
-      end
+    file_path = "#{dir_path}/#{result.filename}"
+
+    File.open(file_path, 'wb') do |file|
+      file.write(result.encrypted_data)
     end
+
+    return { encryptor_result: result, file_path: file_path }
 
     # Write the file to S3 instead of whatever dir_path winds up being
   end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -221,7 +221,7 @@ else
       irs_attempt_events_aggregator: {
         class: 'IrsAttemptsEventsBatchJob',
         cron: cron_1h,
-        args: -> { [Time.zone.now - 1.hour] },
+        args: -> { [timestamp: Time.zone.now - 1.hour] },
       },
     }
   end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -217,6 +217,12 @@ else
         class: 'ThreatMetrixJsVerificationJob',
         cron: cron_1h,
       },
+      # Batch up IRS Attempts API events
+      irs_attempt_events_aggregator: {
+        class: 'IrsAttemptsEventsBatchJob',
+        cron: cron_1h,
+        args: -> { [Time.zone.now - 1.hour] },
+      },
     }
   end
   # rubocop:enable Metrics/BlockLength

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
   describe '#perform' do
-
-    events = { "key1": "SomeEncryptedEvent1" }
+    events = { key1: 'SomeEncryptedEvent1' }
     Result = Struct.new(:filename, :iv, :encrypted_key, :encrypted_data, keyword_init: true)
 
     let(:redis_client) { instance_double(IrsAttemptsApi::RedisClient) }
@@ -13,58 +12,55 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
 
     context 'IRS attempts API is enabled' do
       before do
-
         allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)
 
-        allow(IrsAttemptsApi::RedisClient)
-        .to receive(:new)
-        .and_return(redis_client)
-  
-        allow(redis_client)
-          .to receive(:read_events)
-          .and_return(events)
-  
-        allow(IrsAttemptsApi::EnvelopeEncryptor)
-        .to receive(:encrypt)
-        .and_return(
-          Result.new(
-            filename: "test_filename",
-            encrypted_data: "EnvelopeEncryptedEvents",
+        allow(IrsAttemptsApi::RedisClient).
+          to receive(:new).
+          and_return(redis_client)
+
+        allow(redis_client).
+          to receive(:read_events).
+          and_return(events)
+
+        allow(IrsAttemptsApi::EnvelopeEncryptor).
+          to receive(:encrypt).
+          and_return(
+            Result.new(
+              filename: 'test_filename',
+              encrypted_data: 'EnvelopeEncryptedEvents',
+            ),
           )
-        )
 
-        allow(File)
-          .to receive(:exists?)
-          .and_return(true)
+        allow(File).
+          to receive(:exists?).
+          and_return(true)
 
-        allow(File)
-          .to receive(:open)
-          .and_return(file_double)
+        allow(File).
+          to receive(:open).
+          and_return(file_double)
 
-        allow(file_double)
-          .to receive(:write)
-        
-        allow(file_double)
-          .to receive(:close)
+        allow(file_double).
+          to receive(:write)
 
-        allow(file_double)
-          .to receive(:path)
-          .and_return("./attempts_api_output/test_filename")
+        allow(file_double).
+          to receive(:close)
 
+        allow(file_double).
+          to receive(:path).
+          and_return('./attempts_api_output/test_filename')
       end
-      
+
       it 'batches and writes attempt events to an encrypted file' do
-        # event hash values are read from redis, 
+        # event hash values are read from redis,
         # then wrote to a file that then is passed through envelope encryptor
 
         # batch job is run hourly by default
         # batches events from the beginning of the previous hour by default
         # file is stored at:  "./attempts_api_output" by default
 
-        file_path = IrsAttemptsEventsBatchJob.perform_now()
+        file_path = IrsAttemptsEventsBatchJob.perform_now
 
-        expect(file_path).to eq("./attempts_api_output/test_filename")
-        
+        expect(file_path).to eq('./attempts_api_output/test_filename')
       end
     end
 
@@ -74,12 +70,9 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
       end
 
       it 'returns nil if IRS attempts API is not enabled' do
-
-        file_path = IrsAttemptsEventsBatchJob.perform_now()
+        file_path = IrsAttemptsEventsBatchJob.perform_now
         expect(file_path).to eq(nil)
-
       end
     end
-
   end
 end

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
   describe '#perform' do
 
-    events = { "key1": "SomeEncryptedEvent1", "key1": "SomeEncryptedEvent2", "key1": "SomeEncryptedEvent3" }
+    events = { "key1": "SomeEncryptedEvent1" }
     Result = Struct.new(:filename, :iv, :encrypted_key, :encrypted_data, keyword_init: true)
 
     let(:redis_client) { instance_double(IrsAttemptsApi::RedisClient) }
@@ -62,9 +62,6 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
         # file is stored at:  "./attempts_api_output" by default
 
         file_path = IrsAttemptsEventsBatchJob.perform_now()
-
-       # expect(file_double).to receive(:write)
-       # expect(file_double).to receive(:close)
 
         expect(file_path).to eq("./attempts_api_output/test_filename")
         

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
         # batches events from the beginning of the previous hour by default
         # file is stored at:  "./attempts_api_output" by default
 
-        IrsAttemptsEventsBatchJob.perform_now()
+        IrsAttemptsEventsBatchJob.perform_now
 
         expect(file_double.path).to eq('./attempts_api_output/test_filename')
       end

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -1,5 +1,88 @@
 require 'rails_helper'
 
 RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#perform' do
+
+    events = { "key1": "SomeEncryptedEvent1", "key1": "SomeEncryptedEvent2", "key1": "SomeEncryptedEvent3" }
+    Result = Struct.new(:filename, :iv, :encrypted_key, :encrypted_data, keyword_init: true)
+
+    let(:redis_client) { instance_double(IrsAttemptsApi::RedisClient) }
+    let(:envelope_encryptor) { instance_double(IrsAttemptsApi::EnvelopeEncryptor) }
+
+    let(:file_double) { instance_double(File) }
+
+    context 'IRS attempts API is enabled' do
+      before do
+
+        allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)
+
+        allow(IrsAttemptsApi::RedisClient)
+        .to receive(:new)
+        .and_return(redis_client)
+  
+        allow(redis_client)
+          .to receive(:read_events)
+          .and_return(events)
+  
+        allow(IrsAttemptsApi::EnvelopeEncryptor)
+        .to receive(:encrypt)
+        .and_return(
+          Result.new(
+            filename: "test_filename",
+            encrypted_data: "EnvelopeEncryptedEvents",
+          )
+        )
+
+        allow(File)
+          .to receive(:exists?)
+          .and_return(true)
+
+        allow(File)
+          .to receive(:open)
+          .and_return(file_double)
+
+        allow(file_double)
+          .to receive(:write)
+        
+        allow(file_double)
+          .to receive(:close)
+
+        allow(file_double)
+          .to receive(:path)
+          .and_return("./attempts_api_output/test_filename")
+
+      end
+      
+      it 'batches and writes attempt events to an encrypted file' do
+        # event hash values are read from redis, 
+        # then wrote to a file that then is passed through envelope encryptor
+
+        # batch job is run hourly by default
+        # batches events from the beginning of the previous hour by default
+        # file is stored at:  "./attempts_api_output" by default
+
+        file_path = IrsAttemptsEventsBatchJob.perform_now()
+
+       # expect(file_double).to receive(:write)
+       # expect(file_double).to receive(:close)
+
+        expect(file_path).to eq("./attempts_api_output/test_filename")
+        
+      end
+    end
+
+    context 'IRS attempts API is not enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(false)
+      end
+
+      it 'returns nil if IRS attempts API is not enabled' do
+
+        file_path = IrsAttemptsEventsBatchJob.perform_now()
+        expect(file_path).to eq(nil)
+
+      end
+    end
+
+  end
 end

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
         # batches events from the beginning of the previous hour by default
         # file is stored at:  "./attempts_api_output" by default
 
-        file_path = IrsAttemptsEventsBatchJob.perform_now
+        IrsAttemptsEventsBatchJob.perform_now()
 
-        expect(file_path).to eq('./attempts_api_output/test_filename')
+        expect(file_double.path).to eq('./attempts_api_output/test_filename')
       end
     end
 

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
changelog: Internal, Attempts API, Add batch job to package events.

## 🎫 Ticket

[Link to the relevant ticket.](https://cm-jira.usa.gov/browse/LG-7470)

## 🛠 Summary of changes

Added a batch job to read attempt events from the previous hour from redis. Writes those events to a file and encrypts the file. File is then stored in a placeholder location until we get an S3 bucket. 

Want to get some early eyes on this. WIP and still needs lots of cleanup.
