### PR TITLE
Remove email/password prefilling via URL

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,6 +13,7 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
+    before_action :update_devise_params_sanitizer, only: [:new]
 
     def new
       analytics.sign_in_page_visit(
@@ -235,6 +236,10 @@ module Users
       policy.script_src(*policy.script_src, 'dap.digitalgov.gov', 'www.google-analytics.com')
       policy.connect_src(*policy.connect_src, 'www.google-analytics.com')
       request.content_security_policy = policy
+    end
+
+    def update_devise_params_sanitizer
+      devise_parameter_sanitizer.permit(:sign_in, except: [:email, :password])
     end
   end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -639,6 +639,22 @@ describe Users::SessionsController, devise: true do
         get :new, params: { user: 'this_is_not_a_hash' }
       end.to_not raise_error
     end
+
+    context 'with prefilled email/password via url params' do
+      render_views
+
+      it 'does not prefill the form' do
+        email = Faker::Internet.safe_email
+        password = SecureRandom.uuid
+
+        get :new, params: { user: { email: email, password: password } }
+
+        doc = Nokogiri::HTML(response.body)
+
+        expect(doc.at_css('input[name="user[email]"]')[:value]).to be_nil
+        expect(doc.at_css('input[name="user[password]"]')[:value]).to be_nil
+      end
+    end
   end
 
   describe 'POST /sessions/keepalive' do


### PR DESCRIPTION
The Devise gem we use has some behavior where you can prefill a form via URL, this disables that behavior

Example: https://idp.mhenke.identitysandbox.gov/?user[email]=abc@abc.com


| Before | After |
| --- | --- |
| http://localhost:3000/?user[email]=abc@abc.com&user[password]=abcdef | http://localhost:3000/?user[email]=abc@abc.com&user[password]=abcdef |
|  <img width="911" alt="Screen Shot 2023-01-11 at 10 36 51 AM" src="https://user-images.githubusercontent.com/458784/211890252-57c6ab70-5185-44ff-910f-1eebf30e6e1f.png"> | <img width="911" alt="Screen Shot 2023-01-11 at 10 36 27 AM" src="https://user-images.githubusercontent.com/458784/211890257-38437b20-b1eb-438a-8ddd-9b5f7aa8ef4e.png"> |



<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
