### PR TITLE
Fix warnings related to DidYouMean deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -835,4 +835,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.2.33
+   2.4.4


### PR DESCRIPTION
## 🛠 Summary of changes

Updates version of Bundler `bundled_with` in `Gemfile.lock` to remove messages related to `DidYouMean` deprecation:

>Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.

## 📜 Testing Plan

1. Run `bundle`
2. Observe no warnings