### PR TITLE
Reduce flakiness of in-person proofing spec

### DIFF
--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -188,7 +188,9 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
 
     it 'returns number of minutes since enrollment was established' do
-      expect(enrollment.minutes_since_established).to be_within(0.01).of(120)
+      freeze_time do
+        expect(enrollment.minutes_since_established).to eq 120
+      end
     end
 
     it 'returns nil if enrollment has not been established' do


### PR DESCRIPTION
## 🛠 Summary of changes

Sometimes this test [fails](https://gitlab.login.gov/lg/identity-idp/-/jobs/283316) due to time drift, so this patch freezes time to prevent it reliably.

```
  1) InPersonEnrollment minutes_since_established returns number of minutes since enrollment was established
     Failure/Error: expect(enrollment.minutes_since_established).to be_within(0.01).of(120)
       expected 120.03 to be within 0.01 of 120
     # ./spec/models/in_person_enrollment_spec.rb:191:in `block (3 levels) in <top (required)>'
```
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
