### PR TITLE
Revert "Remove concurrency limits from scheduled cron jobs in GoodJob"

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -10,6 +10,14 @@ class GetUspsProofingResultsJob < ApplicationJob
   ]
 
   queue_as :default
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    key: 'get_usps_proofing_results',
+  )
+
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
   def email_analytics_attributes(enrollment)
     {

--- a/app/jobs/gpo_daily_job.rb
+++ b/app/jobs/gpo_daily_job.rb
@@ -1,6 +1,15 @@
 class GpoDailyJob < ApplicationJob
   queue_as :low
 
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    key: -> { "gpo-daily-job-#{arguments.first}" },
+  )
+
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
   # Enqueue a test letter every day, but only upload letters on working weekdays
   def perform(date)
     GpoDailyTestSender.new.run

--- a/app/jobs/phone_number_opt_out_sync_job.rb
+++ b/app/jobs/phone_number_opt_out_sync_job.rb
@@ -1,5 +1,14 @@
 class PhoneNumberOptOutSyncJob < ApplicationJob
   queue_as :long_running
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    key: -> do
+      rounded = TimeService.round_time(time: arguments.first, interval: 1.hour)
+      "phone-number-opt-out-sync-#{rounded.to_i}"
+    end,
+  )
 
   def perform(_now)
     all_phone_numbers = Set.new

--- a/app/jobs/psql_stats_job.rb
+++ b/app/jobs/psql_stats_job.rb
@@ -1,5 +1,16 @@
 class PsqlStatsJob < ApplicationJob
   queue_as :default
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    key: -> do
+      rounded = TimeService.round_time(time: arguments.first, interval: 1.minute)
+      "psql_bloat_statistics-#{rounded.to_i}"
+    end,
+  )
+
+  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
   # gather data on bloat for each table
   # https://github.com/ioguix/pgsql-bloat-estimation/blob/master/table/table_bloat.sql

