### PR TITLE
Scrub the error message from JSON parse errors of LexisNexis response bodies

### DIFF
--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -31,12 +31,14 @@ module Proofing
       # @api private
       def response_body
         @response_body ||= JSON.parse(response.body)
-      rescue JSON::ParserError => exception
+      rescue JSON::ParserError
         # IF a JSON parse error occurs the resulting error message will contain the portion of the
         # response body where the error occured. This portion of the response could potentially
         # include sensitive informaiton. This commit scrubs the error message by raising a JSON
         # parse error with a generic message.
-        raise JSON::ParserError, 'An error occured parsing the response body JSON'
+        content_type = response.headers&.[]('Content-Type')
+        error_message = "An error occured parsing the response body JSON, status=#{response.status} content_type=#{content_type}" # rubocop:disable Layout/LineLength
+        raise JSON::ParserError, error_message
       end
 
       private

--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -31,6 +31,12 @@ module Proofing
       # @api private
       def response_body
         @response_body ||= JSON.parse(response.body)
+      rescue JSON::ParserError => exception
+        # IF a JSON parse error occurs the resulting error message will contain the portion of the
+        # response body where the error occured. This portion of the response could potentially
+        # include sensitive informaiton. This commit scrubs the error message by raising a JSON
+        # parse error with a generic message.
+        raise JSON::ParserError, 'An error occured parsing the response body JSON'
       end
 
       private

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -78,4 +78,17 @@ describe Proofing::LexisNexis::Response do
       end
     end
   end
+
+  describe '#response_body' do
+    context 'the result includes invalid JSON' do
+      let(:response_body) { '$":^&' }
+
+      it 'raises a JSON parse error with a generic error message' do
+        expect { subject.response_body }.to raise_error(
+          JSON::ParserError,
+          'An error occured parsing the response body JSON',
+        )
+      end
+    end
+  end
 end

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -86,7 +86,7 @@ describe Proofing::LexisNexis::Response do
       it 'raises a JSON parse error with a generic error message' do
         expect { subject.response_body }.to raise_error(
           JSON::ParserError,
-          error_message = 'An error occured parsing the response body JSON, status=200 content_type='
+          'An error occured parsing the response body JSON, status=200 content_type=',
         )
       end
     end

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -86,7 +86,7 @@ describe Proofing::LexisNexis::Response do
       it 'raises a JSON parse error with a generic error message' do
         expect { subject.response_body }.to raise_error(
           JSON::ParserError,
-          'An error occured parsing the response body JSON',
+          error_message = 'An error occured parsing the response body JSON, status=200 content_type='
         )
       end
     end


### PR DESCRIPTION
The LexisNexis response bodies may contain information that we do not wish to be logged or reported to NewRelic (such as PII).

When a JSON parse error is raised it includes the portion of the JSON that resulted in the error. This commit rescues the JSON parse errors that are raised when a LexisNexis response body is being parsed. These error messages may contain sensitive information. As a result a new JSON parse error is raised in their place with a message that does not include the JSON that caused the error.

[skip changelog]
