### PR TITLE
LG-7483: Remove feature flag select_multiple_mfa_options

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -2,7 +2,7 @@ module MfaSetupConcern
   extend ActiveSupport::Concern
 
   def next_setup_path
-    if user_needs_confirmation_screen?
+    if suggest_second_mfa?
       auth_method_confirmation_url
     elsif next_setup_choice
       confirmation_path
@@ -43,11 +43,6 @@ module MfaSetupConcern
     return if user_fully_authenticated?
     return unless MfaPolicy.new(current_user).two_factor_enabled?
     redirect_to user_two_factor_authentication_url
-  end
-
-  def user_needs_confirmation_screen?
-    suggest_second_mfa? &&
-      IdentityConfig.store.select_multiple_mfa_options
   end
 
   def in_multi_mfa_selection_flow?

--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -6,7 +6,6 @@ module Users
 
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
-    before_action :multiple_factors_enabled?
 
     def index
       two_factor_options_form
@@ -69,11 +68,6 @@ module Users
 
     def two_factor_options_form_params
       params.require(:two_factor_options_form).permit(:selection, selection: [])
-    end
-
-    def multiple_factors_enabled?
-      return if IdentityConfig.store.select_multiple_mfa_options
-      redirect_to after_mfa_setup_path
     end
   end
 end

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -8,7 +8,7 @@ class TwoFactorOptionsForm
                                             backup_code] }
 
   validates :selection, length: { minimum: 1 }, if: :has_no_mfa_or_in_required_flow?
-  validates :selection, length: { minimum: 2, message: 'phone' }, if: :phone_validations?
+  validates :selection, length: { minimum: 2, message: 'phone' }, if: :phone_valid?
 
   def initialize(user:, phishing_resistant_required:, piv_cac_required:)
     self.user = user
@@ -74,9 +74,10 @@ class TwoFactorOptionsForm
     count >= 2 || (count == 1 && MfaContext.new(user).phone_configurations.none?)
   end
 
-  def phone_validations?
-    IdentityConfig.store.select_multiple_mfa_options &&
-      phone_selected? && has_no_configured_mfa? &&
-      !phone_alternative_enabled? && kantara_2fa_phone_restricted?
+  def phone_valid?
+    phone_selected? &&
+      has_no_configured_mfa? &&
+      !phone_alternative_enabled? &&
+      kantara_2fa_phone_restricted?
   end
 end

--- a/app/policies/mfa_policy.rb
+++ b/app/policies/mfa_policy.rb
@@ -18,9 +18,11 @@ class MfaPolicy
   end
 
   def multiple_non_restricted_factors_enabled?
-    IdentityConfig.store.select_multiple_mfa_options ?
-      mfa_user.enabled_non_restricted_mfa_methods_count > 1 :
+    if IdentityConfig.store.kantara_2fa_phone_restricted
+      mfa_user.enabled_non_restricted_mfa_methods_count > 1
+    else
       multiple_factors_enabled?
+    end
   end
 
   def unphishable?

--- a/app/presenters/two_factor_authentication/selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/selection_presenter.rb
@@ -120,16 +120,8 @@ module TwoFactorAuthentication
         t('two_factor_authentication.two_factor_choice_options.auth_app_info')
       when 'backup_code'
         t('two_factor_authentication.two_factor_choice_options.backup_code_info')
-      when 'phone'
-        IdentityConfig.store.select_multiple_mfa_options ?
-          t('two_factor_authentication.two_factor_choice_options.phone_info_html') :
-          t('two_factor_authentication.two_factor_choice_options.phone_info')
       when 'piv_cac'
         t('two_factor_authentication.two_factor_choice_options.piv_cac_info')
-      when 'sms'
-        t('two_factor_authentication.two_factor_choice_options.sms_info')
-      when 'voice'
-        t('two_factor_authentication.two_factor_choice_options.voice_info')
       when 'webauthn'
         t('two_factor_authentication.two_factor_choice_options.webauthn_info')
       when 'webauthn_platform'

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -41,10 +41,8 @@ class TwoFactorOptionsPresenter
       t('two_factor_authentication.two_factor_hspd12_choice_intro')
     elsif phishing_resistant_only?
       t('two_factor_authentication.two_factor_aal3_choice_intro')
