### PR TITLE
Configure Rubocop 3.2 syntax for new defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'public/**/*'
-  TargetRubyVersion: 3.0.4
+  TargetRubyVersion: 3.2.0
   TargetRailsVersion: 7.0
   UseCache: true
   DisabledByDefault: true
@@ -1043,6 +1043,7 @@ Style/HashExcept:
 
 Style/HashSyntax:
   EnforcedStyle: ruby19
+  EnforcedShorthandSyntax: either
 
 Style/IdenticalConditionalBranches:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :test do
   gem 'psych'
   gem 'puma'
   gem 'rspec-rails', '~> 6.0'
-  gem 'rubocop', '~> 1.42.0', require: false
+  gem 'rubocop', '~> 1.43.0', require: false
   gem 'rubocop-performance', '~> 1.15.0', require: false
   gem 'rubocop-rails', '>= 2.5.2', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -573,16 +573,16 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.42.0)
+    rubocop (1.43.0)
       json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.24.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     rubocop-performance (1.15.2)
@@ -805,7 +805,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0)
   rspec-retry
   rspec_junit_formatter
-  rubocop (~> 1.42.0)
+  rubocop (~> 1.43.0)
   rubocop-performance (~> 1.15.0)
   rubocop-rails (>= 2.5.2)
   ruby-progressbar

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We recommend using [Homebrew](https://brew.sh/), [rbenv](https://github.com/rben
 #### Dependencies
 1. To start, make sure you have the following dependencies installed and a working development environment:
 
-- Ruby ~> 3.0.4
+- Ruby ~> 3.2.0
 - [PostgreSQL](http://www.postgresql.org/download/)
 - [Redis 5+](http://redis.io/)
 - [Node.js v16](https://nodejs.org)

--- a/app/components/alert_component.html.erb
+++ b/app/components/alert_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(**tag_options, class: css_class, role: role) do %>
+<%= tag.div(**tag_options, class: css_class, role:) do %>
   <div class="usa-alert__body">
     <%= content_tag(text_tag, content, class: 'usa-alert__text') %>
   </div>

--- a/app/components/block_link_component.rb
+++ b/app/components/block_link_component.rb
@@ -19,7 +19,7 @@ class BlockLinkComponent < BaseComponent
   end
 
   def wrapper(&block)
-    wrapper = action.call(**tag_options, href: url, class: css_class, target: target, &block)
+    wrapper = action.call(**tag_options, href: url, class: css_class, target:, &block)
     if wrapper.respond_to?(:render_in)
       render wrapper, &block
     else

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -35,6 +35,6 @@ class ButtonComponent < BaseComponent
   end
 
   def icon_content
-    render IconComponent.new(icon: icon) if icon
+    render IconComponent.new(icon:) if icon
   end
 end

--- a/app/components/clipboard_button_component.rb
+++ b/app/components/clipboard_button_component.rb
@@ -8,7 +8,7 @@ class ClipboardButtonComponent < ButtonComponent
   end
 
   def call
-    content_tag(:'lg-clipboard-button', super, data: { clipboard_text: clipboard_text })
+    content_tag(:'lg-clipboard-button', super, data: { clipboard_text: })
   end
 
   def content

--- a/app/components/countdown_component.rb
+++ b/app/components/countdown_component.rb
@@ -23,7 +23,7 @@ class CountdownComponent < BaseComponent
       data: {
         expiration: expiration.iso8601,
         update_interval: update_interval_in_ms,
-        start_immediately: start_immediately,
+        start_immediately:,
       }.merge(tag_options[:data].to_h),
     )
   end

--- a/app/components/flash_component.html.erb
+++ b/app/components/flash_component.html.erb
@@ -1,3 +1,3 @@
 <% alerts.each do |type, message| %>
-  <%= render AlertComponent.new(type: type, message: message.html_safe, class: 'margin-bottom-4') %>
+  <%= render AlertComponent.new(type:, message: message.html_safe, class: 'margin-bottom-4') %>
 <% end %>

--- a/app/components/form_link_component.html.erb
+++ b/app/components/form_link_component.html.erb
@@ -1,4 +1,4 @@
 <lg-form-link>
   <%= link_to(href, **tag_options) { content } %>
-  <%= form_tag(href, method: method, class: 'display-none') {} %>
+  <%= form_tag(href, method:, class: 'display-none') {} %>
 </lg-form-link>

--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 class IconComponent < BaseComponent
   include AssetHelper
 

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -4,7 +4,7 @@
 <div id="validated-field-hint-<%= unique_id %>" class="usa-hint">
     <%= hint %>
 </div>
-  <%= content_tag :'lg-memorable-date', min: min, max: max, **tag_options do -%>
+  <%= content_tag :'lg-memorable-date', min:, max:, **tag_options do -%>
     <div class="usa-memorable-date">
       <%= content_tag(
             :script,
@@ -41,7 +41,7 @@
                     value: month,
                   },
                   error: false,
-                  required: required,
+                  required:,
                 ) %>
           <% end %>
           <span id=<%= "memorable-date-month-hint-#{unique_id}" %> class="display-none">
@@ -74,7 +74,7 @@
                   value: day,
                 },
                 error: false,
-                required: required,
+                required:,
               ) %>
           <% end %>
           <span id=<%= "memorable-date-day-hint-#{unique_id}" %> class="display-none">
