### PR TITLE
Update GSA links to use www subdomain

### DIFF
--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,11 +1,11 @@
 <footer class="footer">
-  <%= new_window_link_to('https://gsa.gov', class: 'display-none tablet:display-inline') do %>
+  <%= new_window_link_to('https://www.gsa.gov', class: 'display-none tablet:display-inline') do %>
     <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1') %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
   <div class="footer__links">
-    <%= new_window_link_to('https://gsa.gov', class: 'tablet:display-none margin-right-2') do %>
+    <%= new_window_link_to('https://www.gsa.gov', class: 'tablet:display-none margin-right-2') do %>
       <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: t('shared.footer_lite.gsa') %>
     <% end %>
     <%= new_window_link_to(t('links.help'), MarketingSite.help_url, class: 'margin-right-2') %>

--- a/spec/helpers/go_back_helper_spec.rb
+++ b/spec/helpers/go_back_helper_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GoBackHelper do
     end
 
     context 'referer from different domain' do
-      let(:referer) { 'https://gsa.gov/' }
+      let(:referer) { 'https://www.gsa.gov/' }
 
       it 'is nil' do
         expect(subject).to be_nil
@@ -38,10 +38,10 @@ RSpec.describe GoBackHelper do
     end
 
     context 'referer from same domain' do
-      let(:referer) { 'https://gsa.gov/' }
+      let(:referer) { 'https://www.gsa.gov/' }
 
       before do
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('gsa.gov')
+        allow(IdentityConfig.store).to receive(:domain_name).and_return('www.gsa.gov')
       end
 
       it 'is path from referer' do
@@ -52,7 +52,7 @@ RSpec.describe GoBackHelper do
 
   describe '#extract_path_and_query_from_uri' do
     it 'preserves query parameter and path from uri' do
-      uri = URI.parse('https://gsa.gov/path/to/?with_params=true')
+      uri = URI.parse('https://www.gsa.gov/path/to/?with_params=true')
       extracted = extract_path_and_query_from_uri(uri)
 
       expect(extracted).to eq('/path/to/?with_params=true')
@@ -69,10 +69,10 @@ RSpec.describe GoBackHelper do
     subject { app_host }
 
     context 'without port' do
-      let(:domain_name) { 'gsa.gov' }
+      let(:domain_name) { 'www.gsa.gov' }
 
       it 'returns host' do
-        expect(subject).to eq('gsa.gov')
+        expect(subject).to eq('www.gsa.gov')
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates GSA website links to use canonical URL in order to avoid an unnecessary redirect.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1673266030524959

## 📜 Testing Plan

1. Go to http://localhost:3000/
2. Click GSA link in the footer
3. Observe you are shown the GSA website