### PR TITLE
Enforce consistent hash line breaks with Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -235,6 +235,9 @@ Layout/MultilineHashBraceLayout:
   Enabled: true
   EnforcedStyle: symmetrical
 
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
 Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -253,7 +253,8 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def update_phone_attributes
     UpdateUser.new(
       user: current_user,
-      attributes: { phone_id: user_session[:phone_id], phone: user_session[:unconfirmed_phone],
+      attributes: { phone_id: user_session[:phone_id],
+                    phone: user_session[:unconfirmed_phone],
                     phone_confirmed_at: Time.zone.now,
                     otp_make_default_number: selected_otp_make_default_number },
     ).call

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -93,7 +93,8 @@ describe Idv::InPerson::UspsLocationsController do
     subject(:response) do
       post :index, params: { address: { street_address: '1600 Pennsylvania Ave',
                                         city: 'Washington',
-                                        state: 'DC', zip_code: '20500' } }
+                                        state: 'DC',
+                                        zip_code: '20500' } }
     end
 
     before do
@@ -139,7 +140,8 @@ describe Idv::InPerson::UspsLocationsController do
           response = post :index,
                           params: { address: { street_address: '742 Evergreen Terrace',
                                                city: 'Springfield',
-                                               state: 'MO', zip_code: '89011' } }
+                                               state: 'MO',
+                                               zip_code: '89011' } }
           json = response.body
           facilities = JSON.parse(json)
           expect(facilities.length).to eq 0

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -26,8 +26,10 @@ describe SignUp::CompletionsController do
           user = create(:user)
           stub_sign_in(user)
           subject.session[:sp] = {
-            issuer: current_sp.issuer, ial2: false, requested_attributes: [:email],
-            request_url: 'http://localhost:3000'
+            issuer: current_sp.issuer,
+            ial2: false,
+            requested_attributes: [:email],
+            request_url: 'http://localhost:3000',
           }
           get :show
 
@@ -53,8 +55,10 @@ describe SignUp::CompletionsController do
         before do
           stub_sign_in(user)
           subject.session[:sp] = {
-            issuer: current_sp.issuer, ial2: true, requested_attributes: [:email],
-            request_url: 'http://localhost:3000'
+            issuer: current_sp.issuer,
+            ial2: true,
+            requested_attributes: [:email],
+            request_url: 'http://localhost:3000',
           }
           allow(controller).to receive(:user_session).and_return('decrypted_pii' => pii.to_json)
         end
@@ -114,7 +118,9 @@ describe SignUp::CompletionsController do
         user = create(:user)
         sp = create(:service_provider, issuer: 'https://awesome')
         stub_sign_in(user)
-        subject.session[:sp] = { issuer: sp.issuer, ial2: false, requested_attributes: [:email],
+        subject.session[:sp] = { issuer: sp.issuer,
+                                 ial2: false,
+                                 requested_attributes: [:email],
                                  request_url: 'http://localhost:3000' }
         get :show
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -62,7 +62,8 @@ describe SignUp::RegistrationsController, devise: true do
       end
 
       it 'sets the users preferred email locale and sends an email in that locale' do
-        post :create, params: { user: { email: 'test@test.com', email_language: 'es',
+        post :create, params: { user: { email: 'test@test.com',
+                                        email_language: 'es',
                                         terms_accepted: '1' } }
 
         expect(User.find_with_email('test@test.com').email_language).to eq('es')

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -44,7 +44,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         it 'tracks an analytics event' do
           get :show, params: { platform: true }
           result = { context: 'authentication',
-                     multi_factor_auth_method: 'webauthn_platform', webauthn_configuration_id: nil }
+                     multi_factor_auth_method: 'webauthn_platform',
+                     webauthn_configuration_id: nil }
           expect(@analytics).to have_received(:track_event).with(
             'Multi-Factor Authentication: enter webAuthn authentication visited',
             result,
@@ -75,8 +76,11 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           credential_public_key: credential_public_key,
         )
         allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
-        result = { context: 'authentication', errors: {}, multi_factor_auth_method: 'webauthn',
-                   success: true, webauthn_configuration_id: webauthn_configuration.id }
+        result = { context: 'authentication',
+                   errors: {},
+                   multi_factor_auth_method: 'webauthn',
+                   success: true,
+                   webauthn_configuration_id: webauthn_configuration.id }
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(result)
         expect(@analytics).to receive(:track_event).
@@ -99,9 +103,11 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           platform_authenticator: true,
         )
         allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
-        result = { context: 'authentication', errors: {},
+        result = { context: 'authentication',
+                   errors: {},
                    multi_factor_auth_method: 'webauthn_platform',
-                   success: true, webauthn_configuration_id: WebauthnConfiguration.first.id }
+                   success: true,
+                   webauthn_configuration_id: WebauthnConfiguration.first.id }
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(result)
         expect(@analytics).to receive(:track_event).
@@ -123,8 +129,11 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           credential_public_key: credential_public_key,
         )
 
