### PR TITLE
Avoid extraneous read for SpMetadataInSession after saving

### DIFF
--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -10,9 +10,12 @@ class ServiceProviderRequestHandler
     pull_request_id_from_current_sp_session_id
 
     delete_sp_request_if_session_has_matching_request_id
-    ServiceProviderRequestProxy.create!(attributes)
 
-    StoreSpMetadataInSession.new(session: session, request_id: request_id).call
+    service_provider_request = ServiceProviderRequestProxy.create!(attributes)
+
+    StoreSpMetadataInSession.new(session: session, request_id: request_id).call(
+      service_provider_request: service_provider_request,
+    )
   end
 
   private

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -4,8 +4,8 @@ class StoreSpMetadataInSession
     @request_id = request_id
   end
 
-  def call
-    Rails.logger.info(event_attributes)
+  def call(service_provider_request: nil)
+    @sp_request = service_provider_request if service_provider_request
 
     return if sp_request.is_a?(NullServiceProviderRequest)
 

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -4,24 +4,15 @@ describe StoreSpMetadataInSession do
   describe '#call' do
     context 'when a ServiceProviderRequestProxy is not found' do
       it 'does not set the session[:sp] hash' do
-        allow(Rails.logger).to receive(:info)
         app_session = {}
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: 'foo')
-        info_hash = {
-          event: 'StoreSpMetadataInSession',
-          request_id_present: true,
-          sp_request_class: 'NullServiceProviderRequest',
-        }.to_json
 
         expect { instance.call }.to_not change(app_session, :keys)
-        expect(Rails.logger).to have_received(:info).with(info_hash)
       end
     end
 
     context 'when a ServiceProviderRequestProxy is found' do
       it 'sets the session[:sp] hash' do
-        allow(Rails.logger).to receive(:info)
-
         app_session = {}
         request_id = SecureRandom.uuid
         ServiceProviderRequestProxy.find_or_create_by(uuid: request_id) do |sp_request|
@@ -31,12 +22,6 @@ describe StoreSpMetadataInSession do
           sp_request.requested_attributes = %w[email]
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
-
-        info_hash = {
-          event: 'StoreSpMetadataInSession',
-          request_id_present: true,
-          sp_request_class: 'ServiceProviderRequest',
-        }.to_json
 
         app_session_hash = {
           issuer: 'issuer',
@@ -52,15 +37,12 @@ describe StoreSpMetadataInSession do
         }
 
         instance.call
-        expect(Rails.logger).to have_received(:info).with(info_hash)
         expect(app_session[:sp]).to eq app_session_hash
       end
     end
 
     context 'when IAL2 and AAL3 are requested' do
       it 'sets the session[:sp] hash' do
-        allow(Rails.logger).to receive(:info)
-
         app_session = {}
         request_id = SecureRandom.uuid
         ServiceProviderRequestProxy.find_or_create_by(uuid: request_id) do |sp_request|
@@ -71,12 +53,6 @@ describe StoreSpMetadataInSession do
           sp_request.requested_attributes = %w[email]
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
-
-        info_hash = {
-          event: 'StoreSpMetadataInSession',
-          request_id_present: true,
-          sp_request_class: 'ServiceProviderRequest',
-        }.to_json
 
         app_session_hash = {
           issuer: 'issuer',
@@ -92,15 +68,12 @@ describe StoreSpMetadataInSession do
         }
 
         instance.call
-        expect(Rails.logger).to have_received(:info).with(info_hash)
         expect(app_session[:sp]).to eq app_session_hash
       end
     end
 
     context 'when IAL2 and phishing-resistant are requested' do
       it 'sets the session[:sp] hash' do
-        allow(Rails.logger).to receive(:info)
-
         app_session = {}
         request_id = SecureRandom.uuid
         ServiceProviderRequestProxy.find_or_create_by(uuid: request_id) do |sp_request|
@@ -111,12 +84,6 @@ describe StoreSpMetadataInSession do
           sp_request.requested_attributes = %w[email]
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
-
-        info_hash = {
-          event: 'StoreSpMetadataInSession',
-          request_id_present: true,
-          sp_request_class: 'ServiceProviderRequest',
-        }.to_json
 
         app_session_hash = {
           issuer: 'issuer',
@@ -132,7 +99,6 @@ describe StoreSpMetadataInSession do
         }
 
         instance.call
-        expect(Rails.logger).to have_received(:info).with(info_hash)
         expect(app_session[:sp]).to eq app_session_hash
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

`StoreSpMetadataInSession#call` reads the value written to Redis in `ServiceProviderRequestProxy.create!(attributes)` to put the information in the session.

I couldn't find anything that suggested this pattern was necessary since the value returned is the value that was written. To avoid the extra read, this change adds an option to pass the value directly rather than read it from Redis.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
