### PR TITLE
Fix unhandled exception when state_id_number attribute is missing in DDP Proofer

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -20,7 +20,7 @@ module Proofing
             account_first_name: applicant[:first_name],
             account_last_name: applicant[:last_name],
             account_telephone: '', # applicant[:phone], decision was made not to send phone
-            account_drivers_license_number: applicant[:state_id_number].gsub(/\W/, ''),
+            account_drivers_license_number: applicant[:state_id_number]&.gsub(/\W/, ''),
             account_drivers_license_type: 'us_dl',
             account_drivers_license_issuer: applicant[:state_id_jurisdiction].to_s.strip,
             event_type: 'ACCOUNT_CREATION',


### PR DESCRIPTION
## 🛠 Summary of changes

I noticed an error in [NewRelic](https://onenr.io/0VRV5N67Wwa) where we raise an exception if `state_id_number` is nil:

```
NoMethodError: undefined method `gsub' for nil:NilClass
…vices/proofing/lexis_nexis/ddp/verification_request.rb:   23:in `build_request_body'
```

SSN has a similar operation, but I'm assuming that will always be present.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