@@ -107,7 +107,7 @@
                   value: year,
                 },
                 error: false,
-                required: required,
+                required:,
               ) %>
           <% end %>
           <span id=<%= "memorable-date-year-hint-#{unique_id}" %> class="display-none">

--- a/app/components/memorable_date_component.rb
+++ b/app/components/memorable_date_component.rb
@@ -128,7 +128,7 @@ class MemorableDateComponent < BaseComponent
     base_error_messages = {
       missing_month_day_year: t(
         'components.memorable_date.errors.missing_month_day_year',
-        label: label,
+        label:,
       ),
       missing_month_day: t('components.memorable_date.errors.missing_month_day'),
       missing_month_year: t('components.memorable_date.errors.missing_month_year'),
@@ -144,7 +144,7 @@ class MemorableDateComponent < BaseComponent
     if label && min
       base_error_messages[:range_underflow] =
         t(
-          'components.memorable_date.errors.range_underflow', label: label,
+          'components.memorable_date.errors.range_underflow', label:,
                                                               date: i18n_long_format(min)
         )
     end
@@ -152,7 +152,7 @@ class MemorableDateComponent < BaseComponent
     if label && max
       base_error_messages[:range_overflow] =
         t(
-          'components.memorable_date.errors.range_overflow', label: label,
+          'components.memorable_date.errors.range_overflow', label:,
                                                              date: i18n_long_format(max)
         )
     end
@@ -161,7 +161,7 @@ class MemorableDateComponent < BaseComponent
       base_error_messages[:outside_date_range] =
         t(
           'components.memorable_date.errors.outside_date_range',
-          label: label,
+          label:,
           min: i18n_long_format(min),
           max: i18n_long_format(max),
         )

--- a/app/components/one_time_code_input_component.html.erb
+++ b/app/components/one_time_code_input_component.html.erb
@@ -1,15 +1,15 @@
-<%= content_tag(:'lg-one-time-code-input', **tag_options, transport: transport) do %>
+<%= content_tag(:'lg-one-time-code-input', **tag_options, transport:) do %>
   <%= render ValidatedFieldComponent.new(
-        form: form,
-        name: name,
+        form:,
+        name:,
         label: t('components.one_time_code_input.label'),
-        hint: hint,
+        hint:,
         required: true,
         **field_options,
         input_html: {
           **field_options[:input_html].to_h,
-          value: value,
-          maxlength: maxlength,
+          value:,
+          maxlength:,
           autofocus: autofocus?,
           class: input_css_class,
           pattern: input_pattern,

--- a/app/components/password_toggle_component.html.erb
+++ b/app/components/password_toggle_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(:'lg-password-toggle', **tag_options) do %>
   <%= render ValidatedFieldComponent.new(
-        form: form,
+        form:,
         name: :password,
         type: :password,
         label: default_label,

--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -2,8 +2,8 @@
       'lg-phone-input',
       class: tag_options[:class],
       data: {
-        delivery_methods: delivery_methods,
-        translated_country_code_names: translated_country_code_names,
+        delivery_methods:,
+        translated_country_code_names:,
       },
     ) do %>
   <%= content_tag(
@@ -48,7 +48,7 @@
           valueMissing: t('errors.messages.phone_required'),
         },
         as: :tel,
-        required: required,
+        required:,
         label: false,
         wrapper_html: {
           class: 'margin-bottom-0',

--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -1,6 +1,6 @@
 class ProcessListComponent < BaseComponent
   renders_many :items, ->(**kwargs, &block) {
-    ProcessListItemComponent.new(heading_level: heading_level, **kwargs, &block)
+    ProcessListItemComponent.new(heading_level:, **kwargs, &block)
   }
 
   attr_reader :heading_level, :big, :connected, :tag_options

--- a/app/components/status_page_component.html.erb
+++ b/app/components/status_page_component.html.erb
@@ -1,4 +1,4 @@
-<%= render AlertIconComponent.new(icon_name: icon_name, class: 'display-block margin-bottom-4', width: 54, height: 54) %>
+<%= render AlertIconComponent.new(icon_name:, class: 'display-block margin-bottom-4', width: 54, height: 54) %>
 <%= header %>
 
 <%= content %>

--- a/app/components/submit_button_component.rb
+++ b/app/components/submit_button_component.rb
@@ -1,6 +1,6 @@
 class SubmitButtonComponent < ButtonComponent
   def initialize(big: true, wide: true, **tag_options)
-    super(big: big, wide: wide, **tag_options)
+    super(big:, wide:, **tag_options)
   end
 
   def call

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 class MarketingSite
   BASE_URL = URI('https://www.login.gov').freeze
 

--- a/lib/makefile_help_parser.rb
+++ b/lib/makefile_help_parser.rb
@@ -1,5 +1,4 @@
 require 'open3'
-require 'set'
 
 # Parses comment strings (## help) out of the Makefile
 # and also uses the `make --print-data-base` output to expand out targets based on variables

--- a/spec/components/accordion_component_spec.rb
+++ b/spec/components/accordion_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AccordionComponent, type: :component do
   let(:bordered) { nil }
   let(:tag_options) { {} }
-  let(:options) { { bordered: bordered, **tag_options }.compact }
+  let(:options) { { bordered:, **tag_options }.compact }
 
   subject(:rendered) do
     render_inline(described_class.new(**options)) do |c|

--- a/spec/components/click_observer_component_spec.rb
+++ b/spec/components/click_observer_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ClickObserverComponent, type: :component do
 
   subject(:rendered) do
     render_inline ClickObserverComponent.new(
-      event_name: event_name,
+      event_name:,
       **tag_options,
     ).with_content(content)
   end

--- a/spec/components/clipboard_button_component_spec.rb
+++ b/spec/components/clipboard_button_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ClipboardButtonComponent, type: :component do
   let(:tag_options) { {} }
 
   subject(:rendered) do
-    render_inline ClipboardButtonComponent.new(clipboard_text: clipboard_text, **tag_options)
+    render_inline ClipboardButtonComponent.new(clipboard_text:, **tag_options)
   end
 
   it 'renders with clipboard text as data-attribute' do

--- a/spec/components/countdown_alert_component_spec.rb
+++ b/spec/components/countdown_alert_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
 
   it 'renders element with expected attributes and initial expiration time' do
     rendered = render_inline CountdownAlertComponent.new(
-      countdown_options: { expiration: expiration },
+      countdown_options: { expiration: },
     )
 
     expect(rendered).to have_css('lg-countdown-alert', text: '1 minute and 1 second remaining')
@@ -20,7 +20,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
     it 'renders as hidden by default with expected attributes' do
       rendered = render_inline CountdownAlertComponent.new(
         show_at_remaining: 1.minute,
-        countdown_options: { expiration: expiration },
+        countdown_options: { expiration: },
       )
 
       expect(rendered).to have_css('lg-countdown-alert[show-at-remaining=60000].display-none')
@@ -30,7 +30,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
       it 'renders with attributes' do
         rendered = render_inline CountdownAlertComponent.new(
           show_at_remaining: 1.minute,
-          countdown_options: { expiration: expiration },
+          countdown_options: { expiration: },
           class: 'example',
           data: { foo: 'bar' },
         )
@@ -43,7 +43,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
   context 'with tag options' do
     it 'renders with attributes' do
       rendered = render_inline CountdownAlertComponent.new(
-        countdown_options: { expiration: expiration },
+        countdown_options: { expiration: },
         class: 'example',
         data: { foo: 'bar' },
       )
@@ -55,7 +55,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
   context 'with countdown options' do
     it 'renders countdown with attributes' do
       rendered = render_inline CountdownAlertComponent.new(
-        countdown_options: { expiration: expiration, data: { foo: 'bar' } },
+        countdown_options: { expiration:, data: { foo: 'bar' } },
       )
 
       expect(rendered).to have_css('lg-countdown[data-expiration][data-foo="bar"]')
@@ -65,7 +65,7 @@ RSpec.describe CountdownAlertComponent, type: :component do
   context 'with alert options' do
     it 'renders alert with attributes' do
       rendered = render_inline CountdownAlertComponent.new(
-        countdown_options: { expiration: expiration },
+        countdown_options: { expiration: },
         alert_options: { data: { foo: 'bar' } },
       )
 

--- a/spec/components/countdown_component_spec.rb
+++ b/spec/components/countdown_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CountdownComponent, type: :component do
   end
 
   it 'renders element with expected attributes and initial expiration time' do
-    rendered = render_inline CountdownComponent.new(expiration: expiration)
+    rendered = render_inline CountdownComponent.new(expiration:)
 
     element = rendered.css('lg-countdown', text: '1 minute and 1 second').first
     expect(element).to be_present
@@ -20,7 +20,7 @@ RSpec.describe CountdownComponent, type: :component do
   context 'with tag options' do
     it 'renders with attributes' do
       rendered = render_inline CountdownComponent.new(
-        expiration: expiration,
+        expiration:,
         data: { foo: 'bar' },
       )
 
@@ -31,7 +31,7 @@ RSpec.describe CountdownComponent, type: :component do
   context 'with custom update interval' do
     it 'assigns update interval in milliseconds' do
       rendered = render_inline CountdownComponent.new(
-        expiration: expiration,
+        expiration:,
         update_interval: 30.seconds,
       )
 
@@ -42,7 +42,7 @@ RSpec.describe CountdownComponent, type: :component do
   context 'with controlled start immediately' do
     it 'assigns attribute to start immediately' do
       rendered = render_inline CountdownComponent.new(
-        expiration: expiration,
+        expiration:,
         start_immediately: false,
       )
 

--- a/spec/components/download_button_component_spec.rb
+++ b/spec/components/download_button_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe DownloadButtonComponent, type: :component do
   let(:tag_options) { {} }
   let(:instance) do
     DownloadButtonComponent.new(
-      file_data: file_data,
-      file_name: file_name,
+      file_data:,
+      file_name:,
       **tag_options,
     )
   end

--- a/spec/components/flash_component_spec.rb
+++ b/spec/components/flash_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FlashComponent, type: :component do
   let(:flash) { {} }
 
-  subject(:rendered) { render_inline FlashComponent.new(flash: flash) }
+  subject(:rendered) { render_inline FlashComponent.new(flash:) }
 
   context 'flash key, but not message, is present' do
     let(:flash) { { 'error' => '' } }

--- a/spec/components/javascript_required_component_spec.rb
+++ b/spec/components/javascript_required_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
   let(:content) { 'JavaScript-required content' }
 
   subject(:rendered) do
-    render_inline described_class.new(header: header, intro: intro).with_content(content)
+    render_inline described_class.new(header:, intro:).with_content(content)
   end
 
   it 'renders instructions to enable JavaScript' do
@@ -51,7 +51,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
     it 'only renders the alert once' do
       rendered
 
-      second_rendered = render_inline described_class.new(header: header)
+      second_rendered = render_inline described_class.new(header:)
 
       expect(second_rendered).not_to have_content(t('components.javascript_required.enabled_alert'))
     end

--- a/spec/components/language_picker_component_spec.rb
+++ b/spec/components/language_picker_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LanguagePickerComponent, type: :component do
 
     I18n.available_locales.each do |locale|
       expect(rendered).to have_xpath(
-        ".//a[text()='#{t("i18n.locale.#{locale}", locale: locale)}'][@lang='#{locale}']",
+        ".//a[text()='#{t("i18n.locale.#{locale}", locale:)}'][@lang='#{locale}']",
         visible: false,
       )
     end

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -23,18 +23,18 @@ RSpec.describe MemorableDateComponent, type: :component do
   let(:tag_options) { {} }
   let(:options) do
     {
-      name: name,
-      month: month,
-      day: day,
-      year: year,
+      name:,
+      month:,
+      day:,
+      year:,
       min: Date.parse(min),
       max: Date.parse(max),
-      hint: hint,
-      label: label,
+      hint:,
+      label:,
       form: form_builder,
-      required: required,
-      error_messages: error_messages,
-      range_errors: range_errors,
+      required:,
+      error_messages:,
+      range_errors:,
       **tag_options,
     }.compact
   end
@@ -134,7 +134,7 @@ RSpec.describe MemorableDateComponent, type: :component do
         'error_messages' => {
           'missing_month_day_year' => t(
             'components.memorable_date.errors.missing_month_day_year',
-            label: label,
+            label:,
           ),
           'missing_month_day' => t('components.memorable_date.errors.missing_month_day'),
           'missing_month_year' => t('components.memorable_date.errors.missing_month_year'),
@@ -148,18 +148,18 @@ RSpec.describe MemorableDateComponent, type: :component do
           'invalid_date' => t('components.memorable_date.errors.invalid_date'),
           'range_underflow' =>
             t(
-              'components.memorable_date.errors.range_underflow', label: label,
+              'components.memorable_date.errors.range_underflow', label:,
                                                                   date: formatted_min
             ),
           'range_overflow' =>
           t(
-            'components.memorable_date.errors.range_overflow', label: label,
+            'components.memorable_date.errors.range_overflow', label:,
                                                                date: formatted_max
           ),
           'outside_date_range' =>
           t(
             'components.memorable_date.errors.outside_date_range',
-            label: label,
+            label:,
             min: formatted_min,
             max: formatted_max,
           ),

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
   let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
   let(:options) { {} }
 
-  subject(:rendered) { render_inline OneTimeCodeInputComponent.new(form: form, **options) }
+  subject(:rendered) { render_inline OneTimeCodeInputComponent.new(form:, **options) }
 
   describe 'name' do
     context 'no name given' do

--- a/spec/components/password_toggle_component_spec.rb
+++ b/spec/components/password_toggle_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PasswordToggleComponent, type: :component do
   let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
   let(:options) { {} }
 
-  subject(:rendered) { render_inline PasswordToggleComponent.new(form: form, **options) }
+  subject(:rendered) { render_inline PasswordToggleComponent.new(form:, **options) }
 
   it 'renders default markup' do
     expect(rendered).to have_css('lg-password-toggle')
@@ -26,7 +26,7 @@ RSpec.describe PasswordToggleComponent, type: :component do
   describe '#toggle_label' do
     context 'with custom label' do
       let(:toggle_label) { 'Custom Toggle Label' }
-      let(:options) { { toggle_label: toggle_label } }
+      let(:options) { { toggle_label: } }
 
       it 'renders custom field label' do
         expect(rendered).to have_field(toggle_label, type: :checkbox)
@@ -36,8 +36,8 @@ RSpec.describe PasswordToggleComponent, type: :component do
 
   describe '#toggle_id' do
     it 'is unique across instances' do
-      toggle_one = PasswordToggleComponent.new(form: form)
-      toggle_two = PasswordToggleComponent.new(form: form)
+      toggle_one = PasswordToggleComponent.new(form:)
+      toggle_two = PasswordToggleComponent.new(form:)
 
       expect(toggle_one.toggle_id).to be_present
       expect(toggle_two.toggle_id).to be_present
@@ -47,8 +47,8 @@ RSpec.describe PasswordToggleComponent, type: :component do
 
   describe '#input_id' do
     it 'is unique across instances' do
-      toggle_one = PasswordToggleComponent.new(form: form)
-      toggle_two = PasswordToggleComponent.new(form: form)
+      toggle_one = PasswordToggleComponent.new(form:)
+      toggle_two = PasswordToggleComponent.new(form:)
 
       expect(toggle_one.input_id).to be_present
       expect(toggle_two.input_id).to be_present
@@ -69,7 +69,7 @@ RSpec.describe PasswordToggleComponent, type: :component do
   context 'with field options' do
     let(:label) { 'Custom Label' }
     let(:options) do
-      { field_options: { label: label, required: true } }
+      { field_options: { label:, required: true } }
     end
 
     it 'forwards options to rendered field' do

--- a/spec/components/phone_input_component_spec.rb
+++ b/spec/components/phone_input_component_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe PhoneInputComponent, type: :component do
   let(:options) do
     {
       form: form_builder,
-      allowed_countries: allowed_countries,
-      confirmed_phone: confirmed_phone,
-      required: required,
-      delivery_methods: delivery_methods,
+      allowed_countries:,
+      confirmed_phone:,
+      required:,
+      delivery_methods:,
       **tag_options,
     }.compact
   end

--- a/spec/components/previews/accordion_component_preview.rb
+++ b/spec/components/previews/accordion_component_preview.rb
@@ -19,7 +19,7 @@ class AccordionComponentPreview < BaseComponentPreview
   # @param content text
   # @param bordered toggle
   def workbench(header: 'Header', content: 'Content', bordered: true)
-    render(AccordionComponent.new(bordered: bordered)) do |c|
+    render(AccordionComponent.new(bordered:)) do |c|
       c.header { header }
       content
     end

--- a/spec/components/previews/alert_component_preview.rb
+++ b/spec/components/previews/alert_component_preview.rb
@@ -36,6 +36,6 @@ class AlertComponentPreview < BaseComponentPreview
   # @param message text
   # @param type select [info, success, warning, error, emergency, other]
   def workbench(message: 'An important message', type: :info)
-    render(AlertComponent.new(message: message, type: type))
+    render(AlertComponent.new(message:, type:))
   end
 end

--- a/spec/components/previews/barcode_component_preview.rb
+++ b/spec/components/previews/barcode_component_preview.rb
@@ -8,6 +8,6 @@ class BarcodeComponentPreview < BaseComponentPreview
   # @param barcode_data text
   # @param label text
   def workbench(barcode_data: '1234567812345678', label: 'Barcode')
-    render(BarcodeComponent.new(barcode_data: barcode_data, label: label))
+    render(BarcodeComponent.new(barcode_data:, label:))
   end
 end

--- a/spec/components/previews/block_link_component_preview.rb
+++ b/spec/components/previews/block_link_component_preview.rb
@@ -13,6 +13,6 @@ class BlockLinkComponentPreview < BaseComponentPreview
   # @param url text
   # @param new_tab toggle
   def workbench(content: 'Link text', url: '', new_tab: false)
-    render(BlockLinkComponent.new(url: url, new_tab: new_tab).with_content(content))
+    render(BlockLinkComponent.new(url:, new_tab:).with_content(content))
   end
 end

--- a/spec/components/previews/button_component_preview.rb
+++ b/spec/components/previews/button_component_preview.rb
@@ -68,12 +68,12 @@ class ButtonComponentPreview < BaseComponentPreview
     render(
       ButtonComponent.new(
         icon: icon&.to_sym,
-        big: big,
-        wide: wide,
-        full_width: full_width,
-        outline: outline,
-        unstyled: unstyled,
-        danger: danger,
+        big:,
+        wide:,
+        full_width:,
+        outline:,
+        unstyled:,
+        danger:,
       ).with_content(content),
     )
   end

--- a/spec/components/previews/clipboard_button_component_preview.rb
+++ b/spec/components/previews/clipboard_button_component_preview.rb
@@ -7,6 +7,6 @@ class ClipboardButtonComponentPreview < BaseComponentPreview
 
   # @param clipboard_text text
   def workbench(clipboard_text: 'Copied Text')
-    render(ClipboardButtonComponent.new(clipboard_text: clipboard_text))
+    render(ClipboardButtonComponent.new(clipboard_text:))
   end
 end

--- a/spec/components/previews/countdown_alert_component_preview.rb
+++ b/spec/components/previews/countdown_alert_component_preview.rb
@@ -25,7 +25,7 @@ class CountdownAlertComponentPreview < BaseComponentPreview
     render(
       CountdownAlertComponent.new(
         show_at_remaining: show_at_remaining_seconds&.seconds,
-        countdown_options: { expiration: expiration },
+        countdown_options: { expiration: },
       ),
     )
   end

--- a/spec/components/previews/countdown_component_preview.rb
+++ b/spec/components/previews/countdown_component_preview.rb
@@ -15,9 +15,9 @@ class CountdownComponentPreview < BaseComponentPreview
   )
     render(
       CountdownComponent.new(
-        expiration: expiration,
+        expiration:,
         update_interval: update_interval.seconds,
-        start_immediately: start_immediately,
+        start_immediately:,
       ),
     )
   end

--- a/spec/components/previews/download_button_component_preview.rb
+++ b/spec/components/previews/download_button_component_preview.rb
@@ -8,6 +8,6 @@ class DownloadButtonComponentPreview < BaseComponentPreview
   # @param file_data text
   # @param file_name text
   def workbench(file_data: 'File Data', file_name: 'file_name.txt')
-    render(DownloadButtonComponent.new(file_data: file_data, file_name: file_name))
+    render(DownloadButtonComponent.new(file_data:, file_name:))
   end
 end

--- a/spec/components/previews/memorable_date_component_preview.rb
+++ b/spec/components/previews/memorable_date_component_preview.rb
@@ -23,10 +23,10 @@ class MemorableDateComponentPreview < BaseComponentPreview
       MemorableDateComponent.new(
         form: form_builder,
         name: :date,
-        label: label,
-        hint: hint,
-        min: min,
-        max: max,
+        label:,
+        hint:,
+        min:,
+        max:,
       ),
     )
   end

--- a/spec/components/previews/one_time_code_input_component_preview.rb
+++ b/spec/components/previews/one_time_code_input_component_preview.rb
@@ -13,6 +13,6 @@ class OneTimeCodeInputComponentPreview < BaseComponentPreview
   # @display form true
   # @param numeric toggle
   def workbench(numeric: true)
-    render(OneTimeCodeInputComponent.new(form: form_builder, numeric: numeric))
+    render(OneTimeCodeInputComponent.new(form: form_builder, numeric:))
   end
 end

--- a/spec/components/previews/password_toggle_component_preview.rb
+++ b/spec/components/previews/password_toggle_component_preview.rb
@@ -11,8 +11,8 @@ class PasswordToggleComponentPreview < BaseComponentPreview
     render(
       PasswordToggleComponent.new(
         form: form_builder,
-        **{ toggle_label: toggle_label }.compact,
-        field_options: { label: label }.compact,
+        **{ toggle_label: }.compact,
+        field_options: { label: }.compact,
       ),
     )
   end

--- a/spec/components/previews/process_list_component_preview.rb
+++ b/spec/components/previews/process_list_component_preview.rb
@@ -32,7 +32,7 @@ class ProcessListComponentPreview < BaseComponentPreview
   # @param connected toggle
   # @param big toggle
   def workbench(big: false, connected: false)
-    render(ProcessListComponent.new(big: big, connected: connected)) do |c|
+    render(ProcessListComponent.new(big:, connected:)) do |c|
       c.item(heading: 'Item 1') { 'Item 1 Content' }
       c.item(heading: 'Item 2') { 'Item 2 Content' }
     end

--- a/spec/components/previews/spinner_button_component_preview.rb
+++ b/spec/components/previews/spinner_button_component_preview.rb
@@ -21,7 +21,7 @@ class SpinnerButtonComponentPreview < BaseComponentPreview
       SpinnerButtonComponent.new(
         form: form_builder,
         big: true,
-        **{ action_message: action_message }.compact,
+        **{ action_message: }.compact,
       ).with_content('Submit'),
     )
   end

--- a/spec/components/previews/time_component_preview.rb
+++ b/spec/components/previews/time_component_preview.rb
@@ -7,6 +7,6 @@ class TimeComponentPreview < BaseComponentPreview
 
   # @param time datetime-local
   def workbench(time: Time.zone.now + 5.hours)
-    render TimeComponent.new(time: time)
+    render TimeComponent.new(time:)
   end
 end

--- a/spec/components/previews/validated_field_component_preview.rb
+++ b/spec/components/previews/validated_field_component_preview.rb
@@ -56,8 +56,8 @@ class ValidatedFieldComponentPreview < BaseComponentPreview
       ValidatedFieldComponent.new(
         form: form_builder,
         name: :input,
-        label: label,
-        required: required,
+        label:,
+        required:,
         as: input_type.underscore.tr(' ', '_').to_sym,
       ),
     )

--- a/spec/components/step_indicator_component_spec.rb
+++ b/spec/components/step_indicator_component_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe StepIndicatorComponent, type: :component do
 
   subject(:rendered) do
     render_inline StepIndicatorComponent.new(
-      steps: steps,
-      current_step: current_step,
-      locale_scope: locale_scope,
+      steps:,
+      current_step:,
+      locale_scope:,
       class: classes,
     )
   end

--- a/spec/components/step_indicator_step_component_spec.rb
+++ b/spec/components/step_indicator_step_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StepIndicatorStepComponent, type: :component do
   let(:status) { nil }
 
   subject(:rendered) do
-    render_inline StepIndicatorStepComponent.new(title: title, status: status)
+    render_inline StepIndicatorStepComponent.new(title:, status:)
   end
 
   it 'renders step title' do

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe ValidatedFieldComponent, type: :component do
   let(:tag_options) { {} }
   let(:options) do
     {
-      name: name,
+      name:,
       form: form_builder,
-      error_messages: error_messages,
+      error_messages:,
       **tag_options,
     }.compact
   end

--- a/spec/components/vendor_outage_alert_component_spec.rb
+++ b/spec/components/vendor_outage_alert_component_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe VendorOutageAlertComponent, type: :component do
 
   subject(:rendered) do
     render_inline VendorOutageAlertComponent.new(
-      vendors: vendors,
-      context: context,
-      only_if_all: only_if_all,
+      vendors:,
+      context:,
+      only_if_all:,
     )
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

This updates and configures Rubocop to target Ruby 3.2 syntax, available as of #7594.

~Most notably, this brings in new default behaviors for [`Style/HashSyntax`'s `EnforcedShorthandSyntax`](https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax), which defaults to `always` when configured for Ruby 3.1 syntax.~ **Edit:** After discussion, decision is to configure as `either` for now and revisit once the team has had some time to warm up to the new syntax (see 376f09e).

## 📜 Testing Plan

- `bundle exec rubocop`