### PR TITLE
Only log IRS Metadata event if the IRS event is being written to Redis

### DIFF
--- a/app/services/irs_attempts_api/attempt_event.rb
+++ b/app/services/irs_attempts_api/attempt_event.rb
@@ -63,8 +63,7 @@ module IrsAttemptsApi
     end
 
     def payload_json
-      return @payload_json if defined?(@payload_json)
-      @payload_json = payload.to_json
+      @payload_json ||= payload.to_json
     end
 
     private

--- a/app/services/irs_attempts_api/attempt_event.rb
+++ b/app/services/irs_attempts_api/attempt_event.rb
@@ -20,7 +20,7 @@ module IrsAttemptsApi
 
     def to_jwe
       JWE.encrypt(
-        payload.to_json,
+        payload_json,
         event_data_encryption_key,
         typ: 'secevent+jwe',
         zip: 'DEF',
@@ -60,6 +60,11 @@ module IrsAttemptsApi
           long_event_type => event_data,
         },
       }
+    end
+
+    def payload_json
+      return @payload_json if defined?(@payload_json)
+      @payload_json = payload.to_json
     end
 
     private

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -44,6 +44,7 @@ module IrsAttemptsApi
       if enabled?
         analytics.irs_attempts_api_event_metadata(
           event_type: event_type,
+          unencrypted_payload_num_bytes: event.payload_json.bytesize,
           recorded: true,
         )
         redis_client.write_event(

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -16,7 +16,7 @@ module IrsAttemptsApi
     end
 
     def track_event(event_type, metadata = {})
-      return if !enabled? && !IdentityConfig.store.irs_attempt_api_payload_size_logging_enabled
+      return if !enabled?
 
       if metadata.has_key?(:failure_reason) &&
          (metadata[:failure_reason].blank? ||
@@ -42,11 +42,14 @@ module IrsAttemptsApi
       )
 
       if enabled?
-        analytics.irs_attempts_api_event_metadata(
-          event_type: event_type,
-          unencrypted_payload_num_bytes: event.payload_json.bytesize,
-          recorded: true,
-        )
+        if IdentityConfig.store.irs_attempt_api_payload_size_logging_enabled
+          analytics.irs_attempts_api_event_metadata(
+            event_type: event_type,
+            unencrypted_payload_num_bytes: event.payload_json.bytesize,
+            recorded: true,
+          )
+        end
+
         redis_client.write_event(
           event_key: event.event_key,
           jwe: event.to_jwe,

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -41,15 +41,11 @@ module IrsAttemptsApi
         event_metadata: event_metadata,
       )
 
-      if IdentityConfig.store.irs_attempt_api_payload_size_logging_enabled
+      if enabled?
         analytics.irs_attempts_api_event_metadata(
           event_type: event_type,
-          unencrypted_payload_num_bytes: event.payload.to_json.bytesize,
-          recorded: !!enabled?,
+          recorded: true,
         )
-      end
-
-      if enabled?
         redis_client.write_event(
           event_key: event.event_key,
           jwe: event.to_jwe,

--- a/spec/services/irs_attempts_api/tracker_spec.rb
+++ b/spec/services/irs_attempts_api/tracker_spec.rb
@@ -111,12 +111,8 @@ RSpec.describe IrsAttemptsApi::Tracker do
         end
       end
 
-      it 'still logs metadata about the event' do
-        expect(analytics).to receive(:irs_attempts_api_event_metadata).with(
-          event_type: :test_event,
-          unencrypted_payload_num_bytes: kind_of(Integer),
-          recorded: false,
-        )
+      it 'does not log metadata about the event' do
+        expect(analytics).to_not receive(:irs_attempts_api_event_metadata)
 
         subject.track_event(:test_event, foo: :bar)
       end
@@ -135,12 +131,8 @@ RSpec.describe IrsAttemptsApi::Tracker do
         end
       end
 
-      it 'still logs metadata about the event' do
-        expect(analytics).to receive(:irs_attempts_api_event_metadata).with(
-          event_type: :test_event,
-          unencrypted_payload_num_bytes: kind_of(Integer),
-          recorded: false,
-        )
+      it 'does not log metadata about the event' do
+        expect(analytics).to_not receive(:irs_attempts_api_event_metadata)
 
         subject.track_event(:test_event, foo: :bar)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

This event was initially intended for development of the features related to this, but it generates a more significant amount of logs. This change reduces the scope to only the log the metadata when the data will be written to Redis to maintain some of the signal that the log provides without deleting it completely. The amount of data written is also being removed from the log.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
