### PR TITLE
Define max login OTP confirmation attempts as configuration

### DIFF
--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -4,7 +4,7 @@ module UserOtpMethods
   extend ActiveSupport::Concern
 
   def max_login_attempts?
-    second_factor_attempts_count.to_i >= max_login_attempts
+    second_factor_attempts_count.to_i >= IdentityConfig.store.login_otp_confirmation_max_attempts
   end
 
   def create_direct_otp
@@ -36,9 +36,5 @@ module UserOtpMethods
 
   def clear_direct_otp
     update(direct_otp: nil, direct_otp_sent_at: nil)
-  end
-
-  def max_login_attempts
-    3
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -175,6 +175,7 @@ lexisnexis_threatmetrix_js_signing_cert: ''
 ###################################################################
 lockout_period_in_minutes: 10
 log_to_stdout: false
+login_otp_confirmation_max_attempts: 3
 logins_per_email_and_ip_bantime: 60
 logins_per_email_and_ip_limit: 5
 logins_per_email_and_ip_period: 60

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -249,6 +249,7 @@ class IdentityConfig
     config.add(:lexisnexis_threatmetrix_js_signing_cert, type: :string)
     config.add(:lockout_period_in_minutes, type: :integer)
     config.add(:log_to_stdout, type: :boolean)
+    config.add(:login_otp_confirmation_max_attempts, type: :integer)
     config.add(:logins_per_email_and_ip_bantime, type: :integer)
     config.add(:logins_per_email_and_ip_limit, type: :integer)
     config.add(:logins_per_email_and_ip_period, type: :integer)


### PR DESCRIPTION
## 🎫 Ticket

[LG-8065](https://cm-jira.usa.gov/browse/LG-8065) (supporting refactor)

## 🛠 Summary of changes

Updates max OTP login attempts to be defined as an application configuration.

**Why?**

- Consistency with other throttling max values
   - Making it easier to find
   - Also named with consistent "_max_attempts" suffix
- Supports option for adjustments to live environments without code changes
- Supporting future refactoring:
   - Implement OTP attempts as throttle, where this would become the `max_attempts` value in the [throttle configuration](https://github.com/18F/identity-idp/blob/3358791eaa7c3f7a859a7c873308de925c821a69/app/services/throttle.rb#L7-L52)
   - Split throttling for non-login OTP confirmations (e.g. [identity verification phone verification](https://github.com/18F/identity-idp/blob/3358791eaa7c3f7a859a7c873308de925c821a69/app/forms/idv/phone_confirmation_otp_verification_form.rb#L33-L42))
      - Named to uniquely configure for login OTP confirmations

## 📜 Testing Plan

- [ ] Confirm that you are still locked out after 3 failed MFA attempts