### PR TITLE
LG-8742 Add throttle checks for VerifyInfo#update

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -10,7 +10,15 @@ module Idv
       increment_step_counts
       analytics.idv_doc_auth_verify_visited(**analytics_arguments)
 
-      redirect_to throttled_url and return if any_throttled?
+      if ssn_throttle.throttled?
+        redirect_to idv_session_errors_ssn_failure_url
+        return
+      end
+
+      if resolution_throttle.throttled?
+        redirect_to throttled_url
+        return
+      end
 
       process_async_state(load_async_state)
     end
@@ -26,6 +34,11 @@ module Idv
           step_name: 'verify_info',
         )
         redirect_to idv_session_errors_ssn_failure_url
+        return
+      end
+
+      if resolution_throttle.throttled?
+        redirect_to throttled_url
         return
       end
 
@@ -150,10 +163,6 @@ module Idv
         target: Pii::Fingerprinter.fingerprint(pii[:ssn]),
         throttle_type: :proof_ssn,
       )
-    end
-
-    def any_throttled?
-      ssn_throttle.throttled? || resolution_throttle.throttled?
     end
 
     def idv_failure(result)

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -3,6 +3,18 @@ require 'rails_helper'
 describe Idv::VerifyInfoController do
   include IdvHelper
 
+  let(:flow_session) do
+    { 'error_message' => nil,
+      'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
+      :pii_from_doc => Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup,
+      'threatmetrix_session_id' => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
+      :flow_path => 'standard' }
+  end
+
+  before do
+    allow(subject).to receive(:flow_session).and_return(flow_session)
+  end
+
   describe 'before_actions' do
     it 'checks that feature flag is enabled' do
       expect(subject).to have_actions(
@@ -27,13 +39,6 @@ describe Idv::VerifyInfoController do
   end
 
   describe '#show' do
-    let(:flow_session) do
-      { 'error_message' => nil,
-        'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-        :pii_from_doc => Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
-        'threatmetrix_session_id' => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
-        :flow_path => 'standard' }
-    end
     let(:analytics_name) { 'IdV: doc auth verify visited' }
     let(:analytics_args) do
       {
@@ -51,7 +56,6 @@ describe Idv::VerifyInfoController do
       stub_analytics
       stub_attempts_tracker
       allow(@analytics).to receive(:track_event)
-      allow(subject).to receive(:flow_session).and_return(flow_session)
     end
 
     context 'when doc_auth_verify_info_controller_enabled' do
@@ -90,10 +94,10 @@ describe Idv::VerifyInfoController do
           ).increment_to_throttled!
         end
 
-        it 'redirects to throttled url' do
+        it 'redirects to ssn failure url' do
           get :show
 
-          expect(response).to redirect_to idv_session_errors_failure_url
+          expect(response).to redirect_to idv_session_errors_ssn_failure_url
         end
       end
 
@@ -123,6 +127,47 @@ describe Idv::VerifyInfoController do
         get :show
 
         expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "#update" do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
+        and_return(true)
+      user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
+      stub_verify_steps_one_and_two(user)
+    end
+
+    context 'when the user is ssn throttled' do
+      before do
+        Throttle.new(
+          target: Pii::Fingerprinter.fingerprint(
+            Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          ),
+          throttle_type: :proof_ssn,
+        ).increment_to_throttled!
+      end
+
+      it 'redirects to ssn failure url' do
+        put :update
+
+        expect(response).to redirect_to idv_session_errors_ssn_failure_url
+      end
+    end
+
+    context 'when the user is proofing throttled' do
+      before do
+        Throttle.new(
+          user: subject.current_user,
+          throttle_type: :idv_resolution,
+        ).increment_to_throttled!
+      end
+
+      it 'redirects to throttled url' do
+        put :update
+
+        expect(response).to redirect_to idv_session_errors_failure_url
       end
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -131,7 +131,7 @@ describe Idv::VerifyInfoController do
     end
   end
 
-  describe "#update" do
+  describe '#update' do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
         and_return(true)


### PR DESCRIPTION
and redirect to ssn error page for ssn throttle on #show

Co-authored-by: Eric Gade <eric.gade@gsa.gov>

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

LG-8742

## 🛠 Summary of changes

For new VerifyInfo controller, check whether ssn throttling or resolution throttling are in force and redirect to the correct error page if so.

Analytics get logged when the throttle is first triggered, but not on further attempts to update. This can be added if desired. The show action logs a visit before redirecting if throttled, but does not log about the redirect. Show action now redirects to different error pages depending on whether the user has triggered the ssn throttle or resolution throttle.

Added controller tests.

## 📜 Testing Plan

- [ ] This is easiest to test with automated tests that can repeat actions enough times to trigger throttles. 

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
