### PR TITLE
Lg-7579 aria describedby

### DIFF
--- a/app/components/validated_field_component.html.erb
+++ b/app/components/validated_field_component.html.erb
@@ -20,7 +20,7 @@
               invalid: false,
               describedby: [
                 *tag_options.dig(:input_html, :aria, :describedby),
-                tag_options[:hint].present? ? "validated-field-hint-#{unique_id}" : "",
+                tag_options[:hint].present? ? "validated-field-hint-#{unique_id}" : '',
               ],
             },
           },

--- a/app/components/validated_field_component.html.erb
+++ b/app/components/validated_field_component.html.erb
@@ -1,4 +1,4 @@
-<lg-validated-field>
+<%= content_tag :'lg-validated-field', 'error-id': "validated-field-error-#{unique_id}", **tag_options do -%>
   <%= content_tag(
         :script,
         error_messages.to_json,
@@ -20,8 +20,7 @@
               invalid: false,
               describedby: [
                 *tag_options.dig(:input_html, :aria, :describedby),
-                "validated-field-error-#{unique_id}",
-                "validated-field-hint-#{unique_id}",
+                tag_options[:hint].present? ? "validated-field-hint-#{unique_id}" : "",
               ],
             },
           },
@@ -31,4 +30,4 @@
           error_html: { id: "validated-field-error-#{unique_id}" },
         ),
       ) %>
-</lg-validated-field>
+<% end -%>

