### PR TITLE
Remove unused return value for MFA analytics method

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -87,7 +87,6 @@ class Analytics
       **attributes,
       pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
     )
-    attributes[:success] ? 'success' : 'fail'
   end
 
   def request_attributes


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the logic for `Analytics#track_mfa_submit_event`'s return value, as it is not used. It appears to be originally [used as part of Google Analytics measurements](https://github.com/18F/identity-idp/pull/2835/files#diff-7d70ee23bf46aada63c06abeff7370d8bfc04653e750081f438526e163c15411R23) which have since been removed.

## 📜 Testing Plan

- [ ] Specs pass
- [ ] No regression in sign in MFA