### PR TITLE
LG-7934: Rename OTP security code to one-time code

### DIFF
--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code') %>
+<% title t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.backup_code_header_text')) %>
 

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code') %>
+<% title t('titles.enter_2fa_code.one_time_code') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code') %>
+<% title t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.personal_key_header_text')) %>
 

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code') %>
+<% title t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -7,14 +7,14 @@ en:
       account to cancel.
     authentication_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
         passcode is, %{code}, This code expires in %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Hello! Your %{app_name} one time passcode is, %{code}, again, your
@@ -23,7 +23,7 @@ en:
       phone.  Please take a photo of your state issued ID."
     error:
       friendly_message:
-        daily_voice_limit_reached: Your security code failed to send because you
+        daily_voice_limit_reached: Your one-time code failed to send because you
           exceeded the maximum number of phone calls in 24 hours to this phone
           number. You can either request a code by text message or use a
           different number to receive a phone call.

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -7,7 +7,7 @@ es:
       %{app_name} para cancelar.
     authentication_otp:
       sms: |-
-        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: El código de un solo uso es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
 
         @%{domain} #%{code}
       voice: '¡Hola! Su código de acceso de %{app_name} es, %{code}, nuevamente, su
@@ -15,7 +15,7 @@ es:
         minutos.'
     confirmation_otp:
       sms: |-
-        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: El código de un solo uso es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
 
         @%{domain} #%{code}
       voice: '¡Hola! Su código de acceso de %{app_name} es, %{code}, nuevamente, su
@@ -26,10 +26,10 @@ es:
       estado'
     error:
       friendly_message:
-        daily_voice_limit_reached: Your one-time code failed to send because you
-          exceeded the maximum number of phone calls in 24 hours to this phone
-          number. You can either request a code by text message or use a
-          different number to receive a phone call.
+        daily_voice_limit_reached: Su código de un solo uso no se ha podido enviar, ya
+          que ha superado el número máximo de llamadas en 24 horas a este número
+          de teléfono. Puedes solicitar un código por mensaje de texto o
+          utilizar un número diferente para recibir una llamada telefónica.
         duplicate_endpoint: El número de teléfono ingresado no es válido.
         generic: Se produjo un error al enviar el código de seguridad.
         invalid_calling_area: No se admiten llamadas a ese número de teléfono. Intenta

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -7,7 +7,7 @@ es:
       %{app_name} para cancelar.
     authentication_otp:
       sms: |-
-        %{app_name}: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: '¡Hola! Su código de acceso de %{app_name} es, %{code}, nuevamente, su
@@ -15,7 +15,7 @@ es:
         minutos.'
     confirmation_otp:
       sms: |-
-        %{app_name}: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: '¡Hola! Su código de acceso de %{app_name} es, %{code}, nuevamente, su
@@ -26,10 +26,10 @@ es:
       estado'
     error:
       friendly_message:
-        daily_voice_limit_reached: No se pudo enviar tu código de seguridad porque
-          excediste el número máximo de llamadas telefónicas en 24 horas a este
-          número de teléfono. Puedes solicitar un código por mensaje de texto o
-          utilizar un número diferente para recibir una llamada telefónica.
+        daily_voice_limit_reached: Your one-time code failed to send because you
+          exceeded the maximum number of phone calls in 24 hours to this phone
+          number. You can either request a code by text message or use a
+          different number to receive a phone call.
         duplicate_endpoint: El número de teléfono ingresado no es válido.
         generic: Se produjo un error al enviar el código de seguridad.
         invalid_calling_area: No se admiten llamadas a ese número de teléfono. Intenta

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -7,7 +7,7 @@ fr:
       votre compte %{app_name} pour le annuler.
     authentication_otp:
       sms: |-
-        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez pas partager ce code avec personne.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
@@ -15,7 +15,7 @@ fr:
         expirera dans %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez pas partager ce code avec personne.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -7,7 +7,7 @@ fr:
       votre compte %{app_name} pour le annuler.
     authentication_otp:
       sms: |-
-        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
@@ -15,7 +15,7 @@ fr:
         expirera dans %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+        %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
@@ -26,10 +26,10 @@ fr:
       émise par l'état"
     error:
       friendly_message:
-        daily_voice_limit_reached: Your one-time code failed to send because you
-          exceeded the maximum number of phone calls in 24 hours to this phone
-          number. You can either request a code by text message or use a
-          different number to receive a phone call.
+        daily_voice_limit_reached: L’envoi de votre code à usage unique a échoué car
+          vous avez dépassé le nombre maximal d’appels vers ce numéro de
+          téléphone en 24 heures. Vous pouvez demander un code par SMS ou
+          utiliser un autre numéro pour recevoir un appel téléphonique.
         duplicate_endpoint: Le numéro de téléphone entré n’est pas valide.
         generic: Échec de l’envoi de votre code de sécurité.
         invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -7,7 +7,7 @@ fr:
       votre compte %{app_name} pour le annuler.
     authentication_otp:
       sms: |-
