### PR TITLE
Only allow email parameter in SessionsController#new

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,7 +15,6 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
-    before_action :update_devise_params_sanitizer, only: [:new]
 
     def new
       analytics.sign_in_page_visit(
@@ -240,8 +239,8 @@ module Users
       request.content_security_policy = policy
     end
 
-    def update_devise_params_sanitizer
-      devise_parameter_sanitizer.permit(:sign_in, except: [:email, :password]) if !request.post?
+    def sign_in_params
+      params[resource_name]&.permit(:email) if request.post?
     end
   end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -235,6 +235,7 @@ describe Users::SessionsController, devise: true do
         sp_request_url_present: false,
         remember_device: false,
       }
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
 
       expect(@analytics).to receive(:track_event).
         with('Email and Password Authentication', analytics_hash)
@@ -252,6 +253,7 @@ describe Users::SessionsController, devise: true do
         sp_request_url_present: false,
         remember_device: false,
       }
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
 
       expect(@analytics).to receive(:track_event).
         with('Email and Password Authentication', analytics_hash)


### PR DESCRIPTION
## 🛠 Summary of changes

Following some of the changes in #7621 and #7657, we noticed that the `password=` function can unnecessarily digest and encrypt the password, which is an expensive operation. This PR overrides the `sign_in_params` method from Devise so that we only pass the `email` parameter to avoid an unnecessary call to `password=`

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
