### PR TITLE
Make sure analytics event params all have types

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1400,7 +1400,7 @@ module AnalyticsEvents
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's
   #        current proofing components
-  # @param address_verification_method The method (phone or gpo) being
+  # @param [String] address_verification_method The method (phone or gpo) being
   #        used to verify the user's identity
   # User visited IDV password confirm page
   def idv_review_info_visited(proofing_components: nil,

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -84,6 +84,7 @@ class AnalyticsEventsDocumenter
     !!@require_extra_params
   end
 
+  # rubocop:disable Metrics/BlockLength
   # Checks for params that are missing documentation, and returns a list of
   # @return [Array<String>]
   def missing_documentation
@@ -125,6 +126,7 @@ class AnalyticsEventsDocumenter
       errors
     end
   end
+  # rubocop:enable Metrics/BlockLength
 
   # @return [{ events: Array<Hash>}]
   def as_json

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -118,6 +118,10 @@ class AnalyticsEventsDocumenter
         errors << "#{error_prefix} don't use * as an argument, remove all args or name args"
       end
 
+      method_object.tags('param').each do |tag|
+        errors << "#{error_prefix} #{tag.name} missing types" if !tag.types
+      end
+
       errors
     end
   end

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -159,7 +159,8 @@ RSpec.describe AnalyticsEventsDocumenter do
       RUBY
 
       it 'has an error documentation to be missing' do
-        expect(documenter.missing_documentation.first).to include('some_event success missing types')
+        expect(documenter.missing_documentation.first).
+          to include('some_event success missing types')
       end
     end
 

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -148,6 +148,21 @@ RSpec.describe AnalyticsEventsDocumenter do
       end
     end
 
+    context 'when a method documents a param but leaves out types' do
+      let(:source_code) { <<~RUBY }
+        class AnalyticsEvents
+          # @param success
+          def some_event(success:, **extra)
+            track_event('Some Event')
+          end
+        end
+      RUBY
+
+      it 'has an error documentation to be missing' do
+        expect(documenter.missing_documentation.first).to include('some_event success missing types')
+      end
+    end
+
     context 'when a method does not have a **extra param' do
       let(:require_extra_params) { true }
 


### PR DESCRIPTION
**Why**: breaks documentation

(currently analytics doc page is broken, because something is null we're not expecting). I may also make a PR to the handbook to make it more resilient
