### PR TITLE
Make PR template text commented out by default

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,18 @@
+<!-- Comment in the sections you need for your PR! -->
+
+<!--
 ## 🎫 Ticket
 
 Link to the relevant ticket.
+-->
 
+<!--
 ## 🛠 Summary of changes
 
 Write a brief description of what you changed.
+-->
 
+<!--
 ## 📜 Testing Plan
 
 Provide a checklist of steps to confirm the changes.
@@ -13,7 +20,9 @@ Provide a checklist of steps to confirm the changes.
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
+-->
 
+<!--
 ## 👀 Screenshots
 
 If relevant, include a screenshot or screen capture of the changes.
@@ -27,7 +36,10 @@ If relevant, include a screenshot or screen capture of the changes.
 <summary>After:</summary>
 
 </details>
+-->
 
+<!--
 ## 🚀 Notes for Deployment
 
 Include any special instructions for deployment.
+-->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -37,9 +37,3 @@ If relevant, include a screenshot or screen capture of the changes.
 
 </details>
 -->
-
-<!--
-## 🚀 Notes for Deployment
-
-Include any special instructions for deployment.
--->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Comment in the sections you need for your PR! -->
+<!-- Uncomment and update the sections you need for your PR! -->
 
 <!--
 ## 🎫 Ticket


### PR DESCRIPTION
**Why**: Still prompts PR authors to add known sections, but leaves less visual clutter if submitted un-modified

As discussed at [Eng Huddle 11/9](https://docs.google.com/document/d/1g_V2vlT79tScBKIVw7M4UXf15TrG69iUrLHE0yE1GGI/edit?disco=AAAAjoftSFw)