### PR TITLE
LG-8060 | Fetch from Redis in batches

### DIFF
--- a/app/services/irs_attempts_api/redis_client.rb
+++ b/app/services/irs_attempts_api/redis_client.rb
@@ -17,11 +17,15 @@ module IrsAttemptsApi
       end
     end
 
-    def read_events(timestamp:)
+    def read_events(timestamp:, batch_size: 5000)
       key = key(timestamp)
+      events = {}
       redis_pool.with do |client|
-        client.hgetall(key)
+        client.hscan_each(key, count: batch_size) do |k, v|
+          events[k] = v
+        end
       end
+      events
     end
 
     def key(timestamp)


### PR DESCRIPTION
changelog: Internal, Attempts API, Fetch from Redis in batches


## 🎫 Ticket

LG-8060

## 🛠 Summary of changes

This story was initially for a series of changes to the background job. Ultimately, none gave a performance improvement, except that reading in batches could be slightly faster, depending on batch size.

**But**, @zachmargolis pointed out that, because Redis is single-threaded, it's much kinder to Redis to read in batches rather than one gigantic `hgetall`. That's the big win; the performance improvement is very marginal.

I initially coded this to call `hscan` inside a loop, introduced a lulzy infinite loop where we ran until `counter == 0` when `counter` was actually returned as a string, and then realized while looking at the source that `hscan_each` already did what I wanted. I have progressively whittled this down to just a few lines.

Note that this will fetch from Redis in batches, but it still builds everything up in one big array before returning it. We may some day want to accept a block to allow us to operate on batches. Today is not that day, though -- the existing EnvelopeEncryptor code expects that we have the whole payload in memory.