### PR TITLE
Jess/LG-8333: Configure IPP CTA throttling for nationwide launch

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -127,7 +127,7 @@ idv_send_link_max_attempts: 5
 ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
 in_person_cta_variant_testing_enabled: true
-in_person_cta_variant_testing_percents: '{"A":50, "B":50}'
+in_person_cta_variant_testing_percents: '{"A":12.5, "B":12.5, "C":75}'
 in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4


### PR DESCRIPTION
## 🎫 Ticket

[LG-8333](https://cm-jira.usa.gov/browse/LG-8333)

## 🛠 Summary of changes

changelog: Internal, In-person proofing, Hide the in-person proofing call to action from 75% of viewers and split the rest evenly between variants A and B of the CTA


## 📜 Testing Plan
- Automated test suite succeeds
- Manual verification that sessions were bucketed into all configured categories

## Additional Details
Requires PR#7669 / LG-8274, and represents desired values for Feb 1 and later. DO NOT MERGE YET. DRAFT ONLY.
