### PR TITLE
Redirect to TM sad screen after GPO verification

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -41,6 +41,8 @@ module Idv
         if result.success?
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
+          elsif result.extra[:threatmetrix_check_failed]
+            redirect_to idv_come_back_later_url
           else
             event, disavowal_token = create_user_event_with_disavowal(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(
@@ -50,6 +52,7 @@ module Idv
               disavowal_token: disavowal_token,
             )
             flash[:success] = t('account.index.verification.success')
+
             redirect_to sign_up_completed_url
           end
         else

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -41,8 +41,6 @@ module Idv
         if result.success?
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
-          elsif result.extra[:threatmetrix_check_failed]
-            redirect_to idv_setup_errors_url
           else
             event, disavowal_token = create_user_event_with_disavowal(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(
@@ -53,7 +51,11 @@ module Idv
             )
             flash[:success] = t('account.index.verification.success')
 
-            redirect_to sign_up_completed_url
+            if result.extra[:threatmetrix_check_failed]
+              redirect_to idv_setup_errors_url
+            else
+              redirect_to sign_up_completed_url
+            end
           end
         else
           flash[:error] = @gpo_verify_form.errors.first.message

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -2,6 +2,7 @@ module Idv
   class GpoVerifyController < ApplicationController
     include IdvSession
     include StepIndicatorConcern
+    include ThreatmetrixReviewConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
@@ -52,7 +53,7 @@ module Idv
             flash[:success] = t('account.index.verification.success')
 
             if result.extra[:threatmetrix_check_failed]
-              redirect_to idv_setup_errors_url
+              redirect_to_threatmetrix_review
             else
               redirect_to sign_up_completed_url
             end

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -42,7 +42,7 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           elsif result.extra[:threatmetrix_check_failed]
-            redirect_to idv_come_back_later_url
+            redirect_to idv_setup_errors_url
           else
             event, disavowal_token = create_user_event_with_disavowal(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -45,7 +45,7 @@ module Idv
           else
             event, disavowal_token = create_user_event_with_disavowal(:account_verified)
 
-            if result.extra[:threatmetrix_check_failed]
+            if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
               redirect_to_threatmetrix_review
             else
               UserAlerts::AlertUserAboutAccountVerified.call(
@@ -98,6 +98,10 @@ module Idv
     def confirm_verification_needed
       return if current_user.decorate.pending_profile_requires_verification?
       redirect_to account_url
+    end
+
+    def threatmetrix_enabled?
+      IdentityConfig.store.proofing_device_profiling_decisioning_enabled
     end
   end
 end

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -44,17 +44,17 @@ module Idv
             redirect_to idv_in_person_ready_to_verify_url
           else
             event, disavowal_token = create_user_event_with_disavowal(:account_verified)
-            UserAlerts::AlertUserAboutAccountVerified.call(
-              user: current_user,
-              date_time: event.created_at,
-              sp_name: decorated_session.sp_name,
-              disavowal_token: disavowal_token,
-            )
-            flash[:success] = t('account.index.verification.success')
 
             if result.extra[:threatmetrix_check_failed]
               redirect_to_threatmetrix_review
             else
+              UserAlerts::AlertUserAboutAccountVerified.call(
+                user: current_user,
+                date_time: event.created_at,
+                sp_name: decorated_session.sp_name,
+                disavowal_token: disavowal_token,
+              )
+              flash[:success] = t('account.index.verification.success')
               redirect_to sign_up_completed_url
             end
           end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -36,7 +36,7 @@ class GpoVerifyForm
         enqueued_at: gpo_confirmation_code&.code_sent_at,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: pending_in_person_enrollment?,
-        threatmetrix_check_failed?: threatmetrix_check_failed?
+        threatmetrix_check_failed?: threatmetrix_check_failed?,
       },
     )
   end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -36,7 +36,7 @@ class GpoVerifyForm
         enqueued_at: gpo_confirmation_code&.code_sent_at,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: pending_in_person_enrollment?,
-        threatmetrix_check_failed?: threatmetrix_check_failed?,
+        threatmetrix_check_failed: threatmetrix_check_failed?,
       },
     )
   end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -81,7 +81,8 @@ class GpoVerifyForm
   end
 
   def threatmetrix_check_failed?
