### PR TITLE
Remove ThreatMetrix deactivation

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -21,8 +21,6 @@ class GpoVerifyForm
       if pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
-      elsif threatmetrix_check_failed?
-        pending_profile&.deactivate(:threatmetrix_review_pending)
       else
         activate_profile
       end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -48,21 +48,21 @@ feature 'idv gpo otp verification step', :js do
       it_behaves_like 'gpo otp verification'
     end
 
-    context 'ThreatMetrix says "review"' do
-      let(:threatmetrix_review_status) { 'review' }
-      let(:redirect_after_verification) { idv_setup_errors_path }
-      let(:profile_should_be_active) { false }
-      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
-      it_behaves_like 'gpo otp verification'
-    end
+    # context 'ThreatMetrix says "review"' do
+    #   let(:threatmetrix_review_status) { 'review' }
+    #   let(:redirect_after_verification) { idv_setup_errors_path }
+    #   let(:profile_should_be_active) { false }
+    #   let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
+    #   it_behaves_like 'gpo otp verification'
+    # end
 
-    context 'ThreatMetrix says "reject"' do
-      let(:threatmetrix_review_status) { 'reject' }
-      let(:redirect_after_verification) { idv_setup_errors_path }
-      let(:profile_should_be_active) { false }
-      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
-      it_behaves_like 'gpo otp verification'
-    end
+    # context 'ThreatMetrix says "reject"' do
+    #   let(:threatmetrix_review_status) { 'reject' }
+    #   let(:redirect_after_verification) { idv_setup_errors_path }
+    #   let(:profile_should_be_active) { false }
+    #   let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
+    #   it_behaves_like 'gpo otp verification'
+    # end
 
     context 'No ThreatMetrix result on proofing component' do
       let(:threatmetrix_review_status) { nil }


### PR DESCRIPTION
## 🛠 Summary of changes

We are not intending to disable users with ThreatMetrix currently, so this removes the logic.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