-        %{app_name}: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
@@ -15,7 +15,7 @@ fr:
         expirera dans %{expiration} minutes.
     confirmation_otp:
       sms: |-
-        %{app_name}: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+        %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
         @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de %{app_name} est,
@@ -26,10 +26,10 @@ fr:
       émise par l'état"
     error:
       friendly_message:
-        daily_voice_limit_reached: L'envoi de votre code de sécurité a échoué, car vous
-          avez dépassé le nombre maximal d'appels téléphoniques en 24 heures
-          vers ce numéro de téléphone. Vous pouvez demander un code par SMS ou
-          utiliser un autre numéro pour recevoir un appel téléphonique.
+        daily_voice_limit_reached: Your one-time code failed to send because you
+          exceeded the maximum number of phone calls in 24 hours to this phone
+          number. You can either request a code by text message or use a
+          different number to receive a phone call.
         duplicate_endpoint: Le numéro de téléphone entré n’est pas valide.
         generic: Échec de l’envoi de votre code de sécurité.
         invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -25,8 +25,8 @@ en:
       password: Edit your password
       phone: Edit your phone number
     enter_2fa_code:
-      security_code: Enter the secure one-time security code
       one_time_code: Enter the secure one-time code
+      security_code: Enter the secure one-time security code
     failure:
       information_not_verified: Personal information not verified
       phone_verification: Phone number not verified

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -13,7 +13,7 @@ en:
       address: Update your mailing address
       doc_capture: Add your ID
       link_sent: Link sent
-      otp_delivery: Receive a security code
+      otp_delivery: Receive a one-time code
       processing_images: Processing your images
       ssn: Enter your Social Security number
       switch_back: Switch back to your computer
@@ -24,7 +24,9 @@ en:
       email_language: Edit email language preference
       password: Edit your password
       phone: Edit your phone number
-    enter_2fa_code: Enter the secure one-time security code
+    enter_2fa_code:
+      security_code: Enter the secure one-time security code
+      one_time_code: Enter the secure one-time code
     failure:
       information_not_verified: Personal information not verified
       phone_verification: Phone number not verified
@@ -55,7 +57,7 @@ en:
       confirm: Confirm the password for your account
       forgot: Reset password
     personal_key: Just in case
-    phone_setup: Send your security code via text message (SMS) or phone call
+    phone_setup: Send your one-time code via text message (SMS) or phone call
     piv_cac_login:
       add: Add your PIV or CAC
       new: Use your PIV/CAC to sign in to your account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -13,7 +13,7 @@ es:
       address: Actualice su dirección postal
       doc_capture: Agrega tu identificación
       link_sent: Enlace enviado
-      otp_delivery: Receive a one-time code
+      otp_delivery: Reciba un código de un solo uso
       processing_images: Procesando tus imágenes
       ssn: Ingresa tu número del seguro social
       switch_back: Regresar a tu computadora
@@ -25,8 +25,8 @@ es:
       password: Edite su contraseña
       phone: Edite su número de teléfono
     enter_2fa_code:
+      one_time_code: Ingrese el código de seguridad de un solo uso
       security_code: Ingese su código de seguridad de sólo un uso
-      one_time_code: Enter the secure one-time code
     failure:
       information_not_verified: Información personal no verificada
       phone_verification: Número telefónico no verificado
@@ -57,7 +57,8 @@ es:
       confirm: Confirme la contraseña de su cuenta
       forgot: Restablecer la contraseña
     personal_key: Por si acaso
-    phone_setup: Send your one-time code via text message (SMS) or phone call
+    phone_setup: Envíe su código de un solo uso a través de un mensaje de texto
+      (SMS) o una llamada telefónica
     piv_cac_login:
       add: Agregue su PIV o CAC
       new: Use su PIV / CAC para iniciar sesión en su cuenta

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -13,7 +13,7 @@ es:
       address: Actualice su dirección postal
       doc_capture: Agrega tu identificación
       link_sent: Enlace enviado
-      otp_delivery: Recibe un código de seguridad
+      otp_delivery: Receive a one-time code
       processing_images: Procesando tus imágenes
       ssn: Ingresa tu número del seguro social
       switch_back: Regresar a tu computadora
@@ -24,7 +24,9 @@ es:
       email_language: Editar la preferencia de idioma del correo electrónico
       password: Edite su contraseña
       phone: Edite su número de teléfono
-    enter_2fa_code: Ingese su código de seguridad de sólo un uso
+    enter_2fa_code:
+      security_code: Ingese su código de seguridad de sólo un uso
+      one_time_code: Enter the secure one-time code
     failure:
       information_not_verified: Información personal no verificada
       phone_verification: Número telefónico no verificado
