### PR TITLE
LG-8032: Manually set cache expiry if cache store is redis

### DIFF
--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -156,5 +156,14 @@ RSpec.describe ArcgisApi::Geocoder do
       expect(WebMock).to have_requested(:get, %r{/suggest}).
         with(headers: { 'Authorization' => 'Bearer token1' }).twice
     end
+
+    it 'manually sets the expiration if the cache store is redis' do
+      stub_generate_token_response
+      redis = double('Redis cache store')
+      expect(redis).to receive(:expire).once
+      expect(Rails.cache).to receive(:redis).and_return(redis)
+
+      subject.retrieve_token!
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8032](https://cm-jira.usa.gov/browse/LG-8032)

## 🛠 Summary of changes

* If using redis as our cache store manually set the expires_in timestamp. This works around an issue where our redis configuration doesn't automatically expire cache entries when using `Rails.cache.write`

## 📜 Testing Plan

- [ ] Deploy as a feature branch to the Joy sandbox
- [ ] Use the Rails console to initiate an ArcGIS request. Observe that a new auth token is retrieved and is cached and has an expiration associated with it
- [ ] Wait one hour
- [ ] Ensure cache entry has expired. Make a new ArcGIS request. Ensure a new auth token is retrieve and cached