### PR TITLE
LG-7987 add IdV inherited proofing cancellation analytics

### DIFF
--- a/app/controllers/idv/inherited_proofing_cancellations_controller.rb
+++ b/app/controllers/idv/inherited_proofing_cancellations_controller.rb
@@ -61,19 +61,9 @@ module Idv
       idv_session.go_back_path
     end
 
-    # AllowlistedFlowStepConcern Concern overrides
-
     def flow_step_allowlist
       @flow_step_allowlist ||= Idv::Flows::InheritedProofingFlow::STEPS.keys.map(&:to_s)
     end
-
-    # NOTE: Override and use Inherited Proofing (IP)-specific :throttle_type
-    # if current IDV-specific :idv_resolution type is unacceptable!
-    # def idv_attempter_throttled?
-    #   ...
-    # end
-
-    # IdvSession Concern > EffectiveUser Concern overrides
 
     def effective_user_id
       current_user&.id

--- a/app/controllers/idv/inherited_proofing_cancellations_controller.rb
+++ b/app/controllers/idv/inherited_proofing_cancellations_controller.rb
@@ -8,9 +8,7 @@ module Idv
     before_action :confirm_idv_needed
 
     def new
-      # LG-7128: Implement Inherited Proofing analytics here.
-      # properties = ParseControllerFromReferer.new(request.referer).call
-      # analytics.idv_inherited_proofing_cancellation_visited(step: params[:step], **properties)
+      analytics.idv_cancellation_visited(step: params[:step], **analytics_properties)
       self.session_go_back_path = go_back_path || idv_inherited_proofing_path
       @presenter = CancellationsPresenter.new(
         sp_name: decorated_session.sp_name,
@@ -19,14 +17,12 @@ module Idv
     end
 
     def update
-      # LG-7128: Implement Inherited Proofing analytics here.
-      # analytics.idv_inherited_proofing_cancellation_go_back(step: params[:step])
+      analytics.idv_cancellation_go_back(step: params[:step], **analytics_properties)
       redirect_to session_go_back_path || idv_inherited_proofing_path
     end
 
     def destroy
-      # LG-7128: Implement Inherited Proofing analytics here.
-      # analytics.idv_inherited_proofing_cancellation_confirmed(step: params[:step])
+      analytics.idv_cancellation_confirmed(step: params[:step], **analytics_properties)
       cancel_session
       render json: { redirect_url: cancelled_redirect_path }
     end
@@ -81,6 +77,11 @@ module Idv
 
     def effective_user_id
       current_user&.id
+    end
+
+    def analytics_properties
+      route_properties = ParseControllerFromReferer.new(request.referer).call
+      route_properties.merge({ analytics_id: @analytics_id })
     end
   end
 end

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -46,7 +46,6 @@ module Idv
       analytics.idv_start_over(
         step: location_params[:step],
         location: location_params[:location],
-        analytics_id: @analytics_id,
       )
     end
   end

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -43,12 +43,10 @@ module Idv
     end
 
     def log_analytics
-      # LG-7128: Implement Inherited Proofing analytics here.
-      # include InheritedProofingConcern and if inherited_proofing?,
-      # pass flow/param/analytics_ids param to the existing idv_start_over event.
       analytics.idv_start_over(
         step: location_params[:step],
         location: location_params[:location],
+        analytics_id: @analytics_id,
       )
     end
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -572,7 +572,7 @@ module AnalyticsEvents
   # The user agrees to allow us to access their data via api call
   def idv_inherited_proofing_agreement_submitted(success:, errors:, flow_path:, step:, **extra)
     track_event(
-      'Idv: inherited proofing agreement submitted',
+      'IdV: inherited proofing agreement submitted',
       success: success,
       errors: errors,
       flow_path: flow_path,
@@ -586,7 +586,7 @@ module AnalyticsEvents
   # The user visited the inherited proofing agreement page
   def idv_inherited_proofing_agreement_visited(flow_path:, step:, **extra)
     track_event(
-      'Idv: inherited proofing agreement visited',
+      'IdV: inherited proofing agreement visited',
       flow_path: flow_path,
       step: step,
       **extra,
@@ -600,7 +600,7 @@ module AnalyticsEvents
   # The user chooses to begin the inherited proofing process
   def idv_inherited_proofing_get_started_submitted(success:, errors:, flow_path:, step:, **extra)
     track_event(
-      'Idv: inherited proofing get started submitted',
+      'IdV: inherited proofing get started submitted',
       success: success,
       errors: errors,
       flow_path: flow_path,
@@ -614,7 +614,7 @@ module AnalyticsEvents
   # The user visited the inherited proofing get started step
   def idv_inherited_proofing_get_started_visited(flow_path:, step:, **extra)
     track_event(
-      'Idv: inherited proofing get started visited',
+      'IdV: inherited proofing get started visited',
       flow_path: flow_path,
       step: step,
       **extra,

--- a/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
@@ -115,13 +115,13 @@ describe Idv::InheritedProofingCancellationsController do
       end
 
       it 'renders template' do
-        subject
+        action
 
         expect(response).to render_template(:new)
       end
 
       it 'stores go back path' do
-        subject
+        action
 
         expect(controller.user_session[:idv][:go_back_path]).to eq(go_back_path)
       end
@@ -138,7 +138,7 @@ describe Idv::InheritedProofingCancellationsController do
           analytics_id: nil,
         )
 
-        subject
+        action
       end
     end
   end

--- a/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
@@ -236,7 +236,7 @@ describe Idv::InheritedProofingCancellationsController do
           step: step.to_s,
           proofing_components: nil,
           analytics_id: nil,
-          )
+        )
 
         action
       end

--- a/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
+++ b/spec/controllers/idv/inherited_proofing_cancellations_controller_spec.rb
@@ -106,31 +106,54 @@ describe Idv::InheritedProofingCancellationsController do
     end
 
     context 'when there is a session' do
+      subject(:action) do
+        get :new, params: { step: step }
+      end
+
       before do
         stub_sign_in
       end
 
       it 'renders template' do
-        get :new, params: { step: step }
+        subject
 
         expect(response).to render_template(:new)
       end
 
       it 'stores go back path' do
-        get :new, params: { step: step }
+        subject
 
         expect(controller.user_session[:idv][:go_back_path]).to eq(go_back_path)
+      end
+
+      it 'tracks the event in analytics' do
+        stub_analytics
+        request.env['HTTP_REFERER'] = 'https://example.com/'
+
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: cancellation visited',
+          request_came_from: 'users/sessions#new',
+          step: step.to_s,
+          proofing_components: nil,
+          analytics_id: nil,
+        )
+
+        subject
       end
     end
   end
 
   describe '#update' do
+    subject(:action) do
+      put :update, params: { step: step, cancel: 'true' }
+    end
+
     before do
       stub_sign_in
     end
 
     it 'redirects to idv_inherited_proofing_path' do
-      put :update, params: { step: step, cancel: 'true' }
+      action
 
       expect(response).to redirect_to idv_inherited_proofing_url
     end
@@ -145,17 +168,36 @@ describe Idv::InheritedProofingCancellationsController do
       end
 
       it 'redirects to go back path' do
-        put :update, params: { step: step, cancel: 'true' }
+        action
 
         expect(response).to redirect_to go_back_path
       end
     end
+
+    it 'tracks the event in analytics' do
+      stub_analytics
+      request.env['HTTP_REFERER'] = 'https://example.com/'
+
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: cancellation go back',
+        request_came_from: 'users/sessions#new',
+        step: step.to_s,
+        proofing_components: nil,
+        analytics_id: nil,
+      )
+
+      action
+    end
   end
 
   describe '#destroy' do
