### PR TITLE
Separate proofing job queues and dynamic worker database connection pool sizing

### DIFF
--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -1,7 +1,7 @@
 class AddressProofingJob < ApplicationJob
   include JobHelpers::StaleJobHelper
 
-  queue_as :default
+  queue_as :high_address_proofing
 
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 

--- a/app/jobs/document_proofing_job.rb
+++ b/app/jobs/document_proofing_job.rb
@@ -1,7 +1,7 @@
 class DocumentProofingJob < ApplicationJob
   include JobHelpers::StaleJobHelper
 
-  queue_as :default
+  queue_as :high_document_proofing
 
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -1,7 +1,7 @@
 class ResolutionProofingJob < ApplicationJob
   include JobHelpers::StaleJobHelper
 
-  queue_as :default
+  queue_as :high_resolution_proofing
 
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require_relative '../lib/identity_config'
 require_relative '../lib/fingerprinter'
 require_relative '../lib/identity_job_log_subscriber'
 require_relative '../lib/email_delivery_observer'
+require_relative '../lib/good_job_connection_pool_size'
 
 Bundler.require(*Rails.groups)
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -459,7 +459,6 @@ production:
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379
   report_timeout: 1_000_000
-  ruby_workers_cron_enabled: 'false'
   ruby_workers_idv_enabled: false
   s3_report_bucket_prefix: login-gov.reports
   s3_report_public_bucket_prefix: login-gov-pubdata

--- a/config/database.yml
+++ b/config/database.yml
@@ -51,8 +51,23 @@ test:
     migrations_paths: db/worker_jobs_migrate
 
 <%
-  pool = if Identity::Hostdata.instance_role == 'worker'
-    IdentityConfig.store.good_job_max_threads + IdentityConfig.store.database_pool_idp + IdentityConfig.store.database_pool_extra_connections_for_worker
+  worker_pool = if Identity::Hostdata.instance_role == 'worker'
+    GoodJobConnectionPoolSize.calculate_worker_pool_size(
+      queues: IdentityConfig.store.good_job_queues,
+      cron_enabled: true,
+      max_threads: IdentityConfig.store.good_job_max_threads,
+    )
+  else
+    IdentityConfig.store.database_pool_idp
+  end
+%>
+
+<%
+  primary_pool = if Identity::Hostdata.instance_role == 'worker'
+    GoodJobConnectionPoolSize.calculate_primary_pool_size(
+      queues: IdentityConfig.store.good_job_queues,
+      max_threads: IdentityConfig.store.good_job_max_threads,
+    )
   else
     IdentityConfig.store.database_pool_idp
   end
@@ -65,7 +80,7 @@ production:
     username: <%= IdentityConfig.store.database_username %>
     host: <%= IdentityConfig.store.database_host %>
     password: <%= IdentityConfig.store.database_password %>
-    pool: <%= pool %>
+    pool: <%= primary_pool %>
     sslmode: 'verify-full'
     sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'
     migrations_paths: db/primary_migrate
@@ -75,7 +90,7 @@ production:
     username: <%= IdentityConfig.store.database_readonly_username %>
     host: <%= IdentityConfig.store.database_read_replica_host %>
     password: <%= IdentityConfig.store.database_readonly_password %>
-    pool: <%= pool %>
+    pool: <%= primary_pool %>
     sslmode: 'verify-full'
     sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'
     replica: true
@@ -85,7 +100,7 @@ production:
     username: <%= IdentityConfig.store.database_worker_jobs_username %>
     host: <%= IdentityConfig.store.database_worker_jobs_host %>
     password: <%= IdentityConfig.store.database_worker_jobs_password %>
-    pool: <%= pool %>
+    pool: <%= worker_pool %>
     sslmode: 'verify-full'
     sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'
     migrations_paths: db/worker_jobs_migrate

--- a/lib/good_job_connection_pool_size.rb
+++ b/lib/good_job_connection_pool_size.rb
@@ -1,20 +1,14 @@
+# This class provides a starting point to dynamically calculate the number of database connections
+# needed for our multi-threaded GoodJob deployment. Each process will create
+# a certain number of threads based on configuration in the environment.
+# The calculations here are guided by https://github.com/bensheldon/good_job/blob/8e7ac0cd47c0382544d99a6e2d7ee2a3053b2490/README.md#database-connections
 class GoodJobConnectionPoolSize
+  # Calculates the number of worker database connections the worker process needs.
   def self.calculate_worker_pool_size(queues:, cron_enabled:, max_threads:)
     queues = queues.split(';')
     # LISTEN/NOTIFY requires 1 connection
     connections = 1
