### PR TITLE
Update zxcvbn to 0.1.9. Fixes dictionary searches performance: polynomial O(n^2) to linear O(n)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'yard'
 
 # This version of the zxcvbn gem matches the data and behavior of the zxcvbn NPM package.
 # It should not be updated without verifying that the behavior still matches JS version 4.4.2.
-gem 'zxcvbn', '0.1.7'
+gem 'zxcvbn', '0.1.9'
 
 group :development do
   gem 'better_errors', '>= 2.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -711,7 +711,7 @@ GEM
       webrick (~> 1.7.0)
     zeitwerk (2.6.6)
     zonebie (0.6.1)
-    zxcvbn (0.1.7)
+    zxcvbn (0.1.9)
 
 PLATFORMS
   ruby
@@ -829,7 +829,7 @@ DEPENDENCIES
   xmlenc (~> 0.7, >= 0.7.1)
   yard
   zonebie
-  zxcvbn (= 0.1.7)
+  zxcvbn (= 0.1.9)
 
 RUBY VERSION
    ruby 3.2.0p0


### PR DESCRIPTION
## 🛠 Summary of changes

Update version of `zxcvbn` gem to 0.1.9.
Results produced are still compatible with dropbox/zxcvbn.js 4.4.2 but this one solves an issue with performance that could cause considerable impacts. This version makes the algorithm to work with performance linear `O(n)` in relation to size of passwords, before it could be polynomial `O(n^c)`.
There are more details on `zxcvbn` Changelog and on issue: formigarafa/zxcvbn-rb#6 and the code changes on PR formigarafa/zxcvbn-rb#7.