--- a/app/javascript/packages/validated-field/validated-field-element.ts
+++ b/app/javascript/packages/validated-field/validated-field-element.ts
@@ -145,8 +145,15 @@ class ValidatedFieldElement extends HTMLElement {
 
       const errorId = this.getAttribute('error-id');
 
+      const descriptorId = (this.descriptorId?.split(' ') || []).find(
+        (id) => document.getElementById(id) === null,
+      );
+
       if (errorId) {
         this.errorMessage.id = errorId;
+      }
+      if (!errorId && descriptorId) {
+        this.errorMessage.id = descriptorId;
       }
 
       if (this.input && TEXT_LIKE_INPUT_TYPES.has(this.input.type)) {

--- a/app/javascript/packages/validated-field/validated-field-element.ts
+++ b/app/javascript/packages/validated-field/validated-field-element.ts
@@ -69,11 +69,34 @@ class ValidatedFieldElement extends HTMLElement {
   setErrorMessage(message?: string | null) {
     if (message) {
       this.getOrCreateErrorMessageElement().textContent = message;
+      this.showAriaDescribedByError();
       if (this.errorMessage?.style.display === 'none') {
         this.errorMessage.style.display = '';
       }
     } else if (this.errorMessage) {
       this.errorMessage.style.display = 'none';
+      this.hideAriaDescribedByError();
+    }
+  }
+
+  private showAriaDescribedByError() {
+    const aria = this.input?.getAttribute('aria-describedby');
+    const errorId = this.getAttribute('error-id');
+    const ariaContents = aria?.split(/s+/) || [];
+    if (errorId && this.input && !ariaContents.includes(errorId)) {
+      this.input?.setAttribute('aria-describedby', [...ariaContents, errorId].join(' '));
+    }
+  }
+
+  private hideAriaDescribedByError() {
+    const aria = this.input?.getAttribute('aria-describedby');
+    const errorId = this.getAttribute('error-id');
+    const ariaContents = aria?.split(/s+/) || [];
+    if (errorId && this.input && ariaContents.includes(errorId)) {
+      this.input?.setAttribute(
+        'aria-describedby',
+        ariaContents.filter((e) => e !== errorId).join(' '),
+      );
     }
   }
 
@@ -120,13 +143,12 @@ class ValidatedFieldElement extends HTMLElement {
       this.errorMessage = this.ownerDocument.createElement('div');
       this.errorMessage.classList.add('usa-error-message');
 
-      const descriptorId = (this.descriptorId?.split(' ') || []).find(
-        (id) => document.getElementById(id) === null,
-      );
+      const errorId = this.getAttribute('error-id');
 
-      if (descriptorId) {
-        this.errorMessage.id = descriptorId;
+      if (errorId) {
+        this.errorMessage.id = errorId;
       }
+
       if (this.input && TEXT_LIKE_INPUT_TYPES.has(this.input.type)) {
         this.errorMessage.style.maxWidth = `${this.input.offsetWidth}px`;
       }

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe ValidatedFieldComponent, type: :component do
     expect(field.attributes).to_not include('aria-describedby')
   end
 
+  it 'includes error-id' do
+    field = rendered.at_css('lg-validated-field')
+
+    expect(field.attr('error-id')).to include('validated-field-error-')
+  end
+
   describe 'error message strings' do
     subject(:strings) do
       script = rendered.at_css('script[type="application/json"]')
@@ -68,15 +74,15 @@ RSpec.describe ValidatedFieldComponent, type: :component do
 
   context 'with tag options' do
     context 'with aria tag option' do
-      let(:tag_options) { { input_html: { aria: { describedby: 'foo', invalid: 'true' } }, hint: 'hint' } }
-      let(:input) {}
+      let(:tag_options) do
+        { input_html: { aria: { describedby: 'foo', invalid: true } }, hint: 'hint' }
+      end
+      let(:input) { { aria: { invalid: true } } }
       let(:error_messages) { { valueMissing: 'missing' } }
 
-      # want to ensure validated-field-error is present when input is invalid
       it 'merges aria-describedby with the one applied by the field' do
         field = rendered.at_css('input')
 
-        expect(field.attr('aria-describedby')).to include('validated-field-error-')
         expect(field.attr('aria-describedby')).to include('foo')
       end
 
@@ -86,7 +92,6 @@ RSpec.describe ValidatedFieldComponent, type: :component do
         expect(tag_options).to include(:hint)
         expect(field.attr('aria-describedby')).to include('validated-field-hint-')
       end
-
     end
   end
 end

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -75,10 +75,8 @@ RSpec.describe ValidatedFieldComponent, type: :component do
   context 'with tag options' do
     context 'with aria tag option' do
       let(:tag_options) do
-        { input_html: { aria: { describedby: 'foo', invalid: true } }, hint: 'hint' }
+        { input_html: { aria: { describedby: 'foo' } }, hint: 'hint' }
       end
-      let(:input) { { aria: { invalid: true } } }
-      let(:error_messages) { { valueMissing: 'missing' } }
 
       it 'merges aria-describedby with the one applied by the field' do
         field = rendered.at_css('input')

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -25,13 +25,10 @@ RSpec.describe ValidatedFieldComponent, type: :component do
     render_inline(described_class.new(**options))
   end
 
-  it 'renders aria-describedby to establish connection between input and error message' do
+  it 'does not render aria-describedby when component is first rendered' do
     field = rendered.at_css('input')
 
-    expect(field.attr('aria-describedby').split(' ')).to include(
-      start_with('validated-field-hint-'),
-      start_with('validated-field-error-'),
-    )
+    expect(field.attributes).to_not include('aria-describedby')
   end
 
   describe 'error message strings' do
@@ -71,14 +68,25 @@ RSpec.describe ValidatedFieldComponent, type: :component do
 
   context 'with tag options' do
     context 'with aria tag option' do
-      let(:tag_options) { { input_html: { aria: { describedby: 'foo' } } } }
+      let(:tag_options) { { input_html: { aria: { describedby: 'foo', invalid: 'true' } }, hint: 'hint' } }
+      let(:input) {}
+      let(:error_messages) { { valueMissing: 'missing' } }
 
+      # want to ensure validated-field-error is present when input is invalid
       it 'merges aria-describedby with the one applied by the field' do
         field = rendered.at_css('input')
 
         expect(field.attr('aria-describedby')).to include('validated-field-error-')
         expect(field.attr('aria-describedby')).to include('foo')
       end
+
+      it 'includes hint in aria-describedby when hint is present in tag options' do
+        field = rendered.at_css('input')
+
+        expect(tag_options).to include(:hint)
+        expect(field.attr('aria-describedby')).to include('validated-field-hint-')
+      end
+
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7579](https://cm-jira.usa.gov/browse/LG-7579)


## 🛠 Summary of changes

This pr addresses two issues with the ValidatedFieldComponent. Currently when the component is first rendered the aria-describedby attribute includes "validated-field-hint-{id}" and "validated-field-error-{id}". The hint id is included even if there  is not a hint, and the error id is included before an actual hint exists. These id's should not be included in aria-describedby unless the hint and error exist. 
To correct the hint issue, a check is added in the validated-field-component.html.erb for the presence of the hint.
For the error issue, the error id is shown when the input is invalid (user has submitted field w/o valid input), and also adds the error id to the element that displays the error (this is to create a connection between the error element and the validated field component). 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Navigate to the state id form
- [ ] run the ibm equal access accessibility checker (plugin)
- [ ] Under "name, role, value" ensure that there is not an error about aria-describedby being invalid
- [ ] do not enter any values in the input fields, click submit button on page 
- [ ] run scan again inn the a11y checker
- [ ] Under "name, role, value" ensure that there is not an error about aria-describedby being invalid

