### PR TITLE
Update GoodJob and re-remove concurrency controls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       rake
     formatador (0.2.5)
     foundation_emails (2.2.1.0)
-    fugit (1.7.1)
+    fugit (1.8.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     geocoder (1.7.0)
@@ -300,7 +300,7 @@ GEM
       ffi (~> 1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    good_job (3.6.0)
+    good_job (3.7.2)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
@@ -714,7 +714,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.26)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
     zonebie (0.6.1)
     zxcvbn (0.1.7)
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -10,14 +10,6 @@ class GetUspsProofingResultsJob < ApplicationJob
   ]
 
   queue_as :long_running
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  good_job_control_concurrency_with(
-    total_limit: 1,
-    key: 'get_usps_proofing_results',
-  )
-
-  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
   def email_analytics_attributes(enrollment)
     {

--- a/app/jobs/gpo_daily_job.rb
+++ b/app/jobs/gpo_daily_job.rb
@@ -1,15 +1,6 @@
 class GpoDailyJob < ApplicationJob
   queue_as :low
 
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  good_job_control_concurrency_with(
-    total_limit: 1,
-    key: -> { "gpo-daily-job-#{arguments.first}" },
-  )
-
-  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-
   # Enqueue a test letter every day, but only upload letters on working weekdays
   def perform(date)
     GpoDailyTestSender.new.run

--- a/app/jobs/in_person/email_reminder_job.rb
+++ b/app/jobs/in_person/email_reminder_job.rb
@@ -7,15 +7,6 @@ module InPerson
 
     queue_as :low
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: 'in_person_email_reminder_job',
-    )
-
-    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-
     def perform(_now)
       return true unless IdentityConfig.store.in_person_proofing_enabled
 

--- a/app/jobs/phone_number_opt_out_sync_job.rb
+++ b/app/jobs/phone_number_opt_out_sync_job.rb
@@ -1,14 +1,5 @@
 class PhoneNumberOptOutSyncJob < ApplicationJob
   queue_as :long_running
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  good_job_control_concurrency_with(
-    total_limit: 1,
-    key: -> do
-      rounded = TimeService.round_time(time: arguments.first, interval: 1.hour)
-      "phone-number-opt-out-sync-#{rounded.to_i}"
-    end,
-  )
 
   def perform(_now)
     all_phone_numbers = Set.new

--- a/app/jobs/psql_stats_job.rb
+++ b/app/jobs/psql_stats_job.rb
@@ -1,16 +1,5 @@
 class PsqlStatsJob < ApplicationJob
   queue_as :default
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  good_job_control_concurrency_with(
-    total_limit: 1,
-    key: -> do
-      rounded = TimeService.round_time(time: arguments.first, interval: 1.minute)
-      "psql_bloat_statistics-#{rounded.to_i}"
-    end,
-  )
-
-  discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
 
   # gather data on bloat for each table
   # https://github.com/ioguix/pgsql-bloat-estimation/blob/master/table/table_bloat.sql

--- a/app/jobs/reports/agreement_summary_report.rb
+++ b/app/jobs/reports/agreement_summary_report.rb
@@ -4,13 +4,6 @@ module Reports
   class AgreementSummaryReport < BaseReport
     REPORT_NAME = 'agreement-summary-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date)
       csv = build_report
 

--- a/app/jobs/reports/base_report.rb
+++ b/app/jobs/reports/base_report.rb
@@ -4,9 +4,6 @@ module Reports
   class BaseReport < ApplicationJob
     queue_as :long_running
 
-    # We use good_job's concurrency features to cancel "extra" or duplicative runs of the same job
-    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-
     def self.transaction_with_timeout(rails_env = Rails.env)
       # rspec-rails's use_transactional_tests does not seem to act as expected when switching
       # connections mid-test, so we just skip for now :[

--- a/app/jobs/reports/combined_invoice_supplement_report.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report.rb
@@ -4,13 +4,6 @@ module Reports
   class CombinedInvoiceSupplementReport < BaseReport
     REPORT_NAME = 'combined-invoice-supplement-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date)
       iaas = IaaReportingHelper.iaas
 

--- a/app/jobs/reports/daily_auths_report.rb
+++ b/app/jobs/reports/daily_auths_report.rb
@@ -2,13 +2,6 @@ module Reports
   class DailyAuthsReport < BaseReport
     REPORT_NAME = 'daily-auths-report'
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     attr_reader :report_date
 
     def perform(report_date)

--- a/app/jobs/reports/daily_dropoffs_report.rb
+++ b/app/jobs/reports/daily_dropoffs_report.rb
@@ -18,13 +18,6 @@ module Reports
       verified
     ].freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     attr_reader :report_date
 
     def perform(report_date)

--- a/app/jobs/reports/deleted_user_accounts_report.rb
+++ b/app/jobs/reports/deleted_user_accounts_report.rb
@@ -5,13 +5,6 @@ module Reports
   class DeletedUserAccountsReport < BaseReport
     REPORT_NAME = 'deleted-user-accounts-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date)
       configs = IdentityConfig.store.deleted_user_accounts_report_configs
       configs.each do |report_hash|

