### PR TITLE
LG-7947: Remove "top" position option for password toggle

### DIFF
--- a/app/assets/stylesheets/components/_password-toggle.scss
+++ b/app/assets/stylesheets/components/_password-toggle.scss
@@ -2,12 +2,7 @@ lg-password-toggle {
   display: block;
   position: relative;
 
-  &.password-toggle--toggle-top .password-toggle__toggle-label {
-    @include u-pin-right;
-    top: -24px;
-  }
-
-  &.password-toggle--toggle-bottom .validated-field__input-wrapper {
+  .validated-field__input-wrapper {
     margin-bottom: units(2);
   }
 }

--- a/app/assets/stylesheets/components/_password-toggle.scss
+++ b/app/assets/stylesheets/components/_password-toggle.scss
@@ -1,15 +1,9 @@
 lg-password-toggle {
   display: block;
-  position: relative;
 
   .validated-field__input-wrapper {
-    margin-bottom: units(2);
+    margin-bottom: units(0.5);
   }
-}
-
-.password-toggle__toggle-wrapper {
-  display: flex;
-  justify-content: end;
 }
 
 .password-toggle__toggle-label.usa-checkbox__label {

--- a/app/assets/stylesheets/components/_password-toggle.scss
+++ b/app/assets/stylesheets/components/_password-toggle.scss
@@ -2,10 +2,11 @@ lg-password-toggle {
   display: block;
 
   .validated-field__input-wrapper {
-    margin-bottom: units(0.5);
+    margin-bottom: 0;
   }
 }
 
 .password-toggle__toggle-label.usa-checkbox__label {
   @include u-margin-y(0);
+  @include u-padding-y(1);
 }

--- a/app/components/password_toggle_component.html.erb
+++ b/app/components/password_toggle_component.html.erb
@@ -1,9 +1,9 @@
-<%= content_tag(:'lg-password-toggle', class: css_class) do %>
+<%= content_tag(:'lg-password-toggle', **tag_options) do %>
   <%= render ValidatedFieldComponent.new(
         form: form,
         name: :password,
         type: :password,
-        label: label,
+        label: default_label,
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
           id: input_id,

--- a/app/components/password_toggle_component.html.erb
+++ b/app/components/password_toggle_component.html.erb
@@ -10,18 +10,16 @@
           class: ['password-toggle__input', *field_options.dig(:input_html, :class)],
         ),
       ) %>
-  <div class="password-toggle__toggle-wrapper js">
-    <input
-      id="<%= toggle_id %>"
-      type="checkbox"
-      class="usa-checkbox__input usa-checkbox__input--bordered password-toggle__toggle"
-      aria-controls="<%= input_id %>"
-    >
-    <label
-      for="<%= toggle_id %>"
-      class="usa-checkbox__label password-toggle__toggle-label"
-    >
-      <%= toggle_label %>
-    </label>
-  </div>
+  <input
+    id="<%= toggle_id %>"
+    type="checkbox"
+    class="usa-checkbox__input password-toggle__toggle"
+    aria-controls="<%= input_id %>"
+  >
+  <label
+    for="<%= toggle_id %>"
+    class="usa-checkbox__label password-toggle__toggle-label"
+  >
+    <%= toggle_label %>
+  </label>
 <% end %>

--- a/app/components/password_toggle_component.rb
+++ b/app/components/password_toggle_component.rb
@@ -1,25 +1,21 @@
 class PasswordToggleComponent < BaseComponent
-  attr_reader :form, :label, :toggle_label, :toggle_position, :field_options
+  attr_reader :form, :label, :toggle_label, :field_options, :tag_options
 
   def initialize(
     form:,
-    label: t('components.password_toggle.label'),
     toggle_label: t('components.password_toggle.toggle_label'),
-    toggle_position: :top,
-    **field_options
+    field_options: {},
+    **tag_options
   )
     @form = form
     @label = label
     @toggle_label = toggle_label
-    @toggle_position = toggle_position
     @field_options = field_options
+    @tag_options = tag_options
   end
 
-  def css_class
-    classes = []
-    classes << 'password-toggle--toggle-top' if toggle_position == :top
-    classes << 'password-toggle--toggle-bottom' if toggle_position == :bottom
-    classes
+  def default_label
+    t('components.password_toggle.label')
   end
 
   def toggle_id

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -14,8 +14,10 @@
   <%= f.full_error :reset_password_token %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        label: t('forms.passwords.edit.labels.password'),
-        required: true,
+        field_options: {
+          label: t('forms.passwords.edit.labels.password'),
+          required: true,
+        },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= f.submit t('forms.passwords.edit.buttons.submit'), class: 'margin-bottom-4' %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -20,7 +20,7 @@
         },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
