### PR TITLE
Change the API for `expect_delivered_email` to not include an index

### DIFF
--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -439,10 +439,8 @@ describe Idv::ReviewController do
 
             expect_delivered_email_count(1)
             expect_delivered_email(
-              0, {
-                to: [user.email_addresses.first.email],
-                subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
-              }
+              to: [user.email_addresses.first.email],
+              subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
             )
           end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -421,10 +421,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
             expect_delivered_email_count(1)
             expect_delivered_email(
-              0, {
-                to: [subject.current_user.email_addresses.first.email],
-                subject: t('user_mailer.phone_added.subject'),
-              }
+              to: [subject.current_user.email_addresses.first.email],
+              subject: t('user_mailer.phone_added.subject'),
             )
           end
         end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -69,10 +69,8 @@ describe Users::PasswordsController do
 
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [user.email_addresses.first.email],
-            subject: t('devise.mailer.password_updated.subject'),
-          }
+          to: [user.email_addresses.first.email],
+          subject: t('devise.mailer.password_updated.subject'),
         )
       end
     end

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -12,6 +12,12 @@ feature 'adding email address' do
     visit account_path
     expect(page).to have_content(unconfirmed_email_text)
 
+    expect_delivered_email_count(1)
+    expect_delivered_email(
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
+    )
+
     click_on_link_in_confirmation_email
 
     expect(page).to have_current_path(account_path)
@@ -19,10 +25,6 @@ feature 'adding email address' do
     expect(page).to_not have_content(unconfirmed_email_text)
 
     expect_delivered_email_count(3)
