### PR TITLE
Add configurable phone carrier registration blocklist

### DIFF
--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -13,6 +13,7 @@ class NewPhoneForm
   validate :validate_not_voip
   validate :validate_not_duplicate
   validate :validate_not_premium_rate
+  validate :validate_allowed_carrier
 
   attr_accessor :phone, :international_code, :otp_delivery_preference,
                 :otp_make_default_number
@@ -77,6 +78,14 @@ class NewPhoneForm
       errors.add(:phone, I18n.t('errors.messages.voip_phone'), type: :voip_phone)
     elsif phone_info.error
       errors.add(:phone, I18n.t('errors.messages.voip_check_error'), type: :voip_check_error)
+    end
+  end
+
+  def validate_allowed_carrier
+    return if phone.blank? || phone_info.blank?
+
+    if IdentityConfig.store.phone_carrier_registration_blocklist.include?(phone_info.carrier)
+      errors.add(:phone, I18n.t('errors.messages.phone_carrier'), type: :phone_carrier)
     end
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -208,6 +208,7 @@ participate_in_dap: false
 partner_api_bucket_prefix: ''
 password_max_attempts: 3
 personal_key_retired: true
+phone_carrier_registration_blocklist: ''
 phone_confirmation_max_attempts: 20
 phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_setups_per_ip_limit: 25

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -65,6 +65,8 @@ en:
       not_a_number: is not a number
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
+      phone_carrier: Sorry, we are unable to support that phone carrier at this time.
+        Please select a different number and try again.
       phone_confirmation_throttled: You tried too many times, please try again in %{timeout}.
       phone_duplicate: This account is already using the phone number you entered as
         an authenticator. Please use a different phone number.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -66,6 +66,8 @@ es:
       not_a_number: no es un número
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
+      phone_carrier: Lo sentimos, no podemos admitir ese operador telefónico en este
+        momento. Por favor, seleccione un número diferente e inténtelo de nuevo.
       phone_confirmation_throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
       phone_duplicate: Esta cuenta ya está utilizando el número de teléfono que
         ingresó como autenticador. Por favor, use un número de teléfono

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -73,6 +73,9 @@ fr:
       not_a_number: N’est pas un nombre
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
+      phone_carrier: Nous nous excusons, car nous ne pouvons pas prendre en charge cet
+        opérateur téléphonique pour le moment. Veuillez sélectionner un autre
+        numéro puis réessayer.
       phone_confirmation_throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
       phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez
         entré en tant qu’authentificateur. Veuillez utiliser un numéro de

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -295,6 +295,7 @@ class IdentityConfig
     config.add(:password_max_attempts, type: :integer)
     config.add(:password_pepper, type: :string)
     config.add(:personal_key_retired, type: :boolean)
+    config.add(:phone_carrier_registration_blocklist, type: :comma_separated_string_list)
     config.add(:phone_confirmation_max_attempts, type: :integer)
     config.add(:phone_confirmation_max_attempt_window_in_minutes, type: :integer)
     config.add(:phone_setups_per_ip_limit, type: :integer)

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -299,6 +299,30 @@ describe NewPhoneForm do
       end
     end
 
+    context 'blocklisted carrier numbers' do
+      before do
+        allow(IdentityConfig.store).to receive(:phone_carrier_registration_blocklist).and_return(
+          ['Blocked Phone Carrier'],
+        )
+      end
+
+      context 'when phone number carrier is in blocklist' do
+        it 'is invalid' do
+          expect(Telephony).to receive(:phone_info).and_return(
+            Telephony::PhoneNumberInfo.new(
+              type: :mobile,
+              carrier: 'Blocked Phone Carrier',
+              error: nil,
+            ),
+          )
+
+          result = subject.submit(params)
+          expect(result.success?).to eq(false)
+          expect(result.errors[:phone]).to eq([I18n.t('errors.messages.phone_carrier')])
+        end
+      end
+    end
+
     context 'premium rate phone numbers like 1-900' do
       let(:premium_rate_phone_number) { '+1 900 867 5309' }
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🛠 Summary of changes

To improve the precision we have to control phone registration and volume, this PR adds a configuration to allow blocking specific carriers.

Example:

![image](https://user-images.githubusercontent.com/1430443/202780213-6d5c9061-8b25-4dcc-8781-0326fcfbd119.png)