--- a/app/jobs/reports/irs_weekly_summary_report.rb
+++ b/app/jobs/reports/irs_weekly_summary_report.rb
@@ -5,13 +5,6 @@ module Reports
     attr_reader :report_date
     REPORT_NAME = 'irs-weekly-summary-report'
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(report_date)
       @name = REPORT_NAME
       @report_date = report_date

--- a/app/jobs/reports/monthly_gpo_letter_requests_report.rb
+++ b/app/jobs/reports/monthly_gpo_letter_requests_report.rb
@@ -4,13 +4,6 @@ module Reports
   class MonthlyGpoLetterRequestsReport < BaseReport
     REPORT_NAME = 'monthly-usps-letter-requests-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date, start_time: first_of_this_month, end_time: end_of_today)
       daily_results = transaction_with_timeout do
         ::LetterRequestsToGpoFtpLog.where(ftp_at: start_time..end_time)

--- a/app/jobs/reports/sp_active_users_report.rb
+++ b/app/jobs/reports/sp_active_users_report.rb
@@ -4,13 +4,6 @@ module Reports
   class SpActiveUsersReport < BaseReport
     REPORT_NAME = 'sp-active-users-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     # This daily job captures the total number of active users per SP from the beginning of the the
     # current fiscal year until now.
     #

--- a/app/jobs/reports/sp_user_counts_report.rb
+++ b/app/jobs/reports/sp_user_counts_report.rb
@@ -4,13 +4,6 @@ module Reports
   class SpUserCountsReport < BaseReport
     REPORT_NAME = 'sp-user-counts-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date)
       user_counts = transaction_with_timeout do
         Db::Identity::SpUserCounts.call

--- a/app/jobs/reports/total_ial2_costs_report.rb
+++ b/app/jobs/reports/total_ial2_costs_report.rb
@@ -5,13 +5,6 @@ module Reports
     REPORT_NAME = 'total-ial2-costs'.freeze
     NUM_LOOKBACK_DAYS = 45
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(date)
       results = transaction_with_timeout { query(date) }
 

--- a/app/jobs/reports/total_monthly_auths_report.rb
+++ b/app/jobs/reports/total_monthly_auths_report.rb
@@ -4,13 +4,6 @@ module Reports
   class TotalMonthlyAuthsReport < BaseReport
     REPORT_NAME = 'total-monthly-auths-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(_date)
       auth_counts = Db::MonthlySpAuthCount::TotalMonthlyAuthCounts.call
       save_report(REPORT_NAME, auth_counts.to_json, extension: 'json')

--- a/app/jobs/reports/verification_failures_report.rb
+++ b/app/jobs/reports/verification_failures_report.rb
@@ -6,13 +6,6 @@ module Reports
   class VerificationFailuresReport < BaseReport
     REPORT_NAME = 'verification-failures-report'.freeze
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> { "#{REPORT_NAME}-#{arguments.first}" },
-    )
-
     def perform(date)
       csv_reports = []
       configs = IdentityConfig.store.verification_errors_report_configs

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -2,18 +2,6 @@ module AccountReset
   class GrantRequestsAndSendEmails < ApplicationJob
     queue_as :low
 
-    include GoodJob::ActiveJobExtensions::Concurrency
-
-    good_job_control_concurrency_with(
-      total_limit: 1,
-      key: -> do
-        rounded = TimeService.round_time(time: arguments.first, interval: 5.minutes)
-        "grant-requests-and-send-emails-#{rounded.to_i}"
-      end,
-    )
-
-    discard_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-
     def perform(now)
       notifications_sent = 0
       AccountResetRequest.where(

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,7 @@ module Identity
     config.good_job.enable_cron = true
     config.good_job.max_threads = IdentityConfig.store.good_job_max_threads
     config.good_job.queues = IdentityConfig.store.good_job_queues
-    config.good_job.preserve_job_records = true
+    config.good_job.preserve_job_records = false
     config.good_job.queue_select_limit = IdentityConfig.store.good_job_queue_select_limit
     # see config/initializers/job_configurations.rb for cron schedule
 

--- a/spec/jobs/gpo_daily_job_spec.rb
+++ b/spec/jobs/gpo_daily_job_spec.rb
@@ -48,13 +48,4 @@ RSpec.describe GpoDailyJob do
       end
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).to eq("gpo-daily-job-#{date}")
-    end
-  end
 end

