### PR TITLE
LG-7766: Update hint text and label for memorable date component

### DIFF
--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -102,7 +102,7 @@
                   aria: {
                     invalid: false,
                     describedby: "validated-field-error-#{unique_id}",
-                    labelledby:[
+                    labelledby: [
                       "memorable-date-year-label-#{unique_id}",
                       "memorable-date-year-hint-#{unique_id}",
                     ],

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -1,4 +1,4 @@
-<label class="usa-label" for="doc_auth_dob">
+<label class="usa-label">
     <%= label %>
 </label>
 <div id="validated-field-hint-<%= unique_id %>" class="usa-hint">
@@ -31,7 +31,7 @@
                     aria: {
                       invalid: false,
                       describedby: "validated-field-error-#{unique_id}",
-                      labelledby: 'month_hint_id',
+                      labelledby: "memorable-date-month-hint-#{unique_id}",
                     },
                     value: month,
                   },
@@ -39,7 +39,7 @@
                   required: required,
                 ) %>
           <% end %>
-          <span id="month_hint_id" class="usa-sr-only" aria-hidden="true">
+          <span id=<%="memorable-date-month-hint-#{unique_id}"%> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.month') %>
           </span>
           </lg-validated-field>
@@ -59,7 +59,7 @@
                   aria: {
                     invalid: false,
                     describedby: "validated-field-error-#{unique_id}",
-                    labelledby: 'day_hint_id',
+                    labelledby: "memorable-date-day-hint-#{unique_id}",
                   },
                   value: day,
                 },
@@ -67,7 +67,7 @@
                 required: required,
               ) %>
           <% end %>
-          <span id="day_hint_id" class="usa-sr-only" aria-hidden="true">
+          <span id=<%="memorable-date-day-hint-#{unique_id}"%> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.day') %>
           </span>
           </lg-validated-field>
@@ -87,7 +87,7 @@
                   aria: {
                     invalid: false,
                     describedby: "validated-field-error-#{unique_id}",
-                    labelledby: 'year_hint_id',
+                    labelledby: "memorable-date-year-hint-#{unique_id}",
                   },
                   value: year,
                 },
@@ -95,7 +95,7 @@
                 required: required,
               ) %>
           <% end %>
-          <span id="year_hint_id" class="usa-sr-only" aria-hidden="true">
+          <span id=<%="memorable-date-year-hint-#{unique_id}"%> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.year') %>
           </span>
         </lg-validated-field>

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -39,7 +39,7 @@
                   required: required,
                 ) %>
           <% end %>
-          <span id=<%="memorable-date-month-hint-#{unique_id}"%> class="display-none">
+          <span id=<%= "memorable-date-month-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.month') %>
           </span>
           </lg-validated-field>
@@ -67,7 +67,7 @@
                 required: required,
               ) %>
           <% end %>
-          <span id=<%="memorable-date-day-hint-#{unique_id}"%> class="display-none">
+          <span id=<%= "memorable-date-day-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.day') %>
           </span>
           </lg-validated-field>
@@ -95,7 +95,7 @@
                 required: required,
               ) %>
           <% end %>
-          <span id=<%="memorable-date-year-hint-#{unique_id}"%> class="display-none">
+          <span id=<%= "memorable-date-year-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.year') %>
           </span>
         </lg-validated-field>

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -22,7 +22,10 @@
                   pattern: '(1[0-2])|(0?[1-9])',
                   wrapper_html: { class: 'usa-form-group usa-form-group--month margin-bottom-0' },
                   label: t('components.memorable_date.month'),
-                  label_html: { class: 'usa-label' },
+                  label_html: {
+                    class: 'usa-label',
+                    id: "memorable-date-month-label-#{unique_id}",
+                  },
                   input_html: {
                     type: 'text',
                     class: 'validated-field__input memorable-date__month',
@@ -31,7 +34,10 @@
                     aria: {
                       invalid: false,
                       describedby: "validated-field-error-#{unique_id}",
-                      labelledby: "memorable-date-month-hint-#{unique_id}",
+                      labelledby: [
+                        "memorable-date-month-label-#{unique_id}",
+                        "memorable-date-month-hint-#{unique_id}",
+                      ],
                     },
                     value: month,
                   },
