### PR TITLE
Fix flaky telephony pool tests

### DIFF
--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -31,6 +31,10 @@ describe Telephony::Pinpoint::SmsSender do
       Pinpoint::MockClient.message_response_result_status_message = status_message
     end
 
+    after do
+      Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
+    end
+
     context 'when endpoint is a duplicate' do
       let(:delivery_status) { 'DUPLICATE' }
 
@@ -202,6 +206,8 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
+      ensure
+        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -234,6 +240,8 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
+      ensure
+        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -268,6 +276,8 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
+      ensure
+        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -282,6 +292,10 @@ describe Telephony::Pinpoint::SmsSender do
 
         mock_build_client
         mock_build_backup_client
+      end
+
+      after do
+        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
 
       context 'when the first config succeeds' do
@@ -401,6 +415,10 @@ describe Telephony::Pinpoint::SmsSender do
 
         allow(mock_client).to receive(:send_messages).and_return(phone_numbers)
         allow(backup_mock_client).to receive(:send_messages).and_return(phone_numbers)
+      end
+
+      after do
+        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
 
       it 'does not include the phone number in the results' do

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -31,7 +31,10 @@ describe Telephony::Pinpoint::SmsSender do
       Pinpoint::MockClient.message_response_result_status_message = status_message
     end
 
-    after do
+    around do |ex|
+      ex.run
+
+    ensure
       Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
     end
 
@@ -175,6 +178,13 @@ describe Telephony::Pinpoint::SmsSender do
       }
     end
 
+    around do |ex|
+      ex.run
+
+    ensure
+      Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
+    end
+
     context 'in a country with sender_id' do
       let(:country_code) { 'PH' }
 
@@ -206,8 +216,6 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
-      ensure
-        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -240,8 +248,6 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
-      ensure
-        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -276,8 +282,6 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.success?).to eq(true)
         expect(response.error).to eq(nil)
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
-      ensure
-        Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
     end
 
@@ -294,7 +298,9 @@ describe Telephony::Pinpoint::SmsSender do
         mock_build_backup_client
       end
 
-      after do
+      around do |ex|
+        ex.run
+      ensure
         Telephony::Pinpoint::SmsSender::CLIENT_POOL.clear
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

I think https://github.com/18F/identity-idp/pull/7314 introduced some mutation of the constant that can affect other tests and may not always clean it up which can lead to failed specs elsewhere ([example](https://gitlab.login.gov/lg/identity-idp/-/jobs/177055))

To reproduce the flaky test reliably, run `rspec spec/lib/telephony/pinpoint/sms_sender_spec.rb spec/lib/telephony/telephony_spec.rb --seed 8116`, which should result in:

```
Failures:

  1) Telephony.phone_info with pinpoint adapter uses the pinpoint adapter
     Failure/Error:
       response = client.phone_number_validate(
         number_validate_request: { phone_number: phone_number },
       )

     NoMethodError:
       undefined method `phone_number_validate' for #<Pinpoint::MockClient:0x00007f94fb854e30 @config=#<struct Telephony::PinpointSmsConfiguration application_id="fake-pinpoint-application-id-sms", shortcode="123456", country_code_longcode_pool={"PR"=>["+19393334444"]}, region="fake-pinpoint-region-sms", access_key_id="fake-pnpoint-access-key-id-sms", secret_access_key="fake-pinpoint-secret-access-key-sms", credential_role_arn=nil, credential_role_session_name=nil, credential_external_id=nil>>
```

This PR tries to ensure that all of the client pool mocking is reset in this spec file.