### PR TITLE
Microoptimize new_window_link_to implementation

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,35 +1,15 @@
 module LinkHelper
   EXTERNAL_LINK_CLASS = 'usa-link--external'.freeze
 
-  def new_window_link_to(name = nil, options = nil, html_options = nil, &block)
-    if block
-      html_options = options
-      options = name
-      name = block
-    end
-    options ||= {}
-    html_options ||= {}
+  def new_window_link_to(name = nil, options = nil, html_options = {}, &block)
+    html_options, options, name = options, name, yield(block) if block
 
-    url = url_for(options)
-    html_options[:href] ||= url
-    html_options[:class] ||= html_options[:class].to_s
     html_options[:target] = '_blank'
+    html_options[:class] = [*html_options[:class], EXTERNAL_LINK_CLASS]
 
-    classes = html_options[:class].split(' ').append(EXTERNAL_LINK_CLASS)
+    name = safe_join([name, content_tag('span', t('links.new_window'), class: 'usa-sr-only')], ' ')
 
-    html_options[:class] = classes.uniq.join(' ')
-
-    if block
-      link_to(url, html_options) do
-        yield(block)
-        concat content_tag('span', t('links.new_window'), class: 'usa-sr-only')
-      end
-    else
-      link_to(url, html_options) do
-        content_tag('span', name) +
-          content_tag('span', t('links.new_window'), class: 'usa-sr-only')
-      end
-    end
+    link_to(name, options, html_options)
   end
 
   def button_or_link_to(name = nil, options = nil, html_options = nil, &block)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -2,7 +2,7 @@ module LinkHelper
   EXTERNAL_LINK_CLASS = 'usa-link--external'.freeze
 
   def new_window_link_to(name = nil, options = nil, html_options = {}, &block)
-    html_options, options, name = options, name, yield(block) if block
+    html_options, options, name = options, name, capture(&block) if block
 
     html_options[:target] = '_blank'
     html_options[:class] = [*html_options[:class], EXTERNAL_LINK_CLASS]

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -16,9 +16,7 @@
                                                       'aria-label': t('shared.footer_lite.gsa') } do %>
             <%= image_tag asset_url('sp-logos/square-gsa.svg'),
                           size: 20, class: 'float-left margin-right-1', alt: '' %>
-            <span>
-              <%= t('shared.footer_lite.gsa') %>
-            </span>
+            <%= t('shared.footer_lite.gsa') %>
           <% end %>
         </div>
       </div>

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -3,6 +3,53 @@ require 'rails_helper'
 RSpec.describe LinkHelper do
   include LinkHelper
 
+  describe '#new_window_link_to' do
+    let(:html_options) { {} }
+
+    subject(:link) { new_window_link_to('Link', '', **html_options) }
+
+    it 'opens in a new tab' do
+      expect(link).to have_css('[target=_blank]')
+    end
+
+    it 'includes an accessibility hint about opening in a new tab' do
+      expect(link).to have_content("Link #{t('links.new_window')}")
+      expect(link).to have_css('.usa-sr-only', text: t('links.new_window'))
+    end
+
+    it 'adds design system external link class' do
+      expect(link).to have_css('.usa-link--external')
+    end
+
+    context 'with custom classes' do
+      let(:html_options) { { class: 'example' } }
+
+      it 'adds design system external link class' do
+        expect(link).to have_css('.example.usa-link--external')
+      end
+
+      context 'with custom classes as array' do
+        let(:html_options) { { class: ['example'] } }
+
+        it 'adds design system external link class' do
+          expect(link).to have_css('.example.usa-link--external')
+        end
+      end
+    end
+
+    context 'content given as block' do
+      let(:html_options) { { data: { foo: 'bar' } } }
+      subject(:link) { new_window_link_to('/url', **html_options) { 'Link' } }
+
+      it 'renders a link with the expected attributes' do
+        expect(link).to have_css(
+          '.usa-link--external[href="/url"][target=_blank][data-foo="bar"]',
+          text: 'Link',
+        )
+      end
+    end
+  end
+
   describe '#button_or_link_to' do
     let(:method) { nil }
     let(:text) { 'Example' }

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe LinkHelper do
       it 'renders a link with the expected attributes' do
         expect(link).to have_css(
           '.usa-link--external[href="/url"][target=_blank][data-foo="bar"]',
-          text: 'Link',
+          text: "Link #{t('links.new_window')}",
         )
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Simplifies and optimizes the implementation of `new_window_link_to`, which had been showing as consuming some time on flamegraphs for profiling critical flows.

Side benefits:

- Simpler
- More compatible with `link_to` signature (e.g. support for `class` as an array of strings)
- Adds a space between text and accessible label ("Link(Opens in new window)" ➡️  "Link (Opens in new window)")
- Includes missing test coverage

Benchmark:

```rb
require 'benchmark/ips'

ENV['RAILS_ENV'] = 'production'
require File.expand_path('./config/environment.rb', __dir__)

class BenchmarksController < ActionController::Base
  include LinkHelper
end
controller_view = BenchmarksController.new.view_context

Benchmark.ips do |x|
  x.time = 10
  x.warmup = 2

  x.report('before') { controller_view.old_new_window_link_to('Link', '') }
  x.report('after') { controller_view.new_window_link_to('Link', '') }

  x.compare!
end
```

Result:

tl;dr: ~15% improvement

```
$ ruby benchmark.rb
Warming up --------------------------------------
              before     1.503k i/100ms
               after     1.696k i/100ms
Calculating -------------------------------------
              before     15.084k (± 7.9%) i/s -    150.300k in  10.077435s
               after     17.419k (± 2.6%) i/s -    174.688k in  10.035779s

Comparison:
               after:    17419.4 i/s
              before:    15084.2 i/s - 1.15x  (± 0.00) slower
```

## 📜 Testing Plan

- Spot check "Opens in new tab" links (e.g. footer links)
- `rspec spec/helpers/link_helper_spec.rb`