### PR TITLE
Disable unused design system CSS utility classes

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -1,0 +1,4 @@
+@import 'identity-style-guide/dist/assets/scss/uswds/utilities/utility-fonts';
+@import 'identity-style-guide/dist/assets/scss/uswds/utilities/rules/package';
+@import 'variables/utilities';
+@include render-utilities-in($utilities-package);

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -5,6 +5,6 @@
 @import 'identity-style-guide/dist/assets/scss/packages/global';
 @import 'identity-style-guide/dist/assets/scss/packages/components';
 @import 'components/all';
-@import 'identity-style-guide/dist/assets/scss/packages/utilities';
+@import 'utilities';
 @import 'utilities/all';
 @import 'print';

--- a/app/assets/stylesheets/variables/_utilities.scss
+++ b/app/assets/stylesheets/variables/_utilities.scss
@@ -1,0 +1,96 @@
+@use 'sass:map';
+
+$utilities-package: map.remove(
+  $utilities-package,
+  'align-self',
+  'add-aspect',
+  'bottom',
+  'box-shadow',
+  'circle',
+  'cursor',
+  'height',
+  'left',
+  'letter-spacing',
+  'measure',
+  'max-height',
+  'max-width',
+  'min-height',
+  'min-width',
+  'opacity',
+  'order',
+  'outline',
+  'outline-color',
+  'pin',
+  'right',
+  'square',
+  'text-decoration',
+  'text-decoration-color',
+  'text-indent',
+  'text-transform',
+  'top',
+  'vertical-align',
+  'z-index'
+);
+
+$utilities-package: map.deep-merge(
+  $utilities-package,
+  (
+    'background-color': (
+      'settings': (
+        hover: false,
+      ),
+    ),
+    'border': (
+      'settings': (
+        hover: false,
+        responsive: false,
+      ),
+    ),
+    'border-color': (
+      'settings': (
+        hover: false,
+        responsive: false,
+      ),
+    ),
+    'border-radius': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+    'color': (
+      'settings': (
+        hover: false,
+      ),
+    ),
+    'font': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+    'font-weight': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+    'justify-content': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+    'line-height': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+    'width': (
+      'settings': (
+        responsive: false,
+      ),
+    ),
+  )
+);
+
+$utilities-package: map.deep-remove($utilities-package, 'border-radius', 'modifiers', 'top');
+$utilities-package: map.deep-remove($utilities-package, 'border-radius', 'modifiers', 'right');
+$utilities-package: map.deep-remove($utilities-package, 'border-radius', 'modifiers', 'bottom');
+$utilities-package: map.deep-remove($utilities-package, 'border-radius', 'modifiers', 'left');

--- a/app/views/shared/_nav_branded.html.erb
+++ b/app/views/shared/_nav_branded.html.erb
@@ -1,3 +1,3 @@
 <%= image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: APP_NAME) %>
-<div class="margin-x-105 height-5 border-right border-primary-light"></div>
+<div class="margin-x-105 border-right border-primary-light"></div> <!-- TBD -->
 <%= image_tag(decorated_session.sp_logo_url, height: 40, alt: decorated_session.sp_name) %>

--- a/app/views/users/mfa_selection/index.html.erb
+++ b/app/views/users/mfa_selection/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('mfa.additional_mfa_required.heading')) %>
 
-<p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
+<p class="margin-bottom-0"><%= @presenter.intro %></p> <!-- TBD -->
 
 <%= simple_form_for @two_factor_options_form,
                     html: { autocomplete: 'off' },

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -12,7 +12,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
+<p class="margin-bottom-0"><%= @presenter.intro %></p> <!-- TBD -->
 
 <%= simple_form_for @two_factor_options_form,
                     html: { autocomplete: 'off' },


### PR DESCRIPTION
## 🛠 Summary of changes

Reconfigures default USDWS design system utility classes to reduce size of application stylesheet size, disabling some altogether while reconfiguring others to avoid responsive and/or hover modifiers.

This does pose potential developer experience challenges for confusion surrounding the availability of utility classes. It's easy enough to un-disable a utility if we'd want to use it, but it may not be obvious to know to do this.

**Impact:**

```sh
yarn build:css && gzip-size app/assets/builds/application.css 
```

**Before:** 50.9kb
**After:** 42.4kb
**Diff%:** -16.7%

**Resources:**

- Default package: https://github.com/uswds/uswds/blob/v2.13.3/src/stylesheets/utilities/rules/_package.scss
- Utilities documentation: https://designsystem.digital.gov/utilities/

**Draft:**

- [ ] Sort out "TBD" items for CSS classes which would ideally be disabled by default