### PR TITLE
Use a connection pool for talking to KMS

### DIFF
--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -1,15 +1,21 @@
 require 'json'
 module Encryption
   class MultiRegionKmsClient
-    def initialize
-      @aws_clients = {}
-      # Instantiate an array of aws clients based on the provided regions in the environment
-      IdentityConfig.store.aws_kms_regions.each do |region|
-        @aws_clients[region] = Aws::KMS::Client.new(
+    # Lazily-loaded per-region client factory
+    KMS_REGION_CLIENT_POOL = Hash.new do |h, region|
+      h[region] = ConnectionPool.new(size: IdentityConfig.store.aws_kms_client_multi_pool_size) do
+        Aws::KMS::Client.new(
           instance_profile_credentials_timeout: 1, # defaults to 1 second
           instance_profile_credentials_retries: 5, # defaults to 0 retries
           region: region, # The region in which the client is being instantiated
         )
+      end
+    end
+
+    def initialize
+      @aws_client_pools = {}
+      IdentityConfig.store.aws_kms_regions.each do |region|
+        @aws_client_pools[region] = KMS_REGION_CLIENT_POOL[region]
       end
     end
 
@@ -25,49 +31,57 @@ module Encryption
 
     def decrypt(ciphertext, encryption_context)
       cipher_data = resolve_decryption(ciphertext)
-      cipher_data.region_client.decrypt(
-        ciphertext_blob: cipher_data.resolved_ciphertext,
-        encryption_context: encryption_context,
-      ).plaintext
+      cipher_data.region_client_pool.with do |region_client|
+        region_client.decrypt(
+          ciphertext_blob: cipher_data.resolved_ciphertext,
+          encryption_context: encryption_context,
+        ).plaintext
+      end
     end
 
     private
 
     def encrypt_multi(key_id, plaintext, encryption_context)
       region_ciphers = {}
-      @aws_clients.each do |region, kms_client|
-        raw_region_ciphertext = kms_client.encrypt(
-          key_id: key_id,
-          plaintext: plaintext,
-          encryption_context: encryption_context,
-        )
+      @aws_client_pools.each do |region, kms_client_pool|
+        raw_region_ciphertext = kms_client_pool.with do |kms_client|
+          kms_client.encrypt(
+            key_id: key_id,
+            plaintext: plaintext,
+            encryption_context: encryption_context,
+          )
+        end
         region_ciphers[region] = Base64.strict_encode64(raw_region_ciphertext.ciphertext_blob)
       end
       { regions: region_ciphers }.to_json
     end
 
     def encrypt_legacy(key_id, plaintext, encryption_context)
-      region_client = @aws_clients[IdentityConfig.store.aws_region]
-      unless region_client
+      region_client_pool = @aws_client_pools[IdentityConfig.store.aws_region]
+      unless region_client_pool
         raise EncryptionError, 'Current region not found in clients for legacy encryption'
       end
-      region_client.encrypt(
-        key_id: key_id,
-        plaintext: plaintext,
-        encryption_context: encryption_context,
-      ).ciphertext_blob
+      region_client_pool.with do |region_client|
+        region_client.encrypt(
+          key_id: key_id,
+          plaintext: plaintext,
+          encryption_context: encryption_context,
+        ).ciphertext_blob
+      end
     end
 
     CipherData = RedactedStruct.new(
-      :region_client,
+      :region_client_pool,
       :resolved_ciphertext,
-      allowed_members: [:region_client],
+      allowed_members: [:region_client_pool],
     )
 
     def find_available_region(regions)
       regions.each do |region, cipher|
-        region_client = @aws_clients[region]
-        return CipherData.new(region_client, Base64.strict_decode64(cipher)) if region_client
+        region_client_pool = @aws_client_pools[region]
+        if region_client_pool
+          return CipherData.new(region_client_pool, Base64.strict_decode64(cipher))
+        end
       end
       raise EncryptionError, 'No supported region found in ciphertext'
     end
@@ -75,10 +89,10 @@ module Encryption
     def resolve_region_decryption(regions)
       # For each region that the ciphertext has a cipher for, check to see if that region is
       # represented in the clients available. Check default region before checking others
-      curr_region_client = @aws_clients[IdentityConfig.store.aws_region]
+      curr_region_client_pool = @aws_client_pools[IdentityConfig.store.aws_region]
       curr_region_cipher = regions[IdentityConfig.store.aws_region]
-      if curr_region_cipher && curr_region_client
-        CipherData.new(curr_region_client, Base64.strict_decode64(curr_region_cipher))
+      if curr_region_cipher && curr_region_client_pool
+        CipherData.new(curr_region_client_pool, Base64.strict_decode64(curr_region_cipher))
       else
         find_available_region(regions)
       end
@@ -87,9 +101,9 @@ module Encryption
     def resolve_legacy_decryption(ciphertext)
       # Decode the raw ciphertext
       curr_region = IdentityConfig.store.aws_region
-      region_client = @aws_clients[curr_region]
+      region_client_pool = @aws_client_pools[curr_region]
       resolved_ciphertext = ciphertext
-      return CipherData.new(region_client, resolved_ciphertext) if region_client
+      return CipherData.new(region_client_pool, resolved_ciphertext) if region_client_pool
       raise EncryptionError, "No client found for region #{curr_region}"
     end
 

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -14,6 +14,7 @@ module Encryption
 
     def initialize
       @aws_client_pools = {}
+      # Eager-loaded per-region clients based on current region configs
       IdentityConfig.store.aws_kms_regions.each do |region|
         @aws_client_pools[region] = KMS_REGION_CLIENT_POOL[region]
       end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -51,6 +51,8 @@ aws_http_timeout: 5
 aws_http_retry_limit: 2
 aws_http_retry_max_delay: 1
 aws_kms_key_id: alias/login-dot-gov-test-keymaker
+aws_kms_client_contextless_pool_size: 5
+aws_kms_client_multi_pool_size: 5
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 aws_kms_multi_region_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -114,6 +114,8 @@ class IdentityConfig
     config.add(:aws_kms_key_id, type: :string)
     config.add(:aws_kms_multi_region_enabled, type: :boolean)
     config.add(:aws_kms_regions, type: :json)
+    config.add(:aws_kms_client_contextless_pool_size, type: :integer)
+    config.add(:aws_kms_client_multi_pool_size, type: :integer)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -5,6 +5,13 @@ describe Encryption::ContextlessKmsClient do
   let(:local_plaintext) { 'local plaintext' }
   let(:local_ciphertext) { 'local ciphertext' }
 
+  before do
+    stub_const(
+      'Encryption::ContextlessKmsClient::KMS_CLIENT_POOL',
+      AwsKmsClientHelper::FakeConnectionPool.new,
+    )
+  end
+
   context 'with kms plaintext less than 4k' do
     let(:kms_plaintext) { 'kms plaintext' }
     let(:kms_ciphertext) { 'kms ciphertext' }

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -8,7 +8,7 @@ describe Encryption::ContextlessKmsClient do
   before do
     stub_const(
       'Encryption::ContextlessKmsClient::KMS_CLIENT_POOL',
-      AwsKmsClientHelper::FakeConnectionPool.new,
+      AwsKmsClientHelper::FakeConnectionPool.new { Aws::KMS::Client.new },
     )
   end
 

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -7,6 +7,13 @@ describe Encryption::MultiRegionKmsClient do
   let(:aws_region) { 'us-north-1' }
 
   before do
+    stub_const(
+      'Encryption::MultiRegionKmsClient::KMS_REGION_CLIENT_POOL',
+      Hash.new do |h, region|
+        h[region] = AwsKmsClientHelper::FakeConnectionPool.new(region: region)
+      end,
+    )
+
     allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
     allow(FeatureManagement).to receive(:kms_multi_region_enabled?).
       and_return(kms_multi_region_enabled)

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -10,7 +10,9 @@ describe Encryption::MultiRegionKmsClient do
     stub_const(
       'Encryption::MultiRegionKmsClient::KMS_REGION_CLIENT_POOL',
       Hash.new do |h, region|
-        h[region] = AwsKmsClientHelper::FakeConnectionPool.new(region: region)
+        h[region] = AwsKmsClientHelper::FakeConnectionPool.new do
+          Aws::KMS::Client.new(region: region)
+        end
       end,
     )
 

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -1,4 +1,16 @@
 module AwsKmsClientHelper
+  # The real ConnectionPools persist clients across specs which
+  # makes stubbing via the Aws.config unreliable
+  class FakeConnectionPool
+    def initialize(**options)
+      @options = options
+    end
+
+    def with
+      yield Aws::KMS::Client.new(**@options)
+    end
+  end
+
   def stub_aws_kms_client(random_key = random_str, ciphered_key = random_str)
     aws_key_id = IdentityConfig.store.aws_kms_key_id
     Aws.config[:kms] = {

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -2,12 +2,12 @@ module AwsKmsClientHelper
   # The real ConnectionPools persist clients across specs which
   # makes stubbing via the Aws.config unreliable
   class FakeConnectionPool
-    def initialize(**options)
-      @options = options
+    def initialize(&block)
+      @block = block
     end
 
     def with
-      yield Aws::KMS::Client.new(**@options)
+      yield @block.call
     end
   end
 


### PR DESCRIPTION
Hypothesis: creating new clients as often as we does makes too many IAM metadata requests, so this cuts down on that


