### PR TITLE
remove prepare steps on prepare page

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -1,14 +1,6 @@
 import { useContext, useState } from 'react';
 import type { MouseEventHandler } from 'react';
-import {
-  Alert,
-  Link,
-  IconList,
-  IconListItem,
-  PageHeading,
-  ProcessList,
-  ProcessListItem,
-} from '@18f/identity-components';
+import { Alert, Link, PageHeading, ProcessList, ProcessListItem } from '@18f/identity-components';
 import { removeUnloadProtection } from '@18f/identity-url';
 import { getConfigValue } from '@18f/identity-config';
 import { useI18n } from '@18f/identity-react-i18n';
@@ -64,44 +56,6 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
           headingUnstyled
         />
       </ProcessList>
-
-      <hr className="margin-bottom-4" />
-
-      <h2>{t('in_person_proofing.body.prepare.bring_title')}</h2>
-
-      <IconList>
-        <IconListItem
-          icon="check_circle"
-          title={t('in_person_proofing.body.prepare.bring_barcode_header')}
-        >
-          <p>{t('in_person_proofing.body.prepare.bring_barcode_info')}</p>
-        </IconListItem>
-
-        <IconListItem
-          icon="check_circle"
-          title={t('in_person_proofing.body.prepare.bring_id_header')}
-        >
-          <p>{t('in_person_proofing.body.prepare.bring_id_info_acceptable')}</p>
-          <ul>
-            <li>{t('in_person_proofing.body.prepare.bring_id_info_dl')}</li>
-            <li>{t('in_person_proofing.body.prepare.bring_id_info_id_card')}</li>
-          </ul>
-          <p>{t('in_person_proofing.body.prepare.bring_id_info_no_other_forms')}</p>
-        </IconListItem>
-
-        <IconListItem
-          icon="check_circle"
-          title={t('in_person_proofing.process.proof_of_address.heading')}
-        >
-          <p>{t('in_person_proofing.process.proof_of_address.info')}</p>
-          <ul>
-            {t(['in_person_proofing.process.proof_of_address.acceptable_proof']).map((proof) => (
-              <li key={proof}>{proof}</li>
-            ))}
-          </ul>
-          <p>{t('in_person_proofing.process.proof_of_address.physical_or_digital_copy')}</p>
-        </IconListItem>
-      </IconList>
       {flowPath === 'hybrid' && <FormStepsButton.Continue />}
       {inPersonURL && flowPath === 'standard' && (
         <div className="margin-y-5">

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -45,15 +45,6 @@ en:
         retail_hours_weekday: 'Monday to Friday:'
       prepare:
         alert_selected_post_office: You’ve selected the %{name} Post Office.
-        bring_barcode_header: A copy of your barcode
-        bring_barcode_info: We will give you a unique code that expires within 30 days.
-        bring_id_header: Your state-issued ID
-        bring_id_info_acceptable: 'Your ID must not be expired. Acceptable forms of ID are:'
-        bring_id_info_dl: State Driver’s License
-        bring_id_info_id_card: State Non-Driver’s Identification Card
-        bring_id_info_no_other_forms: We do not currently accept any other forms of
-          Identification, such as passports and military IDs
-        bring_title: 'When you go to the Post Office, please bring:'
         privacy_disclaimer: '%{app_name} is a secure, government website. We and the
           U.S. Postal Service use your data to verify your identity.'
         privacy_disclaimer_link: Learn more about privacy and security.

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -51,16 +51,6 @@ es:
         retail_hours_weekday: 'De Lunes a Viernes:'
       prepare:
         alert_selected_post_office: Ha seleccionado la oficina de correos %{name}.
-        bring_barcode_header: Una copia de su código de barras
-        bring_barcode_info: Le daremos un código único que caducará en 30 días.
-        bring_id_header: Su cédula emitida por el estado
-        bring_id_info_acceptable: 'Su cédula de identidad no debe estar caducada. Las
-          formas de identificación aceptables son:'
-        bring_id_info_dl: Licencia de conducir estatal
-        bring_id_info_id_card: Tarjeta de identificación estatal para no conductores
-        bring_id_info_no_other_forms: Actualmente no aceptamos otras formas de
-          identificación, como pasaportes y cartillas militares.
-        bring_title: 'Cuando vaya a la oficina de correos, lleve:'
         privacy_disclaimer: '%{app_name} es un sitio web seguro del gobierno. Nosotros y
           el Servicio Postal de los Estados Unidos utilizamos sus datos para
           verificar su identidad.'

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -51,17 +51,6 @@ fr:
         retail_hours_weekday: 'Lundi à Vendredi:'
       prepare:
         alert_selected_post_office: Vous avez sélectionné le bureau de poste de %{name}.
-        bring_barcode_header: Une copie de votre code-barres
-        bring_barcode_info: Nous vous donnerons un code unique qui expirera dans les 30 jours.
-        bring_id_header: Votre document d’identité délivré par l’État
-        bring_id_info_acceptable: 'Votre pièce d’identité ne doit pas être expirée. Les
-          formes d’identification acceptables sont:'
-        bring_id_info_dl: Permis de conduire d’État
-        bring_id_info_id_card: Document d’identité de non-conducteur d’État
-        bring_id_info_no_other_forms: Nous n’acceptons actuellement aucune autre forme
-          d’identification, comme les passeports et les documents d’identité
-          militaires.
-        bring_title: 'Lorsque vous allez au bureau de poste, veuillez apporter:'
         privacy_disclaimer: '%{app_name} est un site gouvernemental sécurisé. Nous et le
           service postal américain utilisons vos données pour vérifier votre
           identité.'


### PR DESCRIPTION
## 🎫 Ticket

[Lg-8384](https://cm-jira.usa.gov/browse/LG-8384)


## 🛠 Summary of changes

Remove steps that describe what to do to prepare for in person proofing.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through ipp flow using failing id
- [ ] Make sure prepare page matches design in [figma](https://www.figma.com/file/baXQsBjUKuRE0ADaiYKbeX/LG-8166%3A-A%2FB%3A-Prepare-Page-Instructions-%2F-Test-%235---Prep?node-id=1%3A700&t=MhMZuVvsWbQPU0ig-0)

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="737" alt="Screen Shot 2022-12-15 at 11 23 09 AM" src="https://user-images.githubusercontent.com/20867088/207914110-96a9d5da-66d7-4f89-a0b0-8a4b2869ad01.png">
<img width="643" alt="Screen Shot 2022-12-15 at 11 23 22 AM" src="https://user-images.githubusercontent.com/20867088/207914113-517a8039-3bba-47b4-a46b-36f32369fe2d.png">

</details>

<details>
<summary>After:</summary>
<img width="932" alt="Screen Shot 2022-12-15 at 10 50 35 AM" src="https://user-images.githubusercontent.com/20867088/207911683-ab40c68d-37a3-4a18-976c-421e00bccab1.png">
<img width="990" alt="Screen Shot 2022-12-15 at 10 50 49 AM" src="https://user-images.githubusercontent.com/20867088/207911688-2ce8a8fb-bd71-40af-a4e2-2d1ea0f1691c.png">

</details>

<details>
<summary>Mobile:</summary>
<img width="383" alt="Screen Shot 2022-12-15 at 11 20 13 AM" src="https://user-images.githubusercontent.com/20867088/207913366-09244b55-1b61-4d99-8b50-48eeefbba18a.png">
<img width="370" alt="Screen Shot 2022-12-15 at 11 20 23 AM" src="https://user-images.githubusercontent.com/20867088/207913370-d9a10cd8-ab73-4aba-a896-28aae3ba7f58.png">

</details>