-    expect_delivered_email(
-      to: [email],
-      subject: t('user_mailer.add_email.subject'),
-    )
     expect_delivered_email(
       to: [original_email],
       subject: t('user_mailer.email_added.subject'),

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -5,6 +5,7 @@ feature 'adding email address' do
 
   it 'allows the user to add an email and confirm with an active session' do
     user = create(:user, :signed_up)
+    original_email = user.email_addresses.first.email
     sign_in_user_and_add_email(user)
     unconfirmed_email_text = "#{email}  #{t('email_addresses.unconfirmed')}"
 
@@ -19,27 +20,22 @@ feature 'adding email address' do
 
     expect_delivered_email_count(3)
     expect_delivered_email(
-      0, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
     expect_delivered_email(
-      1, {
-        to: [user.confirmed_email_addresses[0].email],
-        subject: t('user_mailer.email_added.subject'),
-      }
+      to: [original_email],
+      subject: t('user_mailer.email_added.subject'),
     )
     expect_delivered_email(
-      2, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.email_added.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.email_added.subject'),
     )
   end
 
   it 'allows the user to add an email and confirm without an active session' do
     user = create(:user, :signed_up)
+    original_email = user.email_addresses.first.email
     sign_in_user_and_add_email(user)
 
     Capybara.reset_session!
@@ -50,22 +46,16 @@ feature 'adding email address' do
 
     expect_delivered_email_count(3)
     expect_delivered_email(
-      0, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
     expect_delivered_email(
-      1, {
-        to: [user.confirmed_email_addresses[0].email],
-        subject: t('user_mailer.email_added.subject'),
-      }
+      to: [original_email],
+      subject: t('user_mailer.email_added.subject'),
     )
     expect_delivered_email(
-      2, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.email_added.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.email_added.subject'),
     )
   end
 
@@ -85,10 +75,8 @@ feature 'adding email address' do
 
     expect_delivered_email_count(3)
     expect_delivered_email(
-      0, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
   end
 
@@ -105,10 +93,8 @@ feature 'adding email address' do
 
     expect_delivered_email_count(3)
     expect_delivered_email(
-      0, {
-        to: [user.confirmed_email_addresses[1].email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
   end
 
@@ -127,10 +113,8 @@ feature 'adding email address' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [user.reload.email_addresses.order(:created_at).last.email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
   end
 
@@ -146,16 +130,12 @@ feature 'adding email address' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [initial_user.email_addresses.first.email],
-        subject: t('mailer.email_reuse_notice.subject'),
-      }
+      to: [initial_user.email_addresses.first.email],
+      subject: t('mailer.email_reuse_notice.subject'),
     )
     expect_delivered_email(
-      0, {
-        to: [email],
-        subject: t('mailer.email_reuse_notice.subject'),
-      }
+      to: [email],
+      subject: t('mailer.email_reuse_notice.subject'),
     )
   end
 
@@ -243,16 +223,12 @@ feature 'adding email address' do
 
     expect_delivered_email_count(2)
     expect_delivered_email(
-      0, {
-        to: [user.email_addresses.order(:created_at).last.email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
     expect_delivered_email(
-      1, {
-        to: [user.email_addresses.order(:created_at).last.email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
   end
 
@@ -270,10 +246,8 @@ feature 'adding email address' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [user.reload.email_addresses[1].email],
-        subject: t('user_mailer.add_email.subject'),
-      }
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
     )
   end
 

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -40,6 +40,12 @@ feature 'adding email address' do
     original_email = user.email_addresses.first.email
     sign_in_user_and_add_email(user)
 
+    expect_delivered_email_count(1)
+    expect_delivered_email(
+      to: [email],
+      subject: t('user_mailer.add_email.subject'),
+    )
+
     Capybara.reset_session!
 
     click_on_link_in_confirmation_email
@@ -47,10 +53,6 @@ feature 'adding email address' do
     expect(page).to have_content(t('devise.confirmations.confirmed_but_sign_in'))
 
     expect_delivered_email_count(3)
-    expect_delivered_email(
-      to: [email],
-      subject: t('user_mailer.add_email.subject'),
-    )
     expect_delivered_email(
       to: [original_email],
       subject: t('user_mailer.email_added.subject'),

--- a/spec/features/multiple_emails/email_management_spec.rb
+++ b/spec/features/multiple_emails/email_management_spec.rb
@@ -83,16 +83,12 @@ feature 'managing email address' do
 
       expect_delivered_email_count(2)
       expect_delivered_email(
-        0, {
-          to: [confirmed_email1.email],
-          subject: t('user_mailer.email_deleted.subject'),
-        }
+        to: [confirmed_email1.email],
+        subject: t('user_mailer.email_deleted.subject'),
       )
       expect_delivered_email(
-        1, {
-          to: [confirmed_email2.email],
-          subject: t('user_mailer.email_deleted.subject'),
-        }
+        to: [confirmed_email2.email],
+        subject: t('user_mailer.email_deleted.subject'),
       )
     end
 

--- a/spec/features/multiple_emails/reset_password_spec.rb
+++ b/spec/features/multiple_emails/reset_password_spec.rb
@@ -12,10 +12,8 @@ describe 'reset password with multiple emails' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [email1],
-        subject: t('user_mailer.reset_password_instructions.subject'),
-      }
+      to: [email1],
+      subject: t('user_mailer.reset_password_instructions.subject'),
     )
 
     Capybara.reset_session!
@@ -27,10 +25,8 @@ describe 'reset password with multiple emails' do
 
     expect_delivered_email_count(2)
     expect_delivered_email(
-      1, {
-        to: [email2],
-        subject: t('user_mailer.reset_password_instructions.subject'),
-      }
+      to: [email2],
+      subject: t('user_mailer.reset_password_instructions.subject'),
     )
   end
 
@@ -51,11 +47,9 @@ describe 'reset password with multiple emails' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [unconfirmed_email_address.email],
-        subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
-        body: [create_account_instructions_text],
-      }
+      to: [unconfirmed_email_address.email],
+      subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
+      body: [create_account_instructions_text],
     )
   end
 end

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -56,7 +56,7 @@ describe 'New device tracking' do
         subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
         body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
               strftime('%B %-d, %Y %H:%M Eastern Time'),
-              'From 127.0.0.1 (IP address potentially located in United States)'],
+               'From 127.0.0.1 (IP address potentially located in United States)'],
       )
       expect(Telephony::Test::Message.messages.count).to eq 0
     end

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -17,13 +17,11 @@ describe 'New device tracking' do
 
       expect_delivered_email_count(1)
       expect_delivered_email(
-        0, {
-          to: [user.email_addresses.first.email],
-          subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
-          body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
-                 strftime('%B %-d, %Y %H:%M Eastern Time'),
-                 'From 127.0.0.1 (IP address potentially located in United States)'],
-        }
+        to: [user.email_addresses.first.email],
+        subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
+        body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
+               strftime('%B %-d, %Y %H:%M Eastern Time'),
+               'From 127.0.0.1 (IP address potentially located in United States)'],
       )
     end
   end
@@ -54,13 +52,11 @@ describe 'New device tracking' do
       device = user.devices.order(created_at: :desc).first
       expect_delivered_email_count(1)
       expect_delivered_email(
-        0, {
-          to: [user.email_addresses.first.email],
-          subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
-          body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
-                 strftime('%B %-d, %Y %H:%M Eastern Time'),
-                 'From 127.0.0.1 (IP address potentially located in United States)'],
-        }
+        to: [user.email_addresses.first.email],
+        subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
+        body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
+              strftime('%B %-d, %Y %H:%M Eastern Time'),
+              'From 127.0.0.1 (IP address potentially located in United States)'],
       )
       expect(Telephony::Test::Message.messages.count).to eq 0
     end

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -36,10 +36,8 @@ describe 'Add a new phone number' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [user.email_addresses.first.email],
-        subject: t('user_mailer.phone_added.subject'),
-      }
+      to: [user.email_addresses.first.email],
+      subject: t('user_mailer.phone_added.subject'),
     )
   end
 

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -21,10 +21,8 @@ feature 'Signing in via one-time use personal key' do
 
     expect_delivered_email_count(1)
     expect_delivered_email(
-      0, {
-        to: [user.email_addresses.first.email],
-        subject: t('user_mailer.personal_key_sign_in.subject'),
-      }
+      to: [user.email_addresses.first.email],
+      subject: t('user_mailer.personal_key_sign_in.subject'),
     )
   end
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -24,10 +24,8 @@ feature 'View personal key', js: true do
 
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [user.email_addresses.first.email],
-            subject: t('user_mailer.personal_key_regenerated.subject'),
-          }
+          to: [user.email_addresses.first.email],
+          subject: t('user_mailer.personal_key_regenerated.subject'),
         )
       end
     end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -27,10 +27,8 @@ describe RegisterUserEmailForm do
         expect(subject.email).to eq 'taken@gmail.com'
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [subject.email],
-            subject: t('mailer.email_reuse_notice.subject'),
-          }
+          to: [subject.email],
+          subject: t('mailer.email_reuse_notice.subject'),
         )
       end
 

