### PR TITLE
LG-7185: Add error handling and analytics to in-person proofing email reminder job

### DIFF
--- a/app/jobs/in_person/email_reminder_job.rb
+++ b/app/jobs/in_person/email_reminder_job.rb
@@ -43,7 +43,6 @@ module InPerson
       enrollments.each do |enrollment|
         send_reminder_email(enrollment.user, enrollment)
       rescue StandardError => err
-        puts "err: #{err}"
         NewRelic::Agent.notice_error(err)
         analytics(user: enrollment.user).idv_in_person_email_reminder_job_exception(
           enrollment_id: enrollment.id,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3088,6 +3088,25 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks exceptions that are raised when running InPerson::EmailReminderJob
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_email_reminder_job_exception(
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
   # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
   # @param [String] enrollment_code
   # @param [String] enrollment_id
@@ -3122,6 +3141,21 @@ module AnalyticsEvents
     track_event(
       'GetUspsProofingResultsJob: Success or failure email initiated',
       email_type: email_type,
+      **extra,
+    )
+  end
+
+  # Tracks emails that are initiated during InPerson::EmailReminderJob
+  # @param [String] email_type early or late
+  def idv_in_person_email_reminder_job_email_initiated(
+    email_type:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Reminder email initiated',
+      email_type: email_type,
+      enrollment_id: enrollment_id,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3147,6 +3147,7 @@ module AnalyticsEvents
 
   # Tracks emails that are initiated during InPerson::EmailReminderJob
   # @param [String] email_type early or late
+  # @param [String] enrollment_id
   def idv_in_person_email_reminder_job_email_initiated(
     email_type:,
     enrollment_id:,

--- a/spec/jobs/in_person/email_reminder_job_spec.rb
+++ b/spec/jobs/in_person/email_reminder_job_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe InPerson::EmailReminderJob do
         create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days)
       end
 
-      context 'an error is raised whne sending an email' do
+      context 'an error is raised when sending an email' do
         let(:error_message) { 'A standard error happened' }
         let!(:error) { StandardError.new(error_message) }
 

--- a/spec/jobs/in_person/email_reminder_job_spec.rb
+++ b/spec/jobs/in_person/email_reminder_job_spec.rb
@@ -11,108 +11,116 @@ RSpec.describe InPerson::EmailReminderJob do
   end
 
   describe '#perform' do
-    let!(:passed_enrollment) { create(:in_person_enrollment, :passed) }
-    let!(:failing_enrollment) { create(:in_person_enrollment, :failed) }
-    let!(:expired_enrollment) { create(:in_person_enrollment, :expired) }
-    let!(:pending_enrollment_needing_late_reminder) do
-      create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days)
-    end
-    let!(:pending_enrollment_needing_early_reminder) do
-      create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 19.days)
-    end
+    context 'with many enrollments' do
+      let!(:passed_enrollment) { create(:in_person_enrollment, :passed) }
+      let!(:failing_enrollment) { create(:in_person_enrollment, :failed) }
+      let!(:expired_enrollment) { create(:in_person_enrollment, :expired) }
+      let!(:pending_enrollment_needing_late_reminder) do
+        create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days)
+      end
+      let!(:pending_enrollment_needing_early_reminder) do
+        create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 19.days)
+      end
 
-    let!(:pending_enrollment_received_late_reminder) do
-      create(
-        :in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days,
-                                         late_reminder_sent: true
-      )
-    end
-    let!(:pending_enrollment_received_early_reminder) do
-      create(
-        :in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 19.days,
-                                         early_reminder_sent: true
-      )
-    end
-
-    let!(:pending_enrollments) do
-      [
-        create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now),
-        create(:in_person_enrollment, :pending, created_at: Time.zone.now),
-      ]
-    end
-
-    context 'late email reminder' do
-      it 'queues emails for enrollments that need the late email reminder sent' do
-        user = pending_enrollment_needing_late_reminder.user
-        expect do
-          job.perform(Time.zone.now)
-        end.to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
-          params: { user: user, email_address: user.email_addresses.first },
-          args: [{ enrollment: pending_enrollment_needing_late_reminder }],
+      let!(:pending_enrollment_received_late_reminder) do
+        create(
+          :in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days,
+                                           late_reminder_sent: true
         )
