### PR TITLE
LG-7450 Implement "Try Again" Button Functionality on the First Error Page

### DIFF
--- a/app/forms/idv/inherited_proofing/base_form.rb
+++ b/app/forms/idv/inherited_proofing/base_form.rb
@@ -35,6 +35,8 @@ module Idv
         raise ArgumentError, 'payload_hash is blank?' if payload_hash.blank?
         raise ArgumentError, 'payload_hash is not a Hash' unless payload_hash.is_a? Hash
 
+        super()
+
         self.class.attr_accessor(*self.class.fields)
 
         @payload_hash = payload_hash.dup
@@ -43,12 +45,10 @@ module Idv
       end
 
       def submit
-        validate
-
         FormResponse.new(
-          success: valid?,
+          success: validate,
           errors: errors,
-          extra: {},
+          extra: extra || {},
         )
       end
 
@@ -63,6 +63,11 @@ module Idv
       private
 
       attr_writer :payload_hash
+
+      # Return extra data used to instantiate the FormResponse
+      # returned upon #submit.
+      def extra
+      end
 
       # Populates our field data from the payload hash.
       def populate_field_data

--- a/app/forms/idv/inherited_proofing/base_form.rb
+++ b/app/forms/idv/inherited_proofing/base_form.rb
@@ -35,8 +35,6 @@ module Idv
         raise ArgumentError, 'payload_hash is blank?' if payload_hash.blank?
         raise ArgumentError, 'payload_hash is not a Hash' unless payload_hash.is_a? Hash
 
-        super()
-
         self.class.attr_accessor(*self.class.fields)
 
         @payload_hash = payload_hash.dup
@@ -48,7 +46,7 @@ module Idv
         FormResponse.new(
           success: validate,
           errors: errors,
-          extra: extra || {},
+          extra: {},
         )
       end
 
@@ -63,11 +61,6 @@ module Idv
       private
 
       attr_writer :payload_hash
-
-      # Return extra data used to instantiate the FormResponse
-      # returned upon #submit.
-      def extra
-      end
 
       # Populates our field data from the payload hash.
       def populate_field_data

--- a/app/forms/idv/inherited_proofing/base_form.rb
+++ b/app/forms/idv/inherited_proofing/base_form.rb
@@ -11,31 +11,15 @@ module Idv
         def namespaced_model_name
           self.to_s.gsub('::', '')
         end
-
-        def fields
-          @fields ||= required_fields + optional_fields
-        end
-
-        def required_fields
-          raise NotImplementedError,
-                'Override this method and return an Array of required field names as Symbols'
-        end
-
-        def optional_fields
-          raise NotImplementedError,
-                'Override this method and return an Array of optional field names as Symbols'
-        end
       end
 
-      private_class_method :namespaced_model_name, :required_fields, :optional_fields
+      private_class_method :namespaced_model_name
 
       attr_reader :payload_hash
 
       def initialize(payload_hash:)
         raise ArgumentError, 'payload_hash is blank?' if payload_hash.blank?
         raise ArgumentError, 'payload_hash is not a Hash' unless payload_hash.is_a? Hash
-
-        self.class.attr_accessor(*self.class.fields)
 
         @payload_hash = payload_hash.dup
 
@@ -44,7 +28,7 @@ module Idv
 
       def submit
         FormResponse.new(
-          success: validate,
+          success: valid?,
           errors: errors,
           extra: {},
         )

--- a/app/forms/idv/inherited_proofing/va/form.rb
+++ b/app/forms/idv/inherited_proofing/va/form.rb
@@ -2,18 +2,30 @@ module Idv
   module InheritedProofing
     module Va
       class Form < Idv::InheritedProofing::BaseForm
+        include ActiveModel::Validations::Callbacks
+
         class << self
           def required_fields
-            @required_fields ||= %i[first_name last_name birth_date ssn address_street address_zip]
+            @required_fields ||= %i[first_name
+                                    last_name
+                                    birth_date
+                                    ssn
+                                    address_street
+                                    address_zip]
           end
 
           def optional_fields
-            @optional_fields ||= %i[phone address_street2 address_city address_state
-                                    address_country]
+            @optional_fields ||= %i[phone
+                                    address_street2
+                                    address_city
+                                    address_state
+                                    address_country
+                                    service_error]
           end
         end
 
-        validates(*required_fields, presence: true)
+        before_validation :add_service_error_if
+        validates(*required_fields, presence: true, unless: :service_error?)
 
         def user_pii
           raise 'User PII is invalid' unless valid?
@@ -29,6 +41,30 @@ module Idv
           user_pii[:state] = address_state
           user_pii[:zipcode] = address_zip
           user_pii
+        end
+
+        def service_error?
+          service_error.present?
+        end
+
+        private
+
+        def extra
+          # Make sure the service-related error gets passed along
+          # to our FormResponse upon #submit.
+          { service_error: service_error } if service_error?
+        end
+
+        def add_service_error_if
+          return unless service_error?
+
+          errors.add(
+            :service_provider,
+            # Use a "safe" error message for the model in case it's displayed
+            # to the user at any point.
+            I18n.t('inherited_proofing.errors.service_provider.communication'),
+            type: :service_error,
+          )
         end
       end
     end