-  <%= f.submit t('forms.passwords.edit.buttons.submit'), class: 'margin-bottom-4' %>
+  <%= f.submit t('forms.passwords.edit.buttons.submit'), class: 'display-block margin-y-5' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -35,8 +35,8 @@
       ) %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        required: true,
-        wrapper_html: { class: 'margin-top-6' },
+        class: 'margin-bottom-4',
+        field_options: { required: true },
       ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: @request_id } %>
   <div class='margin-bottom-4'>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,5 +1,5 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
-  <div class="margin-bottom-4">
+  <div class="margin-top-1 margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,5 +1,5 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
-  <div class="margin-top-1 margin-bottom-4">
+  <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,5 +1,5 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
-  <div class='margin-top-neg-3 margin-bottom-4'>
+  <div class="margin-top-1 margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>
       <div class='pw-bar'></div>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -12,8 +12,10 @@
                                   input_html: { value: @disavowal_token, name: :disavowal_token } %>
     <%= render PasswordToggleComponent.new(
           form: f,
-          label: t('forms.passwords.edit.labels.password'),
-          required: true,
+          field_options: {
+            label: t('forms.passwords.edit.labels.password'),
+            required: true,
+          },
         ) %>
     <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
     <%= f.submit t('forms.passwords.edit.buttons.submit'), class: 'margin-bottom-4' %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -32,7 +32,7 @@
           required: true,
         },
       ) %>
-  <div class="text-right margin-top-2 margin-bottom-4">
+  <div class="text-right margin-top-neg-3 margin-bottom-4">
     <%= link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1') %>
   </div>
   <%= render AccordionComponent.new do |c| %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -23,13 +23,14 @@
 <%= simple_form_for(
       current_user,
       url: idv_review_path,
-      html: { autocomplete: 'off', method: :put, class: 'margin-top-6' },
+      html: { autocomplete: 'off', method: :put, class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        label: t('idv.form.password'),
-        required: true,
-        wrapper_html: { class: 'margin-bottom-0' },
+        field_options: {
+          label: t('idv.form.password'),
+          required: true,
+        },
       ) %>
   <div class="text-right margin-top-2 margin-bottom-4">
     <%= link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1') %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -32,7 +32,7 @@
           required: true,
         },
       ) %>
-  <div class="text-right margin-top-neg-3 margin-bottom-4">
+  <div class="text-right margin-top-neg-4 margin-bottom-4">
     <%= link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1') %>
   </div>
   <%= render AccordionComponent.new do |c| %>

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -11,9 +11,9 @@
 <%= simple_form_for(
       current_user,
       url: reauthn_user_password_path,
-      html: { autocomplete: 'off', method: 'post', class: 'margin-top-6' },
+      html: { autocomplete: 'off', method: 'post', class: 'margin-top-4' },
     ) do |f| %>
-  <%= render PasswordToggleComponent.new(form: f, required: true) %>
+  <%= render PasswordToggleComponent.new(form: f, field_options: { required: true }) %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 <%= render 'shared/cancel', link: account_path %>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -7,12 +7,14 @@
       as: :user,
       url: capture_password_url,
       method: :post,
-      html: { autocomplete: 'off', class: 'margin-top-6' },
+      html: { autocomplete: 'off', class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        label: t('account.index.password'),
-        required: true,
+        field_options: {
+          label: t('account.index.password'),
+          required: true,
+        },
       ) %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -5,18 +5,19 @@ locals:
 
 <%# maxlength set and includes '-' delimiters to work around cleave bug %>
 <%= render PasswordToggleComponent.new(
-      name: :ssn,
       form: f,
-      as: :password,
-      label: t('idv.form.ssn_label_html'),
       toggle_label: t('forms.ssn.show'),
-      toggle_position: :bottom,
-      hint: t('forms.example') + ' 123-45-6789',
-      required: true,
-      pattern: '^\d{3}-?\d{2}-?\d{4}$',
-      maxlength: 11,
-      input_html: { aria: { invalid: false }, class: 'ssn-toggle usa-input', value: '' },
-      error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
+      field_options: {
+        name: :ssn,
+        as: :password,
+        label: t('idv.form.ssn_label_html'),
+        hint: t('forms.example') + ' 123-45-6789',
+        required: true,
+        pattern: '^\d{3}-?\d{2}-?\d{4}$',
+        maxlength: 11,
+        input_html: { aria: { invalid: false }, class: 'ssn-toggle usa-input', value: '' },
+        error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
+      },
     ) %>
 
 <%= javascript_packs_tag_once('ssn-field') %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -13,9 +13,11 @@
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        label: t('forms.password'),
-        required: true,
-        input_html: { aria: { describedby: 'password-description' } },
+        field_options: {
+          label: t('forms.password'),
+          required: true,
+          input_html: { aria: { describedby: 'password-description' } },
+        },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -22,7 +22,7 @@
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
-  <%= f.submit t('forms.buttons.continue'), class: 'margin-bottom-5' %>
+  <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -24,12 +24,14 @@
 
   <%= render PasswordToggleComponent.new(
         form: f,
-        name: :password,
-        label: t('idv.form.password'),
-        required: true,
+        field_options: {
+          name: :password,
+          label: t('idv.form.password'),
+          required: true,
+        },
       ) %>
 