@@ -55,8 +57,7 @@ es:
       confirm: Confirme la contraseña de su cuenta
       forgot: Restablecer la contraseña
     personal_key: Por si acaso
-    phone_setup: Envíe su código de seguridad a través de un mensaje de texto o de
-      una llamada telefónica
+    phone_setup: Send your one-time code via text message (SMS) or phone call
     piv_cac_login:
       add: Agregue su PIV o CAC
       new: Use su PIV / CAC para iniciar sesión en su cuenta

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -13,7 +13,7 @@ fr:
       address: Mettez à jour votre adresse postale
       doc_capture: Ajoutez votre pièce d’identité
       link_sent: Lien envoyé
-      otp_delivery: Recevez un code de sécurité
+      otp_delivery: Receive a one-time code
       processing_images: Traitement de vos images
       ssn: Entrez votre numéro de sécurité sociale
       switch_back: Retournez sur votre ordinateur
@@ -24,7 +24,9 @@ fr:
       email_language: Modifier la préférence de langue des e-mails
       password: Modifier votre mot de passe
       phone: Modifier votre numéro de téléphone
-    enter_2fa_code: Entrez le code de sécurité à utilisation unique
+    enter_2fa_code:
+      security_code: Entrez le code de sécurité à utilisation unique
+      one_time_code: Enter the secure one-time code
     failure:
       information_not_verified: Informations personnelles non vérifiées
       phone_verification: Numéro de téléphone non vérifié
@@ -55,7 +57,7 @@ fr:
       confirm: Confirmez le mot de passe de votre compte
       forgot: Réinitialisez le mot de passe
     personal_key: Juste au cas
-    phone_setup: Envoyer votre code de sécurité par SMS ou par appel téléphonique
+    phone_setup: Send your one-time code via text message (SMS) or phone call
     piv_cac_login:
       add: Ajoutez votre PIV ou CAC
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -13,7 +13,7 @@ fr:
       address: Mettez à jour votre adresse postale
       doc_capture: Ajoutez votre pièce d’identité
       link_sent: Lien envoyé
-      otp_delivery: Receive a one-time code
+      otp_delivery: Recevez un code à usage unique
       processing_images: Traitement de vos images
       ssn: Entrez votre numéro de sécurité sociale
       switch_back: Retournez sur votre ordinateur
@@ -25,8 +25,8 @@ fr:
       password: Modifier votre mot de passe
       phone: Modifier votre numéro de téléphone
     enter_2fa_code:
+      one_time_code: Entrez le code de sécurité à usage unique
       security_code: Entrez le code de sécurité à utilisation unique
-      one_time_code: Enter the secure one-time code
     failure:
       information_not_verified: Informations personnelles non vérifiées
       phone_verification: Numéro de téléphone non vérifié
@@ -57,7 +57,8 @@ fr:
       confirm: Confirmez le mot de passe de votre compte
       forgot: Réinitialisez le mot de passe
     personal_key: Juste au cas
-    phone_setup: Send your one-time code via text message (SMS) or phone call
+    phone_setup: Envoyez votre code à usage unique par message texte (SMS) ou par
+      appel téléphonique.
     piv_cac_login:
       add: Ajoutez votre PIV ou CAC
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -55,8 +55,8 @@ en:
       too many times.
     max_generic_login_attempts_reached: For your security, your account is temporarily locked.
     max_otp_login_attempts_reached: For your security, your account is temporarily
-      locked because you have entered the one-time code incorrectly too
-      many times.
+      locked because you have entered the one-time code incorrectly too many
+      times.
     max_otp_requests_reached: For your security, your account is temporarily locked
       because you have requested a one-time code too many times.
     max_personal_key_login_attempts_reached: For your security, your account is

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -20,8 +20,8 @@ en:
     header_text: Enter your one-time code
     important_alert_icon: important alert icon
     invalid_backup_code: That backup code is invalid.
-    invalid_otp: That security code is invalid. You can try entering it again or
-      request a new one-time security code.
+    invalid_otp: That one-time code is invalid. You can try entering it again or
+      request a new one-time code.
     invalid_personal_key: That personal key is invalid.
     invalid_piv_cac: That PIV/CAC didn’t work. Make sure it’s the right PIV/CAC for
       this account. If it is, there may be a problem with your PIV/CAC, PIN, or
@@ -38,9 +38,9 @@ en:
       piv_cac: Government employee ID
       piv_cac_info: Use your PIV/CAC card instead of a security code.
       sms: Text message
-      sms_info_html: Get security code via text message to <strong>%{phone}</strong>.
+      sms_info_html: Get one-time code via text message to <strong>%{phone}</strong>.
       voice: Automated phone call
-      voice_info_html: Get security code via phone call to <strong>%{phone}</strong>
+      voice_info_html: Get one-time code via phone call to <strong>%{phone}</strong>
         (North America phone numbers only).
       webauthn: Security key
       webauthn_info: Use your security key to access your account.
