### PR TITLE
Additional OTP language updates

### DIFF
--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -45,7 +45,7 @@
       outline: true,
       icon: :loop,
       class: 'margin-bottom-4',
-    ).with_content(t('links.two_factor_authentication.get_another_code')) %>
+    ).with_content(t('links.two_factor_authentication.send_another_code')) %>
 
 <p>
   <%= t('instructions.mfa.wrong_number') %><br>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -51,7 +51,7 @@
         outline: true,
         icon: :loop,
         class: 'margin-bottom-neg-1',
-      ).with_content(t('links.two_factor_authentication.get_another_code')) %>
+      ).with_content(t('links.two_factor_authentication.send_another_code')) %>
 <% end %>
 
 <% if @presenter.unconfirmed_phone? %>

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -23,5 +23,5 @@ en:
     reverify: Please verify your identity again.
     sign_out: Sign out
     two_factor_authentication:
-      get_another_code: Get another code
+      get_another_code: Send another code
     what_is_totp: What is an authentication app?

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -23,5 +23,5 @@ en:
     reverify: Please verify your identity again.
     sign_out: Sign out
     two_factor_authentication:
-      get_another_code: Send another code
+      send_another_code: Send another code
     what_is_totp: What is an authentication app?

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -23,5 +23,5 @@ es:
     reverify: Verifique su identidad nuevamente.
     sign_out: Cerrar sesión
     two_factor_authentication:
-      get_another_code: Obtener otro código
+      get_another_code: Enviar otro código
     what_is_totp: '¿Qué es una app de autenticación?'

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -23,5 +23,5 @@ es:
     reverify: Verifique su identidad nuevamente.
     sign_out: Cerrar sesión
     two_factor_authentication:
-      get_another_code: Enviar otro código
+      send_another_code: Enviar otro código
     what_is_totp: '¿Qué es una app de autenticación?'

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -23,5 +23,5 @@ fr:
     reverify: Veuillez vérifier votre identité de nouveau.
     sign_out: Déconnexion
     two_factor_authentication:
-      get_another_code: Obtenir un autre code
+      get_another_code: Envoyer un autre code
     what_is_totp: Qu’est-ce qu’une application d’authentification?

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -23,5 +23,5 @@ fr:
     reverify: Veuillez vérifier votre identité de nouveau.
     sign_out: Déconnexion
     two_factor_authentication:
-      get_another_code: Envoyer un autre code
+      send_another_code: Envoyer un autre code
     what_is_totp: Qu’est-ce qu’une application d’authentification?

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -26,7 +26,7 @@ feature 'phone otp rate limiting', :js do
       complete_idv_steps_before_phone_otp_verification_step(user)
 
       (max_attempts - 1).times do
-        click_on t('links.two_factor_authentication.get_another_code')
+        click_on t('links.two_factor_authentication.send_another_code')
       end
 
       expect_max_otp_request_rate_limiting
@@ -48,7 +48,7 @@ feature 'phone otp rate limiting', :js do
       choose_idv_otp_delivery_method_sms
 
       # nth attempt
-      click_on t('links.two_factor_authentication.get_another_code')
+      click_on t('links.two_factor_authentication.send_another_code')
 
       expect_max_otp_request_rate_limiting
     end

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -49,7 +49,7 @@ feature 'phone otp verification step spec', :js do
 
     sent_message_count = Telephony::Test::Message.messages.count
 
-    click_on t('links.two_factor_authentication.get_another_code')
+    click_on t('links.two_factor_authentication.send_another_code')
 
     expect(Telephony::Test::Message.messages.count).to eq(sent_message_count + 1)
     expect(current_path).to eq(idv_otp_verification_path)
@@ -73,7 +73,7 @@ feature 'phone otp verification step spec', :js do
     )
     allow(Telephony).to receive(:send_confirmation_otp).and_return(response)
 
