### PR TITLE
Change Rack::Timeout logging to Error level to reduce logging noise

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -27,6 +27,8 @@ module Rack
   end
 end
 
+Rack::Timeout::Logger.level = Logger::ERROR
+
 Rails.application.config.middleware.insert_before(
   Rack::Runtime,
   Rack::Timeout,


### PR DESCRIPTION
## 🛠 Summary of changes

Rack::Timeout logs for every request, but we'd really only be interested if there is a timeout or other issue.

Lines like the following are not all that useful:

```
source=rack-timeout id=8bb2ab5a-6a27-4468-8e77-a58af46ec06c timeout=600000ms service=29ms state=completed
source=rack-timeout id=51358686-208d-4afe-8e3b-68bdc5d2c02e timeout=600000ms state=ready
```

We'd still get logs where the request timed out:

```
source=rack-timeout id=a8b52429-8602-4f02-ad38-a609bac91ef1 timeout=1000ms service=1005ms state=timed_out
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