-        pending_enrollment_needing_late_reminder.reload
-        expect(pending_enrollment_needing_late_reminder.late_reminder_sent).to be_truthy
-        expect(job_analytics).to have_logged_event(
-          'InPerson::EmailReminderJob: Reminder email initiated',
-          email_type: 'late',
-          enrollment_id: pending_enrollment_needing_late_reminder.id,
+      end
+      let!(:pending_enrollment_received_early_reminder) do
+        create(
+          :in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 19.days,
+                                           early_reminder_sent: true
         )
       end
 
-      it 'does not queue emails for enrollments that had late email reminder sent' do
-        user = pending_enrollment_received_late_reminder.user
-        expect do
-          job.perform(Time.zone.now)
-        end.not_to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
-          params: { user: user, email_address: user.email_addresses.first },
-          args: [{ enrollment: pending_enrollment_received_late_reminder }],
-        )
-        expect(pending_enrollment_received_late_reminder.late_reminder_sent).to be_truthy
+      let!(:pending_enrollments) do
+        [
+          create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now),
+          create(:in_person_enrollment, :pending, created_at: Time.zone.now),
+        ]
+      end
+
+      context 'late email reminder' do
+        it 'queues emails for enrollments that need the late email reminder sent' do
+          user = pending_enrollment_needing_late_reminder.user
+          expect do
+            job.perform(Time.zone.now)
+          end.to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
+            params: { user: user, email_address: user.email_addresses.first },
+            args: [{ enrollment: pending_enrollment_needing_late_reminder }],
+          )
+          pending_enrollment_needing_late_reminder.reload
+          expect(pending_enrollment_needing_late_reminder.late_reminder_sent).to be_truthy
+          expect(job_analytics).to have_logged_event(
+            'InPerson::EmailReminderJob: Reminder email initiated',
+            email_type: 'late',
+            enrollment_id: pending_enrollment_needing_late_reminder.id,
+          )
+        end
+
+        it 'does not queue emails for enrollments that had late email reminder sent' do
+          user = pending_enrollment_received_late_reminder.user
+          expect do
+            job.perform(Time.zone.now)
+          end.not_to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
+            params: { user: user, email_address: user.email_addresses.first },
+            args: [{ enrollment: pending_enrollment_received_late_reminder }],
+          )
+          expect(pending_enrollment_received_late_reminder.late_reminder_sent).to be_truthy
+        end
+      end
+
+      context 'early email reminder' do
+        it 'queues emails for enrollments that need the early email reminder sent' do
+          user = pending_enrollment_needing_early_reminder.user
+          expect do
+            job.perform(Time.zone.now)
+          end.to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
+            params: { user: user, email_address: user.email_addresses.first },
+            args: [{ enrollment: pending_enrollment_needing_early_reminder }],
+          )
+          pending_enrollment_needing_early_reminder.reload
+          expect(pending_enrollment_needing_early_reminder.early_reminder_sent).to be_truthy
+          expect(job_analytics).to have_logged_event(
+            'InPerson::EmailReminderJob: Reminder email initiated',
+            email_type: 'early',
+            enrollment_id: pending_enrollment_needing_early_reminder.id,
+          )
+        end
+
+        it 'does not queue emails for enrollments that had early email reminder sent' do
+          user = pending_enrollment_received_early_reminder.user
+          expect do
+            job.perform(Time.zone.now)
+          end.not_to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
+            params: { user: user, email_address: user.email_addresses.first },
+            args: [{ enrollment: pending_enrollment_received_early_reminder }],
+          )
+          expect(pending_enrollment_received_early_reminder.early_reminder_sent).to be_truthy
+        end
       end
     end
 
