### PR TITLE
Fix flakey email spec

### DIFF
--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -239,16 +239,18 @@ feature 'adding email address' do
 
     click_button t('links.resend')
 
+    user.reload
+
     expect_delivered_email_count(2)
     expect_delivered_email(
       0, {
-        to: [user.reload.email_addresses[1].email],
+        to: [user.email_addresses.order(:created_at).last.email],
         subject: t('user_mailer.add_email.subject'),
       }
     )
     expect_delivered_email(
       1, {
-        to: [user.email_addresses[1].email],
+        to: [user.email_addresses.order(:created_at).last.email],
         subject: t('user_mailer.add_email.subject'),
       }
     )


### PR DESCRIPTION
## 🛠 Summary of changes

Attempts to resolve an email mailer spec which is commonly failing intermittently.

Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1669069995915509

Same premise as #7359.

There are a couple other occurrences of `User#email_addresses` in this file, but based on how they're used, they shouldn't be prone to the same problem.