### PR TITLE
LG-8076 Display inline errors for an empty address field

### DIFF
--- a/app/javascript/packages/document-capture/components/address-search.tsx
+++ b/app/javascript/packages/document-capture/components/address-search.tsx
@@ -13,7 +13,7 @@ interface Location {
 
 interface AddressSearchProps {
   onAddressFound?: (location: Location) => void;
-  registerField: () => {};
+  registerField: (field: string) => {};
 }
 
 export const ADDRESS_SEARCH_URL = '/api/addresses';

--- a/app/javascript/packages/document-capture/components/address-search.tsx
+++ b/app/javascript/packages/document-capture/components/address-search.tsx
@@ -1,6 +1,7 @@
 import { TextInput, Button } from '@18f/identity-components';
 import { request } from '@18f/identity-request';
-import { useState, useCallback, ChangeEvent } from 'react';
+import { useState, useCallback, ChangeEvent, useRef } from 'react';
+import ValidatedField from '@18f/identity-validated-field/validated-field';
 
 interface Location {
   street_address: string;
@@ -12,37 +13,56 @@ interface Location {
 
 interface AddressSearchProps {
   onAddressFound?: (location: Location) => void;
+  registerField: () => {};
 }
 
 export const ADDRESS_SEARCH_URL = '/api/addresses';
 
-function AddressSearch({ onAddressFound = () => {} }: AddressSearchProps) {
+function AddressSearch({ onAddressFound = () => {}, registerField }: AddressSearchProps) {
+  const validatedFieldRef = useRef();
   const [unvalidatedAddressInput, setUnvalidatedAddressInput] = useState('');
   const [addressQuery, setAddressQuery] = useState({} as Location);
-  const handleAddressSearch = useCallback(async () => {
-    const addressCandidates = await request(ADDRESS_SEARCH_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      json: { address: unvalidatedAddressInput },
-    });
 
-    const bestMatchedAddress = addressCandidates[0];
-    setAddressQuery(bestMatchedAddress);
-    onAddressFound(bestMatchedAddress);
-  }, [unvalidatedAddressInput]);
+  const handleAddressSearch = useCallback(
+    async (event) => {
+      event.preventDefault();
+      validatedFieldRef.current.reportValidity();
+      if (unvalidatedAddressInput === '') {
+        return null;
+      }
+      const addressCandidates = await request(ADDRESS_SEARCH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        json: { address: unvalidatedAddressInput },
+      });
+
+      const bestMatchedAddress = addressCandidates[0];
+      setAddressQuery(bestMatchedAddress);
+      onAddressFound(bestMatchedAddress);
+    },
+    [unvalidatedAddressInput],
+  );
 
   return (
     <>
-      <TextInput
-        value={unvalidatedAddressInput}
-        onChange={(event: ChangeEvent) => {
-          const target = event.target as HTMLInputElement;
-
-          setUnvalidatedAddressInput(target.value);
-        }}
-        label="Search for an address"
-      />
-      <Button onClick={handleAddressSearch}>Search</Button>
+      <ValidatedField
+        ref={validatedFieldRef}
+        messages={{ valueMissing: 'Include a city, state, and ZIP code' }}
+      >
+        <TextInput
+          required
+          ref={registerField('address')}
+          value={unvalidatedAddressInput}
+          onChange={(event: ChangeEvent) => {
+            const target = event.target as HTMLInputElement;
+            setUnvalidatedAddressInput(target.value);
+          }}
+          label="Search for an address"
+        />
+      </ValidatedField>
+      <Button type="submit" onClick={handleAddressSearch}>
+        Search
+      </Button>
       <>{addressQuery.address}</>
     </>
   );

--- a/app/javascript/packages/document-capture/components/in-person-location-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-step.tsx
@@ -80,7 +80,7 @@ const prepToSend = (location: object) => {
   return sendObject;
 };
 
-function InPersonLocationStep({ onChange, toPreviousStep }) {
+function InPersonLocationStep({ onChange, toPreviousStep, registerField }) {
   const { t } = useI18n();
   const [locationData, setLocationData] = useState([] as FormattedLocation[]);
   const [foundAddress, setFoundAddress] = useState({} as LocationQuery);
@@ -201,7 +201,9 @@ function InPersonLocationStep({ onChange, toPreviousStep }) {
   return (
     <>
       <PageHeading>{t('in_person_proofing.headings.location')}</PageHeading>
-      {arcgisSearchEnabled && <AddressSearch onAddressFound={handleFoundAddress} />}
+      {arcgisSearchEnabled && (
+        <AddressSearch onAddressFound={handleFoundAddress} registerField={registerField} />
+      )}
       <p>{t('in_person_proofing.body.location.location_step_about')}</p>
       {locationsContent}
       <BackButton onClick={toPreviousStep} />

--- a/app/javascript/packages/validated-field/validated-field.tsx
+++ b/app/javascript/packages/validated-field/validated-field.tsx
@@ -29,6 +29,11 @@ interface ValidatedFieldProps {
   validate?: ValidatedFieldValidator;
 
   /**
+   * Optional key and value that indicates the error and resulting error message
+   */
+  messages?: Object;
+
+  /**
    * Optional input to use in place of the default rendered input. The input will be cloned and
    * extended with behaviors for validation.
    */

--- a/app/javascript/packages/validated-field/validated-field.tsx
+++ b/app/javascript/packages/validated-field/validated-field.tsx
@@ -1,4 +1,12 @@
-import { useRef, useEffect, Children, cloneElement, createElement } from 'react';
+import {
+  useRef,
+  useEffect,
+  Children,
+  cloneElement,
+  createElement,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
 import type {
   MutableRefObject,
   ReactNode,
@@ -56,13 +64,20 @@ export function getErrorMessages(inputType?: string) {
   return messages;
 }
 
-function ValidatedField({
-  validate = () => {},
-  children,
-  ...inputProps
-}: ValidatedFieldProps & InputHTMLAttributes<HTMLInputElement>) {
+function ValidatedField(
+  {
+    validate = () => {},
+    messages,
+    children,
+    ...inputProps
+  }: ValidatedFieldProps & InputHTMLAttributes<HTMLInputElement>,
+  forwardedRef,
+) {
   const fieldRef = useRef<ValidatedFieldElement>();
   const instanceId = useInstanceId();
+  useImperativeHandle(forwardedRef, () => ({
+    reportValidity: () => fieldRef.current.input.reportValidity(),
+  }));
   useEffect(() => {
     if (fieldRef.current && fieldRef.current.input) {
       const { input } = fieldRef.current;
@@ -98,7 +113,7 @@ function ValidatedField({
   return (
     <lg-validated-field ref={fieldRef}>
       <script type="application/json" className="validated-field__error-strings">
-        {JSON.stringify(getErrorMessages(inputProps.type))}
+        {JSON.stringify({ ...getErrorMessages(messages, inputProps.type), ...messages })}
       </script>
       <div className="validated-field__input-wrapper">
         {cloneElement(input, {
@@ -112,4 +127,4 @@ function ValidatedField({
   );
 }
 
-export default ValidatedField;
+export default forwardRef(ValidatedField);


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[Inline error implementation in search box (validate presence of address search input)](https://cm-jira.usa.gov/browse/LG-8076)



## 🛠 Summary of changes

This is a new and improved version of PR #7438.  Thanks for saving the day, git cherry-pick! 🍒 

- 'Include a city, state, and ZIP code' error displays if the user attempts to search on blank input
- The address search no longer blows up if the user attempts to search on blank input
- If the user hits "enter" after typing in an address, the page now behaves similarly to when users click "search"



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Click search for a blank text input.  Observe the inline error.
- [ ] Hit enter for a blank text input.    Observe the inline error.
- [ ] Confirm you can still search for actual addresses



## 👀 Screenshots

Here's a demo of the inline errors.

https://user-images.githubusercontent.com/80347702/206032048-1cefb6e9-25ee-4459-a6bb-a74389b36fbc.mov



</details>

