### PR TITLE
Updating ThreatMetrix failure (sad face) screen content

### DIFF
--- a/app/views/idv/setup_errors/show.html.erb
+++ b/app/views/idv/setup_errors/show.html.erb
@@ -12,6 +12,6 @@
       heading: t('idv.failure.setup.heading'),
     ) do %>
     <p>
-        <%= t('idv.failure.setup.fail_html', support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
+        <%= t('idv.failure.setup.fail_html', support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code, contact_number: IdentityConfig.store.idv_contact_phone_number) %>
     </p>
 <% end %>

--- a/app/views/idv/setup_errors/show.html.erb
+++ b/app/views/idv/setup_errors/show.html.erb
@@ -11,7 +11,7 @@
       title: t('titles.failure.information_not_verified'),
       heading: t('idv.failure.setup.heading'),
     ) do %>
-  <p>
-    <%= t('idv.failure.setup.fail_html', contact_form_link: link_to(t('idv.failure.setup.link_text'), contact_redirect_url(flow: :idv, step: :secure_account)), support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
-  </p>
+    <p>
+        <%= t('idv.failure.setup.fail_html', support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code) %>
+    </p>
 <% end %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -112,6 +112,7 @@ identity_pki_disabled: false
 identity_pki_local_dev: false
 idv_attempt_window_in_hours: 6
 idv_contact_url: https://www.example.com
+idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13
 idv_acuant_sdk_version_default: '11.7.1'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -82,10 +82,10 @@ en:
         warning: Please check the information you entered and try again. Common mistakes
           are an incorrect Social Security number or ZIP Code.
       setup:
-        fail_html: Please %{contact_form_link} and enter the code <b>%{support_code}</b>
-          in the detail field.
-        heading: There is an issue with your information
-        link_text: fill out our contact form
+        fail_html: 'Please call our contact center at <strong>(844) 875-6446</strong> to
+          continue verifying your identity. You will need to provide them with
+          the error code <strong>%{support_code}</strong>.'
+        heading: Please give us a call
       timeout: We are experiencing higher than usual wait time processing your
         request. Please try again.
     forgot_password:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -82,9 +82,9 @@ en:
         warning: Please check the information you entered and try again. Common mistakes
           are an incorrect Social Security number or ZIP Code.
       setup:
-        fail_html: 'Please call our contact center at <strong>(844) 875-6446</strong> to
-          continue verifying your identity. You will need to provide them with
-          the error code <strong>%{support_code}</strong>.'
+        fail_html: 'Please call our contact center at <strong>%{contact_number}</strong>
+          to continue verifying your identity. You will need to provide them
+          with the error code <strong>%{support_code}</strong>.'
         heading: Please give us a call
       timeout: We are experiencing higher than usual wait time processing your
         request. Please try again.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -92,7 +92,6 @@ es:
           para seguir verificando su identidad. Deberá proporcionarnos el código
           de error <strong>%{support_code}</strong>.
         heading: Llámenos
-        link_text: rellene nuestro formulario decontacto
       timeout: Estamos experimentando un tiempo de espera superior al habitual al
         procesar su solicitud. Inténtalo de nuevo.
     forgot_password:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -88,9 +88,10 @@ es:
           Los errores más comunes suelen producirse al ingresar un Número de
           Seguridad Social o un Código Postal incorrecto.
       setup:
-        fail_html: Por favor, %{contact_form_link} e introduzca el código
-          <b>%{support_code}</b> en el campo de detalle.
-        heading: Hay un problema con tu información
+        fail_html: Llame a nuestro centro de contacto al <strong>(844) 875-6446</strong>
+          para seguir verificando su identidad. Deberá proporcionarnos el código
+          de error <strong>%{support_code}</strong>.
+        heading: Llámenos
         link_text: rellene nuestro formulario decontacto
       timeout: Estamos experimentando un tiempo de espera superior al habitual al
         procesar su solicitud. Inténtalo de nuevo.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -88,9 +88,10 @@ es:
           Los errores más comunes suelen producirse al ingresar un Número de
           Seguridad Social o un Código Postal incorrecto.
       setup:
-        fail_html: Llame a nuestro centro de contacto al <strong>(844) 875-6446</strong>
-          para seguir verificando su identidad. Deberá proporcionarnos el código
-          de error <strong>%{support_code}</strong>.
+        fail_html: Llame a nuestro centro de contacto al
+          <strong>%{contact_number}</strong> para seguir verificando su
+          identidad. Deberá proporcionarnos el código de error
+          <strong>%{support_code}</strong>.
         heading: Llámenos
       timeout: Estamos experimentando un tiempo de espera superior al habitual al
         procesar su solicitud. Inténtalo de nuevo.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -91,9 +91,9 @@ fr:
           Les erreurs les plus courantes sont un numéro de sécurité sociale ou
           un code postal incorrect.
       setup:
-        fail_html: Veuillez appeler notre centre de contact au <strong>(844)
-          875-6446</strong> pour poursuivre la vérification de votre identité.
-          Vous devrez leur fournir le code d’erreur
+        fail_html: Veuillez appeler notre centre de contact au
+          <strong>%{contact_number}</strong> pour poursuivre la vérification de
+          votre identité. Vous devrez leur fournir le code d’erreur
           <strong>%{support_code}</strong>.
         heading: S’il vous plaît, appelez-nous
       timeout: Le temps d’attente pour le traitement de votre demande est plus long

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -96,7 +96,6 @@ fr:
           Vous devrez leur fournir le code d’erreur
           <strong>%{support_code}</strong>.
         heading: S’il vous plaît, appelez-nous
-        link_text: remplir notre formulaire de contact
       timeout: Le temps d’attente pour le traitement de votre demande est plus long
         que d’habitude Veuillez réessayer.
     forgot_password:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -91,9 +91,11 @@ fr:
           Les erreurs les plus courantes sont un numéro de sécurité sociale ou
           un code postal incorrect.
       setup:
-        fail_html: Veuillez %{contact_form_link} et entrer le code
-          <b>%{support_code}</b> dans le champ de détail.
-        heading: Il y a un problème avec vos informations
+        fail_html: Veuillez appeler notre centre de contact au <strong>(844)
+          875-6446</strong> pour poursuivre la vérification de votre identité.
+          Vous devrez leur fournir le code d’erreur
+          <strong>%{support_code}</strong>.
+        heading: S’il vous plaît, appelez-nous
         link_text: remplir notre formulaire de contact
       timeout: Le temps d’attente pour le traitement de votre demande est plus long
         que d’habitude Veuillez réessayer.

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -191,6 +191,7 @@ class IdentityConfig
     config.add(:identity_pki_local_dev, type: :boolean)
     config.add(:idv_attempt_window_in_hours, type: :integer)
     config.add(:idv_contact_url, type: :string)
+    config.add(:idv_contact_phone_number, type: :string)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)
     config.add(:idv_acuant_sdk_version_default, type: :string)

