### PR TITLE
Add application/json header to in-person API call

### DIFF
--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -572,6 +572,7 @@ RSpec.describe GetUspsProofingResultsJob do
             {
               status: 400,
               body: { 'responseMessage' => 'This USPS location has closed 😭' }.to_json,
+              headers: { 'content-type': 'application/json' },
             },
           )
         end


### PR DESCRIPTION
This change is necessary since the Faraday upgrade. It looks like it got missed when the Faraday change was merged before this.

This commit fixes a CI failure on main.
