### PR TITLE
Do not allow people to re-enter the verify info step once it is completed

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -4,6 +4,7 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete
+    before_action :confirm_profile_not_already_confirmed
 
     def show
       increment_step_counts
@@ -117,6 +118,11 @@ module Idv
     def confirm_ssn_step_complete
       return if pii.present? && pii[:ssn].present?
       redirect_to idv_doc_auth_url
+    end
+
+    def confirm_profile_not_already_confirmed
+      return unless idv_session.profile_confirmation == true
+      redirect_to idv_review_url
     end
 
     def current_flow_step_counts

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -13,6 +13,8 @@ describe Idv::VerifyInfoController do
 
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
+    user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
+    stub_idv_steps_before_verify_step(user)
   end
 
   describe 'before_actions' do
@@ -44,8 +46,6 @@ describe Idv::VerifyInfoController do
     end
 
     before do
-      user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
-      stub_verify_steps_one_and_two(user)
       stub_analytics
       stub_attempts_tracker
       allow(@analytics).to receive(:track_event)
@@ -75,6 +75,16 @@ describe Idv::VerifyInfoController do
         analytics_args[:step_count] = 2
 
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      context 'when the user has already verified their info' do
+        it 'redirects to the review controller' do
+          controller.idv_session.profile_confirmation = true
+
+          get :show
+
+          expect(response).to redirect_to(idv_review_url)
+        end
       end
 
       context 'when the user is ssn throttled' do
@@ -115,8 +125,6 @@ describe Idv::VerifyInfoController do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
         and_return(true)
-      user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
-      stub_verify_steps_one_and_two(user)
     end
 
     context 'when the user is ssn throttled' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -33,6 +33,25 @@ module ControllerHelper
     allow(controller).to receive(:signed_in_url).and_return(account_url)
   end
 
+  def stub_idv_steps_before_verify_step(user)
+    user_session = {}
+    stub_sign_in(user)
+    idv_session = Idv::Session.new(
+      user_session: user_session, current_user: user,
+      service_provider: nil
+    )
+    idv_session.applicant = {
+      first_name: 'Some',
+      last_name: 'One',
+      uuid: SecureRandom.uuid,
+      dob: 50.years.ago.to_date.to_s,
+      ssn: '666-12-1234',
+    }.with_indifferent_access
+    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:idv_session).and_return(idv_session)
+    allow(subject).to receive(:user_session).and_return(user_session)
+  end
+
   def stub_verify_steps_one_and_two(user)
     user_session = {}
     stub_sign_in(user)


### PR DESCRIPTION
This is a fix for an issue that is a result of an assumption the flow state machine made. It did not allow steps to be re-entrant without using specific "actions" to ensure the state was correct.

This step adds this behavior to the new verify info controller until the actions it can trigger (i.e. change address and update SSN) can be made to work in a re-entrant manner.
