### PR TITLE
Restructure analytics error_details as hash

### DIFF
--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -56,9 +56,7 @@ class FormResponse
   end
 
   def flatten_details(details)
-    details.transform_values do |errors|
-      errors.map { |error| [error.error, true] }.to_h
-    end
+    details.transform_values { |errors| errors.pluck(:error).index_with(true) }
   end
 
   attr_reader :success

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -56,7 +56,9 @@ class FormResponse
   end
 
   def flatten_details(details)
-    details.transform_values { |errors| errors.pluck(:error) }
+    details.transform_values do |errors|
+      errors.map { |error| [error.error, true] }.to_h
+    end
   end
 
   attr_reader :success

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -56,7 +56,9 @@ class FormResponse
   end
 
   def flatten_details(details)
-    details.transform_values { |errors| errors.pluck(:error).index_with(true) }
+    details.transform_values do |errors|
+      errors.map { |error| error[:type] || error[:error] }.index_with(true)
+    end
   end
 
   attr_reader :success

--- a/app/services/password_reset_token_validator.rb
+++ b/app/services/password_reset_token_validator.rb
@@ -17,6 +17,7 @@ class PasswordResetTokenValidator
   attr_accessor :user
 
   def valid_token
-    errors.add(:user, 'token_expired', type: :user) unless user.reset_password_period_valid?
+    return if user.reset_password_period_valid?
+    errors.add(:user, 'token_expired', type: :token_expired)
   end
 end

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -30,7 +30,7 @@ describe AccountReset::CancelController do
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)] },
         error_details: {
-          token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
+          token: { cancel_token_invalid: true },
         },
         user_id: 'anonymous-uuid',
       }
@@ -46,7 +46,7 @@ describe AccountReset::CancelController do
       analytics_hash = {
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_missing', app_name: APP_NAME)] },
-        error_details: { token: [:blank] },
+        error_details: { token: { blank: true } },
         user_id: 'anonymous-uuid',
       }
 
@@ -91,7 +91,7 @@ describe AccountReset::CancelController do
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)] },
         error_details: {
-          token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
+          token: { cancel_token_invalid: true },
         },
       }
       expect(@analytics).to receive(:track_event).

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -61,7 +61,7 @@ describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: invalid_token_error,
-        error_details: invalid_token_error,
+        error_details: { token: { granted_token_invalid: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
@@ -92,7 +92,7 @@ describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_missing', app_name: APP_NAME)] },
-        error_details: { token: [:blank] },
+        error_details: { token: { blank: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
@@ -118,9 +118,7 @@ describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
-        error_details: {
-          token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)],
-        },
+        error_details: { token: { granted_token_invalid: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 2,
@@ -146,7 +144,7 @@ describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: invalid_token_error,
-        error_details: invalid_token_error,
+        error_details: { token: { granted_token_invalid: true } },
       }
       expect(@analytics).to receive(:track_event).
         with('Account Reset: granted token validation', properties)
@@ -167,9 +165,7 @@ describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
-        error_details: {
-          token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)],
-        },
+        error_details: { token: { granted_token_invalid: true } },
       }
       expect(@analytics).to receive(:track_event).
         with('Account Reset: granted token validation', properties)

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -416,7 +416,7 @@ describe Idv::DocAuthController do
           errors: include(
             pii: [I18n.t('doc_auth.errors.general.no_liveness')],
           ),
-          error_details: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
+          error_details: { pii: { generic_error: true } },
           attention_with_barcode: false,
           success: false,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,
@@ -431,7 +431,7 @@ describe Idv::DocAuthController do
           errors: include(
             pii: [I18n.t('doc_auth.errors.general.no_liveness')],
           ),
-          error_details: { pii: [I18n.t('doc_auth.errors.general.no_liveness')] },
+          error_details: { pii: { generic_error: true } },
           attention_with_barcode: false,
           success: false,
           remaining_attempts: IdentityConfig.store.doc_auth_max_attempts,

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe Idv::GpoVerifyController do
 
   describe '#create' do
     let(:otp_code_error_message) { { otp: [t('errors.messages.confirmation_code_incorrect')] } }
-    let(:otp_code_incorrect) { { otp: [:confirmation_code_incorrect] } }
     let(:success_properties) { { success: true, failure_reason: nil } }
 
     subject(:action) do
@@ -175,11 +174,11 @@ RSpec.describe Idv::GpoVerifyController do
           errors: otp_code_error_message,
           pending_in_person_enrollment: false,
           enqueued_at: nil,
-          error_details: otp_code_incorrect,
+          error_details: { otp: { confirmation_code_incorrect: true } },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
-          with(success: false, failure_reason: otp_code_incorrect)
+          with(success: false, failure_reason: { otp: { confirmation_code_incorrect: true } })
 
         action
 
