### PR TITLE
Optimize banner to render lock icon as external asset

### DIFF
--- a/app/views/shared/_banner-lock-icon.html.erb
+++ b/app/views/shared/_banner-lock-icon.html.erb
@@ -1,19 +1,7 @@
-<span class="icon-lock">
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="52"
-    height="64"
-    viewBox="0 0 52 64"
-    class="usa-banner__lock-image"
-    role="img"
-    aria-labelledby="banner-lock-title banner-lock-description"
-  >
-    <title id="banner-lock-title"><%= t('shared.banner.lock') %></title>
-    <desc id="banner-lock-description"><%= t('shared.banner.lock_description') %></desc>
-    <path
-      fill="#000000"
-      fill-rule="evenodd"
-      d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
-    />
-  </svg>
-</span>
+<%= image_tag(
+      design_system_asset_path('img/lock.svg'),
+      width: 9,
+      height: 12,
+      class: 'usa-banner__lock-image',
+      alt: t('shared.banner.lock_description'),
+    ) %>

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -8,10 +8,9 @@ en:
       gov_heading: Official websites use .gov
       how: Here’s how you know
       landmark_label: Official government website
-      lock: Lock
       lock_description: A locked padlock
       official_site: An official website of the United States government
-      secure_description_html: A <strong>lock</strong> (%{lock_icon}) or
+      secure_description_html: A <strong>lock</strong> ( %{lock_icon} ) or
         <strong>https://</strong> means you’ve safely connected to the .gov
         website. Share sensitive information only on official, secure websites.
       secure_heading: Secure .gov websites use HTTPS

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -8,10 +8,9 @@ es:
       gov_heading: Los sitios web oficiales usan .gov
       how: Así es como usted puede verificarlo
       landmark_label: Sitio web oficial del Gobierno
-      lock: Candado
       lock_description: Un candado cerrado
       official_site: Un sitio oficial del Gobierno de Estados Unidos
-      secure_description_html: Un <strong>candado</strong> (%{lock_icon}) o
+      secure_description_html: Un <strong>candado</strong> ( %{lock_icon} ) o
         <strong>https://</strong> significa que usted se conectó de forma segura
         a un sitio web .gov. Comparta información sensible sólo en sitios web
         oficiales y seguros.

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -8,10 +8,9 @@ fr:
       gov_heading: Les sites Web officiels utilisent .gov
       how: Voici comment vous savez
       landmark_label: Site officiel du gouvernement
-      lock: Serrure
       lock_description: Un cadenas fermé
       official_site: Un site web officiel du gouvernement des États-Unis
-      secure_description_html: Un <strong>verrou</strong> (%{lock_icon}) ou
+      secure_description_html: Un <strong>verrou</strong> ( %{lock_icon} ) ou
         <strong>https://</strong> signifie que vous êtes connecté en toute
         sécurité au site Web .gov. Partagez des informations sensibles
         uniquement sur des sites Web officiels et sécurisés.


### PR DESCRIPTION
## 🛠 Summary of changes

Revises the implementation of the "Official government website" banner to display the "Secure .gov websites use HTTPS" inline lock icon as an external asset.

The intent with these changes is to improve performance, to avoid...

- Translations of multiple strings
- Increasing page size by inlining SVG images
- Allowing for browser caching of the image
- Deferring load of image to only when the user expands "Here's how you know", which is assumed to not be a critical user behavior

For reference, newer versions of [USWDS banner guidance](https://designsystem.digital.gov/components/banner/) use `aria-labelledby` to reference the single description text "Locked padlock icon" for the image, so the combination of `title` and `desc` would not be used anyways, hence the removal of the additional string and inlining of label as the image `alt` value.

## 📜 Testing Plan

- Observe there is no difference in the rendered display of the "Here's how you know" banner expanded content