### PR TITLE
Lg-7767 change location item layout to address navigation issue

### DIFF
--- a/app/javascript/packages/document-capture/components/location-collection-item.spec.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.spec.tsx
@@ -23,10 +23,12 @@ describe('LocationCollectionItem', () => {
     const locationCollectionItem = wrapper.firstElementChild!;
     expect(locationCollectionItem.classList.contains('usa-collection__body')).to.be.true();
     const display = locationCollectionItem.firstElementChild!;
-    expect(display.classList.contains('display-flex')).to.be.true();
-    expect(display.classList.contains('flex-justify')).to.be.true();
-    const heading = display.firstElementChild!;
+    expect(display.classList.contains('grid-row')).to.be.true();
+    const column = display.firstElementChild!;
+    expect(column.classList.contains('grid-col-fill')).to.be.true();
+    const heading = column.firstElementChild!;
     expect(heading.classList.contains('usa-collection__heading')).to.be.true();
+    expect(heading.classList.contains('margin-bottom-1')).to.be.true();
   });
 
   it('renders the component with expected data', () => {

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -41,7 +41,7 @@ function LocationCollectionItem({
                 })}
               </h3>
             )}
-            {!distance && <h3 className="usa-collection__heading">{name}</h3>}
+            {!distance && <h3 className="usa-collection__heading margin-bottom-1">{name}</h3>}
             <div>{streetAddress}</div>
             <div>{formattedCityStateZip}</div>
             {(weekdayHours || saturdayHours || sundayHours) && (

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -70,7 +70,7 @@ function LocationCollectionItem({
             )}
             <Button
               id={`location_button_mobile_${selectId}`}
-              className="tablet:display-none margin-top-2 width-full heey"
+              className="tablet:display-none margin-top-2 width-full"
               onClick={(event) => handleSelect(event, selectId)}
               type="submit"
             >

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -32,56 +32,64 @@ function LocationCollectionItem({
   return (
     <li className="location-collection-item">
       <div className="usa-collection__body">
-        <div className="display-flex flex-justify">
-          {numericDistance && (
-            <h3 className="usa-collection__heading">
-              {t('in_person_proofing.body.location.distance', {
-                count: parseFloat(numericDistance),
-              })}
-            </h3>
-          )}
-          {!distance && <h3 className="usa-collection__heading">{name}</h3>}
-          <Button
-            id={`location_button_desktop_${selectId}`}
-            className="display-none tablet:display-inline-block"
-            onClick={(event) => {
-              handleSelect(event, selectId);
-            }}
-            type="submit"
-          >
-            {t('in_person_proofing.body.location.location_button')}
-          </Button>
+        <div className="grid-row">
+          <div className="grid-col-fill">
+            {numericDistance && (
+              <h3 className="usa-collection__heading margin-bottom-1">
+                {t('in_person_proofing.body.location.distance', {
+                  count: parseFloat(numericDistance),
+                })}
+              </h3>
+            )}
+            {!distance && <h3 className="usa-collection__heading">{name}</h3>}
+            <div>{streetAddress}</div>
+            <div>{formattedCityStateZip}</div>
+            {(weekdayHours || saturdayHours || sundayHours) && (
+              <h4>{t('in_person_proofing.body.location.retail_hours_heading')}</h4>
+            )}
+            {weekdayHours && (
+              <div>
+                {`${t('in_person_proofing.body.location.retail_hours_weekday')} ${weekdayHours}`}
+              </div>
+            )}
+            {saturdayHours && (
+              <div>
+                {`${t('in_person_proofing.body.location.retail_hours_sat')} ${saturdayHours}`}
+              </div>
+            )}
+            {sundayHours && (
+              <div>
+                {`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}
+              </div>
+            )}
+            {phone && (
+              <div>
+                <h4>{t('in_person_proofing.body.location.contact_info_heading')}</h4>
+                <div>{`${t('in_person_proofing.body.location.phone')} ${phone}`}</div>
+              </div>
+            )}
+            <Button
+              id={`location_button_mobile_${selectId}`}
+              className="tablet:display-none margin-top-2 width-full heey"
+              onClick={(event) => handleSelect(event, selectId)}
+              type="submit"
+            >
+              {t('in_person_proofing.body.location.location_button')}
+            </Button>
+          </div>
+          <div className="grid-auto">
+            <Button
+              id={`location_button_desktop_${selectId}`}
+              className="display-none tablet:display-inline-block order-three"
+              onClick={(event) => {
+                handleSelect(event, selectId);
+              }}
+              type="submit"
+            >
+              {t('in_person_proofing.body.location.location_button')}
+            </Button>
+          </div>
         </div>
-        <div>{streetAddress}</div>
-        <div>{formattedCityStateZip}</div>
-        {(weekdayHours || saturdayHours || sundayHours) && (
-          <h4>{t('in_person_proofing.body.location.retail_hours_heading')}</h4>
-        )}
-        {weekdayHours && (
-          <div>
-            {`${t('in_person_proofing.body.location.retail_hours_weekday')} ${weekdayHours}`}
-          </div>
-        )}
-        {saturdayHours && (
-          <div>{`${t('in_person_proofing.body.location.retail_hours_sat')} ${saturdayHours}`}</div>
-        )}
-        {sundayHours && (
-          <div>{`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}</div>
-        )}
-        {phone && (
-          <div>
-            <h4>{t('in_person_proofing.body.location.contact_info_heading')}</h4>
-            <div>{`${t('in_person_proofing.body.location.phone')} ${phone}`}</div>
-          </div>
-        )}
-        <Button
-          id={`location_button_mobile_${selectId}`}
-          className="tablet:display-none margin-top-2 width-full"
-          onClick={(event) => handleSelect(event, selectId)}
-          type="submit"
-        >
-          {t('in_person_proofing.body.location.location_button')}
-        </Button>
       </div>
     </li>
   );

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -77,10 +77,10 @@ function LocationCollectionItem({
               {t('in_person_proofing.body.location.location_button')}
             </Button>
           </div>
-          <div className="grid-auto">
+          <div className="grid-col-auto">
             <Button
               id={`location_button_desktop_${selectId}`}
-              className="display-none tablet:display-inline-block order-three"
+              className="display-none tablet:display-inline-block"
               onClick={(event) => {
                 handleSelect(event, selectId);
               }}


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7767](https://cm-jira.usa.gov/browse/LG-7767)


## 🛠 Summary of changes

Currently when navigating the location result page using a screen reader the select button is first read out and then the post office information. This does not give screen reader users enough information about what they are selecting. This pr makes changes to the LocationCollectionItem layout so that the post office information will be read first and then the accompanying select button. It changes the layout so that the po info and button are in separate columns in the same row so that the po info proceeds the button in the DOM tree. This is similar to how the form input review page is structured. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

To test w/o search ability: 
- [ ] make sure `arcgis_search_enabled` is false
- [ ] Use failed id to navigate to select location page
- [ ] Use voiceover or other screen reader to ensure po info is read before select button
To test w/ search ability: 
- [ ]  make sure `arcgis_search_enabled` is true
- [ ] Use failed id to navigate to search page
- [ ] Use voiceover or other screen reader to ensure po info is read before select button


## 👀 Screenshots

What the updates to layout look like:

<details>
<summary>Search disabled:</summary>
<img width="785" alt="Screen Shot 2023-01-05 at 5 55 23 PM" src="https://user-images.githubusercontent.com/20867088/211049776-ee84dd6e-eaca-46c3-b4a5-086a1906e220.png">

</details>

<details>
<summary>Search enabled, no distance:</summary>
<img width="692" alt="Screen Shot 2023-01-06 at 11 05 19 AM" src="https://user-images.githubusercontent.com/20867088/211050694-0cb8c428-8433-42f2-9f40-c2c7e81b3855.png">

</details>

<details>
<summary>Search enabled, w/ distance:</summary>
<img width="738" alt="Screen Shot 2023-01-06 at 9 20 03 AM" src="https://user-images.githubusercontent.com/20867088/211050175-cf7687d0-0cff-4fae-aaab-fb186e2e2251.png">
<img width="710" alt="Screen Shot 2023-01-06 at 9 20 18 AM" src="https://user-images.githubusercontent.com/20867088/211050176-db19bb3f-7170-4aa2-bc31-bd6697b2d84a.png">

</details>
