### PR TITLE
Allow changelog prefix fully case-insensitive

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?[cC]hangelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}
+  %r{^(?:\* )?changelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
 CATEGORIES = [
   'User-Facing Improvements',
   'Improvements', # Temporary for transitional period

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -82,7 +82,7 @@ squashed_commit_invalid:
 commit_changelog_capitalized:
   commit_log: |
     title: Improve changelog tool flexibility for commit messages (#7000)
-    body:Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages
+    body:ChAngElOg: Internal, Changelog, Improve changelog tool flexibility for commit messages
     DELIMITER
   title: Improve changelog tool flexibility for commit messages (#7000)
   category: Internal
@@ -90,7 +90,7 @@ commit_changelog_capitalized:
   change: Improve changelog tool flexibility for commit messages
   pr_number: '7000'
   commit_messages:
-    - 'Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages'
+    - 'ChAngElOg: Internal, Changelog, Improve changelog tool flexibility for commit messages'
 commit_changelog_whitespace:
   commit_log: |
     title: Improve changelog tool flexibility for commit messages (#7000)


### PR DESCRIPTION
## 🛠 Summary of changes

Allows the `changelog:` prefix of the changelog entry to be detected regardless of its capitalization.

See: https://github.com/18F/identity-idp/pull/7711#issuecomment-1406656814

## 📜 Testing Plan

- Observe that the build here passes despite the capitalization of my own changelog
- `rspec spec/scripts/changelog_check_spec.rb`