### PR TITLE
changelog: User-Facing Improvements, Authentication, Add authentication troubleshooting options to phone OTP verification page

### DIFF
--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -45,6 +45,35 @@ module TwoFactorAuthCode
       ''
     end
 
+    def troubleshooting_header
+      t('two_factor_authentication.phone_verification.troubleshooting.header')
+    end
+
+    def troubleshooting_options
+      [
+        {
+          url: unconfirmed_phone ? phone_setup_path : login_two_factor_options_path,
+          text: troubleshoot_change_phone_or_option_text
+        },
+        {
+          url: MarketingSite.help_center_article_url(
+            category: 'get-started',
+            article: 'authentication-options',
+          ),
+          text: t('two_factor_authentication.phone_verification.troubleshooting.code_not_received'),
+          new_tab: true,
+        },
+        {
+          url: MarketingSite.help_center_article_url(
+            category: 'get-started',
+            article: 'authentication-options',
+          ),
+          text: t('two_factor_authentication.phone_verification.troubleshooting.learn_more'),
+          new_tab: true,
+        },
+      ]
+    end
+
     def cancel_link
       locale = LinkLocaleResolver.locale
       if confirmation_for_add_phone || reauthn
@@ -54,7 +83,12 @@ module TwoFactorAuthCode
       end
     end
 
-    private
+    private 
+
+    def troubleshoot_change_phone_or_option_text
+      unconfirmed_phone ? t('two_factor_authentication.phone_verification.troubleshooting.change_phone_number') : 
+        t('two_factor_authentication.login_options_link_text')
+    end
 
     attr_reader(
       :phone_number,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -56,14 +56,12 @@
       ).with_content(t('links.two_factor_authentication.send_another_code')) %>
 <% end %>
 
-<% if @presenter.unconfirmed_phone? %>
-  <div class="margin-top-5">
-    <%= t('instructions.mfa.wrong_number') %><br>
-    <%= link_to(t('forms.two_factor.try_again'), phone_setup_path) %>
-  </div>
-<% else %>
-  <%= render 'shared/fallback_links', presenter: @presenter %>
-<% end %>
+
+<%= render(
+        'shared/troubleshooting_options',
+        heading: @presenter.troubleshooting_header,
+        options: @presenter.troubleshooting_options,
+      ) %>
 
 <% if MfaPolicy.new(current_user).two_factor_enabled? %>
   <%= render 'shared/cancel', link: @presenter.cancel_link %>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -114,6 +114,12 @@ en:
     phone_fee_disclosure: Message and data rates may apply.
     phone_info_html: We’ll send you a one-time code <strong>each time you sign in</strong>.
     phone_label: Phone number
+    phone_verification:
+      troubleshooting:
+        header: 'Having trouble? Here’s what you can do:'
+        change_phone_number: Use another phone number
+        code_not_received: I didn't receive my one-time code
+        learn_more: Learn more about authentication options
     piv_cac_fallback:
       question: Don’t have your PIV or CAC available?
     piv_cac_header_text: Present your PIV/CAC


### PR DESCRIPTION
Adds authentication troubleshooting options to the OTP verification page in authentication. 
![Screen Shot 2023-01-25 at 10 31 19 AM](https://user-images.githubusercontent.com/23225522/214606019-1ceb7089-32e2-4b09-a604-f5f85952a40c.png)
![Screen Shot 2023-01-25 at 10 32 23 AM](https://user-images.githubusercontent.com/23225522/214606023-d1f83660-492a-4ca7-b1fa-72f119ae6ca1.png)
