### PR TITLE
Improve OIDC Authorization Performance

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -14,7 +14,7 @@ module OpenidConnect
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
     before_action :store_request, only: [:index]
     before_action :check_sp_active, only: [:index]
-    before_action :apply_secure_headers_override, only: [:index]
+    before_action :secure_headers_override, only: [:index]
     before_action :handle_banned_user
     before_action :confirm_user_is_authenticated_with_fresh_mfa, only: :index
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
@@ -112,6 +112,14 @@ module OpenidConnect
 
     def build_authorize_form_from_params
       @authorize_form = OpenidConnectAuthorizeForm.new(authorization_params)
+    end
+
+    def secure_headers_override
+      csp_uris = SecureHeadersAllowList.csp_with_sp_redirect_uris(
+        @authorize_form.redirect_uri,
+        @authorize_form.service_provider.redirect_uris,
+      )
+      override_form_action_csp(csp_uris)
     end
 
     def authorization_params

--- a/app/models/federated_protocols/oidc.rb
+++ b/app/models/federated_protocols/oidc.rb
@@ -20,6 +20,10 @@ module FederatedProtocols
       OpenidConnectAttributeScoper.new(request.scope).requested_attributes
     end
 
+    def service_provider
+      request.service_provider
+    end
+
     private
 
     attr_reader :request

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -22,6 +22,10 @@ module FederatedProtocols
       ).requested_attributes
     end
 
+    def service_provider
+      current_service_provider
+    end
+
     private
 
     attr_reader :request
@@ -35,7 +39,8 @@ module FederatedProtocols
     end
 
     def current_service_provider
-      ServiceProvider.find_by(issuer: issuer)
+      return @current_service_provider if defined?(@current_service_provider)
+      @current_service_provider = ServiceProvider.find_by(issuer: issuer)
     end
   end
 end

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -15,6 +15,7 @@ class ServiceProviderRequestHandler
 
     StoreSpMetadataInSession.new(session: session, request_id: request_id).call(
       service_provider_request: service_provider_request,
+      requested_service_provider: protocol.service_provider,
     )
   end
 

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -4,8 +4,9 @@ class StoreSpMetadataInSession
     @request_id = request_id
   end
 
-  def call(service_provider_request: nil)
+  def call(service_provider_request: nil, requested_service_provider: nil)
     @sp_request = service_provider_request if service_provider_request
+    @service_provider = requested_service_provider
 
     return if sp_request.is_a?(NullServiceProviderRequest)
 
@@ -62,6 +63,7 @@ class StoreSpMetadataInSession
   end
 
   def service_provider
-    ServiceProvider.find_by(issuer: sp_request.issuer)
+    return @service_provider if defined?(@service_provider)
+    @service_provider = ServiceProvider.find_by(issuer: sp_request.issuer)
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

OIDC and SAML auth are one of the hotter request paths, so we did a bit of work today to find opportunities to speed them up. This PR has two commits to implement two separate refactors. Both try to reduce duplicative work.

https://github.com/18F/identity-idp/commit/114f3d03531b60820b47044f8369e20fb4565ab6 adds a parameter to `StoreSpMetadata` to avoid querying the DB (typically ActiveRecord DB cache) for the `ServiceProvider` that has already been fetched. It also memoizes the `service_provider` method to avoid further queries in the class.

11b6cd2998e5c7e35eb7f376ce30004fc8858c2a is the bigger improvement by avoiding [apply_secure_headers_override](https://github.com/18F/identity-idp/blob/25b78167726a5aa03cd4bb2630d7f39c57cffbaa/app/controllers/concerns/secure_headers_concern.rb#L4-L11) which re-parses the request parameters, re-validates the OIDC form, and hits the database (cache) again. The change brings it closer in line with how [SAML](https://github.com/18F/identity-idp/blob/25b78167726a5aa03cd4bb2630d7f39c57cffbaa/app/controllers/saml_idp_controller.rb#L153-L158) calls `override_form_action_csp` directly with the URIs in the controller.

Together, they improve the speed of the common-case OIDC Authorization Request by ~15%. SAML benefits a little bit as a result of the first commit (~1%).

<details>
<summary>
Performance Test Results
</summary>

OIDC

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

(1.0330 seconds) "skip re-parsing and validating OIDC parameters"
  FASTER 🚀🚀🚀 by:
     1.1898x [older/newer]
    15.9510% [(older - newer) / older * 100]
 (1.2290 seconds) "main"

Iterations per sample: 200
Samples: 200

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.15174271293851463
D max: 0.845

Histograms (time ranges are in seconds):

   description:                                                                        description:
     "skip re-parsing and validating OIDC parameters"                                "main"
              ┌                                        ┐                ┌                                        ┐
   [0.8, 1.0) ┤▇▇▇▇▇▇▇▇▇▇▇ 43                                [0.8, 1.0) ┤ 0
   [1.0, 1.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 137       [1.0, 1.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 57
   [1.2, 1.4) ┤▇▇▇ 11                                        [1.2, 1.4) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 118
   [1.4, 1.6) ┤▇ 4                                           [1.4, 1.6) ┤▇▇▇▇ 12
   [1.6, 1.8) ┤▇ 3                                           [1.6, 1.8) ┤▇▇ 6
   [1.8, 2.0) ┤ 0                                            [1.8, 2.0) ┤▇ 3
   [2.0, 2.2) ┤ 1                                            [2.0, 2.2) ┤ 0
   [2.2, 2.4) ┤ 0                                            [2.2, 2.4) ┤▇ 4
   [2.4, 2.6) ┤ 0                                            [2.4, 2.6) ┤ 0
   [2.6, 2.8) ┤ 0                                            [2.6, 2.8) ┤ 0
   [2.8, 3.0) ┤ 1                                            [2.8, 3.0) ┤ 0
              └                                        ┘                └                                        ┘
                         # of runs in range                                        # of runs in range
```

SAML

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

(2.4706 seconds) "skip re-parsing and validating OIDC parameters" ref: 
  FASTER 🚀🚀🚀 by:
    1.0198x [older/newer]
    1.9391% [(older - newer) / older * 100]
(2.5194 seconds) "main"

Iterations per sample: 200
Samples: 51

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.30049534876137013
D max: 0.3333333333333333

Histograms (time ranges are in seconds):

   description:                                                   description:
     "skip re-parsing and validating OIDC parameters"              "main"
              ┌                                        ┐                ┌                                        ┐
   [2.0, 2.8) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 46       [2.0, 2.8) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 42
   [2.8, 3.6) ┤▇▇▇ 4                                         [2.8, 3.6) ┤▇▇▇▇▇ 6
   [3.5, 4.3) ┤▇ 1                                           [3.5, 4.3) ┤▇▇ 2
   [4.3, 5.1) ┤ 0                                            [4.3, 5.1) ┤ 0
   [5.0, 5.8) ┤ 0                                            [5.0, 5.8) ┤ 0
   [5.8, 6.6) ┤ 0                                            [5.8, 6.6) ┤▇ 1
              └                                        ┘                └                                        ┘
                         # of runs in range                                        # of runs in range
```