-    elsif IdentityConfig.store.select_multiple_mfa_options
-      t('mfa.info')
     else
-      t('two_factor_authentication.two_factor_choice_intro')
+      t('mfa.info')
     end
   end
 

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -14,7 +14,7 @@
   <%= render 'sign_up/completions/requested_attributes', pii: @presenter.pii %>
 </div>
 
-<% if !@multiple_factors_enabled && IdentityConfig.store.select_multiple_mfa_options %>
+<% if !@multiple_factors_enabled %>
   <%= render(AlertComponent.new(type: :warning, class: 'margin-bottom-4')) do %>
     <%= link_to(
           t('mfa.second_method_warning.link'),

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -21,34 +21,11 @@
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-0">
       <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.intro %></legend>
-      <% if IdentityConfig.store.select_multiple_mfa_options %>
-        <%= hidden_field_tag 'two_factor_options_form[selection][]', nil %>
-      <% end %>
+      <%= hidden_field_tag 'two_factor_options_form[selection][]', nil %>
       <% @presenter.options.each do |option| %>
         <div id="<%= "select_#{option.type}" %>" class="<%= option.html_class %>">
-          <% if IdentityConfig.store.select_multiple_mfa_options %>
-            <%= render partial: 'partials/multi_factor_authentication/mfa_selection',
-                       locals: { form: f, option: option } %>
-          <% else %>
-            <%= radio_button_tag(
-                  'two_factor_options_form[selection]',
-                  option.type,
-                  false,
-                  disabled: option.disabled?,
-                  class: 'usa-radio__input usa-radio__input--tile',
-                ) %>
-            <%= label_tag(
-                  "two_factor_options_form_selection_#{option.type}",
-                  class: 'usa-radio__label usa-radio__label--illustrated',
-                ) do %>
-                    <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: "#{option.label} icon", class: 'usa-radio__image') %>
-                    <div class="usa-radio__label--text"><%= option.label %>
-                      <span class="usa-radio__label-description">
-                        <%= option.info %>
-                      </span>
-                    </div>
-                  <% end %>
-          <% end %>
+          <%= render partial: 'partials/multi_factor_authentication/mfa_selection',
+                     locals: { form: f, option: option } %>
         </div>
       <% end %>
     </fieldset>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -278,7 +278,6 @@ s3_reports_enabled: false
 saml_internal_post: false
 saml_secret_rotation_enabled: false
 seed_agreements_data: true
-select_multiple_mfa_options: false
 service_provider_request_ttl_hours: 24
 session_check_delay: 30
 session_check_frequency: 30
@@ -389,7 +388,6 @@ development:
   saml_endpoint_configs: '[{"suffix":"2021","secret_key_passphrase":"trust-but-verify"},{"suffix":"2022","secret_key_passphrase":"trust-but-verify"}]'
   scrypt_cost: 10000$8$1$
   secret_key_base: development_secret_key_base
-  select_multiple_mfa_options: true
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   show_account_recovery_recovery_options: true
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
@@ -564,7 +562,6 @@ test:
   saml_endpoint_configs: '[{"suffix":"2022","secret_key_passphrase":"trust-but-verify"}]'
   saml_internal_post: true
   scrypt_cost: 800$8$1$
-  select_multiple_mfa_options: false
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -125,8 +125,6 @@ en:
       need to verify your identity using a physical device such as a security
       key or government employee ID (PIV or CAC) to access your information.
     two_factor_choice: Authentication method setup
-    two_factor_choice_intro: Add another layer of security by using one of the
-      multi-factor authentication options below.
     two_factor_choice_options:
       auth_app: Authentication application
       auth_app_info: Download or use an authentication app of your choice to generate

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -134,8 +134,6 @@ es:
       llave de seguridad o una identificación de empleado del Gobierno (PIV o
       CAC) para acceder a su información.
     two_factor_choice: Configuración del método de autenticación
-    two_factor_choice_intro: Agregue un nivel adicional de seguridad usando una de
-      las siguientes opciones de autenticación de múltiples factores.
     two_factor_choice_options:
       auth_app: Aplicación de autenticación
       auth_app_info: Descargue o use la aplicación de autenticación de su preferencia

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -139,8 +139,6 @@ fr:
       physique tel qu’une clé de sécurité ou un badge d’employé du gouvernement
       (PIV ou CAC) pour accéder à vos informations.
     two_factor_choice: Configuration de la méthode d’authentification
