### PR TITLE
Do not send registration emails to invalid email addresses

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -29,10 +29,6 @@ class RegisterUserEmailForm
     email_address&.email
   end
 
-  def resend
-    'true'
-  end
-
   def validate_terms_accepted
     return if @terms_accepted
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -30,7 +30,7 @@ class RegisterUserEmailForm
   end
 
   def validate_terms_accepted
-    return if @terms_accepted
+    return if @terms_accepted || email_address_record&.user&.accepted_terms_at.present?
 
     errors.add(:terms_accepted, t('errors.registration.terms'), type: :terms)
   end

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -75,15 +75,10 @@ class RegisterUserEmailForm
     user.email_language = email_language
   end
 
-  def valid_form?
-    valid? && !email_taken?
-  end
-
   def lookup_email_taken
-    email_address = EmailAddress.find_with_email(email)
-    email_owner = email_address&.user
+    email_owner = email_address_record&.user
     return false if email_owner.blank?
-    return email_address.confirmed? if email_owner.confirmed?
+    return email_address_record.confirmed? if email_owner.confirmed?
     true
   end
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -42,11 +42,9 @@ class RegisterUserEmailForm
       email_language: params[:email_language],
     )
     self.request_id = params[:request_id]
-    if valid?
-      process_successful_submission(request_id, instructions)
-    else
-      self.success = false
-    end
+
+    self.success = valid?
+    process_successful_submission(request_id, instructions) if success
 
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
@@ -85,7 +83,6 @@ class RegisterUserEmailForm
   def process_successful_submission(request_id, instructions)
     # To prevent discovery of existing emails, we check to see if the email is
     # already taken and if so, we act as if the user registration was successful.
-    self.success = true
     if email_taken? && user_unconfirmed?
       send_sign_up_unconfirmed_email(request_id)
     elsif email_taken?

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -83,6 +83,8 @@ class RegisterUserEmailForm
   end
 
   def process_successful_submission(request_id, instructions)
+    # To prevent discovery of existing emails, we check to see if the email is
+    # already taken and if so, we act as if the user registration was successful.
     self.success = true
     if email_taken? && user_unconfirmed?
       send_sign_up_unconfirmed_email(request_id)


### PR DESCRIPTION
## 🛠 Summary of changes

Registration emails currently ignore validation errors if the email has already been created, which is kind of confusing. This also means we may send an email if the user has not accepted the terms or to an email domain that is invalid.  This PR reorganizes the logic to _not_ send if it is invalid.

I suspect that this behavior is in part due to the more limited validation that existed when the form was initially implemented.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
