### PR TITLE
LG-8312 Drop the device profiling enabled column from service providers

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -20,8 +20,7 @@ class ResolutionProofingJob < ApplicationJob
     user_id: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,
-    issuer: nil, # rubocop:disable Lint:UnusedMethodArgument
-    dob_year_only: false # rubocop:disable Lint:UnusedMethodArgument
+    issuer: nil # rubocop:disable Lint:UnusedMethodArgument
   )
     timer = JobHelpers::Timer.new
 

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -16,8 +16,6 @@ class ServiceProvider < ApplicationRecord
            primary_key: 'issuer',
            dependent: :destroy
 
-  self.ignored_columns = [:device_profiling_enabled]
-
   # Do not define validations in this model.
   # See https://github.com/18F/identity_validations
   include IdentityValidations::ServiceProviderValidation

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -10,8 +10,7 @@ module Idv
       trace_id:,
       user_id:,
       threatmetrix_session_id:,
-      request_ip:,
-      issuer:
+      request_ip:
     )
       document_capture_session.create_proofing_session
 
@@ -27,7 +26,6 @@ module Idv
         user_id: user_id,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
-        issuer: issuer,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -200,7 +200,6 @@ module Idv
           user_id: user_id,
           threatmetrix_session_id: flow_session[:threatmetrix_session_id],
           request_ip: request.remote_ip,
-          issuer: sp_session[:issuer],
         )
       end
 

--- a/db/primary_migrate/20221214161643_drop_device_profiling_enabled_from_service_providers.rb
+++ b/db/primary_migrate/20221214161643_drop_device_profiling_enabled_from_service_providers.rb
@@ -1,0 +1,5 @@
+class DropDeviceProfilingEnabledFromServiceProviders < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :service_providers, :device_profiling_enabled, :boolean, default: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_06_223643) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_14_161643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -527,7 +527,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_06_223643) do
     t.boolean "email_nameid_format_allowed", default: false
     t.boolean "use_legacy_name_id_behavior", default: false
     t.boolean "irs_attempts_api_enabled"
-    t.boolean "device_profiling_enabled", default: false
     t.boolean "in_person_proofing_enabled", default: false
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end


### PR DESCRIPTION
A previous commit stopped reads from this column and ignored it. This commit goes back and cleans it up entirely.

This commit also cleans up some job arguments that we changed in the same commit that stopped reads from this column.

PR that stopped use of this column: https://github.com/18F/identity-idp/pull/7446

[skip changelog]