-    two_factor_choice_intro: Ajoutez une autre étape de sécurité en utilisant l’une
-      des options d’authentification multifactorielle ci-dessous.
     two_factor_choice_options:
       auth_app: Demande d’authentification
       auth_app_info: Téléchargez ou utilisez une application d’authentification de

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -372,7 +372,6 @@ class IdentityConfig
     config.add(:scrypt_cost, type: :string)
     config.add(:secret_key_base, type: :string)
     config.add(:seed_agreements_data, type: :boolean)
-    config.add(:select_multiple_mfa_options, type: :boolean)
     config.add(:service_provider_request_ttl_hours, type: :integer)
     config.add(:saml_internal_post, type: :boolean)
     config.add(:session_check_delay, type: :integer)

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -572,11 +572,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
           end
         end
 
-        context 'Feature flag #select_multiple_mfa_options is true' do
+        describe 'multiple MFA handling' do
           let(:mfa_selections) { ['sms', 'backup_code'] }
           before do
             subject.user_session[:mfa_selections] = mfa_selections
-            allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
 
             post(
               :create,

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -53,13 +53,12 @@ describe Users::BackupCodeSetupController do
     expect(user.backup_code_configurations.length).to eq 10
   end
 
-  context 'with multiple MFA selection on' do
+  describe 'multiple MFA handling' do
     let(:mfa_selections) { ['backup_code', 'voice'] }
     before do
       @user = build(:user)
       stub_sign_in(@user)
       controller.user_session[:mfa_selections] = mfa_selections
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
     end
 
     context 'when user selects multiple mfas on account creation' do

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 describe Users::MfaSelectionController do
   let(:current_sp) { create(:service_provider) }
-  before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-  end
 
   describe '#index' do
     before do
@@ -47,9 +44,8 @@ describe Users::MfaSelectionController do
       patch :update, params: voice_params
     end
 
-    context 'when the selection is only phone and multi mfa is enabled' do
+    context 'when the selection is only phone and kantara phone restriction is enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
         allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
         stub_sign_in_before_2fa
 

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -94,137 +94,92 @@ describe Users::PivCacAuthenticationSetupController do
         end
 
         context 'when redirected with a good token' do
-          context 'with multiple MFA options feature toggle on' do
-            let(:user) do
-              create(:user)
-            end
-            let(:mfa_selections) { ['piv_cac', 'voice'] }
-            before do
-              subject.user_session[:mfa_selections] = mfa_selections
-              allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
-            end
+          let(:user) do
+            create(:user)
+          end
+          let(:mfa_selections) { ['piv_cac', 'voice'] }
+          before do
+            subject.user_session[:mfa_selections] = mfa_selections
+          end
 
-            context 'with no additional MFAs chosen on setup' do
-              let(:mfa_selections) { ['piv_cac'] }
-              it 'redirects to suggest 2nd MFA page' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
+          context 'with no additional MFAs chosen on setup' do
+            let(:mfa_selections) { ['piv_cac'] }
+            it 'redirects to suggest 2nd MFA page' do
+              stub_attempts_tracker
+              expect(@irs_attempts_api_tracker).to receive(:track_event).with(
+                :mfa_enroll_piv_cac,
+                success: true,
+                subject_dn: 'some dn',
+                failure_reason: nil,
+              )
 
-                get :new, params: { token: good_token }
-                expect(response).to redirect_to(auth_method_confirmation_url)
-              end
-
-              it 'sets the piv/cac session information' do
-                get :new, params: { token: good_token }
-                json = {
-                  'subject' => 'some dn',
-                  'issuer' => nil,
-                  'presented' => true,
-                }.to_json
-
-                expect(subject.user_session[:decrypted_x509]).to eq json
-              end
-
-              it 'sets the session to not require piv setup upon sign-in' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
-
-                get :new, params: { token: good_token }
-
-                expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
-              end
+              get :new, params: { token: good_token }
+              expect(response).to redirect_to(auth_method_confirmation_url)
             end
 
-            context 'with additional MFAs leftover' do
-              it 'redirects to Mfa Confirmation page' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
+            it 'sets the piv/cac session information' do
+              get :new, params: { token: good_token }
+              json = {
+                'subject' => 'some dn',
+                'issuer' => nil,
+                'presented' => true,
+              }.to_json
 
-                get :new, params: { token: good_token }
-                expect(response).to redirect_to(phone_setup_url)
-              end
+              expect(subject.user_session[:decrypted_x509]).to eq json
+            end
 
-              it 'sets the piv/cac session information' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
+            it 'sets the session to not require piv setup upon sign-in' do
+              stub_attempts_tracker
+              expect(@irs_attempts_api_tracker).to receive(:track_event).with(
+                :mfa_enroll_piv_cac,
+                success: true,
+                subject_dn: 'some dn',
+                failure_reason: nil,
+              )
 
-                get :new, params: { token: good_token }
-                json = {
-                  'subject' => 'some dn',
-                  'issuer' => nil,
-                  'presented' => true,
-                }.to_json
+              get :new, params: { token: good_token }
 
-                expect(subject.user_session[:decrypted_x509]).to eq json
-              end
-
-              it 'sets the session to not require piv setup upon sign-in' do
-                get :new, params: { token: good_token }
-
-                expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
-              end
+              expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
             end
           end
 
-          context 'with multiple MFA options feature toggle off' do
-            context 'with no additional MFAs chosen on setup' do
-              it 'redirects to suggest account page' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
+          context 'with additional MFAs leftover' do
+            it 'redirects to Mfa Confirmation page' do
+              stub_attempts_tracker
+              expect(@irs_attempts_api_tracker).to receive(:track_event).with(
+                :mfa_enroll_piv_cac,
+                success: true,
+                subject_dn: 'some dn',
+                failure_reason: nil,
+              )
 
-                get :new, params: { token: good_token }
-                expect(response).to redirect_to(account_url)
-              end
+              get :new, params: { token: good_token }
+              expect(response).to redirect_to(phone_setup_url)
+            end
 
-              it 'sets the piv/cac session information' do
-                get :new, params: { token: good_token }
-                json = {
-                  'subject' => 'some dn',
-                  'issuer' => nil,
-                  'presented' => true,
-                }.to_json
+            it 'sets the piv/cac session information' do
+              stub_attempts_tracker
+              expect(@irs_attempts_api_tracker).to receive(:track_event).with(
+                :mfa_enroll_piv_cac,
+                success: true,
+                subject_dn: 'some dn',
+                failure_reason: nil,
+              )
 
-                expect(subject.user_session[:decrypted_x509]).to eq json
-              end
+              get :new, params: { token: good_token }
+              json = {
+                'subject' => 'some dn',
+                'issuer' => nil,
+                'presented' => true,
+              }.to_json
 
-              it 'sets the session to not require piv setup upon sign-in' do
-                stub_attempts_tracker
-                expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-                  :mfa_enroll_piv_cac,
-                  success: true,
-                  subject_dn: 'some dn',
-                  failure_reason: nil,
-                )
+              expect(subject.user_session[:decrypted_x509]).to eq json
+            end
 
