### PR TITLE
Add spec to ensure cron job classes are valid

### DIFF
--- a/spec/config/initializers/job_configurations_spec.rb
+++ b/spec/config/initializers/job_configurations_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'GoodJob.cron' do
+  it 'has valid cron jobs' do
+    expect(Rails.application.config.good_job.cron).to be_present
+    aggregate_failures do
+      Rails.application.config.good_job.cron.each do |key, config|
+        expect(config[:class].constantize.new).to be_kind_of(ApplicationJob)
+
+        expect(Fugit.parse(config[:cron])).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Follow up to #7431 to have an automatic check that validates class names. This is kind of the minimal case, we could add other checks as well.

Catches the current misconfiguration:

```
Run options: include {:locations=>{"./spec/config/initializers/job_configurations_spec.rb"=>[10]}}

Randomized with seed 11193

job_configurations
  has valid cron jobs (FAILED - 1)

Failures:

  1) job_configurations has valid cron jobs
     Failure/Error: config[:class].constantize.new

     NameError:
       uninitialized constant IrsWeeklySummaryReport
```

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
