### PR TITLE
LG-8050 | Attempts API timestamp parsing fix

### DIFF
--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -81,7 +81,7 @@ module Api
       timestamp_param = params.permit(:timestamp)[:timestamp]
       return nil if timestamp_param.nil?
 
-      date_fmt = timestamp_param.match?('\.') ? '%Y-%m-%dT%H:%M:%S.%N%z' : '%Y-%m-%dT%H:%M:%S%z'
+      date_fmt = timestamp_param.include?('.') ? '%Y-%m-%dT%H:%M:%S.%N%z' : '%Y-%m-%dT%H:%M:%S%z'
 
       Time.strptime(timestamp_param, date_fmt)
     rescue ArgumentError

--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -81,7 +81,9 @@ module Api
       timestamp_param = params.permit(:timestamp)[:timestamp]
       return nil if timestamp_param.nil?
 
-      Time.strptime(timestamp_param, '%Y-%m-%dT%H:%M:%S%z')
+      date_fmt = timestamp_param.match?('\.') ? '%Y-%m-%dT%H:%M:%S.%N%z' : '%Y-%m-%dT%H:%M:%S%z'
+
+      Time.strptime(timestamp_param, date_fmt)
     rescue ArgumentError
       nil
     end

--- a/app/services/irs_attempts_api/envelope_encryptor.rb
+++ b/app/services/irs_attempts_api/envelope_encryptor.rb
@@ -18,7 +18,7 @@ module IrsAttemptsApi
       formatted_time = formatted_timestamp(timestamp)
 
       filename =
-        "FCI-#{IdentityConfig.store.irs_attempt_api_csp_id}_#{formatted_time}_#{digest}.dat.gz.hex"
+        "FCI-Logingov_#{formatted_time}_#{digest}.dat.gz.hex"
 
       Result.new(
         filename: filename,

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe Api::IrsAttemptsApiController do
     end
 
     context 'with a timestamp including a fractional second' do
-      let(:timestamp) { "2022-11-08T18:00:00.000Z" }
+      let(:timestamp) { '2022-11-08T18:00:00.000Z' }
 
       it 'accepts the timestamp as valid' do
-        post :create, params: {timestamp: timestamp}
+        post :create, params: { timestamp: timestamp }
         expect(response.status).to eq(200)
       end
     end

--- a/spec/controllers/api/irs_attempts_api_controller_spec.rb
+++ b/spec/controllers/api/irs_attempts_api_controller_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe Api::IrsAttemptsApiController do
       end
     end
 
+    context 'with a timestamp including a fractional second' do
+      let(:timestamp) { "2022-11-08T18:00:00.000Z" }
+
+      it 'accepts the timestamp as valid' do
+        post :create, params: {timestamp: timestamp}
+        expect(response.status).to eq(200)
+      end
+    end
+
     it 'renders a 404 if disabled' do
       allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(false)
 


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-8050 + https://cm-jira.usa.gov/browse/LG-8051

## 🛠 Summary of changes

The IRS is sending us timestamps with milliseconds in them, which currently generates an HTTP 422. Just accept this format.

I'm working in a related change to what we call the generated file, based on their request.
