### PR TITLE
Update text fields to use ValidatedFieldComponent

### DIFF
--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -15,7 +15,7 @@ locals:
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
         maxlength: 11,
-        input_html: { aria: { invalid: false }, class: 'ssn-toggle usa-input', value: '' },
+        input_html: { class: 'ssn-toggle usa-input', value: '' },
         error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
       },
     ) %>

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -6,10 +6,12 @@
       url: sign_up_register_path,
       html: { autocomplete: 'off', method: :post },
     ) do |f| %>
-  <%= f.input :email,
-              label: t('forms.registration.labels.email'),
-              required: true,
-              input_html: { aria: { invalid: false } } %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :email,
+        label: t('forms.registration.labels.email'),
+        required: true,
+      ) %>
   <%= f.input :request_id, as: :hidden %>
   <%= f.submit t('forms.buttons.resend_confirmation'), class: 'margin-top-2 margin-bottom-1' %>
 <% end %>

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -10,8 +10,12 @@
         html: { autocomplete: 'off' },
         url: add_email_path,
       ) do |f| %>
-    <%= f.input :email, label: t('forms.registration.labels.email'), required: true,
-                        input_html: { aria: { invalid: false } } %>
+    <%= render ValidatedFieldComponent.new(
+          form: f,
+          name: :email,
+          label: t('forms.registration.labels.email'),
+          required: true,
+        ) %>
     <%= f.submit t('forms.buttons.submit.default') %>
   <% end %>
 </div>


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-5362](https://cm-jira.usa.gov/browse/LG-5362)

## 🛠 Summary of changes

Updates a few text fields which still use native form validation error messaging instead of our desired custom error messaging.

## 📜 Testing Plan

**Add email:**

1. Sign in
2. From account dashboard, click "Add new email"
3. Click "Submit" without entering an email address
4. Observe design system (red highlighted) error effect

**Sign up email resend:**

1. Go to http://localhost:3000/sign_up/email/confirm?_request_id=&confirmation_token=
3. Click "Submit" without entering an email address
4. Observe design system (red highlighted) error effect

## 👀 Screenshots

Screen|Before|After
---|---|---
Add email|![Screen Shot 2023-01-06 at 8 58 54 AM](https://user-images.githubusercontent.com/1779930/211038751-0233b995-ecfe-4360-bd4a-bdf6122a36d9.png)|![Screen Shot 2023-01-06 at 8 58 36 AM](https://user-images.githubusercontent.com/1779930/211038760-28febf44-fcf1-442c-869b-29e24588e5d5.png)
Sign up email resend|![Screen Shot 2023-01-06 at 8 55 38 AM](https://user-images.githubusercontent.com/1779930/211038791-a089e75a-0cbc-44d5-9a74-01affc463a7b.png)|![Screen Shot 2023-01-06 at 8 55 23 AM](https://user-images.githubusercontent.com/1779930/211038809-caee9dd4-5d56-4ee1-bf09-c0047531296d.png)
