### PR TITLE
Fix 500 error when submitting invalid email domain in reset password form

### DIFF
--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -1,5 +1,6 @@
 module FormEmailValidator
   extend ActiveSupport::Concern
+  include ActionView::Helpers::TranslationHelper
 
   included do
     include ActiveModel::Validations::Callbacks

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -50,6 +50,20 @@ describe PasswordResetEmailForm do
           active_profile: false,
         )
       end
+
+      it 'returns false and adds errors to the form object when domain is invalid' do
+        subject = PasswordResetEmailForm.new('test@çà.com')
+        errors = { email: [t('valid_email.validations.email.invalid')] }
+
+        expect(subject.submit.to_h).to include(
+          success: false,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          user_id: 'nonexistent-uuid',
+          confirmed: false,
+          active_profile: false,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

The `FormEmailValidator` module does not include translation helpers, and raises an exception when calling the `t` translation helper method ([NewRelic error](https://onenr.io/07wk178enjL)).

This was missed when the validation was added in #7380 because the `RegisterUserEmailForm` includes the translation helper itself, the `PasswordResetEmailForm` does not, and no test was written against it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