-    pending_profile&.proofing_components&.[]('threatmetrix_review_status') == 'reject'
+    status = pending_profile&.proofing_components&.[]('threatmetrix_review_status')
+    !status.nil? && status != 'pass'
   end
 
   def activate_profile

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -21,6 +21,8 @@ class GpoVerifyForm
       if pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
+      elsif threatmetrix_check_failed?
+        pending_profile&.deactivate(:threatmetrix_review_pending)
       else
         activate_profile
       end
@@ -34,6 +36,7 @@ class GpoVerifyForm
         enqueued_at: gpo_confirmation_code&.code_sent_at,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: pending_in_person_enrollment?,
+        threatmetrix_check_failed?: threatmetrix_check_failed?
       },
     )
   end
@@ -75,6 +78,10 @@ class GpoVerifyForm
 
   def pending_in_person_enrollment?
     pending_profile&.proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS
+  end
+
+  def threatmetrix_check_failed?
+    pending_profile&.proofing_components&.[]('threatmetrix_review_status') == 'reject'
   end
 
   def activate_profile

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -219,20 +219,20 @@ RSpec.describe Idv::GpoVerifyController do
               threatmetrix_review_status: 'review'
             )
           end
-          it 'does not redirect to the sad face screen' do
+          it 'redirects to the sad face screen' do
             expect(@analytics).to receive(:track_event).with(
               'IdV: GPO verification submitted',
               success: true,
               errors: {},
               pending_in_person_enrollment: false,
-              threatmetrix_check_failed: false,
+              threatmetrix_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
             )
 
             action
 
-            expect(response).to redirect_to(sign_up_completed_url)
+            expect(response).to redirect_to(idv_setup_errors_url)
           end
         end
       end

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Idv::GpoVerifyController do
   end
   let(:proofing_components) { nil }
   let(:user) { create(:user) }
+  let(:threatmetrix_enabled) { false }
 
   before do
     stub_analytics
@@ -28,6 +29,13 @@ RSpec.describe Idv::GpoVerifyController do
     )
     allow(decorated_user).to receive(:pending_profile_requires_verification?).
       and_return(has_pending_profile)
+
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
+      and_return(threatmetrix_enabled)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+      and_return(threatmetrix_enabled)
+    allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
+      and_return(threatmetrix_enabled)
   end
 
   describe '#index' do
@@ -109,6 +117,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: true,
           errors: {},
           pending_in_person_enrollment: false,
+          threatmetrix_check_failed: false,
           enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
@@ -146,6 +155,7 @@ RSpec.describe Idv::GpoVerifyController do
             success: true,
             errors: {},
             pending_in_person_enrollment: true,
+            threatmetrix_check_failed: false,
             enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
             pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
           )
@@ -163,6 +173,59 @@ RSpec.describe Idv::GpoVerifyController do
           action
         end
       end
+
+      context 'threatmetrix enabled' do
+        let(:threatmetrix_enabled) { true }
+
+        context 'with threatmetrix status of "reject"' do
+          let(:proofing_components) do
+            ProofingComponent.create(
+              user: user, threatmetrix: true,
+              threatmetrix_review_status: 'reject'
+            )
+          end
+
+          it 'redirects to the sad face screen' do
+            expect(@analytics).to receive(:track_event).with(
+              'IdV: GPO verification submitted',
+              success: true,
+              errors: {},
+              pending_in_person_enrollment: false,
+              threatmetrix_check_failed: true,
+              enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
+              pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+            )
+
+            action
+
+            expect(response).to redirect_to(idv_setup_errors_url)
+          end
+        end
+
+        context 'with threatmetrix status of "review"' do
+          let(:proofing_components) do
+            ProofingComponent.create(
+              user: user, threatmetrix: true,
+              threatmetrix_review_status: 'review'
+            )
+          end
+          it 'does not redirect to the sad face screen' do
+            expect(@analytics).to receive(:track_event).with(
+              'IdV: GPO verification submitted',
+              success: true,
+              errors: {},
+              pending_in_person_enrollment: false,
+              threatmetrix_check_failed: false,
+              enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
+              pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+            )
+
+            action
+
+            expect(response).to redirect_to(sign_up_completed_url)
+          end
+        end
+      end
     end
 
     context 'with an invalid form' do
@@ -174,6 +237,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: false,
           errors: otp_code_error_message,
           pending_in_person_enrollment: false,
+          threatmetrix_check_failed: false,
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
@@ -204,6 +268,7 @@ RSpec.describe Idv::GpoVerifyController do
           success: false,
           errors: otp_code_error_message,
           pending_in_person_enrollment: false,