@@ -55,10 +55,10 @@ en:
       too many times.
     max_generic_login_attempts_reached: For your security, your account is temporarily locked.
     max_otp_login_attempts_reached: For your security, your account is temporarily
-      locked because you have entered the one-time security code incorrectly too
+      locked because you have entered the one-time code incorrectly too
       many times.
     max_otp_requests_reached: For your security, your account is temporarily locked
-      because you have requested a security code too many times.
+      because you have requested a one-time code too many times.
     max_personal_key_login_attempts_reached: For your security, your account is
       temporarily locked because you have entered the personal key incorrectly
       too many times.
@@ -71,12 +71,12 @@ en:
       cant_use_phone: 'Can’t use your phone?'
       error_retry: 'Sorry, we are having trouble opting you in. Please try again.'
       opted_out_html: 'You’ve opted out of receiving text messages at %{phone_number}.
-        You can opt in and receive a security code again to that phone number.'
+        You can opt in and receive a one-time code again to that phone number.'
       opted_out_last_30d_html: 'You’ve opted out of receiving text messages at
         %{phone_number} within the last 30 days. We can only opt in a phone
         number once every 30 days.'
-      title: We could not send a security code to your phone number
-      wait_30d_opt_in: 'After 30 days, you can opt in and receive a security code to
+      title: We could not send a one-time code to your phone number
+      wait_30d_opt_in: 'After 30 days, you can opt in and receive a one-time code to
         that phone number.'
     otp_delivery_preference:
       instruction: You can change this selection the next time you sign in. If you
@@ -107,7 +107,7 @@ en:
     phone_fallback:
       question: Can’t use your phone?
     phone_fee_disclosure: Message and data rates may apply.
-    phone_info_html: We’ll send you a security code <strong>each time you sign in</strong>.
+    phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
     phone_label: Phone number
     piv_cac_fallback:
       question: Don’t have your PIV or CAC available?
@@ -146,12 +146,12 @@ en:
       piv_cac: Government employee ID
       piv_cac_info: PIV/CAC cards for government and military employees. Desktop only.
       sms: Text message / SMS
-      sms_info: Get your security code via text message / SMS.
+      sms_info: Get your one-time code via text message / SMS.
       unused_backup_code:
         one: '(%{count} unused code)'
         other: '(%{count} unused codes)'
       voice: Phone call
-      voice_info: Get your security code via phone call.
+      voice_info: Get your one-time code via phone call.
       webauthn: Security key
       webauthn_info: A physical device, often shaped like a USB drive, that you plug
         in to your device.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -20,8 +20,8 @@ es:
     header_text: Introduzca su código único
     important_alert_icon: ícono de aviso importante
     invalid_backup_code: Esa código de respaldo no es válida.
-    invalid_otp: That one-time code is invalid. You can try entering it again or
-      request a new one-time code.
+    invalid_otp: El código de un solo uso no es válido. Puede intentar ingresarlo
+      nuevamente o solicitar uno nuevo.
     invalid_personal_key: Esa clave personal no es válida.
     invalid_piv_cac: Ese PIV/CAC no funcionó. Asegúrese de que sea el PIV/CAC
       correcto para esta cuenta. Si es así, puede haber un problema con su
@@ -40,10 +40,12 @@ es:
       piv_cac: Empleados del Gobierno
       piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta.
       sms: Mensaje de texto / SMS
-      sms_info_html: Get one-time code via text message to <strong>%{phone}</strong>.
+      sms_info_html: Obtenga el código de un solo uso a través de un mensaje de texto
+        al <strong>%{phone}</strong>.
       voice: Llamada telefónica automatizada
-      voice_info_html: Get one-time code via phone call to <strong>%{phone}</strong>
-        (North America phone numbers only).
+      voice_info_html: Obtenga el código de un solo uso a través de una llamada
+        telefónica al <strong>%{phone}</strong>. (Solo números de teléfono de
+        América del Norte).
       webauthn: Llave de seguridad
       webauthn_info: Use su llave de seguridad para acceder a su cuenta.
       webauthn_platform: Desbloqueo facial o táctil
@@ -57,11 +59,11 @@ es:
       bloqueada temporalmente porque ha ingresado el código de respaldo
       incorrectamente muchas veces.
     max_generic_login_attempts_reached: Para su seguridad, su cuenta está bloqueada temporalmente.
-    max_otp_login_attempts_reached: For your security, your account is temporarily
-      locked because you have entered the one-time code incorrectly too
-      many times.
-    max_otp_requests_reached: For your security, your account is temporarily locked
-      because you have requested a one-time code too many times.
+    max_otp_login_attempts_reached: Como medida de seguridad, su cuenta ha sido
+      bloqueada de forma temporal, ya que ingresó el código de un solo uso de
+      forma incorrecta reiteradas veces.
+    max_otp_requests_reached: Para su seguridad, su cuenta está temporalmente
+      bloqueada porque ha solicitado un código único demasiadas veces.
     max_personal_key_login_attempts_reached: Para su seguridad, su cuenta ha sido
       bloqueada temporalmente porque ha ingresado incorrectamente la clave
       personal demasiadas veces.
