### PR TITLE
Remove lingering references to "Pending" step indicator status

### DIFF
--- a/app/javascript/packages/step-indicator/step-indicator-step.tsx
+++ b/app/javascript/packages/step-indicator/step-indicator-step.tsx
@@ -3,7 +3,6 @@ import { t } from '@18f/identity-i18n';
 export enum StepStatus {
   CURRENT,
   COMPLETE,
-  PENDING,
   INCOMPLETE,
 }
 
@@ -20,7 +19,7 @@ export interface StepIndicatorStepProps {
 }
 
 function StepIndicatorStep({ title, status }: StepIndicatorStepProps) {
-  const { CURRENT, COMPLETE, PENDING, INCOMPLETE } = StepStatus;
+  const { CURRENT, COMPLETE, INCOMPLETE } = StepStatus;
 
   const classes = [
     'step-indicator__step',
@@ -38,9 +37,6 @@ function StepIndicatorStep({ title, status }: StepIndicatorStepProps) {
     case INCOMPLETE:
       statusText = t('step_indicator.status.not_complete');
       break;
-    case PENDING:
-      statusText = t('step_indicator.status.pending');
-      break;
     default:
       statusText = t('step_indicator.status.current');
   }
@@ -48,9 +44,7 @@ function StepIndicatorStep({ title, status }: StepIndicatorStepProps) {
   return (
     <li className={classes}>
       <span className="step-indicator__step-title">{title}</span>
-      <span className={status === PENDING ? 'step-indicator__step-subtitle' : 'usa-sr-only'}>
-        {statusText}
-      </span>
+      <span className="usa-sr-only">{statusText}</span>
     </li>
   );
 }

--- a/config/locales/step_indicator/en.yml
+++ b/config/locales/step_indicator/en.yml
@@ -16,4 +16,3 @@ en:
       complete: Completed
       current: Current step
       not_complete: Not completed
-      pending: Pending

--- a/config/locales/step_indicator/es.yml
+++ b/config/locales/step_indicator/es.yml
@@ -16,4 +16,3 @@ es:
       complete: Completo
       current: Siguiente paso
       not_complete: No se ha completado
-      pending: Pendiente

--- a/config/locales/step_indicator/fr.yml
+++ b/config/locales/step_indicator/fr.yml
@@ -16,4 +16,3 @@ fr:
       complete: Terminé
       current: Étape en cours
       not_complete: Non terminé
-      pending: En attente


### PR DESCRIPTION
## 🎫 Ticket

Originally [LG-6307](https://cm-jira.usa.gov/browse/LG-6307)

## 🛠 Summary of changes

Removes references to "Pending" status for a step indicator step. This was meant to be handled as part of #6860 / [LG-6307](https://cm-jira.usa.gov/browse/LG-6307), but a few references remained. 

See related discussion: https://github.com/18F/identity-idp/pull/7613#discussion_r1066982082

## 📜 Testing Plan

- Observe no regression in the appearance of the step indicator in the document capture step