### PR TITLE
Remove transient Event#diavowal_token, return it as a tuple

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -223,10 +223,10 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def send_phone_added_email
-    event = create_user_event_with_disavowal(:phone_added, current_user)
+    _event, disavowal_token = create_user_event_with_disavowal(:phone_added, current_user)
     current_user.confirmed_email_addresses.each do |email_address|
       UserMailer.with(user: current_user, email_address: email_address).
-        phone_added(disavowal_token: event.disavowal_token).deliver_now_or_later
+        phone_added(disavowal_token: disavowal_token).deliver_now_or_later
     end
   end
 

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -42,12 +42,12 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
-            event = create_user_event_with_disavowal(:account_verified)
+            event, disavowal_token = create_user_event_with_disavowal(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(
               user: current_user,
               date_time: event.created_at,
               sp_name: decorated_session.sp_name,
-              disavowal_token: event.disavowal_token,
+              disavowal_token: disavowal_token,
             )
             flash[:success] = t('account.index.verification.success')
             redirect_to sign_up_completed_url

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -96,12 +96,12 @@ module Idv
       end
 
       if idv_session.profile.active?
-        event = create_user_event_with_disavowal(:account_verified)
+        event, disavowal_token = create_user_event_with_disavowal(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,
           date_time: event.created_at,
           sp_name: decorated_session.sp_name,
-          disavowal_token: event.disavowal_token,
+          disavowal_token: disavowal_token,
         )
       end
     end

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -35,8 +35,8 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
-        event = create_user_event_with_disavowal(:personal_key_used)
-        alert_user_about_personal_key_sign_in(event)
+        _event, disavowal_token = create_user_event_with_disavowal(:personal_key_used)
+        alert_user_about_personal_key_sign_in(disavowal_token)
         generate_new_personal_key_for_verified_users_otherwise_retire_the_key_and_ensure_two_mfa
         handle_valid_otp
       else
@@ -44,10 +44,8 @@ module TwoFactorAuthentication
       end
     end
 
-    def alert_user_about_personal_key_sign_in(event)
-      response = UserAlerts::AlertUserAboutPersonalKeySignIn.call(
-        current_user, event.disavowal_token
-      )
+    def alert_user_about_personal_key_sign_in(disavowal_token)
+      response = UserAlerts::AlertUserAboutPersonalKeySignIn.call(current_user, disavowal_token)
       analytics.personal_key_alert_about_sign_in(**response.to_h)
     end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -56,8 +56,8 @@ module Users
     end
 
     def create_event_and_notify_user_about_password_change
-      event = create_user_event_with_disavowal(:password_changed)
-      UserAlerts::AlertUserAboutPasswordChange.call(current_user, event.disavowal_token)
+      _event, disavowal_token = create_user_event_with_disavowal(:password_changed)
+      UserAlerts::AlertUserAboutPasswordChange.call(current_user, disavowal_token)
     end
 
     def handle_invalid_password

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -149,8 +149,8 @@ module Users
     end
 
     def create_reset_event_and_send_notification
-      event = create_user_event_with_disavowal(:password_changed, resource)
-      UserAlerts::AlertUserAboutPasswordChange.call(resource, event.disavowal_token)
+      _event, disavowal_token = create_user_event_with_disavowal(:password_changed, resource)
+      UserAlerts::AlertUserAboutPasswordChange.call(resource, disavowal_token)
     end
 
     def user_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,8 +2,6 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :device
 
-  attr_accessor :disavowal_token
-
   enum event_type: {
     account_created: 1,
     phone_confirmed: 2,


### PR DESCRIPTION
**Why**: transient attributes on AR models can be confusing, this makes it clear it's not persisted

following up on https://github.com/18F/identity-idp/pull/7301/files#r1015533019
