### PR TITLE
Remove selfie and liveness enabled job and client args

### DIFF
--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -5,15 +5,13 @@ class DocumentProofingJob < ApplicationJob
 
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 
-  # rubocop:disable Lint/UnusedMethodArgument
   def perform(
     result_id:,
     encrypted_arguments:,
     trace_id:,
     image_metadata:,
     analytics_data:,
-    flow_path:,
-    liveness_checking_enabled: nil
+    flow_path:
   )
     timer = JobHelpers::Timer.new
 
@@ -85,7 +83,6 @@ class DocumentProofingJob < ApplicationJob
       }.to_json,
     )
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 
   private
 

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -41,7 +41,6 @@ module DocAuth
         front_image:,
         back_image:,
         image_source:,
-        liveness_checking_enabled: nil,
         user_uuid: nil,
         uuid_prefix: nil
       )

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -24,14 +24,9 @@ module DocAuth
         raise NotImplementedError
       end
 
-      # The unused selfie_image and liveness_checking_enabled should be removed once the calls to
-      # these no longer have those args
-      # rubocop:disable Lint/UnusedMethodArgument
       def post_images(
         front_image:,
         back_image:,
-        selfie_image: nil,
-        liveness_checking_enabled: nil,
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil
@@ -45,7 +40,6 @@ module DocAuth
           image_source: image_source,
         ).fetch
       end
-      # rubocop:enable Lint/UnusedMethodArgument
     end
   end
 end

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -46,12 +46,9 @@ module DocAuth
         DocAuth::Response.new(success: true)
       end
 
-      # NOTE: remove selfie_image arg when it is no longer expected by
-      # the front-end and specs
       def post_images(
         front_image:,
         back_image:,
-        selfie_image: nil,
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil


### PR DESCRIPTION
The code that quits calling the document proofing job with the selfie image and liveness enabled args is merged and deployed to prod. As such it should be safe to remove these args form the job.

Additionally, the doc auth clients themselves should no longer be called with these args so they should be safe to remove from those as well.
