### PR TITLE
Fix "No such file" error on "make normalize_yaml"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the developme
 
 normalize_yaml: ## Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation
-	find ./config/locales/telephony "./config/locales/telephony*" -type f | xargs yarn normalize-yaml --disable-smart-punctuation
+	find ./config/locales/telephony -type f | xargs yarn normalize-yaml --disable-smart-punctuation
 	find ./config/locales -not -path "./config/locales/telephony*" -type f | xargs yarn normalize-yaml \
 		config/pinpoint_supported_countries.yml \
 		config/pinpoint_overrides.yml \


### PR DESCRIPTION
## 🛠 Summary of changes

Resolves an error which occurs when running `make normalize_yaml`.

**Before:**

```
$ make normalize_yaml
# ...
find ./config/locales/telephony "./config/locales/telephony*" -type f | xargs yarn normalize-yaml --disable-smart-punctuation
find: ./config/locales/telephony*: No such file or directory
yarn run v1.22.19
```

**After:**

```
$ make normalize_yaml
# ...
find ./config/locales/telephony -type f | xargs yarn normalize-yaml --disable-smart-punctuation
yarn run v1.22.19
```
