### PR TITLE
Fix typo in doc auth translation file

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -79,7 +79,7 @@ en:
       http:
         image_load: The image file that you added is not supported. Please take new
           photos of your ID and try again.
-        image_size: You image size is too large or too small. Please add images of your
+        image_size: Your image size is too large or too small. Please add images of your
           ID that are about 2025 x 1275 pixels.
         pixel_depth: The pixel depth of your image file is not supported. Please take
           new photos of your ID and try again. Supported image pixel depth is


### PR DESCRIPTION
"Your image" instead of "You image"