--- a/spec/services/account_reset/cancel_spec.rb
+++ b/spec/services/account_reset/cancel_spec.rb
@@ -60,10 +60,8 @@ describe AccountReset::Cancel do
 
       expect_delivered_email_count(1)
       expect_delivered_email(
-        0, {
-          to: [user.email_addresses.first.email],
-          subject: t('user_mailer.account_reset_cancel.subject'),
-        }
+        to: [user.email_addresses.first.email],
+        subject: t('user_mailer.account_reset_cancel.subject'),
       )
     end
 

--- a/spec/services/account_reset/notify_user_of_request_cancellation_spec.rb
+++ b/spec/services/account_reset/notify_user_of_request_cancellation_spec.rb
@@ -14,16 +14,12 @@ describe AccountReset::NotifyUserOfRequestCancellation do
 
       expect_delivered_email_count(2)
       expect_delivered_email(
-        0, {
-          to: [email_address1.email],
-          subject: t('user_mailer.account_reset_cancel.subject'),
-        }
+        to: [email_address1.email],
+        subject: t('user_mailer.account_reset_cancel.subject'),
       )
       expect_delivered_email(
-        1, {
-          to: [email_address2.email],
-          subject: t('user_mailer.account_reset_cancel.subject'),
-        }
+        to: [email_address2.email],
+        subject: t('user_mailer.account_reset_cancel.subject'),
       )
     end
 

