### PR TITLE
Retire mailcatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development do
   gem 'derailed_benchmarks', '~> 1.8'
   gem 'guard-rspec', require: false
   gem 'irb'
+  gem 'letter_opener', '~> 1.7'
   gem 'octokit', '>= 4.25.0'
   gem 'rack-mini-profiler', '>= 1.1.3', require: false
   gem 'rails-erd', '>= 1.6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :development do
   gem 'derailed_benchmarks', '~> 1.8'
   gem 'guard-rspec', require: false
   gem 'irb'
-  gem 'letter_opener', '~> 1.7'
+  gem 'letter_opener', '~> 1.8'
   gem 'octokit', '>= 4.25.0'
   gem 'rack-mini-profiler', '>= 1.1.3', require: false
   gem 'rails-erd', '>= 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,8 @@ GEM
       rake
     launchy (2.5.0)
       addressable (~> 2.7)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -757,6 +759,7 @@ DEPENDENCIES
   jwe
   jwt
   knapsack
+  letter_opener (~> 1.7)
   lograge (>= 0.11.2)
   lookbook (~> 1.4.5)
   lru_redux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -759,7 +759,7 @@ DEPENDENCIES
   jwe
   jwt
   knapsack
-  letter_opener (~> 1.7)
+  letter_opener (~> 1.8)
   lograge (>= 0.11.2)
   lookbook (~> 1.4.5)
   lru_redux

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,4 @@
 web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-${HOST:-localhost}}
 worker: bundle exec good_job start
-mailcatcher: mailcatcher -f $([ -n "$HTTPS" ] && echo "--http-ip=0.0.0.0")
 js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack $([ -n "$HTTPS" ] && echo "--watch" || echo "serve")
 css: yarn build:css --watch

--- a/README.md
+++ b/README.md
@@ -122,10 +122,25 @@ We recommend using [Homebrew](https://brew.sh/), [rbenv](https://github.com/rben
 
 #### Viewing email messages
 
-  In local development, the application does not deliver real email messages. Instead, we use a tool called [Mailcatcher](https://github.com/sj26/mailcatcher) to capture all messages.
+  In local development, the application does not deliver real email messages. Instead, we use a tool
+  called [letter_opener](https://github.com/ryanb/letter_opener) to display messages.
 
-  - To view email messages which would have been sent, visit http://localhost:1080/ while the application is running.
-  - To view email templates with placeholder values, visit http://localhost:3000/rails/mailers/ to see a list of template previews.
+##### Disabling letter opener new window behavior
+
+  Letter opener will open each outgoing email in a new browser window or tab. In cases where this
+  will be annoying the application also supports writing outgoing emails to a file. To write emails
+  to a file add the following config to the `development` group in `config/application.yml`:
+
+  ```
+  development:
+    development_mailer_deliver_method: file
+  ```
+
+  After restarting the app emails will be written to the `tmp/mails` folder.
+
+##### Email template previews
+
+  To view email templates with placeholder values, visit http://localhost:3000/rails/mailers/ to see a list of template previews.
 
 #### Translations
 

--- a/bin/setup
+++ b/bin/setup
@@ -55,8 +55,6 @@ Dir.chdir APP_ROOT do
   run 'gem install foreman --conservative && gem update foreman'
   run "bundle check || bundle install --without deploy production"
   run "yarn install"
-  run "gem install thin -v 1.5.1 -- --with-cflags=\"-Wno-error=implicit-function-declaration\""
-  run "gem install mailcatcher -- --with-cppflags=-I$(brew --prefix openssl@1.1)/include"
 
   puts "\n== Preparing database =="
   run 'bin/rake db:create'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -72,6 +72,7 @@ database_statement_timeout: 2_500
 database_timeout: 5_000
 deliver_mail_async: false
 deleted_user_accounts_report_configs: '[]'
+development_mailer_deliver_method: letter_opener
 disable_csp_unsafe_inline: true
 disable_email_sending: true
 disallow_all_web_crawlers: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,8 +25,8 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = IdentityConfig.store.mailer_domain_name
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
   config.action_mailer.show_previews = IdentityConfig.store.rails_mailer_previews_enabled
+  config.action_mailer.delivery_method = IdentityConfig.store.development_mailer_deliver_method
 
   routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.show_previews = IdentityConfig.store.rails_mailer_previews_enabled
   config.action_mailer.delivery_method = IdentityConfig.store.development_mailer_deliver_method
+  if IdentityConfig.store.development_mailer_deliver_method == :letter_opener
+    config.action_mailer.perform_deliveries = true
+  end
 
   routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -30,12 +30,9 @@ services:
       DOCKER_DB_USER: 'postgres'
       # '' == 1 thread for tests; performs better in a container
       TEST_ENV_NUMBER: ''
-      SMTP_HOST: 'mailcatcher'
     depends_on:
       - db
       - redis
-  #    - web
-      - mailcatcher
   web:
     image: nginx:alpine
     ports:
@@ -49,8 +46,3 @@ services:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
   redis:
     image: redis:5-alpine
-  mailcatcher:
-    image: rordi/docker-mailcatcher
-    container_name: mailcatcher
-    ports:
-      - 1080:1080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,10 @@ services:
       DOCKER_DB_USER: 'postgres'
       # '' == 1 thread for tests; performs better in a container
       TEST_ENV_NUMBER: ''
-      SMTP_HOST: 'mailcatcher'
       NODE_ENV: 'development'
     depends_on:
       - db
       - redis
-      - mailcatcher
     tty: true
     stdin_open: true
   db:
@@ -42,8 +40,3 @@ services:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
   redis:
     image: redis:5-alpine
-  mailcatcher:
-    image: rordi/docker-mailcatcher
-    container_name: mailcatcher
-    ports:
-      - 1080:1080

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -143,6 +143,7 @@ class IdentityConfig
     config.add(:database_worker_jobs_password, type: :string)
     config.add(:deleted_user_accounts_report_configs, type: :json)
     config.add(:deliver_mail_async, type: :boolean)
+    config.add(:development_mailer_deliver_method, type: :symbol, enum: [:file, :letter_opener])
     config.add(:disable_csp_unsafe_inline, type: :boolean)
     config.add(:disable_email_sending, type: :boolean)
     config.add(:disallow_all_web_crawlers, type: :boolean)


### PR DESCRIPTION
After we upgraded to Ruby 3.2 we lost support for mailcatcher. Mailcatcher depends on Fixnum was was previously deprecated and is now removed in Ruby 3.2

This commit removes mailcatcher and adds 2 new options for previewing emails:

1. Letter opener
2. File previews

This commit has letter opener as the default method with the ability to switch to the file method by changing configs in your local `application.yml`.
