### PR TITLE
LG-8521 Re-enable ThreatMetrix redirects

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -21,6 +21,7 @@ module OpenidConnect
     before_action :bump_auth_count, only: [:index]
 
     def index
+      return redirect_to_threatmetrix_review if threatmetrix_review_pending_for_ial2_request?
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
       link_identity_to_service_provider

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -25,6 +25,7 @@ class SamlIdpController < ApplicationController
 
   def auth
     capture_analytics
+    return redirect_to_threatmetrix_review if threatmetrix_review_pending? && ial2_requested?
     return redirect_to_verification_url if profile_or_identity_needs_verification_or_decryption?
     return redirect_to(sign_up_completed_url) if needs_completion_screen_reason
     if auth_count == 1 && first_visit_for_sp?


### PR DESCRIPTION
These were removed in an attempt to fix an issue where decisioning was enabled (#7560). That change actually did not address the issue. The change in #7562 addressed the issue.

This commit puts this code back.

[skip changelog]
