### PR TITLE
Improve reliability of flakey countdown spec

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -278,7 +278,7 @@ feature 'Sign in' do
       pattern2 = Regexp.new(
         minutes_and + t(
           'datetime.dotiw.seconds.other',
-          count: (((seconds - 10) % 60)...seconds).to_a.join('|'),
+          count: (seconds - 10...seconds).to_a.join('|'),
         ),
       )
       expect(page).to have_content(pattern2, wait: 5)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -266,12 +266,22 @@ feature 'Sign in' do
     end
 
     scenario 'user sees warning before session times out' do
-      expect(page).to have_content(/14 minutes and 5[0-9] seconds/, wait: 5)
+      minutes_and = [
+        t('datetime.dotiw.minutes', count: IdentityConfig.store.session_timeout_in_minutes - 1),
+        t('datetime.dotiw.two_words_connector'),
+      ].join('')
 
-      time1 = page.text[/14 minutes and 5[0-9] seconds/]
-      sleep(1.5)
-      time2 = page.text[/14 minutes and 5[0-9] seconds/]
-      expect(time2).to be < time1
+      pattern1 = Regexp.new(minutes_and + t('datetime.dotiw.seconds.other', count: '\d+'))
+      expect(page).to have_content(pattern1, wait: 5)
+      time = page.text[pattern1]
+      seconds = time.split(t('datetime.dotiw.two_words_connector')).last[/\d+/].to_i
+      pattern2 = Regexp.new(
+        minutes_and + t(
+          'datetime.dotiw.seconds.other',
+          count: (((seconds - 10) % 60)...seconds).to_a.join('|'),
+        ),
+      )
+      expect(page).to have_content(pattern2, wait: 5)
     end
 
     scenario 'user can continue browsing' do


### PR DESCRIPTION
## 🛠 Summary of changes

Rewrites parts of a sign-in spec to improve reliability. This had previously been attempted for improvement in #7466, but build failures still occur ([example](https://gitlab.login.gov/lg/identity-idp/-/jobs/230794)).

This rewrite also has a few improvements:

- Passes regardless of locale
- Passes regardless of text changes to `datetime/en.yml` string data
- ~Passes regardless of minutes being traversed~ (**Edit:** Removed in 6e5221b, see https://github.com/18F/identity-idp/pull/7512#discussion_r1052374756)
- Passes regardless of config changes to `session_timeout_in_minutes`

## 📜 Testing Plan

`rspec spec/features/users/sign_in_spec.rb:269`