### PR TITLE
LG-8595: Label text for radio buttons should not be optional

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -62,7 +62,7 @@ SimpleForm.setup do |config|
                     item_label_class: item_label_class do |b|
       b.use :html5
       b.wrapper :legend, tag: 'legend', class: legend_class do |ba|
-        ba.optional :label_text
+        ba.use :label_text
       end
       b.optional :hint, wrap_with: { tag: 'div', class: 'usa-hint margin-bottom-05' }
       b.wrapper :grid_row, tag: :div, class: 'grid-row margin-bottom-neg-1' do |gr|

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe 'In Person Proofing', js: true do
     # address page
     expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
     expect(page).to have_content(t('in_person_proofing.headings.address'))
+    expect(page).to have_content(t('in_person_proofing.form.address.same_address'))
     complete_address_step(user)
 
     # ssn page


### PR DESCRIPTION
## 🎫 Ticket

[LG-8595](https://cm-jira.usa.gov/browse/LG-8595)

## 🛠 Summary of changes

The label text for radio buttons was set `optional` in #7539. This caused the label for the radio buttons on the in-person proofing address page to stop rendering. This PR reverts radio button label text back to `use`.

## 📜 Testing Plan

Navigate to the in-person proofing address page locally and confirm that the label for the radio buttons is visible.

## 👀 Screenshots

<details>
<summary>Before (form with missing label)</summary>

<img width="678" alt="missing" src="https://user-images.githubusercontent.com/45415133/211459919-48ee9176-0f23-4be2-9d80-c4196d10a6e6.png">
</details>


<details>
<summary>After (form showing label)</summary>

<img width="661" alt="showing" src="https://user-images.githubusercontent.com/45415133/211460081-fc3cdb8d-5a35-4402-af48-29dd0af5adaa.png">
</details>
