### PR TITLE
Lg-7695 enrollment creation event

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2983,6 +2983,28 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when USPS in-person proofing enrollment is created
+  # @param [String] enrollment_code
+  # @param [Integer] enrollment_id
+  # @param [String] user_id
+  # @param [String] service_provider
+  def usps_ippaas_enrollment_created(
+    enrollment_code:,
+    enrollment_id:,
+    user_id:,
+    service_provider:,
+    **extra
+  )
+    track_event(
+      'USPS IPPaaS enrollment created',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      user_id: user_id,
+      service_provider: service_provider,
+      **extra,
+    )
+  end
+
   # Tracks if USPS in-person proofing enrollment request fails
   # @param [String] context
   # @param [String] reason

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -17,7 +17,7 @@ module UspsInPersonProofing
         enrollment.enrollment_established_at = Time.zone.now
         enrollment.save!
 
-        analytics.usps_ippaas_enrollment_created(
+        analytics(user: user).usps_ippaas_enrollment_created(
           enrollment_code: enrollment.enrollment_code,
           enrollment_id: enrollment.id,
           user_id: enrollment.user_id,

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -17,6 +17,13 @@ module UspsInPersonProofing
         enrollment.enrollment_established_at = Time.zone.now
         enrollment.save!
 
+        analytics.usps_ippaas_enrollment_created(
+          enrollment_code: enrollment.enrollment_code,
+          enrollment_id: enrollment.id,
+          user_id: enrollment.user_id,
+          service_provider: enrollment.service_provider,
+        )
+
         send_ready_to_verify_email(user, enrollment)
       end
 
@@ -87,6 +94,10 @@ module UspsInPersonProofing
 
       def handle_standard_error(err, enrollment)
         raise Exception::RequestEnrollException.new(err.message, err, enrollment.id)
+      end
+
+      def analytics(user: AnonymousUser.new)
+        Analytics.new(user: user, request: nil, session: {}, sp: nil)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[Lg-7695](https://cm-jira.usa.gov/browse/LG-7695)

## 🛠 Summary of changes

Analytics event added to track when usps enrollment is created. This occurs in the schedule_in_person_enrollment method of the enrollment helper. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Navigate through ipp flow using failing id
- [ ] Continue all the way through to ready to verify page
- [ ] Go to local events.log file in repo
- [ ] Confirm `'USPS IPPaaS enrollment created'` event is created with enrollment_code, enrollment_id, user_id and service_provider


## 👀 Screenshots
<img width="1376" alt="Screen Shot 2023-01-12 at 11 43 51 AM" src="https://user-images.githubusercontent.com/20867088/212128100-763973a6-8e21-47f5-92ec-e2843b977288.png">
<img width="989" alt="Screen Shot 2023-01-12 at 11 43 19 AM" src="https://user-images.githubusercontent.com/20867088/212128170-e99010b6-1a63-4626-85ad-1466d5ee0ff1.png">


