### PR TITLE
LG-8086 Include millisec in the Attempts Timestamp

### DIFF
--- a/app/services/irs_attempts_api/attempt_event.rb
+++ b/app/services/irs_attempts_api/attempt_event.rb
@@ -70,7 +70,7 @@ module IrsAttemptsApi
           'subject_type' => 'session',
           'session_id' => session_id,
         },
-        'occurred_at' => occurred_at.to_i,
+        'occurred_at' => occurred_at.to_f,
       }.merge(event_metadata || {})
     end
 

--- a/spec/services/irs_attempts_api/attempt_event_spec.rb
+++ b/spec/services/irs_attempts_api/attempt_event_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe IrsAttemptsApi::AttemptEvent do
         'subject_type' => 'session', 'session_id' => 'test-session-id',
       )
       expect(event_data['foo']).to eq('bar')
-      expect(event_data['occurred_at']).to eq(occurred_at.to_i)
+      expect(event_data['occurred_at']).to eq(occurred_at.to_f)
     end
   end
 


### PR DESCRIPTION
changelog: Internal, Attempts API, Standardize events