### PR TITLE
LG-8703 use shared wait.html.erb, remove duplicates

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -20,7 +20,7 @@ module Idv
         analytics.idv_phone_of_record_visited
         render :new, locals: { gpo_letter_available: gpo_letter_available }
       elsif async_state.in_progress?
-        render :wait
+        render 'shared/wait'
       elsif async_state.missing?
         analytics.proofing_address_result_missing
         flash.now[:error] = I18n.t('idv.failure.timeout')

--- a/app/views/idv/gpo/wait.html.erb
+++ b/app/views/idv/gpo/wait.html.erb
@@ -1,4 +1,0 @@
-<%= content_for(:meta_refresh) { '15' } %>
-<% title t('titles.doc_auth.verify') %>
-
-<%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/idv/phone/wait.html.erb
+++ b/app/views/idv/phone/wait.html.erb
@@ -1,4 +1,0 @@
-<%= content_for(:meta_refresh) { '15' } %>
-<% title t('titles.doc_auth.verify') %>
-
-<%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>


### PR DESCRIPTION
## 🎫 Ticket

LG-8703, subtask of LG-7401

## 🛠 Summary of changes

PhoneController had a duplicate of the VerifyInfo wait.html.erb file, so change to use the shared version.
app/views/idv/gpo also had a duplicate that's unused, so remove it.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create user
- [ ] Test unsupervised proofing, confirm that phone step works as expected
- [ ] Create another user (or start over)
- [ ] Confirm that gpo flow works as expected

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
