### PR TITLE
Fix flakey IPP sample data rake spec

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,9 +1,3 @@
-class SampleDataCreator
-  def self.delay(seconds)
-    sleep(seconds)
-  end
-end
-
 namespace :dev do
   desc 'Sample data for local development environment'
   task prime: :environment do
@@ -152,7 +146,7 @@ namespace :dev do
                 else
                   success = true
                 end
-                SampleDataCreator.delay(usps_request_delay_ms / 1000.0) if usps_request_delay_ms
+                Kernel.sleep(usps_request_delay_ms / 1000.0) if usps_request_delay_ms
               end
             else
               enrollment = InPersonEnrollment.create!(

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,3 +1,9 @@
+class SampleDataCreator
+  def self.delay(seconds)
+    sleep(seconds)
+  end
+end
+
 namespace :dev do
   desc 'Sample data for local development environment'
   task prime: :environment do
@@ -146,7 +152,7 @@ namespace :dev do
                 else
                   success = true
                 end
-                sleep(usps_request_delay_ms / 1000.0) if usps_request_delay_ms
+                SampleDataCreator.delay(usps_request_delay_ms / 1000.0) if usps_request_delay_ms
               end
             else
               enrollment = InPersonEnrollment.create!(

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -330,7 +330,7 @@ describe 'dev rake tasks' do
       stub_request_token
       stub_request_enroll
 
-      expect(SampleDataCreator).to receive(:delay).exactly(10).times.with(0.2)
+      expect(Kernel).to receive(:sleep).exactly(10).times.with(0.2)
 
       Rake::Task['dev:random_in_person_users'].invoke
     end
@@ -436,7 +436,7 @@ describe 'dev rake tasks' do
         ).times(1)
       expect(UspsInPersonProofing::EnrollmentHelper).
         to receive(:schedule_in_person_enrollment).and_call_original.exactly(3).times
-      expect(SampleDataCreator).to receive(:delay).exactly(3).times.with(0.2)
+      expect(Kernel).to receive(:sleep).exactly(3).times.with(0.2)
 
       Rake::Task['dev:random_in_person_users'].invoke
     end

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -330,7 +330,7 @@ describe 'dev rake tasks' do
       stub_request_token
       stub_request_enroll
 
-      expect_any_instance_of(Object).to receive(:sleep).exactly(10).times.with(0.2)
+      expect(SampleDataCreator).to receive(:delay).exactly(10).times.with(0.2)
 
       Rake::Task['dev:random_in_person_users'].invoke
     end
@@ -436,7 +436,7 @@ describe 'dev rake tasks' do
         ).times(1)
       expect(UspsInPersonProofing::EnrollmentHelper).
         to receive(:schedule_in_person_enrollment).and_call_original.exactly(3).times
-      expect_any_instance_of(Object).to receive(:sleep).exactly(3).times.with(0.2)
+      expect(SampleDataCreator).to receive(:delay).exactly(3).times.with(0.2)
 
       Rake::Task['dev:random_in_person_users'].invoke
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Tries to resolve a flakey spec failure caused by other parts of the code also calling `sleep`.

```
The message 'sleep' was received by #<Object:386240 > but has already been received by #<Puma::ThreadPool::Automaton:0x000056521827c098>
```

Example failure: https://gitlab.login.gov/lg/identity-idp/-/jobs/157885

## 📜 Testing Plan

- `rspec spec/lib/tasks/dev_rake_spec.rb`