### PR TITLE
Remove password strength fallback behavior for IE9

### DIFF
--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -111,7 +111,6 @@ export function getForbiddenPasswords(element) {
 }
 
 function analyzePw() {
-  const { userAgent } = window.navigator;
   const input = document.querySelector('.password-toggle__input');
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');
@@ -137,10 +136,6 @@ function analyzePw() {
 
     clearErrors();
     disableSubmit(submit, z.password.length, z.score);
-  }
-
-  if (/(msie 9)/i.test(userAgent)) {
-    input.addEventListener('keyup', checkPasswordStrength);
   }
 
   input.addEventListener('input', checkPasswordStrength);


### PR DESCRIPTION
## 🛠 Summary of changes

Removes code which provided fallback behavior for buggy browser behavior in Internet Explorer 9. As of LG-8525 (#7563), we no longer support Internet Explorer.

## 📜 Testing Plan

- Password strength meter continues to work as expected