-  <%= f.submit t('users.delete.actions.delete'), danger: true, class: 'margin-top-1 margin-bottom-2' %>
+  <%= f.submit t('users.delete.actions.delete'), danger: true, class: 'margin-top-5 margin-bottom-2' %>
 <% end %>
 
 <%= link_to(

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -21,7 +21,7 @@
         },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
-  <%= f.submit t('forms.buttons.submit.update'), class: 'margin-top-2 margin-bottom-4' %>
+  <%= f.submit t('forms.buttons.submit.update'), class: 'display-block margin-top-5 margin-bottom-4' %>
 <% end %>
 
 <%= render 'shared/password_accordion' %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -13,10 +13,12 @@
   <%= f.error_notification %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        name: :password,
-        label: t('forms.passwords.edit.labels.password'),
-        required: true,
-        input_html: { aria: { describedby: 'password-description' } },
+        field_options: {
+          name: :password,
+          label: t('forms.passwords.edit.labels.password'),
+          required: true,
+          input_html: { aria: { describedby: 'password-description' } },
+        },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= f.submit t('forms.buttons.submit.update'), class: 'margin-top-2 margin-bottom-4' %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -12,9 +12,11 @@
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,
-        name: :password,
-        label: t('idv.form.password'),
-        required: true,
+        field_options: {
+          name: :password,
+          label: t('idv.form.password'),
+          required: true,
+        },
       ) %>
   <%= f.submit t('forms.buttons.continue') %>
 <% end %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -18,7 +18,7 @@
           required: true,
         },
       ) %>
-  <%= f.submit t('forms.buttons.continue') %>
+  <%= f.submit t('forms.buttons.continue'), class: 'margin-top-5' %>
 <% end %>
 
 <div class='margin-top-6'>

--- a/spec/components/password_toggle_component_spec.rb
+++ b/spec/components/password_toggle_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PasswordToggleComponent, type: :component do
   subject(:rendered) { render_inline PasswordToggleComponent.new(form: form, **options) }
 
   it 'renders default markup' do
-    expect(rendered).to have_css('lg-password-toggle.password-toggle--toggle-top')
+    expect(rendered).to have_css('lg-password-toggle')
     expect(rendered).to have_field(t('components.password_toggle.label'), type: :password)
     expect(rendered).to have_field(t('components.password_toggle.toggle_label'), type: :checkbox)
   end
@@ -23,17 +23,6 @@ RSpec.describe PasswordToggleComponent, type: :component do
     expect(rendered).to have_css("[aria-controls='#{input_id}']")
   end
 
-  describe '#label' do
-    context 'with custom label' do
-      let(:label) { 'Custom Label' }
-      let(:options) { { label: label } }
-
-      it 'renders custom field label' do
-        expect(rendered).to have_field(label, type: :password)
-      end
-    end
-  end
-
   describe '#toggle_label' do
     context 'with custom label' do
       let(:toggle_label) { 'Custom Toggle Label' }
@@ -41,24 +30,6 @@ RSpec.describe PasswordToggleComponent, type: :component do
 
       it 'renders custom field label' do
         expect(rendered).to have_field(toggle_label, type: :checkbox)
-      end
-    end
-  end
-
-  describe '#toggle_position' do
-    context 'with top toggle position' do
-      let(:options) { { toggle_position: :top } }
-
-      it 'renders modifier class' do
-        expect(rendered).to have_css('lg-password-toggle.password-toggle--toggle-top')
-      end
-    end
-
-    context 'with bottom toggle position' do
-      let(:options) { { toggle_position: :bottom } }
-
-      it 'renders modifier class' do
-        expect(rendered).to have_css('lg-password-toggle.password-toggle--toggle-bottom')
       end
     end
   end
@@ -85,17 +56,25 @@ RSpec.describe PasswordToggleComponent, type: :component do
     end
   end
 
-  describe '#field' do
-    context 'with field options' do
-      let(:options) do
-        { input_html: { class: 'my-custom-field', data: { foo: 'bar' } }, required: true }
-      end
+  context 'with tag options' do
+    let(:options) do
+      { class: 'my-custom-field', data: { foo: 'bar' } }
+    end
 
