### PR TITLE
Generate language picker URL by string manipulation of current URL

### DIFF
--- a/app/components/language_picker_component.html.erb
+++ b/app/components/language_picker_component.html.erb
@@ -19,13 +19,9 @@
     class="usa-accordion__content language-picker__list"
     hidden
   >
-    <% I18n.available_locales.each do |locale| %>
+    <% locale_urls.each do |locale, url| %>
       <li>
-        <%= link_to(
-              t("i18n.locale.#{locale}"),
-              url_generator.call(sanitized_request_params.merge(locale: locale)),
-              lang: locale,
-            ) %>
+        <%= content_tag(:a, href: url, lang: locale) { t("i18n.locale.#{locale}") } %>
       </li>
     <% end %>
   </ul>

--- a/app/components/language_picker_component.rb
+++ b/app/components/language_picker_component.rb
@@ -1,8 +1,7 @@
 class LanguagePickerComponent < BaseComponent
-  attr_reader :url_generator, :tag_options
+  attr_reader :tag_options
 
-  def initialize(url_generator: method(:url_for), **tag_options)
-    @url_generator = url_generator
+  def initialize(**tag_options)
     @tag_options = tag_options
   end
 
@@ -10,7 +9,17 @@ class LanguagePickerComponent < BaseComponent
     ['language-picker', 'usa-accordion', *tag_options[:class]]
   end
 
-  def sanitized_request_params
-    request.query_parameters.slice(:request_id)
+  def locale_urls
+    I18n.available_locales.index_with { |locale| "/#{locale}#{fullpath_without_locale}" }
+  end
+
+  private
+
+  def fullpath_without_locale
+    @fullpath_without_locale ||= begin
+      path = request.fullpath
+      path = path.slice(params[:locale].size + 1..) if params[:locale].present?
+      path
+    end
   end
 end

--- a/spec/components/language_picker_component_spec.rb
+++ b/spec/components/language_picker_component_spec.rb
@@ -42,17 +42,4 @@ RSpec.describe LanguagePickerComponent, type: :component do
       expect(rendered).to have_css('.language-picker.usa-accordion.example[data-foo="bar"]')
     end
   end
-
-  context 'with custom url generator' do
-    it 'uses url generator to generate locale links' do
-      rendered = render_inline LanguagePickerComponent.new(
-        url_generator: ->(params) { "/#{params[:locale]}" },
-      )
-
-      actual_hrefs = rendered.css('a').pluck(:href)
-      expected_hrefs = I18n.available_locales.map { |locale| "/#{locale}" }
-
-      expect(actual_hrefs).to match_array(expected_hrefs)
-    end
-  end
 end

--- a/spec/components/previews/language_picker_component_preview.rb
+++ b/spec/components/previews/language_picker_component_preview.rb
@@ -2,22 +2,18 @@ class LanguagePickerComponentPreview < BaseComponentPreview
   # @!group Preview
   # @display body_class tablet:bg-primary-darker padding-top-10
   def default
-    render(LanguagePickerComponent.new(url_generator: url_generator, class: css_class))
+    render(LanguagePickerComponent.new(class: css_class))
   end
   # @!endgroup
 
   # @display body_class tablet:bg-primary-darker padding-top-10
   def workbench
-    render(LanguagePickerComponent.new(url_generator: url_generator, class: css_class))
+    render(LanguagePickerComponent.new(class: css_class))
   end
 
   private
 
   def css_class
     'margin-top-10 tablet:display-inline-block'
-  end
-
-  def url_generator
-    proc { '' }
   end
 end

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -166,7 +166,7 @@ feature 'IAL1 Single Sign On' do
         find_link(t('i18n.locale.es'), visible: false).click
       end
 
-      expect(current_url).to match(%r{http://www.example.com/es\?request_id=.+})
+      expect(current_url).to match(%r{http://www.example.com/es/\?request_id=.+})
     end
   end
 

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -93,7 +93,7 @@ feature 'Internationalization' do
       %w[en es fr].each do |locale|
         links = page.all(:link, t("i18n.locale.#{locale}"), visible: :all)
         expect(links).to be_present
-        links.each { |link| expect(link[:href]).to eq("/#{locale}?host=test.com") }
+        expect(links).to all satisfy { |link| link[:href] == "/#{locale}?host=test.com" }
       end
     end
   end

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -87,7 +87,7 @@ feature 'Internationalization' do
   end
 
   context 'visit homepage with host parameter' do
-    it 'maintain query parameters as query parameters' do
+    it 'maintains query parameters as query parameters' do
       visit '/fr?host=test.com'
 
       %w[en es fr].each do |locale|

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -87,14 +87,13 @@ feature 'Internationalization' do
   end
 
   context 'visit homepage with host parameter' do
-    it 'does not include the host parameter in the language link URLs' do
+    it 'maintain query parameters as query parameters' do
       visit '/fr?host=test.com'
 
       %w[en es fr].each do |locale|
-        expect(page).to_not have_link(
-          t("i18n.locale.#{locale}"),
-          href: "http://test.com/#{locale}",
-        )
+        links = page.all(:link, t("i18n.locale.#{locale}"), visible: :all)
+        expect(links).to be_present
+        links.each { |link| expect(link[:href]).to eq("/#{locale}?host=test.com") }
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Indirectly resolves [LG-8322](https://cm-jira.usa.gov/browse/LG-8322)

## 🛠 Summary of changes

Changes the logic of how the language picker generates URL to avoid using URL helpers, so that...

- We can safely retain query parameters to avoid buggy behaviors such as [LG-8322](https://cm-jira.usa.gov/browse/LG-8322) where a query parameter may be dropped when changing locales
- Performance of slow UI elements in critical paths is improved
- We can simplify the supported options of `LanguagePickerComponent` to drop `url_generator`, which was only necessary for compatibility of Lookbook component previews with route lookups

## 📜 Testing Plan

- Check that language picker works as expected when navigating from the default locale to another locale, and vice-versa
- Specs pass
- Verify there is no regression of [LG-236](https://cm-jira.usa.gov/browse/LG-236)
- Check that [component preview](http://localhost:3000/components/inspect/language_picker/preview) renders without errors