-                get :new, params: { token: good_token }
+            it 'sets the session to not require piv setup upon sign-in' do
+              get :new, params: { token: good_token }
 
-                expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
-              end
+              expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
             end
           end
         end

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -285,7 +285,6 @@ describe Users::TotpSetupController, devise: true do
           allow(@irs_attempts_api_tracker).to receive(:track_event)
           subject.user_session[:new_totp_secret] = secret
           subject.user_session[:mfa_selections] = mfa_selections
-          allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
 
           patch :confirm, params: { name: name, code: generate_totp_code(secret) }
         end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -117,9 +117,8 @@ describe Users::TwoFactorAuthenticationSetupController do
       }
     end
 
-    context 'when the selection is only phone and multi mfa is enabled' do
+    context 'when the selection is only phone and kantara phone restriction is enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
         allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
         stub_sign_in_before_2fa
 

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -172,12 +172,11 @@ describe Users::WebauthnSetupController do
       request.host = 'localhost:3000'
       controller.user_session[:webauthn_challenge] = webauthn_challenge
     end
-    context ' Multiple MFA options turned on' do
+    describe 'multiple MFA handling' do
       let(:mfa_selections) { ['webauthn', 'voice'] }
 
       before do
         controller.user_session[:mfa_selections] = mfa_selections
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
       end
 
       context 'with multiple MFA methods chosen on account creation' do