--- a/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
+++ b/app/jobs/reports/agency_invoice_iaa_supplement_report.rb
@@ -2,6 +2,13 @@ module Reports
   class AgencyInvoiceIaaSupplementReport < BaseReport
     REPORT_NAME = 'agency-invoice-iaa-supplemement-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       raw_results = IaaReportingHelper.iaas.flat_map do |iaa|
         Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa.call(

--- a/app/jobs/reports/agency_invoice_issuer_supplement_report.rb
+++ b/app/jobs/reports/agency_invoice_issuer_supplement_report.rb
@@ -2,6 +2,13 @@ module Reports
   class AgencyInvoiceIssuerSupplementReport < BaseReport
     REPORT_NAME = 'agency-invoice-issuer-supplemement-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       raw_results = service_providers.flat_map do |service_provider|
         transaction_with_timeout do

--- a/app/jobs/reports/agency_user_counts_report.rb
+++ b/app/jobs/reports/agency_user_counts_report.rb
@@ -4,6 +4,13 @@ module Reports
   class AgencyUserCountsReport < BaseReport
     REPORT_NAME = 'agency-user-counts-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       user_counts = transaction_with_timeout do
         Db::AgencyIdentity::AgencyUserCounts.call

--- a/app/jobs/reports/agreement_summary_report.rb
+++ b/app/jobs/reports/agreement_summary_report.rb
@@ -4,6 +4,13 @@ module Reports
   class AgreementSummaryReport < BaseReport
     REPORT_NAME = 'agreement-summary-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       csv = build_report
 

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -4,6 +4,9 @@ module Reports
   class BaseReport < ApplicationJob
     queue_as :long_running
 
+    # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
+    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
     def self.transaction_with_timeout(rails_env = Rails.env)
       # rspec-rails's use_transactional_tests does not seem to act as expected when switching
       # connections mid-test, so we just skip for now :[

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -4,6 +4,13 @@ module Reports
   class CombinedInvoiceSupplementReport < BaseReport
     REPORT_NAME = 'combined-invoice-supplement-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       iaas = IaaReportingHelper.iaas
 

--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -2,6 +2,13 @@ module Reports
   class DailyAuthsReport < BaseReport
     REPORT_NAME = 'daily-auths-report'
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     attr_reader :report_date
 
     def perform(report_date)

--- a/app/jobs/reports/daily_dropoffs_report.rb
+++ b/app/jobs/reports/daily_dropoffs_report.rb
@@ -4,6 +4,13 @@ module Reports
   class DailyDropoffsReport < BaseReport
     REPORT_NAME = 'daily-dropoffs-report'
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     attr_reader :report_date
 
     def perform(report_date)

--- a/app/jobs/reports/deleted_user_accounts_report.rb
+++ b/app/jobs/reports/deleted_user_accounts_report.rb
@@ -5,6 +5,13 @@ module Reports
   class DeletedUserAccountsReport < BaseReport
     REPORT_NAME = 'deleted-user-accounts-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       configs = IdentityConfig.store.deleted_user_accounts_report_configs
       configs.each do |report_hash|

--- a/app/jobs/reports/doc_auth_drop_off_rates_per_sprint_report.rb
+++ b/app/jobs/reports/doc_auth_drop_off_rates_per_sprint_report.rb
@@ -5,6 +5,13 @@ module Reports
     REPORT_NAME = 'doc-auth-drop-offs-per-sprint-report'.freeze
     FIRST_SPRINT_DATE = '10-10-2019'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       ret = generate_report
       save_report(REPORT_NAME, ret.join, extension: 'txt')

--- a/app/jobs/reports/doc_auth_drop_off_rates_report.rb
+++ b/app/jobs/reports/doc_auth_drop_off_rates_report.rb
@@ -4,6 +4,13 @@ module Reports
   class DocAuthDropOffRatesReport < BaseReport
     REPORT_NAME = 'doc-auth-drop-off-rates-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       ret = generate_report
       save_report(REPORT_NAME, ret.join, extension: 'txt')

--- a/app/jobs/reports/doc_auth_funnel_report.rb
+++ b/app/jobs/reports/doc_auth_funnel_report.rb
@@ -4,6 +4,13 @@ module Reports
   class DocAuthFunnelReport < BaseReport
     REPORT_NAME = 'doc-auth-funnel-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       report = transaction_with_timeout do
         Db::DocAuthLog::DocAuthFunnelSummaryStats.new.call

--- a/app/jobs/reports/gpo_report.rb
+++ b/app/jobs/reports/gpo_report.rb
@@ -4,6 +4,13 @@ module Reports
   class GpoReport < BaseReport
     REPORT_NAME = 'usps-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(today)
       @results = {
         today: today.to_s,

--- a/app/jobs/reports/monthly_gpo_letter_requests_report.rb
+++ b/app/jobs/reports/monthly_gpo_letter_requests_report.rb
@@ -4,6 +4,13 @@ module Reports
   class MonthlyGpoLetterRequestsReport < BaseReport
     REPORT_NAME = 'monthly-usps-letter-requests-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date, start_time: first_of_this_month, end_time: end_of_today)
       daily_results = transaction_with_timeout do
         ::LetterRequestsToGpoFtpLog.where(ftp_at: start_time..end_time)

--- a/app/jobs/reports/omb_fitara_report.rb
+++ b/app/jobs/reports/omb_fitara_report.rb
@@ -6,6 +6,13 @@ module Reports
     MOST_RECENT_MONTHS_COUNT = 2
     REPORT_NAME = 'omb-fitara-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       results = transaction_with_timeout do
         report_hash

--- a/app/jobs/reports/proofing_costs_report.rb
+++ b/app/jobs/reports/proofing_costs_report.rb
@@ -4,6 +4,13 @@ module Reports
   class ProofingCostsReport < BaseReport
     REPORT_NAME = 'proofing-costs-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       report = transaction_with_timeout do
         Db::ProofingCost::ProofingCostsSummary.new.call

--- a/app/jobs/reports/sp_active_users_over_period_of_performance_report.rb
+++ b/app/jobs/reports/sp_active_users_over_period_of_performance_report.rb
@@ -4,6 +4,13 @@ module Reports
   class SpActiveUsersOverPeriodOfPerformanceReport < BaseReport
     REPORT_NAME = 'sp-active-users-over-period-of-performance-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       results = transaction_with_timeout do
         Db::Identity::SpActiveUserCountsWithinIaaWindow.call

--- a/app/jobs/reports/sp_active_users_report.rb
+++ b/app/jobs/reports/sp_active_users_report.rb
@@ -4,6 +4,13 @@ module Reports
   class SpActiveUsersReport < BaseReport
     REPORT_NAME = 'sp-active-users-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     # This daily job captures the total number of active users per SP from the beginning of the the
     # current fiscal year until now.
     #

--- a/app/jobs/reports/sp_cost_report.rb
+++ b/app/jobs/reports/sp_cost_report.rb
@@ -4,6 +4,13 @@ module Reports
   class SpCostReport < BaseReport
     REPORT_NAME = 'sp-cost-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       results = transaction_with_timeout do
         Db::SpCost::SpCostSummary.call(first_of_this_month, end_of_today)

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -4,6 +4,13 @@ module Reports
   class SpUserCountsReport < BaseReport
     REPORT_NAME = 'sp-user-counts-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       user_counts = transaction_with_timeout do
         Db::Identity::SpUserCounts.call

--- a/app/jobs/reports/sp_user_quotas_report.rb
+++ b/app/jobs/reports/sp_user_quotas_report.rb
@@ -4,6 +4,13 @@ module Reports
   class SpUserQuotasReport < BaseReport
     REPORT_NAME = 'sp-user-quotas-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       results = run_report_and_save_to_s3
       update_quota_limit_cache

--- a/app/jobs/reports/total_ial2_costs_report.rb
+++ b/app/jobs/reports/total_ial2_costs_report.rb
@@ -5,6 +5,13 @@ module Reports
     REPORT_NAME = 'total-ial2-costs'.freeze
     NUM_LOOKBACK_DAYS = 45
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(date)
       results = transaction_with_timeout { query(date) }
 

--- a/app/jobs/reports/total_monthly_auths_report.rb
+++ b/app/jobs/reports/total_monthly_auths_report.rb
@@ -4,6 +4,13 @@ module Reports
   class TotalMonthlyAuthsReport < BaseReport
     REPORT_NAME = 'total-monthly-auths-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       auth_counts = transaction_with_timeout do
         Db::MonthlySpAuthCount::TotalMonthlyAuthCounts.call

--- a/app/jobs/reports/total_sp_cost_report.rb
+++ b/app/jobs/reports/total_sp_cost_report.rb
@@ -4,6 +4,13 @@ module Reports
   class TotalSpCostReport < BaseReport
     REPORT_NAME = 'total-sp-cost-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(_date)
       auth_counts = transaction_with_timeout do
         Db::SpCost::TotalSpCostSummary.call(first_of_this_month, end_of_today)

--- a/app/jobs/reports/verification_failures_report.rb
+++ b/app/jobs/reports/verification_failures_report.rb
@@ -6,6 +6,13 @@ module Reports
   class VerificationFailuresReport < BaseReport
     REPORT_NAME = 'verification-failures-report'.freeze
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
+    )
+
     def perform(date)
       csv_reports = []
       configs = IdentityConfig.store.verification_errors_report_configs

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -2,6 +2,18 @@ module AccountReset
   class GrantRequestsAndSendEmails < ApplicationJob
     queue_as :low
 
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> do
+        rounded = TimeService.round_time(time: arguments.first, interval: 5.minutes)
+        "grant-requests-and-send-emails-#{rounded.to_i}"
+      end,
+    )
+
+    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
     def perform(now)
       notifications_sent = 0
       AccountResetRequest.where(

--- a/app/services/agreements/reports/partner_api_report.rb
+++ b/app/services/agreements/reports/partner_api_report.rb
@@ -3,6 +3,15 @@ module Agreements
     class PartnerApiReport < ApplicationJob
       queue_as :low
 
+      include GoodJob::ActiveJobExtensions::Concurrency
+
+      good_job_control_concurrency_with(
+        total_limit: 1,
+        key: -> { "partner-api-report-#{arguments.first}" },
+      )
+
+      discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+
       def perform(_date)
         return unless IdentityConfig.store.enable_partner_api
 

--- a/spec/jobs/gpo_daily_job_spec.rb
+++ b/spec/jobs/gpo_daily_job_spec.rb
@@ -48,4 +48,13 @@ RSpec.describe GpoDailyJob do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).to eq("gpo-daily-job-#{date}")
+    end
+  end
 end