--- a/app/forms/idv/inherited_proofing/va/form.rb
+++ b/app/forms/idv/inherited_proofing/va/form.rb
@@ -2,28 +2,23 @@ module Idv
   module InheritedProofing
     module Va
       class Form < Idv::InheritedProofing::BaseForm
-        class << self
-          def required_fields
-            @required_fields ||= %i[first_name
-                                    last_name
-                                    birth_date
-                                    ssn
-                                    address_street
-                                    address_zip]
-          end
+        REQUIRED_FIELDS = %i[first_name
+                             last_name
+                             birth_date
+                             ssn
+                             address_street
+                             address_zip].freeze
+        OPTIONAL_FIELDS = %i[phone
+                             address_street2
+                             address_city
+                             address_state
+                             address_country
+                             service_error].freeze
+        FIELDS = (REQUIRED_FIELDS + OPTIONAL_FIELDS).freeze
 
-          def optional_fields
-            @optional_fields ||= %i[phone
-                                    address_street2
-                                    address_city
-                                    address_state
-                                    address_country
-                                    service_error]
-          end
-        end
-
+        attr_accessor(*FIELDS)
         validate :add_service_error, if: :service_error?
-        validates(*required_fields, presence: true, unless: :service_error?)
+        validates(*REQUIRED_FIELDS, presence: true, unless: :service_error?)
 
         def submit
           extra = {}

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -621,6 +621,12 @@ module AnalyticsEvents
     )
   end
 
+  # Retry retrieving the user PII in the case where the first attempt fails
+  # in the agreement step, and the user initiates a "retry".
+  def idv_inherited_proofing_redo_retrieve_user_info_submitted(**extra)
+    track_event('IdV: inherited proofing retry retrieve user information submitted', **extra)
+  end
+
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
   # The user visited the in person proofing location step
   def idv_in_person_location_visited(flow_path:, **extra)

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -1,5 +1,7 @@
 module Flow
   class BaseFlow
+    include Failure
+
     attr_accessor :flow_session
     attr_reader :steps, :actions, :current_user, :current_sp, :params, :request, :json,
                 :http_status, :controller

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -1,6 +1,7 @@
 module Flow
   class BaseStep
     include Rails.application.routes.url_helpers
+    include Failure
 
     def initialize(flow, name)
       @flow = flow
@@ -49,13 +50,6 @@ module Flow
 
     def form_submit
       FormResponse.new(success: true)
-    end
-
-    def failure(message, extra = nil)
-      flow_session[:error_message] = message
-      form_response_params = { success: false, errors: { message: message } }
-      form_response_params[:extra] = extra unless extra.nil?
-      FormResponse.new(**form_response_params)
     end
 
     def flow_params

--- a/app/services/flow/failure.rb
+++ b/app/services/flow/failure.rb
@@ -1,0 +1,12 @@
+module Flow
+  module Failure
+    private
+
+    def failure(message, extra = nil)
+      flow_session[:error_message] = message
+      form_response_params = { success: false, errors: { message: message } }
+      form_response_params[:extra] = extra unless extra.nil?
+      FormResponse.new(**form_response_params)
+    end
+  end
+end

--- a/app/services/idv/actions/inherited_proofing/redo_retrieve_user_info_action.rb
+++ b/app/services/idv/actions/inherited_proofing/redo_retrieve_user_info_action.rb
@@ -1,0 +1,19 @@
+module Idv
+  module Actions
+    module InheritedProofing
+      class RedoRetrieveUserInfoAction < Idv::Steps::InheritedProofing::VerifyWaitStepShow
+        class << self
+          def analytics_submitted_event
+            :idv_inherited_proofing_redo_retrieve_user_info_submitted
+          end
+        end
+
+        def call
+          enqueue_job unless api_call_already_in_progress?
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/flows/inherited_proofing_flow.rb
+++ b/app/services/idv/flows/inherited_proofing_flow.rb
@@ -18,7 +18,9 @@ module Idv
         { name: :secure_account },
       ].freeze
 
-      ACTIONS = {}.freeze
+      ACTIONS = {
+        redo_retrieve_user_info: Idv::Actions::InheritedProofing::RedoRetrieveUserInfoAction,
+      }.freeze
 
       attr_reader :idv_session
 

--- a/app/services/idv/inherited_proofing/va/mocks/service.rb
+++ b/app/services/idv/inherited_proofing/va/mocks/service.rb
@@ -36,7 +36,7 @@ module Idv
           }.freeze
 
           ERROR_HASH = {
-            errors: 'InheritedProofing::Errors::MHVIdentityDataNotFoundError',
+            service_error: 'the server responded with status 401',
           }.freeze
 
           def initialize(service_provider_data)

