### PR TITLE
Initialize JavaScript tests with polyfilled fetch

### DIFF
--- a/app/javascript/packages/document-capture/components/address-search.spec.tsx
+++ b/app/javascript/packages/document-capture/components/address-search.spec.tsx
@@ -2,7 +2,6 @@ import { render } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import type { SetupServerApi } from 'msw/node';
-import { fetch } from 'whatwg-fetch';
 import { useSandbox } from '@18f/identity-test-helpers';
 import userEvent from '@testing-library/user-event';
 import AddressSearch, { ADDRESS_SEARCH_URL } from './address-search';
@@ -26,7 +25,6 @@ describe('AddressSearch', () => {
 
   let server: SetupServerApi;
   before(() => {
-    global.window.fetch = fetch;
     server = setupServer(
       rest.post(ADDRESS_SEARCH_URL, (_req, res, ctx) => res(ctx.json(DEFAULT_RESPONSE))),
     );
@@ -35,7 +33,6 @@ describe('AddressSearch', () => {
 
   after(() => {
     server.close();
-    global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
   });
 
   it('fires the callback with correct input', async () => {

--- a/app/javascript/packs/form-steps-wait.tsx
+++ b/app/javascript/packs/form-steps-wait.tsx
@@ -5,6 +5,8 @@ interface FormStepsWaitElements {
   form: HTMLFormElement;
 }
 
+type FetchOrFetchPolyfill = typeof window.fetch & { polyfill?: boolean };
+
 interface FormStepsWaitOptions {
   /**
    * Poll interval.
@@ -118,7 +120,7 @@ export class FormStepsWait {
       body: new window.FormData(form),
     });
 
-    if ('polyfill' in window.fetch) {
+    if ((window.fetch as FetchOrFetchPolyfill).polyfill) {
       // The fetch polyfill is implemented using XMLHttpRequest, which suffers from an issue where a
       // Content-Type header from a POST is carried into a redirected GET, which is exactly the flow
       // we are handling here. The current version of Rack neither handles nor provides easy insight

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -95,6 +95,10 @@ describe('FormStepsWait', () => {
     return form;
   }
 
+  beforeEach(() => {
+    sandbox.stub(window.fetch, 'polyfill').value(undefined);
+  });
+
   it('submits form via fetch', () => {
     const action = new URL('/', window.location).toString();
     const method = 'post';

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import dirtyChai from 'dirty-chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import { Response } from 'whatwg-fetch';
+import { fetch, Response } from 'whatwg-fetch'; // Remove in favor of native fetch in Node v20+ (https://nodejs.org/docs/latest/api/globals.html#fetch)
 import { createDOM, useCleanDOM } from './support/dom';
 import { chaiConsoleSpy, useConsoleLogSpy } from './support/console';
 import { sinonChaiAsPromised } from './support/sinon';
@@ -26,7 +26,7 @@ const windowGlobals = Object.fromEntries(
     .map((key) => [key, window[key]]),
 );
 Object.assign(global, windowGlobals);
-global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
+global.window.fetch = fetch;
 Object.defineProperty(global.window, 'crypto', { value: webcrypto });
 global.window.URL.createObjectURL = createObjectURLAsDataURL;
 global.window.URL.revokeObjectURL = () => {};


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces default spec behavior of throwing on attempted `fetch` request with working polyfill.

This was originally planned for #7502, but blocked by failures in `form-steps-wait-spec.tsx`, addressed here.

The issue with the specs is that `form-steps-wait.tsx` has special handling for polyfill'd fetch, due to circumstances of real browsers handling of `XMLHttpRequest`. Since we are expecting to fully simulate the network request, we should bypass this workaround handling. (Aside: The workaround will be removed anyways as part of upcoming sunsetting of Internet Explorer support)

## 📜 Testing Plan

```
yarn test
```