--- a/spec/jobs/phone_number_opt_out_sync_job_spec.rb
+++ b/spec/jobs/phone_number_opt_out_sync_job_spec.rb
@@ -32,4 +32,19 @@ RSpec.describe PhoneNumberOptOutSyncJob do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    it 'is the job name and the current time, rounded to the nearest hour' do
+      now = Time.zone.at(1629817200)
+
+      job_now = PhoneNumberOptOutSyncJob.new(now)
+      expect(job_now.good_job_concurrency_key).to eq("phone-number-opt-out-sync-#{now.to_i}")
+
+      job_plus_30m = PhoneNumberOptOutSyncJob.new(now + 30.minutes)
+      expect(job_plus_30m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
+
+      job_plus_1h = PhoneNumberOptOutSyncJob.new(now + 1.hour)
+      expect(job_plus_1h.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
+    end
+  end
 end

--- a/spec/jobs/reports/agency_invoice_iaa_supplement_report_spec.rb
+++ b/spec/jobs/reports/agency_invoice_iaa_supplement_report_spec.rb
@@ -258,4 +258,14 @@ RSpec.describe Reports::AgencyInvoiceIaaSupplementReport do
       partner_account: partner_account,
     )
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/agency_invoice_issuer_supplement_report_spec.rb
+++ b/spec/jobs/reports/agency_invoice_issuer_supplement_report_spec.rb
@@ -66,4 +66,14 @@ RSpec.describe Reports::AgencyInvoiceIssuerSupplementReport do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/agency_user_counts_report_spec.rb
+++ b/spec/jobs/reports/agency_user_counts_report_spec.rb
@@ -16,4 +16,14 @@ describe Reports::AgencyUserCountsReport do
 
     expect(subject.perform(Time.zone.today)).to eq(result)
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/agreement_summary_report_spec.rb
+++ b/spec/jobs/reports/agreement_summary_report_spec.rb
@@ -78,4 +78,14 @@ RSpec.describe Reports::AgreementSummaryReport do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
@@ -215,4 +215,14 @@ RSpec.describe Reports::CombinedInvoiceSupplementReport do
       partner_account: partner_account,
     )
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -108,4 +108,14 @@ RSpec.describe Reports::DailyAuthsReport do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/daily_dropoffs_report_spec.rb
+++ b/spec/jobs/reports/daily_dropoffs_report_spec.rb
@@ -140,4 +140,14 @@ RSpec.describe Reports::DailyDropoffsReport do
       end
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/deleted_user_accounts_report_spec.rb
+++ b/spec/jobs/reports/deleted_user_accounts_report_spec.rb
@@ -38,4 +38,14 @@ describe Reports::DeletedUserAccountsReport do
 
     subject.perform(Time.zone.today)
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/gpo_report_spec.rb
+++ b/spec/jobs/reports/gpo_report_spec.rb
@@ -42,6 +42,16 @@ describe Reports::GpoReport do
     expect(JSON.parse(subject.perform(Time.zone.today))).to eq(one_letter_sent_and_verified_report)
   end
 
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+
   def create_ucc_for(profile)
     GpoConfirmationCode.create(
       profile: profile,

--- a/spec/jobs/reports/sp_active_users_over_period_of_performance_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_over_period_of_performance_report_spec.rb
@@ -51,4 +51,14 @@ describe Reports::SpActiveUsersOverPeriodOfPerformanceReport do
       }],
     )
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -79,6 +79,16 @@ describe Reports::SpActiveUsersReport do
     expect(subject.perform(job_date)).to eq(result)
   end
 
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+
   describe '#reporting_range' do
     it 'returns entire last fiscal year when it is October 1st' do
       job_date = Date.new(2022, 10, 1)