--- a/spec/features/multi_factor_authentication/mfa_cta_spec.rb
+++ b/spec/features/multi_factor_authentication/mfa_cta_spec.rb
@@ -17,11 +17,7 @@ feature 'mfa cta banner' do
     end
   end
 
-  context 'When the multiple factor authentication feature is enabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-    end
-
+  describe 'multiple MFA handling' do
     it 'displays a banner after configuring a single MFA method' do
       visit_idp_from_sp_with_ial1(:oidc)
       user = sign_up_and_set_password

--- a/spec/features/multi_factor_authentication/mfa_cta_spec.rb
+++ b/spec/features/multi_factor_authentication/mfa_cta_spec.rb
@@ -4,19 +4,6 @@ feature 'mfa cta banner' do
   include DocAuthHelper
   include SamlAuthHelper
 
-  context 'When multiple factor authentication feature is disabled' do
-    it 'does not display a banner as the feature is disabled' do
-      visit_idp_from_sp_with_ial1(:oidc)
-      user = sign_up_and_set_password
-      select_2fa_option('backup_code')
-      click_continue
-
-      expect(MfaPolicy.new(user).multiple_factors_enabled?).to eq false
-      expect(page).to have_current_path(sign_up_completed_path)
-      expect(page).not_to have_content(t('mfa.second_method_warning.text'))
-    end
-  end
-
   describe 'multiple MFA handling' do
     it 'displays a banner after configuring a single MFA method' do
       visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -20,7 +20,7 @@ describe 'phone otp confirmation' do
     def expect_successful_otp_confirmation(delivery_method)
       expect(page).to have_content(t('notices.phone_confirmed'))
 
-      expect(page).to have_current_path(account_path)
+      expect(page).to have_current_path(auth_method_confirmation_path)
       expect(phone_configuration.confirmed_at).to_not be_nil
       expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
     end

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -34,6 +34,7 @@ feature 'Remembering a phone' do
       check t('forms.messages.remember_device')
       fill_in_code_with_last_phone_otp
       click_submit_default
+      skip_second_mfa_prompt
 
       first(:link, t('links.sign_out')).click
       user

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -106,6 +106,7 @@ feature 'remember device sp expiration' do
     check t('forms.messages.remember_device')
     fill_in_code_with_last_phone_otp
     click_submit_default
+    skip_second_mfa_prompt
 
     first(:link, t('links.sign_out')).click
     user_record

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -30,6 +30,7 @@ describe 'Remembering a TOTP device' do
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default
+      skip_second_mfa_prompt
 
       first(:link, t('links.sign_out')).click
       user

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -15,6 +15,7 @@ describe 'Unchecking remember device' do
         uncheck 'remember_device'
 
         click_button 'Submit'
+        skip_second_mfa_prompt
 
         first(:link, t('links.sign_out')).click
         sign_in_user(user)
@@ -41,6 +42,7 @@ describe 'Unchecking remember device' do
 
         mock_press_button_on_hardware_key_on_setup
         click_continue
+        skip_second_mfa_prompt
 
         first(:link, t('links.sign_out')).click
         sign_in_user(user)
@@ -68,6 +70,7 @@ describe 'Unchecking remember device' do
         uncheck 'remember_device'
 
         click_submit_default
+        skip_second_mfa_prompt
 
         first(:link, t('links.sign_out')).click
         sign_in_user(user)

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -45,6 +45,7 @@ describe 'Remembering a webauthn device' do
         fill_in_nickname_and_click_continue
         check t('forms.messages.remember_device')
         mock_press_button_on_hardware_key_on_setup
+        skip_second_mfa_prompt
 
         first(:link, t('links.sign_out')).click
         user
@@ -108,6 +109,7 @@ describe 'Remembering a webauthn device' do
         fill_in_nickname_and_click_continue
         check t('forms.messages.remember_device')
         mock_press_button_on_hardware_key_on_setup
+        skip_second_mfa_prompt
 
         first(:link, t('links.sign_out')).click
         user

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -15,7 +15,6 @@ feature 'IAL1 Single Sign On' do
 
       perform_in_browser(:two) do
         confirm_email_in_a_different_browser(email)
