### PR TITLE
Try to fix flakey email spec

### DIFF
--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -128,7 +128,7 @@ feature 'adding email address' do
     expect_delivered_email_count(1)
     expect_delivered_email(
       0, {
-        to: [user.reload.email_addresses[1].email],
+        to: [user.reload.email_addresses.order(:created_at).last.email],
         subject: t('user_mailer.add_email.subject'),
       }
     )


### PR DESCRIPTION
## 🛠 Summary of changes

Attempts to resolve an email mailer spec which is commonly failing intermittently.

Example build: https://gitlab.login.gov/lg/identity-idp/-/jobs/157721 

The hypothesis here is that the email address order is not specified so cannot be guaranteed to be an array in the order assumed by the test assertion. Other specs in the same file may not be prone to this since they reference [`User#confirmed_email_addresses`](https://github.com/18F/identity-idp/blob/db385004eb2015ed4859e24d12646ac28e6b592e/app/models/user.rb#L60-L62), which has a built-in order. Because this spec cannot operate on the confirmed email addresses, the changes here instead manually add an order to guarantee the expected outcome.

## 📜 Testing Plan

- `rspec spec/features/multiple_emails/add_email_spec.rb:129`