@@ -205,7 +204,7 @@ RSpec.describe Idv::GpoVerifyController do
           errors: otp_code_error_message,
           pending_in_person_enrollment: false,
           enqueued_at: nil,
-          error_details: otp_code_incorrect,
+          error_details: { otp: { confirmation_code_incorrect: true } },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         ).exactly(max_attempts).times
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -59,7 +59,7 @@ describe Idv::ImageUploadsController do
             front: ['Please fill in this field.'],
           },
           error_details: {
-            front: [:blank],
+            front: { blank: true },
           },
           user_id: user.uuid,
           attempts: 1,
@@ -120,7 +120,7 @@ describe Idv::ImageUploadsController do
             front: [I18n.t('doc_auth.errors.not_a_file')],
           },
           error_details: {
-            front: [I18n.t('doc_auth.errors.not_a_file')],
+            front: { not_a_file: true },
           },
           user_id: user.uuid,
           attempts: 1,
@@ -220,7 +220,7 @@ describe Idv::ImageUploadsController do
             limit: [I18n.t('errors.doc_auth.throttled_heading')],
           },
           error_details: {
-            limit: [I18n.t('errors.doc_auth.throttled_heading')],
+            limit: { throttled: true },
           },
           user_id: user.uuid,
           attempts: IdentityConfig.store.doc_auth_max_attempts,
