### PR TITLE
Add phone metadata to telephony logging

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -272,19 +272,24 @@ module Users
       end
 
       current_user.create_direct_otp
-      params = {
+      otp_params = {
         to: phone_to_deliver_to,
         otp: current_user.direct_otp,
         expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         channel: method.to_sym,
         domain: IdentityConfig.store.domain_name,
         country_code: parsed_phone.country,
+        extra_metadata: {
+          area_code: parsed_phone.area_code,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+          resend: params.dig(:otp_delivery_selection_form, :resend),
+        },
       }
 
       if UserSessionContext.authentication_or_reauthentication_context?(context)
-        Telephony.send_authentication_otp(**params)
+        Telephony.send_authentication_otp(**otp_params)
       else
-        Telephony.send_confirmation_otp(**params)
+        Telephony.send_confirmation_otp(**otp_params)
       end
     end
 

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -60,6 +60,11 @@ module Idv
         channel: delivery_method,
         domain: IdentityConfig.store.domain_name,
         country_code: parsed_phone.country,
+        extra_metadata: {
+          area_code: parsed_phone.area_code,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+          resend: nil,
+        },
       )
       otp_sent_response
     end

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -43,7 +43,8 @@ module Telephony
     @config
   end
 
-  def self.send_authentication_otp(to:, otp:, expiration:, channel:, domain:, country_code:)
+  def self.send_authentication_otp(to:, otp:, expiration:, channel:, domain:, country_code:,
+                                   extra_metadata:)
     OtpSender.new(
       to: to,
       otp: otp,
@@ -51,10 +52,12 @@ module Telephony
       channel: channel,
       domain: domain,
       country_code: country_code,
+      extra_metadata: extra_metadata,
     ).send_authentication_otp
   end
 
-  def self.send_confirmation_otp(to:, otp:, expiration:, channel:, domain:, country_code:)
+  def self.send_confirmation_otp(to:, otp:, expiration:, channel:, domain:, country_code:,
+                                 extra_metadata:)
     OtpSender.new(
       to: to,
       otp: otp,
@@ -62,6 +65,7 @@ module Telephony
       channel: channel,
       domain: domain,
       country_code: country_code,
+      extra_metadata: extra_metadata,
     ).send_confirmation_otp
   end
 

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -1,14 +1,16 @@
 module Telephony
   class OtpSender
-    attr_reader :recipient_phone, :otp, :expiration, :channel, :domain, :country_code
+    attr_reader :recipient_phone, :otp, :expiration, :channel, :domain, :country_code,
+                :extra_metadata
 
-    def initialize(to:, otp:, expiration:, channel:, domain:, country_code:)
+    def initialize(to:, otp:, expiration:, channel:, domain:, country_code:, extra_metadata:)
       @recipient_phone = to
       @otp = otp
       @expiration = expiration
       @channel = channel.to_sym
       @domain = domain
       @country_code = country_code
+      @extra_metadata = extra_metadata
     end
 
     def send_authentication_otp
@@ -75,11 +77,14 @@ module Telephony
     end
 
     def log_response(response, context:)
-      extra = {
-        adapter: Telephony.config.adapter,
-        channel: channel,
-        context: context,
-      }
+      extra = extra_metadata.merge(
+        {
+          adapter: Telephony.config.adapter,
+          channel: channel,
+          context: context,
+          country_code: country_code,
+        },
+      )
       output = response.to_h.merge(extra).to_json
       Telephony.config.logger.info(output)
     end

--- a/spec/controllers/test/telephony_controller_spec.rb
+++ b/spec/controllers/test/telephony_controller_spec.rb
@@ -10,6 +10,7 @@ describe Test::TelephonyController do
         channel: :sms,
         domain: IdentityConfig.store.domain_name,
         country_code: 'US',
+        extra_metadata: {},
       )
       Telephony.send_authentication_otp(
         to: '(555) 555-5000',
@@ -18,6 +19,7 @@ describe Test::TelephonyController do
         channel: :voice,
         domain: IdentityConfig.store.domain_name,
         country_code: 'US',
+        extra_metadata: {},
       )
 
       get :index
@@ -47,6 +49,7 @@ describe Test::TelephonyController do
         channel: :sms,
         domain: IdentityConfig.store.domain_name,
         country_code: 'US',
+        extra_metadata: {},
       )
       Telephony.send_authentication_otp(
         to: '(555) 555-5000',
@@ -55,6 +58,7 @@ describe Test::TelephonyController do
         channel: :voice,
         domain: IdentityConfig.store.domain_name,
         country_code: 'US',
+        extra_metadata: {},
       )
 
       delete :destroy

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -289,13 +289,21 @@ describe Users::TwoFactorAuthenticationController do
       it 'sends OTP via SMS for sign in' do
         get :send_code, params: otp_delivery_form_sms
 
