### PR TITLE
Update zxcvbn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'yard'
 
 # This version of the zxcvbn gem matches the data and behavior of the zxcvbn NPM package.
 # It should not be updated without verifying that the behavior still matches JS version 4.4.2.
-gem 'zxcvbn', '0.1.7'
+gem 'zxcvbn', '0.1.9'
 
 group :development do
   gem 'better_errors', '>= 2.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -711,7 +711,7 @@ GEM
       webrick (~> 1.7.0)
     zeitwerk (2.6.6)
     zonebie (0.6.1)
-    zxcvbn (0.1.7)
+    zxcvbn (0.1.9)
 
 PLATFORMS
   ruby
@@ -829,7 +829,7 @@ DEPENDENCIES
   xmlenc (~> 0.7, >= 0.7.1)
   yard
   zonebie
-  zxcvbn (= 0.1.7)
+  zxcvbn (= 0.1.9)
 
 RUBY VERSION
    ruby 3.2.0p0


### PR DESCRIPTION
## 🛠 Summary of changes

Brings in the changes in #7713 from @formigarafa in a maintainer PR so that CI can run. From the original:

>Update version of zxcvbn gem to 0.1.9.
Results produced are still compatible with dropbox/zxcvbn.js 4.4.2 but this one solves an issue with performance that could cause considerable impacts. This version makes the algorithm to work with performance linear O(n) in relation to size of passwords, before it could be polynomial O(n^c).
There are more details on zxcvbn Changelog and on issue: https://github.com/formigarafa/zxcvbn-rb/issues/6 and the code changes on PR https://github.com/formigarafa/zxcvbn-rb/pull/7.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
