### PR TITLE
Upgrade Lookbook to fix default toggle preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jsbundling-rails', '~> 1.0.0'
 gem 'jwe'
 gem 'jwt'
 gem 'lograge', '>= 0.11.2'
-gem 'lookbook', '~> 1.3.3', require: false
+gem 'lookbook', '~> 1.4.5', require: false
 gem 'lru_redux'
 gem 'maxminddb'
 gem 'multiset'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,7 +367,7 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (1.3.3)
+    lookbook (1.4.5)
       actioncable
       activemodel
       css_parser
@@ -544,7 +544,7 @@ GEM
     retries (0.0.5)
     rexml (3.2.5)
     rotp (6.2.0)
-    rouge (4.0.0)
+    rouge (4.0.1)
     rqrcode (2.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -766,7 +766,7 @@ DEPENDENCIES
   jwt
   knapsack
   lograge (>= 0.11.2)
-  lookbook (~> 1.3.3)
+  lookbook (~> 1.4.5)
   lru_redux
   maxminddb
   multiset

--- a/spec/components/previews/one_time_code_input_component_preview.rb
+++ b/spec/components/previews/one_time_code_input_component_preview.rb
@@ -12,7 +12,7 @@ class OneTimeCodeInputComponentPreview < BaseComponentPreview
 
   # @display form true
   # @param numeric toggle
-  def workbench(numeric: false)
+  def workbench(numeric: true)
     render(OneTimeCodeInputComponent.new(form: form_builder, numeric: numeric))
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Lookbook to the latest version, to be able to remove a workaround previously introduced in #7523 due to an [upstream issue](https://github.com/ViewComponent/lookbook/issues/267) related to default toggle values for component previews, which has since been fixed in v1.4.5 ([see changelog](https://github.com/ViewComponent/lookbook/releases/tag/v1.4.5)).

## 📜 Testing Plan

1. Go to http://localhost:3000/components/inspect/one_time_code_input/workbench
2. Observe that the preview shows a numeric one time code input and that the "Params" panel shows the "Numeric" toggle as checked
3. Confirm that toggling the checkbox updates the preview accordingly