### PR TITLE
Simplify and optimize footer markup

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -14,10 +14,54 @@ html {
 }
 
 .footer {
-  flex: none; // 2
-  position: relative;
+  @include u-bg('primary-lighter');
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  font-size: 0.75rem;
+
+  @include at-media('tablet') {
+    @include u-bg('primary-darker');
+    flex-direction: row;
+  }
+
+  a {
+    text-decoration: none;
+
+    @include at-media('tablet') {
+      &,
+      &:visited {
+        color: color($theme-link-reverse-color);
+      }
+
+      &:hover {
+        color: color($theme-link-reverse-hover-color);
+      }
+    }
+  }
 }
 
 .site-wrap {
   flex: 1 0 auto; // 2
+}
+
+.footer__language-picker {
+  @include at-media-max('tablet') {
+    @include u-border-bottom(1px, 'primary-light');
+
+    &.language-picker {
+      width: 100%;
+    }
+  }
+
+  @include at-media('tablet') {
+    @include u-margin-x(2);
+    @include u-margin-y(0.5);
+  }
+}
+
+.footer__links {
+  @include u-padding-y(1);
+  display: flex;
 }

--- a/app/assets/stylesheets/components/_language-picker.scss
+++ b/app/assets/stylesheets/components/_language-picker.scss
@@ -16,6 +16,11 @@
   }
 }
 
+.language-picker__label,
+.language-picker__list {
+  font-size: 1rem;
+}
+
 .language-picker__label {
   align-items: center;
   display: flex;

--- a/app/assets/stylesheets/components/_language-picker.scss
+++ b/app/assets/stylesheets/components/_language-picker.scss
@@ -1,6 +1,7 @@
 .language-picker {
   position: relative;
   width: auto;
+  font-size: 1rem;
 
   .usa-accordion__content {
     @include u-bg('primary');
@@ -14,11 +15,6 @@
     z-index: 10;
     bottom: 100%;
   }
-}
-
-.language-picker__label,
-.language-picker__list {
-  font-size: 1rem;
 }
 
 .language-picker__label {

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,58 +1,24 @@
-<footer class='footer bg-primary-lighter tablet:bg-primary-darker'>
-  <%= render LanguagePickerComponent.new(class: 'tablet:display-none border-bottom border-primary-light') %>
-  <div class="padding-y-1 padding-x-2 tablet:padding-x-0 tablet:padding-y-0">
-    <div class="display-flex flex-align-center flex-justify-center">
-      <div class="display-flex flex-auto">
-        <div class="display-flex tablet:display-none">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'text-no-underline h6 margin-right-2 tablet:display-none',
-                                                      'aria-label': t('shared.footer_lite.gsa') } do %>
-            <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'),
-                          size: 20, alt: '' %>
-          <% end %>
-        </div>
-
-        <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
-          <%= new_window_link_to 'https://gsa.gov', { class: 'text-no-underline h6 margin-right-2',
-                                                      'aria-label': t('shared.footer_lite.gsa') } do %>
-            <%= image_tag asset_url('sp-logos/square-gsa.svg'),
-                          size: 20, class: 'float-left margin-right-1', alt: '' %>
-            <%= t('shared.footer_lite.gsa') %>
-          <% end %>
-        </div>
-      </div>
-      <div class="display-flex flex-align-center flex-justify-center">
-        <%= render LanguagePickerComponent.new(class: 'display-none tablet:display-block margin-x-2 margin-y-05') %>
-
-        <div class="display-flex tablet:display-none">
-          <%= new_window_link_to(
-                t('links.help'), MarketingSite.help_url,
-                class: 'h6 text-primary text-no-underline margin-right-2'
-              ) %>
-          <%= new_window_link_to(
-                t('links.contact'), MarketingSite.contact_url,
-                class: 'h6 text-primary text-no-underline margin-right-2'
-              ) %>
-          <%= new_window_link_to(
-                t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                class: 'h6 text-primary text-no-underline'
-              ) %>
-        </div>
-
-        <div class="display-none tablet:display-flex usa-dark-background bg-primary-darker">
-          <%= new_window_link_to(
-                t('links.help'), MarketingSite.help_url,
-                class: 'h6 text-no-underline margin-right-2'
-              ) %>
-          <%= new_window_link_to(
-                t('links.contact'), MarketingSite.contact_url,
-                class: 'h6 text-no-underline margin-right-2'
-              ) %>
-          <%= new_window_link_to(
-                t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                class: 'h6 text-no-underline'
-              ) %>
-        </div>
-      </div>
-    </div>
+<footer class="footer">
+  <%= new_window_link_to('https://gsa.gov', class: 'display-none tablet:display-inline') do %>
+    <%= image_tag(
+          asset_url('sp-logos/square-gsa.svg'),
+          size: 20,
+          alt: '',
+          class: 'float-left margin-right-1',
+        ) %>
+    <%= t('shared.footer_lite.gsa') %>
+  <% end %>
+  <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
+  <div class="footer__links">
+    <%= new_window_link_to(
+          'https://gsa.gov',
+          aria: { label: t('shared.footer_lite.gsa') },
+          class: 'tablet:display-none margin-right-2',
+        ) do %>
+      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '' %>
+    <% end %>
+    <%= new_window_link_to(t('links.help'), MarketingSite.help_url, class: 'margin-right-2') %>
+    <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url, class: 'margin-right-2') %>
+    <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url) %>
   </div>
 </footer>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,21 +1,12 @@
 <footer class="footer">
   <%= new_window_link_to('https://gsa.gov', class: 'display-none tablet:display-inline') do %>
-    <%= image_tag(
-          asset_url('sp-logos/square-gsa.svg'),
-          size: 20,
-          alt: '',
-          class: 'float-left margin-right-1',
-        ) %>
+    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1') %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
   <div class="footer__links">
-    <%= new_window_link_to(
-          'https://gsa.gov',
-          aria: { label: t('shared.footer_lite.gsa') },
-          class: 'tablet:display-none margin-right-2',
-        ) do %>
-      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '' %>
+    <%= new_window_link_to('https://gsa.gov', class: 'tablet:display-none margin-right-2') do %>
+      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: t('shared.footer_lite.gsa') %>
     <% end %>
     <%= new_window_link_to(t('links.help'), MarketingSite.help_url, class: 'margin-right-2') %>
     <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url, class: 'margin-right-2') %>


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors the footer partial in order to...

1. Remove duplicate renderings between mobile and desktop viewports (e.g. `LanguagePickerComponent` and `new_window_link_to`, see also #7455 and #7451)
2. Simplify the markup itself to reduce size of page and browser processing

It's not expected there should be any visual effect of these changes.

## 📜 Testing Plan

- Spot check the footer