@@ -446,7 +446,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.alerts.full_name_check')],
               },
               error_details: {
-                pii: [I18n.t('doc_auth.errors.alerts.full_name_check')],
+                pii: { name_error: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,
@@ -524,7 +524,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.general.no_liveness')],
               },
               error_details: {
-                pii: [I18n.t('doc_auth.errors.general.no_liveness')],
+                pii: { generic_error: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,
@@ -602,7 +602,7 @@ describe Idv::ImageUploadsController do
                 pii: [I18n.t('doc_auth.errors.alerts.birth_date_checks')],
               },
               error_details: {
-                pii: [I18n.t('doc_auth.errors.alerts.birth_date_checks')],
+                pii: { dob_error: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -195,7 +195,7 @@ describe Idv::OtpDeliveryMethodController do
         result = {
           success: false,
           errors: { otp_delivery_preference: ['is not included in the list'] },
-          error_details: { otp_delivery_preference: [:inclusion] },
+          error_details: { otp_delivery_preference: { inclusion: true } },
           otp_delivery_preference: '🎷',
         }
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -136,8 +136,8 @@ describe Idv::PhoneController do
     context 'when form is invalid' do
       let(:improbable_phone_error) do
         {
-          phone: [:improbable_phone],
-          otp_delivery_preference: [:inclusion],
+          phone: { improbable_phone: true },
+          otp_delivery_preference: { inclusion: true },
         }
       end
       let(:improbable_phone_message) { t('errors.messages.improbable_phone') }

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -744,7 +744,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { authn_context: [t('errors.messages.unauthorized_authn_context')] },
-          error_details: { authn_context: [:unauthorized_authn_context] },
+          error_details: { authn_context: { unauthorized_authn_context: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
           authn_context_comparison: 'exact',
@@ -917,7 +917,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
-          error_details: { service_provider: [:unauthorized_service_provider] },
+          error_details: { service_provider: { unauthorized_service_provider: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
           authn_context_comparison: 'exact',
@@ -959,8 +959,8 @@ describe SamlIdpController do
             authn_context: [t('errors.messages.unauthorized_authn_context')],
           },
           error_details: {
-            authn_context: [:unauthorized_authn_context],
-            service_provider: [:unauthorized_service_provider],
+            authn_context: { unauthorized_authn_context: true },
+            service_provider: { unauthorized_service_provider: true },
           },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
@@ -1350,7 +1350,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
-          error_details: { nameid_format: [:unauthorized_nameid_format] },
+          error_details: { nameid_format: { unauthorized_nameid_format: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: request_authn_contexts,
           authn_context_comparison: 'exact',

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe SignUp::EmailConfirmationsController do
   describe '#create' do
-    let(:token_not_found_error) { { confirmation_token: [:not_found] } }
-    let(:token_expired_error) { { confirmation_token: [:expired] } }
+    let(:token_not_found_error) { { confirmation_token: { not_found: true } } }
+    let(:token_expired_error) { { confirmation_token: { expired: true } } }
     let(:analytics_token_error_hash) do
       {
         success: false,

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -69,7 +69,7 @@ describe SignUp::PasswordsController do
     end
 
     it 'tracks an invalid password event' do
-      password_short_error = { password: [:too_short] }
+      password_short_error = { password: { too_short: true } }
       token = 'new token'
       user = create(:user, :unconfirmed, confirmation_token: token)
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -125,7 +125,7 @@ describe SignUp::RegistrationsController, devise: true do
         success: false,
         throttled: false,
         errors: { email: [t('valid_email.validations.email.invalid')] },
-        error_details: { email: [:invalid] },
+        error_details: { email: { invalid: true } },
         email_already_exists: false,
         user_id: 'anonymous-uuid',
         domain_name: 'invalid',

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -96,7 +96,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
         properties = {
           success: false,
-          error_details: { code: [:incorrect_length, :incorrect] },
+          error_details: { code: { incorrect_length: true, incorrect: true } },
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
@@ -153,7 +153,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
         properties = {
           success: false,
-          error_details: { code: [:incorrect_length, :incorrect] },
+          error_details: { code: { incorrect_length: true, incorrect: true } },
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
@@ -469,7 +469,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             properties = {
               success: false,
               errors: nil,
-              error_details: { code: [:incorrect_length, :incorrect] },
+              error_details: { code: { incorrect_length: true, incorrect: true } },
               confirmation_for_add_phone: true,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -38,7 +38,7 @@ describe Users::EditPhoneController do
         attributes = {
           success: false,
           errors: hash_including(:delivery_preference),
-          error_details: { delivery_preference: [:inclusion] },
+          error_details: { delivery_preference: { inclusion: true } },
           delivery_preference: 'noise',
           make_default_number: true,
           phone_configuration_id: phone_configuration.id,

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -79,7 +79,7 @@ describe Users::PasswordsController do
 
     context 'form returns failure' do
       it 'renders edit' do
-        password_short_error = { password: [:too_short] }
+        password_short_error = { password: { too_short: true } }
         stub_sign_in
 
         stub_analytics

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -48,10 +48,10 @@ describe Users::PhoneSetupController do
           ],
         },
         error_details: {
-          phone: [
-            :improbable_phone,
-            t('two_factor_authentication.otp_delivery_preference.voice_unsupported', location: ''),
-          ],
+          phone: {
+            improbable_phone: true,
+            voice_unsupported: true,
+          },
         },
         otp_delivery_preference: 'sms',
         area_code: nil,

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -219,7 +219,7 @@ describe Users::TotpSetupController, devise: true do
 
           result = {
             success: false,
-            error_details: { name: [:blank] },
+            error_details: { name: { blank: true } },
             errors: { name: [t('errors.messages.blank')] },
             totp_secret_present: true,
             multi_factor_auth_method: 'totp',

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -162,7 +162,7 @@ describe Users::VerifyPersonalKeyController do
         expect(@analytics).to receive(:track_event).with(
           'Personal key reactivation: Personal key form submitted',
           errors: { personal_key: ['Please fill in this field.', error_text] },
-          error_details: { personal_key: [:blank, :personal_key_incorrect] },
+          error_details: { personal_key: { blank: true, personal_key_incorrect: true } },
           success: false,
           pii_like_keypaths: pii_like_keypaths_errors,
         ).once

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -305,10 +305,7 @@ describe Users::WebauthnSetupController do
                 'errors.webauthn_platform_setup.attestation_error',
                 link: MarketingSite.contact_url,
               )] },
-              error_details: { name: [I18n.t(
-                'errors.webauthn_platform_setup.attestation_error',
-                link: MarketingSite.contact_url,
-              )] },
+              error_details: { name: { attestation_error: true } },
               in_multi_mfa_selection_flow: true,
               mfa_method_counts: {},
               multi_factor_auth_method: 'webauthn_platform',

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           expect(result.to_h).to eq(
             success: false,
             errors: { response_type: ['is not included in the list'] },
-            error_details: { response_type: [:inclusion] },
+            error_details: { response_type: { inclusion: true } },
             client_id: client_id,
             redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
                           "Response+type+is+not+included+in+the+list&state=#{state}",

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:blank],
+            code: { blank: true },
           },
           multi_factor_auth_method: 'otp_code',
         )
@@ -64,7 +64,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:user_otp_missing],
+            code: { user_otp_missing: true },
           },
           multi_factor_auth_method: 'otp_code',
         )
@@ -85,7 +85,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:incorrect_length, :incorrect],
+            code: { incorrect_length: true, incorrect: true },
           },
           multi_factor_auth_method: 'otp_code',
         )
@@ -106,7 +106,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:pattern_mismatch, :incorrect],
+            code: { pattern_mismatch: true, incorrect: true },
           },
           multi_factor_auth_method: 'otp_code',
         )
