### PR TITLE
Fixing IRS weekly report bug

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -131,7 +131,7 @@ else
       # Weekly IRS report returning system demand
       irs_weekly_summary_report: {
         class: 'Reports::IrsWeeklySummaryReport',
-        cron: cron_1w,
+        cron: cron_1h,
         args: -> { [Time.zone.now] },
       },
       # Backfill service_provider_identities last_consented_at

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -130,7 +130,7 @@ else
       },
       # Weekly IRS report returning system demand
       irs_weekly_summary_report: {
-        class: 'IrsWeeklySummaryReport',
+        class: 'Reports::IrsWeeklySummaryReport',
         cron: cron_1w,
         args: -> { [Time.zone.now] },
       },

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -131,7 +131,7 @@ else
       # Weekly IRS report returning system demand
       irs_weekly_summary_report: {
         class: 'Reports::IrsWeeklySummaryReport',
-        cron: cron_1h,
+        cron: cron_1w,
         args: -> { [Time.zone.now] },
       },
       # Backfill service_provider_identities last_consented_at


### PR DESCRIPTION



No relevant ticket, this is a quickfix for an error found in NewRelic for the IRS Weekly Report job


## 🛠 Summary of changes

I added the Reports:: prefix in the job configurations which was causing the error. I also changed the job to run every hour temporarily so we can test that this job is working as expected rather than having to wait a whole additional week. @zachmargolis  if there is a better way to do this feel free to comment. 




## 👀 Screenshots

Error showing in NewRelic that we needed to fix
<img width="1315" alt="Screen Shot 2022-12-05 at 3 16 22 PM" src="https://user-images.githubusercontent.com/6639858/205734472-072ef3c1-23a6-4d94-9db6-2f4cd5f5bc93.png">