@@ -74,14 +76,15 @@ es:
       cant_use_phone: '¿No puede utilizar su teléfono?'
       error_retry: 'Lo sentimos, estamos teniendo problemas para aceptarlo. Por favor,
         inténtelo de nuevo.'
-      opted_out_html: 'You’ve opted out of receiving text messages at %{phone_number}.
-        You can opt in and receive a one-time code again to that phone number.'
+      opted_out_html: 'Ha optado por no recibir mensajes de texto en el
+        %{phone_number}. Puede optar por recibir de nuevo un código de un solo
+        uso a ese número de teléfono.'
       opted_out_last_30d_html: 'Canceló su suscripción para recibir mensajes de texto
         al %{phone_number} en los últimos 30 días. Solo podemos suscribir un
         número telefónico una vez cada 30 días.'
-      title: We could not send a one-time code to your phone number
-      wait_30d_opt_in: 'After 30 days, you can opt in and receive a one-time code to
-        that phone number.'
+      title: No hemos podido enviar el código de un solo uso a su número de teléfono
+      wait_30d_opt_in: 'Luego de 30 días, usted podrá recibir el código de un solo uso
+        a ese número de teléfono.'
     otp_delivery_preference:
       instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
       no_supported_options: No podemos verificar los números de teléfono de %{location}
@@ -110,7 +113,8 @@ es:
     phone_fallback:
       question: '¿No puede utilizar su teléfono?'
     phone_fee_disclosure: Se pueden aplicar tarifas por mensajes y datos.
-    phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
+    phone_info_html: Le enviaremos un código de un solo uso <strong>cada vez que
+      ingrese</strong>.
     phone_label: Número de teléfono
     piv_cac_fallback:
       question: '¿No tienes su PIV o CAC disponibles?'
@@ -153,12 +157,12 @@ es:
       piv_cac_info: Credenciales PIV/CAC para empleados gubernamentales y del
         ejército. Únicamente versión de escritorio.
       sms: Mensaje de texto / SMS
-      sms_info: Get your one-time code via text message / SMS.
+      sms_info: Obtenga su código de un solo uso a través de un mensaje de texto/SMS.
       unused_backup_code:
         one: '(%{count} código sin usar)'
         other: '(%{count} códigos sin usar)'
       voice: Llamada telefónica
-      voice_info: Get your one-time code via phone call.
+      voice_info: Obtenga su código de un solo uso a través de una llamada telefónica.
       webauthn: Clave de seguridad
       webauthn_info: Un dispositivo físico que suele tener la forma de una unidad USB
         y se conecta a su dispositivo.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -20,8 +20,8 @@ es:
     header_text: Introduzca su código único
     important_alert_icon: ícono de aviso importante
     invalid_backup_code: Esa código de respaldo no es válida.
-    invalid_otp: Ese código de seguridad no es válido. Puede intentar ingresarlo de
-      nuevo o solicitar un nuevo código de seguridad de sólo un uso.
+    invalid_otp: That one-time code is invalid. You can try entering it again or
+      request a new one-time code.
     invalid_personal_key: Esa clave personal no es válida.
     invalid_piv_cac: Ese PIV/CAC no funcionó. Asegúrese de que sea el PIV/CAC
       correcto para esta cuenta. Si es así, puede haber un problema con su
@@ -40,12 +40,10 @@ es:
       piv_cac: Empleados del Gobierno
       piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta.
       sms: Mensaje de texto / SMS
-      sms_info_html: Obtenga su código de seguridad a través de mensajes de texto /
-        SMS a <strong>%{phone}</strong>.
+      sms_info_html: Get one-time code via text message to <strong>%{phone}</strong>.
       voice: Llamada telefónica automatizada
-      voice_info_html: Obtenga su código de seguridad a través de una llamada
-        telefónica a <strong>%{phone}</strong>. (Solo números de teléfono de
-        América del Norte).
+      voice_info_html: Get one-time code via phone call to <strong>%{phone}</strong>
+        (North America phone numbers only).
       webauthn: Llave de seguridad
       webauthn_info: Use su llave de seguridad para acceder a su cuenta.
       webauthn_platform: Desbloqueo facial o táctil
@@ -59,12 +57,11 @@ es:
       bloqueada temporalmente porque ha ingresado el código de respaldo
       incorrectamente muchas veces.
     max_generic_login_attempts_reached: Para su seguridad, su cuenta está bloqueada temporalmente.
