### PR TITLE
Base GPO expiration on original request date

### DIFF
--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -22,7 +22,7 @@ class GpoConfirmationExporter
   def make_psv(csv)
     csv << make_header_row(confirmations.size)
     confirmations.each do |confirmation|
-      csv << make_entry_row(confirmation.entry)
+      csv << make_entry_row(confirmation)
     end
   end
 
@@ -30,9 +30,11 @@ class GpoConfirmationExporter
     [HEADER_ROW_ID, num_entries]
   end
 
-  def make_entry_row(entry)
+  def make_entry_row(confirmation)
     now = current_date
-    due = now + OTP_MAX_VALID_DAYS.days
+    due = confirmation.created_at + OTP_MAX_VALID_DAYS.days
+
+    entry = confirmation.entry
     service_provider = ServiceProvider.find_by(issuer: entry[:issuer])
 
     [

--- a/spec/services/gpo_confirmation_exporter_spec.rb
+++ b/spec/services/gpo_confirmation_exporter_spec.rb
@@ -17,7 +17,7 @@ describe GpoConfirmationExporter do
           otp: 'ZYX987',
           issuer: issuer,
         },
-        created_at: '2018-06-29 01`:02:03'.to_datetime,
+        created_at: Time.zone.parse('2018-06-29T01:02:03Z'),
       ),
       GpoConfirmation.new(
         entry: {
@@ -31,7 +31,7 @@ describe GpoConfirmationExporter do
           otp: 'ABC123',
           issuer: '',
         },
-        created_at: '2018-07-04 01:02:03'.to_datetime,
+        created_at: Time.zone.parse('2018-07-04T01:02:03Z'),
       ),
     ]
   end

--- a/spec/services/gpo_confirmation_exporter_spec.rb
+++ b/spec/services/gpo_confirmation_exporter_spec.rb
@@ -17,6 +17,7 @@ describe GpoConfirmationExporter do
           otp: 'ZYX987',
           issuer: issuer,
         },
+        created_at: '2018-06-29 01`:02:03'.to_datetime,
       ),
       GpoConfirmation.new(
         entry: {
@@ -30,6 +31,7 @@ describe GpoConfirmationExporter do
           otp: 'ABC123',
           issuer: '',
         },
+        created_at: '2018-07-04 01:02:03'.to_datetime,
       ),
     ]
   end
@@ -45,8 +47,8 @@ describe GpoConfirmationExporter do
     it 'creates psv string' do
       result = <<~HEREDOC
         01|2\r
-        02|John Johnson|123 Sesame St|""|Anytown|WA|98021|ZYX987|July 6, 2018|July 16, 2018|#{service_provider.friendly_name}|#{IdentityConfig.store.domain_name}\r
-        02|Söme Öne|123 Añy St|Sté 123|Sömewhere|KS|66666-1234|ABC123|July 6, 2018|July 16, 2018|Login.gov|#{IdentityConfig.store.domain_name}\r
+        02|John Johnson|123 Sesame St|""|Anytown|WA|98021|ZYX987|July 6, 2018|July 9, 2018|#{service_provider.friendly_name}|#{IdentityConfig.store.domain_name}\r
+        02|Söme Öne|123 Añy St|Sté 123|Sömewhere|KS|66666-1234|ABC123|July 6, 2018|July 14, 2018|Login.gov|#{IdentityConfig.store.domain_name}\r
       HEREDOC
 
       psv_contents = subject.run


### PR DESCRIPTION
## 🎫 Ticket

[LG-8063](https://cm-jira.usa.gov/browse/LG-8063)

## 🛠 Summary of changes

The expiration date printed on GPO letters was being calculated as 30 days after the GPO upload job was run rather than 30 days after the original request was made.

This PR updates the GPO exporter to base expiration dates on the `created_at` field of the `GpoConfirmation` record.