### PR TITLE
Drop large user_id, last_sign_in_at DESC index on email_addresses

### DIFF
--- a/db/primary_migrate/20221104210336_drop_email_addresses_user_id_last_sign_in_at_desc_index.rb
+++ b/db/primary_migrate/20221104210336_drop_email_addresses_user_id_last_sign_in_at_desc_index.rb
@@ -1,0 +1,5 @@
+class DropEmailAddressesUserIdLastSignInAtDescIndex < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :email_addresses, name: "index_email_addresses_on_user_id_and_last_sign_in_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_204944) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_210336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -210,7 +210,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_04_204944) do
     t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token", unique: true
     t.index ["email_fingerprint", "user_id"], name: "index_email_addresses_on_email_fingerprint_and_user_id", unique: true
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
-    t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }
     t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

This is the follow-up PR to #7298 that drops the large and write-heavy index on `email_addresses`.

This PR should not be merged until #7298 is deployed. It is in theory safe to deploy both changes together since the second migration won't run if the first one fails, but this is erring on the side of caution.