### PR TITLE
Add exception handling back to DDP proofer

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -64,6 +64,9 @@ module Proofing
         def proof(applicant)
           response = send_verification_request(applicant)
           process_response(response)
+        rescue => exception
+          NewRelic::Agent.notice_error(exception)
+          Proofing::Result.new(exception: exception)
         end
 
         private

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -82,5 +82,21 @@ describe Proofing::LexisNexis::Ddp::Proofer do
         expect(result.errors).to be_empty
       end
     end
+
+    context 'when the response raises an exception' do
+      let(:response_body) { '' }
+
+      it 'returns an exception result' do
+        error = RuntimeError.new('hi')
+
+        expect(NewRelic::Agent).to receive(:notice_error).with(error)
+
+        stub_request(:post, verification_request.url).to_raise(error)
+
+        expect(result.success?).to eq(false)
+        expect(result.errors).to be_empty
+        expect(result.exception).to eq(error)
+      end
+    end
   end
 end


### PR DESCRIPTION
A recent refactor of the DDP proofer failed to include this rescue. As a result exceptions are unhandled and raised to the background job and cause a background job failure.