-      it 'forwards field options' do
-        expect(rendered).to have_css(
-          '.password-toggle__input.my-custom-field[data-foo="bar"][required]',
-        )
-      end
+    it 'forwards options to rendered tag' do
+      expect(rendered).to have_css('lg-password-toggle.my-custom-field[data-foo="bar"]')
+    end
+  end
+
+  context 'with field options' do
+    let(:label) { 'Custom Label' }
+    let(:options) do
+      { field_options: { label: label, required: true } }
+    end
+
+    it 'forwards options to rendered field' do
+      expect(rendered).to have_css('.password-toggle__input[required]')
+      expect(rendered).to have_field(label, type: :password)
     end
   end
 end

--- a/spec/components/previews/password_toggle_component_preview.rb
+++ b/spec/components/previews/password_toggle_component_preview.rb
@@ -7,13 +7,12 @@ class PasswordToggleComponentPreview < BaseComponentPreview
 
   # @param label text
   # @param toggle_label text
-  # @param toggle_position select [~,top,bottom]
-  def workbench(label: nil, toggle_label: nil, toggle_position: 'top')
+  def workbench(label: nil, toggle_label: nil)
     render(
       PasswordToggleComponent.new(
         form: form_builder,
-        **{ label: label, toggle_label: toggle_label }.compact,
-        toggle_position: toggle_position.to_sym,
+        **{ toggle_label: toggle_label }.compact,
+        field_options: { label: label }.compact,
       ),
     )
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7947](https://cm-jira.usa.gov/browse/LG-7947)

## 🛠 Summary of changes

Revises all password toggles to display the toggle input _below_ the password field, in order to correct tab order behavior such that the visual placement and tab order of the toggle always occurs after the password field.

Related Slack discussions:

- https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1667415655701599
- https://gsa-tts.slack.com/archives/C01710KMYUB/p1667488908112899
- https://gsa-tts.slack.com/archives/C01710KMYUB/p1667496041397299

## 👀 Screenshots

Screen|Before|After
---|---|---
Sign in|![7947-sign-in-1](https://user-images.githubusercontent.com/1779930/199790292-4bc860c9-0bf9-464d-ac76-d73329e8d2a0.png)|![7947-sign-in-2](https://user-images.githubusercontent.com/1779930/200584705-afcbf512-e11c-4acb-afdd-1e30e9ddb06f.png)
Sign up password|![7947-sign-up-pw-1](https://user-images.githubusercontent.com/1779930/199790295-ac381f89-c087-42b8-b203-fffbf4dbd2e5.png)|![7947-sign-up-2](https://user-images.githubusercontent.com/1779930/200584709-670d45ae-aba5-4385-b66e-7e6d318a6657.png)
Edit password|![7947-edit-pw-1](https://user-images.githubusercontent.com/1779930/199790282-f4a9bdac-5c8e-4193-b70e-60485c30cabf.png)|![7947-edit-2](https://user-images.githubusercontent.com/1779930/200584697-61135fd3-1a3a-460d-b92b-1cb91d471c64.png)
Reauthn|![7947-reauthn-1](https://user-images.githubusercontent.com/1779930/199790289-95be6de0-6121-4173-bad7-eb5b6761811d.png)|![7947-reauthn-2](https://user-images.githubusercontent.com/1779930/200584702-80c3f6ec-88fe-4a1e-874f-f371b604fd9c.png)
Delete account|![7947-delete-1](https://user-images.githubusercontent.com/1779930/199790273-8837061e-f4c1-40fd-ae97-8a50e59a50fd.png)|![7947-delete-2](https://user-images.githubusercontent.com/1779930/200584691-12cb801e-3982-4d38-b44c-279f2830d93a.png)
IdV SSN|![7947-ssn-1](https://user-images.githubusercontent.com/1779930/200043941-8d605ac8-91dc-42a9-bd55-d4070fd77c03.png)|![7947-ssn-2](https://user-images.githubusercontent.com/1779930/200584711-84595d1a-96d0-4537-8e27-f0f08d3b45f2.png)
IdV password re-entry|![7947-verify-review-1](https://user-images.githubusercontent.com/1779930/199790297-1a9bdfef-182f-4cd4-9745-dd44c67bdd7b.png)|![7947-verify-2](https://user-images.githubusercontent.com/1779930/200584713-7cf123bb-a73e-4b03-8a38-04be8754193b.png)
IdV account reactivation|![7947-reactive-1](https://user-images.githubusercontent.com/1779930/199790288-123bacd4-aafc-4fb7-98f0-52ce8cc8633d.png)|![7947-reactivate-2](https://user-images.githubusercontent.com/1779930/200584700-07c1680d-eec9-4330-847a-147c4c45989b.png)