### PR TITLE
LG-8215 Update proofing_components on profile model to include inherited_proofing_proofed

### DIFF
--- a/app/services/idv/steps/inherited_proofing/verify_info_step.rb
+++ b/app/services/idv/steps/inherited_proofing/verify_info_step.rb
@@ -13,6 +13,7 @@ module Idv
         end
 
         def call
+          save_proofing_components
         end
 
         def extra_view_variables
@@ -24,6 +25,18 @@ module Idv
 
         def pii
           flow_session[:pii_from_user]
+        end
+
+        private
+
+        def save_proofing_components
+          raise 'current_user is not present' unless current_user.present?
+
+          component_attributes = {
+            inherited_proofing_proofed: true,
+          }
+
+          ProofingComponent.create_or_find_by(user: current_user).update(component_attributes)
         end
       end
     end

--- a/app/services/idv/steps/inherited_proofing/verify_info_step.rb
+++ b/app/services/idv/steps/inherited_proofing/verify_info_step.rb
@@ -30,8 +30,6 @@ module Idv
         private
 
         def save_proofing_components
-          raise 'current_user is not present' unless current_user.present?
-
           component_attributes = {
             inherited_proofing_proofed: true,
           }

--- a/db/primary_migrate/20221129175844_add_inherited_proofing_proofed_to_proofing_component.rb
+++ b/db/primary_migrate/20221129175844_add_inherited_proofing_proofed_to_proofing_component.rb
@@ -1,0 +1,7 @@
+class AddInheritedProofingProofedToProofingComponent < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :proofing_components, :inherited_proofing_proofed, :boolean, default: false, null: false, comment: "When the user is proofed via inherited proofing"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -463,6 +463,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_02_163826) do
     t.string "threatmetrix_review_status"
     t.string "threatmetrix_risk_rating"
     t.string "threatmetrix_policy_score"
+    t.boolean "inherited_proofing_proofed", default: false, null: false, comment: "When the user is proofed via inherited proofing"
     t.index ["user_id"], name: "index_proofing_components_on_user_id", unique: true
     t.index ["verified_at"], name: "index_proofing_components_on_verified_at"
   end

--- a/spec/features/idv/inherited_proofing/verify_info_step_spec.rb
+++ b/spec/features/idv/inherited_proofing/verify_info_step_spec.rb
@@ -11,11 +11,12 @@ feature 'inherited proofing verify info' do
     allow_any_instance_of(Idv::InheritedProofingController).to \
       receive(:va_inherited_proofing_auth_code).and_return auth_code
 
-    sign_in_and_2fa_user
+    sign_in_and_2fa_user user
     complete_inherited_proofing_steps_before_verify_step
   end
 
   let(:auth_code) { Idv::InheritedProofing::Va::Mocks::Service::VALID_AUTH_CODE }
+  let(:user) { user_with_2fa }
 
   describe 'page content' do
     it 'renders the Continue button' do
@@ -49,6 +50,19 @@ feature 'inherited proofing verify info' do
     it "can display the user's ssn when selected" do
       check 'Show Social Security number'
       expect(page).to have_text '123-45-6789'
+    end
+  end
+
+  describe 'user proofing components' do
+    before do
+      click_on t('inherited_proofing.buttons.continue')
+      expect(page).to have_current_path(idv_phone_path)
+    end
+
+    context 'when the user verifies their PII' do
+      it 'indicates the user has been proofed using inherited proofing' do
+        expect(user.proofing_component['inherited_proofing_proofed']).to eq true
+      end
     end
   end
 end

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'proofing components' do
         proofing_components = user.active_profile.proofing_components
         expect(proofing_components['document_check']).to eq('mock')
         expect(proofing_components['document_type']).to eq('state_id')
+        expect(proofing_components['inherited_proofing_proofed']).to eq(false)
       end
     end
 
@@ -45,6 +46,7 @@ RSpec.describe 'proofing components' do
         proofing_components = user.active_profile.proofing_components
         expect(proofing_components['document_check']).to eq('mock')
         expect(proofing_components['document_type']).to eq('state_id')
+        expect(proofing_components['inherited_proofing_proofed']).to eq(false)
       end
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8215 Update proofing_components on profile model to include inherited_proofing_proofed](https://cm-jira.usa.gov/browse/LG-8215)

## 🛠 Summary of changes

Add `inherited_proofing_proofed` column to `proofing_components` table via migrations to track inherited proofing (IP) users through the IDV workflow for analytics.

When IP users verify their user PII, set `ProofingComponent#inherited_proofing_proofed` to true to indicate that the user has been proofed as far as IP is concerned.

Add

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [X] Automated tests

