### PR TITLE
LG-7400 Add update functionality to VerifyInfoController outside Flow State Machine

### DIFF
--- a/app/controllers/concerns/string_redacter.rb
+++ b/app/controllers/concerns/string_redacter.rb
@@ -1,0 +1,7 @@
+module StringRedacter
+  extend ActiveSupport::Concern
+
+  def redact_alphanumeric(text)
+    text.gsub(/[a-z]/i, 'X').gsub(/\d/i, '#')
+  end
+end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   class ReviewController < ApplicationController
     before_action :personal_key_confirmed
+    before_action :confirm_verify_info_complete
 
     include IdvStepConcern
     include StepIndicatorConcern
@@ -122,6 +123,16 @@ module Idv
 
     def password
       params.fetch(:user, {})[:password].presence
+    end
+
+    def confirm_verify_info_complete
+      # rubocop:disable Style/IfUnlessModifier
+      if IdentityConfig.store.doc_auth_verify_info_controller_enabled
+        if !idv_session.resolution_successful
+          redirect_to idv_verify_info_url
+        end
+      end
+      # rubocop:enable Style/IfUnlessModifier
     end
 
     def personal_key_confirmed

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -126,13 +126,10 @@ module Idv
     end
 
     def confirm_verify_info_complete
-      # rubocop:disable Style/IfUnlessModifier
-      if IdentityConfig.store.doc_auth_verify_info_controller_enabled
-        if !idv_session.resolution_successful
-          redirect_to idv_verify_info_url
-        end
+      if IdentityConfig.store.doc_auth_verify_info_controller_enabled &&
+         !idv_session.resolution_successful
+        redirect_to idv_verify_info_url
       end
-      # rubocop:enable Style/IfUnlessModifier
     end
 
     def personal_key_confirmed

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -9,17 +9,16 @@ module Idv
     def show
       increment_step_counts
       analytics.idv_doc_auth_verify_visited(**analytics_arguments)
+
+      redirect_to failure_url(:fail) and return if throttle.throttled?
+
+      process_async_state(load_async_state)
     end
 
     def update
-      return if idv_session.idv_verify_info_step_document_capture_session_uuid
+      return if idv_session.verify_info_step_document_capture_session_uuid
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
-
-      throttle = Throttle.new(
-        target: Pii::Fingerprinter.fingerprint(pii[:ssn]),
-        throttle_type: :proof_ssn,
-      )
 
       if throttle.throttled_else_increment?
         analytics.throttler_rate_limit_triggered(
@@ -36,7 +35,9 @@ module Idv
       )
       document_capture_session.requested_at = Time.zone.now
 
-      idv_session.idv_verify_info_step_document_capture_session_uuid = document_capture_session.uuid
+      idv_session.verify_info_step_document_capture_session_uuid = document_capture_session.uuid
+      idv_session.vendor_phone_confirmation = false
+      idv_session.user_phone_confirmation = false
 
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
@@ -100,6 +101,10 @@ module Idv
       @pii = flow_session[:pii_from_doc] if flow_session
     end
 
+    def delete_pii
+      flow_session.delete(:pii_from_user)
+    end
+
     # copied from address_controller
     def confirm_ssn_step_complete
       return if pii.present? && pii[:ssn].present?
@@ -133,5 +138,250 @@ module Idv
       banlist.include?(sp_session[:issuer])
     end
 