-        click_submit_default
         expect(current_path).to eq sign_up_completed_path
         within('.requested-attributes') do
           expect(page).to have_content t('help_text.requested_attributes.email')

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -17,7 +17,8 @@ feature 'sign up with backup code' do
     click_continue
 
     expect(page).to have_content(t('notices.backup_codes_configured'))
-    expect(current_path).to eq account_path
+
+    expect(current_path).to eq auth_method_confirmation_path
     expect(user.backup_code_configurations.count).to eq(10)
   end
 
@@ -66,6 +67,7 @@ feature 'sign up with backup code' do
     sign_up_and_set_password
     select_2fa_option('backup_code')
     click_continue
+    skip_second_mfa_prompt
 
     expect(page).to have_current_path(sign_up_completed_path)
 

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 feature 'Multi Two Factor Authentication' do
   before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
     allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
   end
 

--- a/spec/features/users/non_restricted_required_sign_in_spec.rb
+++ b/spec/features/users/non_restricted_required_sign_in_spec.rb
@@ -10,7 +10,6 @@ feature 'Existing USer Non Restricted Method Required' do
   let(:enforcement_date) { Time.zone.today - 6.days }
 
   before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
     allow(IdentityConfig.store).to receive(:kantara_2fa_phone_existing_user_restriction).
       and_return(true)
     allow(IdentityConfig.store).to receive(:kantara_restriction_enforcement_date).

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -150,6 +150,7 @@ feature 'Sign in' do
     click_send_one_time_code
     fill_in_code_with_last_phone_otp
     click_submit_default
+    skip_second_mfa_prompt
     click_agree_and_continue
     expect(current_url).to start_with('http://localhost:7654/auth/result')
   end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -179,6 +179,8 @@ feature 'Sign Up' do
 
       fill_in 'name', with: 'Authentication app'
       click_button 'Submit'
+      skip_second_mfa_prompt
+
       expect(page).to have_current_path account_path
     end
   end
@@ -231,6 +233,7 @@ feature 'Sign Up' do
   it 'allows a user to choose TOTP as 2FA method during sign up' do
     sign_in_user
     set_up_2fa_with_authenticator_app
+    skip_second_mfa_prompt
 
     expect(page).to have_current_path account_path
   end

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -42,8 +42,9 @@ describe 'webauthn hide' do
   end
 
   def webauthn_option_hidden?
-    page.find(
-      'label[for=two_factor_options_form_selection_webauthn]',
-    ).find(:xpath, '..')[:class].include?('display-none')
+    page.find('label[for=two_factor_options_form_selection_webauthn]').ancestor('.display-none')
+    true
+  rescue Capybara::ElementNotFound
+    false
   end
 end

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -13,7 +13,7 @@ feature 'webauthn sign up' do
 
   def expect_webauthn_setup_success
     expect(page).to have_content(t('notices.webauthn_configured'))
-    expect(page).to have_current_path(account_path)
+    expect(page).to have_current_path(auth_method_confirmation_path)
   end
 
   def expect_webauthn_setup_error
@@ -34,6 +34,7 @@ feature 'webauthn sign up' do
 
       fill_in_nickname_and_click_continue
       mock_press_button_on_hardware_key_on_setup
+      skip_second_mfa_prompt
 
       expect(current_path).to eq(sign_up_completed_path)
     end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -25,8 +25,7 @@ describe TwoFactorOptionsForm do
       end
     end
 
-    it 'is unsuccessful if the selection is invalid for multi mfa' do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
+    it 'is unsuccessful if the selection is invalid for kantara phone restriction' do
       allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
       %w[phone sms voice !!!!].each do |selection|
         result = subject.submit(selection: selection)
@@ -99,7 +98,6 @@ describe TwoFactorOptionsForm do
 
     context 'when phone is selected as their first authentication method' do
       before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
         allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
       end
 
@@ -112,10 +110,6 @@ describe TwoFactorOptionsForm do
       let(:user) { build(:user, :with_authentication_app) }
       let(:enabled_mfa_methods_count) { 1 }
       let(:mfa_selection) { ['phone'] }
-
-      before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-      end
 
       it 'submits the form' do
         expect(submit_phone.success?).to eq true
@@ -134,10 +128,6 @@ describe TwoFactorOptionsForm do
       let(:mfa_selection) { ['phone'] }
       let(:phishing_resistant_required) { true }
       let(:piv_cac_required) { false }
