### PR TITLE
Fix flakey in-person feature test

### DIFF
--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -319,7 +319,11 @@ RSpec.describe 'In Person Proofing', js: true do
         complete_doc_auth_steps_before_send_link_step
         fill_in :doc_auth_phone, with: '415-555-0199'
         click_idv_continue
+
+        expect(page).to have_content(t('doc_auth.headings.text_message'))
       end
+
+      expect(@sms_link).to be_present
 
       perform_in_browser(:mobile) do
         visit @sms_link

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -3,8 +3,9 @@ module DocumentCaptureStepHelper
     click_on 'Submit'
 
     # Wait for the the loading interstitial to disappear before continuing
-    expect(page).to have_content(t('doc_auth.headings.interstitial'))
-    expect(page).not_to have_content(t('doc_auth.headings.interstitial'), wait: 10)
+    if page.has_content?(t('doc_auth.headings.interstitial'))
+      expect(page).not_to have_content(t('doc_auth.headings.interstitial'), wait: 10)
+    end
   end
 
   def attach_and_submit_images

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -3,9 +3,7 @@ module DocumentCaptureStepHelper
     click_on 'Submit'
 
     # Wait for the the loading interstitial to disappear before continuing
-    if page.has_content?(t('doc_auth.headings.interstitial'))
-      expect(page).not_to have_content(t('doc_auth.headings.interstitial'), wait: 10)
-    end
+    expect(page).not_to have_content(t('doc_auth.headings.interstitial'), wait: 10)
   end
 
   def attach_and_submit_images


### PR DESCRIPTION
## 🛠 Summary of changes

Resolves a flakey feature test that started failing after #7384 was merged. After that change, it was possible in certain cases for the doc auth image upload interstitial to disappear before it could be detected by capybara matchers.

This PR preserves waiting for the interstitial to disappear before proceeding, but removes the initial expectation that it be present.

## 📜 Testing Plan

```bash
bundle exec rspec spec/features/idv/in_person_spec.rb:314
```
