### PR TITLE
LG-8297: Capitalize "Example" hint labels

### DIFF
--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -52,7 +52,7 @@ en:
     email:
       buttons:
         delete: Delete email address
-    example: 'example:'
+    example: 'Example:'
     messages:
       remember_device: Remember this browser
     password: Password

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -57,7 +57,7 @@ es:
     email:
       buttons:
         delete: Eliminar correo electrónico
-    example: 'ejemplo:'
+    example: 'Ejemplo:'
     messages:
       remember_device: Recuerde este navegador
     password: Contraseña

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -58,7 +58,7 @@ fr:
     email:
       buttons:
         delete: Supprimer l’email
-    example: 'exemple:'
+    example: 'Exemple:'
     messages:
       remember_device: Enregistrer ce navigateur
     password: Mot de passe


### PR DESCRIPTION
## 🎫 Ticket

[LG-8297](https://cm-jira.usa.gov/browse/LG-8297)

## 🛠 Summary of changes

Reverts the change in #7330 which revised the hint label from capitalized "Example" to lower-case "example".

Related discussion:

- https://github.com/18F/identity-idp/pull/7330#discussion_r1024338937
- https://gsa-tts.slack.com/archives/CNCGEHG1G/p1670252355858679

## 📜 Testing Plan

- Check that every hint label in the application uses "Example" upper-case (e.g. IdV phone step)

## 👀 Screenshots

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/205738334-4dab4d29-9c7b-451d-90d5-b07c48e7ac74.png)|![image](https://user-images.githubusercontent.com/1779930/205738292-a814cffa-d483-4856-a38b-b127fa39b4a9.png)
