### PR TITLE
Link to the handbook from README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We’re so glad you’re thinking about contributing to a Technology Transformat
 
 TTS is committed to building a safe, welcoming, harassment-free culture for everyone. We expect everyone on the TTS team and everyone within TTS spaces, including contributors to our projects, to follow the [TTS Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md).
 
-We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), [README](README.md)
+We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md). When you are ready to make a pull request, read our [pull request process](https://handbook.login.gov/articles/pull-request-review.html), which is a part of [the Login.gov Handbook](https://handbook.login.gov/).
 
 If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository]( https://github.com/18f/open-source-policy), or [send us an email](mailto:18f@gsa.gov).
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository contains the core code base and documentation for the identity m
 
 Thank you for your interest in contributing to the Login.gov IdP! For complete instructions on how to contribute code, please read through our [CONTRIBUTING.md](CONTRIBUTING.md) documentation.
 
+You may also want to read the [the Login.gov team Handbook](https://handbook.login.gov/).
+
 ## Creating your local development environment
 
 ### Installing on your local machine


### PR DESCRIPTION
## 🛠 Summary of changes

Per a discussion with @soniaconnolly the repo's README and CONTRIBUTING docs should link to the Login.gov handbook to allow better open-source contributions and better onboarding
