### PR TITLE
LG-6543 Adding doc auth rate triggered analytics call for acuant

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -36,6 +36,8 @@ module Idv
 
     def throttled
       @expires_at = Throttle.new(user: effective_user, throttle_type: :idv_doc_auth).expires_at
+      analytics.throttler_rate_limit_triggered(throttle_type: :idv_doc_auth)
+      irs_attempts_api_tracker.idv_document_upload_rate_limited
     end
 
     private

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -60,7 +60,9 @@ feature 'doc auth document capture step', :js do
         attach_and_submit_images
         click_on t('idv.failure.button.warning')
       end
+    end
 
+    it 'redirects to the throttled error page' do
       freeze_time do
         attach_and_submit_images
         timeout = distance_of_time_in_words(
@@ -68,14 +70,12 @@ feature 'doc auth document capture step', :js do
         )
         message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
         expect(page).to have_content(message)
+        expect(page).to have_current_path(idv_session_errors_throttled_path)
       end
     end
 
-    it 'redirects to the throttled error page' do
-      expect(page).to have_current_path(idv_session_errors_throttled_path)
-    end
-
     it 'logs the throttled analytics event for doc_auth' do
+      attach_and_submit_images
       expect(fake_analytics).to have_logged_event(
         'Throttler Rate Limit Triggered',
         throttle_type: :idv_doc_auth,
@@ -83,6 +83,7 @@ feature 'doc auth document capture step', :js do
     end
 
     it 'logs irs attempts event for rate limiting' do
+      attach_and_submit_images
       expect(fake_attempts_tracker).to have_received(:idv_document_upload_rate_limited)
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -44,7 +44,9 @@ feature 'doc auth document capture step', :js do
     let(:message) { '' }
     let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
     before do
-      allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).and_return(fake_attempts_tracker)
+      allow_any_instance_of(ApplicationController).to receive(
+        :irs_attempts_api_tracker,
+      ).and_return(fake_attempts_tracker)
       allow(fake_attempts_tracker).to receive(:idv_document_upload_rate_limited)
       allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
       DocAuth::Mock::DocAuthMockClient.mock_response!(
@@ -66,9 +68,12 @@ feature 'doc auth document capture step', :js do
         timeout = distance_of_time_in_words(
           Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
         )
+        # rubocop:disable Lint/UselessAssignment
         message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
+        # rubocop:enable Lint/UselessAssignment
       end
     end
+
     it 'redirects to the throttled error page' do
       expect(page).to have_current_path(idv_session_errors_throttled_path)
       expect(page).to have_content(message)

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -41,7 +41,6 @@ feature 'doc auth document capture step', :js do
   end
 
   context 'throttles calls to acuant', allow_browser_log: true do
-    let(:message) { '' }
     let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
     before do
       allow_any_instance_of(ApplicationController).to receive(
@@ -67,15 +66,13 @@ feature 'doc auth document capture step', :js do
         timeout = distance_of_time_in_words(
           Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
         )
-        # rubocop:disable Lint/UselessAssignment
         message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
-        # rubocop:enable Lint/UselessAssignment
+        expect(page).to have_content(message)
       end
     end
 
     it 'redirects to the throttled error page' do
       expect(page).to have_current_path(idv_session_errors_throttled_path)
-      expect(page).to have_content(message)
     end
 
     it 'logs the throttled analytics event for doc_auth' do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -9,7 +9,6 @@ feature 'doc auth document capture step', :js do
   let(:user) { user_with_2fa }
   let(:doc_auth_enable_presigned_s3_urls) { false }
   let(:fake_analytics) { FakeAnalytics.new }
-  let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
   let(:sp_name) { 'Test SP' }
   before do
     allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).
@@ -41,36 +40,50 @@ feature 'doc auth document capture step', :js do
     end
   end
 
-  it 'throttles calls to acuant', allow_browser_log: true do
-    allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
-    DocAuth::Mock::DocAuthMockClient.mock_response!(
-      method: :post_front_image,
-      response: DocAuth::Response.new(
-        success: false,
-        errors: { network: I18n.t('doc_auth.errors.general.network_error') },
-      ),
-    )
-
-    allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
-    (max_attempts - 1).times do
-      attach_and_submit_images
-      click_on t('idv.failure.button.warning')
-    end
-
-    freeze_time do
-      attach_and_submit_images
-      timeout = distance_of_time_in_words(
-        Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
+  context 'throttles calls to acuant', allow_browser_log: true do
+    let(:message) { '' }
+    let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).and_return(fake_attempts_tracker)
+      allow(fake_attempts_tracker).to receive(:idv_document_upload_rate_limited)
+      allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
+      DocAuth::Mock::DocAuthMockClient.mock_response!(
+        method: :post_front_image,
+        response: DocAuth::Response.new(
+          success: false,
+          errors: { network: I18n.t('doc_auth.errors.general.network_error') },
+        ),
       )
-      message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
+
+      allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
+      (max_attempts - 1).times do
+        attach_and_submit_images
+        click_on t('idv.failure.button.warning')
+      end
+
+      freeze_time do
+        attach_and_submit_images
+        timeout = distance_of_time_in_words(
+          Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
+        )
+        message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
+      end
+    end
+    it 'redirects to the throttled error page' do
+      expect(page).to have_current_path(idv_session_errors_throttled_path)
       expect(page).to have_content(message)
     end
 
-    expect(page).to have_current_path(idv_session_errors_throttled_path)
-    expect(fake_analytics).to have_logged_event(
-      'Throttler Rate Limit Triggered',
-      throttle_type: :idv_doc_auth,
-    )
+    it 'logs the throttled analytics event for doc_auth' do
+      expect(fake_analytics).to have_logged_event(
+        'Throttler Rate Limit Triggered',
+        throttle_type: :idv_doc_auth,
+      )
+    end
+
+    it 'logs irs attempts event for rate limiting' do
+      expect(fake_attempts_tracker).to have_received(:idv_document_upload_rate_limited)
+    end
   end
 
   it 'catches network connection errors on post_front_image', allow_browser_log: true do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -67,12 +67,10 @@ feature 'doc auth document capture step', :js do
     end
 
     expect(page).to have_current_path(idv_session_errors_throttled_path)
-    # Bug: Rate limit event is not always logged (LG-6543)
-    # expect(fake_analytics).to have_logged_event(
-    #   'Throttler Rate Limit Triggered',
-    #   throttle_type: :idv_doc_auth,
-    # )
-    # expect(fake_attempts_tracker).to receive(:idv_document_upload_rate_limited)
+    expect(fake_analytics).to have_logged_event(
+      'Throttler Rate Limit Triggered',
+      throttle_type: :idv_doc_auth,
+    )
   end
 
   it 'catches network connection errors on post_front_image', allow_browser_log: true do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -57,7 +57,6 @@ feature 'doc auth document capture step', :js do
         ),
       )
 
-      allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
       (max_attempts - 1).times do
         attach_and_submit_images
         click_on t('idv.failure.button.warning')


### PR DESCRIPTION
## 🎫 Ticket

[LG-6543](https://cm-jira.usa.gov/browse/LG-6543)

## 🛠 Summary of changes

Throttle limit being reached for doc auth was not being logged in analytics. This PR rectifies that issue.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] 1. Complete proofing flow up to document capture
- [ ] 2. Fail document capture 5 times (use [error payload](https://developers.login.gov/testing/#testing-identity-proofing) for back image)
- [ ] 3. Check logs for `Throttler Rate Limit Triggered` for `:doc_auth`
