### PR TITLE
Replace workflow name

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ If you'd like to work with the previous implementation see the [Docker documenta
 
 ### Linting
 
-Run `make lint`
+Run `make lint` to look for errors; `make lintfix` can repair some linting errors.
 
 ### Running jobs
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ If you'd like to work with the previous implementation see the [Docker documenta
 
 Run `make lint` to look for errors; `make lintfix` can repair some linting errors.
 
+### Configuration variables
+
+Default configuration values &mdash; like feature flags, timeout settings, and third-party connection details &mdash; are found in [`config/application.yml.default`](config/application.yml/default). From these defaults the file `config/application.yml` is created during `make setup` for use during local development. [See the handbook](https://handbook.login.gov/articles/appdev-secrets-configuration.html).
+
+In deployed environments, configuration values are managed with the [app-s3-secret](https://github.com/18F/identity-devops/blob/main/bin/app-s3-secret) script. [See the handbook](https://handbook.login.gov/articles/devops-scripts.html#app-s3-secret).
+
 ### Running jobs
 
 We run background jobs / workers with ActiveJob and GoodJob. You shouldn't normally have to start it manually because `make run` runs [the `Procfile`](Procfile), which handles it. The manual command is: `bundle exec good_job start`

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -24,6 +24,13 @@ module Proofing
               },
               DateOfBirth: DateFormatter.new(applicant[:dob]).formatted_date,
               Addresses: [formatted_address],
+              Licenses: [
+                {
+                  Number: applicant[:state_id_number],
+                  Issuer: applicant[:state_id_jurisdiction],
+                  Type: 'drivers',
+                }
+              ],
             },
           }.to_json
         end

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -29,7 +29,7 @@ module Proofing
                   Number: applicant[:state_id_number],
                   Issuer: applicant[:state_id_jurisdiction],
                   Type: 'drivers',
-                }
+                },
               ],
             },
           }.to_json

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -157,7 +157,7 @@ lexisnexis_password: test_password
 lexisnexis_phone_finder_timeout: 1.0
 lexisnexis_phone_finder_workflow: customers.gsa.phonefinder.workflow
 lexisnexis_instant_verify_timeout: 1.0
-lexisnexis_instant_verify_workflow: customers.gsa.instant.verify.workflow
+lexisnexis_instant_verify_workflow: gsa.chk32.test.wf
 # TrueID DocAuth Integration
 lexisnexis_trueid_account_id: '12345'
 lexisnexis_trueid_username: test_username

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -155,18 +155,18 @@ lexisnexis_account_id: test_account
 lexisnexis_username: test_username
 lexisnexis_password: test_password
 lexisnexis_phone_finder_timeout: 1.0
-lexisnexis_phone_finder_workflow: customers.gsa.phonefinder.workflow
+lexisnexis_phone_finder_workflow: customers.gsa2.phonefinder.workflow
 lexisnexis_instant_verify_timeout: 1.0
-lexisnexis_instant_verify_workflow: gsa.chk32.test.wf
+lexisnexis_instant_verify_workflow: gsa2.chk32.test.wf
 # TrueID DocAuth Integration
 lexisnexis_trueid_account_id: '12345'
 lexisnexis_trueid_username: test_username
 lexisnexis_trueid_password: test_password
 lexisnexis_trueid_timeout: 60.0
-lexisnexis_trueid_liveness_cropping_workflow: customers.gsa.trueid.workflow
-lexisnexis_trueid_liveness_nocropping_workflow: customers.gsa.trueid.workflow
-lexisnexis_trueid_noliveness_cropping_workflow: customers.gsa.trueid.workflow
-lexisnexis_trueid_noliveness_nocropping_workflow: customers.gsa.trueid.workflow
+lexisnexis_trueid_liveness_cropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_liveness_nocropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_noliveness_cropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_noliveness_nocropping_workflow: customers.gsa2.trueid.workflow
 ###################################################################
 # LexisNexis DDP/ThreatMetrix #####################################
 lexisnexis_threatmetrix_api_key: test_api_key

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/request.json
@@ -30,6 +30,13 @@
         "Country": "US",
         "Context": "primary"
       }
+    ],
+    "Licenses": [
+      {
+        "Number": "132465879",
+        "Issuer": "LA",
+        "Type": "drivers"
+      }
     ]
   }
 }

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/successful_response.json
@@ -41,6 +41,10 @@
           "ItemStatus": "pass"
         },
         {
+          "ItemName": "DriversLicenseVerification",
+          "ItemStatus": "pass"
+        },
+        {
           "ItemName": "DOBFullVerified",
           "ItemStatus": "pass"
         },

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -15,6 +15,9 @@ describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
       city: 'Baton Rouge',
       state: 'LA',
       zipcode: '70802-12345',