--- a/app/services/idv/inherited_proofing/va/service.rb
+++ b/app/services/idv/inherited_proofing/va/service.rb
@@ -21,9 +21,9 @@ module Idv
             response = request
             return payload_to_hash decrypt_payload(response) if response.status == 200
 
-            service_error not_200_service_error(response.status)
+            service_error(not_200_service_error(response.status))
           rescue => error
-            return service_error error.message
+            service_error(error.message)
           end
         end
 

--- a/app/services/idv/inherited_proofing/va/service.rb
+++ b/app/services/idv/inherited_proofing/va/service.rb
@@ -17,11 +17,34 @@ module Idv
         def execute
           raise 'The provided auth_code is blank?' if auth_code.blank?
 
-          response = request
-          payload_to_hash decrypt_payload(response)
+          begin
+            response = request
+            return payload_to_hash decrypt_payload(response) if response.status == 200
+
+            service_error not_200_service_error(response.status)
+          rescue => error
+            return service_error error.message
+          end
         end
 
         private
+
+        def service_error(message)
+          { service_error: message }
+        end
+
+        def not_200_service_error(http_status)
+          # Under certain circumstances, Faraday may return a nil http status.
+          # https://lostisland.github.io/faraday/middleware/raise-error
+          if http_status.blank?
+            http_status = 'unavailable'
+            http_status_description = 'unavailable'
+          else
+            http_status_description = Rack::Utils::HTTP_STATUS_CODES[http_status]
+          end
+          "The service provider API returned an http status other than 200: " \
+            "#{http_status} (#{http_status_description})"
+        end
 
         def request
           connection.get(request_uri) { |req| req.headers = request_headers }

--- a/app/services/idv/steps/inherited_proofing/agreement_step.rb
+++ b/app/services/idv/steps/inherited_proofing/agreement_step.rb
@@ -2,6 +2,8 @@ module Idv
   module Steps
     module InheritedProofing
       class AgreementStep < VerifyBaseStep
+        include UserPiiJobInitiator
+
         delegate :controller, :idv_session, to: :@flow
         STEP_INDICATOR_STEP = :getting_started
 
@@ -23,28 +25,6 @@ module Idv
 
         def consent_form_params
           params.require(:inherited_proofing).permit(:ial2_consent_given)
-        end
-
-        def enqueue_job
-          return if api_call_already_in_progress?
-
-          doc_capture_session = create_document_capture_session(
-            inherited_proofing_verify_step_document_capture_session_uuid_key,
-          )
-
-          doc_capture_session.create_proofing_session
-
-          InheritedProofingJob.perform_later(
-            controller.inherited_proofing_service_provider,
-            controller.inherited_proofing_service_provider_data,
-            doc_capture_session.uuid,
-          )
-        end
-
-        def api_call_already_in_progress?
-          DocumentCaptureSession.find_by(
-            uuid: flow_session['inherited_proofing_verify_step_document_capture_session_uuid'],
-          )&.in_progress?
         end
       end
     end

--- a/app/services/idv/steps/inherited_proofing/user_pii_job_initiator.rb
+++ b/app/services/idv/steps/inherited_proofing/user_pii_job_initiator.rb
@@ -1,0 +1,35 @@
+module Idv
+  module Steps
+    module InheritedProofing
+      module UserPiiJobInitiator
+        private
+
+        def enqueue_job
+          return if api_call_already_in_progress?
+
+          create_document_capture_session(
+            inherited_proofing_verify_step_document_capture_session_uuid_key,
+          ).tap do |doc_capture_session|
+            doc_capture_session.create_proofing_session
+
+            InheritedProofingJob.perform_later(
+              controller.inherited_proofing_service_provider,
+              controller.inherited_proofing_service_provider_data,
+              doc_capture_session.uuid,
+            )
+          end
+        end
+
+        def api_call_already_in_progress?
+          DocumentCaptureSession.find_by(
+            uuid: flow_session[inherited_proofing_verify_step_document_capture_session_uuid_key],
+          ).present?
+        end
+
+        def delete_async
+          flow_session.delete(inherited_proofing_verify_step_document_capture_session_uuid_key)
+        end
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/inherited_proofing/verify_wait_step_show.rb
+++ b/app/services/idv/steps/inherited_proofing/verify_wait_step_show.rb
@@ -14,18 +14,6 @@ module Idv
         end
 
         def call
-          # NOTE: The only way throttle.attempts will be > 0, is if our job to
-          # retrieve the user's PII failed on the first attempt (from the previous
-          # :agreement step), and the user subsequently clicks the "Retry" button on the
-          # Inherited Proofing (IP) Warning UI. The IP Warning UI "Retry" button
-          # routes to this step, allowing the user to retry PII retrieval from the Service
-          # Provider IdentityConfig.store.inherited_proofing_max_attempts times, before
-          # the IP Error UI is displayed, allowing no further retry attempts. #enqueue_job
-          # checks to make sure that a job is not already in progress before enqueuing a
-          # new job to retrieve the users PII, so there is no danger here of jobs being
-          # added to the queue while polling the async state is in progress.
-          enqueue_job if throttle.attempts > 0
-
           poll_with_meta_refresh(IdentityConfig.store.poll_rate_for_verify_in_seconds)
 
           process_async_state(async_state)

