### PR TITLE
Mattw/lg 7470 tweaks

### DIFF
--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -52,11 +52,10 @@ module Api
     end
 
     def encrypted_security_event_log_result
-      events = security_event_tokens.join("\r\n")
-      decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
-
       IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-        data: events, timestamp: timestamp, public_key_str: decoded_key_der,
+        data: security_event_tokens.join("\r\n"),
+        timestamp: timestamp,
+        public_key_str: IdentityConfig.store.irs_attempt_api_public_key,
       )
     end
 

--- a/app/controllers/api/irs_attempts_api_controller.rb
+++ b/app/controllers/api/irs_attempts_api_controller.rb
@@ -54,10 +54,9 @@ module Api
     def encrypted_security_event_log_result
       events = security_event_tokens.join("\r\n")
       decoded_key_der = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
-      pub_key = OpenSSL::PKey::RSA.new(decoded_key_der)
 
       IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-        data: events, timestamp: timestamp, public_key: pub_key,
+        data: events, timestamp: timestamp, public_key_str: decoded_key_der,
       )
     end
 

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -9,10 +9,10 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     events = IrsAttemptsApi::RedisClient.new.read_events(timestamp: timestamp)
     event_values = events.values.join("\r\n")
 
-    decoded_key_string = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
+    public_key = IdentityConfig.store.irs_attempt_api_public_key
 
     result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-      data: event_values, timestamp: timestamp, public_key_str: decoded_key_string,
+      data: event_values, timestamp: timestamp, public_key_str: public_key,
     )
 
     bucket_name = IdentityConfig.store.irs_attempt_api_bucket_name

--- a/app/jobs/irs_attempts_events_batch_job.rb
+++ b/app/jobs/irs_attempts_events_batch_job.rb
@@ -10,10 +10,9 @@ class IrsAttemptsEventsBatchJob < ApplicationJob
     event_values = events.values.join("\r\n")
 
     decoded_key_string = Base64.strict_decode64(IdentityConfig.store.irs_attempt_api_public_key)
-    pub_key = OpenSSL::PKey::RSA.new(decoded_key_string)
 
     result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-      data: event_values, timestamp: timestamp, public_key: pub_key,
+      data: event_values, timestamp: timestamp, public_key_str: decoded_key_string,
     )
 
     bucket_name = IdentityConfig.store.irs_attempt_api_bucket_name

--- a/app/services/irs_attempts_api/envelope_encryptor.rb
+++ b/app/services/irs_attempts_api/envelope_encryptor.rb
@@ -6,12 +6,13 @@ module IrsAttemptsApi
 
     # A new key is generated for each encryption.  This key is encrypted with the public_key
     # provided so that only the owner of the private key may decrypt this data.
-    def self.encrypt(data:, timestamp:, public_key:)
+    def self.encrypt(data:, timestamp:, public_key_str:)
       compressed_data = Zlib.gzip(data)
       cipher = OpenSSL::Cipher.new('aes-256-cbc')
       cipher.encrypt
       key = cipher.random_key
       iv = cipher.random_iv
+      public_key = OpenSSL::PKey::RSA.new(Base64.strict_decode64(public_key_str))
       encrypted_data = cipher.update(compressed_data) + cipher.final
       encoded_data = Base16.encode16(encrypted_data)
       digest = Digest::SHA256.hexdigest(encoded_data)

--- a/spec/jobs/irs_attempts_events_batch_job_spec.rb
+++ b/spec/jobs/irs_attempts_events_batch_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe IrsAttemptsEventsBatchJob, type: :job do
     context 'IRS attempts API is enabled' do
       let(:start_time) { Time.new(2020, 1, 1, 12, 0, 0, 'UTC') }
       let(:private_key) { OpenSSL::PKey::RSA.new(4096) }
-      #let(:public_key) { private_key.public_key }
+      # let(:public_key) { private_key.public_key }
       let(:encoded_public_key) { Base64.strict_encode64(private_key.public_key.to_der) }
       let(:bucket_name) { 'test-bucket-name' }
       let(:events) do

--- a/spec/services/irs_attempts_api/envelope_encryptor_spec.rb
+++ b/spec/services/irs_attempts_api/envelope_encryptor_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 RSpec.describe IrsAttemptsApi::EnvelopeEncryptor do
   let(:private_key) { OpenSSL::PKey::RSA.new(4096) }
-  let(:public_key) { private_key.public_key }
+  let(:public_key) { Base64.strict_encode64(private_key.public_key.to_der) }
   describe '.encrypt' do
     it 'returns encrypted result' do
       text = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
-        data: text, timestamp: time, public_key: public_key,
+        data: text, timestamp: time, public_key_str: public_key,
       )
 
       expect(result.encrypted_data).to_not eq text
@@ -20,7 +20,7 @@ RSpec.describe IrsAttemptsApi::EnvelopeEncryptor do
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
         data: text, timestamp: time,
-        public_key: public_key
+        public_key_str: public_key
       )
       digest = Digest::SHA256.hexdigest(result.encrypted_data)
 
@@ -37,7 +37,7 @@ RSpec.describe IrsAttemptsApi::EnvelopeEncryptor do
       time = Time.zone.now
       result = IrsAttemptsApi::EnvelopeEncryptor.encrypt(
         data: text, timestamp: time,
-        public_key: public_key
+        public_key_str: public_key
       )
       key = private_key.private_decrypt(result.encrypted_key)
 


### PR DESCRIPTION
This is a PR against [Richard's PR for LG-7470](https://github.com/18F/identity-idp/pull/7323).

We've gone back and forth a bit about what to test here. Perhaps we are testing too much&mdash;we've had to stub out a whole lot here.

Conversely, perhaps we're not testing enough. We have the private key available, so we could decrypt the result. But we don't (and shouldn't) return the encrypted data, so we would have to separately do the encryption and compare the results. But it occurs to me that calling the Encryptor separately and comparing them isn't really testing anything&mdash;we're ultimately comparing it to itself, so an issue with how we do encryption wouldn't get caught.

We could implement the encryption code ourselves in the test and compare the results, but that starts to feel extremely out of place in this test.

Or maybe we're testing neither too much nor too little, and it's instead just right. ![goldilocks](https://media.giphy.com/media/xT5LMD7WPgqXfjUJsQ/giphy.gif)