### PR TITLE
Consistently render legend elements as design system labels

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -7,10 +7,6 @@ $radio-checkbox-space: 1.5rem;
   }
 }
 
-legend {
-  font-weight: $heading-font-weight;
-}
-
 .field {
   background-color: #f2f9ff;
   border-style: solid;

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -1,6 +1,5 @@
 $line-height: 1.5 !default;
 $bold-font-weight: bold !default;
-$heading-font-weight: bold !default;
 
 $h1: 1.5rem !default;
 $h2: 1.25rem !default;

--- a/app/views/users/edit_phone/_delivery_preference_selection.html.erb
+++ b/app/views/users/edit_phone/_delivery_preference_selection.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
-    <legend class="margin-bottom-1">
+    <legend class="usa-label margin-bottom-1">
       <%= t('two_factor_authentication.otp_delivery_preference.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_delivery_preference_instruction">

--- a/app/views/users/edit_phone/_make_default_number.html.erb
+++ b/app/views/users/edit_phone/_make_default_number.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
-    <legend class="margin-bottom-1">
+    <legend class="usa-label margin-bottom-1">
       <% if @edit_phone_form.one_phone_configured? %>
         <%= t('two_factor_authentication.otp_make_default_number.one_number_title') %>
       <% else %>

--- a/app/views/users/shared/_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.erb
@@ -5,7 +5,7 @@
 
 <div class="js-otp-delivery-preferences margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
-    <legend class="margin-bottom-1">
+    <legend class="usa-label margin-bottom-1">
       <%= t('two_factor_authentication.otp_delivery_preference.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_delivery_preference_instruction">

--- a/app/views/users/shared/_otp_make_default_number.html.erb
+++ b/app/views/users/shared/_otp_make_default_number.html.erb
@@ -4,7 +4,7 @@
 
 <div class="margin-bottom-4">
   <fieldset class="margin-0 padding-0 border-0">
-    <legend class="margin-bottom-1">
+    <legend class="usa-label margin-bottom-1">
       <%= t('two_factor_authentication.otp_make_default_number.title') %>
     </legend>
     <p class="margin-top-0 margin-bottom-2" id="otp_make_default_number_instruction">


### PR DESCRIPTION
## 🛠 Summary of changes

Removes global styling for `legend` elements.

Benefits:

- Reduce size of main application stylesheet, which is the largest asset on the critical path
- Avoid global element CSS selectors
- Migrate toward design system and eventual removal of this file altogether
- Consistency of radio button display, some of which are already using these styles:
   - https://github.com/18F/identity-idp/blob/3a636640bce084f37b19992037c934faae9c1930/config/initializers/simple_form.rb#L52

## 📜 Testing Plan

- Spot-check phone number pages "Make default phone" and "Delivery preference" labels