### PR TITLE
Send email deletion emails synchronously to avoid missing record errors

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -111,9 +111,13 @@ module Users
     end
 
     def send_delete_email_notification
+      # These emails must be delivered now because the EmailAddress record will not exist
+      # when run asynchronously
       @current_confirmed_emails.each do |confirmed_email|
+        # rubocop:disable IdentityIdp/MailLaterLinter
         UserMailer.with(user: current_user, email_address: confirmed_email).
-          email_deleted.deliver_now_or_later
+          email_deleted.deliver_now
+        # rubocop:enable IdentityIdp/MailLaterLinter
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

When a user deletes an email address, we send email notifications to all email addresses in the account (including the deleted one). This doesn't work so well when we try to send it asynchronously since the EmailAddress record is gone by the time it tries to run ([NewRelic error](https://one.newrelic.com/nr1-core/errors/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058MTA0NDEwMDY1?account=1376370&duration=43200000&state=2d14a545-0514-4c13-62cb-6229d93eed52)).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