+          threatmetrix_check_failed: false,
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -200,6 +200,16 @@ RSpec.describe Idv::GpoVerifyController do
 
             expect(response).to redirect_to(idv_setup_errors_url)
           end
+
+          it 'does not show a flash message' do
+            expect(flash[:success]).to be_nil
+            action
+          end
+
+          it 'does not dispatch account verified alert' do
+            expect(UserAlerts::AlertUserAboutAccountVerified).not_to receive(:call)
+            action
+          end
         end
 
         context 'with threatmetrix status of "review"' do

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -9,6 +9,10 @@ feature 'idv gpo otp verification step', :js do
       :profile,
       deactivation_reason: :gpo_verification_pending,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
+      proofing_components: {
+        threatmetrix: threatmetrix_enabled,
+        threatmetrix_review_status: threatmetrix_review_status,
+      },
     )
   end
   let(:gpo_confirmation_code) do
@@ -20,15 +24,11 @@ feature 'idv gpo otp verification step', :js do
   end
   let(:user) { profile.user }
 
+  let(:threatmetrix_enabled) { false }
+  let(:threatmetrix_review_status) { nil }
+
   it 'prompts for one-time code at sign in' do
-    sign_in_live_with_2fa(user)
-
-    expect(current_path).to eq idv_gpo_verify_path
-    expect(page).to have_content t('idv.messages.gpo.resend')
-
-    gpo_confirmation_code
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
+    sign_in_and_enter_otp
 
     expect(user.events.account_verified.size).to eq 1
     expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
@@ -51,6 +51,93 @@ feature 'idv gpo otp verification step', :js do
   end
 
   it 'allows a user to resend a letter' do
+    resend_letter
+  end
+
+  context 'with gpo feature disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_gpo_verification?).and_return(true)
+    end
+
+    it 'allows a user to verify their account for an existing pending profile' do
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq idv_gpo_verify_path
+      expect(page).to have_content t('idv.messages.gpo.resend')
+
+      gpo_confirmation_code
+      fill_in t('forms.verify_profile.name'), with: otp
+      click_button t('forms.verify_profile.submit')
+
+      expect(user.events.account_verified.size).to eq 1
+      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+    end
+  end
+
+  context 'ThreatMetrix enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(threatmetrix_enabled)
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+        and_return(threatmetrix_enabled)
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
+        and_return(threatmetrix_enabled)
+    end
+
+    context 'ThreatMetrix evaluates as "pass"' do
+      let(:threatmetrix_review_status) { 'pass' }
+      it 'redirects to account page after OTP' do
+        sign_in_and_enter_otp
+      end
+      it 'allows requesting a new letter' do
+        resend_letter
+      end
+    end
+
+    context 'ThreatMetrix evaluates as "review"' do
+      let(:threatmetrix_review_status) { 'review' }
+      it 'redirects to account page after OTP' do
+        sign_in_and_enter_otp
+      end
+      it 'allows requesting a new letter' do
+        resend_letter
+      end
+    end
+
+    context 'ThreatMetrix evaluates as "reject"' do
+      let(:threatmetrix_review_status) { 'reject' }
+      it 'redirects to sad face after OTP' do
+        binding.pry
+        sign_in_and_enter_otp
+        expect(page).to have_current_path(idv_come_back_later_path)
+      end
+      it 'allows requesting a new letter' do
+        resend_letter
+      end
+    end
+
+    context 'ThreatMetrix evaluates as nil' do
+      let(:threatmetrix_review_status) { nil }
+      it 'redirects to account page after OTP' do
+        sign_in_and_enter_otp
+      end
+      it 'allows requesting a new letter' do
+        resend_letter
+      end
+    end
+  end
+
+  def sign_in_and_enter_otp
+    sign_in_live_with_2fa(user)
+
+    expect(current_path).to eq idv_gpo_verify_path
+    expect(page).to have_content t('idv.messages.gpo.resend')
+
+    gpo_confirmation_code
+    fill_in t('forms.verify_profile.name'), with: otp
+    click_button t('forms.verify_profile.submit')
+  end
+
+  def resend_letter
     allow(Base32::Crockford).to receive(:encode).and_return(otp)
 
     sign_in_live_with_2fa(user)
