### PR TITLE
Lg 8234 load test get facility

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -228,7 +228,7 @@ namespace :dev do
     
     (0...ENV['NUM_USERS'].to_i).each do
       body = {
-        sponsorID: 4,
+        sponsorID: ENV['SPONSOR_ID'],
         streetAddress: '2 Massachusetts ave NE',
         city: 'Washington',
         state: 'DC',


### PR DESCRIPTION
Add a scalable load test for getting the USPS facilities and log to metrics.
Provide the following environment variables in the rake command:
BASE_URL - the environment url
NUM_USERS - the number of calls to be made
SPONSOR_ID - the requisite sponsor id.

Additionally, ensure usps_ipp_* values are set in application.yml
