### PR TITLE
Add filename fingerprint to JavaScript locale data script

### DIFF
--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.spec.js
@@ -6,11 +6,29 @@ const {
 
 describe('getAdditionalAssetFilename', () => {
   it('adds suffix to an existing file name', () => {
-    const original = 'original.js';
-    const suffix = 'en';
+    const filename = 'original.js';
+    const locale = 'en';
+    const content = 'content';
+    const includeHash = false;
     const expected = 'original.en.js';
 
-    expect(getAdditionalAssetFilename(original, suffix)).to.equal(expected);
+    expect(getAdditionalAssetFilename({ filename, locale, content, includeHash })).to.equal(
+      expected,
+    );
+  });
+
+  context('with hash included', () => {
+    it('adds suffix to an file name', () => {
+      const filename = 'original.js';
+      const locale = 'en';
+      const content = 'content';
+      const includeHash = true;
+      const expected = 'original-ae771fd2.en.js';
+
+      expect(getAdditionalAssetFilename({ filename, locale, content, includeHash })).to.equal(
+        expected,
+      );
+    });
   });
 });
 

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
@@ -123,6 +123,69 @@ describe('RailsI18nWebpackPlugin', () => {
       },
     );
   });
+
+  context('in production mode', () => {
+    it('adds hash suffix to javascript locale assets', (done) => {
+      webpack(
+        {
+          mode: 'production',
+          devtool: false,
+          entry: path.resolve(__dirname, 'spec/fixtures/production/in.js'),
+          plugins: [
+            new RailsI18nWebpackPlugin({
+              configPath: path.resolve(__dirname, 'spec/fixtures/locales'),
+            }),
+            new WebpackAssetsManifest({
+              entrypoints: true,
+              publicPath: true,
+              writeToDisk: true,
+              output: 'actualmanifest.json',
+            }),
+          ],
+          externals: {
+            '@18f/identity-i18n': '_i18n_',
+          },
+          output: {
+            path: path.resolve(__dirname, 'spec/fixtures/production'),
+            filename: 'actual[name].js',
+          },
+        },
+        async (webpackError) => {
+          try {
+            expect(webpackError).to.be.null();
+            const manifest = JSON.parse(
+              await fs.readFile(
+                path.resolve(__dirname, 'spec/fixtures/production/actualmanifest.json'),
+                'utf-8',
+              ),
+            );
+
+            expect(manifest).to.deep.equal({
+              'actualmain-3b0c232b.en.js': 'actualmain-3b0c232b.en.js',
+              'actualmain-a43216c8.es.js': 'actualmain-a43216c8.es.js',
+              'actualmain.js': 'actualmain.js',
+              entrypoints: {
+                main: {
+                  assets: {
+                    js: [
+                      'actualmain.js',
+                      'actualmain-3b0c232b.en.js',
+                      'actualmain-a43216c8.es.js',
+                      'actualmain-3b0c232b.fr.js',
+                    ],
+                  },
+                },
+              },
+              'main.js': 'actualmain-3b0c232b.fr.js',
+            });
+            done();
+          } catch (error) {
+            done(error);
+          }
+        },
+      );
+    });
+  });
 });
 
 describe('dig', () => {

--- a/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/production/in.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/spec/fixtures/production/in.js
@@ -1,0 +1,1 @@
+t('forms.button.submit');


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes issue where locale data scripts used the same fingerprint associated with their chunk, so if there were content-only revisions (as in #7501), it would not effectively invalidate the locale script.

The change here adds a hash based on the locale data's own content when compiling for production.

A more elegant solution would probably account for various Webpack options like [`options.output.filename`](https://webpack.js.org/configuration/output/#outputfilename) and/or [`options.output.hashFunction`](https://webpack.js.org/configuration/output/#outputhashfunction).

## 📜 Testing Plan

Test and ensure no errors occur when testing various JavaScript behaviors (notably document capture) when either compiled for development or production.

e.g.

```
NODE_ENV=production yarn build && yarn build:css
rails s
```