### PR TITLE
Optimize base16 encoding

### DIFF
--- a/app/services/irs_attempts_api/envelope_encryptor.rb
+++ b/app/services/irs_attempts_api/envelope_encryptor.rb
@@ -1,3 +1,5 @@
+require 'base16'
+
 module IrsAttemptsApi
   class EnvelopeEncryptor
     Result = Struct.new(:filename, :iv, :encrypted_key, :encrypted_data, keyword_init: true)

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require_relative '../lib/identity_config'
 require_relative '../lib/fingerprinter'
 require_relative '../lib/identity_job_log_subscriber'
 require_relative '../lib/email_delivery_observer'
-require_relative '../lib/base_16' # Should I need to do this?
 
 Bundler.require(*Rails.groups)
 

--- a/lib/base16.rb
+++ b/lib/base16.rb
@@ -1,18 +1,10 @@
 # See https://www.rfc-editor.org/rfc/rfc4648#section-8
 class Base16
   def self.encode16(str)
-    output = ''
-    str.bytes.each do |char|
-      output << char.to_s(16).upcase.rjust(2, "0")
-    end
-    output
+    str.unpack('H*').first
   end
 
   def self.decode16(str)
-    output = ''
-    str.chars.each_slice(2) do |chars|
-      output << chars.join.to_i(16).chr
-    end
-    output
+    [str].pack('H*')
   end
 end

--- a/lib/base16.rb
+++ b/lib/base16.rb
@@ -1,7 +1,7 @@
 # See https://www.rfc-editor.org/rfc/rfc4648#section-8
 class Base16
   def self.encode16(str)
-    str.unpack('H*').first
+    str.unpack('H*').first.tap(&:upcase!)
   end
 
   def self.decode16(str)

--- a/lib/base16.rb
+++ b/lib/base16.rb
@@ -1,9 +1,11 @@
+# See https://www.rfc-editor.org/rfc/rfc4648#section-8
 class Base16
-
-  # The IRS has requested data be encoded this way. Loosely emulate the Base64 class.
-
   def self.encode16(str)
-    str.bytes.map { |char| char.to_s(16).upcase.rjust(2, "0") }.join
+    output = ''
+    str.bytes.each do |char|
+      output << char.to_s(16).upcase.rjust(2, "0")
+    end
+    output
   end
 
   def self.decode16(str)

--- a/lib/tasks/attempts.rake
+++ b/lib/tasks/attempts.rake
@@ -1,3 +1,5 @@
+require 'base16'
+
 namespace :attempts do
   desc 'Retrieve events via the API'
   task fetch_events: :environment do

--- a/spec/lib/base16_spec.rb
+++ b/spec/lib/base16_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe Base16 do
     end
   end
 
-  context 'with a less reasonable input', skip: true do
+  context 'with a less reasonable input' do
     context 'given a zany-face emoji' do
       let(:input) { "🤪" }
       it 'should return the same thing but does not' do
         encoded = described_class.encode16(input)
-        decoded = described_class.decode16(encoded)
+        decoded = described_class.decode16(encoded).force_encoding('UTF-8')
         expect(decoded).to eq input
       end
     end

--- a/spec/lib/base16_spec.rb
+++ b/spec/lib/base16_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Base16 do
   context 'with a less reasonable input' do
     context 'given a zany-face emoji' do
       let(:input) { "🤪" }
-      it 'should return the same thing but does not' do
+      it 'returns the same bytes' do
         encoded = described_class.encode16(input)
         decoded = described_class.decode16(encoded).force_encoding('UTF-8')
         expect(decoded).to eq input

--- a/spec/lib/base16_spec.rb
+++ b/spec/lib/base16_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'base16'
 
 RSpec.describe Base16 do
 


### PR DESCRIPTION
- `<<` turns out to be faster than `[].join`

See "encode_3" for some improvements over existing. Normally I would not try to pre-optimize this, but we I know that we were planning to do this for multiple megabytes of data at a time

Here's what I did to benchmark this against https://github.com/18F/identity-idp/pull/7204

```ruby
require 'benchmark/ips'
require 'base16'
require 'securerandom'

class PrBase16
  def self.encode16(str)
    str.bytes.map { |char| char.to_s(16).upcase.rjust(2, "0") }.join
  end

  def self.decode16(str)
    output = ''
    str.chars.each_slice(2) do |chars|
      output << chars.join.to_i(16).chr
    end
    output
  end
end

class Base16V3
  def self.encode16(str)
    output = ''
    str.bytes.each { |char| output << char.to_s(16).upcase.rjust(2, "0") }
    output
  end

  def self.decode16(str)
    str.chars.each_slice(2).map do |pair|
      pair.join.to_i(16).chr
    end.join
  end
end

random_10k_bytes = SecureRandom.random_bytes(10_000)
random_10k_hex = SecureRandom.hex(10_000)

Benchmark.ips do|x|
  x.report('encode_gem') do
    Base16.encode16(random_10k_bytes)
  end

  x.report('encode_pr') do
    PrBase16.encode16(random_10k_bytes)
  end

  x.report('encode_3') do
    Base16V3.encode16(random_10k_bytes)
  end

  x.compare!
end

Benchmark.ips do|x|
  x.report('decode_gem') do
    Base16.decode16(random_10k_hex)
  end

  x.report('decode_pr') do
    PrBase16.decode16(random_10k_hex)
  end

  x.report('decode_3') do
    Base16V3.decode16(random_10k_hex)
  end

  x.compare!
end
```
