### PR TITLE
LG-8489: Improve YAML normalization error tolerance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ lint_yarn_lock: package.json yarn.lock
 
 lint_lockfiles: lint_gemfile_lock lint_yarn_lock ## Lints to ensure lockfiles are in sync
 
-lintfix: ## Try to automatically fix any ruby, ERB, javascript, or CSS lint errors
+lintfix: ## Try to automatically fix any Ruby, ERB, JavaScript, YAML, or CSS lint errors
 	@echo "--- rubocop fix ---"
 	bundle exec rubocop -a
 	@echo "--- erblint fix ---"
@@ -122,6 +122,8 @@ lintfix: ## Try to automatically fix any ruby, ERB, javascript, or CSS lint erro
 	yarn lint --fix
 	@echo "--- stylelint fix ---"
 	yarn lint:css --fix
+	@echo "--- normalize yaml ---"
+	make normalize_yaml
 
 brakeman: ## Runs brakeman
 	bundle exec brakeman

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+/* eslint-disable no-console */
+
 import { promises as fsPromises } from 'fs';
 import { join } from 'path';
 import prettier from 'prettier';
@@ -24,10 +27,24 @@ const options = {
   ),
 };
 
+/**
+ * @type {Error[]}
+ */
+const errors = [];
+
 Promise.all(
   files.map(async (relativePath) => {
     const absolutePath = join(process.cwd(), relativePath);
     const content = await readFile(absolutePath, 'utf8');
-    await writeFile(absolutePath, normalize(content, options));
+    try {
+      await writeFile(absolutePath, normalize(content, options));
+    } catch (error) {
+      errors.push(new Error(`Error normalizing ${relativePath}: ${error.message}`));
+    }
   }),
-);
+).then(() => {
+  if (errors.length) {
+    errors.forEach((error) => console.error(error.message));
+    process.exit(1);
+  }
+});

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -27,24 +27,17 @@ const options = {
   ),
 };
 
-/**
- * @type {Error[]}
- */
-const errors = [];
+let exitCode = 0;
 
-Promise.all(
-  files.map(async (relativePath) => {
-    const absolutePath = join(process.cwd(), relativePath);
-    const content = await readFile(absolutePath, 'utf8');
-    try {
-      await writeFile(absolutePath, normalize(content, options));
-    } catch (error) {
-      errors.push(new Error(`Error normalizing ${relativePath}: ${error.message}`));
-    }
-  }),
-).then(() => {
-  if (errors.length) {
-    errors.forEach((error) => console.error(error.message));
-    process.exit(1);
+for await (const relativePath of files) {
+  const absolutePath = join(process.cwd(), relativePath);
+  const content = await readFile(absolutePath, 'utf8');
+  try {
+    await writeFile(absolutePath, normalize(content, options));
+  } catch (error) {
+    console.error(`Error normalizing ${relativePath}: ${error.message}`);
+    exitCode = 1;
   }
-});
+}
+
+process.exit(exitCode);

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -29,15 +29,17 @@ const options = {
 
 let exitCode = 0;
 
-for await (const relativePath of files) {
-  const absolutePath = join(process.cwd(), relativePath);
-  const content = await readFile(absolutePath, 'utf8');
-  try {
-    await writeFile(absolutePath, normalize(content, options));
-  } catch (error) {
-    console.error(`Error normalizing ${relativePath}: ${error.message}`);
-    exitCode = 1;
-  }
-}
+await Promise.all(
+  files.map(async (relativePath) => {
+    const absolutePath = join(process.cwd(), relativePath);
+    const content = await readFile(absolutePath, 'utf8');
+    try {
+      await writeFile(absolutePath, normalize(content, options));
+    } catch (error) {
+      console.error(`Error normalizing ${relativePath}: ${error.message}`);
+      exitCode = 1;
+    }
+  }),
+);
 
 process.exit(exitCode);


### PR DESCRIPTION
## 🎫 Ticket

[LG-8489](https://cm-jira.usa.gov/browse/LG-8489)

## 🛠 Summary of changes

Improves `@18f/identity-normalize-yaml` CLI to avoid deleting file contents when a parse error occurs.

See prior discussion: https://github.com/18F/identity-idp/pull/7528#issuecomment-1363220406

Changes also include:

- Refactor the CLI script logic to leverage [top-level await](https://v8.dev/features/top-level-await), now available as [stable as of Node.js v14.8+](https://nodejs.org/en/blog/release/v14.8.0/)
- Add `make normalize_yaml` to `make lintfix`, per prior discussion

## 📜 Testing Plan

1. Introduce a syntax error to a YAML file (e.g. `git cherry-pick be410b8`)
2. Run `make normalize_yaml`
3. Observe:
   1. File contents are not deleted
   2. Process exits with non-zero status code (confirm via `echo $?`)