-
-      before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-      end
 
       context 'when user is didnt select an mfa' do
         let(:mfa_selection) { nil }
@@ -161,7 +151,6 @@ describe TwoFactorOptionsForm do
 
     context 'when the feature flag toggle for 2FA phone restriction is off' do
       before do
-        allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
         allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(false)
       end
 

--- a/spec/presenters/additional_mfa_required_presenter_spec.rb
+++ b/spec/presenters/additional_mfa_required_presenter_spec.rb
@@ -7,7 +7,6 @@ describe AdditionalMfaRequiredPresenter do
   let(:current_date) { Time.zone.today }
 
   before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
     allow(IdentityConfig.store).to receive(:kantara_restriction_enforcement_date).
       and_return(enforcement_date.to_datetime)
   end

--- a/spec/presenters/mfa_confirmation_presenter_spec.rb
+++ b/spec/presenters/mfa_confirmation_presenter_spec.rb
@@ -4,10 +4,6 @@ describe MfaConfirmationPresenter do
   let(:user) { create(:user, :with_phone) }
   let(:presenter) { described_class.new(user) }
 
-  before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
-  end
-
   describe '#heading?' do
     it 'supplies a message' do
       expect(presenter.heading).

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -41,6 +41,7 @@ module Features
       uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
+      skip_second_mfa_prompt
       user
     end
 
@@ -442,7 +443,7 @@ module Features
       submit_form_with_valid_password
 
       set_up_2fa_with_valid_phone
-      # expect(page).to have_css('img[src*=sp-logos]')
+      skip_second_mfa_prompt
     end
 
     def click_sign_in_from_landing_page_then_click_create_account
@@ -529,6 +530,7 @@ module Features
     def register_user(email = 'test@test.com')
       confirm_email_and_password(email)
       set_up_2fa_with_valid_phone
+      skip_second_mfa_prompt
       User.find_with_email(email)
     end
 
@@ -548,6 +550,7 @@ module Features
     def register_user_with_authenticator_app(email = 'test@test.com')
       confirm_email_and_password(email)
       set_up_2fa_with_authenticator_app
+      skip_second_mfa_prompt
     end
 
     def set_up_2fa_with_authenticator_app
@@ -570,6 +573,7 @@ module Features
       )
 
       set_up_2fa_with_piv_cac
+      skip_second_mfa_prompt
     end
 
     def set_up_2fa_with_piv_cac
@@ -585,6 +589,10 @@ module Features
         uuid: SecureRandom.uuid,
         subject: 'SomeIgnoredSubject',
       )
+    end
+
+    def skip_second_mfa_prompt
+      click_on t('mfa.skip')
     end
 
     def sign_in_via_branded_page(user)

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -9,7 +9,6 @@ shared_examples 'creating an account with the site in Spanish' do |sp|
         to(include('form-action \'self\' http://localhost:7654'))
     end
 
-    click_submit_default if sp == :saml
     click_agree_and_continue
     if :sp == :saml
       expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: :es)
@@ -76,7 +75,6 @@ shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
       expect(page.response_headers['Content-Security-Policy']).
         to(include('form-action \'self\' http://localhost:7654'))
     end
-    click_submit_default if sp == :saml
 
     click_agree_and_continue
     expect(current_url).to eq complete_saml_url if sp == :saml
@@ -97,6 +95,7 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     select_2fa_option('webauthn', visible: :all)
     fill_in_nickname_and_click_continue
     mock_press_button_on_hardware_key_on_setup
+    skip_second_mfa_prompt
     expect(page).to have_current_path(idv_doc_auth_step_path(step: :welcome))
     complete_all_doc_auth_steps
     fill_out_phone_form_ok
@@ -130,7 +129,6 @@ shared_examples 'creating two accounts during the same session' do |sp|
 
     perform_in_browser(:two) do
       confirm_email_in_a_different_browser(first_email)
-      click_submit_default if sp == :saml
       click_agree_and_continue
 
       continue_as(first_email)
@@ -152,7 +150,6 @@ shared_examples 'creating two accounts during the same session' do |sp|
     perform_in_browser(:two) do
       Capybara.reset_session!
       confirm_email_in_a_different_browser(second_email)
