### PR TITLE
Revert "Render unauthenticated session expire redirect as meta tag"

### DIFF
--- a/app/javascript/packs/session-expire-session.js
+++ b/app/javascript/packs/session-expire-session.js
@@ -1,0 +1,10 @@
+const expireConfig = document.getElementById('js-expire-session');
+
+if (expireConfig && expireConfig.dataset.sessionTimeoutIn) {
+  const sessionTimeoutIn = parseInt(expireConfig.dataset.sessionTimeoutIn, 10) * 1000;
+  const timeoutRefreshPath = expireConfig.dataset.timeoutRefreshPath || '';
+
+  setTimeout(() => {
+    document.location.href = timeoutRefreshPath;
+  }, sessionTimeoutIn);
+}

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -12,9 +12,6 @@
   <% if content_for?(:meta_refresh) %>
   <meta content="<%= yield(:meta_refresh) %>" http-equiv="refresh" />
   <% end %>
-  <% if !current_user && !@skip_session_expiration %>
-    <%= render 'session_timeout/expire_session' %>
-  <% end %>
 
   <% if session_with_trust? || FeatureManagement.disallow_all_web_crawlers? %>
   <meta content="noindex,nofollow" name="robots" />
@@ -70,7 +67,7 @@
 
   <%= render 'shared/footer_lite' %>
 
-  <% if current_user %>
+  <% if current_user # Render the JS snipped that collects platform authenticator analytics %>
     <%= render partial: 'session_timeout/ping',
                locals: {
                  timeout_url: timeout_url,
@@ -78,6 +75,11 @@
                  start: session_timeout_start,
                  frequency: session_timeout_frequency,
                  modal: session_modal,
+               } %>
+  <% elsif !@skip_session_expiration %>
+    <%= render partial: 'session_timeout/expire_session',
+               locals: {
+                 session_timeout_in: Devise.timeout_in,
                } %>
   <% end %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -67,7 +67,7 @@
 
   <%= render 'shared/footer_lite' %>
 
-  <% if current_user # Render the JS snipped that collects platform authenticator analytics %>
+  <% if current_user %>
     <%= render partial: 'session_timeout/ping',
                locals: {
                  timeout_url: timeout_url,

--- a/app/views/session_timeout/_expire_session.html.erb
+++ b/app/views/session_timeout/_expire_session.html.erb
@@ -1,1 +1,7 @@
-<meta http-equiv="refresh" content="<%= IdentityConfig.store.session_timeout_in_minutes.minutes.seconds.to_i %>;url=<%= timeout_refresh_path %>" />
+<%= tag.div id: 'js-expire-session',
+            data: {
+              session_timeout_in: session_timeout_in,
+              timeout_refresh_path: timeout_refresh_path,
+            } %>
+
+<%= javascript_packs_tag_once 'session-expire-session' %>

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -318,15 +318,6 @@ feature 'Sign in' do
       expect(page).to have_field(t('forms.registration.labels.email'), with: '')
       expect(current_url).to match Regexp.escape(sign_up_email_path(request_id: '123abc'))
     end
-
-    it 'does not refresh the page after the session expires', js: true do
-      allow(Devise).to receive(:timeout_in).and_return(60)
-
-      visit root_path
-      expect(page).to_not have_content(
-        t('notices.session_cleared', minutes: IdentityConfig.store.session_timeout_in_minutes),
-      )
-    end
   end
 
   context 'signing back in after session timeout length' do
@@ -365,6 +356,7 @@ feature 'Sign in' do
 
       expect(page).to have_content(
         t('notices.session_cleared', minutes: IdentityConfig.store.session_timeout_in_minutes),
+        wait: 5,
       )
       expect(find_field('Email').value).to be_blank
       expect(find_field('Password').value).to be_blank


### PR DESCRIPTION
Reverts 18F/identity-idp#7249

Related Slack conversation: https://gsa-tts.slack.com/archives/C0NGESUN5/p1667331820015699

The changes in #7249, while functionally equivalent to what had existed previously, introduce new errors flagged by accessibility testing tools related to `http-equiv="refresh"`. Future iterations should explore how to allow a user to extend the timeout, while remaining compatible with technical requirements for CSRF token expiration of 15 minutes.

~_(Draft while I undo some of the diff to keep some desirable changes like template comment corrections and spec removal)_~ **Edit:** Edited in 3438c5e.