### PR TITLE
Fix new_window_link_to link appearance in Safari

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,13 +1,15 @@
 module LinkHelper
   EXTERNAL_LINK_CLASS = 'usa-link--external'.freeze
 
-  def new_window_link_to(name = nil, options = nil, html_options = {}, &block)
+  def new_window_link_to(name = nil, options = nil, html_options = nil, &block)
     html_options, options, name = options, name, capture(&block) if block
 
+    html_options ||= {}
     html_options[:target] = '_blank'
     html_options[:class] = [*html_options[:class], EXTERNAL_LINK_CLASS]
 
-    name = safe_join([name, content_tag('span', t('links.new_window'), class: 'usa-sr-only')], ' ')
+    name = ERB::Util.unwrapped_html_escape(name).rstrip.html_safe # rubocop:disable Rails/OutputSafety
+    name << content_tag('span', t('links.new_window'), class: 'usa-sr-only')
 
     link_to(name, options, html_options)
   end

--- a/app/javascript/packages/components/link.tsx
+++ b/app/javascript/packages/components/link.tsx
@@ -56,7 +56,7 @@ function Link({
   return (
     <a href={href} {...newTabProps} {...anchorProps} className={classes}>
       {children}
-      {isNewTab && <span className="usa-sr-only"> {t('links.new_window')}</span>}
+      {isNewTab && <span className="usa-sr-only">{t('links.new_window')}</span>}
     </a>
   );
 }

--- a/app/javascript/packages/components/troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/components/troubleshooting-options.spec.tsx
@@ -43,7 +43,7 @@ describe('TroubleshootingOptions', () => {
     const links = getAllByRole('link') as HTMLAnchorElement[];
 
     expect(links).to.have.lengthOf(2);
-    expect(links[0].textContent).to.equal('Option 1 links.new_window');
+    expect(links[0].textContent).to.equal('Option 1links.new_window');
     expect(links[0].getAttribute('href')).to.equal(`/1`);
     expect(links[0].target).to.equal('_blank');
     expect(links[1].textContent).to.equal('Option 2');

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -40,14 +40,14 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
 
     expect(links).to.have.lengthOf(2);
     expect(links[0].textContent).to.equal(
-      'idv.troubleshooting.options.doc_capture_tips links.new_window',
+      'idv.troubleshooting.options.doc_capture_tipslinks.new_window',
     );
     expect(links[0].getAttribute('href')).to.equal(
       'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=document_capture_troubleshooting_options',
     );
     expect(links[0].target).to.equal('_blank');
     expect(links[1].textContent).to.equal(
-      'idv.troubleshooting.options.supported_documents links.new_window',
+      'idv.troubleshooting.options.supported_documentslinks.new_window',
     );
     expect(links[1].getAttribute('href')).to.equal(
       'https://example.com/redirect/?category=verify-your-identity&article=accepted-state-issued-identification&location=document_capture_troubleshooting_options',
@@ -65,21 +65,21 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
 
       expect(links).to.have.lengthOf(3);
       expect(links[0].textContent).to.equal(
-        'idv.troubleshooting.options.doc_capture_tips links.new_window',
+        'idv.troubleshooting.options.doc_capture_tipslinks.new_window',
       );
       expect(links[0].getAttribute('href')).to.equal(
         'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=document_capture_troubleshooting_options',
       );
       expect(links[0].target).to.equal('_blank');
       expect(links[1].textContent).to.equal(
-        'idv.troubleshooting.options.supported_documents links.new_window',
+        'idv.troubleshooting.options.supported_documentslinks.new_window',
       );
       expect(links[1].getAttribute('href')).to.equal(
         'https://example.com/redirect/?category=verify-your-identity&article=accepted-state-issued-identification&location=document_capture_troubleshooting_options',
       );
       expect(links[1].target).to.equal('_blank');
       expect(links[2].textContent).to.equal(
-        'idv.troubleshooting.options.get_help_at_sp links.new_window',
+        'idv.troubleshooting.options.get_help_at_splinks.new_window',
       );
       expect(links[2].href).to.equal(
         'http://example.test/url/to/failure-to-proof?location=document_capture_troubleshooting_options',

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -4,21 +4,46 @@ RSpec.describe LinkHelper do
   include LinkHelper
 
   describe '#new_window_link_to' do
+    let(:name) { 'Link' }
     let(:html_options) { {} }
 
-    subject(:link) { new_window_link_to('Link', '', **html_options) }
+    subject(:link) { new_window_link_to(name, '', **html_options) }
 
     it 'opens in a new tab' do
       expect(link).to have_css('[target=_blank]')
     end
 
     it 'includes an accessibility hint about opening in a new tab' do
-      expect(link).to have_content("Link #{t('links.new_window')}")
+      expect(link).to have_content("#{name}#{t('links.new_window')}")
       expect(link).to have_css('.usa-sr-only', text: t('links.new_window'))
     end
 
     it 'adds design system external link class' do
       expect(link).to have_css('.usa-link--external')
+    end
+
+    context 'with unsafe html' do
+      let(:name) { '<span data-unsafe>Link</span>' }
+
+      it 'renders unsafe html as escaped' do
+        expect(link).to have_content(name)
+        expect(link).not_to have_css('[data-unsafe]')
+      end
+    end
+
+    context 'with whitespace in the link text' do
+      subject(:link) do
+        new_window_link_to('', {}) do
+          concat content_tag(:span, name)
+          concat ' '
+        end
+      end
+
+      it 'trims whitespace between link text and the accessible label' do
+        # Regression: Safari's handling of the trailing whitespace would cause the external link
+        # icon to be shown on a new line.
+        expect(link).to have_content("#{name}#{t('links.new_window')}")
+      end
     end
 
     context 'with custom classes' do
@@ -38,14 +63,21 @@ RSpec.describe LinkHelper do
     end
 
     context 'content given as block' do
-      let(:html_options) { { data: { foo: 'bar' } } }
-      subject(:link) { new_window_link_to('/url', **html_options) { 'Link' } }
+      subject(:link) { new_window_link_to('/url', **html_options) { name } }
 
       it 'renders a link with the expected attributes' do
         expect(link).to have_css(
-          '.usa-link--external[href="/url"][target=_blank][data-foo="bar"]',
-          text: "Link #{t('links.new_window')}",
+          '.usa-link--external[href="/url"][target=_blank]',
+          text: "#{name}#{t('links.new_window')}",
         )
+      end
+
+      context 'with additional html options' do
+        let(:html_options) { { class: 'example', data: { foo: 'bar' } } }
+
+        it 'renders attributes on the link' do
+          expect(link).to have_css('.example.usa-link--external[data-foo="bar"]')
+        end
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

This fixes a small regression of #7455, where links which open in a new window would incorrectly display the "External" icon on a separate line, due to how Safari treats the addition of the extra space character added in #7455. This essentially reverts to the previous behavior where the link text and accessible label were combined. In testing, since the accessible label is bounded by parantheses, it does not appear to make a difference whether a space is included when the text is announced by a screen reader.

This also fixes another potential issue where certain calls to `new_window_link_to` with a block and explicitly-nil `html_options` could raise an exception, and also improves test coverage to enforce expected behavior of HTML safety for the concatenated text.

## 📜 Testing Plan

- `rspec spec/helpers/link_helper_spec.rb`

## 👀 Screenshots

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/206725336-3577d0dc-c30d-4e76-83e0-aec0d23c8014.png)|![Screen Shot 2022-12-09 at 9 27 32 AM](https://user-images.githubusercontent.com/1779930/206725365-1be3baf4-8aaa-410c-bb2d-c993560c5d52.png)
