### PR TITLE
LG-8139: Increase max OTP confirmation attempts

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -175,7 +175,7 @@ lexisnexis_threatmetrix_js_signing_cert: ''
 ###################################################################
 lockout_period_in_minutes: 10
 log_to_stdout: false
-login_otp_confirmation_max_attempts: 3
+login_otp_confirmation_max_attempts: 10
 logins_per_email_and_ip_bantime: 60
 logins_per_email_and_ip_limit: 5
 logins_per_email_and_ip_period: 60

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -65,7 +65,12 @@ feature 'phone otp rate limiting', :js do
   end
 
   describe 'otp attempts' do
-    let(:max_attempts) { 3 }
+    let(:max_attempts) { 2 }
+
+    before do
+      allow(IdentityConfig.store).to receive(:login_otp_confirmation_max_attempts).
+        and_return(max_attempts)
+    end
 
     it 'rate limits otp attempts at the otp verification step' do
       start_idv_from_sp

--- a/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
+++ b/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
@@ -13,11 +13,17 @@ describe Idv::PhoneConfirmationOtpVerificationForm do
       delivery_method: :sms,
     )
   end
+  let(:max_attempts) { 2 }
   let(:irs_attempts_api_tracker) do
     instance_double(
       IrsAttemptsApi::Tracker,
       idv_phone_otp_submitted_rate_limited: true,
     )
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:login_otp_confirmation_max_attempts).
+      and_return(max_attempts)
   end
 
   describe '#submit' do
@@ -37,7 +43,7 @@ describe Idv::PhoneConfirmationOtpVerificationForm do
       end
 
       it 'clears the second factor attempts' do
-        user.update(second_factor_attempts_count: 4)
+        user.update(second_factor_attempts_count: max_attempts + 1)
 
         try_submit(phone_confirmation_otp_code)
 
@@ -53,18 +59,18 @@ describe Idv::PhoneConfirmationOtpVerificationForm do
       end
 
       it 'increments second factor attempts' do
-        2.times do
+        (max_attempts - 1).times do
           try_submit('xxxxxx')
         end
 
         user.reload
 
-        expect(user.second_factor_attempts_count).to eq(2)
+        expect(user.second_factor_attempts_count).to eq(max_attempts - 1)
         expect(user.second_factor_locked_at).to eq(nil)
 
         try_submit('xxxxxx')
 
-        expect(user.second_factor_attempts_count).to eq(3)
+        expect(user.second_factor_attempts_count).to eq(max_attempts)
         expect(user.second_factor_locked_at).to be_within(1.second).of(Time.zone.now)
       end
     end
@@ -83,18 +89,18 @@ describe Idv::PhoneConfirmationOtpVerificationForm do
       end
 
       it 'increment second factor attempts and locks out user after too many' do
-        2.times do
+        (max_attempts - 1).times do
           try_submit(phone_confirmation_otp_code)
         end
 
         user.reload
 
-        expect(user.second_factor_attempts_count).to eq(2)
+        expect(user.second_factor_attempts_count).to eq(max_attempts - 1)
         expect(user.second_factor_locked_at).to eq(nil)
 
         try_submit(phone_confirmation_otp_code)
 
-        expect(user.second_factor_attempts_count).to eq(3)
+        expect(user.second_factor_attempts_count).to eq(max_attempts)
         expect(user.second_factor_locked_at).to be_within(1.second).of(Time.zone.now)
         expect(irs_attempts_api_tracker).to have_received(:idv_phone_otp_submitted_rate_limited).
           with({ phone_number: phone })

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -1,7 +1,14 @@
 shared_examples 'phone rate limitting' do |delivery_method|
+  let(:max_attempts) { 2 }
+
+  before do
+    allow(IdentityConfig.store).to receive(:login_otp_confirmation_max_attempts).
+      and_return(max_attempts)
+  end
+
   it 'limits the number of times the user can resend an OTP' do
     visit_otp_confirmation(delivery_method)
-    2.times do
+    (max_attempts - 1).times do
       click_on t('links.two_factor_authentication.send_another_code')
     end
 
@@ -12,7 +19,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
 
   it 'limits the number of times a code can be sent to a phone across accounts' do
     visit_otp_confirmation(delivery_method)
-    2.times do
+    (max_attempts - 1).times do
       click_on t('links.two_factor_authentication.send_another_code')
     end
 
@@ -32,7 +39,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
 
   it 'limits the number of times the user can enter an OTP' do
     visit_otp_confirmation(delivery_method)
-    2.times do
+    (max_attempts - 1).times do
       fill_in :code, with: '123456'
       click_submit_default
 
@@ -61,7 +68,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
   end
 
   def expect_rate_limitting_to_expire
-    travel_to(6.minutes.from_now) do
+    travel (IdentityConfig.store.lockout_period_in_minutes + 1).minutes do
       visit root_path
 
       signin(

--- a/spec/support/shared_examples/phone/rate_limitting.rb
+++ b/spec/support/shared_examples/phone/rate_limitting.rb
@@ -1,14 +1,17 @@
 shared_examples 'phone rate limitting' do |delivery_method|
-  let(:max_attempts) { 2 }
+  let(:max_confirmation_attempts) { 2 }
+  let(:max_otp_sends) { 2 }
 
   before do
     allow(IdentityConfig.store).to receive(:login_otp_confirmation_max_attempts).
-      and_return(max_attempts)
+      and_return(max_confirmation_attempts)
+    allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).
+      and_return(max_otp_sends)
   end
 
   it 'limits the number of times the user can resend an OTP' do
     visit_otp_confirmation(delivery_method)
-    (max_attempts - 1).times do
+    max_otp_sends.times do
       click_on t('links.two_factor_authentication.send_another_code')
     end
 
@@ -19,7 +22,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
 
   it 'limits the number of times a code can be sent to a phone across accounts' do
     visit_otp_confirmation(delivery_method)
-    (max_attempts - 1).times do
+    max_otp_sends.times do
       click_on t('links.two_factor_authentication.send_another_code')
     end
 
@@ -39,7 +42,7 @@ shared_examples 'phone rate limitting' do |delivery_method|
 
   it 'limits the number of times the user can enter an OTP' do
     visit_otp_confirmation(delivery_method)
-    (max_attempts - 1).times do
+    (max_confirmation_attempts - 1).times do
       fill_in :code, with: '123456'
       click_submit_default
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-8139](https://cm-jira.usa.gov/browse/LG-8139)

## 🛠 Summary of changes

Increases the default configured number of allowed MFA confirmation attempts before lock-out.

Per [NIST usability guidance](https://pages.nist.gov/800-63-3/sp800-63b.html#-101-usability-considerations-common-to-authenticators):

>Allow at least 10 entry attempts for authenticators requiring the entry of the authenticator output by the user.

See ticket description for additional context.

## 📜 Testing Plan

1. Create or sign in to a user which has a code-based authenticator (phone, TOTP, etc)
2. Enter and submit an incorrect value 10 times
3. Observe that lockout occurs after 10th failed attempt
