### PR TITLE
Include kid in JWT

### DIFF
--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -64,7 +64,13 @@ module PushNotification
     def jwt(service_provider)
       payload = jwt_payload(service_provider)
 
-      JWT.encode(payload, AppArtifacts.store.oidc_private_key, 'RS256', typ: 'secevent+jwt')
+      JWT.encode(
+        payload,
+        AppArtifacts.store.oidc_private_key,
+        'RS256',
+        typ: 'secevent+jwt',
+        kid: JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid,
+      )
     end
 
     def jwt_payload(service_provider)

--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -69,9 +69,11 @@ RSpec.describe PushNotification::HttpPush do
             AppArtifacts.store.oidc_public_key,
             true,
             algorithm: 'RS256',
+            kid: JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid,
           )
 
           expect(headers['typ']).to eq('secevent+jwt')
+          expect(headers['kid']).to eq(JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid)
 
           expect(payload['iss']).to eq(root_url)
           expect(payload['iat']).to eq(now.to_i)


### PR DESCRIPTION
changelog: add kid to JWT

## 🎫 Ticket

LG-7797

## 🛠 Summary of changes

Adds kid (Key ID) to the JWT token we send. This request came from a partner.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

