### PR TITLE
Account Recovery Rate Limit bugfix

### DIFF
--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -22,7 +22,6 @@ module Users
 
     def create
       if throttle.throttled_else_increment?
-        irs_attempts_api_tracker.personal_key_reactivation_rate_limited
         render_throttled
       else
         result = personal_key_form.submit
@@ -56,6 +55,8 @@ module Users
       analytics.throttler_rate_limit_triggered(
         throttle_type: :verify_personal_key,
       )
+
+      irs_attempts_api_tracker.personal_key_reactivation_rate_limited
 
       @expires_at = throttle.expires_at
       render :throttled

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -63,7 +63,7 @@ describe Users::VerifyPersonalKeyController do
           throttle_type: :verify_personal_key,
         ).once
 
-        expect(@irs_attempts_api_tracker).not_to receive(:personal_key_reactivation_rate_limited)
+        expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited)
 
         get :new
 


### PR DESCRIPTION
changelog: Internal, Attempts API, fixed event trigger bug

<!-- Uncomment and update the sections you need for your PR! -->

[LG-8212 - Ticket](https://cm-jira.usa.gov/browse/LG-8212)

## 🛠 Summary of changes

Fixed a bug where `personal_key_reactivation_rate_limited` was not firing

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
