### PR TITLE
Microoptimize reproof_for_irs to avoid database query

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -62,8 +62,8 @@ class UserDecorator
   end
 
   def reproof_for_irs?(service_provider:)
-    return false unless user.active_profile.present?
     return false unless service_provider&.irs_attempts_api_enabled
+    return false unless user.active_profile.present?
     !user.active_profile.initiating_service_provider&.irs_attempts_api_enabled
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Optimizes `UserDecorator#reproof_for_irs?` to avoid a database query by short-circuiting on a known value (`service_provider`) when possible. This avoids a database query for every non-IRS service provider.

Inspired by #7279, since we're now logging the value of `reproof_for_irs?` for every analytics event in identity verification.