### PR TITLE
Lg-8357 Change fr distance translations to en translation

### DIFF
--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -37,8 +37,8 @@ fr:
       location:
         contact_info_heading: Information de contact
         distance:
-          one: 'à %{count} mile'
-          other: 'à %{count} milles'
+          one: '%{count} mile away'
+          other: '%{count} miles away'
         inline_error: Saisissez une adresse valide avec la ville, l’état et le code postal
         location_button: Sélectionner
         location_step_about: Si vous ne parvenez pas à ajouter votre pièce d’identité,
@@ -61,7 +61,7 @@ fr:
             50 États et certains territoires américains seront bientôt
             disponibles.
           results_description: Il y a %{count} de bureaux de poste participants dans un
-            rayon de 80 km autour de %{address}.
+            rayon de 50 miles autour de %{address}.
           results_instructions: Sélectionnez un emplacement de bureau de poste ci-dessous,
             ou effectuez une nouvelle recherche en utilisant une autre adresse.
             Pour l’accessibilité des installations, utilisez les informations de

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -37,8 +37,8 @@ fr:
       location:
         contact_info_heading: Information de contact
         distance:
-          one: '%{count} mile away'
-          other: '%{count} miles away'
+          one: 'à %{count} mile'
+          other: 'à %{count} miles'
         inline_error: Saisissez une adresse valide avec la ville, l’état et le code postal
         location_button: Sélectionner
         location_step_about: Si vous ne parvenez pas à ajouter votre pièce d’identité,

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -17,8 +17,6 @@ module I18n
         { key: 'doc_auth.headings.photo', locales: %i[fr] }, # "Photo" is "Photo" in French
         { key: /^i18n\.locale\./ }, # Show locale options translated as that language
         { key: /^countries/ }, # Some countries have the same name across languages
-        { key: 'in_person_proofing.body.location.distance.one', locales: %i[fr] }, # Show English translation
-        { key: 'in_person_proofing.body.location.distance.other', locales: %i[fr] }, # Show English translation
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'simple_form.required.html' }, # No text content

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -17,6 +17,8 @@ module I18n
         { key: 'doc_auth.headings.photo', locales: %i[fr] }, # "Photo" is "Photo" in French
         { key: /^i18n\.locale\./ }, # Show locale options translated as that language
         { key: /^countries/ }, # Some countries have the same name across languages
+        { key: 'in_person_proofing.body.location.distance.one', locales: %i[fr] }, # Show English translation
+        { key: 'in_person_proofing.body.location.distance.other', locales: %i[fr] }, # Show English translation
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'simple_form.required.html' }, # No text content


### PR DESCRIPTION
## 🎫 Ticket

[Lg-8357](https://cm-jira.usa.gov/browse/LG-8357)


## 🛠 Summary of changes

Update distance in fr translations to use the en translation. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Make sure `arcgis_search_enabled:` is true
- [ ] On line 43 of `app/javascript/packages/document-capture/components/in-person-locations.tsx` remove `!` from `!isPilot`
- [ ] Use failing id to navigate through ipp
- [ ] On search page submit an address
- [ ] Confirm bold text above search results include `50 miles`
- [ ] Confirm search results include distance in miles


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Results description before:</summary>
<img width="532" alt="Screen Shot 2023-01-10 at 2 25 53 PM" src="https://user-images.githubusercontent.com/20867088/211661461-1d6646d3-ef66-48a7-bc74-7bf6cc628705.png">

</details>

<details>
<summary>Results description after:</summary>
<img width="515" alt="Screen Shot 2023-01-10 at 2 31 30 PM" src="https://user-images.githubusercontent.com/20867088/211661588-3b826fe9-16ed-472e-9ea8-b982a7d666d5.png">

</details>

<details>
<summary>Distance before:</summary>
<img width="725" alt="Screen Shot 2023-01-10 at 11 51 13 AM" src="https://user-images.githubusercontent.com/20867088/211661659-0e41f837-dcf9-4cdf-bdfb-d4a951111107.png">

</details>

<details>
<summary>Distance after:</summary>
<img width="597" alt="Screen Shot 2023-01-10 at 4 39 55 PM" src="https://user-images.githubusercontent.com/20867088/211676771-34d2c2a9-dedc-4ec4-baac-7849464aa2a4.png">

</details>

