### PR TITLE
Removed ProofingComponent updates for TMX in rake task

### DIFF
--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -19,9 +19,8 @@ describe 'review_profile' do
   describe 'users:review:pass' do
     let(:task_name) { 'users:review:pass' }
 
-    it 'sets threatmetrix_review_status to pass' do
+    it 'activates the users profile' do
       invoke_task
-      expect(user.reload.proofing_component.threatmetrix_review_status).to eq('pass')
       expect(user.reload.profiles.first.active).to eq(true)
     end
 
@@ -41,9 +40,8 @@ describe 'review_profile' do
   describe 'users:review:reject' do
     let(:task_name) { 'users:review:reject' }
 
-    it 'sets threatmetrix_review_status to reject' do
+    it 'deactivates the users profile with reason threatmetrix_review_rejected' do
       invoke_task
-      expect(user.reload.proofing_component.threatmetrix_review_status).to eq('reject')
       expect(user.reload.profiles.first.deactivation_reason).to eq('threatmetrix_review_rejected')
     end
   end


### PR DESCRIPTION
[skip changelog]

Removed the updates to ProofingComponent in the rake task for activating or deactivating a user's profile who is under threatmetrix review.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