@@ -72,25 +159,5 @@ feature 'idv gpo otp verification step', :js do
 
     expect(confirmation_code.otp_fingerprint).to eq(otp_fingerprint)
     expect(confirmation_code.profile).to eq(profile)
-  end
-
-  context 'with gpo feature disabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:enable_gpo_verification?).and_return(true)
-    end
-
-    it 'allows a user to verify their account for an existing pending profile' do
-      sign_in_live_with_2fa(user)
-
-      expect(current_path).to eq idv_gpo_verify_path
-      expect(page).to have_content t('idv.messages.gpo.resend')
-
-      gpo_confirmation_code
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
-
-      expect(user.events.account_verified.size).to eq 1
-      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
-    end
   end
 end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -54,26 +54,6 @@ feature 'idv gpo otp verification step', :js do
     resend_letter
   end
 
-  context 'with gpo feature disabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:enable_gpo_verification?).and_return(true)
-    end
-
-    it 'allows a user to verify their account for an existing pending profile' do
-      sign_in_live_with_2fa(user)
-
-      expect(current_path).to eq idv_gpo_verify_path
-      expect(page).to have_content t('idv.messages.gpo.resend')
-
-      gpo_confirmation_code
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
-
-      expect(user.events.account_verified.size).to eq 1
-      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
-    end
-  end
-
   context 'ThreatMetrix enabled' do
     before do
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
@@ -159,5 +139,25 @@ feature 'idv gpo otp verification step', :js do
 
     expect(confirmation_code.otp_fingerprint).to eq(otp_fingerprint)
     expect(confirmation_code.profile).to eq(profile)
+  end
+
+  context 'with gpo feature disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_gpo_verification?).and_return(true)
+    end
+
+    it 'allows a user to verify their account for an existing pending profile' do
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq idv_gpo_verify_path
+      expect(page).to have_content t('idv.messages.gpo.resend')
+
+      gpo_confirmation_code
+      fill_in t('forms.verify_profile.name'), with: otp
+      click_button t('forms.verify_profile.submit')
+
+      expect(user.events.account_verified.size).to eq 1
+      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+    end
   end
 end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -76,7 +76,8 @@ feature 'idv gpo otp verification step', :js do
 
   context 'ThreatMetrix enabled' do
     before do
-      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(threatmetrix_enabled)
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
+        and_return(threatmetrix_enabled)
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
         and_return(threatmetrix_enabled)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
@@ -106,7 +107,6 @@ feature 'idv gpo otp verification step', :js do
     context 'ThreatMetrix evaluates as "reject"' do
       let(:threatmetrix_review_status) { 'reject' }
       it 'redirects to sad face after OTP' do
-        binding.pry
         sign_in_and_enter_otp
         expect(page).to have_current_path(idv_come_back_later_path)
       end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -40,22 +40,26 @@ feature 'idv gpo otp verification step', :js do
   context 'ThreatMetrix enabled' do
     let(:threatmetrix_enabled) { true }
 
-    context 'ThreatMetrix evaluates as "pass"' do
+    context 'ThreatMetrix says "pass"' do
       let(:threatmetrix_review_status) { 'pass' }
       it_behaves_like 'gpo otp verification'
     end
 
-    context 'ThreatMetrix evaluates as "review"' do
+    context 'ThreatMetrix says "review"' do
       let(:threatmetrix_review_status) { 'review' }
       it_behaves_like 'gpo otp verification'
     end
 
-    context 'ThreatMetrix evaluates as "reject"' do
+    context 'ThreatMetrix says "reject"' do
       let(:threatmetrix_review_status) { 'reject' }
-      it_behaves_like 'gpo otp verification', redirect_after_verification: :idv_setup_errors_path
+      it_behaves_like 'gpo otp verification', {
+        redirect_after_verification: :idv_setup_errors_path,
+        profile_should_be_active: false,
+        expected_deactivation_reason: 'threatmetrix_review_pending',
+      }
     end
 
-    context 'ThreatMetrix evaluates as nil' do
+    context 'No ThreatMetrix result on proofing component' do
       let(:threatmetrix_review_status) { nil }
       it_behaves_like 'gpo otp verification'
     end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -50,6 +50,9 @@ feature 'idv gpo otp verification step', :js do
 
     context 'ThreatMetrix says "review"' do
       let(:threatmetrix_review_status) { 'review' }
