### PR TITLE
LG-7918: Begin caching USPS auth tokens in the redis cache

### DIFF
--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -62,7 +62,7 @@ module ArcgisApi
       token, expires = request_token.fetch_values('token', 'expires')
       expires_at = Time.zone.at(expires / 1000)
       Rails.cache.write(API_TOKEN_CACHE_KEY, token, expires_at: expires_at)
-      # If using a redis cache we have to manually set the expires_in. This is because we aren't
+      # If using a redis cache we have to manually set the expires_at. This is because we aren't
       # using a dedicated Redis cache and instead are just using our existing Redis server with
       # mixed usage patterns. Without this cache entries don't expire.
       # More at https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -38,7 +38,7 @@ module UspsInPersonProofing
     # USPS sends an email to the email address with instructions and the enrollment code.
     # The API response also includes the enrollment code which should be
     # stored with the unique ID to be able to request the status of proofing.
-    # @param applicant [Object]
+    # @param applicant [Hash]
     # @return [Hash] API response
     def request_enroll(applicant)
       url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant"
@@ -150,7 +150,7 @@ module UspsInPersonProofing
     # Retrieve and return the set of dynamic headers that are used for most
     # requests to USPS. An auth token will be retrieved if a valid one isn't
     # already cached.
-    # @return [Object] Headers to add to USPS requests
+    # @return [Hash] Headers to add to USPS requests
     def dynamic_headers
       {
         'Authorization' => token,

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,6 +1,6 @@
 module UspsInPersonProofing
   class Proofer
-    AUTH_TOKEN_CACHE_KEY = :usps_auth_token
+    AUTH_TOKEN_CACHE_KEY = :usps_ippaas_api_auth_token
 
     # Makes HTTP request to get nearby in-person proofing facilities
     # Requires address, city, state and zip code.

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -1,6 +1,6 @@
 module UspsInPersonProofing
   class Proofer
-    mattr_reader :token, :token_expires_at
+    AUTH_TOKEN_CACHE_KEY = :usps_auth_token
 
     # Makes HTTP request to get nearby in-person proofing facilities
     # Requires address, city, state and zip code.
@@ -101,18 +101,26 @@ module UspsInPersonProofing
       end.body
     end
 
-    # Makes a request to retrieve a new OAuth token
-    # and modifies self to store the token and when
-    # it expires (15 minutes).
+    # Makes a request to retrieve a new OAuth token, caches it, and returns it. Tokens have
+    # historically had 15 minute expirys
     # @return [String] the token
     def retrieve_token!
       body = request_token
-      @@token_expires_at = Time.zone.now + body['expires_in']
-      @@token = "#{body['token_type']} #{body['access_token']}"
+      expires_at = Time.zone.now + body['expires_in']
+      token = "#{body['token_type']} #{body['access_token']}"
+      Rails.cache.write(AUTH_TOKEN_CACHE_KEY, token, expires_at: expires_at)
+      # If using a redis cache we have to manually set the expires_at. This is because we aren't
+      # using a dedicated Redis cache and instead are just using our existing Redis server with
+      # mixed usage patterns. Without this cache entries don't expire.
+      # More at https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html
+      Rails.cache.try(:redis)&.expireat(AUTH_TOKEN_CACHE_KEY, expires_at.to_i)
+      token
     end
 
-    def token_valid?
-      token.present? && token_expires_at.present? && token_expires_at.future?
+    # Returns an auth token. The token will be renewed first if it has expired.
+    # @return [String] Auth token
+    def token
+      Rails.cache.read(AUTH_TOKEN_CACHE_KEY) || retrieve_token!
     end
 
     private
@@ -139,13 +147,11 @@ module UspsInPersonProofing
       end
     end
 
-    # Retrieve the OAuth2 token (if needed) and then pass
-    # the headers to an arbitrary block of code as a Hash.
-    #
-    # Returns the same value returned by that block of code.
+    # Retrieve and return the set of dynamic headers that are used for most
+    # requests to USPS. An auth token will be retrieved if a valid one isn't
+    # already cached.
+    # @return [Object] Headers to add to USPS requests
     def dynamic_headers
-      retrieve_token! unless token_valid?
-
       {
         'Authorization' => token,
         'RequestID' => request_id,

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ArcgisApi::Geocoder do
         )
       end
 
-      it 'manually sets the expiration if the cache store is redis' do
+      it 'manually sets the expiration' do
         stub_generate_token_response
         subject.retrieve_token!
         ttl = Rails.cache.redis.ttl(ArcgisApi::Geocoder::API_TOKEN_CACHE_KEY)

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe UspsInPersonProofing::Proofer do
       subject.retrieve_token!
 
       expect(subject.token).to be_present
-      expect(subject.token_expires_at).to be_present
     end
 
     it 'calls the endpoint with the expected params' do
@@ -22,13 +21,13 @@ RSpec.describe UspsInPersonProofing::Proofer do
       password = 'test password'
       client_id = 'test client id'
 
-      allow(IdentityConfig.store).to receive(:usps_ipp_root_url).
+      expect(IdentityConfig.store).to receive(:usps_ipp_root_url).
         and_return(root_url)
-      allow(IdentityConfig.store).to receive(:usps_ipp_username).
+      expect(IdentityConfig.store).to receive(:usps_ipp_username).
         and_return(username)
-      allow(IdentityConfig.store).to receive(:usps_ipp_password).
+      expect(IdentityConfig.store).to receive(:usps_ipp_password).
         and_return(password)
-      allow(IdentityConfig.store).to receive(:usps_ipp_client_id).
+      expect(IdentityConfig.store).to receive(:usps_ipp_client_id).
         and_return(client_id)
 
       subject.retrieve_token!
@@ -49,6 +48,47 @@ RSpec.describe UspsInPersonProofing::Proofer do
             'Content-Type': 'application/json; charset=utf-8',
           },
         )
