### PR TITLE
Add component preview for One Time Code input

### DIFF
--- a/spec/components/previews/one_time_code_input_component_preview.rb
+++ b/spec/components/previews/one_time_code_input_component_preview.rb
@@ -1,0 +1,18 @@
+class OneTimeCodeInputComponentPreview < BaseComponentPreview
+  # @!group Preview
+  # @display form true
+  def numeric
+    render(OneTimeCodeInputComponent.new(form: form_builder))
+  end
+
+  def alphanumeric
+    render(OneTimeCodeInputComponent.new(form: form_builder, numeric: false))
+  end
+  # @!endgroup
+
+  # @display form true
+  # @param numeric toggle
+  def workbench(numeric: false)
+    render(OneTimeCodeInputComponent.new(form: form_builder, numeric: numeric))
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a component preview for `OneTimeCodeInputComponent`, to further reinforce its intended reusability (particularly highlighting alphanumeric vs. numeric variants).

## 📜 Testing Plan

- Go to http://localhost:3000/components/inspect/one_time_code_input/preview