### PR TITLE
LG-8066: Show example hint for OTP format

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -12,11 +12,6 @@ legend {
   font-weight: $heading-font-weight;
 }
 
-label {
-  display: inline-block;
-  margin-bottom: units(0.5);
-}
-
 textarea {
   resize: vertical;
 }
@@ -29,6 +24,7 @@ textarea {
   border-radius: $border-radius;
   color: color('ink');
   font-weight: $bold-font-weight;
+  margin-top: units(0.5);
 
   &[type='number'],
   &.phone {
@@ -65,4 +61,15 @@ input::-webkit-inner-spin-button {
   @include at-media('desktop') {
     margin-left: 0;
   }
+}
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/325
+.usa-input,
+.usa-textarea {
+  margin-top: units(0.5);
+}
+
+// Upstream: https://github.com/18F/identity-style-guide/pull/325
+.usa-hint {
+  margin: 0;
 }

--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -2,7 +2,7 @@ lg-phone-input {
   display: block;
 
   .validated-field__input-wrapper {
-    margin-top: units(1);
+    margin-top: units(0.5);
   }
 
   .iti__flag {

--- a/app/components/one_time_code_input_component.html.erb
+++ b/app/components/one_time_code_input_component.html.erb
@@ -3,6 +3,7 @@
         form: form,
         name: name,
         label: t('components.one_time_code_input.label'),
+        hint: hint,
         required: true,
         **field_options,
         input_html: {

--- a/app/components/one_time_code_input_component.html.erb
+++ b/app/components/one_time_code_input_component.html.erb
@@ -2,7 +2,7 @@
   <%= render ValidatedFieldComponent.new(
         form: form,
         name: name,
-        label: t('forms.two_factor.code'),
+        label: t('components.one_time_code_input.label'),
         required: true,
         **field_options,
         input_html: {

--- a/app/components/one_time_code_input_component.rb
+++ b/app/components/one_time_code_input_component.rb
@@ -45,6 +45,14 @@ class OneTimeCodeInputComponent < BaseComponent
     @tag_options = tag_options
   end
 
+  def hint
+    if numeric?
+      t('components.one_time_code_input.hint.numeric')
+    else
+      t('components.one_time_code_input.hint.alphanumeric')
+    end
+  end
+
   def input_pattern
     if numeric?
       '[0-9]*'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -27,7 +27,7 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'text-bold'
+    b.use :label, class: 'usa-label'
     b.use :hint,  wrap_with: { tag: 'div', class: 'usa-hint' }
     b.use :input, class: 'display-block width-full field', error_class: 'usa-input--error'
     b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -33,6 +33,8 @@ en:
         range_underflow: Enter a date on or after %{date}
       month: Month
       year: Year
+    one_time_code_input:
+      label: One-time code
     password_toggle:
       label: Password
       toggle_label: Show password

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -35,6 +35,9 @@ en:
       year: Year
     one_time_code_input:
       label: One-time code
+      hint:
+        numeric: 'Example: 123456'
+        alphanumeric: 'Example: 123ABC'
     password_toggle:
       label: Password
       toggle_label: Show password

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -34,10 +34,10 @@ en:
       month: Month
       year: Year
     one_time_code_input:
-      label: One-time code
       hint:
-        numeric: 'Example: 123456'
         alphanumeric: 'Example: 123ABC'
+        numeric: 'Example: 123456'
+      label: One-time code
     password_toggle:
       label: Password
       toggle_label: Show password

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -35,6 +35,9 @@ es:
       year: Año
     one_time_code_input:
       label: Código de un solo uso
+      hint:
+        numeric: 'Ejemplo: 123456'
+        alphanumeric: 'Ejemplo: 123ABC'
     password_toggle:
       label: Contraseña
       toggle_label: Mostrar contraseña

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -33,6 +33,8 @@ es:
         range_underflow: Ingrese una fecha a partir del %{date}
       month: Mes
       year: Año
+    one_time_code_input:
+      label: Código de un solo uso
     password_toggle:
       label: Contraseña
       toggle_label: Mostrar contraseña

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -34,10 +34,10 @@ es:
       month: Mes
       year: Año
     one_time_code_input:
-      label: Código de un solo uso
       hint:
-        numeric: 'Ejemplo: 123456'
         alphanumeric: 'Ejemplo: 123ABC'
+        numeric: 'Ejemplo: 123456'
+      label: Código de un solo uso
     password_toggle:
       label: Contraseña
       toggle_label: Mostrar contraseña

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -34,10 +34,10 @@ fr:
       month: Mois
       year: An
     one_time_code_input:
-      label: Code à usage unique
       hint:
-        numeric: 'Exemple: 123456'
         alphanumeric: 'Exemple: 123ABC'
+        numeric: 'Exemple: 123456'
+      label: Code à usage unique
     password_toggle:
       label: Mot de passe
       toggle_label: Afficher le mot de passe

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -33,6 +33,8 @@ fr:
         range_underflow: Entrez une date le ou après le %{date}
       month: Mois
       year: An
+    one_time_code_input:
+      label: Code à usage unique
     password_toggle:
       label: Mot de passe
       toggle_label: Afficher le mot de passe

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -35,6 +35,9 @@ fr:
       year: An
     one_time_code_input:
       label: Code à usage unique
+      hint:
+        numeric: 'Exemple: 123456'
+        alphanumeric: 'Exemple: 123ABC'
     password_toggle:
       label: Mot de passe
       toggle_label: Afficher le mot de passe

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -125,7 +125,6 @@ en:
       totp_step_4: Enter the temporary code from your app
     two_factor:
       backup_code: Security code
-      code: One-time code
       personal_key: Personal key
       try_again: Use another phone number
     validation:
@@ -137,7 +136,7 @@ en:
       title: Confirm your account
       welcome_back: Welcome back
       welcome_back_description: '<p>If you have received your letter, please enter
-        your one-time code below. </p>  <p>If your letter hasn’t arrived yet,
+        your one-time code below. </p><p>If your letter hasn’t arrived yet,
         please be patient as <strong>letters typically take 3 to 7 business days
         to arrive</strong>. Thank you for your patience.</p>'
     webauthn_delete:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -133,7 +133,6 @@ es:
       totp_step_4: Ingrese el código temporal de su aplicación
     two_factor:
       backup_code: Código de seguridad
-      code: Código de un solo uso
       personal_key: Clave personal
       try_again: Use otro número de teléfono.
     validation:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -134,7 +134,6 @@ fr:
       totp_step_4: Entrez le code temporaire de votre application
     two_factor:
       backup_code: Code de sécurité
-      code: Code à usage unique
       personal_key: Clé personnelle
       try_again: Utilisez un autre numéro de téléphone
     validation:

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -58,6 +58,30 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
     end
   end
 
+  describe 'hint' do
+    it 'includes hint text as a descriptor of the field' do
+      descriptors = rendered.
+        at_css('.one-time-code-input__input')['aria-describedby'].
+        split(' ').
+        map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+
+      expect(descriptors).to include t('components.one_time_code_input.hint.numeric')
+    end
+
+    context 'numeric is false' do
+      let(:options) { { numeric: false } }
+
+      it 'includes hint text as a descriptor of the field' do
+        descriptors = rendered.
+          at_css('.one-time-code-input__input')['aria-describedby'].
+          split(' ').
+          map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+
+        expect(descriptors).to include t('components.one_time_code_input.hint.alphanumeric')
+      end
+    end
+  end
+
   describe 'transport' do
     context 'omitted' do
       it 'renders default sms transport' do

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -60,24 +60,18 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
 
   describe 'hint' do
     it 'includes hint text as a descriptor of the field' do
-      descriptors = rendered.
-        at_css('.one-time-code-input__input')['aria-describedby'].
-        split(' ').
-        map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+      field = rendered.at_css('.one-time-code-input__input')
 
-      expect(descriptors).to include t('components.one_time_code_input.hint.numeric')
+      expect(field).to have_description t('components.one_time_code_input.hint.numeric')
     end
 
     context 'numeric is false' do
       let(:options) { { numeric: false } }
 
       it 'includes hint text as a descriptor of the field' do
-        descriptors = rendered.
-          at_css('.one-time-code-input__input')['aria-describedby'].
-          split(' ').
-          map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+        field = rendered.at_css('.one-time-code-input__input')
 
-        expect(descriptors).to include t('components.one_time_code_input.hint.alphanumeric')
+        expect(field).to have_description t('components.one_time_code_input.hint.alphanumeric')
       end
     end
   end

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -122,7 +122,7 @@ describe 'Add a new phone number' do
     expect(input.value).to eq('+81 543543643')
     expect(hidden_select.value).to eq('JP')
     click_continue
-    expect(page).to have_content(t('forms.two_factor.code'))
+    expect(page).to have_content(t('components.one_time_code_input.label'))
   end
 
   scenario 'Displays an error message when max phone numbers are reached' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -581,7 +581,7 @@ feature 'Two Factor Authentication' do
     end
 
     def submit_wrong_otp
-      fill_in t('forms.two_factor.code'), with: wrong_phone_otp
+      fill_in t('components.one_time_code_input.label'), with: wrong_phone_otp
       click_submit_default
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -270,12 +270,12 @@ module Features
 
     def fill_in_code_with_last_phone_otp
       accept_rules_of_use_and_continue_if_displayed
-      fill_in I18n.t('forms.two_factor.code'), with: last_phone_otp
+      fill_in I18n.t('components.one_time_code_input.label'), with: last_phone_otp
     end
 
     def fill_in_code_with_last_totp(user)
       accept_rules_of_use_and_continue_if_displayed
-      fill_in I18n.t('forms.two_factor.code'), with: last_totp(user)
+      fill_in I18n.t('components.one_time_code_input.label'), with: last_totp(user)
     end
 
     def accept_rules_of_use_and_continue_if_displayed

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -24,6 +24,23 @@ RSpec::Matchers.define :label_required_fields do
   end
 end
 
+RSpec::Matchers.define :have_description do |description|
+  def descriptors(element)
+    element['aria-describedby']&.
+      split(' ')&.
+      map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+  end
+
+  match { |element| descriptors(element)&.include?(description) }
+
+  failure_message do |element|
+    <<-STR.squish
+      Expected element would have `aria-describedby` description "#{description}".
+      Found #{descriptors(element)}.
+    STR
+  end
+end
+
 RSpec::Matchers.define :be_uniquely_titled do
   # Attempts to validate conformance to WCAG Success Criteria 2.4.2: Page Titled
   #


### PR DESCRIPTION
## 🎫 Ticket

[LG-8066](https://cm-jira.usa.gov/browse/LG-8066)

## 🛠 Summary of changes

Adds an example hint for one-time code input fields.

(Branch temporarily merges to proposed changes in #7469. The idea would be to merge #7469 first, then rebase this against `main`)

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in to an account which has OTP or TOTP authenticator enabled
3. (If not prompted for MFA, click "Forget browsers", confirm, sign out, and repeat Step 2)
4. Observe hint example when prompted for MFA

## 👀 Screenshots

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/207068008-da1f8c3f-c62d-43fa-aa5c-bb24046d97f7.png)|![Screen Shot 2022-12-12 at 9 14 55 AM](https://user-images.githubusercontent.com/1779930/207068044-98e0a53f-ad39-4b2f-8098-5456b84e4f40.png)
