### PR TITLE
LG-7934: Update another "security code" to "one-time code"

### DIFF
--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -28,7 +28,7 @@ en:
           number. You can either request a code by text message or use a
           different number to receive a phone call.
         duplicate_endpoint: The phone number entered is not valid.
-        generic: Your security code failed to send.
+        generic: Your one-time code failed to send.
         invalid_calling_area: Calls to that phone number are not supported. Please try
           SMS if you have an SMS-capable phone.
         invalid_phone_number: The phone number entered is not valid.

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -31,7 +31,7 @@ es:
           de teléfono. Puedes solicitar un código por mensaje de texto o
           utilizar un número diferente para recibir una llamada telefónica.
         duplicate_endpoint: El número de teléfono ingresado no es válido.
-        generic: Se produjo un error al enviar el código de seguridad.
+        generic: No se pudo enviar su código de verificación.
         invalid_calling_area: No se admiten llamadas a ese número de teléfono. Intenta
           enviar un SMS si tienes un teléfono que permita enviar SMS.
         invalid_phone_number: El número de teléfono ingresado no está en el formato correcto.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -31,7 +31,7 @@ fr:
           téléphone en 24 heures. Vous pouvez demander un code par SMS ou
           utiliser un autre numéro pour recevoir un appel téléphonique.
         duplicate_endpoint: Le numéro de téléphone entré n’est pas valide.
-        generic: Échec de l’envoi de votre code de sécurité.
+        generic: Votre code à usage unique n'a pas été envoyé.
         invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en
           charge. Veuillez essayer par SMS si vous possédez un téléphone
           disposant de cette fonction.


### PR DESCRIPTION
## 🎫 Ticket

[LG-7934](https://cm-jira.usa.gov/browse/LG-7934)

## 🛠 Summary of changes

Updates a lingering reference to "security code" in the context of SMS and Voice authentication codes to "one-time code", missed as part of #7335. This text is shown as a fallback error message in the case of telephony send errors.

Related Slack comment: https://gsa-tts.slack.com/archives/C01710KMYUB/p1668540190720279?thread_ts=1668539716.757899&cid=C01710KMYUB

## 📜 Testing Plan

- [ ] Confirm that no lingering references to "security code" exist unless they are used in the context of other codes (TOTP, personal key, backup code, etc.)