+    subject(:action) do
+      delete :destroy, params: { step: step }
+    end
+
     context 'when there is no session' do
       it 'redirects to root' do
-        delete :destroy, params: { step: step }
+        action
 
         expect(response).to redirect_to(root_url)
       end
@@ -166,25 +208,37 @@ describe Idv::InheritedProofingCancellationsController do
 
       before do
         stub_sign_in user
-      end
-
-      before do
         allow(controller).to receive(:user_session).
           and_return(idv: { go_back_path: '/path/to/return' })
       end
 
       it 'destroys session' do
-        expect(subject).to receive(:cancel_session).once
+        expect(controller).to receive(:cancel_session).once
 
-        delete :destroy, params: { step: step }
+        action
       end
 
       it 'renders a json response with the redirect path set to account_path' do
-        delete :destroy, params: { step: step }
+        action
 
         parsed_body = JSON.parse(response.body, symbolize_names: true)
         expect(response).not_to render_template(:destroy)
         expect(parsed_body).to eq({ redirect_url: account_path })
+      end
+
+      it 'tracks the event in analytics' do
+        stub_analytics
+        request.env['HTTP_REFERER'] = 'https://example.com/'
+
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: cancellation confirmed',
+          request_came_from: 'users/sessions#new',
+          step: step.to_s,
+          proofing_components: nil,
+          analytics_id: nil,
+          )
+
+        action
       end
     end
   end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -45,13 +45,14 @@ describe Idv::SessionsController do
       end
     end
 