-    max_otp_login_attempts_reached: Para su seguridad, su cuenta ha sido bloqueada
-      temporalmente porque ha ingresado incorrectamente el código de seguridad
-      de sólo un uso demasiadas veces.
-    max_otp_requests_reached: Para su seguridad, su cuenta ha sido bloqueada
-      temporalmente porque ha solicitado un código de seguridad demasiadas veces
-      más de lo permitido.
+    max_otp_login_attempts_reached: For your security, your account is temporarily
+      locked because you have entered the one-time code incorrectly too
+      many times.
+    max_otp_requests_reached: For your security, your account is temporarily locked
+      because you have requested a one-time code too many times.
     max_personal_key_login_attempts_reached: Para su seguridad, su cuenta ha sido
       bloqueada temporalmente porque ha ingresado incorrectamente la clave
       personal demasiadas veces.
@@ -77,15 +74,14 @@ es:
       cant_use_phone: '¿No puede utilizar su teléfono?'
       error_retry: 'Lo sentimos, estamos teniendo problemas para aceptarlo. Por favor,
         inténtelo de nuevo.'
-      opted_out_html: 'Ha optado por no recibir mensajes de texto en el
-        %{phone_number}. Puede optar por recibir un código de seguridad de nuevo
-        a ese número de teléfono.'
+      opted_out_html: 'You’ve opted out of receiving text messages at %{phone_number}.
+        You can opt in and receive a one-time code again to that phone number.'
       opted_out_last_30d_html: 'Canceló su suscripción para recibir mensajes de texto
         al %{phone_number} en los últimos 30 días. Solo podemos suscribir un
         número telefónico una vez cada 30 días.'
-      title: 'No hemos podido enviar un código de seguridad a su número de teléfono'
-      wait_30d_opt_in: 'Después de 30 días, podrá inscribirse y recibir un código de
-        seguridad para ese número de teléfono.'
+      title: We could not send a one-time code to your phone number
+      wait_30d_opt_in: 'After 30 days, you can opt in and receive a one-time code to
+        that phone number.'
     otp_delivery_preference:
       instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
       no_supported_options: No podemos verificar los números de teléfono de %{location}
@@ -114,8 +110,7 @@ es:
     phone_fallback:
       question: '¿No puede utilizar su teléfono?'
     phone_fee_disclosure: Se pueden aplicar tarifas por mensajes y datos.
-    phone_info_html: Le enviaremos o llamaremos con un código de seguridad
-      <strong>cada vez que inicie sesión</strong>.
+    phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
     phone_label: Número de teléfono
     piv_cac_fallback:
       question: '¿No tienes su PIV o CAC disponibles?'
@@ -158,12 +153,12 @@ es:
       piv_cac_info: Credenciales PIV/CAC para empleados gubernamentales y del
         ejército. Únicamente versión de escritorio.
       sms: Mensaje de texto / SMS
-      sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS.
+      sms_info: Get your one-time code via text message / SMS.
       unused_backup_code:
         one: '(%{count} código sin usar)'
         other: '(%{count} códigos sin usar)'
       voice: Llamada telefónica
-      voice_info: Obtenga su código de seguridad a través de una llamada telefónica.
+      voice_info: Get your one-time code via phone call.
       webauthn: Clave de seguridad
       webauthn_info: Un dispositivo físico que suele tener la forma de una unidad USB
         y se conecta a su dispositivo.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -21,8 +21,8 @@ fr:
     header_text: Entrez votre code à usage unique
     important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.
-    invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l’entrer
-      de nouveau ou demander un nouveau code de sécurité à utilisation unique.
+    invalid_otp: That one-time code is invalid. You can try entering it again or
+      request a new one-time code.
     invalid_personal_key: Cette clé personnelle est non valide.
     invalid_piv_cac: Ce PIV/CAC n’a pas fonctionné. Assurez-vous que c’est le bon
       PIV/CAC pour ce compte. Si c’est le cas, votre PIV/CAC, votre NIP ou un
@@ -42,11 +42,10 @@ fr:
       piv_cac: Employés du gouvernement
       piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
       sms: SMS
-      sms_info_html: Obtenez votre code de sécurité par SMS à <strong>%{phone}</strong>.
+      sms_info_html: Get one-time code via text message to <strong>%{phone}</strong>.
       voice: Appel téléphonique
-      voice_info_html: Obtenez votre code de sécurité Obtenez votre code de sécurité
-        par SMS à  à <strong>%{phone}</strong>. (Seulement les numéros de
-        téléphone en Amerique du Nord)
+      voice_info_html: Get one-time code via phone call to <strong>%{phone}</strong>
+        (North America phone numbers only).
       webauthn: Clé de sécurité
       webauthn_info: Utilisez votre clé de sécurité pour accéder à votre compte.
       webauthn_platform: Déverrouillage facial ou tactile
@@ -60,11 +59,11 @@ fr:
       temporairement verrouillé car vous avez saisi trop de fois le code de
       sauvegarde.
     max_generic_login_attempts_reached: Pour votre sécurité, votre compte est temporairement verrouillé.
