### PR TITLE
Remove unused textarea CSS styles

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -2,18 +2,13 @@ $radio-checkbox-space: 1.5rem;
 
 @include at-media('tablet') {
   input,
-  select,
-  textarea {
+  select {
     font-size: $form-field-font-size-sm;
   }
 }
 
 legend {
   font-weight: $heading-font-weight;
-}
-
-textarea {
-  resize: vertical;
 }
 
 .field {
@@ -64,8 +59,7 @@ input::-webkit-inner-spin-button {
 }
 
 // Upstream: https://github.com/18F/identity-style-guide/pull/325
-.usa-input,
-.usa-textarea {
+.usa-input {
   margin-top: units(0.5);
 }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused CSS styles.

There are no textareas in the application, so these styles are irrelevant. We can reconsider if and when they become relevant.

Benefits:

- Reduce size of main application stylesheet, which is the largest asset on the critical path
- Avoid global element CSS selectors
- Migrate toward design system and eventual removal of this file altogether