@@ -130,7 +130,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:user_otp_expired],
+            code: { user_otp_expired: true },
           },
           multi_factor_auth_method: 'otp_code',
         )

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -80,7 +80,7 @@ describe TotpSetupForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          error_details: { name: [:blank] },
+          error_details: { name: { blank: true } },
           errors: { name: [t('errors.messages.blank')] },
         )
         expect(user.auth_app_configurations.any?).to eq false
@@ -95,7 +95,7 @@ describe TotpSetupForm do
 
         expect(form2.submit.to_h).to include(
           success: false,
-          error_details: { name: [t('errors.piv_cac_setup.unique_name')] },
+          error_details: { name: { unique_name: true } },
           errors: { name: [t('errors.piv_cac_setup.unique_name')] },
         )
       end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -109,10 +109,7 @@ describe WebauthnSetupForm do
             'errors.webauthn_setup.attestation_error',
             link: MarketingSite.contact_url,
           )] },
-          error_details: { name: [I18n.t(
-            'errors.webauthn_setup.attestation_error',
-            link: MarketingSite.contact_url,
-          )] },
+          error_details: { name: { attestation_error: true } },
           **extra_attributes,
         )
       end

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -155,6 +155,25 @@ describe FormResponse do
         expect(response.to_h).to eq response_hash
       end
 
+      context 'without error type' do
+        it 'falls back to message as key for details' do
+          errors = ActiveModel::Errors.new(build_stubbed(:user))
+          errors.add(:email_language, :blank)
+          response = FormResponse.new(success: false, errors: errors)
+          response_hash = {
+            success: false,
+            errors: {
+              email_language: [t('errors.messages.blank')],
+            },
+            error_details: {
+              email_language: { blank: true },
+            },
+          }
+
+          expect(response.to_h).to eq response_hash
+        end
+      end
+
       it 'omits details if errors are empty' do
         errors = ActiveModel::Errors.new(build_stubbed(:user))
         response = FormResponse.new(success: true, errors: errors)

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -78,7 +78,9 @@ describe FormResponse do
       response2 = FormResponse.new(success: false, errors: errors2)
 
       combined_response = response1.merge(response2)
-      expect(combined_response.to_h[:error_details]).to eq(email_language: [:blank, :invalid])
+      expect(combined_response.to_h[:error_details]).to eq(
+        email_language: { blank: true, invalid: true },
+      )
     end
 
     it 'merges hash and ActiveModel::Errors' do
@@ -93,7 +95,7 @@ describe FormResponse do
       expect(combined_response.errors).to eq(
         email_language: ['Language cannot be blank', 'Language is not valid'],
       )
-      expect(combined_response.to_h[:error_details]).to eq(email_language: [:blank])
+      expect(combined_response.to_h[:error_details]).to eq(email_language: { blank: true })
     end
 
     it 'returns true if one is false and one is true' do
@@ -146,7 +148,7 @@ describe FormResponse do
             email_language: ['Language cannot be blank'],
           },
           error_details: {
-            email_language: [:blank],
+            email_language: { blank: true },
           },
         }
 
@@ -190,7 +192,7 @@ describe FormResponse do
           expect(response.to_h).to eq(
             success: false,
             error_details: {
-              email_language: [:blank],
+              email_language: { blank: true },
             },
           )
         end

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -159,12 +159,12 @@ RSpec.describe IrsAttemptsApi::Tracker do
 
   describe '#parse_failure_reason' do
     let(:mock_error_message) { 'failure_reason_from_error' }
-    let(:mock_error_details) { [{ mock_error: 'failure_reason_from_error_details' }] }
+    let(:mock_error_details) { { mock_error: { failure_reason_from_error_details: true } } }
 
     it 'parses failure_reason from error_details' do
       test_failure_reason = subject.parse_failure_reason(
         { errors: mock_error_message,
-          error_details: mock_error_details },
+          error_details: { mock_error: { failure_reason_from_error_details: true } } },
       )
 
       expect(test_failure_reason).to eq(mock_error_details)


### PR DESCRIPTION
## 🛠 Summary of changes

Revises the structure of `FormResponse` `error_details` handling to serialize a `FormResponse` error details as a hash, in order to improve querying supports for analytics logging, since CloudWatch does not support querying within an array field value.

Related Slack thread: https://gsa-tts.slack.com/archives/C0NGESUN5/p1670357411732859

```
# Before (Does not work!)
filter 'user_otp_expired' in properties.event_properties.error_details.code

# After
filter properties.event_properties.error_details.code.user_otp_expired = true
# Or: filter ispresent(properties.event_properties.error_details.code.user_otp_expired)
```

Based on a search of dashboard Terraform code, we do not currently reference this field, so a breaking change should be alright. 

_Draft while I work through any lingering specs which need to be updated to new format._

## 📜 Testing Plan

- Specs pass