### PR TITLE
Add feature spec for OTP confirmation rate limiting

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -531,7 +531,7 @@ feature 'Two Factor Authentication' do
       end
 
       it 'allows the user to sign in again after lockout has expired' do
-        travel_to Time.zone.now + IdentityConfig.store.lockout_period_in_minutes do
+        travel IdentityConfig.store.lockout_period_in_minutes do
           sign_in_before_2fa(user)
 
           expect(page).to have_content(t('two_factor_authentication.header_text'))

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -531,9 +531,13 @@ feature 'Two Factor Authentication' do
       end
 
       it 'allows the user to sign in again after lockout has expired' do
-        travel IdentityConfig.store.lockout_period_in_minutes do
-          sign_in_before_2fa(user)
+        travel (IdentityConfig.store.lockout_period_in_minutes - 1).minutes do
+          signin(user.email_addresses.first.email, user.password)
+          expect(page).to have_content(t('titles.account_locked'))
+        end
 
+        travel (IdentityConfig.store.lockout_period_in_minutes + 1).minutes do
+          signin(user.email_addresses.first.email, user.password)
           expect(page).to have_content(t('two_factor_authentication.header_text'))
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8065](https://cm-jira.usa.gov/browse/LG-8065) (supporting refactor)

## 🛠 Summary of changes

Implements a feature spec which tests expected real-world rate-limiting behavior for MFA confirmation as a replacement for current spec which stubs lockout. This was originally planned as a refactor to support additional specs for [LG-8065](https://cm-jira.usa.gov/browse/LG-8065), but that ticket may be reprioritized.

**Why?**

* Test real user behavior
* Improve performance by disabling JavaScript (ChromeDriver) for spec

## 📜 Testing Plan

- [ ] `rspec spec/features/two_factor_authentication/sign_in_spec.rb:492`