--- a/spec/services/idv/in_person/completion_survey_sender_spec.rb
+++ b/spec/services/idv/in_person/completion_survey_sender_spec.rb
@@ -28,16 +28,12 @@ describe Idv::InPerson::CompletionSurveySender do
 
         expect_delivered_email_count(2)
         expect_delivered_email(
-          0, {
-            to: [user.confirmed_email_addresses[0].email],
-            subject: t('user_mailer.in_person_completion_survey.subject', app_name: APP_NAME),
-          }
+          to: [user.confirmed_email_addresses[0].email],
+          subject: t('user_mailer.in_person_completion_survey.subject', app_name: APP_NAME),
         )
         expect_delivered_email(
-          1, {
-            to: [user.confirmed_email_addresses[1].email],
-            subject: t('user_mailer.in_person_completion_survey.subject', app_name: APP_NAME),
-          }
+          to: [user.confirmed_email_addresses[1].email],
+          subject: t('user_mailer.in_person_completion_survey.subject', app_name: APP_NAME),
         )
       end
       it 'marks the user as having received a survey' do

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -25,11 +25,9 @@ describe SendSignUpEmailConfirmation do
       subject.call(request_id: request_id, instructions: instructions)
       expect_delivered_email_count(1)
       expect_delivered_email(
-        0, {
-          to: [user.email_addresses.first.email],
-          subject: t('user_mailer.email_confirmation_instructions.subject'),
-          body: [request_id, instructions],
-        }
+        to: [user.email_addresses.first.email],
+        subject: t('user_mailer.email_confirmation_instructions.subject'),
+        body: [request_id, instructions],
       )
     end
 
@@ -43,10 +41,8 @@ describe SendSignUpEmailConfirmation do
 
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [email_address.email],
-            subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
-          }
+          to: [email_address.email],
+          subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
         )
       end
     end
@@ -84,11 +80,9 @@ describe SendSignUpEmailConfirmation do
 
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [user.email_addresses.first.email],
-            subject: t('user_mailer.email_confirmation_instructions.subject'),
-            body: [confirmation_token],
-          }
+          to: [user.email_addresses.first.email],
+          subject: t('user_mailer.email_confirmation_instructions.subject'),
+          body: [confirmation_token],
         )
       end
     end

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -21,25 +21,19 @@ describe UserAlerts::AlertUserAboutAccountVerified do
 
       expect_delivered_email_count(3)
       expect_delivered_email(
-        0, {
-          to: [confirmed_email_addresses[0].email],
-          subject: t('user_mailer.account_verified.subject', sp_name: ''),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[0].email],
+        subject: t('user_mailer.account_verified.subject', sp_name: ''),
+        body: [disavowal_token],
       )
       expect_delivered_email(
-        1, {
-          to: [confirmed_email_addresses[1].email],
-          subject: t('user_mailer.account_verified.subject', sp_name: ''),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[1].email],
+        subject: t('user_mailer.account_verified.subject', sp_name: ''),
+        body: [disavowal_token],
       )
       expect_delivered_email(
-        2, {
-          to: [confirmed_email_addresses[2].email],
-          subject: t('user_mailer.account_verified.subject', sp_name: ''),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[2].email],
+        subject: t('user_mailer.account_verified.subject', sp_name: ''),
+        body: [disavowal_token],
       )
     end
   end

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -15,18 +15,14 @@ describe UserAlerts::AlertUserAboutNewDevice do
 
       expect_delivered_email_count(2)
       expect_delivered_email(
-        0, {
-          to: [confirmed_email_addresses[0].email],
-          subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[0].email],
+        subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
+        body: [disavowal_token],
       )
       expect_delivered_email(
-        1, {
-          to: [confirmed_email_addresses[1].email],
-          subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[1].email],
+        subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
+        body: [disavowal_token],
       )
     end
   end

--- a/spec/services/user_alerts/alert_user_about_password_change_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_password_change_spec.rb
@@ -13,18 +13,14 @@ describe UserAlerts::AlertUserAboutPasswordChange do
 
       expect_delivered_email_count(2)
       expect_delivered_email(
-        0, {
-          to: [confirmed_email_addresses[0].email],
-          subject: t('devise.mailer.password_updated.subject'),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[0].email],
+        subject: t('devise.mailer.password_updated.subject'),
+        body: [disavowal_token],
       )
       expect_delivered_email(
-        1, {
-          to: [confirmed_email_addresses[1].email],
-          subject: t('devise.mailer.password_updated.subject'),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[1].email],
+        subject: t('devise.mailer.password_updated.subject'),
+        body: [disavowal_token],
       )
     end
   end