+    def throttle
+      @throttle ||= Throttle.new(
+        target: Pii::Fingerprinter.fingerprint(pii[:ssn]),
+        throttle_type: :proof_ssn,
+      )
+    end
+
+    def idv_failure(result)
+      throttle.increment! if result.extra.dig(:proofing_results, :exception).blank?
+      if throttle.throttled?
+        idv_failure_log_throttled
+        redirect_to throttled_url
+      elsif result.extra.dig(:proofing_results, :exception).present?
+        idv_failure_log_error
+        redirect_to exception_url
+      else
+        idv_failure_log_warning
+        redirect_to warning_url
+      end
+    end
+
+    def idv_failure_log_throttled
+      irs_attempts_api_tracker.idv_verification_rate_limited
+      analytics.throttler_rate_limit_triggered(
+        throttle_type: :idv_resolution,
+        step_name: self.class.name,
+      )
+    end
+
+    def idv_failure_log_error
+      analytics.idv_doc_auth_exception_visited(
+        step_name: self.class.name,
+        remaining_attempts: throttle.remaining_count,
+      )
+    end
+
+    def idv_failure_log_warning
+      analytics.idv_doc_auth_warning_visited(
+        step_name: self.class.name,
+        remaining_attempts: throttle.remaining_count,
+      )
+    end
+
+    def throttled_url
+      idv_session_errors_failure_url
+    end
+
+    def exception_url
+      idv_session_errors_exception_url
+    end
+
+    def warning_url
+      idv_session_errors_warning_url
+    end
+
+    # copied from verify_base_step. May want reconciliation with phone_step
+    def process_async_state(current_async_state)
+      if current_async_state.none?
+        idv_session.resolution_info_verified = false
+        render :show
+      elsif current_async_state.in_progress?
+        render :wait
+      elsif current_async_state.missing?
+        analytics.idv_proofing_resolution_result_missing
+        flash.now[:error] = I18n.t('idv.failure.timeout')
+        render :show
+
+        delete_async
+        idv_session.resolution_info_verified = false
+
+        log_idv_verification_submitted_event(
+          success: false,
+          failure_reason: { idv_verification: [:timeout] },
+        )
+      elsif current_async_state.done?
+        async_state_done(current_async_state)
+      end
+    end
+
+    def async_state_done(current_async_state)
+      add_proofing_costs(current_async_state.result)
+      form_response = idv_result_to_form_response(
+        result: current_async_state.result,
+        state: pii[:state],
+        state_id_jurisdiction: pii[:state_id_jurisdiction],
+        state_id_number: pii[:state_id_number],
+        # todo: add other edited fields?
+        extra: {
+          address_edited: !!flow_session['address_edited'],
+          pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name]],
+        },
+      )
+      log_idv_verification_submitted_event(
+        success: form_response.success?,
+        failure_reason: irs_attempts_api_tracker.parse_failure_reason(form_response),
+      )
+
+      if form_response.success?
+        response = check_ssn
+        form_response = form_response.merge(response)
+      end
+      summarize_result_and_throttle_failures(form_response)
+      delete_async
+
+      if form_response.success?
+        idv_session.resolution_info_verified = true
+        redirect_to idv_phone_url
+      else
+        idv_session.resolution_info_verified = false
+      end
+
+      analytics.idv_doc_auth_verify_proofing_results(**form_response.to_h)
+    end
+
+    def summarize_result_and_throttle_failures(summary_result)
+      if summary_result.success?
+        add_proofing_components
+        summary_result
+      else
+        idv_failure(summary_result)
+      end
+    end
+
+    def add_proofing_components
+      ProofingComponent.create_or_find_by(user: current_user).update(
+        resolution_check: Idp::Constants::Vendors::LEXIS_NEXIS,
+        source_check: Idp::Constants::Vendors::AAMVA,
+      )
+    end
+
+    def load_async_state
+      dcs_uuid = idv_session.verify_info_step_document_capture_session_uuid
+      dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
+      return ProofingSessionAsyncResult.none if dcs_uuid.nil?
+      return ProofingSessionAsyncResult.missing if dcs.nil?
+
+      proofing_job_result = dcs.load_proofing_result
+      return ProofingSessionAsyncResult.missing if proofing_job_result.nil?
+
+      proofing_job_result
+    end
+
+    def delete_async
+      idv_session.verify_info_step_document_capture_session_uuid = nil
+    end
+
+    def idv_result_to_form_response(
+      result:,
+      state: nil,
+      state_id_jurisdiction: nil,
+      state_id_number: nil,
+      extra: {}
+    )
+      state_id = result.dig(:context, :stages, :state_id)
+      if state_id
+        state_id[:state] = state if state
+        state_id[:state_id_jurisdiction] = state_id_jurisdiction if state_id_jurisdiction
+        state_id[:state_id_number] = redact(state_id_number) if state_id_number
+      end
+      FormResponse.new(
+        success: result[:success],
+        errors: result[:errors],
+        extra: extra.merge(proofing_results: result[:extra]),
+      )
+    end
+
+    def log_idv_verification_submitted_event(success: false, failure_reason: nil)
+      pii_from_doc = pii || {}
+      irs_attempts_api_tracker.idv_verification_submitted(
+        success: success,
+        document_state: pii_from_doc[:state],
+        document_number: pii_from_doc[:state_id_number],
+        document_issued: pii_from_doc[:state_id_issued],
+        document_expiration: pii_from_doc[:state_id_expiration],
+        first_name: pii_from_doc[:first_name],
+        last_name: pii_from_doc[:last_name],
+        date_of_birth: pii_from_doc[:dob],
+        address: pii_from_doc[:address1],
+        ssn: pii_from_doc[:ssn],
+        failure_reason: failure_reason,
+      )
+    end
+
+    def redact(text)
+      text.gsub(/[a-z]/i, 'X').gsub(/\d/i, '#')
+    end
+
+    def check_ssn
+      result = Idv::SsnForm.new(current_user).submit(ssn: pii[:ssn])
+
+      if result.success?
+        save_legacy_state
+        delete_pii
+      end
+
+      result
+    end
+
+    def save_legacy_state
+      skip_legacy_steps
+      idv_session.applicant = pii
+      idv_session.applicant['uuid'] = current_user.uuid
+    end
+
+    def skip_legacy_steps
+      idv_session.profile_confirmation = true
+      idv_session.vendor_phone_confirmation = false
+      idv_session.user_phone_confirmation = false
+      idv_session.address_verification_mechanism = 'phone'
+      idv_session.resolution_successful = 'phone'
+    end
+
+    def add_proofing_costs(results)
+      results[:context][:stages].each do |stage, hash|
+        if stage == :resolution
+          # transaction_id comes from ConversationId
+          add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+        elsif stage == :state_id
+          next if hash[:vendor_name] == 'UnsupportedJurisdiction'
+          process_aamva(hash[:transaction_id])
+        elsif stage == :threatmetrix
+          # transaction_id comes from request_id
+          tmx_id = hash[:transaction_id]
+          add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
+        end
+      end
+    end
+
+    def process_aamva(transaction_id)
+      # transaction_id comes from TransactionLocatorId
+      add_cost(:aamva, transaction_id: transaction_id)
+      track_aamva
+    end
+
+    def track_aamva
+      return unless IdentityConfig.store.state_tracking_enabled
+      doc_auth_log = DocAuthLog.find_by(user_id: current_user.id)
+      return unless doc_auth_log
+      doc_auth_log.aamva = true
+      doc_auth_log.save!
+    end
+
+    def add_cost(token, transaction_id: nil)
+      Db::SpCost::AddSpCost.call(current_sp, 2, token, transaction_id: transaction_id)
+    end
   end
 end

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -157,11 +157,15 @@ module Idv
     end
 
     def idv_failure(result)
