### PR TITLE
Remove a few references to selfies and face images

### DIFF
--- a/app/controllers/api/verify/document_capture_controller.rb
+++ b/app/controllers/api/verify/document_capture_controller.rb
@@ -51,10 +51,8 @@ module Api
           :encryption_key,
           :front_image_iv,
           :back_image_iv,
-          :selfie_image_iv,
           :front_image_url,
           :back_image_url,
-          :selfie_image_url,
         ).to_h
       end
 
@@ -63,10 +61,8 @@ module Api
           :encryption_key,
           :front_image_iv,
           :back_image_iv,
-          :selfie_image_iv,
           :front_image_url,
           :back_image_url,
-          :selfie_image_url,
           :document_capture_session_uuid,
           :flow_path,
         )

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class DocumentCaptureStep < DocAuthBaseStep
       IMAGE_UPLOAD_PARAM_NAMES = %i[
-        front_image back_image selfie_image
+        front_image back_image
       ].freeze
 
       def self.analytics_visited_event
@@ -27,10 +27,6 @@ module Idv
           ),
           back_image_upload_url: url_builder.presigned_image_upload_url(
             image_type: 'back',
-            transaction_id: flow_session[:document_capture_session_uuid],
-          ),
-          selfie_image_upload_url: url_builder.presigned_image_upload_url(
-            image_type: 'selfie',
             transaction_id: flow_session[:document_capture_session_uuid],
           ),
         }.merge(native_camera_ab_testing_variables)

--- a/app/views/idv/capture_doc/document_capture.html.erb
+++ b/app/views/idv/capture_doc/document_capture.html.erb
@@ -6,7 +6,6 @@
       failure_to_proof_url: idv_capture_doc_return_to_sp_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,
-      selfie_image_upload_url: selfie_image_upload_url,
       native_camera_a_b_testing_enabled: native_camera_a_b_testing_enabled,
       native_camera_only: native_camera_only,
     ) %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -6,7 +6,6 @@
       failure_to_proof_url: idv_doc_auth_return_to_sp_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,
-      selfie_image_upload_url: selfie_image_upload_url,
       native_camera_a_b_testing_enabled: native_camera_a_b_testing_enabled,
       native_camera_only: native_camera_only,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% add_document_capture_image_urls_to_csp(
      request,
-     [front_image_upload_url, back_image_upload_url, selfie_image_upload_url],
+     [front_image_upload_url, back_image_upload_url],
    )
    session_id = flow_session[:document_capture_session_uuid]
 %>
@@ -39,7 +39,6 @@
       failure_to_proof_url: failure_to_proof_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,
