### PR TITLE
Avoid double-update to doc_auth_logs table

### DIFF
--- a/app/services/funnel/doc_auth/register_submit_step.rb
+++ b/app/services/funnel/doc_auth/register_submit_step.rb
@@ -4,6 +4,7 @@ module Funnel
       def self.call(doc_auth_log, issuer, token, success)
         update_submit_count(doc_auth_log, issuer, token)
         update_error_count(doc_auth_log, token, success)
+        doc_auth_log.save
       end
 
       def self.update_submit_count(doc_auth_log, issuer, token)
@@ -13,7 +14,6 @@ module Funnel
         method = "#{token}_submit_at".to_sym
         doc_auth_log[method] = Time.zone.now if doc_auth_log.respond_to?(method)
         doc_auth_log.issuer = issuer
-        doc_auth_log.save
       end
       private_class_method :update_submit_count
 
@@ -21,7 +21,6 @@ module Funnel
         error_count = "#{token}_error_count".to_sym
         return unless doc_auth_log.respond_to?(error_count) && !success
         doc_auth_log[error_count] += 1
-        doc_auth_log.save
       end
       private_class_method :update_error_count
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Currently `RegisterSubmitStep` potentially updates a column or two and then updates a second set of columns. This behavior doesn't seem to be required and appears to be a small, but unnecessary increase in write load on the database.

I suspect there are steps in the doc auth flow where `RegisterSubmitStep` is called multiple times quickly, so there's potential to improve this further as well.
 
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
