### PR TITLE
LG-8392: Email user when OK'ing their ThreatMetrix status

### DIFF
--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -31,9 +31,17 @@ class UserEventCreator
     create_event_for_device(event_type: event_type, user: current_user, device: nil)
   end
 
+  def create_out_of_band_user_event_with_disavowal(event_type)
+    create_event_for_device(
+      event_type: event_type,
+      user: current_user,
+      device: nil,
+      disavowal_token: disavowal_token,
+    )
+  end
+
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_user_event_with_disavowal(event_type, user = current_user, device = nil)
-    disavowal_token = SecureRandom.urlsafe_base64(32)
     if device
       create_event_for_existing_device(
         event_type: event_type, user: user, device: device,
@@ -55,6 +63,10 @@ class UserEventCreator
       device: device,
       disavowal_token: disavowal_token,
     )
+  end
+
+  def disavowal_token
+    SecureRandom.urlsafe_base64(32)
   end
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -36,7 +36,7 @@ class UserEventCreator
       event_type: event_type,
       user: current_user,
       device: nil,
-      disavowal_token: disavowal_token,
+      disavowal_token: build_disavowal_token,
     )
   end
 
@@ -45,10 +45,10 @@ class UserEventCreator
     if device
       create_event_for_existing_device(
         event_type: event_type, user: user, device: device,
-        disavowal_token: disavowal_token
+        disavowal_token: build_disavowal_token
       )
     else
-      create_user_event(event_type, user, disavowal_token)
+      create_user_event(event_type, user, build_disavowal_token)
     end
   end
 
@@ -65,7 +65,7 @@ class UserEventCreator
     )
   end
 
-  def disavowal_token
+  def build_disavowal_token
     SecureRandom.urlsafe_base64(32)
   end
 

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -10,11 +10,23 @@ namespace :users do
       if user.decorate.threatmetrix_review_pending? && user.proofing_component.review_eligible?
         result = ProofingComponent.find_by(user: user)
         result.update(threatmetrix_review_status: 'pass')
-        user.profiles.
+
+        profile = user.profiles.
           where(deactivation_reason: 'threatmetrix_review_pending').
-          first.
-          activate
-        puts "User's review state has been updated to #{result.threatmetrix_review_status}."
+          first
+        profile.activate
+
+        event, disavowal_token = UserEventCreator.new(current_user: user).
+          create_out_of_band_user_event_with_disavowal(:account_verified)
+
+        UserAlerts::AlertUserAboutAccountVerified.call(
+          user: user,
+          date_time: event.created_at,
+          sp_name: nil,
+          disavowal_token: disavowal_token,
+        )
+
+        puts "User's review state has been updated to #{result.threatmetrix_review_status} and the user has been notified by email."
       elsif !user.proofing_component.review_eligible?
         puts 'User is past the 30 day review eligibility'
       else

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -26,7 +26,8 @@ namespace :users do
           disavowal_token: disavowal_token,
         )
 
-        puts "User's review state has been updated to #{result.threatmetrix_review_status} and the user has been notified by email."
+        status = result.threatmetrix_review_status
+        puts "User's review state has been updated to #{status} and the user has been emailed."
       elsif !user.proofing_component.review_eligible?
         puts 'User is past the 30 day review eligibility'
       else

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -2,30 +2,47 @@ require 'rails_helper'
 require 'rake'
 
 describe 'review_profile' do
+  let(:user) { create(:user, :deactivated_threatmetrix_profile) }
+  let(:task_name) { nil }
+
+  subject(:invoke_task) do
+    Rake::Task[task_name].reenable
+    Rake::Task[task_name].invoke
+  end
+
   before do
     Rake.application.rake_require('lib/tasks/review_profile', [Rails.root.to_s])
     Rake::Task.define_task(:environment)
+    allow(STDIN).to receive(:getpass) { user.uuid }
   end
 
   describe 'users:review:pass' do
+    let(:task_name) { 'users:review:pass' }
+
     it 'sets threatmetrix_review_status to pass' do
-      user = create(:user, :deactivated_threatmetrix_profile)
-
-      allow(STDIN).to receive(:getpass) { user.uuid }
-
-      Rake::Task['users:review:pass'].invoke
+      invoke_task
       expect(user.reload.proofing_component.threatmetrix_review_status).to eq('pass')
       expect(user.reload.profiles.first.active).to eq(true)
+    end
+
+    it 'dispatches account verified alert' do
+      freeze_time do
+        expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).with(
+          user: user,
+          date_time: Time.zone.now,
+          disavowal_token: kind_of(String),
+          sp_name: nil,
+        )
+        invoke_task
+      end
     end
   end
 
   describe 'users:review:reject' do
+    let(:task_name) { 'users:review:reject' }
+
     it 'sets threatmetrix_review_status to reject' do
-      user = create(:user, :deactivated_threatmetrix_profile)
-
-      allow(STDIN).to receive(:getpass) { user.uuid }
-
-      Rake::Task['users:review:reject'].invoke
+      invoke_task
       expect(user.reload.proofing_component.threatmetrix_review_status).to eq('reject')
       expect(user.reload.profiles.first.deactivation_reason).to eq('threatmetrix_review_rejected')
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8392](https://cm-jira.usa.gov/browse/LG-8392)

## 🛠 Summary of changes

When operators manually OK a user's ThreatMetrix status, send the "You verified your identity" email.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Attempt to verify an account, but get blocked by ThreatMetrix
- [ ] Run `rake users:review:pass` and provide your UUID when prompted
- [ ] Verify you receive a "You verified your identity with Login.gov" email
