### PR TITLE
Fix typo in inherited proofing text

### DIFF
--- a/config/locales/inherited_proofing/en.yml
+++ b/config/locales/inherited_proofing/en.yml
@@ -50,7 +50,8 @@ en:
         your information.
       verify_identity: We’ll retrieve your personal information from %{sp_name} and
         ask you to verify it.
-      welcome_html: '%{sp_name} - not someone pretending to be you.'
+      welcome_html: '%{sp_name} needs to make sure you are you - not someone
+        pretending to be you.'
     instructions:
       consent: By checking this box, you are letting login.gov ask for, use, keep, and
         share your personal information. We will only use it to verify your


### PR DESCRIPTION
Small typo I noticed during a demo. Probably a bad rebase at some point.

changelog: Internal, Inherited Proofing, Text Updates

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
