### PR TITLE
LG-8186 - Document Authorization Upload Success Bugfix

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -97,6 +97,25 @@ module Idv
 
       analytics.idv_doc_auth_submitted_pii_validation(**response.to_h)
 
+      pii_from_doc = response.pii_from_doc || {}
+      stored_image_result = store_encrypted_images_if_required
+
+      irs_attempts_api_tracker.idv_document_upload_submitted(
+        success: response.success?,
+        document_state: pii_from_doc[:state],
+        document_number: pii_from_doc[:state_id_number],
+        document_issued: pii_from_doc[:state_id_issued],
+        document_expiration: pii_from_doc[:state_id_expiration],
+        document_front_image_filename: stored_image_result&.front_filename,
+        document_back_image_filename: stored_image_result&.back_filename,
+        document_image_encryption_key: stored_image_result&.encryption_key,
+        first_name: pii_from_doc[:first_name],
+        last_name: pii_from_doc[:last_name],
+        date_of_birth: pii_from_doc[:dob],
+        address: pii_from_doc[:address1],
+        failure_reason: response.errors&.except(:hints)&.presence,
+      )
+
       store_pii(client_response) if client_response.success? && response.success?
 
       response
@@ -208,23 +227,6 @@ module Idv
           async: false,
           flow_path: params[:flow_path],
         ).merge(acuant_sdk_upgrade_ab_test_data),
-      )
-      pii_from_doc = client_response.pii_from_doc || {}
-      stored_image_result = store_encrypted_images_if_required
-      irs_attempts_api_tracker.idv_document_upload_submitted(
-        success: client_response.success?,
-        document_state: pii_from_doc[:state],
-        document_number: pii_from_doc[:state_id_number],
-        document_issued: pii_from_doc[:state_id_issued],
-        document_expiration: pii_from_doc[:state_id_expiration],
-        document_front_image_filename: stored_image_result&.front_filename,
-        document_back_image_filename: stored_image_result&.back_filename,
-        document_image_encryption_key: stored_image_result&.encryption_key,
-        first_name: pii_from_doc[:first_name],
-        last_name: pii_from_doc[:last_name],
-        date_of_birth: pii_from_doc[:dob],
-        address: pii_from_doc[:address1],
-        failure_reason: client_response.errors&.except(:hints)&.presence,
       )
     end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -381,7 +381,8 @@ describe Idv::ImageUploadsController do
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
               success: false,
-              failure_reason: {pii: ["We couldn’t read the full name on your ID. Try taking new pictures."]},
+              failure_reason: { pii:
+                ['We couldn’t read the full name on your ID. Try taking new pictures.'] },
               document_state: 'ND',
               document_number: nil,
               document_issued: nil,
@@ -459,7 +460,8 @@ describe Idv::ImageUploadsController do
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
               success: false,
-              failure_reason: {pii: ["We couldn’t read the full name on your ID. Try taking new pictures."]},
+              failure_reason: { pii:
+                ['We couldn’t read the full name on your ID. Try taking new pictures.'] },
               document_state: 'ND',
               document_number: nil,
               document_issued: nil,
@@ -537,7 +539,8 @@ describe Idv::ImageUploadsController do
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
               success: false,
-              failure_reason: {pii: ["Try taking new pictures."]},
+              failure_reason: { pii:
+                ['Try taking new pictures.'] },
               document_state: 'Maryland',
               document_number: nil,
               document_issued: nil,
@@ -615,7 +618,8 @@ describe Idv::ImageUploadsController do
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
               success: false,
-              failure_reason: {pii: ["We couldn’t read the birth date on your ID. Try taking new pictures."]},
+              failure_reason: { pii:
+                ['We couldn’t read the birth date on your ID. Try taking new pictures.'] },
               document_back_image_filename: nil,
               document_front_image_filename: nil,
               document_image_encryption_key: nil,

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -380,8 +380,8 @@ describe Idv::ImageUploadsController do
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
-              success: true,
-              failure_reason: nil,
+              success: false,
+              failure_reason: {pii: ["We couldn’t read the full name on your ID. Try taking new pictures."]},
               document_state: 'ND',
               document_number: nil,
               document_issued: nil,
