### PR TITLE
Remove ThreatMetrix review redirects

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -21,7 +21,6 @@ module OpenidConnect
     before_action :bump_auth_count, only: [:index]
 
     def index
-      return redirect_to_threatmetrix_review if threatmetrix_review_pending_for_ial2_request?
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
       link_identity_to_service_provider

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -25,7 +25,6 @@ class SamlIdpController < ApplicationController
 
   def auth
     capture_analytics
-    return redirect_to_threatmetrix_review if threatmetrix_review_pending? && ial2_requested?
     return redirect_to_verification_url if profile_or_identity_needs_verification_or_decryption?
     return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
     if auth_count == 1 && first_visit_for_sp?


### PR DESCRIPTION
## 🛠 Summary of changes

There is a bug where users will be sent to the review screen despite decisioning being disabled, this is a short-term fix until it can be fully addressed.

[Slack thread](https://gsa-tts.slack.com/archives/C20J64X6V/p1672430569691359)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
