### PR TITLE
LG-8390 Write rake tasks to pass or reject users

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -24,6 +24,7 @@ class Profile < ApplicationRecord
     verification_cancelled: 4,
     in_person_verification_pending: 5,
     threatmetrix_review_pending: 6,
+    threatmetrix_review_rejected: 7,
   }
 
   attr_reader :personal_key

--- a/app/models/proofing_component.rb
+++ b/app/models/proofing_component.rb
@@ -1,3 +1,7 @@
 class ProofingComponent < ApplicationRecord
   belongs_to :user
+
+  def review_eligible?
+    verified_at.after?(30.days.ago)
+  end
 end

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -7,10 +7,12 @@ namespace :users do
       user_uuid = STDIN.getpass('Enter the User UUID to pass (input will be hidden):')
       user = User.find_by(uuid: user_uuid)
 
-      if user.decorate.threatmetrix_review_pending?
+      if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'pass')
         puts "User's review state has been updated to #{result.threatmetrix_review_status}."
+      elsif !user.proofing_component.review_eligible?
+        puts 'User is past the 30 day review eligibility'
       else
         puts 'User was not found pending a review'
       end
@@ -21,10 +23,12 @@ namespace :users do
       user_uuid = STDIN.getpass('Enter the User UUID to reject (input will be hidden):')
       user = User.find_by(uuid: user_uuid)
 
-      if user.decorate.threatmetrix_review_pending?
+      if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'reject')
         puts "User's review state has been updated to #{result.threatmetrix_review_status}."
+      elsif !user.proofing_component.review_eligible?
+        puts 'User is past the 30 day review eligibility'
       else
         puts 'User was not found pending a review'
       end

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -10,7 +10,10 @@ namespace :users do
       if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'pass')
-        user.profiles.first.activate
+        user.profiles.
+          where(deactivation_reason: 'threatmetrix_review_pending').
+          first.
+          activate
         puts "User's review state has been updated to #{result.threatmetrix_review_status}."
       elsif !user.proofing_component.review_eligible?
         puts 'User is past the 30 day review eligibility'

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -1,25 +1,33 @@
-namespace :users do
-  desc 'Review a user profile and pass them'
-  task review_user: :environment do |_task, args|
-    require 'io/console'
-    user_uuid = STDIN.getpass('Enter the UUID of the user to look up(input will be hidden): ')
-    user = User.find_by(uuid: user_uuid)
+require 'io/console'
 
-    if user.present?
-      review_status = ProofingComponent.find_by(user: user)
-      puts('Do you want to pass or reject this user? [PASS/REJECT]:')
-      pass_or_reject = STDIN.gets.strip.downcase
-      if pass_or_reject == 'pass'
-        review_status.update(threatmetrix_review_status: 'pass')
-        puts "User's review state is updated to #{review_status.threatmetrix_review_status}"
-      elsif pass_or_reject == 'reject'
-        review_status.update(threatmetrix_review_status: 'reject')
-        puts "User's review state is updated to #{review_status.threatmetrix_review_status}"
+namespace :users do
+  namespace :review do
+    desc 'Pass a user that has a pending review'
+    task pass: :environment do |_task, args|
+      user_uuid = STDIN.getpass('Enter the User UUID to pass (input will be hidden):')
+      user = User.find_by(uuid: user_uuid)
+
+      if user.decorate.threatmetrix_review_pending?
+        result = ProofingComponent.find_by(user: user)
+        result.update(threatmetrix_review_status: 'pass')
+        puts "User's review state has been updated to #{result.threatmetrix_review_status}."
       else
-        puts "User's review status has not changed"
+        puts 'User was not found pending a review'
       end