@@ -458,8 +458,8 @@ describe Idv::ImageUploadsController do
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
-              success: true,
-              failure_reason: nil,
+              success: false,
+              failure_reason: {pii: ["We couldn’t read the full name on your ID. Try taking new pictures."]},
               document_state: 'ND',
               document_number: nil,
               document_issued: nil,
@@ -536,8 +536,8 @@ describe Idv::ImageUploadsController do
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
-              success: true,
-              failure_reason: nil,
+              success: false,
+              failure_reason: {pii: ["Try taking new pictures."]},
               document_state: 'Maryland',
               document_number: nil,
               document_issued: nil,
@@ -614,8 +614,8 @@ describe Idv::ImageUploadsController do
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
               :idv_document_upload_submitted,
-              success: true,
-              failure_reason: nil,
+              success: false,
+              failure_reason: {pii: ["We couldn’t read the birth date on your ID. Try taking new pictures."]},
               document_back_image_filename: nil,
               document_front_image_filename: nil,
               document_image_encryption_key: nil,
@@ -662,7 +662,6 @@ describe Idv::ImageUploadsController do
 
       it 'tracks events' do
         stub_analytics
-        stub_attempts_tracker
 
         expect(@analytics).to receive(:track_event).with(
           'IdV: doc auth image upload form submitted',
@@ -699,25 +698,6 @@ describe Idv::ImageUploadsController do
           flow_path: 'standard',
         )
 
-        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-          :idv_document_upload_submitted,
-          success: false,
-          failure_reason: {
-            front: [I18n.t('doc_auth.errors.general.multiple_front_id_failures')],
-          },
-          document_back_image_filename: nil,
-          document_front_image_filename: nil,
-          document_image_encryption_key: nil,
-          document_state: nil,
-          document_number: nil,
-          document_issued: nil,
-          document_expiration: nil,
-          first_name: nil,
-          last_name: nil,
-          date_of_birth: nil,
-          address: nil,
-        )
-
         action
 
         expect_funnel_update_counts(user, 1)
@@ -744,7 +724,6 @@ describe Idv::ImageUploadsController do
 
       it 'tracks events' do
         stub_analytics
-        stub_attempts_tracker
 
         expect(@analytics).to receive(:track_event).with(
           'IdV: doc auth image upload form submitted',
@@ -781,26 +760,6 @@ describe Idv::ImageUploadsController do
           },
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
-        )
-
-        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
-          :idv_document_upload_submitted,
-          success: false,
-          failure_reason: {
-            general: [I18n.t('doc_auth.errors.alerts.barcode_content_check')],
-            back: [I18n.t('doc_auth.errors.general.fallback_field_level')],
-          },
-          document_back_image_filename: nil,
-          document_front_image_filename: nil,
-          document_image_encryption_key: nil,
-          document_state: nil,
-          document_number: nil,
-          document_issued: nil,
-          document_expiration: nil,
-          first_name: nil,
-          last_name: nil,
-          date_of_birth: nil,
-          address: nil,
         )
 
         action

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe Idv::ApiImageUploadForm do
   describe '#submit' do
     context 'with a valid form' do
       it 'logs analytics' do
+        expect(irs_attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+          {
+            address: '1 FAKE RD',
+            date_of_birth: '1938-10-06',
+            document_back_image_filename: nil,
+            document_expiration: '2099-12-31',
+            document_front_image_filename: nil,
+            document_image_encryption_key: nil,
+            document_issued: '2019-12-31',
+            document_number: '1111111111111',
+            document_state: 'MT',
+            failure_reason: nil,
+            first_name: 'FAKEY',
+            last_name: 'MCFAKERSON',
+            success: true,
+          },
+        )
+
         form.submit
 
         expect(fake_analytics).to have_logged_event(
@@ -244,6 +262,13 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
 
       it 'includes doc_pii errors' do
+        expect(irs_attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+          hash_including(
+            {
+              success: false,
+            },
+          ),
+        )
         response = form.submit
         expect(response.errors[:doc_pii]).to eq('bad')
       end


### PR DESCRIPTION
changelog: Internal, Attempts API, Event bugfix

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8186](https://cm-jira.usa.gov/browse/LG-8186)

## 🛠 Summary of changes

Corrected the form response used by doc_auth_submitted event.
Added missing tests to the spec for this event.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
