### PR TITLE
LG-8071: Add logging for WebAuthn frontend error reasons

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -13,7 +13,7 @@ module TwoFactorAuthentication
     end
 
     def confirm
-      result = form.submit(request.protocol, params)
+      result = form.submit
       analytics.track_mfa_submit_event(
         result.to_h.merge(analytics_properties),
       )
@@ -121,7 +121,16 @@ module TwoFactorAuthentication
     end
 
     def form
-      @form ||= WebauthnVerificationForm.new(current_user, user_session)
+      @form ||= WebauthnVerificationForm.new(
+        user: current_user,
+        challenge: user_session[:webauthn_challenge],
+        protocol: request.protocol,
+        authenticator_data: params[:authenticator_data],
+        client_data_json: params[:client_data_json],
+        signature: params[:signature],
+        credential_id: params[:credential_id],
+        webauthn_error: params[:webauthn_error],
+      )
     end
   end
 end

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -4,7 +4,6 @@ class WebauthnVerificationForm
 
   validates :user, presence: true
   validates :challenge, presence: true
-  validates :protocol, presence: true
   validates :authenticator_data, presence: true
   validates :client_data_json, presence: true
   validates :signature, presence: true
@@ -13,9 +12,9 @@ class WebauthnVerificationForm
   validate :validate_webauthn_error
 
   def initialize(
+    protocol:,
     user: nil,
     challenge: nil,
-    protocol: nil,
     authenticator_data: nil,
     client_data_json: nil,
     signature: nil,
@@ -44,7 +43,7 @@ class WebauthnVerificationForm
 
   def webauthn_configuration
     return @webauthn_configuration if defined?(@webauthn_configuration)
-    @webauthn_configuration = user.webauthn_configurations.find_by(credential_id: credential_id)
+    @webauthn_configuration = user&.webauthn_configurations&.find_by(credential_id: credential_id)
   end
 
   # this gives us a hook to override the domain embedded in the attestation test object
@@ -74,6 +73,10 @@ class WebauthnVerificationForm
   end
 
   def valid_assertion_response?
+    return false if authenticator_data.blank? ||
+                    client_data_json.blank? ||
+                    signature.blank? ||
+                    challenge.blank?
     WebAuthn::AuthenticatorAssertionResponse.new(
       authenticator_data: Base64.decode64(authenticator_data),
       client_data_json: Base64.decode64(client_data_json),

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -4,31 +4,47 @@ class WebauthnVerificationForm
 
   validates :user, presence: true
   validates :challenge, presence: true
+  validates :protocol, presence: true
   validates :authenticator_data, presence: true
   validates :client_data_json, presence: true
   validates :signature, presence: true
+  validates :webauthn_configuration, presence: true
+  validate :validate_assertion_response
+  validate :validate_webauthn_error
 
-  attr_accessor :webauthn_configuration
-
-  def initialize(user, user_session)
+  def initialize(
+    user: nil,
+    challenge: nil,
+    protocol: nil,
+    authenticator_data: nil,
+    client_data_json: nil,
+    signature: nil,
+    credential_id: nil,
+    webauthn_error: nil
+  )
     @user = user
-    @challenge = user_session[:webauthn_challenge]
-    @authenticator_data = nil
-    @client_data_json = nil
-    @signature = nil
-    @credential_id = nil
-    @webauthn_configuration = nil
-    @webauthn_errors = nil
+    @challenge = challenge
+    @protocol = protocol
+    @authenticator_data = authenticator_data
+    @client_data_json = client_data_json
+    @signature = signature
+    @credential_id = credential_id
+    @webauthn_error = webauthn_error
   end
 
-  def submit(protocol, params)
-    consume_parameters(params)
-    success = valid? && valid_assertion_response?(protocol)
+  def submit
+    success = valid?
     FormResponse.new(
       success: success,
       errors: errors,
       extra: extra_analytics_attributes,
+      serialize_error_details_only: true,
     )
+  end
+
+  def webauthn_configuration
+    return @webauthn_configuration if defined?(@webauthn_configuration)
+    @webauthn_configuration = user.webauthn_configurations.find_by(credential_id: credential_id)
   end
 
   # this gives us a hook to override the domain embedded in the attestation test object
@@ -38,46 +54,50 @@ class WebauthnVerificationForm
 
   private
 
-  attr_reader :success,
-              :user,
+  attr_reader :user,
               :challenge,
+              :protocol,
               :authenticator_data,
               :client_data_json,
-              :signature
+              :signature,
+              :credential_id,
+              :webauthn_error
 
-  def consume_parameters(params)
-    @authenticator_data = params[:authenticator_data]
-    @client_data_json = params[:client_data_json]
-    @signature = params[:signature]
-    @credential_id = params[:credential_id]
-    @webauthn_errors = params[:errors]
+  def validate_assertion_response
+    return if webauthn_error.present? || webauthn_configuration.blank? || valid_assertion_response?
+    errors.add(:authenticator_data, :invalid_authenticator_data, type: :invalid_authenticator_data)
   end
 
-  def valid_assertion_response?(protocol)
-    return false if @webauthn_errors.present?
-    assertion_response = ::WebAuthn::AuthenticatorAssertionResponse.new(
-      authenticator_data: Base64.decode64(@authenticator_data),
-      client_data_json: Base64.decode64(@client_data_json),
-      signature: Base64.decode64(@signature),
+  def validate_webauthn_error
+    return if webauthn_error.blank?
+    errors.add(:webauthn_error, webauthn_error, type: :webauthn_error)
+  end
+
+  def valid_assertion_response?
+    WebAuthn::AuthenticatorAssertionResponse.new(
+      authenticator_data: Base64.decode64(authenticator_data),
+      client_data_json: Base64.decode64(client_data_json),
+      signature: Base64.decode64(signature),
+    ).valid?(
+      challenge.pack('c*'),
+      original_origin,
+      public_key: Base64.decode64(public_key),
+      sign_count: 0,
     )
-    original_origin = "#{protocol}#{self.class.domain_name}"
-    @webauthn_configuration = user.webauthn_configurations.find_by(credential_id: @credential_id)
-    return false unless @webauthn_configuration
+  rescue OpenSSL::PKey::PKeyError
+    false
+  end
 
-    public_key = @webauthn_configuration.credential_public_key
+  def original_origin
+    "#{protocol}#{self.class.domain_name}"
+  end
 
-    begin
-      assertion_response.valid?(
-        @challenge.pack('c*'), original_origin,
-        public_key: Base64.decode64(public_key), sign_count: 0
-      )
-    rescue OpenSSL::PKey::PKeyError
-      false
-    end
+  def public_key
+    webauthn_configuration&.credential_public_key
   end
 
   def extra_analytics_attributes
-    auth_method = if @webauthn_configuration&.platform_authenticator
+    auth_method = if webauthn_configuration&.platform_authenticator
                     'webauthn_platform'
                   else
                     'webauthn'
@@ -85,7 +105,7 @@ class WebauthnVerificationForm
 
     {
       multi_factor_auth_method: auth_method,
-      webauthn_configuration_id: @webauthn_configuration&.id,
+      webauthn_configuration_id: webauthn_configuration&.id,
     }
   end
 end

--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -37,7 +37,7 @@ function webauthn() {
         webauthnSuccessContainer.classList.remove('display-none');
       })
       .catch((error: Error) => {
-        (document.getElementById('errors') as HTMLInputElement).value = error.toString();
+        (document.getElementById('webauthn_error') as HTMLInputElement).value = error.name;
         (document.getElementById('platform') as HTMLInputElement).value =
           String(webauthnPlatformRequested);
         (document.getElementById('webauthn_form') as HTMLFormElement).submit();

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -21,7 +21,7 @@
   <%= hidden_field_tag :authenticator_data, '', id: 'authenticator_data' %>
   <%= hidden_field_tag :signature, '', id: 'signature' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
-  <%= hidden_field_tag :errors, '', id: 'errors' %>
+  <%= hidden_field_tag :webauthn_error, '', id: 'webauthn_error' %>
   <%= hidden_field_tag :platform, '', id: 'platform' %>
   <%= hidden_field_tag :webauthn_device, '', id: 'webauthn_device' %>
 

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -77,7 +77,6 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         )
         allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
         result = { context: 'authentication',
-                   errors: {},
                    multi_factor_auth_method: 'webauthn',
                    success: true,
                    webauthn_configuration_id: webauthn_configuration.id }
@@ -104,7 +103,6 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         )
         allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
         result = { context: 'authentication',
-                   errors: {},
                    multi_factor_auth_method: 'webauthn_platform',
                    success: true,
                    webauthn_configuration_id: WebauthnConfiguration.first.id }
@@ -130,9 +128,9 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         )
 
         result = { context: 'authentication',
-                   errors: {},
                    multi_factor_auth_method: 'webauthn',
                    success: false,
+                   error_details: { authenticator_data: [:invalid_authenticator_data] },
                    webauthn_configuration_id: webauthn_configuration.id }
         expect(@analytics).to receive(:track_mfa_submit_event).
           with(result)

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -139,6 +139,7 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
       end
 
       context 'webauthn_platform returns an error from frontend API' do
+        let(:webauthn_error) { 'NotAllowedError' }
         let(:params) do
           {
             authenticator_data: authenticator_data,
@@ -146,7 +147,7 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
             signature: signature,
             credential_id: credential_id,
             platform: true,
-            errors: 'cannot sign in properly',
+            webauthn_error: webauthn_error,
           }
         end
 
@@ -160,6 +161,13 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
             allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
               to receive(:multiple_factors_enabled?).
               and_return(true)
+            create(
+              :webauthn_configuration,
+              user: controller.current_user,
+              credential_id: credential_id,
+              credential_public_key: credential_public_key,
+              platform_authenticator: true,
+            )
           end
 
           it 'redirects to webauthn show page' do
@@ -176,6 +184,20 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
                 login_two_factor_options_path,
               ),
             )