-    context 'early email reminder' do
-      it 'queues emails for enrollments that need the early email reminder sent' do
-        user = pending_enrollment_needing_early_reminder.user
-        expect do
-          job.perform(Time.zone.now)
-        end.to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
-          params: { user: user, email_address: user.email_addresses.first },
-          args: [{ enrollment: pending_enrollment_needing_early_reminder }],
-        )
-        pending_enrollment_needing_early_reminder.reload
-        expect(pending_enrollment_needing_early_reminder.early_reminder_sent).to be_truthy
-        expect(job_analytics).to have_logged_event(
-          'InPerson::EmailReminderJob: Reminder email initiated',
-          email_type: 'early',
-          enrollment_id: pending_enrollment_needing_early_reminder.id,
-        )
+    context 'with one eligible enrollment' do
+      let!(:pending_enrollment_needing_late_reminder) do
+        create(:in_person_enrollment, :pending, enrollment_established_at: Time.zone.now - 26.days)
       end
 
-      it 'does not queue emails for enrollments that had early email reminder sent' do
-        user = pending_enrollment_received_early_reminder.user
-        expect do
+      context 'an error is raised whne sending an email' do
+        let(:error_message) { 'A standard error happened' }
+        let!(:error) { StandardError.new(error_message) }
+
+        it 'it handles and logs the error' do
+          allow(UserMailer).to receive(:with).once.and_raise(error)
+          expect(NewRelic::Agent).to receive(:notice_error).with(error)
           job.perform(Time.zone.now)
-        end.not_to have_enqueued_mail(UserMailer, :in_person_ready_to_verify_reminder).with(
-          params: { user: user, email_address: user.email_addresses.first },
-          args: [{ enrollment: pending_enrollment_received_early_reminder }],
-        )
-        expect(pending_enrollment_received_early_reminder.early_reminder_sent).to be_truthy
-      end
-    end
-
-    context 'an error is raised when sending an email' do
-      let(:error_message) { 'A standard error happened' }
-      let!(:error) { StandardError.new(error_message) }
-
-      it 'it handles and logs the error' do
-        allow(job).to receive(:send_reminder_email).and_raise(error)
-        expect(NewRelic::Agent).to receive(:notice_error).at_least(:once).with(error)
-        job.perform(Time.zone.now)
-        expect(job_analytics).to have_logged_event(
-          'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
-          exception_message: error_message,
-        )
+          expect(job_analytics).to have_logged_event(
+            'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
+            exception_message: error_message,
+          )
+        end
       end
     end
   end

--- a/spec/jobs/in_person/email_reminder_job_spec.rb
+++ b/spec/jobs/in_person/email_reminder_job_spec.rb
@@ -106,11 +106,10 @@ RSpec.describe InPerson::EmailReminderJob do
       let!(:error) { StandardError.new(error_message) }
 
       it 'it handles and logs the error' do
-        allow(UserMailer).to receive(:in_person_ready_to_verify_reminder).and_raise(error)
+        # this causes an error but it's happening 2x
+        allow(job).to receive(:send_reminder_email).and_raise(error)
         expect(NewRelic::Agent).to receive(:notice_error).with(error)
-
         job.perform(Time.zone.now)
-
         expect(job_analytics).to have_logged_event(
           'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
           exception_message: error_message,

--- a/spec/jobs/in_person/email_reminder_job_spec.rb
+++ b/spec/jobs/in_person/email_reminder_job_spec.rb
@@ -106,9 +106,8 @@ RSpec.describe InPerson::EmailReminderJob do
       let!(:error) { StandardError.new(error_message) }
 
       it 'it handles and logs the error' do
-        # this causes an error but it's happening 2x
         allow(job).to receive(:send_reminder_email).and_raise(error)
-        expect(NewRelic::Agent).to receive(:notice_error).with(error)
+        expect(NewRelic::Agent).to receive(:notice_error).at_least(:once).with(error)
         job.perform(Time.zone.now)
         expect(job_analytics).to have_logged_event(
           'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-7185](https://cm-jira.usa.gov/browse/LG-7185)

## 🛠 Summary of changes

Add basic error handling and analytics for `InPerson::EmailReminderJob`