-      resolution_throttle.increment! if result.extra.dig(:proofing_results,  :stages, :resolution, :exception).blank?
+      proofing_results_exception = result.extra.dig(
+        :proofing_results, :stages, :resolution,
+        :exception
+      )
+      resolution_throttle.increment! if proofing_results_exception.blank?
       if resolution_throttle.throttled?
         idv_failure_log_throttled
         redirect_to throttled_url
-      elsif result.extra.dig(:proofing_results,  :stages, :resolution, :exception).present?
+      elsif proofing_results_exception.present?
         idv_failure_log_error
         redirect_to exception_url
       else

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class VerifyInfoController < ApplicationController
+    include StringRedacter
     include IdvSession
 
     before_action :render_404_if_verify_info_controller_disabled
@@ -310,7 +311,7 @@ module Idv
       if state_id
         state_id[:state] = state if state
         state_id[:state_id_jurisdiction] = state_id_jurisdiction if state_id_jurisdiction
-        state_id[:state_id_number] = redact(state_id_number) if state_id_number
+        state_id[:state_id_number] = redact_alphanumeric(state_id_number) if state_id_number
       end
 
       FormResponse.new(
@@ -335,10 +336,6 @@ module Idv
         ssn: pii_from_doc[:ssn],
         failure_reason: failure_reason,
       )
