### PR TITLE
Enhance automated accessibility tests to check idref validity

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,6 +26,7 @@
       html: { autocomplete: 'off' },
     ) do |f|
 %>
+  <input aria-describedby="not-exists" aria-label="example">
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :email,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,7 +26,6 @@
       html: { autocomplete: 'off' },
     ) do |f|
 %>
-  <input aria-describedby="not-exists" aria-label="example">
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :email,

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -10,10 +10,7 @@ feature 'Accessibility on IDV pages', :js do
 
       visit idv_path
 
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'cancel idv' do
@@ -22,10 +19,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_cancel_path
 
       expect(current_path).to eq idv_cancel_path
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'phone info' do
@@ -34,10 +28,7 @@ feature 'Accessibility on IDV pages', :js do
       complete_all_doc_auth_steps
 
       expect(current_path).to eq idv_phone_path
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'review page' do
@@ -46,10 +37,7 @@ feature 'Accessibility on IDV pages', :js do
       complete_all_doc_auth_steps_before_password_step
 
       expect(page).to have_current_path(idv_review_path)
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'personal key / confirmation page' do
@@ -60,10 +48,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_personal_key_path
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'doc auth steps accessibility' do
@@ -74,10 +59,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_personal_key_path
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'doc auth steps accessibility on mobile', driver: :headless_chrome_mobile do
@@ -88,10 +70,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_personal_key_path
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
   end
 end

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -11,6 +11,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_path
 
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -22,6 +23,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(current_path).to eq idv_cancel_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -33,6 +35,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(current_path).to eq idv_phone_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -44,6 +47,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(page).to have_current_path(idv_review_path)
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -57,6 +61,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -70,6 +75,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -83,6 +89,7 @@ feature 'Accessibility on IDV pages', :js do
 
       expect(current_path).to eq idv_personal_key_path
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end

--- a/spec/features/accessibility/static_pages_spec.rb
+++ b/spec/features/accessibility/static_pages_spec.rb
@@ -5,54 +5,36 @@ feature 'Accessibility on static pages', :js do
   scenario 'not found page', allow_browser_log: true do
     visit '/non_existent_page'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario '401 page' do
     visit '/401'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario '406 page' do
     visit '/406'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario '422 page' do
     visit '/422'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario '429 page' do
     visit '/429'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario '500 page' do
     visit '/500'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 end

--- a/spec/features/accessibility/static_pages_spec.rb
+++ b/spec/features/accessibility/static_pages_spec.rb
@@ -6,6 +6,7 @@ feature 'Accessibility on static pages', :js do
     visit '/non_existent_page'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -14,6 +15,7 @@ feature 'Accessibility on static pages', :js do
     visit '/401'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -22,6 +24,7 @@ feature 'Accessibility on static pages', :js do
     visit '/406'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -30,6 +33,7 @@ feature 'Accessibility on static pages', :js do
     visit '/422'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -38,6 +42,7 @@ feature 'Accessibility on static pages', :js do
     visit '/429'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -46,6 +51,7 @@ feature 'Accessibility on static pages', :js do
     visit '/500'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -7,10 +7,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_up_with(email)
 
     expect(current_path).to eq(sign_up_verify_email_path)
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   describe 'user confirmation page' do
@@ -62,10 +59,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'sms')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-        expect(page).to have_valid_idrefs
-        expect(page).to label_required_fields
-        expect(page).to be_uniquely_titled
+        expect_page_to_have_no_accessibility_violations(page)
       end
     end
 
@@ -76,10 +70,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'voice')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
-        expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-        expect(page).to have_valid_idrefs
-        expect(page).to label_required_fields
-        expect(page).to be_uniquely_titled
+        expect_page_to_have_no_accessibility_violations(page)
       end
     end
   end
@@ -88,10 +79,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_in_and_2fa_user
     visit manage_personal_key_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'profile page' do
@@ -99,10 +87,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'delete email page' do
@@ -111,10 +96,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_email_confirm_delete_path(id: user.email_addresses.take.id)
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'edit password page' do
@@ -122,10 +104,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_password_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'edit email language page' do
@@ -133,10 +112,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_email_language_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'add phone page' do
@@ -144,10 +120,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit add_phone_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'edit phone page' do
@@ -155,10 +128,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_phone_path(id: user.phone_configurations.first.id)
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'generate new personal key page' do
@@ -166,10 +136,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_personal_key_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'set up authenticator app page' do
@@ -177,10 +144,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit '/authenticator_setup'
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'device events page' do

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -19,20 +19,14 @@ feature 'Accessibility on pages that require authentication', :js do
       confirm_last_user
 
       expect(current_path).to eq(sign_up_enter_password_path)
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'invalid confirmation token' do
       visit sign_up_create_email_confirmation_path(confirmation_token: '123456')
 
       expect(current_path).to eq(sign_up_email_resend_path)
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
   end
 
@@ -41,10 +35,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_up_and_set_password
 
       expect(current_path).to eq(authentication_methods_setup_path)
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'phone setup page' do
@@ -53,10 +44,7 @@ feature 'Accessibility on pages that require authentication', :js do
       click_button t('forms.buttons.continue')
 
       expect(current_path).to eq(phone_setup_path)
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'two factor auth page' do
@@ -64,10 +52,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_in_before_2fa(user)
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))
-      expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-      expect(page).to have_valid_idrefs
-      expect(page).to label_required_fields
-      expect(page).to be_uniquely_titled
+      expect_page_to_have_no_accessibility_violations(page)
     end
 
     describe 'SMS' do