+        phone = MfaContext.new(subject.current_user).phone_configurations.first.phone
+        parsed_phone = Phonelib.parse(phone)
+
         expect(Telephony).to have_received(:send_authentication_otp).with(
           otp: subject.current_user.direct_otp,
-          to: MfaContext.new(subject.current_user).phone_configurations.first.phone,
+          to: phone,
           expiration: 10,
           channel: :sms,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: nil,
+          },
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -435,14 +443,21 @@ describe Users::TwoFactorAuthenticationController do
         get :send_code, params: {
           otp_delivery_selection_form: { otp_delivery_preference: 'voice' },
         }
+        phone = MfaContext.new(subject.current_user).phone_configurations.first.phone
+        parsed_phone = Phonelib.parse(phone)
 
         expect(Telephony).to have_received(:send_authentication_otp).with(
           otp: subject.current_user.direct_otp,
-          to: MfaContext.new(subject.current_user).phone_configurations.first.phone,
+          to: phone,
           expiration: 10,
           channel: :voice,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: nil,
+          },
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -514,6 +529,7 @@ describe Users::TwoFactorAuthenticationController do
         sign_in_before_2fa(@user)
         subject.user_session[:context] = 'confirmation'
         subject.user_session[:unconfirmed_phone] = @unconfirmed_phone
+        parsed_phone = Phonelib.parse(@unconfirmed_phone)
 
         allow(Telephony).to receive(:send_confirmation_otp).and_call_original
 
@@ -526,6 +542,11 @@ describe Users::TwoFactorAuthenticationController do
           channel: :sms,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: nil,
+          },
         )
       end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -27,6 +27,7 @@ feature 'Changing authentication factor' do
         user = sign_in_and_2fa_user
         phone_configuration = MfaContext.new(user).phone_configurations.first
         old_phone = phone_configuration.phone
+        parsed_phone = Phonelib.parse(old_phone)
 
         travel(IdentityConfig.store.reauthn_window + 1)
         visit manage_phone_path(id: phone_configuration)
@@ -40,7 +41,12 @@ feature 'Changing authentication factor' do
           channel: :sms,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
-        )
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: 'true',
+          },
+        ).once
 
         expect(current_path).
           to eq login_two_factor_path(otp_delivery_preference: 'sms')

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Telephony::OtpSender do
         channel: channel,
         domain: domain,
         country_code: country_code,
+        extra_metadata: { phone_fingerprint: 'abc123' },
       )
     end
 
@@ -42,6 +43,24 @@ RSpec.describe Telephony::OtpSender do
         subject.send_confirmation_otp
 
         expect(Telephony::Test::Message.last_otp).to eq(otp)
+      end
+
+      it 'logs a message being sent' do
+        expect(Telephony.config.logger).to receive(:info).with(
+          {
+            success: true,
+            errors: {},
+            request_id: 'fake-message-request-id',
+            message_id: 'fake-message-id',
+            phone_fingerprint: 'abc123',
+            adapter: :test,
+            channel: :sms,
+            context: :authentication,
+            country_code: 'US',
+          }.to_json,
+        )
+
+        subject.send_authentication_otp
       end
     end
 
@@ -71,6 +90,7 @@ RSpec.describe Telephony::OtpSender do
         channel: channel,
         domain: domain,
         country_code: country_code,
+        extra_metadata: {},
       )
     end
 
@@ -199,6 +219,7 @@ RSpec.describe Telephony::OtpSender do
         expiration: Time.zone.now,
         domain: 'login.gov',
         country_code: country_code,
+        extra_metadata: {},
       )
     end
 
@@ -252,6 +273,7 @@ RSpec.describe Telephony::OtpSender do
         expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         domain: 'secure.login.gov',
         country_code: 'US',
+        extra_metadata: {},
       )
     end
 
@@ -300,6 +322,7 @@ RSpec.describe Telephony::OtpSender do
         expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         domain: 'secure.login.gov',
         country_code: 'US',
+        extra_metadata: {},
       )
     end
 

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Idv::SendPhoneConfirmationOtp do
   let(:phone) { '+1 225-555-5000' }
+  let(:parsed_phone) { Phonelib.parse(phone) }
   let(:delivery_preference) { :sms }
   let(:otp_code) { '777777' }
   let(:user_phone_confirmation_session) do
@@ -62,6 +63,11 @@ describe Idv::SendPhoneConfirmationOtp do
           channel: :sms,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: nil,
+          },
         )
       end
     end
@@ -89,6 +95,11 @@ describe Idv::SendPhoneConfirmationOtp do
           channel: :voice,
           domain: IdentityConfig.store.domain_name,
           country_code: 'US',
+          extra_metadata: {
+            area_code: parsed_phone.area_code,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            resend: nil,
+          },
         )
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

To facilitate the usage of existing metrics/alarms, this adds metadata to `telephony.log` despite similar information being available in `events.log` currently.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
