### PR TITLE
Tweak the FSM and new verify info controllerto work in the 50/50 state

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -61,7 +61,7 @@ module Idv
       if in_person_flow?
         @try_again_path = idv_in_person_path
       else
-        @try_again_path = idv_doc_auth_path
+        @try_again_path = doc_auth_try_again_path
       end
     end
 

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -65,6 +65,14 @@ module Idv
       end
     end
 
+    def doc_auth_try_again_path
+      if IdentityConfig.store.doc_auth_verify_info_controller_enabled
+        idv_verify_info_url
+      else
+        idv_doc_auth_path
+      end
+    end
+
     def in_person_flow?
       params[:flow] == 'in_person'
     end

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -2,7 +2,7 @@ module Idv
   class VerifyInfoController < ApplicationController
     include IdvSession
 
-    before_action :render_404_if_verify_info_controller_disabled
+    # before_action :render_404_if_verify_info_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete
 

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -61,8 +61,6 @@ module Idv
       end
 
       def exit_flow_state_machine
-        mark_step_complete(:verify)
-        mark_step_complete(:verify_wait)
         flow_session[:flow_path] = @flow.flow_path
         redirect_to idv_verify_info_url
       end


### PR DESCRIPTION
This commit makes some changes to ensure that in the 50/50 state the user is sent to the verify info controller and that the old verify info step still works if the users gets there.