+      state_id_number: '132465879',
+      state_id_jurisdiction: 'LA',
+      state_id_type: 'drivers_license'
     }
   end
   let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }
@@ -65,7 +68,7 @@ describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
 
   describe '#url' do
     it 'returns a url for the Instant Verify endpoint' do
-      expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/gsa.chk32.test.wf/conversation')
+      expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/gsa2.chk32.test.wf/conversation')
     end
   end
 end

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -65,7 +65,7 @@ describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
 
   describe '#url' do
     it 'returns a url for the Instant Verify endpoint' do
-      expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/customers.gsa.instant.verify.workflow/conversation')
+      expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/gsa.chk32.test.wf/conversation')
     end
   end
 end

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -17,7 +17,7 @@ describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
       zipcode: '70802-12345',
       state_id_number: '132465879',
       state_id_jurisdiction: 'LA',
-      state_id_type: 'drivers_license'
+      state_id_type: 'drivers_license',
     }
   end
   let(:response_body) { LexisNexisFixtures.instant_verify_success_response_json }

--- a/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
@@ -39,7 +39,7 @@ describe Proofing::LexisNexis::PhoneFinder::VerificationRequest do
   describe '#url' do
     it 'returns a url for the Phone Finder endpoint' do
       expect(subject.url).to eq(
-        'https://example.com/restws/identity/v2/test_account/customers.gsa.phonefinder.workflow/conversation',
+        'https://example.com/restws/identity/v2/test_account/customers.gsa2.phonefinder.workflow/conversation',
       )
     end
   end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -9,8 +9,8 @@ module LexisNexisFixtures
         account_id: 'test_account',
         username: 'test_username',
         password: 'test_password',
-        instant_verify_workflow: 'gsa.chk32.test.wf',
-        phone_finder_workflow: 'customers.gsa.phonefinder.workflow',
+        instant_verify_workflow: 'gsa2.chk32.test.wf',
+        phone_finder_workflow: 'customers.gsa2.phonefinder.workflow',
       )
     end
 

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -9,7 +9,7 @@ module LexisNexisFixtures
         account_id: 'test_account',
         username: 'test_username',
         password: 'test_password',
-        instant_verify_workflow: 'customers.gsa.instant.verify.workflow',
+        instant_verify_workflow: 'gsa.chk32.test.wf',
         phone_finder_workflow: 'customers.gsa.phonefinder.workflow',
       )
     end

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -79,9 +79,14 @@ shared_examples 'a lexisnexis request' do |basic_auth: true|
         to_return(status: 200, body: response_body)
 
       ln_response = subject.send
+
       expect(ln_response).to be_a(Proofing::LexisNexis::Response)
       expect(ln_response.response.status).to eq 200
       expect(ln_response.response.body).to eq response_body
+      expect(ln_response.conversation_id).to be_a(String)
+      expect(ln_response.reference).to be_a(String)
+      expect(ln_response.verification_status).to be_a(String)
+      expect(ln_response.verification_errors).to be_a(Hash)
     end
   end
 end

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -79,7 +79,6 @@ shared_examples 'a lexisnexis request' do |basic_auth: true|
         to_return(status: 200, body: response_body)
 
       ln_response = subject.send
-
       expect(ln_response).to be_a(Proofing::LexisNexis::Response)
       expect(ln_response.response.status).to eq 200
       expect(ln_response.response.body).to eq response_body


### PR DESCRIPTION
## 🎫 Ticket

[LG-6801](https://cm-jira.usa.gov/browse/LG-8260)

## 🛠 Summary of changes

1. Change workflow name variable to and updated string provided by LexisNexis; this updates our RDP2 API endpoint connection used for Instant Verify
2. Modify our LexisNexis Instant Verify implementation to transmit drivers license information

## 📜 Testing Plan

- [ ] Deploy to the Staging environment
- [ ] Ensure updated workflow name [is reflected in S3](https://handbook.login.gov/articles/devops-scripts.html#app-s3-secret)
- [ ] Transmit an Instant Verify request with the Rails console; examine the response JSON
- [ ] Use the proofing workflow UI
- [ ] Monitor logs to ensure Instant Verify works unchanged; neither fail rate nor exception rate should increase