-    max_otp_login_attempts_reached: Pour votre sécurité, votre compte est
-      temporairement verrouillé, car vous avez entré le code de sécurité à
-      utilisation unique de façon erronée à de trop nombreuses reprises.
-    max_otp_requests_reached: Pour votre sécurité, votre compte est temporairement
-      verrouillé car vous avez demandé un code de sécurité à trop de reprises.
+    max_otp_login_attempts_reached: For your security, your account is temporarily
+      locked because you have entered the one-time code incorrectly too
+      many times.
+    max_otp_requests_reached: For your security, your account is temporarily locked
+      because you have requested a one-time code too many times.
     max_personal_key_login_attempts_reached: Pour votre sécurité, votre compte est
       temporairement verrouillé, car vous avez entré le code de sécurité à
       utilisation unique de façon erronée à de trop nombreuses reprises.
@@ -77,16 +76,14 @@ fr:
       cant_use_phone: 'Vous ne pouvez pas utiliser votre téléphone?'
       error_retry: 'Désolé, nous avons des difficultés à vous connecter. Veuillez
         réessayer.'
-      opted_out_html: 'Vous avez choisi de ne plus recevoir de SMS à %{phone_number}.
-        Vous pouvez vous inscrire et recevoir à nouveau un code de sécurité à ce
-        numéro de téléphone.'
+      opted_out_html: 'You’ve opted out of receiving text messages at %{phone_number}.
+        You can opt in and receive a one-time code again to that phone number.'
       opted_out_last_30d_html: 'Vous avez choisi de ne plus recevoir de SMS au
         %{phone_number} au cours des 30 derniers jours. Nous ne pouvons opter
         pour un numéro de téléphone qu’une fois tous les 30 jours.'
-      title: 'Nous n’avons pas pu envoyer un code de sécurité à votre numéro de
-        téléphone'
-      wait_30d_opt_in: 'Après 30 jours, vous pouvez vous inscrire et recevoir un code
-        de sécurité à ce numéro de téléphone.'
+      title: We could not send a one-time code to your phone number
+      wait_30d_opt_in: 'After 30 days, you can opt in and receive a one-time code to
+        that phone number.'
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
       no_supported_options: Nous ne sommes pas en mesure de vérifier les numéros de
@@ -118,8 +115,7 @@ fr:
     phone_fallback:
       question: Vous ne pouvez pas utiliser votre téléphone?
     phone_fee_disclosure: Des messages et débits de données peuvent être appliqués.
-    phone_info_html: Nous vous enverrons ou appellerons avec un code de sécurité
-      <strong>chaque fois que vous vous connectez</strong>.
+    phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
     phone_label: Numéro de téléphone
     piv_cac_fallback:
       question: Votre PIV ou CAC n’est pas disponible?
@@ -161,12 +157,12 @@ fr:
       piv_cac_info: Cartes PIV/CAC pour les fonctionnaires et les militaires. Bureau
         uniquement.
       sms: SMS
-      sms_info: Obtenez votre code de sécurité par SMS.
+      sms_info: Get your one-time code via text message / SMS.
       unused_backup_code:
         one: '(%{count} code non utilisé)'
         other: '(%{count} codes non utilisés)'
       voice: Appel téléphonique
-      voice_info: Obtenez votre code de sécurité par appel téléphonique.
+      voice_info: Get your one-time code via phone call.
       webauthn: Clef de sécurité
       webauthn_info: Un appareil physique, souvent en forme de clé USB, que vous
         branchez sur votre appareil.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -21,8 +21,8 @@ fr:
     header_text: Entrez votre code à usage unique
     important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.
-    invalid_otp: That one-time code is invalid. You can try entering it again or
-      request a new one-time code.
+    invalid_otp: Ce code à usage unique n’est pas valide. Vous pouvez essayer de le
+      saisir à nouveau ou demander un nouveau code à usage unique.
     invalid_personal_key: Cette clé personnelle est non valide.
     invalid_piv_cac: Ce PIV/CAC n’a pas fonctionné. Assurez-vous que c’est le bon
       PIV/CAC pour ce compte. Si c’est le cas, votre PIV/CAC, votre NIP ou un
@@ -42,10 +42,11 @@ fr:
       piv_cac: Employés du gouvernement
       piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
       sms: SMS
-      sms_info_html: Get one-time code via text message to <strong>%{phone}</strong>.
+      sms_info_html: Obtenez un code à usage unique par SMS au <strong>%{phone}</strong>.
       voice: Appel téléphonique
-      voice_info_html: Get one-time code via phone call to <strong>%{phone}</strong>
-        (North America phone numbers only).
+      voice_info_html: Obtenez un code à usage unique par appel téléphonique au
+        <strong>%{phone}</strong> (Seulement les numéros de téléphone en
+        Amerique du Nord).
       webauthn: Clé de sécurité
       webauthn_info: Utilisez votre clé de sécurité pour accéder à votre compte.
       webauthn_platform: Déverrouillage facial ou tactile
