### PR TITLE
WIP - Add RedisSessionHealthChecker

### DIFF
--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -5,6 +5,7 @@ module Health
     def health_checker
       checkers = {
         database: DatabaseHealthChecker,
+        redis_session: RedisSessionHealthChecker,
         account_reset: AccountResetHealthChecker,
       }
       MultiHealthChecker.new(**checkers)

--- a/app/controllers/health/redis_session_controller.rb
+++ b/app/controllers/health/redis_session_controller.rb
@@ -1,0 +1,9 @@
+module Health
+  class RedisSessionController < AbstractHealthController
+    private
+
+    def health_checker
+      RedisSessionHealthChecker
+    end
+  end
+end

--- a/app/services/redis_session_health_checker.rb
+++ b/app/services/redis_session_health_checker.rb
@@ -1,0 +1,30 @@
+module RedisSessionHealthChecker
+  module_function
+
+  # @return [HealthCheckSummary]
+  def check
+    HealthCheckSummary.new(healthy: true, result: health_write_and_read)
+  rescue StandardError => err
+    NewRelic::Agent.notice_error(err)
+    HealthCheckSummary.new(healthy: false, result: err.message)
+  end
+
+  # @api private
+  def health_write_and_read
+    REDIS_POOL.with do |client|
+      client.setex(health_record_key, health_record_ttl, "healthy at " + Time.now.iso8601)
+      client.get(health_record_key) or raise "Unable to read back #{health_record_key} from Redis"
+    end
+  end
+
+  # @api private
+  def health_record_key
+    "healthcheck_" + Socket.gethostname
+  end
+
+  # @api private
+  def health_record_ttl
+    # If we can't read back within a second that is just unacceptable
+    1
+  end
+end

--- a/app/services/redis_session_health_checker.rb
+++ b/app/services/redis_session_health_checker.rb
@@ -13,7 +13,7 @@ module RedisSessionHealthChecker
   def health_write_and_read
     REDIS_POOL.with do |client|
       client.setex(health_record_key, health_record_ttl, "healthy at " + Time.now.iso8601)
-      client.get(health_record_key) or raise "Unable to read back #{health_record_key} from Redis"
+      client.get(health_record_key)
     end
   end
 

--- a/app/services/redis_session_health_checker.rb
+++ b/app/services/redis_session_health_checker.rb
@@ -3,7 +3,7 @@ module RedisSessionHealthChecker
 
   # @return [HealthCheckSummary]
   def check
-    HealthCheckSummary.new(healthy: true, result: health_write_and_read)
+    HealthCheckSummary.new(healthy: health_write_and_read.present?, result: health_write_and_read)
   rescue StandardError => err
     NewRelic::Agent.notice_error(err)
     HealthCheckSummary.new(healthy: false, result: err.message)

--- a/spec/services/redis_session_health_checker_spec.rb
+++ b/spec/services/redis_session_health_checker_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe RedisSessionHealthChecker do
+  describe '.check' do
+    subject(:summary) { RedisSessionHealthChecker.check }
+
+    context 'when the redis session store is healthy' do
+      it 'returns a healthy check' do
+        expect(summary.healthy).to eq(true)
+        expect(summary.result).to start_with("healthy at ")
+      end
+    end
+
+    context 'when the redis session store is unhealthy' do
+      before do
+        expect(RedisSessionHealthChecker).to receive(:simple_query).
+          and_raise(RuntimeError.new('canceling statement due to statement timeout'))
+      end
+
+      it 'returns an unhealthy check' do
+        expect(summary.healthy).to eq(false)
+        expect(summary.result).to include('canceling statement due to statement timeout')
+      end
+
+      it 'notifies NewRelic' do
+        expect(NewRelic::Agent).to receive(:notice_error)
+
+        summary
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

https://github.com/18F/identity-devops/issues/5629

## 🛠 Summary of changes

Add a Redis session check to the existing `/api/health` endpoint to ensure a working connection with Redis when assessing the health of a server.

## 📜 Testing Plan

TBD

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

## 👀 Screenshots

TBD

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
