### PR TITLE
Remove redundant, untranslated banner label

### DIFF
--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,4 +1,4 @@
-<header aria-label="banner">
+<header>
   <%= render 'shared/no_pii_banner' if FeatureManagement.show_no_pii_banner? %>
   <section class="usa-banner" aria-label="<%= t('shared.banner.landmark_label') %>">
     <div class="usa-accordion">


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the "banner" hard-coded label assigned to the site's banner header.

**Why?**

* As a user of assistive technology, I expect that labels would be used to provide additional detail beyond a landmark's semantic default and would not otherwise be assigned, so that I am not exposed to duplicate / redundant information
* As a user of assistive technology browsing Login.gov in a language other than English, I expect that labels would be translated in the page's current language, so that I am not confused by labels read in a different language

**Related resources:**

* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/banner_role
* https://www.w3.org/TR/wai-aria-1.2/#banner
* https://www.w3.org/WAI/WCAG21/Understanding/language-of-page

## 📜 Testing Plan

- [ ] Ensure that you can navigate to the banner landmark with assistive technology in English and non-English locales

## 👀 Screenshots

_English_:

Observe that "banner" is only shown once.

Before|After
---|---
![Screen Shot 2022-11-01 at 3 16 25 PM](https://user-images.githubusercontent.com/1779930/199321157-a9137402-c804-473e-8d73-bc9c6bfba628.png)|![Screen Shot 2022-11-01 at 3 16 10 PM](https://user-images.githubusercontent.com/1779930/199321166-9e06d00c-9337-44e3-acbd-f14a68ce98da.png)

_French:_

Observe that the English word "banner" is no longer present.

Before|After
---|---
![Capture d’écran, le 2022-11-01 à 3 12 02 PM](https://user-images.githubusercontent.com/1779930/199321194-c5115051-ebc1-4234-9fbd-06f985753221.png)|![Capture d’écran, le 2022-11-01 à 3 11 21 PM](https://user-images.githubusercontent.com/1779930/199321206-d01e718e-fd59-4fd1-a310-32261dbcfe57.png)