--- a/spec/views/idv/setup_errors/show.html.erb_spec.rb
+++ b/spec/views/idv/setup_errors/show.html.erb_spec.rb
@@ -17,7 +17,6 @@ describe 'idv/setup_errors/show.html.erb' do
       strip_tags(
         t(
           'idv.failure.setup.fail_html',
-          contact_form_link: t('idv.failure.setup.link_text'),
           support_code: 'ABCD',
         ),
       ),

--- a/spec/views/idv/setup_errors/show.html.erb_spec.rb
+++ b/spec/views/idv/setup_errors/show.html.erb_spec.rb
@@ -18,6 +18,7 @@ describe 'idv/setup_errors/show.html.erb' do
         t(
           'idv.failure.setup.fail_html',
           support_code: 'ABCD',
+          contact_number: '(844) 555-5555',
         ),
       ),
     )


### PR DESCRIPTION
changelog: User Facing Improvements, UX, ThreatMetrix failure screen content

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8315: Update "Sad Face" Screen](https://cm-jira.usa.gov/browse/LG-8315)

## 🛠 Summary of changes

This PR contains content changes for the ThreatMetrix failure screen (with locales)


## 📜 Testing Plan

Basic steps

- [ ] Create a new account and begin idv in a dev or local environment
- [ ] Proceed to the SSN step, select `Reject` or `Review` from the threatmetrix dropdown
- [ ] Continue through the personal key step
- [ ] You should be directed to the new ThreatMetrix "sad face" (ie your account is under review) content


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="667" alt="Screen Shot 2022-12-21 at 4 42 52 PM" src="https://user-images.githubusercontent.com/105373963/209150715-10b75590-c34f-41d9-b469-83adaa72023f.png">

</details>

<details>
<summary>After:</summary>
<img width="676" alt="Screen Shot 2022-12-21 at 4 34 01 PM" src="https://user-images.githubusercontent.com/105373963/209150746-72fb60ca-9df5-458a-86c4-3cc10782357d.png">

</details>