-    end
-
-    def redact(text)
-      text.gsub(/[a-z]/i, 'X').gsub(/\d/i, '#')
     end
 
     def check_ssn

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -196,7 +196,7 @@ module Idv
     # copied from verify_base_step. May want reconciliation with phone_step
     def process_async_state(current_async_state)
       if current_async_state.none?
-        idv_session.resolution_info_verified = false
+        idv_session.resolution_successful = false
         render :show
       elsif current_async_state.in_progress?
         render :wait
@@ -206,7 +206,7 @@ module Idv
         render :show
 
         delete_async
-        idv_session.resolution_info_verified = false
+        idv_session.resolution_successful = false
 
         log_idv_verification_submitted_event(
           success: false,
@@ -243,10 +243,10 @@ module Idv
       delete_async
 
       if form_response.success?
-        idv_session.resolution_info_verified = true
+        idv_session.resolution_successful = true
         redirect_to idv_phone_url
       else
-        idv_session.resolution_info_verified = false
+        idv_session.resolution_successful = false
       end
 
       analytics.idv_doc_auth_verify_proofing_results(**form_response.to_h)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -930,6 +930,10 @@ module AnalyticsEvents
     track_event('IdV: doc auth verify visited', **extra)
   end
 
+  def idv_doc_auth_verify_proofing_results(**extra)
+    track_event('IdV: doc auth verify proofing results', **extra)
+  end
+
   # @identity.idp.previous_event_name IdV: in person proofing verify_wait visited
   def idv_doc_auth_verify_wait_step_visited(**extra)
     track_event('IdV: doc auth verify_wait visited', **extra)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -4,6 +4,7 @@ module Idv
       address_verification_mechanism
       applicant
       go_back_path
+      idv_verify_info_step_document_capture_session_uuid
       idv_phone_step_document_capture_session_uuid
       vendor_phone_confirmation
       user_phone_confirmation

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -5,7 +5,6 @@ module Idv
       applicant
       go_back_path
       verify_info_step_document_capture_session_uuid
-      resolution_info_verified
       idv_phone_step_document_capture_session_uuid
       vendor_phone_confirmation
       user_phone_confirmation

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -4,7 +4,8 @@ module Idv
       address_verification_mechanism
       applicant
       go_back_path
-      idv_verify_info_step_document_capture_session_uuid
+      verify_info_step_document_capture_session_uuid
+      resolution_info_verified
       idv_phone_step_document_capture_session_uuid
       vendor_phone_confirmation
       user_phone_confirmation

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -17,7 +17,6 @@ module Idv
         return invalid_state_response if invalid_state?
 
         flow_session[:pii_from_doc][:ssn] = ssn
-        add_verify_info_variables
 
         @flow.irs_attempts_api_tracker.idv_ssn_submitted(
           ssn: ssn,
@@ -29,10 +28,6 @@ module Idv
           exit_flow_state_machine
         end
         # rubocop:enable Style/IfUnlessModifier
-      end
-
-      def add_verify_info_variables
-        flow_session[:flow_path] = @flow.flow_path
       end
 
       def extra_view_variables
@@ -68,6 +63,7 @@ module Idv
       def exit_flow_state_machine
         mark_step_complete(:verify)
         mark_step_complete(:verify_wait)
+        flow_session[:flow_path] = @flow.flow_path
         redirect_to idv_verify_info_url
       end
     end

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -90,25 +90,15 @@ locals:
     </div>
   </div>
   <div class="margin-top-5">
-    <%= render SpinnerButtonComponent.new(
+    <%= render ButtonComponent.new(
           action: ->(**tag_options, &block) do
-            button_to(url_for, **tag_options, &block)
+            button_to(idv_verify_info_url, **tag_options, &block)
           end,
           big: true,
           wide: true,
-          action_message: t('idv.messages.verifying'),
           method: :put,
-          form: {
-            class: 'button_to',
-            data: {
-              form_steps_wait: '',
-              error_message: t('idv.failure.exceptions.internal_error'),
-              alert_target: '#form-steps-wait-alert',
-              wait_step_path: idv_doc_auth_step_url(step: :verify_wait),
-              poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
-            },
-          },
-        ).with_content(t('forms.buttons.continue')) %>
+    ).with_content(t('forms.buttons.continue'))
+    %>
   </div>
 </div>
 

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -99,6 +99,31 @@ locals:
           method: :put,
     ).with_content(t('forms.buttons.continue'))
     %>
+    <%# <%= button_to( t('forms.buttons.continue'),
+          idv_verify_info_url, 
+          method: :put, 
+          class: 'usa-button usa-button--big usa-button--wide',
+    )
+    %>
+    <%# <%= render SpinnerButtonComponent.new(
+          action: ->(**tag_options, &block) do
+            button_to(url_for, **tag_options, &block)
+          end,
+          big: true,
+          wide: true,
+          action_message: t('idv.messages.verifying'),
+          method: :put,
+          form: {
+            class: 'button_to',
+            data: {
+              form_steps_wait: '',
+              error_message: t('idv.failure.exceptions.internal_error'),
+              alert_target: '#form-steps-wait-alert',
+              wait_step_path: idv_doc_auth_step_url(step: :verify_wait),
+              poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
+            },
+          },
+        ).with_content(t('forms.buttons.continue')) %>
   </div>
 </div>
 

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -97,33 +97,8 @@ locals:
           big: true,
           wide: true,
           method: :put,
