### PR TITLE
Remove a few redundant BassCSS styles

### DIFF
--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -72,16 +72,9 @@ h6 {
   margin-bottom: 0.5em;
 }
 
-p {
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
-dl,
-ol,
+p,
 ul {
   margin-top: 0;
-  margin-bottom: 1rem;
 }
 
 // basscss-utility-typography

--- a/app/views/idv/inherited_proofing/_verify.html.erb
+++ b/app/views/idv/inherited_proofing/_verify.html.erb
@@ -8,7 +8,7 @@ locals:
 <%= render PageHeadingComponent.new.with_content(t('titles.idv.verify_info')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
-    <dl class="grid-col-fill margin-bottom-0">
+    <dl class="grid-col-fill margin-y-0">
       <div>
         <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:first_name] %> </dd>
@@ -24,7 +24,7 @@ locals:
     </dl>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">
-    <dl class='grid-col-fill margin-bottom-0'>
+    <dl class='grid-col-fill margin-y-0'>
       <div>
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:address1] %> </dd>

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -9,7 +9,7 @@ locals:
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
-    <dl class="grid-col-fill margin-bottom-0">
+    <dl class="grid-col-fill margin-y-0">
       <div>
         <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:first_name] %> </dd>
@@ -41,7 +41,7 @@ locals:
     <% end %>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">
-    <dl class='grid-col-fill margin-bottom-0'>
+    <dl class='grid-col-fill margin-y-0'>
       <div>
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= pii[:address1] %> </dd>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -16,7 +16,7 @@ locals:
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
-    <dl class="grid-col-fill margin-bottom-0">
+    <dl class="grid-col-fill margin-y-0">
       <div>
         <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= @pii[:first_name] %> </dd>
@@ -32,7 +32,7 @@ locals:
     </dl>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">
-    <dl class='grid-col-fill margin-bottom-0'>
+    <dl class='grid-col-fill margin-y-0'>
       <div>
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= @pii[:address1] %> </dd>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a few styles and style declarations for BassCSS global styles which were left over the removal of BassCSS styles in #5944, toward eventual removal of the `design-system-waiting-room.scss` file.

These styles are redundant:

- The native bottom margin of `p`, `dl`, `ol`, and `ul` is already `1em`, which would be effectively identical to the style we were applying
- All current instances of `<ol>` and `<dl>` elements are customized such that the `margin-top` default would not be applied

## 📜 Testing Plan

- Spot check affected lists and paragraphs for potential regressions