+          end
+
+          it 'logs an event with error details' do
+            expect(@analytics).to receive(:track_mfa_submit_event).with(
+              hash_including(
+                success: false,
+                error_details: { webauthn_error: [webauthn_error] },
+                context: UserSessionContext::AUTHENTICATION_CONTEXT,
+                multi_factor_auth_method: 'webauthn_platform',
+                webauthn_configuration_id: controller.current_user.webauthn_configurations.first.id,
+              ),
+            )
+
+            patch :confirm, params: params
           end
         end
 

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -7,6 +7,17 @@ describe WebauthnVerificationForm do
   let(:challenge) { webauthn_challenge }
   let(:webauthn_error) { nil }
   let(:platform_authenticator) { false }
+  let(:client_data_json) { verification_client_data_json }
+  let!(:webauthn_configuration) do
+    return if !user
+    create(
+      :webauthn_configuration,
+      user: user,
+      credential_id: credential_id,
+      credential_public_key: credential_public_key,
+      platform_authenticator: platform_authenticator,
+    )
+  end
 
   subject(:form) do
     WebauthnVerificationForm.new(
@@ -14,7 +25,7 @@ describe WebauthnVerificationForm do
       challenge: challenge,
       protocol: protocol,
       authenticator_data: authenticator_data,
-      client_data_json: verification_client_data_json,
+      client_data_json: client_data_json,
       signature: signature,
       credential_id: credential_id,
       webauthn_error: webauthn_error,
@@ -23,44 +34,148 @@ describe WebauthnVerificationForm do
 
   describe '#submit' do
     before do
-      create(
-        :webauthn_configuration,
-        user: user,
-        credential_id: credential_id,
-        credential_public_key: credential_public_key,
-        platform_authenticator: platform_authenticator,
-      )
-
       allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
     end
 
     subject(:result) { form.submit }
 
     context 'when the input is valid' do
-      it 'returns FormResponse with success: true' do
-        expect(result.success?).to eq(true)
-        expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
+      it 'returns successful result' do
+        expect(result.to_h).to eq(
+          success: true,
+          multi_factor_auth_method: 'webauthn',
+          webauthn_configuration_id: webauthn_configuration.id,
+        )
       end
 
       context 'for platform authenticator' do
         let(:platform_authenticator) { true }
 
-        it 'returns FormResponse with success: true' do
-          expect(result.success?).to eq(true)
-          expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn_platform')
+        it 'returns successful result' do
+          expect(result.to_h).to eq(
+            success: true,
+            multi_factor_auth_method: 'webauthn_platform',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
         end
       end
     end
 
     context 'when the input is invalid' do
+      context 'when user is missing' do
+        let(:user) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: { user: [:blank], webauthn_configuration: [:blank] },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: nil,
+          )
+        end
+      end
+
+      context 'when challenge is missing' do
+        let(:challenge) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              challenge: [:blank],
+              authenticator_data: [:invalid_authenticator_data],
+            },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
+
+      context 'when authenticator data is missing' do
+        let(:authenticator_data) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              authenticator_data: [:blank, :invalid_authenticator_data],
+            },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
+
+      context 'when client_data_json is missing' do
+        let(:client_data_json) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              client_data_json: [:blank],
+              authenticator_data: [:invalid_authenticator_data],
+            },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
+
+      context 'when signature is missing' do
+        let(:signature) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              signature: [:blank],
+              authenticator_data: [:invalid_authenticator_data],
+            },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
+
+      context 'when user has no configured webauthn' do
+        let(:webauthn_configuration) { nil }
+
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: { webauthn_configuration: [:blank] },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: nil,
+          )
+        end
+      end
+
+      context 'when a client-side webauthn error is present' do
+        let(:webauthn_error) { 'Unexpected error!' }
+
+        it 'returns unsuccessful result including client-side webauthn error text' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: { webauthn_error: [webauthn_error] },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
+
       context 'when origin is invalid' do
         before do
           allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:6666')
         end
 