-    threads = queues.map do |queue|
-      if queue != '*'
-        _name, size = queue.split(':')
-        Integer(size)
-      else
-        0
-      end
-    end.sum
-
-    threads += max_threads if queues.include?('*')
-
-    connections += threads
+    connections += num_explicit_threads_from_queues(queues: queues, max_threads: max_threads)
 
     # Cron requires two connections
     connections += 2 if cron_enabled
@@ -22,7 +16,20 @@ class GoodJobConnectionPoolSize
     connections
   end
 
+  # Calculates the number of primary database connections the worker process needs.
+  #
+  # Each worker thread may need a primary database connection. We may not strictly need
+  # one connection for each, but we will start there for safety.
   def self.calculate_primary_pool_size(queues:, max_threads:)
+    num_explicit_threads_from_queues(queues: queues, max_threads: max_threads)
+  end
+
+  # The '*' queue will have up to `max_threads` threads. Other queues will use their explicitly
+  # defined thread pool size.
+  #
+  # Example: 'low:1;high:2;*' with 5 max_threads would have up to 8 total threads.
+  # Example: 'low:1;high:2' with 5 max_threads would have up to 3 total threads.
+  def self.num_explicit_threads_from_queues(queues:, max_threads:)
     queues = queues.split(';')
     threads = queues.map do |queue|
       if queue != '*'
@@ -34,9 +41,6 @@ class GoodJobConnectionPoolSize
     end.sum
 
     threads += max_threads if queues.include?('*')
-
-    connections += threads
-
-    connections
+    threads
   end
 end

--- a/lib/good_job_connection_pool_size.rb
+++ b/lib/good_job_connection_pool_size.rb
@@ -1,0 +1,42 @@
+class GoodJobConnectionPoolSize
+  def self.calculate_worker_pool_size(queues:, cron_enabled:, max_threads:)
+    queues = queues.split(';')
+    # LISTEN/NOTIFY requires 1 connection
+    connections = 1
+    threads = queues.map do |queue|
+      if queue != '*'
+        _name, size = queue.split(':')
+        Integer(size)
+      else
+        0
+      end
+    end.sum
+
+    threads += max_threads if queues.include?('*')
+
+    connections += threads
+
+    # Cron requires two connections
+    connections += 2 if cron_enabled
+
+    connections
+  end
+
+  def self.calculate_primary_pool_size(queues:, max_threads:)
+    queues = queues.split(';')
+    threads = queues.map do |queue|
+      if queue != '*'
+        _name, size = queue.split(':')
+        Integer(size)
+      else
+        0
+      end
+    end.sum
+
+    threads += max_threads if queues.include?('*')
+
+    connections += threads
+
+    connections
+  end
+end

--- a/spec/lib/good_job_connection_pool_size_spec.rb
+++ b/spec/lib/good_job_connection_pool_size_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe GoodJobConnectionPoolSize do
+  describe '.num_explicit_threads_from_queues' do
+    it 'uses max_threads for the * queue' do
+      queues = 'low:1;*'
+      connections = GoodJobConnectionPoolSize.num_explicit_threads_from_queues(
+        queues: queues,
+        max_threads: IdentityConfig.store.good_job_max_threads,
+      )
+
+      expect(connections).to eq(IdentityConfig.store.good_job_max_threads + 1)
+    end
+
+    it 'sums individual queue sizes' do
+      queues = 'low:1;medium:2;high:3;'
+      connections = GoodJobConnectionPoolSize.num_explicit_threads_from_queues(
+        queues: queues,
+        max_threads: IdentityConfig.store.good_job_max_threads,
+      )
+
+      expect(connections).to eq(6)
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

This change includes dedicated proofing queues for 3 jobs: 

1. `:high_document_proofing` - `DocumentProofingJob`
2. `:high_resolution_proofing` - `ResolutionProofingJob`
3. `:high_address_proofing` - `AddressProofingJob`

It's a simple mitigation, but it makes a small improvement that should help ensure that some users can move through the linear proofing process even when the default queue is backed up. A dedicated queue for all proofing jobs was also considered, but that could still cause issues with earlier proofing steps eventually taking over the queue and preventing users in later steps from reaching the end. We may or may not use these queues by default.

As we've added more than a couple queues, calculating the number of database connections needed for workers has gotten more difficult. The implementation to dynamically calculate connection pool sizes in this PR is simple and conservative, but it provides a baseline implementation we can iterate with if we need to reduce the number of connections used.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