-    click_on t('links.two_factor_authentication.get_another_code')
+    click_on t('links.two_factor_authentication.send_another_code')
 
     expect(page).to have_content(I18n.t('telephony.error.friendly_message.generic'))
     expect(page).to have_current_path(idv_phone_path)
@@ -92,7 +92,7 @@ feature 'phone otp verification step spec', :js do
     )
     allow(Telephony).to receive(:send_confirmation_otp).and_return(response)
 
-    click_on t('links.two_factor_authentication.get_another_code')
+    click_on t('links.two_factor_authentication.send_another_code')
 
     expect(page).to have_content(calling_area_error.friendly_message)
     expect(page).to have_current_path(idv_phone_path)

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -31,7 +31,7 @@ feature 'Changing authentication factor' do
         travel(IdentityConfig.store.reauthn_window + 1)
         visit manage_phone_path(id: phone_configuration)
         complete_2fa_confirmation_without_entering_otp
-        click_link t('links.two_factor_authentication.get_another_code')
+        click_link t('links.two_factor_authentication.send_another_code')
 
         expect(Telephony).to have_received(:send_authentication_otp).with(
           otp: user.reload.direct_otp,

--- a/spec/support/shared_examples/phone/otp_confirmation.rb
+++ b/spec/support/shared_examples/phone/otp_confirmation.rb
@@ -36,7 +36,7 @@ shared_examples 'phone otp confirmation' do |delivery_method|
   it 'allows the user to resend an OTP and confirm with the new OTP' do
     visit_otp_confirmation(delivery_method)
     old_code = last_otp(delivery_method)
-    click_on t('links.two_factor_authentication.get_another_code')
+    click_on t('links.two_factor_authentication.send_another_code')
     new_code = last_otp(delivery_method)
 
     expect(old_code).to_not eq(new_code)

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -2,7 +2,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
   it 'limits the number of times the user can resend an OTP' do
     visit_otp_confirmation(delivery_method)
     2.times do
-      click_on t('links.two_factor_authentication.get_another_code')
+      click_on t('links.two_factor_authentication.send_another_code')
     end
 
     expect(page).to have_content(t('two_factor_authentication.max_otp_requests_reached'))
@@ -13,7 +13,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
   it 'limits the number of times a code can be sent to a phone across accounts' do
     visit_otp_confirmation(delivery_method)
     2.times do
-      click_on t('links.two_factor_authentication.get_another_code')
+      click_on t('links.two_factor_authentication.send_another_code')
     end
 
     Capybara.reset_session!

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -168,7 +168,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
         )
 
         expect(rendered).to have_link(
-          t('links.two_factor_authentication.get_another_code'),
+          t('links.two_factor_authentication.send_another_code'),
           href: resend_path,
         )
       end
@@ -207,7 +207,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
         )
 
         expect(rendered).to have_link(
-          t('links.two_factor_authentication.get_another_code'),
+          t('links.two_factor_authentication.send_another_code'),
           href: resend_path,
         )
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7717](https://cm-jira.usa.gov/browse/LG-7717)

## 🛠 Summary of changes

This is a follow-on from #7276. There was an additional language change that was missed in the initial translations doc. The "Get another code" button now reads "Send another code". I also updated the key names in the translation file from `get_another_code` to `send_another_code` to keep them consistent.

There is some additional context in the [Slack Acceptance thread for LG-7717](https://gsa-tts.slack.com/archives/C049E3XJQ1F/p1667510933886289).

## 👀 Screenshots

![en](https://user-images.githubusercontent.com/364697/200079611-e964b2b7-4dde-4e77-889a-d5feea3e751e.png)

![es](https://user-images.githubusercontent.com/364697/200079629-7b36ad61-8df2-4b86-bf1f-d114d2a45c33.png)

![fr](https://user-images.githubusercontent.com/364697/200079635-b08de0e6-b98a-4dd2-bdbc-65661e447850.png)

## 🚀 Notes for Deployment

N/A
