### PR TITLE
Remove excess double-quote from Spanish voice OTP

### DIFF
--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -12,7 +12,7 @@ es:
         @%{domain} #%{code}
       voice: ¡Hola! Su código único de %{app_name} es %{code}, Su código único es
         %{code}, De nuevo, su código único es %{code}, Este código expira en
-        %{expiration} minutos".
+        %{expiration} minutos.
     confirmation_otp:
       sms: |-
         %{app_name}: El código de un solo uso es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
@@ -20,7 +20,7 @@ es:
         @%{domain} #%{code}
       voice: ¡Hola! Su código único de %{app_name} es %{code}, Su código único es
         %{code}, De nuevo, su código único es %{code}, Este código expira en
-        %{expiration} minutos".
+        %{expiration} minutos.
     doc_auth_link: '%{link} Has solicitado verificar tu identidad en un teléfono
       móvil. Por favor, tome una foto de la identificación emitida por su
       estado'


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error which currently occurs when requesting OTP code via voice call when viewing the site in Spanish.