--- a/spec/jobs/phone_number_opt_out_sync_job_spec.rb
+++ b/spec/jobs/phone_number_opt_out_sync_job_spec.rb
@@ -32,19 +32,4 @@ RSpec.describe PhoneNumberOptOutSyncJob do
       end
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    it 'is the job name and the current time, rounded to the nearest hour' do
-      now = Time.zone.at(1629817200)
-
-      job_now = PhoneNumberOptOutSyncJob.new(now)
-      expect(job_now.good_job_concurrency_key).to eq("phone-number-opt-out-sync-#{now.to_i}")
-
-      job_plus_30m = PhoneNumberOptOutSyncJob.new(now + 30.minutes)
-      expect(job_plus_30m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
-
-      job_plus_1h = PhoneNumberOptOutSyncJob.new(now + 1.hour)
-      expect(job_plus_1h.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
-    end
-  end
 end

--- a/spec/jobs/reports/agreement_summary_report_spec.rb
+++ b/spec/jobs/reports/agreement_summary_report_spec.rb
@@ -78,14 +78,4 @@ RSpec.describe Reports::AgreementSummaryReport do
       end
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_spec.rb
@@ -215,14 +215,4 @@ RSpec.describe Reports::CombinedInvoiceSupplementReport do
       partner_account: partner_account,
     )
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/daily_auths_report_spec.rb
+++ b/spec/jobs/reports/daily_auths_report_spec.rb
@@ -108,14 +108,4 @@ RSpec.describe Reports::DailyAuthsReport do
       end
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/daily_dropoffs_report_spec.rb
+++ b/spec/jobs/reports/daily_dropoffs_report_spec.rb
@@ -140,14 +140,4 @@ RSpec.describe Reports::DailyDropoffsReport do
       end
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/deleted_user_accounts_report_spec.rb
+++ b/spec/jobs/reports/deleted_user_accounts_report_spec.rb
@@ -38,14 +38,4 @@ describe Reports::DeletedUserAccountsReport do
 
     subject.perform(Time.zone.today)
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -83,16 +83,6 @@ describe Reports::SpActiveUsersReport do
     expect(subject.perform(job_date)).to eq(result)
   end
 
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
-
   describe '#reporting_range' do
     it 'returns entire last fiscal year when it is October 1st' do
       job_date = Date.new(2022, 10, 1)

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -65,14 +65,4 @@ describe Reports::SpUserCountsReport do
 
     expect(subject.perform(Time.zone.today)).to eq(result)
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/total_ial2_costs_report_spec.rb
+++ b/spec/jobs/reports/total_ial2_costs_report_spec.rb
@@ -68,14 +68,4 @@ RSpec.describe Reports::TotalIal2CostsReport do
       report.perform(date)
     end
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/total_monthly_auths_report_spec.rb
+++ b/spec/jobs/reports/total_monthly_auths_report_spec.rb
@@ -34,14 +34,4 @@ describe Reports::TotalMonthlyAuthsReport do
 
     expect(subject.perform(Time.zone.today)).to eq(result)
   end
-
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
 end

--- a/spec/jobs/reports/verification_failures_report_spec.rb
+++ b/spec/jobs/reports/verification_failures_report_spec.rb
@@ -195,16 +195,6 @@ describe Reports::VerificationFailuresReport do
     expect(csv[1]).to eq([uuid, now.to_time.utc.iso8601, 'ABANDON'])
   end
 
-  describe '#good_job_concurrency_key' do
-    let(:date) { Time.zone.today }
-
-    it 'is the job name and the date' do
-      job = described_class.new(date)
-      expect(job.good_job_concurrency_key).
-        to eq("#{described_class::REPORT_NAME}-#{date}")
-    end
-  end
-
   def run_reports
     ServiceProvider.create(issuer: issuer, agency_id: 1, friendly_name: issuer)
     AgencyIdentity.create(agency_id: 1, user_id: user.id, uuid: uuid)

--- a/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
+++ b/spec/services/account_reset/grant_requests_and_send_emails_spec.rb
@@ -70,21 +70,6 @@ describe AccountReset::GrantRequestsAndSendEmails do
     end
   end
 
-  describe '#good_job_concurrency_key' do
-    it 'is the job name and the current time, rounded to the nearest 5 minutes' do
-      now = Time.zone.at(1629819000)
-
-      job_now = AccountReset::GrantRequestsAndSendEmails.new(now)
-      expect(job_now.good_job_concurrency_key).to eq("grant-requests-and-send-emails-#{now.to_i}")
-
-      job_plus_1m = AccountReset::GrantRequestsAndSendEmails.new(now + 1.minute)
-      expect(job_plus_1m.good_job_concurrency_key).to eq(job_now.good_job_concurrency_key)
-
-      job_plus_5m = AccountReset::GrantRequestsAndSendEmails.new(now + 5.minutes)
-      expect(job_plus_5m.good_job_concurrency_key).to_not eq(job_now.good_job_concurrency_key)
-    end
-  end
-
   def before_waiting_the_full_wait_period(now)
     days = IdentityConfig.store.account_reset_wait_period_days.days
     travel_to(now - 1 - days) do


### PR DESCRIPTION
## 🛠 Summary of changes
We removed the concurrency controls in #7197 to improve throughput and reverted it in #7317 as the changes led to double-running cron jobs. GoodJob recently merged https://github.com/bensheldon/good_job/pull/767, which should allow us to safely disable the concurrency controls and job record preservation (since cron jobs are always preserved now).

I've done some initial testing in my sandbox and not seen any double-run issues.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
