### PR TITLE
LG-7918: Use Rails.cache for USPS IPPaaS auth tokens

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -106,8 +106,15 @@ module UspsInPersonProofing
     # it expires (15 minutes).
     # @return [String] Auth token
     def retrieve_token!
-      token, expires_in = request_token.fetch_values('access_token', 'expires_in')
-      Rails.cache.write(API_TOKEN_CACHE_KEY, token, expires_at: Time.zone.now + expires_in)
+      token, expires_in, token_type = request_token.fetch_values(
+        'access_token',
+        'expires_in',
+        'token_type',
+      )
+      Rails.cache.write(
+        API_TOKEN_CACHE_KEY, "#{token_type} #{token}",
+        expires_at: Time.zone.now + expires_in
+      )
       token
     end
 
@@ -147,7 +154,6 @@ module UspsInPersonProofing
     #
     # Returns the same value returned by that block of code.
     def dynamic_headers
-      # todo: are we sending the token correctly? I'm surprised it isn't Bearer: token
       {
         'Authorization' => token,
         'RequestID' => request_id,

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -111,11 +111,12 @@ module UspsInPersonProofing
         'expires_in',
         'token_type',
       )
+      authz = "#{token_type} #{token}"
       Rails.cache.write(
-        API_TOKEN_CACHE_KEY, "#{token_type} #{token}",
+        API_TOKEN_CACHE_KEY, authz,
         expires_at: Time.zone.now + expires_in
       )
-      token
+      authz
     end
 
     # Checks the cache for an unexpired token and returns it. If the cache has expired, retrieves

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -81,11 +81,12 @@ RSpec.describe ArcgisApi::Geocoder do
   end
 
   describe '#retrieve_token!' do
-    it 'sets token and token_expires_at' do
+    it 'caches the token' do
       stub_generate_token_response
-      subject.retrieve_token!
+      token = subject.retrieve_token!
 
-      expect(subject.token).to be_present
+      expect(subject).not_to receive(:request_token)
+      expect(subject.token).to eq(token)
     end
 
     it 'calls the endpoint with the expected params' do

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -122,10 +122,6 @@ RSpec.describe ArcgisApi::Geocoder do
     end
 
     it 'implicitly refreshes the token when expired' do
-      root_url = 'http://my.root.url'
-      allow(IdentityConfig.store).to receive(:arcgis_api_root_url).
-        and_return(root_url)
-
       stub_generate_token_response(expires_at: 1.hour.from_now.to_i, token: 'token1')
       stub_request_suggestions
       subject.suggest('100 Main')

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe UspsInPersonProofing::Proofer do
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
       ).
-        with(headers: { 'Authorization' => 'token1' }).once
+        with(headers: { 'Authorization' => 'Bearer token1' }).once
       expect(WebMock).to have_requested(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
       ).
-        with(headers: { 'Authorization' => 'token2' }).once
+        with(headers: { 'Authorization' => 'Bearer token2' }).once
     end
 
     it 'reuses the cached token across instances' do
@@ -115,7 +115,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
       ).
-        with(headers: { 'Authorization' => 'token1' }).twice
+        with(headers: { 'Authorization' => 'Bearer token1' }).twice
     end
   end
 

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -106,11 +106,12 @@ RSpec.describe UspsInPersonProofing::Proofer do
       stub_request_enroll
       stub_request_enroll
 
-      client2 = UspsInPersonProofing::Proofer.new
+      other_instance = UspsInPersonProofing::Proofer.new
 
       subject.request_enroll(applicant)
-      client2.request_enroll(applicant)
+      other_instance.request_enroll(applicant)
 
+      expect(WebMock).to have_requested(:post, %r{/oauth/authenticate}).once
       expect(WebMock).to have_requested(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -74,13 +74,10 @@ RSpec.describe UspsInPersonProofing::Proofer do
       subject.request_enroll(applicant)
       subject.request_enroll(applicant)
       subject.request_enroll(applicant)
+      expect(WebMock).to have_requested(:post, %r{/oauth/authenticate}).once
     end
 
     it 'implicitly refreshes the token when expired' do
-      root_url = 'http://my.root.url'
-      allow(IdentityConfig.store).to receive(:usps_ipp_root_url).
-        and_return(root_url)
-
       stub_request_token(expires_in: 1.hour.to_i, access_token: 'token1')
       stub_request_enroll
       subject.request_enroll(applicant)

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -1,8 +1,13 @@
 module UspsIppHelper
-  def stub_request_token
+  def stub_request_token(access_token: nil, expires_in: nil)
+    # Overwrite fixture values if values are specified
+    defaults = JSON.parse(UspsInPersonProofing::Mock::Fixtures.request_token_response)
+    body = defaults.merge(
+      { access_token: access_token, expires_in: expires_in }.compact,
+    )
     stub_request(:post, %r{/oauth/authenticate}).to_return(
       status: 200,
-      body: UspsInPersonProofing::Mock::Fixtures.request_token_response,
+      body: body.to_json,
       headers: { 'content-type' => 'application/json' },
     )
   end


### PR DESCRIPTION
## ⚠️  Do not merge

Matt Gardner says that the caching of auth tokens wasn't working as expected for the ArcGIS Geocoder class so I want to dig into that before this PR gets merged.

## 🎫 Ticket

[LG-7918](https://cm-jira.usa.gov/browse/LG-7918)

## 🛠 Summary of changes

* Updates the UspsInPersonProofing::Proofer class to cache authorization tokens to the Rails cache so that they can be re-used across different instances of our IDP web servers.

## 📜 Testing Plan

- [ ] Test IPP flow in dev environment
- [ ] Use a Rails console in the dev environment to ensure that tokens are being requested and cache appropriately, and are being refreshed when the cache expires