### PR TITLE
Remove some indirection in IdentityLinker

### DIFF
--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -61,11 +61,7 @@ class IdentityLinker
   end
 
   def identity
-    @identity ||= find_or_create_identity_with_costing
-  end
-
-  def find_or_create_identity_with_costing
-    user.identities.create_or_find_by(service_provider: service_provider.issuer)
+    @identity ||= user.identities.create_or_find_by(service_provider: service_provider.issuer)
   end
 
   def identity_attributes

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -77,6 +77,6 @@ class IdentityLinker
   end
 
   def combined_verified_attributes(verified_attributes)
-    [*identity.verified_attributes, verified_attributes.to_a.map(&:to_s)].uniq.sort
+    [*identity.verified_attributes, *verified_attributes.to_a.map(&:to_s)].uniq.sort
   end
 end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -7,19 +7,41 @@ class IdentityLinker
     @ial = nil
   end
 
-  def link_identity(**extra_attrs)
+  def link_identity(
+    code_challenge: nil,
+    ial: nil,
+    nonce: nil,
+    rails_session_id: nil,
+    scope: nil,
+    verified_attributes: nil,
+    last_consented_at: nil,
+    clear_deleted_at: nil
+  )
     return unless user && service_provider.present?
-    process_ial(extra_attrs)
-    attributes = merged_attributes(extra_attrs)
-    identity.update!(attributes)
+    process_ial(ial)
+
+    identity.update!(
+      identity_attributes.merge(
+        code_challenge: code_challenge,
+        ial: ial,
+        nonce: nonce,
+        rails_session_id: rails_session_id,
+        scope: scope,
+        verified_attributes: combined_verified_attributes(verified_attributes),
+      ).tap do |hash|
+        hash[:last_consented_at] = last_consented_at if last_consented_at
+        hash[:deleted_at] = nil if clear_deleted_at
+      end,
+    )
+
     AgencyIdentityLinker.new(identity).link_identity
     identity
   end
 
   private
 
-  def process_ial(extra_attrs)
-    @ial = extra_attrs[:ial]
+  def process_ial(ial)
+    @ial = ial
     now = Time.zone.now
     process_ial_at(now)
     process_verified_at(now)
@@ -46,10 +68,6 @@ class IdentityLinker
     user.identities.create_or_find_by(service_provider: service_provider.issuer)
   end
 
-  def merged_attributes(extra_attrs)
-    identity_attributes.merge(optional_attributes(**extra_attrs))
-  end
-
   def identity_attributes
     {
       last_authenticated_at: Time.zone.now,
@@ -58,31 +76,7 @@ class IdentityLinker
     }
   end
 
-  def optional_attributes(
-    code_challenge: nil,
-    ial: nil,
-    nonce: nil,
-    rails_session_id: nil,
-    scope: nil,
-    verified_attributes: nil,
-    last_consented_at: nil,
-    clear_deleted_at: nil
-  )
-    {
-      code_challenge: code_challenge,
-      ial: ial,
-      nonce: nonce,
-      rails_session_id: rails_session_id,
-      scope: scope,
-      verified_attributes: merge_attributes(verified_attributes),
-    }.tap do |hash|
-      hash[:last_consented_at] = last_consented_at if last_consented_at
-      hash[:deleted_at] = nil if clear_deleted_at
-    end
-  end
-
-  def merge_attributes(verified_attributes)
-    verified_attributes = verified_attributes.to_a.map(&:to_s)
-    (identity.verified_attributes.to_a + verified_attributes).uniq.sort
+  def combined_verified_attributes(verified_attributes)
+    [*identity.verified_attributes, verified_attributes.to_a.map(&:to_s)].uniq.sort
   end
 end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -54,7 +54,7 @@ describe IdentityLinker do
       let(:now) { Time.zone.now }
       let(:six_months_ago) { 6.months.ago }
 
-      it 'does override a previous last_consented_at by default' do
+      it 'does not override a previous last_consented_at by default' do
         IdentityLinker.new(user, service_provider).
           link_identity(last_consented_at: six_months_ago)
         last_identity = user.reload.last_identity
@@ -74,7 +74,7 @@ describe IdentityLinker do
       end
     end
 
-    context 'clear_deleted_at' do
+    context ':clear_deleted_at' do
       let(:yesterday) { 1.day.ago }
 
       before do
@@ -88,7 +88,7 @@ describe IdentityLinker do
           link_identity(clear_deleted_at: clear_deleted_at)
       end
 
-      context 'clear_deleted_at is nil' do
+      context ':clear_deleted_at is nil' do
         let(:clear_deleted_at) { nil }
 
         it 'nulls out deleted_at' do
@@ -98,7 +98,7 @@ describe IdentityLinker do
         end
       end
 
-      context 'clear_deleted_at is true' do
+      context ':clear_deleted_at is true' do
         let(:clear_deleted_at) { true }
 
         it 'nulls out deleted_at' do


### PR DESCRIPTION
~Small proposed change related to #7418  (or possibly the next PR after, where we'll to conditionally create `ServiceProviderIdentity` rows but with fewer attributes)~

Originally started as a patch to #7418, but that may not land, and I think these changes would be good regardless