### PR TITLE
Remove Time component IE11 fallback behavior

### DIFF
--- a/app/javascript/packages/time-element/index.spec.ts
+++ b/app/javascript/packages/time-element/index.spec.ts
@@ -48,20 +48,4 @@ describe('TimeElement', () => {
       expect(element.textContent).to.equal('April 21, 2020 at 14:03');
     });
   });
-
-  context('without formatToParts support', () => {
-    usePropertyValue(Intl.DateTimeFormat.prototype, 'formatToParts', undefined);
-
-    it('sets text using Intl.DateTimeFormat#format as fallback', () => {
-      const date = new Date(2020, 3, 21, 14, 3, 24);
-      const element = createElement({
-        format: '%{month} %{day}, %{year} at %{hour}:%{minute} %{day_period}',
-        timestamp: date.toISOString(),
-      });
-
-      const expected = element.formatter.format(date);
-
-      expect(element.textContent).to.equal(expected);
-    });
-  });
 });

--- a/app/javascript/packages/time-element/index.ts
+++ b/app/javascript/packages/time-element/index.ts
@@ -41,19 +41,14 @@ export class TimeElement extends HTMLElement {
 
   setTime() {
     const { formatter } = this;
-    if (typeof formatter.formatToParts === 'function') {
-      const parts = Object.fromEntries(
-        formatter.formatToParts(this.date).map((part) => [part.type, part.value]),
-      ) as Partial<Record<Intl.DateTimeFormatPartTypes, string>>;
+    const parts = Object.fromEntries(
+      formatter.formatToParts(this.date).map((part) => [part.type, part.value]),
+    ) as Partial<Record<Intl.DateTimeFormatPartTypes, string>>;
 
-      this.textContent = replaceVariables(
-        this.#format,
-        mapKeys({ dayPeriod: '', ...parts }, snakeCase),
-      );
-    } else {
-      // Degrade gracefully for environments where formatToParts is unsupported (Internet Explorer)
-      this.textContent = formatter.format(this.date);
-    }
+    this.textContent = replaceVariables(
+      this.#format,
+      mapKeys({ dayPeriod: '', ...parts }, snakeCase),
+    );
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

Relates to [LG-8525](https://cm-jira.usa.gov/browse/LG-8525)

## 🛠 Summary of changes

Following #7563 and #7624, removes another code snippet providing fallback behavior for Internet Explorer's lack of support for `Intl.DateTimeFormat#formatToParts`.

Related:

- https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_formattoparts
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts#browser_compatibility

## 📜 Testing Plan

- `yarn test`
- Observe that time displays continue to appear as expected in the local timezone (e.g. "Connected Apps" account page)