### PR TITLE
Upgrade NewRelic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ GEM
       net-protocol
       timeout
     net-ssh (6.1.0)
-    newrelic_rpm (8.8.0)
+    newrelic_rpm (8.12.0)
     nio4r (2.5.8)
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,4 +1,6 @@
 common: &default_settings
+  code_level_metrics:
+    enabled: false
   application_logging:
     forwarding:
       enabled: false


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the new relic gem and disables a new enabled-by-default setting that we wouldn't need or use.

Includes changes in https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v890 and above