### PR TITLE
Remove unused `issuer` arg from `ResolutionProofingJob`

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -19,8 +19,7 @@ class ResolutionProofingJob < ApplicationJob
     should_proof_state_id:,
     user_id: nil,
     threatmetrix_session_id: nil,
-    request_ip: nil,
-    issuer: nil # rubocop:disable Lint:UnusedMethodArgument
+    request_ip: nil
   )
     timer = JobHelpers::Timer.new
 


### PR DESCRIPTION
This arg used to be used to determine if ThreatMetrix should be used. This was in place because ThreatMetrix was only active for some service providers. A recent change made Threatmetrix active for all service providers.

This argument was left in place with a `nil` default to prevent ArgumentErrors when the workers were running old and new code during deployment. Now that the code that used this argument is not running in any deployed environment the argument can be safely removed.
