### PR TITLE
Split total-monthly-auths-report into separate queries by month

### DIFF
--- a/app/jobs/reports/month_helper.rb
+++ b/app/jobs/reports/month_helper.rb
@@ -29,7 +29,7 @@ module Reports
         current = month_end + 1.day
       end
 
-      results << (date_range.end.beginning_of_month..date_range.end)
+      results << (date_range.end.beginning_of_month..date_range.end) if current < date_range.end
 
       results
     end

--- a/app/jobs/reports/total_monthly_auths_report.rb
+++ b/app/jobs/reports/total_monthly_auths_report.rb
@@ -12,9 +12,7 @@ module Reports
     )
 
     def perform(_date)
-      auth_counts = transaction_with_timeout do
-        Db::MonthlySpAuthCount::TotalMonthlyAuthCounts.call
-      end
+      auth_counts = Db::MonthlySpAuthCount::TotalMonthlyAuthCounts.call
       save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')
     end
   end

--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
@@ -33,8 +33,8 @@ module Db
           WHERE
                 sp_return_logs.returned_at IS NOT NULL
             AND sp_return_logs.billable = true
-            AND %{month_start} <= sp_return_logs.requested_at
-            AND sp_return_logs.requested_at <= %{month_end}
+            AND %{month_start}::date <= sp_return_logs.requested_at::date
+            AND sp_return_logs.requested_at::date <= %{month_end}::date
           GROUP BY
               sp_return_logs.issuer
             , sp_return_logs.ial

--- a/spec/jobs/reports/month_helper_spec.rb
+++ b/spec/jobs/reports/month_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reports::MonthHelper do
     it 'does not double-count when first and last are the same month' do
       expect(months(Date.new(2022, 1, 1)..Date.new(2022, 1, 31))).to eq(
         [
-          Date.new(2022, 1, 1)..Date.new(2022, 1, 31)
+          Date.new(2022, 1, 1)..Date.new(2022, 1, 31),
         ],
       )
     end

--- a/spec/jobs/reports/month_helper_spec.rb
+++ b/spec/jobs/reports/month_helper_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe Reports::MonthHelper do
         ],
       )
     end
+
+    it 'does not double-count when first and last are the same month' do
+      expect(months(Date.new(2022, 1, 1)..Date.new(2022, 1, 31))).to eq(
+        [
+          Date.new(2022, 1, 1)..Date.new(2022, 1, 31)
+        ],
+      )
+    end
   end
 end

--- a/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
+++ b/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
@@ -52,7 +52,7 @@ describe Db::MonthlySpAuthCount::TotalMonthlyAuthCounts do
       ial: 1,
       year_month: '201901',
       total: 10,
-      app_id: app_id
+      app_id: app_id,
     }.stringify_keys
 
     second_month_result = {
@@ -60,7 +60,7 @@ describe Db::MonthlySpAuthCount::TotalMonthlyAuthCounts do
       ial: 1,
       year_month: '201902',
       total: 2,
-      app_id: app_id
+      app_id: app_id,
     }.stringify_keys
 
     result = subject.call

--- a/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
+++ b/spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb
@@ -5,10 +5,9 @@ describe Db::MonthlySpAuthCount::TotalMonthlyAuthCounts do
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }
-  let(:year_month) { '201901' }
 
   it 'is empty' do
-    expect(subject.call.ntuples).to eq(0)
+    expect(subject.call.length).to eq(0)
   end
 
   it 'returns the total auth counts' do
@@ -35,9 +34,39 @@ describe Db::MonthlySpAuthCount::TotalMonthlyAuthCounts do
         billable: true,
       )
     end
-    result = { issuer: issuer, ial: 1, year_month: year_month, total: 10, app_id: app_id }.to_json
 
-    expect(subject.call.ntuples).to eq(1)
-    expect(subject.call[0].to_json).to eq(result)
+    2.times do
+      create(
+        :sp_return_log,
+        issuer: issuer,
+        ial: 1,
+        user_id: 3,
+        requested_at: Date.new(2019, 2, 10),
+        returned_at: Date.new(2019, 2, 10),
+        billable: true,
+      )
+    end
+
+    first_month_result = {
+      issuer: issuer,
+      ial: 1,
+      year_month: '201901',
+      total: 10,
+      app_id: app_id
+    }.stringify_keys
+
+    second_month_result = {
+      issuer: issuer,
+      ial: 1,
+      year_month: '201902',
+      total: 2,
+      app_id: app_id
+    }.stringify_keys
+
+    result = subject.call
+
+    expect(result.length).to eq(2)
+    expect(result.first).to eq(first_month_result)
+    expect(result.last).to eq(second_month_result)
   end
 end