--- a/app/services/idv/steps/inherited_proofing/verify_wait_step_show.rb
+++ b/app/services/idv/steps/inherited_proofing/verify_wait_step_show.rb
@@ -2,6 +2,7 @@ module Idv
   module Steps
     module InheritedProofing
       class VerifyWaitStepShow < VerifyBaseStep
+        include UserPiiJobInitiator
         include UserPiiManagable
         include Idv::InheritedProofing::ServiceProviderForms
         delegate :controller, :idv_session, to: :@flow
@@ -13,6 +14,18 @@ module Idv
         end
 
         def call
+          # NOTE: The only way throttle.attempts will be > 0, is if our job to
+          # retrieve the user's PII failed on the first attempt (from the previous
+          # :agreement step), and the user subsequently clicks the "Retry" button on the
+          # Inherited Proofing (IP) Warning UI. The IP Warning UI "Retry" button
+          # routes to this step, allowing the user to retry PII retrieval from the Service
+          # Provider IdentityConfig.store.inherited_proofing_max_attempts times, before
+          # the IP Error UI is displayed, allowing no further retry attempts. #enqueue_job
+          # checks to make sure that a job is not already in progress before enqueuing a
+          # new job to retrieve the users PII, so there is no danger here of jobs being
+          # added to the queue while polling the async state is in progress.
+          enqueue_job if throttle.attempts > 0
+
           poll_with_meta_refresh(IdentityConfig.store.poll_rate_for_verify_in_seconds)
 
           process_async_state(async_state)
@@ -21,17 +34,15 @@ module Idv
         private
 
         def process_async_state(current_async_state)
+          return if current_async_state.in_progress?
+
           if current_async_state.none?
             mark_step_incomplete(:agreement)
-          elsif current_async_state.in_progress?
-            nil
           elsif current_async_state.missing?
             flash[:error] = I18n.t('idv.failure.timeout')
-            # Need to add path to error pages once they exist
-            # LG-7257
-            # This method overrides VerifyBaseStep#process_async_state:
-            # See the VerifyBaseStep#process_async_state "elsif current_async_state.missing?"
-            # logic as to what is typically needed/performed when hitting this logic path.
+            delete_async
+            mark_step_incomplete(:agreement)
+            @flow.analytics.idv_proofing_resolution_result_missing
           elsif current_async_state.done?
             async_state_done(current_async_state)
           end
@@ -54,11 +65,16 @@ module Idv
           )
           form_response = form.submit
 
+          delete_async
+
           if form_response.success?
             inherited_proofing_save_user_pii_to_session!(form.user_pii)
             mark_step_complete(:verify_wait)
+          elsif throttle.throttled?
+            idv_failure(form_response)
           else
-            mark_step_incomplete(:agreement)
+            mark_step_complete(:agreement)
+            idv_failure(form_response)
           end
 
           form_response
@@ -75,6 +91,34 @@ module Idv
 
         def api_job_result
           document_capture_session.load_proofing_result
+        end
+
+        # Base class overrides
+
+        def throttle
+          @throttle ||= Throttle.new(
+            user: current_user,
+            throttle_type: :inherited_proofing,
+          )
+        end
+
+        def idv_failure_log_throttled
+          @flow.analytics.throttler_rate_limit_triggered(
+            throttle_type: throttle.throttle_type,
+            step_name: self.class.name,
+          )
+        end
+
+        def throttled_url
+          idv_inherited_proofing_errors_failure_url(flow: :inherited_proofing)
+        end
+
+        def exception_url
+          idv_inherited_proofing_errors_failure_url(flow: :inherited_proofing)
+        end
+
+        def warning_url
+          idv_inherited_proofing_errors_no_information_url(flow: :inherited_proofing)
         end
       end
     end

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -78,26 +78,41 @@ module Idv
       def idv_failure(result)
         throttle.increment! if result.extra.dig(:proofing_results, :exception).blank?
         if throttle.throttled?
-          @flow.irs_attempts_api_tracker.idv_verification_rate_limited
-          @flow.analytics.throttler_rate_limit_triggered(
-            throttle_type: :idv_resolution,
-            step_name: self.class.name,
-          )
-          redirect_to idv_session_errors_failure_url
+          idv_failure_log_throttled
+          redirect_to throttled_url
         elsif result.extra.dig(:proofing_results, :exception).present?
-          @flow.analytics.idv_doc_auth_exception_visited(
-            step_name: self.class.name,
-            remaining_attempts: throttle.remaining_count,
-          )
+          idv_failure_log_error
           redirect_to exception_url
         else
-          @flow.analytics.idv_doc_auth_warning_visited(
-            step_name: self.class.name,
-            remaining_attempts: throttle.remaining_count,
-          )
+          idv_failure_log_warning
           redirect_to warning_url
         end
