### PR TITLE
Use i18n pluralization to avoid ignored string

### DIFF
--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -114,11 +114,7 @@ function ReviewIssuesStep({
 
         {remainingAttempts <= DISPLAY_ATTEMPTS && (
           <p>
-            <strong>
-              {remainingAttempts === 1
-                ? t('idv.failure.attempts.one')
-                : t('idv.failure.attempts.other', { count: remainingAttempts })}
-            </strong>
+            <strong>{t('idv.failure.attempts', { count: remainingAttempts })}</strong>
           </p>
         )}
       </Warning>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -99,8 +99,6 @@ ignore_unused:
   - 'errors.messages.*'
   - 'simple_form.*'
   - 'time.*'
-  - 'idv.failure.attempts.one'
-  - 'idv.failure.attempts.other'
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -5,6 +5,8 @@ import {
   UploadContextProvider,
   AnalyticsContext,
 } from '@18f/identity-document-capture';
+import { I18n } from '@18f/identity-i18n';
+import { I18nContext } from '@18f/identity-react-i18n';
 import ReviewIssuesStep from '@18f/identity-document-capture/components/review-issues-step';
 import { toFormEntryError } from '@18f/identity-document-capture/services/upload';
 import { useSandbox } from '@18f/identity-test-helpers';
@@ -38,10 +40,25 @@ describe('document-capture/components/review-issues-step', () => {
   });
 
   it('renders initially with warning page and displays attempts remaining', () => {
-    const { getByRole, getByText } = render(<ReviewIssuesStep {...DEFAULT_PROPS} />);
+    const { getByRole, getByText } = render(
+      <I18nContext.Provider
+        value={
+          new I18n({
+            strings: {
+              'idv.failure.attempts': {
+                one: 'One attempt remaining',
+                other: '%{count} attempts remaining',
+              },
+            },
+          })
+        }
+      >
+        <ReviewIssuesStep {...DEFAULT_PROPS} />
+      </I18nContext.Provider>,
+    );
 
     expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
-    expect(getByText('idv.failure.attempts.other')).to.be.ok();
+    expect(getByText('3 attempts remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
 
     expect(
@@ -56,19 +73,32 @@ describe('document-capture/components/review-issues-step', () => {
 
   it('renders warning page with error and displays one attempt remaining then continues on', async () => {
     const { getByRole, getByLabelText, getByText } = render(
-      <ReviewIssuesStep
-        remainingAttempts={1}
-        unknownFieldErrors={[
-          {
-            field: 'unknown',
-            error: toFormEntryError({ field: 'unknown', message: 'An unknown error occurred' }),
-          },
-        ]}
-      />,
+      <I18nContext.Provider
+        value={
+          new I18n({
+            strings: {
+              'idv.failure.attempts': {
+                one: 'One attempt remaining',
+                other: '%{count} attempts remaining',
+              },
+            },
+          })
+        }
+      >
+        <ReviewIssuesStep
+          remainingAttempts={1}
+          unknownFieldErrors={[
+            {
+              field: 'unknown',
+              error: toFormEntryError({ field: 'unknown', message: 'An unknown error occurred' }),
+            },
+          ]}
+        />
+      </I18nContext.Provider>,
     );
 
     expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
-    expect(getByText('idv.failure.attempts.one')).to.be.ok();
+    expect(getByText('One attempt remaining')).to.be.ok();
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `ReviewIssuesStep` use of localization to use pluralization feature.

Follow-up to #7638 where upgraded `i18n-tasks` detected the direct reference to pluralized string keys as being unused.

`ReviewIssuesStep` predates the introduction of pluralization to the JavaScript implementation in #5950, hence why it was implemented the way it was.

Related Slack discussion: https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1674170306847209

## 📜 Testing Plan

- `yarn mocha spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx`