### PR TITLE
Remove unreachable blank config lockout default logic

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -7,7 +7,6 @@ class UserDecorator
 
   MAX_RECENT_EVENTS = 5
   MAX_RECENT_DEVICES = 5
-  DEFAULT_LOCKOUT_PERIOD = 10.minutes
 
   def initialize(user)
     @user = user
@@ -137,12 +136,7 @@ class UserDecorator
   private
 
   def lockout_period
-    return DEFAULT_LOCKOUT_PERIOD if lockout_period_config.blank?
-    lockout_period_config.minutes
-  end
-
-  def lockout_period_config
-    @lockout_period_config ||= IdentityConfig.store.lockout_period_in_minutes
+    IdentityConfig.store.lockout_period_in_minutes.minutes
   end
 
   def lockout_period_expired?

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -214,9 +214,7 @@ describe UserDecorator do
     end
 
     context 'second factor locked out a while ago' do
-      let(:locked_at) do
-        Time.zone.now - IdentityConfig.store.lockout_period_in_minutes.minutes - 1.second
-      end
+      let(:locked_at) { IdentityConfig.store.lockout_period_in_minutes.minutes.ago - 1.second }
 
       it { expect(locked_out?).to eq(false) }
     end
@@ -243,9 +241,7 @@ describe UserDecorator do
     end
 
     context 'second factor locked out a while ago' do
-      let(:locked_at) do
-        Time.zone.now - IdentityConfig.store.lockout_period_in_minutes.minutes - 1.second
-      end
+      let(:locked_at) { IdentityConfig.store.lockout_period_in_minutes.minutes.ago - 1.second }
 
       it { expect(no_longer_locked_out?).to eq(true) }
     end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -214,7 +214,9 @@ describe UserDecorator do
     end
 
     context 'second factor locked out a while ago' do
-      let(:locked_at) { Time.zone.now - UserDecorator::DEFAULT_LOCKOUT_PERIOD - 1.second }
+      let(:locked_at) do
+        Time.zone.now - IdentityConfig.store.lockout_period_in_minutes.minutes - 1.second
+      end
 
       it { expect(locked_out?).to eq(false) }
     end
@@ -241,7 +243,9 @@ describe UserDecorator do
     end
 
     context 'second factor locked out a while ago' do
-      let(:locked_at) { Time.zone.now - UserDecorator::DEFAULT_LOCKOUT_PERIOD - 1.second }
+      let(:locked_at) do
+        Time.zone.now - IdentityConfig.store.lockout_period_in_minutes.minutes - 1.second
+      end
 
       it { expect(no_longer_locked_out?).to eq(true) }
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a "default" lockout period value which should not ever be reachable given that a configuration value should always be present.

Based on the description of #1507, it appears to stem from a point in time where deployment of configuration values would not occur in sync with the application code and where not all configuration values were explicitly required.

**Why make this change?**

* Assert confidence in the presence of configuration values
* Remove magic number
* Avoid confusion on which lockout period is the correct lockout period
* Marginal performance improvement in a hot path by avoiding redundant check on configuration value

## 📜 Testing Plan

- `rspec spec/features/two_factor_authentication/sign_in_spec.rb:492`