-    ).with_content(t('forms.buttons.continue'))
+        ).with_content(t('forms.buttons.continue'))
     %>
-    <%# <%= button_to( t('forms.buttons.continue'),
-          idv_verify_info_url, 
-          method: :put, 
-          class: 'usa-button usa-button--big usa-button--wide',
-    )
-    %>
-    <%# <%= render SpinnerButtonComponent.new(
-          action: ->(**tag_options, &block) do
-            button_to(url_for, **tag_options, &block)
-          end,
-          big: true,
-          wide: true,
-          action_message: t('idv.messages.verifying'),
-          method: :put,
-          form: {
-            class: 'button_to',
-            data: {
-              form_steps_wait: '',
-              error_message: t('idv.failure.exceptions.internal_error'),
-              alert_target: '#form-steps-wait-alert',
-              wait_step_path: idv_doc_auth_step_url(step: :verify_wait),
-              poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
-            },
-          },
-        ).with_content(t('forms.buttons.continue')) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,7 @@ Rails.application.routes.draw do
       get '/otp_delivery_method' => 'otp_delivery_method#new'
       put '/otp_delivery_method' => 'otp_delivery_method#create'
       get '/verify_info' => 'verify_info#show'
+      put '/verify_info' => 'verify_info#update'
       get '/phone' => 'phone#new'
       put '/phone' => 'phone#create'
       get '/phone/errors/warning' => 'phone_errors#warning'

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -90,5 +90,230 @@ feature 'doc auth verify_info step', :js do
         hash_including(address_edited: false),
       )
     end