-      click_submit_default if sp == :saml
       click_agree_and_continue
 
       continue_as(second_email)

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -81,10 +81,10 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
     end
   end
 
-  context 'when multiple mfa is enabled' do
+  context 'when kantara phone restriction is enabled' do
     let(:user) { create(:user, :with_phone, :with_authentication_app) }
     before do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return true
+      allow(IdentityConfig.store).to receive(:kantara_2fa_phone_restricted).and_return(true)
       assign(
         :presenter,
         AccountShowPresenter.new(

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -5,7 +5,6 @@ describe 'mfa_confirmation/show.html.erb' do
   let(:decorated_user) { user.decorate }
 
   before do
-    allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).and_return(true)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:enforce_second_mfa?).and_return(true)
     @content = MfaConfirmationPresenter.new(user)

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -95,55 +95,26 @@ describe 'sign_up/completions/show.html.erb' do
 
   describe 'MFA CTA banner' do
     let(:multiple_factors_enabled) { nil }
-    let(:select_multiple_mfa_options) { nil }
 
     before do
-      allow(IdentityConfig.store).to receive(:select_multiple_mfa_options).
-        and_return(select_multiple_mfa_options)
       @multiple_factors_enabled = multiple_factors_enabled
     end
 
     context 'with multiple factors disabled' do
       let(:multiple_factors_enabled) { false }
 
-      context 'with multiple MFA feature flag disabled' do
-        let(:select_multiple_mfa_options) { false }
-
-        it 'does not show a banner' do
-          render
-          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
-        end
-      end
-
-      context 'with multiple MFA feature flag enabled' do
-        let(:select_multiple_mfa_options) { true }
-
-        it 'shows a banner if the user selects one MFA option' do
-          render
-          expect(rendered).to have_content(t('mfa.second_method_warning.text'))
-        end
+      it 'shows a banner if the user selects one MFA option' do
+        render
+        expect(rendered).to have_content(t('mfa.second_method_warning.text'))
       end
     end
 
     context 'with multiple factors enabled' do
       let(:multiple_factors_enabled) { true }
 
-      context 'with multiple MFA feature flag disabled' do
-        let(:select_multiple_mfa_options) { false }
-
-        it 'does not show a banner' do
-          render
-          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
-        end
-      end
-
-      context 'with multiple MFA feature flag enabled' do
-        let(:select_multiple_mfa_options) { true }
-
-        it 'does not show a banner' do
-          render
-          expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
-        end
+      it 'does not show a banner' do
+        render
+        expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
       end
     end
   end

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'users/two_factor_authentication_setup/index.html.erb' do
 
   before do
     user = build_stubbed(:user)
-    @presenter = TwoFactorOptionsPresenter.new(user_agent: '')
+    @presenter = TwoFactorOptionsPresenter.new(user_agent: '', user: user)
     @two_factor_options_form = TwoFactorLoginOptionsForm.new(user)
   end
 
@@ -23,7 +23,7 @@ describe 'users/two_factor_authentication_setup/index.html.erb' do
 
     it 'disables phone option' do
       expect(rendered).to have_field(
-        'two_factor_options_form[selection]',
+        'two_factor_options_form[selection][]',
         with: :phone,
         disabled: true,
       )
@@ -42,7 +42,7 @@ describe 'users/two_factor_authentication_setup/index.html.erb' do
 
     it 'does not disable phone option' do
       expect(rendered).to have_field(
-        'two_factor_options_form[selection]',
+        'two_factor_options_form[selection][]',
         with: :phone,
         disabled: false,
       )


### PR DESCRIPTION
## 🎫 Ticket

[LG-7483](https://cm-jira.usa.gov/browse/LG-7483)

## 🛠 Summary of changes

Removes the `select_multiple_mfa_options` feature flag, which is now live in all environments.

Also fixes an issue where MFA "Delete" links would not be shown on the account dashboard in some circumstances, since that was intended to apply only for Kantara restrictions (not live in production), but instead had been keying off the `select_multiple_mfa_options` feature (live in production).

## 📜 Testing Plan

1. Check that you can configure multiple MFA for account creation
2. Check that you can delete MFA methods from your account when you have multiple active, regardless of whether the MFA method is "restricted"

The second test procedure requires overrides in local development `config/application.yml` (until LG-7586):

```
development:
  kantara_2fa_phone_restricted: false
```