--- a/spec/jobs/reports/sp_cost_report_spec.rb
+++ b/spec/jobs/reports/sp_cost_report_spec.rb
@@ -35,4 +35,14 @@ describe Reports::SpCostReport do
        }],
     )
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -65,4 +65,14 @@ describe Reports::SpUserCountsReport do
 
     expect(subject.perform(Time.zone.today)).to eq(result)
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/sp_user_quotas_report_spec.rb
+++ b/spec/jobs/reports/sp_user_quotas_report_spec.rb
@@ -32,4 +32,14 @@ describe Reports::SpUserQuotasReport do
       expect(subject.perform(Time.zone.today)).to eq(results)
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/total_ial2_costs_report_spec.rb
+++ b/spec/jobs/reports/total_ial2_costs_report_spec.rb
@@ -68,4 +68,14 @@ RSpec.describe Reports::TotalIal2CostsReport do
       report.perform(date)
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/total_monthly_auths_report_spec.rb
+++ b/spec/jobs/reports/total_monthly_auths_report_spec.rb
@@ -34,4 +34,14 @@ describe Reports::TotalMonthlyAuthsReport do
 
     expect(subject.perform(Time.zone.today)).to eq(result)
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/total_sp_cost_report_spec.rb
+++ b/spec/jobs/reports/total_sp_cost_report_spec.rb
@@ -26,4 +26,14 @@ describe Reports::TotalSpCostReport do
        }],
     )
   end