+
+    it 'does not proceed to the next page if resolution fails' do
+      expect(fake_attempts_tracker).to receive(:idv_verification_submitted).with(
+        success: false,
+        failure_reason: { ssn: ['Unverified SSN.'] },
+        document_state: 'MT',
+        document_number: '1111111111111',
+        document_issued: '2019-12-31',
+        document_expiration: '2099-12-31',
+        first_name: 'FAKEY',
+        last_name: 'MCFAKERSON',
+        date_of_birth: '1938-10-06',
+        address: '1 FAKE RD',
+        ssn: '123-45-6666',
+      )
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_ssn_step
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_session_errors_warning_path)
+      click_on t('idv.failure.button.warning')
+
+      expect(page).to have_current_path(idv_doc_auth_verify_step)
+    end
+
+    it 'does not proceed to the next page if resolution raises an exception' do
+      expect(fake_attempts_tracker).to receive(:idv_verification_submitted).with(
+        success: false,
+        failure_reason: nil,
+        document_state: 'MT',
+        document_number: '1111111111111',
+        document_issued: '2019-12-31',
+        document_expiration: '2099-12-31',
+        first_name: 'FAKEY',
+        last_name: 'MCFAKERSON',
+        date_of_birth: '1938-10-06',
+        address: '1 FAKE RD',
+        ssn: '000-00-0000',
+      )
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_ssn_step
+      fill_out_ssn_form_with_ssn_that_raises_exception
+      click_idv_continue
+      click_idv_continue
+
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth exception visited',
+        step_name: 'Idv::Steps::VerifyWaitStepShow',
+        remaining_attempts: 5,
+      )
+      expect(page).to have_current_path(idv_session_errors_exception_path)
+
+      click_on t('idv.failure.button.warning')
+
+      expect(page).to have_current_path(idv_doc_auth_verify_step)
+    end
+
+    it 'throttles resolution and continues when it expires' do
+      expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited)
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_ssn_step
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      (max_attempts - 1).times do
+        click_idv_continue
+        expect(page).to have_current_path(idv_session_errors_warning_path)
+        visit idv_doc_auth_verify_step
+      end
+      click_idv_continue
+      expect(page).to have_current_path(idv_session_errors_failure_path)
+      expect(fake_analytics).to have_logged_event(
+        'Throttler Rate Limit Triggered',
+        throttle_type: :idv_resolution,
+        step_name: 'Idv::Steps::VerifyWaitStepShow',
+      )
+      travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_verify_step
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_phone_path)
+      end
+    end
+
+    context 'when the user lives in an AAMVA supported state' do
+      it 'performs a resolution and state ID check' do
+        allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
+          [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
+        )
+        user = create(:user, :signed_up)
+        expect_any_instance_of(Idv::Agent).
+          to receive(:proof_resolution).
+          with(
+            anything,
+            should_proof_state_id: true,
+            trace_id: anything,
+            threatmetrix_session_id: anything,
+            user_id: user.id,
+            request_ip: kind_of(String),
+          ).
+          and_call_original
+
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_verify_step
+        click_idv_continue
+
+        expect(DocAuthLog.find_by(user_id: user.id).aamva).not_to be_nil
+      end
+    end
+
+    context 'when the user does not live in an AAMVA supported state' do
+      it 'does not perform the state ID check' do
+        allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
+          IdentityConfig.store.aamva_supported_jurisdictions -
+            [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]],
+        )
+        user = create(:user, :signed_up)
+        expect_any_instance_of(Idv::Agent).
+          to receive(:proof_resolution).
+          with(
+            anything,
+            should_proof_state_id: false,
+            trace_id: anything,
+            threatmetrix_session_id: anything,
+            user_id: user.id,
+            request_ip: kind_of(String),
+          ).
+          and_call_original
+
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_verify_step
+        click_idv_continue
+
+        expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
+      end
+    end
+
+    context 'when the SP is in the AAMVA banlist' do
+      it 'does not perform the state ID check' do
+        allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
+          and_return('["urn:gov:gsa:openidconnect:sp:server"]')
+        user = create(:user, :signed_up)
+        expect_any_instance_of(Idv::Agent).
+          to receive(:proof_resolution).
+          with(
+            anything,
+            should_proof_state_id: false,
+            trace_id: anything,
+            threatmetrix_session_id: anything,
+            user_id: user.id,
+            request_ip: kind_of(String),
+          ).
+          and_call_original
+
+        visit_idp_from_sp_with_ial1(:oidc)
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_verify_step
+        click_idv_continue
+
+        expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
+      end
+    end
+
+    context 'async missing' do
+      it 'allows resubmitting form' do
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_verify_step
+
+        allow(DocumentCaptureSession).to receive(:find_by).
+          and_return(nil)
+
+        click_idv_continue
+        expect(fake_analytics).to have_logged_event('Proofing Resolution Result Missing')
+        expect(page).to have_content(t('idv.failure.timeout'))
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+        click_idv_continue
+        expect(page).to have_current_path(idv_phone_path)
+      end
+
+      it 'tracks attempts tracker event with failure reason' do
+        expect(fake_attempts_tracker).to receive(:idv_verification_submitted).with(
+          success: false,
+          failure_reason: { idv_verification: [:timeout] },
+          document_state: 'MT',
+          document_number: '1111111111111',
+          document_issued: '2019-12-31',
+          document_expiration: '2099-12-31',
+          first_name: 'FAKEY',
+          last_name: 'MCFAKERSON',
+          date_of_birth: '1938-10-06',
+          address: '1 FAKE RD',
+          ssn: '900-66-1234',
+        )
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_verify_step
+
+        allow(DocumentCaptureSession).to receive(:find_by).
+          and_return(nil)
+
+        click_idv_continue
+        expect(page).to have_content(t('idv.failure.timeout'))
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+      end
+    end
+
+    context 'async timed out' do
+      it 'allows resubmitting form' do
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_verify_step
+
+        allow(DocumentCaptureSession).to receive(:find_by).
+          and_return(nil)
+
+        click_idv_continue
+        expect(page).to have_content(t('idv.failure.timeout'))
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+        allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+        click_idv_continue
+        expect(page).to have_current_path(idv_phone_path)
+      end
+    end
   end
 end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -6,6 +6,7 @@ feature 'doc auth verify_info step', :js do
 
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  let(:max_attempts) { Throttle.max_attempts(:idv_resolution) }
 
   context 'with verify_info_controller enabled' do
     before do
