### PR TITLE
Validate email domains are ASCII to better align with AWS Simple Email Service (SES) support

### DIFF
--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -1,6 +1,7 @@
 class AddUserEmailForm
   include ActiveModel::Model
   include FormAddEmailValidator
+  include ActionView::Helpers::TranslationHelper
 
   attr_reader :email
 

--- a/app/validators/form_add_email_validator.rb
+++ b/app/validators/form_add_email_validator.rb
@@ -13,9 +13,21 @@ module FormAddEmailValidator
                 mx_with_fallback: !ENV['RAILS_OFFLINE'],
                 ban_disposable_email: true,
               }
+    validate :validate_domain
   end
 
   private
+
+  def validate_domain
+    return unless email.present? && errors.blank?
+    domain = Mail::Address.new(email).domain
+
+    if domain && !domain.ascii_only?
+      errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)
+    end
+  rescue Mail::Field::IncompleteParseError
+    errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)
+  end
 
   def downcase_and_strip
     self.email = email&.downcase&.strip

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -18,7 +18,7 @@ module FormEmailValidator
 
   def validate_domain
     return unless email.present?
-    domain = email&.split('@')&.last
+    domain = Mail::Address.new(email).domain
 
     if domain && !domain.ascii_only?
       errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -6,6 +6,7 @@ module FormEmailValidator
 
     before_validation :downcase_and_strip
 
+    validate :validate_domain
     validates :email,
               email: {
                 mx_with_fallback: !ENV['RAILS_OFFLINE'],
@@ -14,6 +15,15 @@ module FormEmailValidator
   end
 
   private
+
+  def validate_domain
+    return unless email.present?
+    domain = email&.split('@')&.last
+
+    if domain && !domain.ascii_only?
+      errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)
+    end
+  end
 
   def downcase_and_strip
     self.email = email&.downcase&.strip

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -6,23 +6,25 @@ module FormEmailValidator
 
     before_validation :downcase_and_strip
 
-    validate :validate_domain
     validates :email,
               email: {
                 mx_with_fallback: !ENV['RAILS_OFFLINE'],
                 ban_disposable_email: true,
               }
+    validate :validate_domain
   end
 
   private
 
   def validate_domain
-    return unless email.present?
+    return unless email.present? && errors.blank?
     domain = Mail::Address.new(email).domain
 
     if domain && !domain.ascii_only?
       errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)
     end
+  rescue Mail::Field::IncompleteParseError
+    errors.add(:email, t('valid_email.validations.email.invalid'), type: :domain)
   end
 
   def downcase_and_strip

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -40,5 +40,16 @@ RSpec.describe AddUserEmailForm do
         expect(response.success?).to eq(true)
       end
     end
+
+    context 'when the domain is invalid' do
+      let(:new_email) { 'test@çà.com' }
+
+      it 'fails and does not send a confirmation email' do
+        expect(SendAddEmailConfirmation).to_not receive(:new)
+
+        response = submit
+        expect(response.success?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -165,6 +165,24 @@ describe RegisterUserEmailForm do
           **extra,
         )
       end
+
+      it 'returns false and adds errors to the form object when domain is invalid' do
+        errors = { email: [t('valid_email.validations.email.invalid')] }
+
+        extra = {
+          email_already_exists: false,
+          throttled: false,
+          user_id: 'anonymous-uuid',
+          domain_name: 'çà.com',
+        }
+
+        expect(subject.submit(email: 'test@çà.com', terms_accepted: '1').to_h).to include(
+          success: false,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          **extra,
+        )
+      end
     end
 
     context 'when request_id is invalid' do


### PR DESCRIPTION
## 🛠 Summary of changes

We had a few unhandled exceptions from SES when trying to send to non-ASCII domain names ([NR link](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=604800000&state=f05676cb-1c5c-6663-133b-2cfa9044e8e4)) with the exception `Aws::SES::Errors::InvalidParameterValue: Domain contains illegal character`.

[SES documentation](https://docs.aws.amazon.com/ses/latest/APIReference/API_Destination.html) confirms this:
>Amazon SES does not support the SMTPUTF8 extension, as described in [RFC6531](https://tools.ietf.org/html/rfc6531). For this reason, the local part of a destination email address (the part of the email address that precedes the @ sign) may only contain [7-bit ASCII characters](https://en.wikipedia.org/wiki/Email_address#Local-part). If the domain part of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in [RFC3492](https://tools.ietf.org/html/rfc3492.html).

I tested non-ASCII in the local part of the email address as well as the domain part. I tested both, and was able to receive emails to addresses with non-ASCII characters in the local part, but received the same error with non-ASCII characters in the domain. Due to that, this PR only adds ASCII validation to the domain for now.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
