### PR TITLE
Convert resend parameter in OTP Delivery Selection to a boolean

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -19,7 +19,10 @@ module Users
       result = otp_delivery_selection_form.submit(delivery_params)
       analytics.otp_delivery_selection(**result.to_h)
       if result.success?
-        handle_valid_otp_params(user_select_delivery_preference, user_selected_default_number)
+        handle_valid_otp_params(
+          result, user_select_delivery_preference,
+          user_selected_default_number
+        )
         update_otp_delivery_preference_if_needed
       else
         handle_invalid_otp_delivery_preference(result)
@@ -81,9 +84,9 @@ module Users
       )
 
       if result.success?
-        handle_valid_otp_params(delivery_preference)
+        handle_valid_otp_params(result, delivery_preference)
       elsif phone_capabilities.supports_sms?
-        handle_valid_otp_params('sms')
+        handle_valid_otp_params(result, 'sms')
         flash[:error] = result.errors[:phone].first
       else
         handle_invalid_otp_delivery_preference(result)
@@ -171,7 +174,7 @@ module Users
       super || otp_form.dig(:otp_delivery_selection_form, :reauthn)
     end
 
-    def handle_valid_otp_params(method, default = nil)
+    def handle_valid_otp_params(otp_delivery_selection_result, method, default = nil)
       otp_rate_limiter.reset_count_and_otp_last_sent_at if decorated_user.no_longer_locked_out?
 
       if exceeded_otp_send_limit?
@@ -190,11 +193,17 @@ module Users
       return handle_too_many_confirmation_sends if exceeded_phone_confirmation_limit?
 
       @telephony_result = send_user_otp(method)
-      handle_telephony_result(method: method, default: default)
+      handle_telephony_result(
+        method: method, default: default,
+        otp_delivery_selection_result: otp_delivery_selection_result
+      )
     end
 
-    def handle_telephony_result(method:, default:)
-      track_events(otp_delivery_preference: method)
+    def handle_telephony_result(method:, default:, otp_delivery_selection_result:)
+      track_events(
+        otp_delivery_preference: method,
+        otp_delivery_selection_result: otp_delivery_selection_result,
+      )
       if @telephony_result.success?
         redirect_to login_two_factor_url(
           otp_delivery_preference: method,
@@ -211,14 +220,14 @@ module Users
       end
     end
 
-    def track_events(otp_delivery_preference:)
+    def track_events(otp_delivery_preference:, otp_delivery_selection_result:)
       analytics.telephony_otp_sent(
         area_code: parsed_phone.area_code,
         country_code: parsed_phone.country,
         phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
         context: context,
         otp_delivery_preference: otp_delivery_preference,
-        resend: params.dig(:otp_delivery_selection_form, :resend),
+        resend: otp_delivery_selection_result.extra[:resend],
         adapter: Telephony.config.adapter,
         telephony_response: @telephony_result.to_h,
         success: @telephony_result.success?,

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -20,8 +20,9 @@ module Users
       analytics.otp_delivery_selection(**result.to_h)
       if result.success?
         handle_valid_otp_params(
-          result, user_select_delivery_preference,
-          user_selected_default_number
+          result,
+          user_select_delivery_preference,
+          user_selected_default_number,
         )
         update_otp_delivery_preference_if_needed
       else

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -195,8 +195,9 @@ module Users
 
       @telephony_result = send_user_otp(method)
       handle_telephony_result(
-        method: method, default: default,
-        otp_delivery_selection_result: otp_delivery_selection_result
+        method: method,
+        default: default,
+        otp_delivery_selection_result: otp_delivery_selection_result,
       )
     end
 

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -15,7 +15,7 @@ class OtpDeliverySelectionForm
 
   def submit(params)
     self.otp_delivery_preference = params[:otp_delivery_preference]
-    self.resend = params[:resend] == true || params[:resend] == 'true'
+    self.resend = params[:resend] == 'true'
 
     @success = valid?
 

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -15,7 +15,7 @@ class OtpDeliverySelectionForm
 
   def submit(params)
     self.otp_delivery_preference = params[:otp_delivery_preference]
-    self.resend = params[:resend]
+    self.resend = params[:resend] == true || params[:resend] == 'true'
 
     @success = valid?
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -319,7 +319,7 @@ describe Users::TwoFactorAuthenticationController do
           success: true,
           errors: {},
           **otp_preference_sms,
-          resend: 'true',
+          resend: true,
           context: 'authentication',
           country_code: 'US',
           area_code: '202',
@@ -332,7 +332,7 @@ describe Users::TwoFactorAuthenticationController do
         expect(@analytics).to receive(:track_event).
           ordered.
           with('Telephony: OTP sent', hash_including(
-            resend: 'true', success: true, **otp_preference_sms,
+            resend: true, success: true, **otp_preference_sms,
             adapter: :test
           ))
 
@@ -473,7 +473,7 @@ describe Users::TwoFactorAuthenticationController do
           success: true,
           errors: {},
           otp_delivery_preference: 'voice',
-          resend: nil,
+          resend: false,
           context: 'authentication',
           country_code: 'US',
           area_code: '202',

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -48,7 +48,7 @@ describe OtpDeliverySelectionForm do
 
         extra = {
           otp_delivery_preference: 'foo',
-          resend: nil,
+          resend: false,
           country_code: nil,
           area_code: nil,
           context: 'authentication',

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -31,7 +31,7 @@ describe OtpDeliverySelectionForm do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(subject.submit(otp_delivery_preference: 'sms', resend: true).to_h).to eq(
+        expect(subject.submit(otp_delivery_preference: 'sms', resend: 'true').to_h).to eq(
           success: true,
           errors: {},
           **extra,


### PR DESCRIPTION
## 🛠 Summary of changes

This change helps with some metrics and observability work in https://github.com/18F/identity-devops/pull/5501 where we want to monitor the number of resends. This parameter is currently logged as a string, but we have it [documented](https://github.com/18F/identity-idp/blob/75f4be473a97af0cf4c044eb5359bfda5a078230/app/services/analytics_events.rb#L2081) as a boolean.

I don't love the form validation and flow of passing the data, so I am super open to feedback!

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