@@ -50,7 +56,10 @@
                 pattern: '(3[01])|([12][0-9])|(0?[1-9])',
                 wrapper_html: { class: 'usa-form-group usa-form-group--day margin-bottom-0' },
                 label: t('components.memorable_date.day'),
-                label_html: { class: 'usa-label' },
+                label_html: {
+                  class: 'usa-label',
+                  id: "memorable-date-day-label-#{unique_id}",
+                },
                 input_html: {
                   type: 'text',
                   class: 'validated-field__input memorable-date__day',
@@ -59,7 +68,10 @@
                   aria: {
                     invalid: false,
                     describedby: "validated-field-error-#{unique_id}",
-                    labelledby: "memorable-date-day-hint-#{unique_id}",
+                    labelledby: [
+                      "memorable-date-day-label-#{unique_id}",
+                      "memorable-date-day-hint-#{unique_id}",
+                    ],
                   },
                   value: day,
                 },
@@ -78,7 +90,10 @@
                 pattern: '\d{4}',
                 wrapper_html: { class: 'usa-form-group usa-form-group--year margin-bottom-0' },
                 label: t('components.memorable_date.year'),
-                label_html: { class: 'usa-label' },
+                label_html: {
+                  class: 'usa-label',
+                  id: "memorable-date-year-label-#{unique_id}",
+                },
                 input_html: {
                   type: 'text',
                   class: 'validated-field__input memorable-date__year',
@@ -87,7 +102,10 @@
                   aria: {
                     invalid: false,
                     describedby: "validated-field-error-#{unique_id}",
-                    labelledby: "memorable-date-year-hint-#{unique_id}",
+                    labelledby:[
+                      "memorable-date-year-label-#{unique_id}",
+                      "memorable-date-year-hint-#{unique_id}",
+                    ],
                   },
                   value: year,
                 },

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -30,10 +30,8 @@
                     maxLength: 2,
                     aria: {
                       invalid: false,
-                      describedby: [
-                        "validated-field-error-#{unique_id}",
-                        "validated-field-hint-#{unique_id}",
-                      ],
+                      describedby: "validated-field-error-#{unique_id}",
+                      labelledby: 'month_hint_id',
                     },
                     value: month,
                   },
@@ -41,6 +39,9 @@
                   required: required,
                 ) %>
           <% end %>
+          <span id="month_hint_id" class="usa-sr-only" aria-hidden="true">
+            <%= t('in_person_proofing.form.state_id.date_hint.month') %>
+          </span>
           </lg-validated-field>
           <lg-validated-field>
           <%= f.simple_fields_for name do |p| %>
@@ -57,10 +58,8 @@
                   maxLength: 2,
                   aria: {
                     invalid: false,
-                    describedby: [
-                      "validated-field-error-#{unique_id}",
-                      "validated-field-hint-#{unique_id}",
-                    ],
+                    describedby: "validated-field-error-#{unique_id}",
+                    labelledby: 'day_hint_id',
                   },
                   value: day,
                 },
@@ -68,6 +67,9 @@
                 required: required,
               ) %>
           <% end %>
+          <span id="day_hint_id" class="usa-sr-only" aria-hidden="true">
+            <%= t('in_person_proofing.form.state_id.date_hint.day') %>
+          </span>
           </lg-validated-field>
           <lg-validated-field>
           <%= f.simple_fields_for name do |p| %>
@@ -84,10 +86,8 @@
                   maxLength: 4,
                   aria: {
                     invalid: false,
-                    describedby: [
-                      "validated-field-error-#{unique_id}",
-                      "validated-field-hint-#{unique_id}",
-                    ],
+                    describedby: "validated-field-error-#{unique_id}",
+                    labelledby: 'year_hint_id',
                   },
                   value: year,
                 },
@@ -95,6 +95,9 @@
                 required: required,
               ) %>
           <% end %>
+          <span id="year_hint_id" class="usa-sr-only" aria-hidden="true">
+            <%= t('in_person_proofing.form.state_id.date_hint.year') %>
+          </span>
         </lg-validated-field>
     </div>
   <% end -%>

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -1,7 +1,7 @@
-<label class="usa-label">     
+<label class="usa-label" for="doc_auth_dob">
     <%= label %>
 </label>
