### PR TITLE
build-sass: Improve error recovery in watch mode

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,3 +1,9 @@
-## 1.0.0
+## 1.1.0 (Unreleased)
+
+### Improvements
+
+- Improves watch mode error recovery to monitor changes to all files in the stack trace of the error.
+
+## 1.0.0 (2022-11-21)
 
 - Initial release

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -50,11 +50,20 @@ const isSassException = (error) => 'span' in /** @type {SassException} */ (error
  *
  * @example
  * ```
- * 'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
- * 'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
- * 'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
- * 'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
- * 'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+ * getErrorStackPaths(
+ *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
+ *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
+ *   'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
+ *   'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
+ *   'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+ * );
+ * // [
+ * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss',
+ * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss',
+ * //   'app/assets/stylesheets/components/_alert.scss',
+ * //   'app/assets/stylesheets/components/all.scss',
+ * //   'app/assets/stylesheets/application.css.scss',
+ * // ]
  * ```
  *
  * @param {string} sassStack Sass stack trace (see example).

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -46,6 +46,28 @@ function watchOnce(paths, callback) {
 const isSassException = (error) => 'span' in /** @type {SassException} */ (error);
 
 /**
+ * Returns all file paths contained in the given Sass stack trace.
+ *
+ * @example
+ * ```
+ * 'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
+ * 'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
+ * 'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
+ * 'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
+ * 'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+ * ```
+ *
+ * @param {string} sassStack Sass stack trace (see example).
+ *
+ * @return {string[]} Array of file paths.
+ */
+const getErrorSassStackPaths = (sassStack) =>
+  sassStack
+    .split(/\.scss \d+:\d+\s+.+?\n/)
+    .filter(Boolean)
+    .map((basename) => `${basename}.scss`);
+
+/**
  * @param {string[]} files
  * @return {Promise<void|void[]>}
  */
@@ -62,9 +84,8 @@ function build(files) {
     /** @param {Error|SassException} error */ (error) => {
       console.error(error);
 
-      if (isWatching && isSassException(error) && error.span.url) {
-        const exceptionPath = fileURLToPath(error.span.url);
-        watchOnce(exceptionPath, () => build(files));
+      if (isWatching && isSassException(error)) {
+        watchOnce(getErrorSassStackPaths(error.sassStack), () => build(files));
       } else {
         throw error;
       }

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -5,6 +5,7 @@
 import { watch } from 'chokidar';
 import { fileURLToPath } from 'url';
 import { buildFile } from './index.js';
+import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
 
 /** @typedef {import('sass-embedded').Options<'sync'>} SyncSassOptions */
 /** @typedef {import('sass-embedded').Exception} SassException */
@@ -44,37 +45,6 @@ function watchOnce(paths, callback) {
  * @return {error is SassException}
  */
 const isSassException = (error) => 'span' in /** @type {SassException} */ (error);
-
-/**
- * Returns all file paths contained in the given Sass stack trace.
- *
- * @example
- * ```
- * getErrorStackPaths(
- *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
- *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
- *   'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
- *   'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
- *   'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
- * );
- * // [
- * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss',
- * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss',
- * //   'app/assets/stylesheets/components/_alert.scss',
- * //   'app/assets/stylesheets/components/all.scss',
- * //   'app/assets/stylesheets/application.css.scss',
- * // ]
- * ```
- *
- * @param {string} sassStack Sass stack trace (see example).
- *
- * @return {string[]} Array of file paths.
- */
-const getErrorSassStackPaths = (sassStack) =>
-  sassStack
-    .split(/\.scss \d+:\d+\s+.+?\n/)
-    .filter(Boolean)
-    .map((basename) => `${basename}.scss`);
 
 /**
  * @param {string[]} files

--- a/app/javascript/packages/build-sass/get-error-sass-stack-paths.js
+++ b/app/javascript/packages/build-sass/get-error-sass-stack-paths.js
@@ -1,0 +1,32 @@
+/**
+ * Returns all file paths contained in the given Sass stack trace.
+ *
+ * @example
+ * ```
+ * getErrorSassStackPaths(
+ *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
+ *   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
+ *   'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
+ *   'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
+ *   'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+ * );
+ * // [
+ * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss',
+ * //   'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss',
+ * //   'app/assets/stylesheets/components/_alert.scss',
+ * //   'app/assets/stylesheets/components/all.scss',
+ * //   'app/assets/stylesheets/application.css.scss',
+ * // ]
+ * ```
+ *
+ * @param {string} sassStack Sass stack trace (see example).
+ *
+ * @return {string[]} Array of file paths.
+ */
+const getErrorSassStackPaths = (sassStack) =>
+  sassStack
+    .split(/\.scss \d+:\d+\s+.+?\n/)
+    .filter(Boolean)
+    .map((basename) => `${basename}.scss`);
+
+export default getErrorSassStackPaths;

--- a/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
@@ -18,4 +18,24 @@ describe('getErrorSassStackPaths', () => {
       'app/assets/stylesheets/application.css.scss',
     ]);
   });
+
+  context('with a stack path containing a space', () => {
+    it('returns an array of paths from a sass stack message', () => {
+      const stackPaths = getErrorSassStackPaths(
+        'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
+          'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
+          'app/assets/stylesheets/components/_alert example.scss 13:5                             @import\n' +
+          'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
+          'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+      );
+
+      expect(stackPaths).to.deep.equal([
+        'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss',
+        'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss',
+        'app/assets/stylesheets/components/_alert example.scss',
+        'app/assets/stylesheets/components/all.scss',
+        'app/assets/stylesheets/application.css.scss',
+      ]);
+    });
+  });
 });

--- a/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
@@ -1,0 +1,21 @@
+import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
+
+describe('getErrorSassStackPaths', () => {
+  it('returns an array of paths from a sass stack message', () => {
+    const stackPaths = getErrorSassStackPaths(
+      'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
+        'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
+        'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
+        'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
+        'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+    );
+
+    expect(stackPaths).to.deep.equal([
+      'node_modules/identity-style-guide/dist/assets/scss/uswds/core/_functions.scss',
+      'node_modules/identity-style-guide/dist/assets/scss/uswds/core/mixins/_icon.scss',
+      'app/assets/stylesheets/components/_alert.scss',
+      'app/assets/stylesheets/components/all.scss',
+      'app/assets/stylesheets/application.css.scss',
+    ]);
+  });
+});


### PR DESCRIPTION
## 🛠 Summary of changes

This improves Sass compilation to avoid a scenario where an error prevents Sass from being rebuilt on file changes. Previously, the watch behavior would only monitor the file in which the error occurred. However, it is quite common that the error occurs in a file different from the file which _caused_ the error. With these changes, because the causing file would be included in the stack trace, an update to that file will now trigger a rebuild.

## 📜 Testing Plan

1. Apply the diff below
2. Run `yarn build:css --watch`
3. Observe error
4. Open and save `app/assets/stylesheets/components/_alert.scss`

Before: You'd see nothing, because there wouldn't be a rebuild.
After: You'll see the error at Step 3 repeated, since it was rebuilt but the error still occurred.

Diff:
 
```diff
diff --git a/app/assets/stylesheets/components/_alert.scss b/app/assets/stylesheets/components/_alert.scss
index 4a67e27c7..9a9968210 100644
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -7,3 +7,14 @@
     background-image: url('alert/info-white.svg');
   }
 }
+
+.usa-alert--info-time {
+  &::before {
+    @include add-color-icon(
+      (
+        name: 'timer',
+        color: 'primary',
+      )
+    );
+  }
+}
```