### PR TITLE
Update ARIA labels / described by on IDV doc auth FileInput component

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -200,9 +200,6 @@ function FileInput(props, ref) {
    * @return {{'aria-label': string} | {'aria-labelledby': string}}
    */
   function getAriaLabelPropsFromValue(fileLabel, fileValue) {
-    // aria-label={getLabelFromValue(label, value)}
-    // aria-labelledby={`${labelId} ${innerHintId}`}
-
     if (fileValue instanceof window.File) {
       return {
         'aria-label': `${fileLabel} - ${fileValue.name}`,

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -159,6 +159,7 @@ function FileInput(props, ref) {
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
   const innerHintId = `${hintId}-inner`;
+  const labelId = `${inputId}-label`;
 
   /**
    * In response to a file input change event, confirms that the file is valid before calling
@@ -194,17 +195,32 @@ function FileInput(props, ref) {
   }
 
   /**
-   * @param {string} fileLabel String velue of the label for input to display
+   * @param {string} fileLabel String value of the label for input to display
    * @param {Blob|string|null|undefined} fileValue File or string for which to generate label.
+   * @return {{'aria-label': string} | {'aria-labelledby': string}}
    */
-  function getLabelFromValue(fileLabel, fileValue) {
+  function getAriaLabelPropsFromValue(fileLabel, fileValue) {
+    // aria-label={getLabelFromValue(label, value)}
+    // aria-labelledby={`${labelId} ${innerHintId}`}
+
     if (fileValue instanceof window.File) {
-      return `${fileLabel} - ${fileValue.name}`;
+      return {
+        'aria-label': `${fileLabel} - ${fileValue.name}`,
+      };
     }
+
     if (fileValue) {
-      return `${fileLabel} - ${t('doc_auth.forms.captured_image')}`;
+      return {
+        'aria-label': `${fileLabel} - ${t('doc_auth.forms.captured_image')}`,
+      };
     }
-    return '';
+
+    // When no file is selected, provide a slightly more verbose label
+    // including the actual <label> contents and the prompt to drag a file or
+    // choose from a folder.
+    return {
+      'aria-labelledby': `${labelId} ${innerHintId}`,
+    };
   }
 
   const shownErrorMessage = errorMessage ?? ownErrorMessage;
@@ -241,6 +257,7 @@ function FileInput(props, ref) {
        */}
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label
+        id={labelId}
         htmlFor={inputId}
         className={['usa-label', shownErrorMessage && 'usa-label--error'].filter(Boolean).join(' ')}
       >
@@ -320,13 +337,13 @@ function FileInput(props, ref) {
             id={inputId}
             className="usa-file-input__input"
             type="file"
-            aria-label={getLabelFromValue(label, value)}
+            {...getAriaLabelPropsFromValue(label, value)}
             aria-busy={isValuePending}
             onChange={onChangeIfValid}
             onClick={onClick}
             onDrop={onDrop}
             accept={accept ? accept.join() : undefined}
-            aria-describedby={hint ? `${innerHintId} ${hintId}` : undefined}
+            aria-describedby={hint ? hintId : undefined}
           />
         </div>
       </div>

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -139,12 +139,8 @@ describe('document-capture/components/file-input', () => {
   it('renders an optional hint', () => {
     const { getByLabelText } = render(<FileInput label="File" hint="Must be small" />);
 
-    /**
-     * The second id in the `aria-descrbedby` value will specify the original
-     * hint.
-     */
     const input = getByLabelText('File');
-    const hintId = input.getAttribute('aria-describedby').split(' ')[1];
+    const hintId = input.getAttribute('aria-describedby');
     const hint = document.getElementById(hintId).textContent;
 
     expect(hint).to.equal('Must be small');
@@ -237,10 +233,10 @@ describe('document-capture/components/file-input', () => {
     expect(onChange.getCall(0).args[0]).to.equal(file);
   });
 
-  it('has a blank aria-label with no input added', () => {
+  it('has an appropriate 2-part aria-label with no input added', () => {
     const { getByLabelText } = render(<FileInput label="File" />);
 
-    const queryByAriaLabel = getByLabelText('');
+    const queryByAriaLabel = getByLabelText('File doc_auth.forms.choose_file_html');
 
     expect(queryByAriaLabel).to.exist();
   });


### PR DESCRIPTION
## 🎫 Ticket

[LG-7770](https://cm-jira.usa.gov/browse/LG-7770)

## 🛠 Summary of changes

Testing identified that users wanted more detail in the ARIA label attached to the `FileInput` component in the IDV doc auth upload step. The request here was that the label include not only the field name ("Front of ID"  / "Back of ID"), but the next step as well ("drag file here or choose from folder").

### How it used to be

Previously, there were two separate hints attached via the [`aria-describedby` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby): "Drag file here..." and "Must be a JPG or PNG". 

Some screen readers (tested in JAWS) would not read this `aria-describedby` content initially without the user triggering it in some way, leading to a confusing experience where the user would focus the control and just hear "Front of ID, button".

### What I changed

This change reworks the component to use `aria-labelledby` to refer to the field name and next step elements, while leaving the "Must be a JPG or PNG" in `aria-describedby`.

The result is the user hearing e.g. "Front of ID - drag file here or choose from folder" on focus, followed by "Must be a JPG or PNG" .

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Visit the document upload page of the IDV workflow
- [ ] Turn on your screen reader
- [ ] Tab between the "Front of ID" and "Back of ID" fields and listen to the screen reader

## 👀 Screenshots

Videos of the new functionality are in [this Slack thread](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1667492156496539).

## 🚀 Notes for Deployment

N/A

