### PR TITLE
Add the drivers license number check to the LexisNexis failed attribute mapper

### DIFF
--- a/app/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/check_to_attribute_mapper.rb
@@ -17,6 +17,7 @@ module Proofing
           'DOBFullVerified' => :dob,
           'DOBYearVerified' => :dob,
           'LexIDDeathMatch' => :dead,
+          'DriversLicenseVerification' => :state_id_number,
         }.freeze
 
         def initialize(instant_verify_errors)


### PR DESCRIPTION
We started sending driver's license numbers to instant verify a while ago. We are using the check as a "warning" indicator currently. The primary purpose of this is to get visibility into how InstantVerify performs for driver's license checks.

The above change means we have a new item in the products array from the LexisNexis response to handle as a failed attribute. Currently this is labeled as an 'unkown' when processed. The change in this commit will make it visible as a failure on drivers license number and indicate that attribute requires additional verification. This will cause it to appear in our logs.
