### PR TITLE
Move GetUspsProofingResultsJob to long running job queue

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -9,7 +9,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     "State non-driver's identification card",
   ]
 
-  queue_as :default
+  queue_as :long_running
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(


### PR DESCRIPTION
## 🛠 Summary of changes

The `GetUspsProofingResultsJob` is longer-running and should be in the long_running job queue to avoid setting off alarms.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
