### PR TITLE
security_code -> one_time_code

### DIFF
--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.idv.enter_security_code') %>
+<% title t('titles.idv.enter_one_time_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.header_text')) %>
 

--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -13,7 +13,7 @@
             MarketingSite.messaging_practices_url,
             class: 'margin-top-2' %>
 
-<%= button_to t('forms.buttons.send_security_code'),
+<%= button_to t('forms.buttons.send_one_time_code'),
               login_two_factor_sms_opt_in_path(opt_out_uuid: @phone_number_opt_out),
               class: 'usa-button usa-button--wide usa-button--big',
               form_class: 'margin-y-5' %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -36,7 +36,7 @@
     <%= render 'users/shared/otp_make_default_number',
                form_obj: @new_phone_form %>
   <% end %>
-  <%= f.submit t('forms.buttons.send_security_code') %>
+  <%= f.submit t('forms.buttons.send_one_time_code') %>
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -42,7 +42,7 @@ en:
       edit: Edit
       manage: Manage
       resend_confirmation: Resend confirmation instructions
-      send_security_code: Send code
+      send_one_time_code: Send code
       submit:
         confirm_change: Confirm change
         default: Submit

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -47,7 +47,7 @@ es:
       edit: Editar
       manage: Administrar
       resend_confirmation: Reenviar instrucciones de confirmación
-      send_security_code: Enviar código
+      send_one_time_code: Enviar código
       submit:
         confirm_change: Confirmar cambio
         default: Enviar

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -48,7 +48,7 @@ fr:
       edit: Modifier
       manage: Administrer
       resend_confirmation: Envoyer les instructions de confirmation de nouveau
-      send_security_code: Envoyer le code
+      send_one_time_code: Envoyer le code
       submit:
         confirm_change: Confirmer le changement
         default: Soumettre

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -33,7 +33,7 @@ en:
       cancellation_prompt: Cancel identity verification
       cancelled: Identity verification is cancelled
       come_back_soon: Come back soon
-      enter_security_code: Enter your one-time code
+      enter_one_time_code: Enter your one-time code
       get_letter: Get a letter
       personal_key: Save your personal key
       phone: Verify your phone number

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -33,7 +33,7 @@ es:
       cancellation_prompt: Cancela la verificación de identidad
       cancelled: Se canceló la verificación de identidad
       come_back_soon: Vuelve pronto
-      enter_security_code: Introduzca su código único
+      enter_one_time_code: Introduzca su código único
       get_letter: Recibe una carta
       personal_key: Guarda tu llave personal
       phone: Verifica tu número telefónico

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -33,7 +33,7 @@ fr:
       cancellation_prompt: Annulez la vérification d’identité
       cancelled: La vérification d’identité est annulée
       come_back_soon: Revenez bientôt
-      enter_security_code: Entrez votre code à usage unique
+      enter_one_time_code: Entrez votre code à usage unique
       get_letter: Obtenez une lettre
       personal_key: Enregistrez votre clé personnelle
       phone: Vérifiez votre numéro de téléphone

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -14,7 +14,7 @@ describe 'phone otp confirmation' do
       select_2fa_option(:phone)
       fill_in :new_phone_form_phone, with: phone
       select_phone_delivery_option(delivery_method)
-      click_send_security_code
+      click_send_one_time_code
     end
 
     def expect_successful_otp_confirmation(delivery_method)

--- a/spec/features/phone/rate_limitting_spec.rb
+++ b/spec/features/phone/rate_limitting_spec.rb
@@ -13,7 +13,7 @@ describe 'phone rate limitting' do
       select_2fa_option(:phone)
       select_phone_delivery_option(delivery_method)
       fill_in :new_phone_form_phone, with: phone
-      click_send_security_code
+      click_send_one_time_code
     end
   end
 

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -30,7 +30,7 @@ feature 'Remembering a phone' do
 
       select_2fa_option('phone')
       fill_in :new_phone_form_phone, with: '2025551212'
-      click_send_security_code
+      click_send_one_time_code
       check t('forms.messages.remember_device')
       fill_in_code_with_last_phone_otp
       click_submit_default

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -102,7 +102,7 @@ feature 'remember device sp expiration' do
 
     select_2fa_option('phone')
     fill_in :new_phone_form_phone, with: '2025551212'
-    click_send_security_code
+    click_send_one_time_code
     check t('forms.messages.remember_device')
     fill_in_code_with_last_phone_otp
     click_submit_default

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -62,7 +62,7 @@ describe 'Unchecking remember device' do
 
         select_2fa_option('phone')
         fill_in 'new_phone_form[phone]', with: '202-555-1212'
-        click_send_security_code
+        click_send_one_time_code
         fill_in_code_with_last_phone_otp
 
         uncheck 'remember_device'

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -83,7 +83,7 @@ feature 'saml api' do
       it 'prompts the user to confirm phone after setting up 2FA' do
         select_2fa_option('phone')
         fill_in 'new_phone_form_phone', with: '202-555-1212'
-        click_send_security_code
+        click_send_one_time_code
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -23,7 +23,7 @@ feature 'Multi Two Factor Authentication' do
       expect(current_path).to eq phone_setup_path
 
       fill_in 'new_phone_form_phone', with: '703-555-1212'
-      click_send_security_code
+      click_send_one_time_code
 
       fill_in_code_with_last_phone_otp
       click_submit_default
@@ -56,7 +56,7 @@ feature 'Multi Two Factor Authentication' do
       expect(current_path).to eq phone_setup_path
 
       fill_in 'new_phone_form_phone', with: '703-555-1212'
-      click_send_security_code
+      click_send_one_time_code
 
       fill_in_code_with_last_phone_otp
       click_submit_default

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -16,7 +16,7 @@ feature 'Two Factor Authentication' do
       expect(page).
         to have_content t('titles.phone_setup')
 