+
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
 end

--- a/spec/jobs/reports/verification_failures_report_spec.rb
+++ b/spec/jobs/reports/verification_failures_report_spec.rb
@@ -195,6 +195,16 @@ describe Reports::VerificationFailuresReport do
     expect(csv[1]).to eq([uuid, now.to_time.utc.iso8601, 'ABANDON'])
   end
 
+  describe '#good_job_concurrency_key' do
+    let(:date) { Time.zone.today }
+
+    it 'is the job name and the date' do
+      job = described_class.new(date)
+      expect(job.good_job_concurrency_key).
+        to eq("#{described_class::REPORT_NAME}-#{date}")
+    end
+  end
+
   def run_reports
     ServiceProvider.create(issuer: issuer, agency_id: 1, friendly_name: issuer)
     AgencyIdentity.create(agency_id: 1, user_id: user.id, uuid: uuid)

--- a/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
+++ b/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
@@ -70,6 +70,21 @@ describe AccountReset::GrantRequestsAndSendEmails do
     end
   end
 
+  describe '#good_job_concurrency_key' do
+    it 'is the job name and the current time, rounded to the nearest 5 minutes' do
+      now = Time.zone.at(1629819000)
+
+      job_now = AccountReset::GrantRequestsAndSendEmails.new(now)
+      expect(job_now.good_job_concurrency_key).to eq("grant-requests-and-send-emails-#{now.to_i}")
+
+      job_plus_1m = AccountReset::GrantRequestsAndSendEmails.new(now + 1.minute)
+      expect(job_plus_1m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
+
+      job_plus_5m = AccountReset::GrantRequestsAndSendEmails.new(now + 5.minutes)
+      expect(job_plus_5m.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
+    end
+  end
+
   def before_waiting_the_full_wait_period(now)
     days = IdentityConfig.store.account_reset_wait_period_days.days
     travel_to(now - 1 - days) do

--- a/spec/services/agreements/reports/partner_api_report_spec.rb
+++ b/spec/services/agreements/reports/partner_api_report_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe Agreements::Reports::PartnerApiReport do
       expect(described_class.new.perform(today)).to eq(true)
     end
   end
+
+  describe '#good_job_concurrency_key' do
+    it 'is the job name and the date' do
+      job = described_class.new(today)
+      expect(job.good_job_concurrency_key).to eq("partner-api-report-#{today}")
+    end
+  end
 end


### PR DESCRIPTION
This reverts commit 65fe73fa8af337d2b66a851359e3f52af5c298fc from #7197

**Why**: We discovered daily jobs like the GpoDailyJob were running twice in the same day, indicating we still need these guards

[Slack discussion link](https://gsa-tts.slack.com/archives/C0NGESUN5/p1667943520490839)