-    it 'logs IDV start over analytics with step and location params' do
+    it 'tracks the event in analytics' do
       delete :destroy, params: { step: 'first', location: 'get_help' }
 
       expect(@analytics).to have_logged_event(
         'IdV: start over',
         step: 'first',
         location: 'get_help',
+        analytics_id: nil,
       )
     end
 

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -52,7 +52,6 @@ describe Idv::SessionsController do
         'IdV: start over',
         step: 'first',
         location: 'get_help',
-        analytics_id: nil,
       )
     end
 

--- a/spec/features/idv/inherited_proofing/analytics_spec.rb
+++ b/spec/features/idv/inherited_proofing/analytics_spec.rb
@@ -9,10 +9,10 @@ feature 'Inherited Proofing Analytics Regression', js: true do
   # rubocop:disable Layout/LineLength
   let(:happy_path_events) do
     {
-      'Idv: inherited proofing get started visited' => { flow_path: 'standard', step: 'get_started', step_count: 1, analytics_id: 'Inherited Proofing' },
-      'Idv: inherited proofing get started submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'get_started', step_count: 1, analytics_id: 'Inherited Proofing' },
-      'Idv: inherited proofing agreement visited' => { flow_path: 'standard', step: 'agreement', step_count: 1, analytics_id: 'Inherited Proofing' },
-      'Idv: inherited proofing agreement submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'agreement', step_count: 1, analytics_id: 'Inherited Proofing' },
+      'IdV: inherited proofing get started visited' => { flow_path: 'standard', step: 'get_started', step_count: 1, analytics_id: 'Inherited Proofing' },
+      'IdV: inherited proofing get started submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'get_started', step_count: 1, analytics_id: 'Inherited Proofing' },
+      'IdV: inherited proofing agreement visited' => { flow_path: 'standard', step: 'agreement', step_count: 1, analytics_id: 'Inherited Proofing' },
+      'IdV: inherited proofing agreement submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'agreement', step_count: 1, analytics_id: 'Inherited Proofing' },
       'IdV: doc auth verify_wait visited' => { flow_path: 'standard', step: 'verify_wait', step_count: 1, analytics_id: 'Inherited Proofing' },
       'IdV: doc auth optional verify_wait submitted' => { success: true, errors: {}, step: 'verify_wait_step_show', analytics_id: 'Inherited Proofing' },
       'IdV: doc auth verify visited' => { flow_path: 'standard', step: 'verify_info', step_count: 1, analytics_id: 'Inherited Proofing' },


### PR DESCRIPTION
  also fix analytics name casing (to IdV from Idv) for consistency

  changelog: Internal, Analytics, add IdV inherited proofing cancellation analytics

## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-7987

## 🛠 Summary of changes
Added calls to the existing inherited proofing cancellations controller. Reused existing IdV analytics cancellation methods, but added the IP analytics_id.

## 📜 Testing Plan
Added controller test examples to validate analytics calls are being made with proper parameters.
