### PR TITLE
Re-enable GoodJob's preserve_old_records

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,7 @@ module Identity
     config.good_job.enable_cron = true
     config.good_job.max_threads = IdentityConfig.store.good_job_max_threads
     config.good_job.queues = IdentityConfig.store.good_job_queues
-    config.good_job.preserve_job_records = false
+    config.good_job.preserve_job_records = true
     config.good_job.queue_select_limit = IdentityConfig.store.good_job_queue_select_limit
     # see config/initializers/job_configurations.rb for cron schedule
 


### PR DESCRIPTION
**Why**: To help make sure that daily scheduled jobs don't get re-run because we use the concurrency_key on old records to check for duplicates

Reverting part of #7196, related to https://github.com/18F/identity-idp/pull/7317
