### PR TITLE
LG-8520 Do not disable profile on GPO OTP verification if threatmetrix is not required to verify

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -21,6 +21,8 @@ class GpoVerifyForm
       if pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
+      elsif threatmetrix_check_failed?
+        pending_profile&.deactivate(:threatmetrix_review_pending)
       else
         activate_profile
       end
@@ -79,6 +81,7 @@ class GpoVerifyForm
   end
 
   def threatmetrix_check_failed?
+    return false unless IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
     status = pending_profile&.proofing_components&.[]('threatmetrix_review_status')
     !status.nil? && status != 'pass'
   end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -21,7 +21,7 @@ class GpoVerifyForm
       if pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
-      elsif threatmetrix_check_failed?
+      elsif threatmetrix_check_failed? && threatmetrix_enabled?
         pending_profile&.deactivate(:threatmetrix_review_pending)
       else
         activate_profile
@@ -80,8 +80,11 @@ class GpoVerifyForm
     pending_profile&.proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS
   end
 
+  def threatmetrix_enabled?
+    IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
+  end
+
   def threatmetrix_check_failed?
-    return false unless IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
     status = pending_profile&.proofing_components&.[]('threatmetrix_review_status')
     !status.nil? && status != 'pass'
   end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -24,6 +24,7 @@ feature 'idv gpo otp verification step', :js do
   end
   let(:user) { profile.user }
   let(:threatmetrix_enabled) { false }
+  let(:threatmetrix_required_to_verify) { false }
   let(:threatmetrix_review_status) { nil }
   let(:redirect_after_verification) { nil }
   let(:profile_should_be_active) { true }
@@ -33,37 +34,48 @@ feature 'idv gpo otp verification step', :js do
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_enabled).
       and_return(threatmetrix_enabled)
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
-      and_return(threatmetrix_enabled)
+      and_return(threatmetrix_required_to_verify)
   end
 
   it_behaves_like 'gpo otp verification'
 
   context 'ThreatMetrix enabled' do
     let(:threatmetrix_enabled) { true }
+    let(:threatmetrix_required_to_verify) { true }
 
     context 'ThreatMetrix says "pass"' do
       let(:threatmetrix_review_status) { 'pass' }
       it_behaves_like 'gpo otp verification'
     end
 
-    # context 'ThreatMetrix says "review"' do
-    #   let(:threatmetrix_review_status) { 'review' }
-    #   let(:redirect_after_verification) { idv_setup_errors_path }
-    #   let(:profile_should_be_active) { false }
-    #   let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
-    #   it_behaves_like 'gpo otp verification'
-    # end
+    context 'ThreatMetrix says "review"' do
+      let(:threatmetrix_review_status) { 'review' }
+      let(:redirect_after_verification) { idv_setup_errors_path }
+      let(:profile_should_be_active) { false }
+      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
+      it_behaves_like 'gpo otp verification'
+    end
 
-    # context 'ThreatMetrix says "reject"' do
-    #   let(:threatmetrix_review_status) { 'reject' }
-    #   let(:redirect_after_verification) { idv_setup_errors_path }
-    #   let(:profile_should_be_active) { false }
-    #   let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
-    #   it_behaves_like 'gpo otp verification'
-    # end
+    context 'ThreatMetrix says "reject"' do
+      let(:threatmetrix_review_status) { 'reject' }
+      let(:redirect_after_verification) { idv_setup_errors_path }
+      let(:profile_should_be_active) { false }
+      let(:expected_deactivation_reason) { 'threatmetrix_review_pending' }
+      it_behaves_like 'gpo otp verification'
+    end
 
     context 'No ThreatMetrix result on proofing component' do
       let(:threatmetrix_review_status) { nil }
+      it_behaves_like 'gpo otp verification'
+    end
+
+    context 'without verification requirement enabled creates active profile' do
+      let(:threatmetrix_required_to_verify) { false }
+
+      let(:threatmetrix_review_status) { 'review' }
+      let(:redirect_after_verification) { account_path } # TODO
+      let(:profile_should_be_active) { true }
+      let(:expected_deactivation_reason) { nil }
       it_behaves_like 'gpo otp verification'
     end
   end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -170,9 +170,40 @@ describe GpoVerifyForm do
           expect(result.success?).to eq true
         end
 
+        it 'does not activate the users profile' do
+          subject.submit
+          profile = user.profiles.first
+          expect(profile.active).to eq(false)
+          expect(profile.deactivation_reason).to eq('threatmetrix_review_pending')
+        end
+
         it 'notes that threatmetrix failed' do
           result = subject.submit
           expect(result.extra).to include(threatmetrix_check_failed: true)
+        end
+
+        context 'threatmetrix is not required for verification' do
+          before do
+            allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
+              and_return(false)
+          end
+
+          it 'returns true' do
+            result = subject.submit
+            expect(result.success?).to eq true
+          end
+
+          it 'does not activate the users profile' do
+            subject.submit
+            profile = user.profiles.first
+            expect(profile.active).to eq(true)
+            expect(profile.deactivation_reason).to eq(nil)
+          end
+
+          it 'notes that threatmetrix failed' do
+            result = subject.submit
+            expect(result.extra).to include(threatmetrix_check_failed: false)
+          end
         end
       end
     end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -193,7 +193,7 @@ describe GpoVerifyForm do
             expect(result.success?).to eq true
           end
 
-          it 'does not activate the users profile' do
+          it 'does activate the users profile' do
             subject.submit
             profile = user.profiles.first
             expect(profile.active).to eq(true)
@@ -202,7 +202,7 @@ describe GpoVerifyForm do
 
           it 'notes that threatmetrix failed' do
             result = subject.submit
-            expect(result.extra).to include(threatmetrix_check_failed: false)
+            expect(result.extra).to include(threatmetrix_check_failed: true)
           end
         end
       end


### PR DESCRIPTION
When Threatmetrix is not required for verification we should not require it for verification after success GPO OTP submisison.

This commit fixes a bug where a ThreatMetrix pass was required to receive an active profile after a successful GPO code entry regardless of whether the Threatmetrix requirement was active.

[skip changelog]