+      let(:redirect_after_verification) { idv_setup_errors_path }
+      let(:profile_should_be_active) { false }
+      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
       it_behaves_like 'gpo otp verification'
     end
 

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -108,7 +108,7 @@ feature 'idv gpo otp verification step', :js do
       let(:threatmetrix_review_status) { 'reject' }
       it 'redirects to sad face after OTP' do
         sign_in_and_enter_otp
-        expect(page).to have_current_path(idv_come_back_later_path)
+        expect(page).to have_current_path(idv_setup_errors_path)
       end
       it 'allows requesting a new letter' do
         resend_letter

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -25,6 +25,9 @@ feature 'idv gpo otp verification step', :js do
   let(:user) { profile.user }
   let(:threatmetrix_enabled) { false }
   let(:threatmetrix_review_status) { nil }
+  let(:redirect_after_verification) { nil }
+  let(:profile_should_be_active) { true }
+  let(:expected_deactivation_reason) { nil }
 
   before do
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
@@ -52,11 +55,10 @@ feature 'idv gpo otp verification step', :js do
 
     context 'ThreatMetrix says "reject"' do
       let(:threatmetrix_review_status) { 'reject' }
-      it_behaves_like 'gpo otp verification', {
-        redirect_after_verification: :idv_setup_errors_path,
-        profile_should_be_active: false,
-        expected_deactivation_reason: 'threatmetrix_review_pending',
-      }
+      let(:redirect_after_verification) { idv_setup_errors_path }
+      let(:profile_should_be_active) { false }
+      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
+      it_behaves_like 'gpo otp verification'
     end
 
     context 'No ThreatMetrix result on proofing component' do

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -23,7 +23,6 @@ feature 'idv gpo otp verification step', :js do
     )
   end
   let(:user) { profile.user }
-
   let(:threatmetrix_enabled) { false }
   let(:threatmetrix_review_status) { nil }
 

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -27,118 +27,39 @@ feature 'idv gpo otp verification step', :js do
   let(:threatmetrix_enabled) { false }
   let(:threatmetrix_review_status) { nil }
 
-  it 'prompts for one-time code at sign in' do
-    sign_in_and_enter_otp
-
-    expect(user.events.account_verified.size).to eq 1
-    expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+  before do
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
+      and_return(threatmetrix_enabled)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+      and_return(threatmetrix_enabled)
+    allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
+      and_return(threatmetrix_enabled)
   end
 
-  it 'renders an error for an expired GPO OTP' do
-    sign_in_live_with_2fa(user)
-
-    gpo_confirmation_code.update(code_sent_at: 11.days.ago)
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
-
-    expect(current_path).to eq idv_gpo_verify_path
-    expect(page).to have_content t('errors.messages.gpo_otp_expired')
-
-    user.reload
-
-    expect(user.events.account_verified.size).to eq 0
-    expect(user.active_profile).to be_nil
-  end
-
-  it 'allows a user to resend a letter' do
-    resend_letter
-  end
+  it_behaves_like 'gpo otp verification'
 
   context 'ThreatMetrix enabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
-        and_return(threatmetrix_enabled)
-      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
-        and_return(threatmetrix_enabled)
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-        and_return(threatmetrix_enabled)
-    end
+    let(:threatmetrix_enabled) { true }
 
     context 'ThreatMetrix evaluates as "pass"' do
       let(:threatmetrix_review_status) { 'pass' }
-      it 'redirects to account page after OTP' do
-        sign_in_and_enter_otp
-      end
-      it 'allows requesting a new letter' do
-        resend_letter
-      end
+      it_behaves_like 'gpo otp verification'
     end
 
     context 'ThreatMetrix evaluates as "review"' do
       let(:threatmetrix_review_status) { 'review' }
-      it 'redirects to account page after OTP' do
-        sign_in_and_enter_otp
-      end
-      it 'allows requesting a new letter' do
-        resend_letter
-      end
+      it_behaves_like 'gpo otp verification'
     end
 
     context 'ThreatMetrix evaluates as "reject"' do
       let(:threatmetrix_review_status) { 'reject' }
-      it 'redirects to sad face after OTP' do
-        sign_in_and_enter_otp
-        expect(page).to have_current_path(idv_setup_errors_path)
-      end
-      it 'allows requesting a new letter' do
-        resend_letter
-      end
+      it_behaves_like 'gpo otp verification', redirect_after_verification: :idv_setup_errors_path
     end
 
     context 'ThreatMetrix evaluates as nil' do
       let(:threatmetrix_review_status) { nil }
