### PR TITLE
Render ValidatedFieldComponent as aria-invalid when errors exist

### DIFF
--- a/app/components/validated_field_component.html.erb
+++ b/app/components/validated_field_component.html.erb
@@ -17,7 +17,7 @@
           input_html: {
             class: [*tag_options.dig(:input_html, :class), 'validated-field__input'],
             aria: {
-              invalid: false,
+              invalid: has_errors?,
               describedby: aria_describedby_idrefs,
             },
           },

--- a/app/components/validated_field_component.rb
+++ b/app/components/validated_field_component.rb
@@ -26,8 +26,6 @@ class ValidatedFieldComponent < BaseComponent
     idrefs
   end
 
-  private
-
   def has_errors?
     form.object.respond_to?(:errors) && form.object.errors.key?(name)
   end
@@ -43,6 +41,8 @@ class ValidatedFieldComponent < BaseComponent
   def hint_id
     "validated-field-hint-#{unique_id}"
   end
+
+  private
 
   def value_missing_error_message
     case input_type

--- a/app/javascript/packages/validated-field/validated-field-element.ts
+++ b/app/javascript/packages/validated-field/validated-field-element.ts
@@ -46,7 +46,11 @@ class ValidatedFieldElement extends HTMLElement {
   }
 
   get descriptorIdRefs(): string[] {
-    return this?.input?.getAttribute('aria-describedby')?.split(' ').filter(Boolean) || [];
+    return this.input?.getAttribute('aria-describedby')?.split(' ').filter(Boolean) || [];
+  }
+
+  get isValid(): boolean {
+    return this.input?.getAttribute('aria-invalid') !== 'true';
   }
 
   /**
@@ -88,6 +92,10 @@ class ValidatedFieldElement extends HTMLElement {
    * @param isValid Whether input is valid.
    */
   setInputIsValid(isValid: boolean) {
+    if (isValid === this.isValid) {
+      return;
+    }
+
     this.input?.classList.toggle('usa-input--error', !isValid);
     this.input?.setAttribute('aria-invalid', String(!isValid));
 

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe ValidatedFieldComponent, type: :component do
     expect(field.attr('aria-describedby')).to be_blank
   end
 
+  it 'is not rendered as invalid' do
+    field = rendered.at_css('input')
+
+    expect(field.attr('aria-invalid')).to eq('false')
+  end
+
   context 'when form has errors for field' do
     let(:error_message) { 'Field is required' }
 
@@ -42,6 +48,12 @@ RSpec.describe ValidatedFieldComponent, type: :component do
       field = rendered.at_css('input')
 
       expect(field).to have_description error_message
+    end
+
+    it 'is rendered as invalid' do
+      field = rendered.at_css('input')
+
+      expect(field.attr('aria-invalid')).to eq('true')
     end
 
     context 'with aria tag option' do


### PR DESCRIPTION
Follow-up to #7484

## 🛠 Summary of changes

Updates `ValidatedFieldComponent` to ensure `aria-invalid` is a reliable indicator of input validity.

Essentially, this aligns the server-rendered implementation to what the JavaScript implementation was already doing by setting `aria-invalid` based on the validity of the field ([source](https://github.com/18F/identity-idp/blob/69a3016076d6c17bbac8b81b0aed5b9f32e6710d/app/javascript/packages/validated-field/validated-field-element.ts#L92)).

By doing so, it opened up the opportunity to make a small optimization to the JavaScript implementation to avoid continued updates to the element when validity state is not changing. While the logic was not substantial, it was touching the DOM, and doing so on every input event (every keystroke) ([source](https://github.com/18F/identity-idp/blob/69a3016076d6c17bbac8b81b0aed5b9f32e6710d/app/javascript/packages/validated-field/validated-field-element.ts#L40)).

## 📜 Testing Plan

Server-rendered errors from `ValidatedFieldComponent` are not commonly encountered since client-side validation will typically catch any issues prior to a submission. You can test simulated VOIP phone detection though when adding a phone.

1. Go to http://localhost:3000
2. Sign in or create a new account
  a. If signing in, proceed to "Add a phone number"
  b. If creating a new account, choose "Phone" as MFA
3. When prompted to enter a phone number, enter "2255552000"
4. Submit
5. Inspect the input field in browser developer tools
6. Observe `aria-invalid="true"` (previously `aria-invalid="false"`)