-        result
+      end
+
+      def idv_failure_log_throttled
+        @flow.irs_attempts_api_tracker.idv_verification_rate_limited
+        @flow.analytics.throttler_rate_limit_triggered(
+          throttle_type: :idv_resolution,
+          step_name: self.class.name,
+        )
+      end
+
+      def idv_failure_log_error
+        @flow.analytics.idv_doc_auth_exception_visited(
+          step_name: self.class.name,
+          remaining_attempts: throttle.remaining_count,
+        )
+      end
+
+      def idv_failure_log_warning
+        @flow.analytics.idv_doc_auth_warning_visited(
+          step_name: self.class.name,
+          remaining_attempts: throttle.remaining_count,
+        )
+      end
+
+      def throttled_url
+        idv_session_errors_failure_url
       end
 
       def exception_url

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -49,6 +49,10 @@ class Throttle
       max_attempts: IdentityConfig.store.phone_confirmation_max_attempts,
       attempt_window: IdentityConfig.store.phone_confirmation_max_attempt_window_in_minutes,
     },
+    inherited_proofing: {
+      max_attempts: IdentityConfig.store.inherited_proofing_max_attempts,
+      attempt_window: IdentityConfig.store.inherited_proofing_max_attempt_window_in_minutes,
+    },
   }.with_indifferent_access.freeze
 
   def initialize(throttle_type:, user: nil, target: nil)

--- a/app/views/idv/inherited_proofing_errors/warning.html.erb
+++ b/app/views/idv/inherited_proofing_errors/warning.html.erb
@@ -8,7 +8,7 @@
      <%= t('inherited_proofing.errors.cannot_retrieve.info') %>
   </p>
 