-      send_security_code_without_entering_phone_number
+      send_one_time_code_without_entering_phone_number
 
       expect(current_path).to eq phone_setup_path
 
@@ -45,7 +45,7 @@ feature 'Two Factor Authentication' do
         select_phone_delivery_option(:voice)
         select 'Bahamas', from: 'new_phone_form_international_code'
         fill_in 'new_phone_form_phone', with: unsupported_phone
-        click_send_security_code
+        click_send_one_time_code
 
         expect(current_path).to eq phone_setup_path
         expect(page).to have_content t(
@@ -66,7 +66,7 @@ feature 'Two Factor Authentication' do
 
         expect(page).to have_css('.phone-input__example', text: '(201) 555-0123')
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.phone_required'))
 
@@ -76,32 +76,32 @@ feature 'Two Factor Authentication' do
 
         fill_in 'new_phone_form_phone', with: '+81 54 354 364'
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.invalid_phone_number'))
 
         fill_in 'new_phone_form_phone', with: ''
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.phone_required'))
 
         fill_in 'new_phone_form_phone', with: '+212 5376'
         expect(page).to have_css('.phone-input__example', text: '0650-123456')
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.invalid_phone_number'))
         expect(page.find('#new_phone_form_international_code', visible: false).value).to eq 'MA'
 
         fill_in 'new_phone_form_phone', with: ''
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.phone_required'))
         fill_in 'new_phone_form_phone', with: '+81 54354'
 
-        click_send_security_code
+        click_send_one_time_code
         expect(page.find(':focus')).to match_css('.phone-input__number')
         expect(page).to have_content(t('errors.messages.invalid_phone_number'))
 
@@ -211,23 +211,23 @@ feature 'Two Factor Authentication' do
     visit account_path
   end
 
-  def send_security_code_without_entering_phone_number
-    click_send_security_code
+  def send_one_time_code_without_entering_phone_number
+    click_send_one_time_code
   end
 
   def submit_2fa_setup_form_with_empty_string_phone
     fill_in 'new_phone_form_phone', with: ''
-    click_send_security_code
+    click_send_one_time_code
   end
 
   def submit_2fa_setup_form_with_invalid_phone
     fill_in 'new_phone_form_phone', with: 'five one zero five five five four three two one'
-    click_send_security_code
+    click_send_one_time_code
   end
 
   def submit_2fa_setup_form_with_valid_phone
     fill_in 'new_phone_form_phone', with: '703-555-1212'
-    click_send_security_code
+    click_send_one_time_code
   end
 
   describe 'When the user has already set up 2FA' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -147,7 +147,7 @@ feature 'Sign in' do
 
     select_2fa_option('phone')
     fill_in :new_phone_form_phone, with: '2025551314'
-    click_send_security_code
+    click_send_one_time_code
     fill_in_code_with_last_phone_otp
     click_submit_default
     click_agree_and_continue

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -102,7 +102,7 @@ feature 'Sign Up' do
     expect(page).to_not have_content t('two_factor_authentication.otp_make_default_number.title')
 
     fill_in 'new_phone_form_phone', with: '225-555-1000'
-    click_send_security_code
+    click_send_one_time_code
 
     expect(current_path).to eq(phone_setup_path)
     expect(page).to have_content(I18n.t('telephony.error.friendly_message.generic'))
@@ -117,7 +117,7 @@ feature 'Sign Up' do
       (IdentityConfig.store.phone_confirmation_max_attempts + 1).times do
         visit phone_setup_path
         fill_in 'new_phone_form_phone', with: '2025551313'
-        click_send_security_code
+        click_send_one_time_code
       end
 
       timeout = distance_of_time_in_words(
@@ -336,7 +336,7 @@ feature 'Sign Up' do
     sign_up_and_set_password
     select_2fa_option('phone')
     fill_in :new_phone_form_phone, with: '2025551313'
-    click_send_security_code
+    click_send_one_time_code
     expect(page).to_not have_checked_field t('forms.messages.remember_device')
   end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -242,7 +242,7 @@ module Features
     end
 
     def click_send_security_code
-      click_button t('forms.buttons.send_security_code')
+      click_button t('forms.buttons.send_one_time_code')
     end
 
     def sign_in_live_with_2fa(user = user_with_2fa)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -37,7 +37,7 @@ module Features
       user = sign_up_and_set_password
       select_2fa_option('phone')
       fill_in 'new_phone_form_phone', with: '202-555-1212'
-      click_send_security_code
+      click_send_one_time_code
       uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
@@ -241,7 +241,7 @@ module Features
       )
     end
 
-    def click_send_security_code
+    def click_send_one_time_code
       click_button t('forms.buttons.send_one_time_code')
     end
 
@@ -501,14 +501,14 @@ module Features
     def set_up_2fa_with_valid_phone
       select_2fa_option('phone')
       fill_in 'new_phone_form[phone]', with: '202-555-1212'
-      click_send_security_code
+      click_send_one_time_code
       fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
     def set_up_mfa_with_valid_phone
       fill_in 'new_phone_form[phone]', with: '202-555-1212'
-      click_send_security_code
+      click_send_one_time_code
       fill_in_code_with_last_phone_otp
       click_submit_default
     end

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -22,7 +22,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
     sign_up_and_set_password
     select_2fa_option(:phone)
     fill_in :new_phone_form_phone, with: phone
-    click_send_security_code
+    click_send_one_time_code
 
     expect(page).to have_content(t('two_factor_authentication.max_otp_requests_reached'))
 


### PR DESCRIPTION
Update translation keys that include `security_code` in their name to now say `one_time_code` to be more consistent with new wording. This was a change identified on #7276 that I didn't get in before hitting the big Merge button.

[skip changelog]
