### PR TITLE
Fix untranslated email input in password reset

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -20,7 +20,7 @@
         label: t('account.index.email'),
         required: true,
         input_html: { autocorrect: 'off',
-                      aria: { invalid: false, describedby: 'email-description' } },
+                      aria: { describedby: 'email-description' } },
       ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,10 +14,14 @@
       url: user_password_path,
       html: { autocomplete: 'off', method: :post },
     ) do |f| %>
-  <%= f.input :email,
-              required: true,
-              input_html: { autocorrect: 'off',
-                            aria: { invalid: false, describedby: 'email-description' } } %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :email,
+        label: t('account.index.email'),
+        required: true,
+        input_html: { autocorrect: 'off',
+                      aria: { invalid: false, describedby: 'email-description' } },
+      ) %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>

--- a/spec/features/multiple_emails/reset_password_spec.rb
+++ b/spec/features/multiple_emails/reset_password_spec.rb
@@ -7,7 +7,7 @@ describe 'reset password with multiple emails' do
 
     visit root_path
     click_link t('links.passwords.forgot')
-    fill_in 'Email', with: email1
+    fill_in t('account.index.email'), with: email1
     click_button t('forms.buttons.continue')
 
     expect_delivered_email_count(1)
@@ -20,7 +20,7 @@ describe 'reset password with multiple emails' do
 
     visit root_path
     click_link t('links.passwords.forgot')
-    fill_in 'Email', with: email2
+    fill_in t('account.index.email'), with: email2
     click_button t('forms.buttons.continue')
 
     expect_delivered_email_count(2)
@@ -42,7 +42,7 @@ describe 'reset password with multiple emails' do
 
     visit root_path
     click_link t('links.passwords.forgot')
-    fill_in 'Email', with: unconfirmed_email_address.email
+    fill_in t('account.index.email'), with: unconfirmed_email_address.email
     click_button t('forms.buttons.continue')
 
     expect_delivered_email_count(1)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -362,7 +362,7 @@ feature 'Sign in' do
       allow(Devise).to receive(:timeout_in).and_return(1)
       user = create(:user)
       visit root_path
-      fill_in 'Email', with: user.email
+      fill_in t('account.index.email'), with: user.email
       fill_in 'Password', with: user.password
 
       expect(page).to have_content(

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -11,7 +11,7 @@ feature 'Password Recovery' do
 
       visit root_path
       click_link t('links.passwords.forgot')
-      fill_in 'Email', with: user.email
+      fill_in t('account.index.email'), with: user.email
 
       expect(PushNotification::HttpPush).to receive(:deliver).
         with(PushNotification::RecoveryActivatedEvent.new(user: user))
@@ -99,7 +99,7 @@ feature 'Password Recovery' do
     before do
       user = create(:user)
       visit new_user_password_path
-      fill_in 'Email', with: user.email
+      fill_in t('account.index.email'), with: user.email
       click_button t('forms.buttons.continue')
       visit edit_user_password_path(reset_password_token: 'invalid_token')
     end
@@ -143,7 +143,7 @@ feature 'Password Recovery' do
       @user = create(:user, :signed_up)
 
       visit new_user_password_path
-      fill_in 'Email', with: @user.email
+      fill_in t('account.index.email'), with: @user.email
       click_button t('forms.buttons.continue')
 
       raw_reset_token, db_confirmation_token =
@@ -226,7 +226,7 @@ feature 'Password Recovery' do
     user = create(:user, :signed_up)
 
     visit new_user_password_path
-    fill_in 'Email', with: user.email
+    fill_in t('account.index.email'), with: user.email
     click_button t('forms.buttons.continue')
 
     user.reset_password_sent_at =
@@ -261,7 +261,7 @@ feature 'Password Recovery' do
 
   def submit_email_for_password_reset(email)
     visit new_user_password_path
-    fill_in 'Email', with: email
+    fill_in t('account.index.email'), with: email
     click_button t('forms.buttons.continue')
   end
 end

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -21,7 +21,7 @@ module PersonalKeyHelper
 
   def trigger_reset_password_and_click_email_link(email)
     visit new_user_password_path
-    fill_in 'Email', with: email
+    fill_in t('account.index.email'), with: email
     click_button t('forms.buttons.continue')
     open_last_email
     click_email_link_matching(/reset_password_token/)


### PR DESCRIPTION
## 🛠 Summary of changes

`simple_form_for` is helpful by automatically generating labels for inputs, but it can't properly internationalize. I'll be looking to see if other locations are affected by this and if there's a long-term fix.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/1430443/209233198-85db6619-7d34-491c-9706-765e9059241b.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/1430443/209233579-993923a6-22a7-4cec-ac3e-3d6fd987d71a.png)

</details>
