### PR TITLE
Raise exception when session store cannot connect to Redis

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -17,6 +17,6 @@ Rails.application.config.session_store(
     client: REDIS_SESSION_POOL_WRAPPER,
   },
   on_session_load_error: SessionEncryptorErrorHandler,
-  on_redis_down: SessionRedisDownErrorHandler,
+  on_redis_down: proc { |error, _env, _sid| raise error },
   serializer: SessionEncryptor.new,
 )

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,6 @@
 require 'session_encryptor'
 require 'legacy_session_encryptor'
 require 'session_encryptor_error_handler'
-require 'session_redis_down_error_handler'
 
 Rails.application.config.session_store(
   :redis_session_store,

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,7 @@
 require 'session_encryptor'
 require 'legacy_session_encryptor'
 require 'session_encryptor_error_handler'
+require 'session_redis_down_error_handler'
 
 Rails.application.config.session_store(
   :redis_session_store,
@@ -16,5 +17,6 @@ Rails.application.config.session_store(
     client: REDIS_SESSION_POOL_WRAPPER,
   },
   on_session_load_error: SessionEncryptorErrorHandler,
+  on_redis_down: SessionRedisDownErrorHandler,
   serializer: SessionEncryptor.new,
 )

--- a/lib/session_redis_down_error_handler.rb
+++ b/lib/session_redis_down_error_handler.rb
@@ -1,0 +1,5 @@
+class SessionRedisDownErrorHandler
+  def self.call(error, _env, _sid)
+    raise error
+  end
+end

--- a/lib/session_redis_down_error_handler.rb
+++ b/lib/session_redis_down_error_handler.rb
@@ -1,5 +1,0 @@
-class SessionRedisDownErrorHandler
-  def self.call(error, _env, _sid)
-    raise error
-  end
-end

--- a/spec/requests/redis_down_spec.rb
+++ b/spec/requests/redis_down_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'redis down session error handling' do
+  context 'with bad Redis connection' do
+    it 'fails loudly' do
+      allow(REDIS_SESSION_POOL_WRAPPER).to receive(:setex).and_raise(Redis::CannotConnectError)
+      expect do
+        get forgot_password_path
+      end.to raise_error(Redis::CannotConnectError)
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Kind of a sibling PR to #7547. This adds a handler to the Redis session store configuration to re-raise Redis connection errors. This change is intended to ensure that it is apparent to us and end users when a critical piece of the system is down.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