-  <%= link_to t('inherited_proofing.buttons.try_again'), idv_inherited_proofing_step_path(step: :verify_wait), class: 'usa-button usa-button--big usa-button--wide' %>
+  <%= button_to t('inherited_proofing.buttons.try_again'), idv_inherited_proofing_step_path(step: :redo_retrieve_user_info), method: :put, class: 'usa-button usa-button--big usa-button--wide' %>
 
   <%= render(
         'shared/troubleshooting_options',

--- a/app/views/idv/inherited_proofing_errors/warning.html.erb
+++ b/app/views/idv/inherited_proofing_errors/warning.html.erb
@@ -8,7 +8,7 @@
      <%= t('inherited_proofing.errors.cannot_retrieve.info') %>
   </p>
 
-  <%= link_to t('inherited_proofing.buttons.try_again'), root_url, class: 'usa-button usa-button--big usa-button--wide' %>
+  <%= link_to t('inherited_proofing.buttons.try_again'), idv_inherited_proofing_step_path(step: :verify_wait), class: 'usa-button usa-button--big usa-button--wide' %>
 
   <%= render(
         'shared/troubleshooting_options',

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -127,6 +127,8 @@ in_person_completion_survey_url: 'https://login.gov'
 include_slo_in_saml_metadata: false
 inherited_proofing_enabled: false
 inherited_proofing_va_base_url: 'https://staging-api.va.gov'
+inherited_proofing_max_attempts: 2
+inherited_proofing_max_attempt_window_in_minutes: 1
 va_inherited_proofing_mock_enabled: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''

--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -27,6 +27,8 @@ en:
         info: We are temporarily having trouble retrieving your information. Please try
           again.
         title: Couldn’t retrieve information
+      service_provider:
+        communication: 'communication was unsuccessful'
     headings:
       lets_go: How verifying your identity works
       retrieval: We are retrieving your information from My HealtheVet

--- a/config/locales/inherited_proofing/es.yml
+++ b/config/locales/inherited_proofing/es.yml
@@ -28,6 +28,8 @@ es:
         info: Estamos teniendo problemas temporalmente para obtener su información.
           Inténtelo de nuevo.
         title: to be implemented
+      service_provider:
+        communication: 'la comunicacion no tuvo exito'
     headings:
       lets_go: to be implemented
       retrieval: Estamos recuperando su información de My HealtheVet

--- a/config/locales/inherited_proofing/fr.yml
+++ b/config/locales/inherited_proofing/fr.yml
@@ -29,6 +29,8 @@ fr:
         info: Nous avons temporairement des difficultés à récupérer vos informations.
           Veuillez réessayer.
         title: to be implemented
+      service_provider:
+        communication: 'la communication a échoué'
     headings:
       lets_go: to be implemented
       retrieval: Nous récupérons vos informations depuis My HealtheVet.

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -206,6 +206,8 @@ class IdentityConfig
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:inherited_proofing_enabled, type: :boolean)
     config.add(:inherited_proofing_va_base_url, type: :string)
+    config.add(:inherited_proofing_max_attempts, type: :integer)
+    config.add(:inherited_proofing_max_attempt_window_in_minutes, type: :integer)
     config.add(:va_inherited_proofing_mock_enabled, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)

--- a/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
@@ -5,7 +5,7 @@ feature 'inherited proofing verify wait', :js do
 
   before do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-    allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return true
+    allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return(true)
     send_user_from_service_provider_to_login_gov_openid_connect(user, inherited_proofing_auth)
   end
 
@@ -49,7 +49,7 @@ feature 'inherited proofing verify wait', :js do
         expect(fake_analytics).to have_logged_event(
           'Throttler Rate Limit Triggered',
           throttle_type: :inherited_proofing,
-          step_name: Idv::Actions::InheritedProofing::RedoRetrieveUserInfoAction,
+          step_name: Idv::Actions::InheritedProofing::RedoRetrieveUserInfoAction.name,
         )
       end
     end

--- a/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+feature 'inherited proofing verify wait', :js do
+  include InheritedProofingWithServiceProviderHelper
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    allow(IdentityConfig.store).to receive(:va_inherited_proofing_mock_enabled).and_return true
+    send_user_from_service_provider_to_login_gov_openid_connect(user, inherited_proofing_auth)
+  end
+
+  let!(:user) { user_with_2fa }
+  let(:inherited_proofing_auth) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
+  let(:fake_analytics) { FakeAnalytics.new }
+
+  context 'when on the "How verifying your identify works" page, ' \
+    'and the user clicks the "Continue" button' do
+    before do
+      complete_steps_up_to_inherited_proofing_we_are_retrieving_step user
+    end
+
+    context 'when there are no service-related errors' do
+      it 'displays the "Verify your information" page' do
+        expect(page).to have_current_path(
+          idv_inherited_proofing_step_path(step: :verify_info),
+        )
+      end
+    end
+
+    context 'when there are service-related errors on the first attempt' do
+      let(:inherited_proofing_auth) { 'invalid-auth-code' }
+
+      it 'displays the warning page and allows retries' do
+        expect(page).to have_current_path(
+          idv_inherited_proofing_errors_no_information_path(flow: :inherited_proofing),
+        )
+      end
+    end
+
+    context 'when there are service-related errors on the second attempt' do
+      let(:inherited_proofing_auth) { 'invalid-auth-code' }
+
+      it 'redirects to the error page, prohibits retries and logs the event' do
+        click_link t('inherited_proofing.buttons.try_again')
+        expect(page).to have_current_path(
+          idv_inherited_proofing_errors_failure_url(flow: :inherited_proofing),
+        )
+        expect(fake_analytics).to have_logged_event(
+          'Throttler Rate Limit Triggered',
+          throttle_type: :inherited_proofing,
+          step_name: Idv::Steps::InheritedProofing::VerifyWaitStepShow,
+        )
+      end
+    end
+  end
+
+  context 'when the async state is missing during polling' do
+    before do
+      allow_any_instance_of(ProofingSessionAsyncResult).to receive(:missing?).and_return(true)
+      complete_steps_up_to_inherited_proofing_we_are_retrieving_step user
+    end
+
+    it 'redirects back to the agreement step and logs the event' do
+      expect(page).to have_current_path(
+        idv_inherited_proofing_step_path(step: :agreement),
+      )
+      expect(fake_analytics).to have_logged_event(
+        'Proofing Resolution Result Missing',
+      )
+    end
+  end
+end

--- a/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/verify_wait_step_spec.rb
@@ -34,6 +34,7 @@ feature 'inherited proofing verify wait', :js do
         expect(page).to have_current_path(
           idv_inherited_proofing_errors_no_information_path(flow: :inherited_proofing),
         )
+        expect(page).to have_selector(:link_or_button, t('inherited_proofing.buttons.try_again'))
       end
     end
 
@@ -41,14 +42,14 @@ feature 'inherited proofing verify wait', :js do
       let(:inherited_proofing_auth) { 'invalid-auth-code' }
 
       it 'redirects to the error page, prohibits retries and logs the event' do
-        click_link t('inherited_proofing.buttons.try_again')
+        click_button t('inherited_proofing.buttons.try_again')
         expect(page).to have_current_path(
           idv_inherited_proofing_errors_failure_url(flow: :inherited_proofing),
         )
         expect(fake_analytics).to have_logged_event(
           'Throttler Rate Limit Triggered',
           throttle_type: :inherited_proofing,
-          step_name: Idv::Steps::InheritedProofing::VerifyWaitStepShow,
+          step_name: Idv::Actions::InheritedProofing::RedoRetrieveUserInfoAction,
         )
       end
     end

--- a/spec/forms/idv/inherited_proofing/base_form_spec.rb
+++ b/spec/forms/idv/inherited_proofing/base_form_spec.rb
@@ -40,24 +40,6 @@ RSpec.describe Idv::InheritedProofing::BaseForm do
   describe '#initialize' do
     subject { form_class }
 
-    context 'when .required_fields is not overridden' do
-      it 'raises an error' do
-        subject.singleton_class.send(:remove_method, :required_fields)
-        expected_error = 'Override this method and return ' \
-          'an Array of required field names as Symbols'
-        expect { subject.new(payload_hash: payload_hash) }.to raise_error(expected_error)
-      end
-    end
-
-    context 'when .optional_fields is not overridden' do
-      it 'raises an error' do
-        subject.singleton_class.send(:remove_method, :optional_fields)
-        expected_error = 'Override this method and return ' \
-          'an Array of optional field names as Symbols'
-        expect { subject.new(payload_hash: payload_hash) }.to raise_error(expected_error)
-      end
-    end
-
     context 'when .user_pii is not overridden' do
       subject do
         Class.new(Idv::InheritedProofing::BaseForm) do
@@ -80,31 +62,6 @@ RSpec.describe Idv::InheritedProofing::BaseForm do
     describe '.model_name' do
       it 'returns the right model name' do
         expect(described_class.model_name).to eq 'IdvInheritedProofingBaseForm'
-      end
-    end
-
-    describe '.fields' do
-      subject do
-        Class.new(Idv::InheritedProofing::BaseForm) do
-          class << self
-            def required_fields; %i[required] end
-
-            def optional_fields; %i[optional] end
-          end
-
-          def user_pii; {} end
-        end
-      end
-
-      let(:expected_field_names) do
-        [
-          :required,
-          :optional,
-        ].sort
-      end
-
-      it 'returns the right field names' do
-        expect(subject.fields).to match_array expected_field_names
       end
     end
   end
@@ -217,8 +174,8 @@ RSpec.describe Idv::InheritedProofing::BaseForm do
         subject.submit
       end
 
-      it 'calls #validate' do
-        expect(subject).to receive(:validate).once
+      it 'calls #valid?' do
+        expect(subject).to receive(:valid?).once
       end
     end
   end

--- a/spec/forms/idv/inherited_proofing/va/form_spec.rb
+++ b/spec/forms/idv/inherited_proofing/va/form_spec.rb
@@ -26,28 +26,30 @@ RSpec.describe Idv::InheritedProofing::Va::Form do
     }
   end
 