-      it 'redirects to account page after OTP' do
-        sign_in_and_enter_otp
-      end
-      it 'allows requesting a new letter' do
-        resend_letter
-      end
+      it_behaves_like 'gpo otp verification'
     end
-  end
-
-  def sign_in_and_enter_otp
-    sign_in_live_with_2fa(user)
-
-    expect(current_path).to eq idv_gpo_verify_path
-    expect(page).to have_content t('idv.messages.gpo.resend')
-
-    gpo_confirmation_code
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
-  end
-
-  def resend_letter
-    allow(Base32::Crockford).to receive(:encode).and_return(otp)
-
-    sign_in_live_with_2fa(user)
-
-    expect(GpoConfirmation.count).to eq(0)
-    expect(GpoConfirmationCode.count).to eq(0)
-    click_on t('idv.messages.gpo.resend')
-
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
-
-    click_on t('idv.buttons.mail.resend')
-
-    expect(GpoConfirmation.count).to eq(1)
-    expect(GpoConfirmationCode.count).to eq(1)
-    expect(current_path).to eq idv_come_back_later_path
-
-    confirmation_code = GpoConfirmationCode.first
-    otp_fingerprint = Pii::Fingerprinter.fingerprint(otp)
-
-    expect(confirmation_code.otp_fingerprint).to eq(otp_fingerprint)
-    expect(confirmation_code.profile).to eq(profile)
   end
 
   context 'with gpo feature disabled' do

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -147,6 +147,36 @@ describe GpoVerifyForm do
           expect(enrollment.enrollment_code).to be_a(String)
         end
       end
+
+      context 'ThreatMetrix rejection' do
+        let(:proofing_components) do
+          ProofingComponent.create(
+            user: user, threatmetrix: true,
+            threatmetrix_review_status: threatmetrix_review_status
+          )
+        end
+
+        let(:threatmetrix_review_status) { 'reject' }
+
+        before do
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
+            and_return(true)
+          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+            and_return(true)
+          allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
+            and_return(true)
+        end
+
+        it 'returns true' do
+          result = subject.submit
+          expect(result.success?).to eq true
+        end
+
+        it 'notes that threatmetrix failed' do
+          result = subject.submit
+          expect(result.extra).to include(threatmetrix_check_failed: true)
+        end
+      end
     end
 
     context 'incorrect OTP' do

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -1,6 +1,26 @@
 shared_examples 'gpo otp verification' do |options|
   include IdvStepHelper
 
+  let(:expected_redirect_after_gpo_otp_verification) do
+    if options && options[:redirect_after_verification]
+      options[:redirect_after_verification].is_a?(Symbol) ?
+        send(options[:redirect_after_verification]) :
+        options[:redirect_after_verification]
+    end
+  end
+
+  let(:account_should_be_verified) do
+    !options || options[:account_should_be_verified] || options[:account_should_be_verified].nil?
+  end
+
+  let(:profile_should_be_active) do
+    !options || options[:profile_should_be_active] || options[:profile_should_be_active].nil?
+  end
+
+  let(:expected_deactivation_reason) do
+    options && options[:expected_profile_deactivation_reason]
+  end
+
   it 'prompts for one-time code at sign in' do
     sign_in_live_with_2fa(user)
 
@@ -11,16 +31,27 @@ shared_examples 'gpo otp verification' do |options|
     fill_in t('forms.verify_profile.name'), with: otp
     click_button t('forms.verify_profile.submit')
 
-    if options && options[:redirect_after_verification]
-      expected_path = options[:redirect_after_verification].is_a?(Symbol) ?
-        send(options[:redirect_after_verification]) :
-        options[:redirect_after_verification]
-
-      expect(page).to have_current_path(expected_path)
+    if expected_redirect_after_gpo_otp_verification
+      expect(page).to have_current_path(expected_redirect_after_gpo_otp_verification)
     end
 
-    expect(user.events.account_verified.size).to eq 1
-    expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+    profile.reload
+
+    if profile_should_be_active
+      expect(profile.active).to be(true)
+    else
+      expect(profile.active).to be(false)
+      if expected_deactivation_reason
+        expect(profile.deactivation_reason).to eq(expected_deactivation_reason)
+      end
+    end
+
+    if account_should_be_verified
+      expect(user.events.account_verified.size).to eq 1
+      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+    else
+      expect(user.events.account_verified.size).to eq 0
+    end
   end
 
   it 'renders an error for an expired GPO OTP' do

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -12,7 +12,12 @@ shared_examples 'gpo otp verification' do |options|
     click_button t('forms.verify_profile.submit')
 
     if options && options[:redirect_after_verification]