-    else
-      puts 'No user found'
+    end
+
+    desc 'Reject a user that has a pending review'
+    task reject: :environment do |_task, args|
+      user_uuid = STDIN.getpass('Enter the User UUID to reject (input will be hidden):')
+      user = User.find_by(uuid: user_uuid)
+
+      if user.decorate.threatmetrix_review_pending?
+        result = ProofingComponent.find_by(user: user)
+        result.update(threatmetrix_review_status: 'reject')
+        puts "User's review state has been updated to #{result.threatmetrix_review_status}."
+      else
+        puts 'User was not found pending a review'
+      end
     end
   end
 end

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -1,0 +1,25 @@
+namespace :users do
+  desc 'Review a user profile and pass them'
+  task review_user: :environment do |_task, args|
+    require 'io/console'
+    user_uuid = STDIN.getpass('Enter the UUID of the user to look up(input will be hidden): ')
+    user = User.find_by(uuid: user_uuid)
+
+    if user.present?
+      review_status = ProofingComponent.find_by(user: user)
+      puts('Do you want to pass or reject this user? [PASS/REJECT]:')
+      pass_or_reject = STDIN.gets.strip.downcase
+      if pass_or_reject == 'pass'
+        review_status.update(threatmetrix_review_status: 'pass')
+        puts "User's review state is updated to #{review_status.threatmetrix_review_status}"
+      elsif pass_or_reject == 'reject'
+        review_status.update(threatmetrix_review_status: 'reject')
+        puts "User's review state is updated to #{review_status.threatmetrix_review_status}"
+      else
+        puts "User's review status has not changed"
+      end
+    else
+      puts 'No user found'
+    end
+  end
+end

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -10,6 +10,7 @@ namespace :users do
       if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'pass')
+        user.profiles.first.activate
         puts "User's review state has been updated to #{result.threatmetrix_review_status}."
       elsif !user.proofing_component.review_eligible?
         puts 'User is past the 30 day review eligibility'
@@ -26,6 +27,10 @@ namespace :users do
       if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'reject')
+        user.profiles.
+          where(deactivation_reason: 'threatmetrix_review_pending').
+          first.
+          deactivate(:threatmetrix_review_rejected)
         puts "User's review state has been updated to #{result.threatmetrix_review_status}."
       elsif !user.proofing_component.review_eligible?
         puts 'User is past the 30 day review eligibility'

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -21,6 +21,11 @@ FactoryBot.define do
       deactivation_reason { :password_reset }
     end
 
+    trait :threatmetrix_review_pending do
+      deactivation_reason { :threatmetrix_review_pending }
+      proofing_components { { threatmetrix_review_status: 'review' } }
+    end
+
     trait :verification_cancelled do
       deactivation_reason { :verification_cancelled }
     end

--- a/spec/factories/proofing_components.rb
+++ b/spec/factories/proofing_components.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :proofing_component do
+    association :user, factory: %i[user signed_up]
+
+    trait :eligible_for_review do
+      verified_at { Time.zone.now }
+      threatmetrix_review_status { 'review' }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -210,6 +210,15 @@ FactoryBot.define do
       end
     end
 
+    trait :deactivated_threatmetrix_profile do
+      signed_up
+
+      after :build do |user|
+        create(:profile, :threatmetrix_review_pending, :with_pii, user: user)
+        create(:proofing_component, :eligible_for_review, user: user)
+      end
+    end
+
     trait :deactivated_password_reset_profile do
       signed_up
 

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -15,6 +15,7 @@ describe 'review_profile' do
 
       Rake::Task['users:review:pass'].invoke
       expect(user.reload.proofing_component.threatmetrix_review_status).to eq('pass')
+      expect(user.reload.profiles.first.active).to eq(true)
     end
   end
 
@@ -26,6 +27,7 @@ describe 'review_profile' do
 
       Rake::Task['users:review:reject'].invoke
       expect(user.reload.proofing_component.threatmetrix_review_status).to eq('reject')
+      expect(user.reload.profiles.first.deactivation_reason).to eq('threatmetrix_review_rejected')
     end
   end
 end

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'review_profile' do
+  before do
+    Rake.application.rake_require('lib/tasks/review_profile', [Rails.root.to_s])
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'users:review:pass' do
+    it 'sets threatmetrix_review_status to pass' do
+      user = create(:user, :deactivated_threatmetrix_profile)
+
+      allow(STDIN).to receive(:getpass) { user.uuid }
+
+      Rake::Task['users:review:pass'].invoke
+      expect(user.reload.proofing_component.threatmetrix_review_status).to eq('pass')
+    end
+  end
+
+  describe 'users:review:reject' do
+    it 'sets threatmetrix_review_status to reject' do
+      user = create(:user, :deactivated_threatmetrix_profile)
+
+      allow(STDIN).to receive(:getpass) { user.uuid }
+
+      Rake::Task['users:review:reject'].invoke
+      expect(user.reload.proofing_component.threatmetrix_review_status).to eq('reject')
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes

Wrote a rake task to pass or reject a user that account is deactivated due to threatmetrix status being in review.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV flow and set user's status to Review on SSN page
- [ ] Run `rake users:review:pass` to pass a user
- [ ] Make sure the output says "User's review state has been set to pass.'


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