+  describe 'constants' do
+    describe 'FIELDS' do
+      it 'returns all the fields' do
+        expect(described_class::FIELDS).to match_array required_fields + optional_fields
+      end
+    end
+
+    describe 'REQUIRED_FIELDS' do
+      it 'returns the required fields' do
+        expect(described_class::REQUIRED_FIELDS).to match_array required_fields
+      end
+    end
+
+    describe 'OPTIONAL_FIELDS' do
+      it 'returns the optional fields' do
+        expect(described_class::OPTIONAL_FIELDS).to match_array optional_fields
+      end
+    end
+  end
+
   describe 'class methods' do
     describe '.model_name' do
       it 'returns the right model name' do
         expect(described_class.model_name).to eq 'IdvInheritedProofingVaForm'
-      end
-    end
-
-    describe '.fields' do
-      it 'returns all the fields' do
-        expect(described_class.fields).to match_array required_fields + optional_fields
-      end
-    end
-
-    describe '.required_fields' do
-      it 'returns the required fields' do
-        expect(described_class.required_fields).to match_array required_fields
-      end
-    end
-
-    describe '.optional_fields' do
-      it 'returns the optional fields' do
-        expect(described_class.optional_fields).to match_array optional_fields
       end
     end
   end

--- a/spec/services/idv/inherited_proofing/va/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Idv::InheritedProofing::Va::Service do
             with(headers: request_headers).
             to_return(status: 200, body: 'xyz', headers: {})
 
-          expect(service.execute.to_s).to match(/unexpected token at 'xyz'/)
+          expect(service.execute[:service_error]).to match(/unexpected token at 'xyz'/)
         end
       end
     end

--- a/spec/services/idv/inherited_proofing/va/service_spec.rb
+++ b/spec/services/idv/inherited_proofing/va/service_spec.rb
@@ -62,5 +62,63 @@ RSpec.describe Idv::InheritedProofing::Va::Service do
         it_behaves_like 'an invalid auth code error is raised'
       end
     end
+
+    context 'when a request error is raised' do
+      before do
+        allow(service).to receive(:request).and_raise('Boom!')
+      end
+
+      it 'rescues and returns the error' do
+        expect(service.execute).to eq({ service_error: 'Boom!' })
+      end
+    end
+
+    context 'when a decryption error is raised' do
+      it 'rescues and returns the error' do
+        freeze_time do
+          stub_request(:get, request_uri).
+            with(headers: request_headers).
+            to_return(status: 200, body: 'xyz', headers: {})
+
+          expect(service.execute.to_s).to match(/unexpected token at 'xyz'/)
+        end
+      end
+    end
+
+    context 'when a non-200 error is raised' do
+      it 'rescues and returns the error' do
+        freeze_time do
+          stub_request(:get, request_uri).
+            with(headers: request_headers).
+            to_return(status: 302, body: encrypted_user_attributes, headers: {})
+
+          expect(service.execute.to_s).to \
+            match(/The service provider API returned an http status other than 200/)
+        end
+      end
+
+      context 'when http status is unavailable (nil)' do
+        before do
+          allow_any_instance_of(Faraday::Response).to receive(:status).and_return(nil)
+        end
+
+        let(:expected_error) do
+          {
+            service_error: 'The service provider API returned an http status other than 200: ' \
+              'unavailable (unavailable)',
+          }
+        end
+
+        it 'rescues and returns the error' do
+          freeze_time do
+            stub_request(:get, request_uri).
+              with(headers: request_headers).
+              to_return(status: nil, body: encrypted_user_attributes, headers: {})
+
+            expect(service.execute).to eq expected_error
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -124,7 +124,8 @@ module IdvHelper
     client_id: sp_oidc_issuer,
     state: SecureRandom.hex,
     nonce: SecureRandom.hex,