-      selfie_image_upload_url: selfie_image_upload_url,
       keep_alive_endpoint: sessions_keepalive_url,
       idv_in_person_url: Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -4,7 +4,6 @@ module Rack
   class Timeout
     @excludes = [
       '/api/verify/images',
-      '/verify/doc_auth/selfie',
       '/verify/doc_auth/document_capture',
       '/verify/doc_auth/verify',
       '/verify/capture_doc/document_capture',

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -97,7 +97,6 @@ describe Idv::CaptureDocController do
           locals: hash_including(
             :back_image_upload_url,
             :front_image_upload_url,
-            :selfie_image_upload_url,
             :flow_session,
             step_template: 'idv/capture_doc/document_capture',
             flow_namespace: 'idv',

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -70,7 +70,6 @@ describe Idv::DocAuthController do
         locals: hash_including(
           :back_image_upload_url,
           :front_image_upload_url,
-          :selfie_image_upload_url,
           :flow_session,
           step_template: 'idv/doc_auth/document_capture',
           flow_namespace: 'idv',

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Idv::ApiImageUploadForm do
   let(:back_image_metadata) do
     { width: 20, height: 20, mimeType: 'image/png', source: 'upload' }.to_json
   end
-  let(:selfie_image) { DocAuthImageFixtures.selfie_image_multipart }
   let!(:document_capture_session) { DocumentCaptureSession.create!(user: create(:user)) }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:fake_analytics) { FakeAnalytics.new }

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -495,11 +495,11 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('renders retry button when value and capture supported', async () => {
-      const selfie = await getFixtureFile('doc_auth_images/selfie.jpg');
+      const image = await getFixtureFile('doc_auth_images/id-front.jpg');
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
-            <AcuantCapture label="Image" value={selfie} />
+            <AcuantCapture label="Image" value={image} />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
       );

--- a/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
+++ b/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
@@ -33,52 +33,22 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
     )
   end
 
-  context 'with no selfie' do
-    it 'has costing for front, back, and result when billed' do
-      subject.call(billed_response)
+  it 'has costing for front, back, and result when billed' do
+    subject.call(billed_response)
 
-      expect(costing_for(:acuant_front_image)).to be_present
-      expect(costing_for(:acuant_back_image)).to be_present
-      expect(costing_for(:acuant_result)).to be_present
-      expect(costing_for(:acuant_selfie)).to be_nil
-    end
-
-    it 'has costing for front, back, but not result when not billed' do
-      subject.call(not_billed_response)
-
-      expect(costing_for(:acuant_front_image)).to be_present
-      expect(costing_for(:acuant_back_image)).to be_present
-      expect(costing_for(:acuant_result)).to be_nil
-      expect(costing_for(:acuant_selfie)).to be_nil
-    end
+    expect(costing_for(:acuant_front_image)).to be_present
+    expect(costing_for(:acuant_back_image)).to be_present
+    expect(costing_for(:acuant_result)).to be_present
+    expect(costing_for(:acuant_selfie)).to be_nil
   end
 
-  context 'with a selfie' do
-    it 'has costing for front, back, and result when is is billed' do
-      subject.call(billed_response)
+  it 'has costing for front, back, but not result when not billed' do
+    subject.call(not_billed_response)
 
-      expect(costing_for(:acuant_front_image)).to be_present
-      expect(costing_for(:acuant_back_image)).to be_present
-      expect(costing_for(:acuant_result)).to be_present
-    end
-
-    it 'has costing for front, back, but not result when it is not billed' do
-      subject.call(not_billed_response)
-
-      expect(costing_for(:acuant_front_image)).to be_present
-      expect(costing_for(:acuant_back_image)).to be_present
-      expect(costing_for(:acuant_result)).to be_nil
-    end
-
-    it 'does not fail when _count field is null' do
-      proofing_cost = ::ProofingCost.create_or_find_by(user_id: user_id)
-      proofing_cost.acuant_front_image_count = nil
-      proofing_cost.save
-
-      subject.call(billed_response)
-
-      expect(proofing_cost.reload.acuant_front_image_count).to eq 1
-    end
+    expect(costing_for(:acuant_front_image)).to be_present
+    expect(costing_for(:acuant_back_image)).to be_present
+    expect(costing_for(:acuant_result)).to be_nil
+    expect(costing_for(:acuant_selfie)).to be_nil
   end
 
   def costing_for(cost_type)

--- a/spec/support/acuant_fixtures.rb
+++ b/spec/support/acuant_fixtures.rb
@@ -15,14 +15,6 @@ module AcuantFixtures
     load_response_fixture('get_results_response_expired.json')
   end
 
-  def self.get_face_image_response
-    load_response_fixture('get_face_image_response.jpg')
-  end
-
-  def self.facial_match_response_success
-    load_response_fixture('facial_match_response_success.json')
-  end
-
   def self.facial_match_response_failure
     load_response_fixture('facial_match_response_failure.json')
   end

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -19,7 +19,6 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(fixture_path('id-back.jpg'), 'image/jpeg')
   end
 
-
   def self.error_yaml_multipart
     path = File.join(
       File.dirname(__FILE__),

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -19,21 +19,6 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(fixture_path('id-back.jpg'), 'image/jpeg')
   end
 
-  def self.document_face_image
-    load_image_data('id-face.jpg')
-  end
-
-  def self.document_face_image_multipart
-    Rack::Test::UploadedFile.new(fixture_path('id-face.jpg'), 'image/jpeg')
-  end
-
-  def self.selfie_image
-    load_image_data('selfie.jpg')
-  end
-
-  def self.selfie_image_multipart
-    Rack::Test::UploadedFile.new(fixture_path('selfie.jpg'), 'image/jpeg')
-  end
 
   def self.error_yaml_multipart
     path = File.join(

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -13,7 +13,6 @@ describe 'idv/shared/_document_capture.html.erb' do
   let(:in_person_proofing_enabled_issuer) { nil }
   let(:front_image_upload_url) { nil }
   let(:back_image_upload_url) { nil }
-  let(:selfie_image_upload_url) { nil }
   let(:native_camera_a_b_testing_enabled) { false }
   let(:native_camera_only) { false }
 
@@ -47,7 +46,6 @@ describe 'idv/shared/_document_capture.html.erb' do
       failure_to_proof_url: failure_to_proof_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,
-      selfie_image_upload_url: selfie_image_upload_url,
       native_camera_a_b_testing_enabled: native_camera_a_b_testing_enabled,
       native_camera_only: native_camera_only,
     }
@@ -71,7 +69,6 @@ describe 'idv/shared/_document_capture.html.erb' do
       let(:async_uploads_enabled) { true }
       let(:front_image_upload_url) { 'https://s3.example.com/bucket/a?X-Amz-Security-Token=UAOL2' }
       let(:back_image_upload_url) { 'https://s3.example.com/bucket/b?X-Amz-Security-Token=UAOL2' }
-      let(:selfie_image_upload_url) { 'https://s3.example.com/bucket/c?X-Amz-Security-Token=UAOL2' }
 
       it 'does modifies CSP connect_src headers to include upload urls' do
         render_partial
@@ -79,7 +76,6 @@ describe 'idv/shared/_document_capture.html.erb' do
         connect_src = controller.request.content_security_policy.connect_src
         expect(connect_src).to include('https://s3.example.com/bucket/a')
         expect(connect_src).to include('https://s3.example.com/bucket/b')
-        expect(connect_src).to include('https://s3.example.com/bucket/c')
       end
     end
   end


### PR DESCRIPTION
We are no longer using selfies to proof since IAL2 strict is deprecated and being removed. This commit removes some of the tooling that enabled selfie upload.
