### PR TITLE
Fully remove references to old ThreatMetrix config flags (LG-8512)

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -233,6 +233,7 @@ proof_address_max_attempts: 5
 proof_address_max_attempt_window_in_minutes: 360
 proof_ssn_max_attempts: 10
 proof_ssn_max_attempt_window_in_minutes: 60
+proofing_device_profiling: disabled
 push_notifications_enabled: false
 pwned_passwords_file_path: 'pwned_passwords/pwned_passwords.txt'
 rack_mini_profiler: false

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -122,14 +122,6 @@ class FeatureManagement
     case IdentityConfig.store.proofing_device_profiling
     when :enabled, :collect_only then true
     when :disabled then false
-    # BEGIN temporary transitional fallback
-    when nil
-      if IdentityConfig.store.proofing_device_profiling_collecting_enabled.nil?
-        false
-      else
-        IdentityConfig.store.proofing_device_profiling_collecting_enabled
-      end
-    # END temporary transitional fallback
     else
       raise 'Invalid value for proofing_device_profiling'
     end
@@ -141,14 +133,6 @@ class FeatureManagement
     case IdentityConfig.store.proofing_device_profiling
     when :enabled then true
     when :collect_only, :disabled then false
-    # BEGIN temporary transitional fallback
-    when nil
-      if IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify.nil?
-        false
-      else
-        IdentityConfig.store.lexisnexis_threatmetrix_required_to_verify
-      end
-    # END temporary transitional fallback
     else
       raise 'Invalid value for proofing_device_profiling'
     end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -251,11 +251,9 @@ class IdentityConfig
     config.add(:lexisnexis_trueid_timeout, type: :float)
     config.add(:lexisnexis_threatmetrix_api_key, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_base_url, type: :string, allow_nil: true)
-    config.add(:lexisnexis_threatmetrix_enabled, type: :boolean, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string,  allow_nil: true)
     config.add(:lexisnexis_threatmetrix_policy, type: :string,  allow_nil: true)
-    config.add(:lexisnexis_threatmetrix_required_to_verify, type: :boolean, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_support_code, type: :string)
     config.add(:lexisnexis_threatmetrix_timeout, type: :float)
     config.add(:lexisnexis_threatmetrix_js_signing_cert, type: :string)
@@ -328,9 +326,7 @@ class IdentityConfig
       :proofing_device_profiling,
       type: :symbol,
       enum: [:disabled, :collect_only, :enabled],
-      allow_nil: true,
     )
-    config.add(:proofing_device_profiling_collecting_enabled, type: :boolean, allow_nil: true)
     config.add(:proof_address_max_attempts, type: :integer)
     config.add(:proof_address_max_attempt_window_in_minutes, type: :integer)
     config.add(:proof_ssn_max_attempts, type: :integer)

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -380,18 +380,10 @@ describe 'FeatureManagement' do
       expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:enabled)
       expect(FeatureManagement.proofing_device_profiling_collecting_enabled?).to eq(true)
     end
-    it 'falls back to legacy config if needed' do
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(nil)
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-        twice.
-        and_return(true)
-      expect(FeatureManagement.proofing_device_profiling_collecting_enabled?).to eq(true)
-    end
-    it 'defaults to false' do
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(nil)
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling_collecting_enabled).
-        and_return(nil)
-      expect(FeatureManagement.proofing_device_profiling_collecting_enabled?).to eq(false)
+    it 'raises for invalid value' do
+      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:emnabled)
+      expect { FeatureManagement.proofing_device_profiling_collecting_enabled? }.
+        to raise_error
     end
   end
 
@@ -408,18 +400,10 @@ describe 'FeatureManagement' do
       expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:enabled)
       expect(FeatureManagement.proofing_device_profiling_decisioning_enabled?).to eq(true)
     end
-    it 'falls back to legacy config' do
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(nil)
-      expect(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
-        twice.
-        and_return(true)
-      expect(FeatureManagement.proofing_device_profiling_decisioning_enabled?).to eq(true)
-    end
-    it 'defaults to false' do
-      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(nil)
-      expect(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_required_to_verify).
-        and_return(nil)
-      expect(FeatureManagement.proofing_device_profiling_decisioning_enabled?).to eq(false)
+    it 'raises for invalid value' do
+      expect(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:dissabled)
+      expect { FeatureManagement.proofing_device_profiling_decisioning_enabled? }.
+        to raise_error
     end
   end
 end


### PR DESCRIPTION
This is a follow-on to #7582. Do not merge until environments have been appropriately configured.

## How to configure an environment:

Remove the following configuration keys:

- `lexisnexis_threatmetrix_enabled`
- `lexisnexis_threatmetrix_required_to_verify`
- `proofing_device_profiling_collecting_enabled`
- `proofing_device_profiling_decisioning_enabled` (should not be present, but just in case)

Add a new configuration key, `proofing_device_profiling`, set to one of `disabled`, `collect_only`, or `enabled`.