-    verified_within: nil
+    verified_within: nil,
+    inherited_proofing_auth: Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE
   )
     @state = state
     @client_id = sp_oidc_issuer
@@ -139,7 +140,7 @@ module IdvHelper
       prompt: 'select_account',
       nonce: nonce,
       verified_within: verified_within,
-      inherited_proofing_auth: Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE,
+      inherited_proofing_auth: inherited_proofing_auth,
     )
   end
 

--- a/spec/support/features/inherited_proofing_with_service_provider_helper.rb
+++ b/spec/support/features/inherited_proofing_with_service_provider_helper.rb
@@ -1,0 +1,55 @@
+require_relative 'idv_step_helper'
+require_relative 'doc_auth_helper'
+
+module InheritedProofingWithServiceProviderHelper
+  include IdvStepHelper
+  include DocAuthHelper
+
+  # Simulates a user (in this case, a VA inherited proofing-authorized user)
+  # coming over to login.gov from a service provider, and hitting the
+  # OpenidConnect::AuthorizationController#index action.
+  def send_user_from_service_provider_to_login_gov_openid_connect(user, inherited_proofing_auth)
+    expect(user).to_not be_nil
+    # NOTE: VA user.
+    visit_idp_from_oidc_va_with_ial2 inherited_proofing_auth: inherited_proofing_auth
+  end
+
+  def complete_steps_up_to_inherited_proofing_get_started_step(user, expect_accessible: false)
+    unless current_path == idv_inherited_proofing_step_path(step: :get_started)
+      complete_idv_steps_before_phone_step(user)
+      click_link t('links.cancel')
+      click_button t('idv.cancel.actions.start_over')
+      expect(page).to have_current_path(idv_inherited_proofing_step_path(step: :get_started))
+    end
+    expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
+  end
+
+  def complete_steps_up_to_inherited_proofing_how_verifying_step(user, expect_accessible: false)
+    complete_steps_up_to_inherited_proofing_get_started_step user,
+                                                             expect_accessible: expect_accessible
+    unless current_path == idv_inherited_proofing_step_path(step: :agreement)
+      click_on t('inherited_proofing.buttons.continue')
+    end
+  end
+
+  def complete_steps_up_to_inherited_proofing_we_are_retrieving_step(user,
+                                                                     expect_accessible: false)
+    complete_steps_up_to_inherited_proofing_how_verifying_step(
+      user,
+      expect_accessible: expect_accessible,
+    )
+    unless current_path == idv_inherited_proofing_step_path(step: :verify_wait)
+      check t('inherited_proofing.instructions.consent', app_name: APP_NAME),
+            allow_label_click: true
+      click_on t('inherited_proofing.buttons.continue')
+    end
+  end
+
+  def complete_steps_up_to_inherited_proofing_verify_your_info_step(user,
+                                                                    expect_accessible: false)
+    complete_steps_up_to_inherited_proofing_we_are_retrieving_step(
+      user,
+      expect_accessible: expect_accessible,
+    )
+  end
+end


### PR DESCRIPTION
Display and implement a "Try again" button so that an Inherited Proofing user can attempt to retrieve their PII from their Service Provider a second time, if the first attempt fails.

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-7450

## 🛠 Summary of changes

- Add "Try again" button to the "We could not retrieve your information from..." UI. Allows user to try a second time to retrieve their user PII from their respective service provider. IP forces the user to acknowledge (checkbox) retrieval of their PII from the service provider in one step, and retrieves the PII in a subsequent ajax/async step. Subsequent retries _do not_ have to be acknowledged (checkbox).
- Implement error handling and bubbling up from service to form class for VA if errors are encountered during the request or errors encountered decrypting the payload returned from the service provider.
- Implement throttling for PII retrieval from the service provider to 2 tries, and a reattempt window of 1 minute.
- Implement automated tests.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [X] Automated testing.
- [X] Manual testing in the UI using Sinatra app.

## 👀 Screenshots

<details>
<summary>Before:</summary>
There are no before images.
</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/346917/201120368-62a1d3c5-a03f-4913-9827-35730d946c09.png)
![image](https://user-images.githubusercontent.com/346917/201120460-a9f2e9e1-7439-43ad-ac1b-a088745279f3.png)
</details>

## 🚀 Notes for Deployment

N/A