@@ -165,7 +166,7 @@ feature 'doc auth verify_info step', :js do
       expect(fake_analytics).to have_logged_event(
         'Throttler Rate Limit Triggered',
         throttle_type: :idv_resolution,
-        step_name: 'Idv::Steps::VerifyWaitStepShow',
+        step_name: 'Idv::VerifyInfoController',
       )
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
         sign_in_and_2fa_user

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -135,12 +135,13 @@ feature 'doc auth verify_info step', :js do
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_ssn_step
       fill_out_ssn_form_with_ssn_that_raises_exception
+
       click_idv_continue
       click_idv_continue
 
       expect(fake_analytics).to have_logged_event(
         'IdV: doc auth exception visited',
-        step_name: 'Idv::Steps::VerifyWaitStepShow',
+        step_name: 'Idv::VerifyInfoController',
         remaining_attempts: 5,
       )
       expect(page).to have_current_path(idv_session_errors_exception_path)

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -81,12 +81,12 @@ feature 'doc auth verify_info step', :js do
 
       expect(page).to have_current_path(idv_phone_path)
       expect(page).to have_content(t('doc_auth.forms.doc_success'))
-      user = User.first
+      user = User.last
       expect(user.proofing_component.resolution_check).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
       expect(user.proofing_component.source_check).to eq(Idp::Constants::Vendors::AAMVA)
       expect(DocAuthLog.find_by(user_id: user.id).aamva).to eq(true)
       expect(fake_analytics).to have_logged_event(
-        'IdV: doc auth optional verify_wait submitted',
+        'IdV: doc auth verify proofing results',
         hash_including(address_edited: false),
       )
     end


### PR DESCRIPTION
ETA: It looks like rebasing on main caused this PR to include extra commits. Created PR [#7676](https://github.com/18F/identity-idp/pull/7676) from the correct cherry-picked commits, recommend merging that one instead.

*What*
Add update functionality to VerifyInfoController outside Flow State Machine
- After submitting the info on the verify screen it is submitted to the enabled vendor(s)
- Errors from the vendor are rendered to the user
- If there are no errors the user is sent to the phone step
- Rate limiting is enforced on this step
- Async functionality included (LG-7401) because it wasn't feasible to separate it out, but LG-7401 will now be the ticket for adding the Spinner button back in.

All changes are hidden behind doc_auth_verify_info_controller_enabled IdentityConfig feature flag which is false in prod.

## 🎫 Ticket

LG-7400

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Confirm that doc_auth_verify_info_controller_enabled flag is false
- [ ] Run through remote proofing, confirm unchanged
- [ ] Set doc_auth_verify_info_controller_enabled flag to true
- [ ] Run through remote proofing, will see /verify/verify_info url in browser for Verify step
- [ ] Screens should otherwise remain unchanged
- [ ] Confirm other proofing flows also unchanged

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