-        result = { context: 'authentication', errors: {}, multi_factor_auth_method: 'webauthn',
-                   success: false, webauthn_configuration_id: webauthn_configuration.id }
+        result = { context: 'authentication',
+                   errors: {},
+                   multi_factor_auth_method: 'webauthn',
+                   success: false,
+                   webauthn_configuration_id: webauthn_configuration.id }
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(result)
 

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -18,11 +18,15 @@ describe Idv::DocPiiForm do
     }
   end
   let(:name_errors_pii) do
-    { first_name: nil, last_name: nil, dob: valid_dob,
+    { first_name: nil,
+      last_name: nil,
+      dob: valid_dob,
       state: Faker::Address.state_abbr }
   end
   let(:name_and_dob_errors_pii) do
-    { first_name: nil, last_name: nil, dob: nil,
+    { first_name: nil,
+      last_name: nil,
+      dob: nil,
       state: Faker::Address.state_abbr }
   end
   let(:dob_min_age_error_pii) do

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -31,7 +31,9 @@ describe Reports::SpActiveUsersReport do
       user_id: 4, service_provider: issuer, uuid: 'foo4',
       last_ial2_authenticated_at: authenticated_time
     )
-    result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
+    result = [{ issuer: issuer,
+                app_id: app_id,
+                total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json
 
     expect(subject.perform(job_date)).to eq(result)
@@ -73,7 +75,9 @@ describe Reports::SpActiveUsersReport do
       last_ial2_authenticated_at: current_fiscal_year
     )
 
-    result = [{ issuer: issuer, app_id: app_id, total_ial1_active: 2,
+    result = [{ issuer: issuer,
+                app_id: app_id,
+                total_ial1_active: 2,
                 total_ial2_active: 3 }].to_json
 
     expect(subject.perform(job_date)).to eq(result)

--- a/spec/services/db/identity/sp_active_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_active_user_counts_spec.rb
@@ -30,7 +30,9 @@ describe Db::Identity::SpActiveUserCounts do
       last_ial1_authenticated_at: now
     )
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 2, total_ial2_active: 0 }.to_json
-    result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 1,
+    result2 = { issuer: issuer2,
+                app_id: app_id2,
+                total_ial1_active: 1,
                 total_ial2_active: 0 }.to_json
 
     tuples = subject.call(fiscal_start_date)
@@ -56,7 +58,9 @@ describe Db::Identity::SpActiveUserCounts do
       last_ial2_authenticated_at: now
     )
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 0, total_ial2_active: 2 }.to_json
-    result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 0,
+    result2 = { issuer: issuer2,
+                app_id: app_id2,
+                total_ial1_active: 0,
                 total_ial2_active: 1 }.to_json
 
     tuples = subject.call(fiscal_start_date)
@@ -86,7 +90,9 @@ describe Db::Identity::SpActiveUserCounts do
       last_ial2_authenticated_at: now
     )
     result = { issuer: issuer, app_id: app_id1, total_ial1_active: 2, total_ial2_active: 1 }.to_json
-    result2 = { issuer: issuer2, app_id: app_id2, total_ial1_active: 1,
+    result2 = { issuer: issuer2,
+                app_id: app_id2,
+                total_ial1_active: 1,
                 total_ial2_active: 2 }.to_json
 
     tuples = subject.call(fiscal_start_date)

--- a/spec/services/gpo_confirmation_maker_spec.rb
+++ b/spec/services/gpo_confirmation_maker_spec.rb
@@ -7,10 +7,15 @@ describe GpoConfirmationMaker do
   let(:zipcode) { '12345' }
   let(:decrypted_attributes) do
     {
-      address1: '123 main st', address2: '',
-      city: 'Baton Rouge', state: 'Louisiana', zipcode: zipcode,
-      first_name: 'Robert', last_name: 'Robertson',
-      otp: otp, issuer: issuer
+      address1: '123 main st',
+      address2: '',
+      city: 'Baton Rouge',
+      state: 'Louisiana',
+      zipcode: zipcode,
+      first_name: 'Robert',
+      last_name: 'Robertson',
+      otp: otp,
+      issuer: issuer,
     }
   end
   let(:pii) do


### PR DESCRIPTION
## 🛠 Summary of changes

Configures Rubocop to enable the [`Layout/MultilineHashKeyLineBreaks` cop](https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilinehashkeylinebreaks).

Why?

- Legibility
- Maintainability
- Consistency

Prior discussion: https://github.com/18F/identity-idp/pull/7441#discussion_r1041479775

## 📜 Testing Plan

- `bundle exec rubocop` passes