-      expected_path = send(options[:redirect_after_verification])
+      expected_path = if options[:redirect_after_verification].is_a?(Symbol);
+        send(options[:redirect_after_verification])
+      else
+        options[:redirect_after_verification]
+      end
+
       expect(page).to have_current_path(expected_path)
       user.reload
     end

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -17,8 +17,6 @@ shared_examples 'gpo otp verification' do |options|
         options[:redirect_after_verification]
 
       expect(page).to have_current_path(expected_path)
-
-      user.reload
     end
 
     expect(user.events.account_verified.size).to eq 1

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -12,13 +12,12 @@ shared_examples 'gpo otp verification' do |options|
     click_button t('forms.verify_profile.submit')
 
     if options && options[:redirect_after_verification]
-      expected_path = if options[:redirect_after_verification].is_a?(Symbol);
-        send(options[:redirect_after_verification])
-      else
+      expected_path = options[:redirect_after_verification].is_a?(Symbol) ?
+        send(options[:redirect_after_verification]) :
         options[:redirect_after_verification]
-      end
 
       expect(page).to have_current_path(expected_path)
+
       user.reload
     end
 

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -1,0 +1,63 @@
+shared_examples 'gpo otp verification' do |options|
+  include IdvStepHelper
+
+  it 'prompts for one-time code at sign in' do
+    sign_in_live_with_2fa(user)
+
+    expect(current_path).to eq idv_gpo_verify_path
+    expect(page).to have_content t('idv.messages.gpo.resend')
+
+    gpo_confirmation_code
+    fill_in t('forms.verify_profile.name'), with: otp
+    click_button t('forms.verify_profile.submit')
+
+    if options && options[:redirect_after_verification]
+      expected_path = send(options[:redirect_after_verification])
+      expect(page).to have_current_path(expected_path)
+      user.reload
+    end
+
+    expect(user.events.account_verified.size).to eq 1
+    expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+  end
+
+  it 'renders an error for an expired GPO OTP' do
+    sign_in_live_with_2fa(user)
+
+    gpo_confirmation_code.update(code_sent_at: 11.days.ago)
+    fill_in t('forms.verify_profile.name'), with: otp
+    click_button t('forms.verify_profile.submit')
+
+    expect(current_path).to eq idv_gpo_verify_path
+    expect(page).to have_content t('errors.messages.gpo_otp_expired')
+
+    user.reload
+
+    expect(user.events.account_verified.size).to eq 0
+    expect(user.active_profile).to be_nil
+  end
+
+  it 'allows a user to resend a letter' do
+    allow(Base32::Crockford).to receive(:encode).and_return(otp)
+
+    sign_in_live_with_2fa(user)
+
+    expect(GpoConfirmation.count).to eq(0)
+    expect(GpoConfirmationCode.count).to eq(0)
+    click_on t('idv.messages.gpo.resend')
+
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
+
+    click_on t('idv.buttons.mail.resend')
+
+    expect(GpoConfirmation.count).to eq(1)
+    expect(GpoConfirmationCode.count).to eq(1)
+    expect(current_path).to eq idv_come_back_later_path
+
+    confirmation_code = GpoConfirmationCode.first
+    otp_fingerprint = Pii::Fingerprinter.fingerprint(otp)
+
+    expect(confirmation_code.otp_fingerprint).to eq(otp_fingerprint)
+    expect(confirmation_code.profile).to eq(profile)
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8351](https://cm-jira.usa.gov/browse/LG-8351)

## 🛠 Summary of changes

Updates GPO OTP verification such that if the user failed a ThreatMetrix check _before_ verifying their OTP, their account is verified, but created in the `threatmetrix_review_pending` state.

## 📜 Testing Plan

- Verify, selecting "Reject" from the "Mock device profiling behavior" box on the SSN screen
- When prompted to verify using a phone number, select "Verify your address by mail" instead
- After you enter the GPO verification code, you should be redirected to the "sad screen" ("Please give us a call")
- You should _not_ receive the "Your identity has been verified" email

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
