### PR TITLE
Add spec for SSML Pinpoint message validation

### DIFF
--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Telephony::OtpSender do
   shared_examples 'pinpoint valid SSML message' do
     it 'does not contain reserved SSML characters' do
       # See: https://docs.aws.amazon.com/polly/latest/dg/escapees.html
-      expect(Nokogiri::XML(message).text).not_to match(/["&'<>]/)
+      expect(Nokogiri::XML(message) { |config| config.strict }.text).not_to match(/["&'<>]/)
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a test case which would have helped avoid the introduction of errors fixed in #7396.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

1. Run `rspec spec/lib/telephony/otp_sender_spec.rb`
  a. Observe success
2. In your local copy of the branch, `git revert 8c40e37`
3. Run `rspec spec/lib/telephony/otp_sender_spec.rb`
  b. Observe failure