@@ -205,10 +190,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_events_path(id: device.id)
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'delete user page' do
@@ -216,9 +198,6 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_delete_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -8,6 +8,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     expect(current_path).to eq(sign_up_verify_email_path)
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -19,6 +20,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
       expect(current_path).to eq(sign_up_enter_password_path)
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -28,6 +30,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
       expect(current_path).to eq(sign_up_email_resend_path)
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -39,6 +42,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
       expect(current_path).to eq(authentication_methods_setup_path)
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -50,6 +54,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
       expect(current_path).to eq(phone_setup_path)
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -60,6 +65,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))
       expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+      expect(page).to have_valid_idrefs
       expect(page).to label_required_fields
       expect(page).to be_uniquely_titled
     end
@@ -72,6 +78,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
         expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+        expect(page).to have_valid_idrefs
         expect(page).to label_required_fields
         expect(page).to be_uniquely_titled
       end
@@ -85,6 +92,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
         expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+        expect(page).to have_valid_idrefs
         expect(page).to label_required_fields
         expect(page).to be_uniquely_titled
       end
@@ -96,6 +104,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit manage_personal_key_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -106,6 +115,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit account_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -117,6 +127,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit manage_email_confirm_delete_path(id: user.email_addresses.take.id)
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -127,6 +138,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit manage_password_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -137,6 +149,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit account_email_language_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -147,6 +160,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit add_phone_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -157,6 +171,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit manage_phone_path(id: user.phone_configurations.first.id)
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -167,6 +182,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit manage_personal_key_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -177,6 +193,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit '/authenticator_setup'
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -189,6 +206,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit account_events_path(id: device.id)
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -199,6 +217,7 @@ feature 'Accessibility on pages that require authentication', :js do
     visit account_delete_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -5,45 +5,30 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'login / root path' do
     visit root_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'forgot password page' do
     visit new_user_password_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'new user start registration page' do
     visit new_user_session_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'new user registration page' do
     visit sign_up_email_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 
   scenario 'new user cancel registration page' do
     visit sign_up_cancel_path
 
-    expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-    expect(page).to have_valid_idrefs
-    expect(page).to label_required_fields
-    expect(page).to be_uniquely_titled
+    expect_page_to_have_no_accessibility_violations(page)
   end
 end

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -6,6 +6,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     visit root_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -14,6 +15,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     visit new_user_password_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -22,6 +24,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     visit new_user_session_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -30,6 +33,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     visit sign_up_email_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end
@@ -38,6 +42,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     visit sign_up_cancel_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+    expect(page).to have_valid_idrefs
     expect(page).to label_required_fields
     expect(page).to be_uniquely_titled
   end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -1,3 +1,27 @@
+RSpec::Matchers.define :have_valid_idrefs do
+  invalid_idref_messages = []
+
+  match do |page|
+    ['aria-describedby', 'aria-labelledby'].each do |idref_attribute|
+      page.all(:css, "[#{idref_attribute}]").each do |element|
+        page.find_by_id(element[idref_attribute]) # rubocop:disable Rails/DynamicFindBy
+      rescue Capybara::ElementNotFound
+        invalid_idref_messages << "[#{idref_attribute}=\"#{element[idref_attribute]}\"]"
+      end
+    end
+
+    invalid_idref_messages.blank?
+  end
+
+  failure_message do |page|
+    <<-STR.strip_heredoc
+      Found #{invalid_idref_messages.count} elements with invalid ID reference links:
+
+      #{invalid_idref_messages.join("\n")}
+    STR
+  end
+end
+
 RSpec::Matchers.define :label_required_fields do
   elements = []
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_valid_idrefs do
   end
 
   failure_message do |page|
-    <<-STR.strip_heredoc
+    <<~STR
       Found #{invalid_idref_messages.count} elements with invalid ID reference links:
 
       #{invalid_idref_messages.join("\n")}

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -81,3 +81,10 @@ RSpec::Matchers.define :be_uniquely_titled do
     "Page '#{page.current_path}' should have a unique and descriptive title. Found '#{page.title}'."
   end
 end
+
+def expect_page_to_have_no_accessibility_violations(page)
+  expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+  expect(page).to have_valid_idrefs
+  expect(page).to label_required_fields
+  expect(page).to be_uniquely_titled
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates accessibility feature specs to check for valid ID references for `aria-describedby` and `aria-labelledby`.

Related:

- https://gsa-tts.slack.com/archives/C01C89LM6UF/p1673541645409329
- #7640
- #7484

## 📜 Testing Plan

1. Intentionally introduce errors to page HTML (e.g. `git cherry-pick 84ce1c5`)
2. `rspec ./spec/features/accessibility/visitor_pages_spec.rb:5`
3. Observe failures

Example:

```
  1) Accessibility on pages that do not require authentication login / root path
     Failure/Error: expect(page).to have_valid_idrefs
     
       Found 1 elements with invalid ID reference links:
     
       [aria-describedby="not-exists"]
```