@@ -59,11 +60,12 @@ fr:
       temporairement verrouillé car vous avez saisi trop de fois le code de
       sauvegarde.
     max_generic_login_attempts_reached: Pour votre sécurité, votre compte est temporairement verrouillé.
-    max_otp_login_attempts_reached: For your security, your account is temporarily
-      locked because you have entered the one-time code incorrectly too
-      many times.
-    max_otp_requests_reached: For your security, your account is temporarily locked
-      because you have requested a one-time code too many times.
+    max_otp_login_attempts_reached: Pour votre sécurité, votre compte est
+      temporairement verrouillé car vous avez saisi le code à usage unique de
+      manière incorrecte un trop grand nombre de fois.
+    max_otp_requests_reached: Pour votre sécurité, votre compte est temporairement
+      verrouillé parce que vous avez demandé un code à usage unique trop
+      souvent.
     max_personal_key_login_attempts_reached: Pour votre sécurité, votre compte est
       temporairement verrouillé, car vous avez entré le code de sécurité à
       utilisation unique de façon erronée à de trop nombreuses reprises.
@@ -76,14 +78,16 @@ fr:
       cant_use_phone: 'Vous ne pouvez pas utiliser votre téléphone?'
       error_retry: 'Désolé, nous avons des difficultés à vous connecter. Veuillez
         réessayer.'
-      opted_out_html: 'You’ve opted out of receiving text messages at %{phone_number}.
-        You can opt in and receive a one-time code again to that phone number.'
+      opted_out_html: 'Vous avez choisi de ne plus recevoir de SMS à %{phone_number}.
+        Vous pouvez choisir de vous inscrire et de recevoir à nouveau un code à
+        usage unique à ce numéro de téléphone.'
       opted_out_last_30d_html: 'Vous avez choisi de ne plus recevoir de SMS au
         %{phone_number} au cours des 30 derniers jours. Nous ne pouvons opter
         pour un numéro de téléphone qu’une fois tous les 30 jours.'
-      title: We could not send a one-time code to your phone number
-      wait_30d_opt_in: 'After 30 days, you can opt in and receive a one-time code to
-        that phone number.'
+      title: Nous n’avons pas pu envoyer de code à usage unique à votre numéro de
+        téléphone.
+      wait_30d_opt_in: 'Après 30 jours, vous pouvez vous inscrire et recevoir un code
+        à usage unique pour ce numéro de téléphone.'
     otp_delivery_preference:
       instruction: Vous pouvez modifier cette sélection lors de votre prochaine connexion.
       no_supported_options: Nous ne sommes pas en mesure de vérifier les numéros de
@@ -115,7 +119,8 @@ fr:
     phone_fallback:
       question: Vous ne pouvez pas utiliser votre téléphone?
     phone_fee_disclosure: Des messages et débits de données peuvent être appliqués.
-    phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
+    phone_info_html: Nous vous enverrons un code à usage unique <strong>à chaque
+      fois que vous vous connecterez</strong>.
     phone_label: Numéro de téléphone
     piv_cac_fallback:
       question: Votre PIV ou CAC n’est pas disponible?
@@ -157,12 +162,12 @@ fr:
       piv_cac_info: Cartes PIV/CAC pour les fonctionnaires et les militaires. Bureau
         uniquement.
       sms: SMS
-      sms_info: Get your one-time code via text message / SMS.
+      sms_info: Recevez votre code à usage unique par message texte/SMS.
       unused_backup_code:
         one: '(%{count} code non utilisé)'
         other: '(%{count} codes non utilisés)'
       voice: Appel téléphonique
-      voice_info: Get your one-time code via phone call.
+      voice_info: Obtenez votre code à usage unique par appel téléphonique.
       webauthn: Clef de sécurité
       webauthn_info: Un appareil physique, souvent en forme de clé USB, que vous
         branchez sur votre appareil.

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -28,7 +28,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
 
     context 'common OTP delivery screen behavior' do
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.enter_2fa_code'))
+        expect(view).to receive(:title).with(t('titles.enter_2fa_code.one_time_code'))
 
         render
       end

--- a/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe 'two_factor_authentication/personal_key_verification/show.html.erb' do
   it_behaves_like 'an otp form'
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.enter_2fa_code'))
+    expect(view).to receive(:title).with(t('titles.enter_2fa_code.security_code'))
 
     render
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-7934](https://cm-jira.usa.gov/browse/LG-7934)

## 🛠 Summary of changes

Updates all existing references to "security code" in the context of SMS and Voice authentication codes to "one-time code".

## 📜 Testing Plan

- [ ] Confirm that no lingering references to "security code" exist unless they are used in the context of other codes (TOTP, personal key, backup code, etc.)
