### PR TITLE
Remove Acuant liveness response fixtures

### DIFF
--- a/spec/fixtures/acuant_responses/liveness_response_failure.json
+++ b/spec/fixtures/acuant_responses/liveness_response_failure.json
@@ -1,6 +1,0 @@
-{
-  "LivenessResult": null,
-  "Error": "Face is too small. Move the camera closer to the face and retake the picture.",
-  "ErrorCode": "FaceTooSmall",
-  "TransactionId": "d506bbcb-82cb-4e52-a489-f9a29a88184b"
-}

--- a/spec/fixtures/acuant_responses/liveness_response_success.json
+++ b/spec/fixtures/acuant_responses/liveness_response_success.json
@@ -1,9 +1,0 @@
-{
-  "LivenessResult": {
-    "Score": 99,
-    "LivenessAssessment": "Live"
-  },
-  "Error": null,
-  "ErrorCode": null,
-  "TransactionId": "ab8e6585-a894-4731-8ee1-0060328aacf4"
-}

--- a/spec/support/acuant_fixtures.rb
+++ b/spec/support/acuant_fixtures.rb
@@ -27,14 +27,6 @@ module AcuantFixtures
     load_response_fixture('facial_match_response_failure.json')
   end
 
-  def self.liveness_response_success
-    load_response_fixture('liveness_response_success.json')
-  end
-
-  def self.liveness_response_failure
-    load_response_fixture('liveness_response_failure.json')
-  end
-
   def self.load_response_fixture(filename)
     path = File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
We no longer need to mock these responses. The IAL2 strict and liveness checking tooling has been deprecated and removed.