-<div class="usa-hint" id="validated-field-hint-<%= unique_id %>">
+<div id="validated-field-hint-<%= unique_id %>" class="usa-hint">
     <%= hint %>
 </div>
   <%= content_tag :'lg-memorable-date', min: min, max: max, **tag_options do -%>

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -71,6 +71,10 @@ en:
       state_id:
         dob: Date of birth
         dob_hint: 'Example: 4 28 1986'
+        date_hint:
+          day: 'Example: 28'
+          month: 'Example: 4'
+          year: 'Example: 1986'
         first_name: First name
         last_name: Last name
         memorable_date:

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -69,12 +69,12 @@ en:
         same_address_choice_yes: This address is on my state-issued ID
         state_prompt: '- Select -'
       state_id:
-        dob: Date of birth
-        dob_hint: 'Example: 4 28 1986'
         date_hint:
           day: 'Example: 28'
           month: 'Example: 4'
           year: 'Example: 1986'
+        dob: Date of birth
+        dob_hint: 'Example: 4 28 1986'
         first_name: First name
         last_name: Last name
         memorable_date:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -77,6 +77,10 @@ es:
       state_id:
         dob: Fecha de nacimiento
         dob_hint: 'Ejemplo: 4 28 1986'
+        date_hint:
+          day: 'Ejemplo: 28'
+          month: 'Ejemplo: 4'
+          year: 'Ejemplo: 1986'
         first_name: Nombre
         last_name: Apellido
         memorable_date:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -75,12 +75,12 @@ es:
         same_address_choice_yes: Esta dirección aparece en mi cédula de identidad emitida por el estado
         state_prompt: '- Seleccione -'
       state_id:
-        dob: Fecha de nacimiento
-        dob_hint: 'Ejemplo: 4 28 1986'
         date_hint:
           day: 'Ejemplo: 28'
           month: 'Ejemplo: 4'
           year: 'Ejemplo: 1986'
+        dob: Fecha de nacimiento
+        dob_hint: 'Ejemplo: 4 28 1986'
         first_name: Nombre
         last_name: Apellido
         memorable_date:

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -78,12 +78,12 @@ fr:
         same_address_choice_yes: Cette adresse figure sur mon document d’identité nationale
         state_prompt: '- Sélectionnez -'
       state_id:
-        dob: Date de naissance
-        dob_hint: 'Exemple: 4 28 1986'
         date_hint:
           day: 'Exemple: 28'
           month: 'Exemple: 4'
           year: 'Exemple: 1986'
+        dob: Date de naissance
+        dob_hint: 'Exemple: 4 28 1986'
         first_name: Prénom
         last_name: Nom de famille
         memorable_date:

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -80,6 +80,10 @@ fr:
       state_id:
         dob: Date de naissance
         dob_hint: 'Exemple: 4 28 1986'
+        date_hint:
+          day: 'Exemple: 28'
+          month: 'Exemple: 4'
+          year: 'Exemple: 1986'
         first_name: Prénom
         last_name: Nom de famille
         memorable_date:

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe MemorableDateComponent, type: :component do
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__month')
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__day')
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__year')
-    puts " rendered: #{rendered}"
   end
 
   it 'renders memorable date input fields with hints' do

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe MemorableDateComponent, type: :component do
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__month')
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__day')
     expect(rendered).to have_css('lg-memorable-date lg-validated-field input.memorable-date__year')
+    puts " rendered: #{rendered}"
+  end
+
+  it 'renders memorable date input fields with hints' do
+    expect(rendered).to have_css('input[aria-labelledby*="memorable-date-month-hint"]')
+    expect(rendered).to have_css('input[aria-labelledby*="memorable-date-day-hint"]')
+    expect(rendered).to have_css('input[aria-labelledby*="memorable-date-year-hint"]')
   end
 
   it 'sets the label' do


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7766](https://cm-jira.usa.gov/browse/LG-7766)

## 🛠 Summary of changes

This pr updates the hint text for the memorable date component. It updates the hint text for each of the inputs (month, day and year) by removing the reference to the hint under the label. It replaces that hint with more specific hints for each input. Also updated the label for the component so it matches other components on the form page. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Navigate to the form page
- [ ] Use a screen reader to navigate through the page
- [ ] Verify hint under date of birth label is read
- [ ] Verify hint text for month is "example: 4"
- [ ] Verify hint text for day is "example: 28"
- [ ] Verify hint text for year is "example: 1986"