-        it 'returns FormResponse with success: false' do
-          expect(result.success?).to eq(false)
-          expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
+        it 'returns unsuccessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: { authenticator_data: [:invalid_authenticator_data] },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
         end
       end
 
@@ -70,9 +185,13 @@ describe WebauthnVerificationForm do
             and_raise(OpenSSL::PKey::PKeyError)
         end
 
-        it 'returns FormResponses with success: false' do
-          expect(result.success?).to eq(false)
-          expect(result.to_h[:multi_factor_auth_method]).to eq('webauthn')
+        it 'returns unsucessful result' do
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: { authenticator_data: [:invalid_authenticator_data] },
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8071](https://cm-jira.usa.gov/browse/LG-8071)

## 🛠 Summary of changes

Enhances WebAuthn verification to ensure that errors occurring in the front-end are logged as part of the back-end verification.

Previously, the frontend error message was being passed as part of the form submission, but was only used as part of a condition considering whether to validate the assertion response. With these changes, the error is now included in the logged error details.

This changes the specific string being logged from using the full error message to the error name, which avoids differences in error messages between browsers.

For example, a cancelled authentication...

- ...in Chrome: 
   - `error.name`: `NotAllowedError`
   - `error.message`: `The operation either timed out or was not allowed. See: https://www.w3.org/TR/webauthn-2/#sctn-privacy-considerations-client.`
- ...in Safari:
   - `error.name`: `NotAllowedError`
   - `error.message`: `This request has been cancelled by the user.`

**Draft while I work to enhance test coverage**

## 📜 Testing Plan

1. Configure an account with Security Key or Face/Touch Unlock
2. Tail logs (`tail -F log/events.log | jq .`)
3. Sign in, but cancel when prompted for Security Key or Face/Touch Unlock
4. Observe event `"Multi-Factor Authentication"` with `errors` including `webauthn_error: ['NotAllowedError']`