### PR TITLE
Fix flaky GPO exporter test

### DIFF
--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -54,7 +54,7 @@ class GpoConfirmationExporter
   end
 
   def format_date(date)
-    "#{date.strftime('%-B %-e')}, #{date.year}"
+    date.utc.strftime('%-B %-e, %Y').to_s
   end
 
   def current_date

--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -54,7 +54,7 @@ class GpoConfirmationExporter
   end
 
   def format_date(date)
-    date.utc.strftime('%-B %-e, %Y').to_s
+    date.in_time_zone('UTC').strftime('%-B %-e, %Y')
   end
 
   def current_date

--- a/spec/services/gpo_confirmation_exporter_spec.rb
+++ b/spec/services/gpo_confirmation_exporter_spec.rb
@@ -41,7 +41,7 @@ describe GpoConfirmationExporter do
   describe '#run' do
     before do
       allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).and_return(10)
-      allow(subject).to receive(:current_date).and_return(Time.zone.local(2018, 7, 6))
+      allow(subject).to receive(:current_date).and_return(Time.utc(2018, 7, 6))
     end
 
     it 'creates psv string' do


### PR DESCRIPTION
Address a flaky test introduced in #7389.

We run tests in CI with a random Timezone each time. This means sometimes the local day and UTC day are different, which was making the updated GPO exporter test fail.

This change updates `GpoConfirmationExporter` to convert dates to UTC before outputting them. This gives us consistency on tests but should not matter in prod, where the Timezone is already set to UTC.

For LG-8233

[skip changelog]
