### PR TITLE
Include configurable SES configuration_set when sending email

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -288,6 +288,7 @@ session_encryptor_v2_enabled: true
 session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
+ses_configuration_set_name: ''
 set_remember_device_session_expiration: false
 sp_handoff_bounce_max_seconds: 2
 show_user_attribute_deprecation_warnings: false

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -9,7 +9,11 @@ module Aws
       def initialize(*); end
 
       def deliver(mail)
-        response = send_raw_email(mail)
+        response = ses_client.send_raw_email(
+          raw_message: { data: mail.to_s },
+          configuration_set_name: IdentityConfig.store.ses_configuration_set_name,
+        )
+
         mail.header[:ses_message_id] = response.message_id
         response
       end
@@ -17,17 +21,6 @@ module Aws
       alias deliver! deliver
 
       private
-
-      def send_raw_email(mail)
-        if IdentityConfig.store.ses_configuration_set_name.present?
-          ses_client.send_raw_email(
-            raw_message: { data: mail.to_s },
-            configuration_set_name: IdentityConfig.store.ses_configuration_set_name,
-          )
-        else
-          ses_client.send_raw_email(raw_message: { data: mail.to_s })
-        end
-      end
 
       def ses_client
         @ses_client ||= Aws::SES::Client.new(ses_client_options)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -383,6 +383,7 @@ class IdentityConfig
     config.add(:session_timeout_in_minutes, type: :integer)
     config.add(:session_timeout_warning_seconds, type: :integer)
     config.add(:session_total_duration_timeout_in_minutes, type: :integer)
+    config.add(:ses_configuration_set_name, type: :string)
     config.add(:set_remember_device_session_expiration, type: :boolean)
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:show_account_recovery_recovery_options, type: :boolean)

--- a/spec/lib/aws/ses_spec.rb
+++ b/spec/lib/aws/ses_spec.rb
@@ -30,6 +30,7 @@ describe Aws::SES::Base do
         raw_message: {
           data: raw_mail_data,
         },
+        configuration_set_name: '',
       )
     end
 

--- a/spec/lib/aws/ses_spec.rb
+++ b/spec/lib/aws/ses_spec.rb
@@ -33,6 +33,20 @@ describe Aws::SES::Base do
       )
     end
 
+    it 'includes the configuration_set_name when it is configured' do
+      allow(IdentityConfig.store).to receive(:ses_configuration_set_name).and_return('abc')
+      raw_mail_data = mail.to_s
+
+      subject.deliver!(mail)
+
+      expect(ses_client).to have_received(:send_raw_email).with(
+        raw_message: {
+          data: raw_mail_data,
+        },
+        configuration_set_name: 'abc',
+      )
+    end
+
     it 'sets the message id on the mail argument' do
       subject.deliver!(mail)
       expect(mail.header['ses-message-id'].value).to eq('123abc')


### PR DESCRIPTION
## 🛠 Summary of changes

This change allows configuring an optional SES [configuration set](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SES/Client.html#send_raw_email-instance_method) for when we send email. This is to help with some of the email observability work in https://github.com/18F/identity-devops/issues/2137.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
