### PR TITLE
Prepare build-sass package for publish

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release

--- a/app/javascript/packages/build-sass/LICENSE.md
+++ b/app/javascript/packages/build-sass/LICENSE.md
@@ -1,0 +1,21 @@
+# License
+
+As a work of the [United States government](https://www.usa.gov/), this project is in the public domain within the United States of America.
+
+Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of their rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute, and perform the work, even for commercial purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.

--- a/app/javascript/packages/build-sass/README.md
+++ b/app/javascript/packages/build-sass/README.md
@@ -1,0 +1,54 @@
+# `@18f/identity-build-sass`
+
+Stylesheet compilation utility with reasonable defaults and fast performance.
+
+Why use it?
+
+- ⚡️ **It's fast**, since it uses native Dart Sass binary through [`sass-embedded`](http://npmjs.com/package/sass-embedded), and the Rust-based [Lightning CSS](https://www.npmjs.com/package/lightningcss) for autoprefixing and minification.
+- 💻 **It includes a CLI**, so it's easy to integrate with command-based build pipelines like NPM scripts or Makefile.
+- 🚀 **It has relevant defaults**, as as to require as little additional configuration as possible.
+
+Default behavior includes:
+
+- Optimizations enabled based on the `NODE_ENV` environment variable.
+- Autoprefixer configuration based on the current project's [Browserslist](https://browsersl.ist/) configuration.
+- Automatically adds `node_modules` as a loaded path for Sass compilation.
+- Output filenames derived from the input filenames (`main.css.scss` becomes `main.css`).
+
+## Usage
+
+### CLI
+
+Invoke the included `build-sass` executable with the source files and any relevant command flags.
+
+```
+npx build-sass path/to/sass/*.css.scss --out-dir=build
+```
+
+Flags:
+
+- `--out-dir`: The output directory
+- `--watch`: Run in watch mode, recompiling files on change
+
+### API
+
+#### `buildFile`
+
+Compiles a given Sass file.
+
+```ts
+function buildFile(
+  file: string,
+  options: {
+    outDir: string,
+    optimize: boolean,
+    ...sassOptions: SassOptions<'sync'>,
+  },
+): Promise<SassCompileResult>;
+```
+
+## License
+
+This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request or issue, you are agreeing to comply with this waiver of copyright interest.

--- a/app/javascript/packages/build-sass/index.js
+++ b/app/javascript/packages/build-sass/index.js
@@ -37,7 +37,7 @@ export async function buildFile(file, options) {
 
   let outFile = basename(file, '.scss');
 
-  const parcelResult = lightningTransform({
+  const lightningResult = lightningTransform({
     filename: outFile,
     code: Buffer.from(sassResult.css),
     minify: optimize,
@@ -48,7 +48,7 @@ export async function buildFile(file, options) {
     outFile = join(outDir, outFile);
   }
 
-  await writeFile(outFile, parcelResult.code);
+  await writeFile(outFile, lightningResult.code);
 
   return sassResult;
 }

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@18f/identity-build-sass",
-  "private": true,
   "version": "1.0.0",
   "type": "module",
   "bin": {
@@ -9,7 +8,7 @@
   "dependencies": {
     "browserslist": "^4.21.4",
     "chokidar": "^3.5.3",
-    "lightningcss": "^1.16.0",
-    "sass-embedded": "^1.55.0"
+    "lightningcss": "^1.16.1",
+    "sass-embedded": "^1.56.1"
   }
 }

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-build-sass",
+  "private": false,
   "version": "1.0.0",
   "type": "module",
   "bin": {

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -1,11 +1,26 @@
 {
   "name": "@18f/identity-build-sass",
-  "private": false,
   "version": "1.0.0",
+  "private": false,
+  "description": "Stylesheet compilation utility with reasonable defaults and fast performance.",
   "type": "module",
   "bin": {
     "build-sass": "./cli.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/18f/identity-idp.git",
+    "directory": "app/javascript/packages/build-sass"
+  },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/18f/identity-idp/issues"
+  },
+  "homepage": "https://github.com/18f/identity-idp",
   "dependencies": {
     "browserslist": "^4.21.4",
     "chokidar": "^3.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4193,61 +4193,61 @@ libphonenumber-js@^1.10.11:
   resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.11.tgz#0078756857bcc5c9dfe097123c6e04ea930e309b"
   integrity sha512-ehoihx4HpRXO6FH/uJ0EnaEV4dVU+FDny+jv0S6k9JPyPsAIr0eXDAFvGRMBKE1daCtyHAaFSKCiuCxrOjVAzQ==
 
-lightningcss-darwin-arm64@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz#f3318a2e64ca160610977675ee1a7e611f4a3617"
-  integrity sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==
+lightningcss-darwin-arm64@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.1.tgz#f67287c500b96bc5d21e6d04de0e2607ff2784ff"
+  integrity sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==
 
-lightningcss-darwin-x64@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.0.tgz#46361b701b572ce9ec29730624000b439c2184bb"
-  integrity sha512-kLPi+OEpDj3UGY6DC8TfjbcULJDKMP+TVKSlrEkNGn8t1YRzi2g4oy7UVTSB5AnSbT0CusUItzdVjHQ49EdoNA==
+lightningcss-darwin-x64@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.1.tgz#2dc89dd4e1eb3c39ca4abbeca769a276c206b038"
+  integrity sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==
 
-lightningcss-linux-arm-gnueabihf@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz#5da29f465dd44d98434b00b424cc4b445ea49eff"
-  integrity sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==
+lightningcss-linux-arm-gnueabihf@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.1.tgz#9edacb0d9bd18fa1830a9d9f9ba00bdc9f8dabc9"
+  integrity sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==
 
-lightningcss-linux-arm64-gnu@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz#21d139f5201c9b8bb3972c24116a5bcbb7e2c3b5"
-  integrity sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==
+lightningcss-linux-arm64-gnu@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.1.tgz#b6986324d21de3813b84432b51c3e7b019dd2224"
+  integrity sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==
 
-lightningcss-linux-arm64-musl@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz#d06936e0570fb51d58cc18ef2fb8858aeecd1979"
-  integrity sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==
+lightningcss-linux-arm64-musl@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.1.tgz#d13a01ed19a72c99b4ef9c5b9d8ee0dcdc4bf3ed"
+  integrity sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==
 
-lightningcss-linux-x64-gnu@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz#fd9881cd839cac4676a01b713b06b0b178743f87"
-  integrity sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==
+lightningcss-linux-x64-gnu@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.1.tgz#6c888ef4faac53333d6d2241da463c405b19ec79"
+  integrity sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==
 
-lightningcss-linux-x64-musl@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz#697d87448e0f6445b6fc3cf8529d89709f3bfacc"
-  integrity sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==
+lightningcss-linux-x64-musl@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.1.tgz#20b51081679dd6b7271ce11df825dc536a0c617c"
+  integrity sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==
 
-lightningcss-win32-x64-msvc@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz#e4a09c12a48534121ecd03ef0be8dadbbbbb63b6"
-  integrity sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==
+lightningcss-win32-x64-msvc@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.1.tgz#7546b4dca78314b1d2701ed220cb6e50b8c6b5ca"
+  integrity sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==
 
-lightningcss@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.16.0.tgz#4c8e4ef8133d54488d1482a115d3758259191c52"
-  integrity sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==
+lightningcss@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.16.1.tgz#b5a16632b6824d023af2fb7d35b1c6fc42608bc6"
+  integrity sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==
   dependencies:
     detect-libc "^1.0.3"
   optionalDependencies:
-    lightningcss-darwin-arm64 "1.16.0"
-    lightningcss-darwin-x64 "1.16.0"
-    lightningcss-linux-arm-gnueabihf "1.16.0"
-    lightningcss-linux-arm64-gnu "1.16.0"
-    lightningcss-linux-arm64-musl "1.16.0"
-    lightningcss-linux-x64-gnu "1.16.0"
-    lightningcss-linux-x64-musl "1.16.0"
-    lightningcss-win32-x64-msvc "1.16.0"
+    lightningcss-darwin-arm64 "1.16.1"
+    lightningcss-darwin-x64 "1.16.1"
+    lightningcss-linux-arm-gnueabihf "1.16.1"
+    lightningcss-linux-arm64-gnu "1.16.1"
+    lightningcss-linux-arm64-musl "1.16.1"
+    lightningcss-linux-x64-gnu "1.16.1"
+    lightningcss-linux-x64-musl "1.16.1"
+    lightningcss-win32-x64-msvc "1.16.1"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -5407,50 +5407,50 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-embedded-darwin-arm64@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.55.0.tgz#f59fb260b88a5691c736ffcb59710a060b4a516e"
-  integrity sha512-cQ43gYDFo4xWSqG01ZmOhTyTgk/RYK7s1a4R+7VSQPhYTsd4VofAmTNw0MkLR3RzR53ziGgawA6uT/WHTm+yjg==
+sass-embedded-darwin-arm64@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.56.1.tgz#fdc0934827fd994d614cfb76c21262ca6219154c"
+  integrity sha512-Y6us8rg7uwLtAzGiKDebAhFn98RLpW3u5Jnfbsvetlm/rDJ1fZg/roVXFttepLdVbYBjimVFTUaNuGxU3bWbBA==
 
-sass-embedded-darwin-x64@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.55.0.tgz#d361403023ec59223bc531909a1d254355dbd0fb"
-  integrity sha512-ra8z++EBey01pkiwCwjWyMbf6G5xm2Uj0dUJzzsS1MI6Fw6XaesrWmYico5pnawm3rOYtKlMxkd2Y6b1Jwxy8A==
+sass-embedded-darwin-x64@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.56.1.tgz#49e7c4af865c2faa77547006199a6ff259af7d41"
+  integrity sha512-UypB3IREbreNNc+dG+L6hG5yoeTujKDCdmu38SSSS/zl9XBFTc8McX58SWapTJOUFK8G43CCimfB3r8FOcyNfA==
 
-sass-embedded-linux-arm64@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.55.0.tgz#ad4778a038aacb5bb90e48152d2bbb170c4d3e29"
-  integrity sha512-P4zL4PnujdiSkek/g0RJjyNZcYEqSm6WFr0sSIrxe3byhGg56mWr4WJdxUNwFZ6sxyy2s0PFSjSKGmBtgEfIpw==
+sass-embedded-linux-arm64@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.56.1.tgz#b4dc0903a5f1f848dc7d61b5b35657dbfd9a32fa"
+  integrity sha512-Ly2wk8EmhjXkBpNPM+yAygSxTVIBjQlf4cDAHYgsaDUIIvRSAKAe2CUmxJjik069Qmv54g+Ac7WF6k63c2CTNw==
 
-sass-embedded-linux-arm@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.55.0.tgz#112d3efd6d5694ceeec7fa15d53e3fe282d69197"
-  integrity sha512-UIW7CaRLjHMWm64jH23n5eji/RAv8XIJ2qpFh0Ds8EJeDZmRA+qyIFHcQ805fZ22u6o0mkxq0kE4+j1XmmbBeg==
+sass-embedded-linux-arm@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.56.1.tgz#8a6f5a8413da918b2292fec6435b890d1dbf6f7d"
+  integrity sha512-pXv+2HlMsjlk0g3dzuVhofuUNJZWUfWVe5xbbWHv+wrdH9kuui6WOyHDhSdUolPrRXOrdsG6Z4/Balr9wa1JWQ==
 
-sass-embedded-linux-ia32@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.55.0.tgz#293f66d01d988728548133d7d2e30a1b596385c5"
-  integrity sha512-9XJyAl4w5KBjR4LAXckfQKqPv9UYPmOv2HFRBwhHD1k4Dc8gZbfTCzK5wl49z5Z4z1GPvqV9ucIZceXzgJ5e6Q==
+sass-embedded-linux-ia32@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.56.1.tgz#b85eb5715f9ef1a9219f62b860cf8ecbddb5bc4b"
+  integrity sha512-cGmhnHdCbwJsQgsogwmlALzS/j8g+qQTiBuKBcXIWyFn4hLWo2BAr4Gm9vY5p+8aapcYrRQF9b0nwpFQcUScOg==
 
-sass-embedded-linux-x64@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.55.0.tgz#998835f63e20310f84fb47998408835e852cfcd4"
-  integrity sha512-vd4/4/L7gZcVyxq03/MY/+rcpGgOI0ihOUpwRJLj+9CmUxvhxCSTF51/QO5CW7Z5oJSYEABA/RYlj8NPm4ZejA==
+sass-embedded-linux-x64@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.56.1.tgz#b254eee1d684f0395b7cc0e5ff66f60365fbdd9b"
+  integrity sha512-yMXS37lP3abTI5ThuydOrLacSNz4Oo9+xlfQDR0pntrugdKzH7vHWK7T7Ynd+vGjVqFajUhI+VihP7vZlhhndw==
 
-sass-embedded-win32-ia32@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.55.0.tgz#48b0c52dade8d2c559303c0c6e30e7b49d393775"
-  integrity sha512-4HxK0byJ3iIn5OECIeNVz9GcGBuQcQT6kTvI+3QSHzuKsqgQrlXOPJ3772zKD6PVwZJNFZJFf3o9w8V2VSHbTQ==
+sass-embedded-win32-ia32@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.56.1.tgz#2b27d7526e92903e603db8d625b264bfe53c1c30"
+  integrity sha512-cjtuKc1O0F+yQZ8hLLYhalulEkBZ6HPdR/ys0l6hn7KTlrYooMyvZXbdU5KaB2lfK1WD29I0HefT8Em7d9cpfA==
 
-sass-embedded-win32-x64@1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.55.0.tgz#f3a25406d8c3c3023f6bc39faa7a3cc3be9bb8ee"
-  integrity sha512-LWUp5YpJy0/Q+5AOVcw919jktw+OnPiM4f4j5K6MJAiaodJwrSTqRGwMa2wOWyAUpjIdka8Ygm6j+2h5HNgSNQ==
+sass-embedded-win32-x64@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.56.1.tgz#b3f98ccf1db8d60581223df21075f7de026b3e99"
+  integrity sha512-VxqwSluQdNBdBEx0p6N2dOrGPIEL3AcG62KuDJ4KD/rHPQgoCPiJvLa5MXKdVHC24tHgE2AYlirILS/iE/N1NQ==
 
-sass-embedded@^1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.55.0.tgz#982a2bb1090bfc11952f0205743be327d3ec7134"
-  integrity sha512-6AkKEyRjxz37iNwOdTOW94I33j5mxcih9Z604q1w0M1dOTKaZgtyNI67O0zb4akwZ9dVZ2VSJBXqY8/1TZRBIw==
+sass-embedded@^1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.56.1.tgz#749fb3c3cbee26b7234224727b33a0475023b867"
+  integrity sha512-8VuohdRoGfqVWgBNeC+iqek1KXIVWYcG6AOQ6rJvRUe08HbdPQgp0+fseDQX7E5UxaoM8wvU5VBwCbZvPwFZQw==
   dependencies:
     buffer-builder "^0.2.0"
     google-protobuf "^3.11.4"
@@ -5458,14 +5458,14 @@ sass-embedded@^1.55.0:
     rxjs "^7.4.0"
     supports-color "^8.1.1"
   optionalDependencies:
-    sass-embedded-darwin-arm64 "1.55.0"
-    sass-embedded-darwin-x64 "1.55.0"
-    sass-embedded-linux-arm "1.55.0"
-    sass-embedded-linux-arm64 "1.55.0"
-    sass-embedded-linux-ia32 "1.55.0"
-    sass-embedded-linux-x64 "1.55.0"
-    sass-embedded-win32-ia32 "1.55.0"
-    sass-embedded-win32-x64 "1.55.0"
+    sass-embedded-darwin-arm64 "1.56.1"
+    sass-embedded-darwin-x64 "1.56.1"
+    sass-embedded-linux-arm "1.56.1"
+    sass-embedded-linux-arm64 "1.56.1"
+    sass-embedded-linux-ia32 "1.56.1"
+    sass-embedded-linux-x64 "1.56.1"
+    sass-embedded-win32-ia32 "1.56.1"
+    sass-embedded-win32-x64 "1.56.1"
 
 saxes@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates dependencies for the `@18f/identity-build-sass` workspace package and prepares it for publishing to NPM (update `package.json`, add changelog, add README).

The plan is to use this in `18F/identity-site` to improve build times, bring consistency of compilation targets.

## 📜 Testing Plan

There shouldn't be any noticeable impact from this, but ensure that the dependencies upgrades incur no regression in expected build behavior.