### PR TITLE
LG-8573 Start logging document classification information for Acuant

### DIFF
--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -63,6 +63,7 @@ module DocAuth
             log_alert_results: log_alert_formatter.log_alerts(alerts),
             image_metrics: processed_image_metrics,
             tamper_result: tamper_result_code&.name,
+            classification_info: classification_info,
           }
         end
 
@@ -100,6 +101,24 @@ module DocAuth
           @processed_image_metrics ||= raw_images_data.index_by do |image|
             image.delete('Uri')
             get_image_side_name(image['Side'])
+          end
+        end
+
+        def classification_info
+          classification_details = parsed_response_body.dig(
+            'Classification', 'ClassificationDetails'
+          )
+          return unless classification_details.present?
+
+          classification_details.transform_values do |classification_detail|
+            classification_detail.slice(
+              'ClassName',
+              'Issue',
+              'IssueType',
+              'Name',
+              'IssuerCode',
+              'IssuerName',
+            )
           end
         end
 

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         image_metrics: a_hash_including(:back, :front),
         alert_failure_count: 2,
         tamper_result: 'Passed',
+        classification_info: {
+          'Back' => {
+            'ClassName' => 'Identification Card',
+            'Issue' => '2014',
+            'IssueType' => 'Back',
+            'Name' => 'North Dakota (ND) Back',
+            'IssuerCode' => 'ND',
+            'IssuerName' => 'North Dakota',
+          },
+          'Front' => {
+            'ClassName' => 'Identification Card',
+            'Issue' => '2014',
+            'IssueType' => 'Non-Driver Identification Card',
+            'Name' => 'North Dakota (ND) Non-Driver Identification Card',
+            'IssuerCode' => 'ND',
+            'IssuerName' => 'North Dakota',
+          },
+        },
       }
 
       processed_alerts = response_hash[:processed_alerts]


### PR DESCRIPTION
In the past we did not log classification information because it reveals information about the applicant's state. We have started logging the state that issued the document elsewhere to provide better debugging. Since the information is already logged we can also start logging this classification info. This will tell us specifically which template the vendor is comparing against. This will allow us to measure the performance of individual templates.