### PR TITLE
LG-8402: Add a cancel link to the in-person proofing barcode page

### DIFF
--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -111,3 +111,8 @@
     </address>
   </section>
 <% end %>
+
+<%= render PageFooterComponent.new(class: 'padding-top-4') do %>
+  <% # todo: fix spacing %>
+  <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'verify') %>
+<% end %>

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -8,6 +8,7 @@ en:
         learn_more: Learn more
       barcode:
         close_window: You may now close this window.
+        cancel_link_text: Cancel your barcode
         deadline: Visit the Post Office by %{deadline}.
         deadline_restart: If you go after the deadline, your information will not be
           saved and you will need to restart the process.

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -9,6 +9,7 @@ es:
         learn_more: Aprende más
       barcode:
         close_window: Ya puede cerrar esta ventana
+        cancel_link_text: Cancelar su código de barras
         deadline: Visite la Oficina de correos antes del %{deadline}
         deadline_restart: Si supera la fecha límite, su información no se guardará y
           tendrá que reiniciar el proceso.

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -9,6 +9,7 @@ fr:
         learn_more: Apprendre encore plus
       barcode:
         close_window: Vous pouvez maintenant fermer cette fenêtre
+        cancel_link_text: Annulez votre code-barres
         deadline: Visitez le bureau de poste d’ici %{deadline}
         deadline_restart: Si vous partez après la date limite, vos informations ne
           seront pas sauvegardées et vous devrez recommencer le processus.

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -46,6 +46,15 @@ describe 'idv/in_person/ready_to_verify/show.html.erb' do
     end
   end
 
+  it 'renders a cancel link' do
+    render
+
+    expect(rendered).to have_link(
+      t('in_person_proofing.body.barcode.cancel_link_text'),
+      href: idv_cancel_path(step: 'verify'),
+    )
+  end
+
   context 'with enrollment where current address matches id' do
     let(:current_address_matches_id) { true }
 


### PR DESCRIPTION

## 🎫 Ticket

[LG-8402](https://cm-jira.usa.gov/browse/LG-8402?filter=-1)

## 🛠 Summary of changes

* Adds a cancel link to the in-person proofing barcode page. This link redirects the user to the exist start over page.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