### PR DESCRIPTION
**Why**: One giant table scan query get cancelled, smaller queries are faster and easier to re-run

- [Bug report in Slack](https://gsa-tts.slack.com/archives/C5E7EJWF7/p1670270166278619)
- [Example error in NewRelic](https://onenr.io/0LwG4L3yzR6)

Query plan before:

```
[{"QUERY PLAN"=>"Finalize GroupAggregate  (cost=44304143.18..63653937.95 rows=64085978 width=133)"},
 {"QUERY PLAN"=>"  Group Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"  ->  Gather Merge  (cost=44304143.18..61250713.77 rows=128171956 width=133)"},
 {"QUERY PLAN"=>"        Workers Planned: 2"},
 {"QUERY PLAN"=>"        ->  Partial GroupAggregate  (cost=44303143.15..46455489.76 rows=64085978 width=133)"},
 {"QUERY PLAN"=>"              Group Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"              ->  Sort  (cost=44303143.15..44528355.13 rows=90084792 width=110)"},
 {"QUERY PLAN"=>"                    Sort Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"                    ->  Hash Join  (cost=75.80..16697524.50 rows=90084792 width=110)"},
 {"QUERY PLAN"=>"                          Hash Cond: ((sp_return_logs.issuer)::text = (service_providers.issuer)::text)"},
 {"QUERY PLAN"=>"                          ->  Parallel Seq Scan on sp_return_logs  (cost=0.00..16233200.98 rows=90084792 width=77)"},
 {"QUERY PLAN"=>"                                Filter: ((returned_at IS NOT NULL) AND billable)"},
 {"QUERY PLAN"=>"                          ->  Hash  (cost=70.91..70.91 rows=391 width=63)"},
 {"QUERY PLAN"=>"                                ->  Seq Scan on service_providers  (cost=0.00..70.91 rows=391 width=63)"}]
```

Query plan after (for one month) [updated to use index]

```
[{"QUERY PLAN"=>"Finalize GroupAggregate  (cost=4397847.35..4538887.24 rows=1072994 width=133)"},
 {"QUERY PLAN"=>"  Group Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"  ->  Gather Merge  (cost=4397847.35..4514214.22 rows=900848 width=133)"},
 {"QUERY PLAN"=>"        Workers Planned: 2"},
 {"QUERY PLAN"=>"        ->  Partial GroupAggregate  (cost=4396847.32..4409233.98 rows=450424 width=133)"},
 {"QUERY PLAN"=>"              Group Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"              ->  Sort  (cost=4396847.32..4397973.38 rows=450424 width=110)"},
 {"QUERY PLAN"=>"                    Sort Key: sp_return_logs.issuer, sp_return_logs.ial, (to_char(sp_return_logs.requested_at, 'YYYYMM'::text))"},
 {"QUERY PLAN"=>"                    ->  Hash Join  (cost=76.50..4328377.43 rows=450424 width=110)"},
 {"QUERY PLAN"=>"                          Hash Cond: ((sp_return_logs.issuer)::text = (service_providers.issuer)::text)"},
 {"QUERY PLAN"=>
   "                          ->  Parallel Index Scan using index_sp_return_logs_on_requested_at_date_issuer on sp_return_logs  (cost=0.70..4325980.39 rows=450424 width=77)"},
 {"QUERY PLAN"=>
   "                                Index Cond: (((requested_at)::date >= '2019-09-01'::date) AND ((requested_at)::date <= '2019-09-30'::date))"},
 {"QUERY PLAN"=>"                                Filter: billable"},
 {"QUERY PLAN"=>"                          ->  Hash  (cost=70.91..70.91 rows=391 width=63)"},
 {"QUERY PLAN"=>"                                ->  Seq Scan on service_providers  (cost=0.00..70.91 rows=391 width=63)"}]
```
