### PR TITLE
Rename "Improvements" changelog category

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,8 @@ pull request is about.
 - If the pull request is in response to a Jira ticket, include the ticket ID in
 the commit title (e.g. "LG-1234 Add the stuff to the thing")
 
-- Include a changelog message which describes the changes in human-readable
-terms. These messages are included in release notes, so they should be easy to
-understand for our partners and users. In the rare case that a change should
-not be included in release notes, add `[skip changelog]` to the commit.
+- Include a changelog message which describes the changes in human-readable terms. Refer to the
+[_Changelog Messages_ section](#changelog-messages) below for specific changelog requirements.
 
 Example:
 
@@ -52,7 +50,9 @@ changelog: Internal, Automated Testing, Improve performance of test suite
 
 #### Changelog Messages
 
-You must include a changelog message in one commit of your pull request.
+You must include a changelog message in one commit of your pull request. The changelog message
+describes the changes in human-readable terms. These messages are included in release notes, so they
+should be easy to understand for our partners and users.
 
 A changelog message should be written in the following format:
 
@@ -71,6 +71,9 @@ Replace `[Category]`, `[Subcategory]`, and `[Description]` with text relevant fo
 - **Description** is a plain language description of the specific changes.
 
 If multiple pull requests iterate on the same feature, it's a good idea to use the same commit message, since identical messages will be combined into a single entry when the release notes are compiled.
+
+In the rare case that a change should not be included in release notes, add `[skip changelog]` to
+the commit.
 
 ### Additional notes on pull requests and code reviews
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ changelog: [Category], [Subcategory], [Description]
 Replace `[Category]`, `[Subcategory]`, and `[Description]` with text relevant for your changes:
 
 - **Category** must be one of the following:
-   - **Improvements** are user-facing improvements to the application experience, such as a new UI component or updated text.
+   - **User-Facing Improvements** are improvements to the application experience benefitting the end-user, such as a new UI component or updated text.
    - **Bug Fixes** are corrections to a broken behavior, such as preventing a raised exception.
    - **Internal** are changes which benefit the Login.gov team, such as analytics or code quality.
    - **Upcoming Features** are iterations contributing to a feature which has not yet been enabled for users in production.

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -5,7 +5,8 @@ require 'optparse'
 CHANGELOG_REGEX =
   %r{^(?:\* )?[cC]hangelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}
 CATEGORIES = [
-  'Improvements',
+  'User-Facing Improvements',
+  'Improvements', # Temporary for transitional period
   'Bug Fixes',
   'Internal',
   'Upcoming Features',
@@ -93,7 +94,7 @@ def generate_invalid_changes(git_log)
 end
 
 def closest_change_category(change)
-  CATEGORIES.
+  category = CATEGORIES.
     map do |category|
       CategoryDistance.new(
         category,
@@ -103,6 +104,10 @@ def closest_change_category(change)
     filter { |category_distance| category_distance.distance <= MAX_CATEGORY_DISTANCE }.
     max { |category_distance| category_distance.distance }&.
     category
+
+  # Temporarily normalize legacy category in transitional period
+  category = 'User-Facing Improvements' if category == 'Improvements'
+  category
 end
 
 # Get the last valid changelog line for every Pull Request and tie it to the commit subject.
@@ -249,7 +254,7 @@ def main(args)
         changelog: CATEGORY, SUBCATEGORY, CHANGE_DESCRIPTION
 
         example:
-        changelog: Improvements, Authentication, Updating Authentication (LG-9998)
+        changelog: User-Facing Improvements, WebAuthn, Improve error flow for WebAuthn (LG-5515)
 
         categories:
         #{CATEGORIES.map { |category| "- #{category}" }.join("\n")}

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -41,7 +41,7 @@ squashed_commit_with_multiple_commits:
 
     * add alert
 
-    * changelog: Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)
+    * changelog: User-Facing Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)
 
     * fix linting, debug
     Co-authored-by: Jessica Dembe <jessica.dembe@gsa.gov>
@@ -51,11 +51,11 @@ squashed_commit_with_multiple_commits:
   commit_messages:
     - '* add check to see if platform is available'
     - '* add alert'
-    - '* changelog: Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)'
+    - '* changelog: User-Facing Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)'
     - '* fix linting, debug'
     - 'Co-authored-by: Jessica Dembe <jessica.dembe@gsa.gov>'
     - 'Co-authored-by: Zach Margolis <zachary.margolis@gsa.gov>'
-  category: 'Improvements'
+  category: 'User-Facing Improvements'
   subcategory: 'Webauthn'
   change: 'Provide better error flow for users who may not be able to leverage webauthn (LG-5515)'
   pr_number: '5976'

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'scripts/changelog_check' do
       formatted_changelog = format_changelog(changelogs)
 
       expect(formatted_changelog).to eq <<~CHANGELOG.chomp
-        ## Improvements
+        ## User-Facing Improvements
         - Webauthn: Provide better error flow for users who may not be able to leverage webauthn (LG-5515) ([#5976](https://github.com/18F/identity-idp/pull/5976))
 
         ## Internal


### PR DESCRIPTION
## 🛠 Summary of changes

Updates contributing document to improve changelog guidance:

- Rename "Improvements" to "User-Facing Improvements" ([see related Engineering Huddle notes 2022-12-14](https://docs.google.com/document/d/1g_V2vlT79tScBKIVw7M4UXf15TrG69iUrLHE0yE1GGI/edit#heading=h.4thd69ufrhdw))
- Moves intent and audience description for changelog messages to the "Changelog Messages" section, to optimize for visibility in deeplinking

## 📜 Testing Plan

`rspec spec/scripts/changelog_check_spec.rb`