--- a/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
@@ -27,18 +27,14 @@ describe UserAlerts::AlertUserAboutPersonalKeySignIn do
 
       expect_delivered_email_count(2)
       expect_delivered_email(
-        0, {
-          to: [confirmed_email_addresses[0].email],
-          subject: t('user_mailer.personal_key_sign_in.subject'),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[0].email],
+        subject: t('user_mailer.personal_key_sign_in.subject'),
+        body: [disavowal_token],
       )
       expect_delivered_email(
-        1, {
-          to: [confirmed_email_addresses[1].email],
-          subject: t('user_mailer.personal_key_sign_in.subject'),
-          body: [disavowal_token],
-        }
+        to: [confirmed_email_addresses[1].email],
+        subject: t('user_mailer.personal_key_sign_in.subject'),
+        body: [disavowal_token],
       )
     end
   end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -98,10 +98,8 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
 
         expect_delivered_email_count(1)
         expect_delivered_email(
-          0, {
-            to: [user.email_addresses.first.email],
-            subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
-          }
+          to: [user.email_addresses.first.email],
+          subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
         )
       end
     end

--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -15,7 +15,30 @@ module MailerHelper
     ActionController::Base.helpers.strip_tags(str)
   end
 
-  def expect_delivered_email(index, hash)
+  def expect_delivered_email(to: nil, subject: nil, body: nil)
+    email = ActionMailer::Base.deliveries.find do |sent_mail|
+      next unless to.present? && sent_mail.to == to
+      next unless subject.present? && sent_mail.subject == subject
+      if body.present?
+        delivered_body = mail.text_part.decoded.squish
+        body.to_a.each do |expected_body|
+          next unless delivered_body.includes?(expected_body)
+        end
+      end
+      true
+    end
+
+    error_message = <<~ERROR
+      Unable to find email matching args:
+        to: #{to}
+        subject: #{subject}
+        body: #{body}
+      Sent mails: #{ActionMailer::Base.deliveries}
+    ERROR
+    expect(email).to_not be(nil), error_message
+  end
+
+  def expect_delivered_email_at_index(index, hash)
     mail = ActionMailer::Base.deliveries[index]
 
     aggregate_failures do
@@ -23,7 +46,7 @@ module MailerHelper
       expect(mail.subject).to eq hash[:subject] if hash[:subject]
 
       if hash[:body]
-        delivered_body = mail.text_part.decoded.gsub("\r\n", ' ')
+        delivered_body = mail.text_part.decoded.squish
         hash[:body].to_a.each do |expected_body|
           expect(delivered_body).to include(expected_body)
         end

--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -20,7 +20,7 @@ module MailerHelper
       next unless to.present? && sent_mail.to == to
       next unless subject.present? && sent_mail.subject == subject
       if body.present?
-        delivered_body = mail.text_part.decoded.squish
+        delivered_body = sent_mail.text_part.decoded.squish
         body.to_a.each do |expected_body|
           next unless delivered_body.includes?(expected_body)
         end
@@ -36,21 +36,5 @@ module MailerHelper
       Sent mails: #{ActionMailer::Base.deliveries}
     ERROR
     expect(email).to_not be(nil), error_message
-  end
-
-  def expect_delivered_email_at_index(index, hash)
-    mail = ActionMailer::Base.deliveries[index]
-
-    aggregate_failures do
-      expect(mail.to).to eq hash[:to] if hash[:to]
-      expect(mail.subject).to eq hash[:subject] if hash[:subject]
-
-      if hash[:body]
-        delivered_body = mail.text_part.decoded.squish
-        hash[:body].to_a.each do |expected_body|
-          expect(delivered_body).to include(expected_body)
-        end
-      end
-    end
   end
 end

--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -22,7 +22,7 @@ module MailerHelper
       if body.present?
         delivered_body = sent_mail.text_part.decoded.squish
         body.to_a.each do |expected_body|
-          next unless delivered_body.includes?(expected_body)
+          next unless delivered_body.include?(expected_body)
         end
       end
       true


### PR DESCRIPTION
The `expect_delivered_email` helper allows tests to confirm that an email with a given subject/recipient/body was in fact sent.

Prior to this commit this method took an index as the first argument. This meant that emails had to be sent in a specific, deterministic order for tests to pass. Problems arose when a users emails could be returned in a non-deterministic order. In most cases emails should be returned in the order in which they are used to sign in. However, for users created with a factory this may not always be the case.

After reviewing the tests that use this helper it does not appear that we need to actually worry about the order in which the emails are sent for most cases. This commit changes this helper to be agnostic about the order and applies the new API.