### PR TITLE
Merge duplicate TM feature flags

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -101,7 +101,7 @@ module Idv
     end
 
     def threatmetrix_enabled?
-      IdentityConfig.store.proofing_device_profiling_decisioning_enabled
+      IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
     end
   end
 end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -85,7 +85,7 @@ module Idv
     end
 
     def blocked_by_device_profiling?
-      return false unless IdentityConfig.store.proofing_device_profiling_decisioning_enabled
+      return false unless IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
       proofing_component = ProofingComponent.find_by(user: current_user)
       # pass users who are inbetween feature flag being enabled and have not had a check run.
       return false if proofing_component.threatmetrix_review_status.nil?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -234,7 +234,6 @@ platform_auth_set_up_enabled: false
 poll_rate_for_verify_in_seconds: 3
 proofer_mock_fallback: true
 proofing_device_profiling_collecting_enabled: true
-proofing_device_profiling_decisioning_enabled: false
 proof_address_max_attempts: 5
 proof_address_max_attempt_window_in_minutes: 360
 proof_ssn_max_attempts: 10

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -323,7 +323,6 @@ class IdentityConfig
     config.add(:poll_rate_for_verify_in_seconds, type: :integer)
     config.add(:proofer_mock_fallback, type: :boolean)
     config.add(:proofing_device_profiling_collecting_enabled, type: :boolean)
-    config.add(:proofing_device_profiling_decisioning_enabled, type: :boolean)
     config.add(:proof_address_max_attempts, type: :integer)
     config.add(:proof_address_max_attempt_window_in_minutes, type: :integer)
     config.add(:proof_ssn_max_attempts, type: :integer)

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -34,8 +34,6 @@ RSpec.describe Idv::GpoVerifyController do
       and_return(threatmetrix_enabled)
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
       and_return(threatmetrix_enabled)
-    allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-      and_return(threatmetrix_enabled)
   end
 
   describe '#index' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -202,7 +202,7 @@ describe Idv::PersonalKeyController do
       before do
         ProofingComponent.create(user: user, threatmetrix: true, threatmetrix_review_status: nil)
         allow(IdentityConfig.store).
-          to receive(:proofing_device_profiling_decisioning_enabled).and_return(true)
+          to receive(:lexisnexis_threatmetrix_required_to_verify).and_return(true)
       end
 
       it 'redirects to account path when threatmetrix review status is nil' do

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe 'In Person Proofing', js: true do
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
         and_return(true)
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-        and_return(true)
     end
 
     it 'allows the user to continue down the happy path', allow_browser_log: true do

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -34,8 +34,6 @@ feature 'idv gpo otp verification step', :js do
       and_return(threatmetrix_enabled)
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
       and_return(threatmetrix_enabled)
-    allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-      and_return(threatmetrix_enabled)
   end
 
   it_behaves_like 'gpo otp verification'

--- a/spec/features/idv/threatmetrix_pending_spec.rb
+++ b/spec/features/idv/threatmetrix_pending_spec.rb
@@ -7,8 +7,6 @@ RSpec.feature 'Users pending threatmetrix review', :js do
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
       and_return(true)
-    allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-      and_return(true)
   end
 
   scenario 'users pending threatmetrix see sad face screen and cannot perform idv' do

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -163,8 +163,6 @@ describe GpoVerifyForm do
             and_return(true)
           allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
             and_return(true)
-          allow(IdentityConfig.store).to receive(:proofing_device_profiling_decisioning_enabled).
-            and_return(true)
         end
 
         it 'returns true' do


### PR DESCRIPTION
There were 2 feature flags for ThreatMetrix behavior that conflicted:

- `proofing_device_profiling_decisioning_enabled`: This determined whether or not a user saw the "sad face" screen
- `lexisnexis_threatmetrix_required_to_verify`: This determined whether or not a user received an active profile after successful proofing

There is no case where we want one and not the other or vice versa. Thus this commit merges them into a single `lexisnexis_threatmetrix_required_to_verify` config.

[skip changelog]
