### PR TITLE
LG-8398 Update screen reader to read headings after user searches for an address

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-locations.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-locations.tsx
@@ -25,7 +25,9 @@ function InPersonLocations({ locations, onSelect, address }: InPersonLocationsPr
   if (locations?.length === 0) {
     return (
       <>
-        <h3>{t('in_person_proofing.body.location.po_search.none_found', { address })}</h3>
+        <h3 role="status">
+          {t('in_person_proofing.body.location.po_search.none_found', { address })}
+        </h3>
         <p>{t('in_person_proofing.body.location.po_search.none_found_tip')}</p>
       </>
     );
@@ -33,7 +35,7 @@ function InPersonLocations({ locations, onSelect, address }: InPersonLocationsPr
 
   return (
     <>
-      <h3>
+      <h3 role="status">
         {t('in_person_proofing.body.location.po_search.results_description', {
           address,
           count: locations?.length,


### PR DESCRIPTION
## 🎫 Ticket
[Update screen reader implementation](https://cm-jira.usa.gov/browse/LG-8398)


## 🛠 Summary of changes
If the user searches for an address on the "Select a location to verify your ID" page.....
- [ ] the screen reader will maintain the user's place on the page
- [ ] if there are no results returned, then the screen reader will read the heading "Sorry, there are no participating Post Offices..."
- [ ] if results are returned, then the screen reader will read the heading "There are %{count} participating Post Offices within 50 miles...."


## 📜 Testing Plan

- [ ]  Navigate to the "Select a location to verify your ID" page
- [ ]  Turn on Voiceover (Command + F5 on macs)
- [ ] Search for an address in the search box and watch the screen reader work

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Screen recording of a search with results returned:</summary>

https://user-images.githubusercontent.com/80347702/207958613-edb4e95e-b8c6-47af-b8a6-d0e58389cf35.mov


</details>

<details>
<summary>Screen recording of a search with no results returned:</summary>

https://user-images.githubusercontent.com/80347702/207958642-1cdbd4c3-5990-460e-a3e9-b6dd8c93a609.mov


</details>

