### PR TITLE
Remove doc auth step specs that test that the user is on the given step

### DIFF
--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -9,12 +9,6 @@ feature 'doc auth verify step', :js do
     complete_doc_auth_steps_before_address_step
   end
 
-  it 'is on the correct page' do
-    expect(page).to have_current_path(idv_address_path)
-    expect(page).to have_content(t('doc_auth.headings.address'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-  end
-
   it 'allows the user to enter in a new address' do
     fill_out_address_form_ok
 

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -10,6 +10,8 @@ feature 'doc auth verify step', :js do
   end
 
   it 'allows the user to enter in a new address' do
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+
     fill_out_address_form_ok
 
     click_button t('forms.buttons.submit.update')

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -88,24 +88,6 @@ feature 'doc auth document capture step', :js do
     expect(page).to have_content(I18n.t('doc_auth.errors.general.network_error'))
   end
 
-  it 'is on the correct page and shows the document upload options' do
-    expect(current_path).to eq(idv_doc_auth_document_capture_step)
-    expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
-    expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-
-    # Document capture tips
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-
-    # No selfie option, evidenced by "Submit" button instead of "Continue"
-    expect(page).to have_content(t('forms.buttons.submit.default'))
-  end
-
   it 'proceeds to the next page with valid info' do
     attach_and_submit_images
 

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -89,6 +89,8 @@ feature 'doc auth document capture step', :js do
   end
 
   it 'proceeds to the next page with valid info' do
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
     attach_and_submit_images
 
     expect(page).to have_current_path(next_step)

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -15,12 +15,6 @@ feature 'doc auth link sent step' do
     complete_doc_auth_steps_before_link_sent_step
   end
 
-  it 'is on the correct page' do
-    expect(page).to have_current_path(idv_doc_auth_link_sent_step)
-    expect(page).to have_content(t('doc_auth.headings.text_message'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-  end
-
   it 'proceeds to the next page with valid info' do
     mock_doc_captured(user.id)
     click_idv_continue

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -16,6 +16,8 @@ feature 'doc auth link sent step' do
   end
 
   it 'proceeds to the next page with valid info' do
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
     mock_doc_captured(user.id)
     click_idv_continue
 

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -18,12 +18,6 @@ feature 'doc auth send link step' do
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
-  it 'is on the correct page' do
-    expect(page).to have_current_path(idv_doc_auth_send_link_step)
-    expect(page).to have_content(t('doc_auth.headings.take_picture'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-  end
-
   it 'proceeds to the next page with valid info' do
     expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:track_event).with(
       :idv_phone_upload_link_sent,

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -29,6 +29,8 @@ feature 'doc auth send link step' do
       with(hash_including(to: '+1 415-555-0199')).
       and_call_original
 
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
     fill_in :doc_auth_phone, with: '415-555-0199'
     click_idv_continue
 

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -5,84 +5,38 @@ feature 'doc auth ssn step', :js do
   include DocAuthHelper
   include DocCaptureHelper
 
-  context 'desktop' do
-    before do
-      allow(IdentityConfig.store).
-        to receive(:no_sp_device_profiling_enabled).and_return(true)
+  before do
+    allow(IdentityConfig.store).
+      to receive(:no_sp_device_profiling_enabled).and_return(true)
 
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_ssn_step
-    end
-
-    it 'is on the correct page' do
-      expect(page).to have_current_path(idv_doc_auth_ssn_step)
-      expect(page).to have_content(t('doc_auth.headings.ssn'))
-      expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    end
-
-    it 'proceeds to the next page with valid info' do
-      fill_out_ssn_form_ok
-
-      match = page.body.match(/session_id=(?<session_id>[^"&]+)/)
-      session_id = match && match[:session_id]
-      expect(session_id).to be_present
-
-      select 'Review', from: 'mock_profiling_result'
-
-      expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('false')
-      click_idv_continue
-
-      expect(page).to have_current_path(idv_doc_auth_verify_step)
-
-      profiling_result = Proofing::Mock::DeviceProfilingBackend.new.profiling_result(session_id)
-      expect(profiling_result).to eq('review')
-    end
-
-    it 'does not proceed to the next page with invalid info' do
-      fill_out_ssn_form_fail
-      click_idv_continue
-
-      expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('true')
-
-      expect(page).to have_current_path(idv_doc_auth_ssn_step)
-    end
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_ssn_step
   end
 
-  context 'doc capture hand-off' do
-    before do
-      allow(Identity::Hostdata::EC2).to receive(:load).
-        and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
-      in_doc_capture_session { complete_doc_capture_steps_before_capture_complete_step }
-      click_on t('forms.buttons.continue')
-    end
+  it 'proceeds to the next page with valid info' do
+    fill_out_ssn_form_ok
 
-    it 'is on the correct page' do
-      expect(page).to have_current_path(idv_doc_auth_ssn_step)
-      expect(page).to have_content(t('doc_auth.headings.ssn'))
-      expect(page).to have_content(t('doc_auth.headings.capture_complete'))
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    end
+    match = page.body.match(/session_id=(?<session_id>[^"&]+)/)
+    session_id = match && match[:session_id]
+    expect(session_id).to be_present
 
-    it 'proceeds to the next page with valid info' do
-      fill_out_ssn_form_ok
-      click_idv_continue
+    select 'Review', from: 'mock_profiling_result'
 
-      expect(page).to have_current_path(idv_doc_auth_verify_step)
-    end
+    expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('false')
+    click_idv_continue
 
-    it 'proceeds to the next page if the user enters extra digits' do
-      fill_in t('idv.form.ssn_label_html'), with: '666-66-12345'
-      click_idv_continue
+    expect(page).to have_current_path(idv_doc_auth_verify_step)
 
-      expect(page).to have_current_path(idv_doc_auth_verify_step)
-    end
+    profiling_result = Proofing::Mock::DeviceProfilingBackend.new.profiling_result(session_id)
+    expect(profiling_result).to eq('review')
+  end
 
-    it 'does not proceed to the next page with invalid info' do
-      fill_out_ssn_form_fail
-      click_idv_continue
+  it 'does not proceed to the next page with invalid info' do
+    fill_out_ssn_form_fail
+    click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_ssn_step)
-    end
+    expect(page.find_field(t('idv.form.ssn_label_html'))['aria-invalid']).to eq('true')
+
+    expect(page).to have_current_path(idv_doc_auth_ssn_step)
   end
 end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -14,6 +14,8 @@ feature 'doc auth ssn step', :js do
   end
 
   it 'proceeds to the next page with valid info' do
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+
     fill_out_ssn_form_ok
 
     match = page.body.match(/session_id=(?<session_id>[^"&]+)/)

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -26,6 +26,8 @@ feature 'doc auth upload step' do
         :idv_document_upload_method_selected,
       ).with({ upload_method: 'desktop' })
 
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
       click_on t('doc_auth.info.upload_computer_link')
 
       expect(page).to have_current_path(idv_doc_auth_email_sent_step)
@@ -59,6 +61,8 @@ feature 'doc auth upload step' do
       expect(fake_attempts_tracker).to receive(
         :idv_document_upload_method_selected,
       ).with({ upload_method: 'desktop' })
+
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
       click_on t('doc_auth.info.upload_computer_link')
 

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -21,11 +21,6 @@ feature 'doc auth upload step' do
       allow(BrowserCache).to receive(:parse).and_return(mobile_device)
     end
 
-    it 'is on the correct page' do
-      expect(page).to have_current_path(idv_doc_auth_upload_step)
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-    end
-
     it 'proceeds to send link via email page when user chooses to upload from computer' do
       expect(fake_attempts_tracker).to receive(
         :idv_document_upload_method_selected,
@@ -58,11 +53,6 @@ feature 'doc auth upload step' do
   context 'on a desktop device' do
     before do
       allow_any_instance_of(Idv::Steps::UploadStep).to receive(:mobile_device?).and_return(false)
-    end
-
-    it 'is on the correct page' do
-      expect(page).to have_current_path(idv_doc_auth_upload_step)
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
     end
 
     it 'proceeds to document capture when user chooses to upload from computer' do

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -25,26 +25,6 @@ feature 'doc capture document capture step', js: true do
     allow_any_instance_of(Browser).to receive(:mobile?).and_return(true)
   end
 
-  it 'is on the correct page and shows the document upload options' do
-    complete_doc_capture_steps_before_first_step(user)
-
-    expect(current_path).to eq(idv_capture_doc_document_capture_step)
-    expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
-    expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-
-    # Document capture tips
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
-    expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
-
-    # No selfie option, evidenced by "Submit" button instead of "Continue"
-    expect(page).to have_content(t('forms.buttons.submit.default'))
-  end
-
   it 'proceeds to the next page with valid info' do
     complete_doc_capture_steps_before_first_step(user)
 

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -28,6 +28,8 @@ feature 'doc capture document capture step', js: true do
   it 'proceeds to the next page with valid info' do
     complete_doc_capture_steps_before_first_step(user)
 
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
     attach_and_submit_images
 
     expect(page).to have_current_path(next_step)


### PR DESCRIPTION
These tests were helpful for development to make sure steps were reachable, but now they are covered by the rest of the tests that cover the actual functionality for these steps.

[skip changelog]
