### PR TITLE
Add a slightly longer sleep to a test that waits for a timer to advance

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -269,7 +269,7 @@ feature 'Sign in' do
       expect(page).to have_content(/14 minutes and 5[0-9] seconds/, wait: 5)
 
       time1 = page.text[/14 minutes and 5[0-9] seconds/]
-      sleep(1)
+      sleep(1.5)
       time2 = page.text[/14 minutes and 5[0-9] seconds/]
       expect(time2).to be < time1
     end


### PR DESCRIPTION
The sign in spec changed in this commit waits for a timer to advance. It waits exactly 1 second, which near the boundaries of the current second can lead to an edge case that leads to the following failure:

```
Failures:
  1) Sign in session approaches timeout user sees warning before session times out
     Failure/Error: expect(time2).to be < time1
       expected: < "14 minutes and 56 seconds"
            got:   "14 minutes and 56 seconds"
     # ./spec/features/users/sign_in_spec.rb:274:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in `block (2 levels) in <top (required)>'
```

This commit modifies the sleep in this test to advance more than a second so that the assertion never runs near the boundary of the recent second.