+    end
+
+    it 'reuses the cached auth token on subsequent requests' do
+      applicant = double(
+        'applicant',
+        address: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zip_code: Faker::Address.zip_code,
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        email: Faker::Internet.safe_email,
+        unique_id: '123456789',
+      )
+      stub_request_token
+      stub_request_enroll
+
+      subject.request_enroll(applicant)
+      subject.request_enroll(applicant)
+      subject.request_enroll(applicant)
+
+      expect(WebMock).to have_requested(:post, %r{/oauth/authenticate}).once
+      expect(WebMock).to have_requested(
+        :post,
+        %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
+      ).times(3)
+    end
+
+    context 'when using redis as a backing store' do
+      before do |ex|
+        allow(Rails).to receive(:cache).and_return(
+          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
+        )
+      end
+
+      it 'manually sets the expiration' do
+        stub_request_token
+        subject.retrieve_token!
+        ttl = Rails.cache.redis.ttl(UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY)
+        expect(ttl).to be > 0
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-7918](https://cm-jira.usa.gov/browse/LG-7918)

## 🛠 Summary of changes

Moves the caching of USPS API auth tokens from class variables on the UspsInPersonProofing::Proofer class to our redis cache. This allows all server instances and all Rails processes to share the same auth tokens which reduces the number of authentication requests we have to make to the USPS API (a pretty slow request).

## 📜 Testing Plan

I tested this feature branch by performing the following steps in the Joy sandbox:

- [x] Deploy feature branch to Joy sandbox
- [x] Open a Rails console in the Joy sandbox
- [x] Invalidate the USPS auth token in Redis: Rails.cache.delete(:usps_auth_token)
- [x] Proceed through the in-person proofing flow in the Joy environment. If you're able to successfully go through the entire flow that means it successfully re-authenticated
- [x] Check that the new auth token has been cached in Redis: `Rails.cache.redis.ttl(:usps_auth_token)`

## 👀 Screenshots

```ruby
irb(main):003:0> Rails.cache.redis.ttl(:usps_auth_token)
=> 469
# wait a while for the cache to expire
Rails.cache.redis.ttl(:usps_auth_token)
=> -2
# cache has expired
proofer = UspsInPersonProofing::Proofer.new
=> #<UspsInPersonProofing::Proofer:0x00007f8d0001a880>
#  The below error is expected! 'blah' is not a valid unique ID
irb(main):010:0> proofer.request_enrollment_code('blah')
{"http_method":"POST","host":"cat-services.usps.com","path":"/oauth/authenticate","duration_seconds":0.665659004,"status":200,"service":"usps_token","name":"request_metric.faraday"}
{"http_method":"POST","host":"cat-services.usps.com","path":"/ivs-ippaas-api/IPPRest/resources/rest/requestEnrollmentCode","duration_seconds":0.448684281,"status":400,"service":"usps_enrollment_code","name":"request_metric.faraday"}
/srv/idp/shared/bundle/ruby/3.0.0/gems/faraday-2.6.0/lib/faraday/response/raise_error.rb:16:in `on_complete': the server responded with status 400 (Faraday::BadRequestError)
irb(main):011:0> Rails.cache.redis.ttl(:usps_auth_token)
=> 892
# cache has been automatically refreshed with a new auth token
```
