### PR TITLE
LG-7934: Remove unreachable references to "security code"

### DIFF
--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -21,19 +21,9 @@ class ReauthnRequiredController < ApplicationController
   def prompt_for_current_password
     store_location(request.url)
     user_session[:context] = 'reauthentication'
-    user_session[:factor_to_change], user_session[:no_factor_message] = factor_and_message
+    user_session[:factor_to_change] = factor_from_controller_name
     user_session[:current_password_required] = true
     redirect_to user_password_confirm_url
-  end
-
-  def factor_and_message
-    factor = factor_from_controller_name
-    message = nil
-    if factor == 'delete'
-      factor = nil
-      message = I18n.t('help_text.no_factor.delete_account')
-    end
-    [factor, message]
   end
 
   def factor_from_controller_name
@@ -42,7 +32,6 @@ class ReauthnRequiredController < ApplicationController
       'emails' => 'email',
       'passwords' => 'password',
       'phones' => 'phone',
-      'delete' => 'delete',
       'personal_keys' => 'personal key',
     }[controller_name]
   end

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -4,8 +4,7 @@
 
 <p>
   <%# for follow up: translate factor_to_change (LG-5701) %>
-  <%= user_session[:no_factor_message] ||
-        t('help_text.change_factor', factor: user_session[:factor_to_change]) %>
+  <%= t('help_text.change_factor', factor: user_session[:factor_to_change]) %>
 </p>
 
 <%= simple_form_for(

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -65,7 +65,6 @@ en:
       missing_field: Please fill in this field.
       no_pending_profile: No profile is waiting for verification
       not_a_number: is not a number
-      otp_failed: Your security code failed to send.
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
       phone_confirmation_throttled: You tried too many times, please try again in %{timeout}.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -67,7 +67,6 @@ es:
       missing_field: Por favor, rellene este campo.
       no_pending_profile: Ningún perfil está esperando verificación
       not_a_number: no es un número
-      otp_failed: Se produjo un error al enviar el código de seguridad.
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
       phone_confirmation_throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -74,7 +74,6 @@ fr:
       missing_field: Veuillez remplir ce champ.
       no_pending_profile: Aucun profil en attente de vérification
       not_a_number: N’est pas un nombre
-      otp_failed: Échec de l’envoi de votre code de sécurité.
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
       phone_confirmation_throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -3,8 +3,6 @@ en:
   help_text:
     change_factor: Before you’re able to reset your %{factor}, you will need to
       confirm your password and use your authentication method.
-    no_factor:
-      delete_account: To delete your account, please confirm your password and security code.
     requested_attributes:
       address: Mailing address
       all_emails: Email addresses on your account

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -3,8 +3,6 @@ es:
   help_text:
     change_factor: Antes de que pueda restablecer su %{factor}, tendrá que confirmar
       su contraseña y utilizar su método de autenticación.
-    no_factor:
-      delete_account: Para eliminar su cuenta, confirme su contraseña y código de seguridad.
     requested_attributes:
       address: Dirección de correo postal
       all_emails: Direcciones de correo electrónico en su cuenta

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -3,9 +3,6 @@ fr:
   help_text:
     change_factor: Avant de pouvoir réinitialiser votre %{factor}, vous devrez
       confirmer votre mot de passe et utiliser votre méthode d’authentification.
-    no_factor:
-      delete_account: Pour supprimer votre compte, veuillez confirmer votre mot de
-        passe et votre code de sécurité.
     requested_attributes:
       address: Adresse postale
       all_emails: Adresses e-mail sur votre compte


### PR DESCRIPTION
## 🎫 Ticket

[LG-7934](https://cm-jira.usa.gov/browse/LG-7934)

## 🛠 Summary of changes

Split from #7335

Removes unreachable references to "security code":

1. `errors.messages.otp_failed` is not referenced in code, but also not marked as unused due to [unused exception for `i18n-tasks.yml`](https://github.com/18F/identity-idp/blob/62cf90c750b947f580da8b3e8eba31b9f844bb63/config/i18n-tasks.yml#L99)
2. `ReauthnRequiredController` creates a mapping based on the subclass controller name, but `DeleteController` no longer extends `ReauthnRequiredController` as of 309042c635c3de3ba52bd768ac475716a30e54dc

## 📜 Testing Plan

- [ ] Specs pass
