### PR TITLE
LG-8200: Add visible countdown timer for SMS messages

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -7,3 +7,19 @@
     background-image: url('alert/info-white.svg');
   }
 }
+
+.usa-alert--info-time {
+  &::before {
+    @include add-color-icon(
+      (
+        name: 'timer',
+        color: 'info',
+        'svg-width': 24,
+        'svg-height': 24,
+        height: units(2),
+      )
+    );
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -266,6 +266,11 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     current_user.direct_otp if FeatureManagement.prefill_otp_codes?
   end
 
+  def otp_expiration
+    return if current_user.direct_otp_sent_at.blank?
+    current_user.direct_otp_sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
+  end
+
   def personal_key_unavailable?
     current_user.encrypted_recovery_code_digest.blank?
   end
@@ -282,6 +287,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     { confirmation_for_add_phone: confirmation_for_add_phone?,
       phone_number: display_phone_to_deliver_to,
       code_value: direct_otp_code,
+      otp_expiration: otp_expiration,
       otp_delivery_preference: two_factor_authentication_method,
       otp_make_default_number: selected_otp_make_default_number,
       voice_otp_delivery_unsupported: voice_otp_delivery_unsupported?,

--- a/app/javascript/packages/countdown-element/index.spec.ts
+++ b/app/javascript/packages/countdown-element/index.spec.ts
@@ -97,6 +97,20 @@ describe('CountdownElement', () => {
     expect(element.textContent).to.equal('0 minutes and 2 seconds');
   });
 
+  it('stops when the countdown is finished', () => {
+    const element = createElement({
+      expiration: new Date(new Date().getTime() + 1000).toISOString(),
+      updateInterval: '1000',
+    });
+
+    sinon.spy(element, 'stop');
+
+    clock.tick(1000);
+
+    expect(element.textContent).to.equal('0 minutes and 0 seconds');
+    expect(element.stop).to.have.been.called();
+  });
+
   describe('#start', () => {
     it('is idempotent', () => {
       const element = createElement({ startImmediately: 'false' });

--- a/app/javascript/packages/countdown-element/index.spec.ts
+++ b/app/javascript/packages/countdown-element/index.spec.ts
@@ -47,11 +47,11 @@ describe('CountdownElement', () => {
 
     clock.tick(1999);
 
-    expect(element.textContent).to.equal('0 minutes and 3 seconds');
+    expect(element.textContent).to.equal('3 seconds');
 
     clock.tick(1);
 
-    expect(element.textContent).to.equal('0 minutes and one second');
+    expect(element.textContent).to.equal('one second');
   });
 
   it('allows a delayed start', () => {
@@ -62,11 +62,11 @@ describe('CountdownElement', () => {
 
     clock.tick(1000);
 
-    expect(element.textContent).to.equal('0 minutes and one second');
+    expect(element.textContent).to.equal('one second');
 
     element.start();
 
-    expect(element.textContent).to.equal('0 minutes and 0 seconds');
+    expect(element.textContent).to.equal('0 seconds');
   });
 
   it('can be stopped and restarted', () => {
@@ -78,11 +78,11 @@ describe('CountdownElement', () => {
     element.stop();
     clock.tick(1000);
 
-    expect(element.textContent).to.equal('0 minutes and 2 seconds');
+    expect(element.textContent).to.equal('2 seconds');
 
     element.start();
 
-    expect(element.textContent).to.equal('0 minutes and one second');
+    expect(element.textContent).to.equal('one second');
   });
 
   it('updates in response to changed expiration', () => {
@@ -90,11 +90,11 @@ describe('CountdownElement', () => {
 
     element.expiration = new Date(new Date().getTime() + 1000);
 
-    expect(element.textContent).to.equal('0 minutes and one second');
+    expect(element.textContent).to.equal('one second');
 
     element.setAttribute('data-expiration', new Date(new Date().getTime() + 2000).toISOString());
 
-    expect(element.textContent).to.equal('0 minutes and 2 seconds');
+    expect(element.textContent).to.equal('2 seconds');
   });
 
   it('stops when the countdown is finished', () => {
@@ -107,7 +107,7 @@ describe('CountdownElement', () => {
 
     clock.tick(1000);
 
-    expect(element.textContent).to.equal('0 minutes and 0 seconds');
+    expect(element.textContent).to.equal('0 seconds');
     expect(element.stop).to.have.been.called();
   });
 

--- a/app/javascript/packages/countdown-element/index.ts
+++ b/app/javascript/packages/countdown-element/index.ts
@@ -52,11 +52,19 @@ export class CountdownElement extends HTMLElement {
   start(): void {
     this.stop();
     this.setTimeRemaining();
-    this.#pollIntervalId = window.setInterval(() => this.setTimeRemaining(), this.updateInterval);
+    this.#pollIntervalId = window.setInterval(() => this.tick(), this.updateInterval);
   }
 
   stop(): void {
     window.clearInterval(this.#pollIntervalId);
+  }
+
+  tick(): void {
+    this.setTimeRemaining();
+
+    if (this.timeRemaining <= 0) {
+      this.stop();
+    }
   }
 
   setTimeRemaining(): void {

--- a/app/javascript/packages/countdown-element/index.ts
+++ b/app/javascript/packages/countdown-element/index.ts
@@ -70,9 +70,14 @@ export class CountdownElement extends HTMLElement {
   setTimeRemaining(): void {
     const { timeRemaining } = this;
 
+    const minutes = Math.floor(timeRemaining / 60000);
+    const seconds = Math.floor(timeRemaining / 1000) % 60;
+
     this.#textNode.nodeValue = [
-      t('datetime.dotiw.minutes', { count: Math.floor(timeRemaining / 60000) }),
-      t('datetime.dotiw.seconds', { count: Math.floor(timeRemaining / 1000) % 60 }),
-    ].join(t('datetime.dotiw.two_words_connector'));
+      minutes && t('datetime.dotiw.minutes', { count: minutes }),
+      t('datetime.dotiw.seconds', { count: seconds }),
+    ]
+      .filter(Boolean)
+      .join(t('datetime.dotiw.two_words_connector'));
   }
 }

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -1,6 +1,9 @@
 module TwoFactorAuthCode
   class PhoneDeliveryPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
-    attr_reader :otp_delivery_preference, :otp_make_default_number, :unconfirmed_phone
+    attr_reader :otp_delivery_preference,
+                :otp_make_default_number,
+                :unconfirmed_phone,
+                :otp_expiration
 
     alias_method :unconfirmed_phone?, :unconfirmed_phone
 

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,5 +1,9 @@
 <% title t('titles.enter_2fa_code.one_time_code') %>
 
+<%= render AlertComponent.new(type: :info, class: 'margin-bottom-4 usa-alert--info-time') do %>
+  <%= render CountdownComponent.new(expiration: @presenter.otp_expiration) %> remaining
+<% end %>
+
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
 <p>


### PR DESCRIPTION
## 🎫 Ticket

[LG-8200](https://cm-jira.usa.gov/browse/LG-8200)

## 🛠 Summary of changes

Displays a visible countdown to a user authenticating with OTP MFA when there is 2 minutes and 30 seconds or less before the OTP is expired.

## 📜 Testing Plan

Optional prerequisite: Add `otp_valid_for: 3` to `config/application.yml` to shorten expiration for local testing.

1. Sign in to an account which has phone MFA configured
   a. If not prompted for MFA, click "Forget browsers" on account dashboard, then sign out, and repeat Step 1
2. At MFA prompt, wait until 2 minutes and 30 seconds prior to OTP expiration (default 10 minutes, unless overridden)
3. Observe that visible countdown timer alert is shown and counts down to expiration

## 👀 Screenshots

![Screen Shot 2022-12-01 at 3 18 29 PM](https://user-images.githubusercontent.com/1779930/205151894-4a074122-31bf-41a2-b182-f639b2c48210.png)