### PR TITLE
Fix alignment in Proofing::Result

### DIFF
--- a/app/services/proofing/result.rb
+++ b/app/services/proofing/result.rb
@@ -65,5 +65,5 @@ module Proofing
         success: success?,
       }
     end
-    end
-      end
+  end
+end


### PR DESCRIPTION
There was an indentation error that slipped through from https://github.com/18F/identity-idp/pull/7349#pullrequestreview-1188913249

I wanted to see if we could use Rubocop to catch these consistently:

```
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: keyword
```

However, the three options for [`Layout/EndAlignment`](https://docs.rubocop.org/rubocop/cops_layout.html#layoutendalignment) produced weird issues for some of our other `if ... end` blocks elsewhere so I think it's just easier to fix this manually for now