### PR TITLE
LG 8742 Throttling feature tests for VerifyInfoController

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -28,7 +28,7 @@ module Idv
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 
-      if ssn_throttle.throttled_else_increment_and_check?
+      if ssn_throttle.throttled_else_increment?
         analytics.throttler_rate_limit_triggered(
           throttle_type: :proof_ssn,
           step_name: 'verify_info',

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -28,7 +28,7 @@ module Idv
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 
-      if ssn_throttle.throttled_else_increment?
+      if ssn_throttle.throttled_else_increment_and_check?
         analytics.throttler_rate_limit_triggered(
           throttle_type: :proof_ssn,
           step_name: 'verify_info',

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -44,16 +44,6 @@ class Throttle
       true
     else
       increment!
-      false
-    end
-  end
-
-  # This is the expected behavior of throttled_else_increment? above
-  def throttled_else_increment_and_check?
-    if throttled?
-      true
-    else
-      increment!
       throttled?
     end
   end

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -48,6 +48,16 @@ class Throttle
     end
   end
 
+  # This is the expected behavior of throttled_else_increment? above
+  def throttled_else_increment_and_check?
+    if throttled?
+      true
+    else
+      increment!
+      throttled?
+    end
+  end
+
   def attempted_at
     return @redis_attempted_at if defined?(@redis_attempted_at)
 

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -150,20 +150,21 @@ feature 'doc auth verify_info step', :js do
       expect(page).to have_current_path(idv_doc_auth_verify_step)
     end
 
-    context 'throttling' do
-      let(:max_attempts) { Throttle.max_attempts(:idv_resolution) }
-
+    context 'resolution throttling' do
+      let(:max_resolution_attempts) { Throttle.max_attempts(:idv_resolution) }
+      # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
       it 'throttles resolution and continues when it expires' do
         expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_ssn_step
         fill_out_ssn_form_with_ssn_that_fails_resolution
         click_idv_continue
-        (max_attempts - 1).times do
+        (max_resolution_attempts - 1).times do
           click_idv_continue
           expect(page).to have_current_path(idv_session_errors_warning_path)
           visit idv_doc_auth_verify_step
         end
+
         click_idv_continue
         expect(page).to have_current_path(idv_session_errors_failure_path)
         expect(fake_analytics).to have_logged_event(
@@ -174,6 +175,49 @@ feature 'doc auth verify_info step', :js do
 
         visit idv_verify_info_url
         expect(page).to have_current_path(idv_session_errors_failure_path)
+
+        travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
+          sign_in_and_2fa_user
+          complete_doc_auth_steps_before_verify_step
+          click_idv_continue
+
+          expect(page).to have_current_path(idv_phone_path)
+        end
+      end
+    end
+
+    context 'ssn throttling' do
+      # Simulates someone trying same SSN with second account
+      let(:max_resolution_attempts) { 5 }
+      let(:max_ssn_attempts) { 4 }
+
+      it 'throttles ssn and continues when it expires' do
+        allow(IdentityConfig.store).to receive(:idv_max_attempts).
+          and_return(max_resolution_attempts)
+
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).
+          and_return(max_ssn_attempts)
+
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_ssn_step
+        fill_out_ssn_form_with_ssn_that_fails_resolution
+        click_idv_continue
+        (max_ssn_attempts - 1).times do
+          click_idv_continue
+          expect(page).to have_current_path(idv_session_errors_warning_path)
+          visit idv_doc_auth_verify_step
+        end
+
+        click_idv_continue
+        expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
+        expect(fake_analytics).to have_logged_event(
+          'Throttler Rate Limit Triggered',
+          throttle_type: :proof_ssn,
+          step_name: 'verify_info',
+        )
+
+        visit idv_verify_info_url
+        expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
 
         travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
           sign_in_and_2fa_user

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -169,6 +169,10 @@ feature 'doc auth verify_info step', :js do
         throttle_type: :idv_resolution,
         step_name: 'Idv::VerifyInfoController',
       )
+
+      visit idv_verify_info_url
+      expect(page).to have_current_path(idv_session_errors_failure_path)
+
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_verify_step

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -127,44 +127,6 @@ RSpec.describe Throttle do
       end
     end
 
-    context 'throttle has not hit limit' do
-      it 'is false' do
-        expect(throttle.throttled_else_increment?).to eq(false)
-      end
-
-      it 'increments the throttle' do
-        expect { throttle.throttled_else_increment? }.to change { throttle.attempts }.by(1)
-      end
-    end
-  end
-
-  describe '#throttled_else_increment_and_check?' do
-    subject(:throttle) { Throttle.new(target: 'aaaa', throttle_type: :idv_doc_auth) }
-
-    context 'throttle has hit limit' do
-      before do
-        (IdentityConfig.store.doc_auth_max_attempts + 1).times do
-          throttle.increment!
-        end
-      end
-
-      it 'is true' do
-        expect(throttle.throttled_else_increment_and_check?).to eq(true)
-      end
-    end
-
-    context 'throttle has not hit limit' do
-      it 'is false' do
-        expect(throttle.throttled_else_increment_and_check?).to eq(false)
-      end
-
-      it 'increments the throttle' do
-        expect { throttle.throttled_else_increment_and_check? }.to change {
-                                                                     throttle.attempts
-                                                                   }.by(1)
-      end
-    end
-
     context 'throttle reaches limit' do
       before do
         (IdentityConfig.store.doc_auth_max_attempts - 1).times do
@@ -174,7 +136,17 @@ RSpec.describe Throttle do
 
       it 'increments the throttle and returns true' do
         expect(throttle.throttled?).to eq(false)
-        expect(throttle.throttled_else_increment_and_check?).to eq(true)
+        expect(throttle.throttled_else_increment?).to eq(true)
+      end
+    end
+
+    context 'throttle has not hit limit' do
+      it 'is false' do
+        expect(throttle.throttled_else_increment?).to eq(false)
+      end
+
+      it 'increments the throttle' do
+        expect { throttle.throttled_else_increment? }.to change { throttle.attempts }.by(1)
       end
     end
   end

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -138,6 +138,47 @@ RSpec.describe Throttle do
     end
   end
 
+  describe '#throttled_else_increment_and_check?' do
+    subject(:throttle) { Throttle.new(target: 'aaaa', throttle_type: :idv_doc_auth) }
+
+    context 'throttle has hit limit' do
+      before do
+        (IdentityConfig.store.doc_auth_max_attempts + 1).times do
+          throttle.increment!
+        end
+      end
+
+      it 'is true' do
+        expect(throttle.throttled_else_increment_and_check?).to eq(true)
+      end
+    end
+
+    context 'throttle has not hit limit' do
+      it 'is false' do
+        expect(throttle.throttled_else_increment_and_check?).to eq(false)
+      end
+
+      it 'increments the throttle' do
+        expect { throttle.throttled_else_increment_and_check? }.to change {
+                                                                     throttle.attempts
+                                                                   }.by(1)
+      end
+    end
+
+    context 'throttle reaches limit' do
+      before do
+        (IdentityConfig.store.doc_auth_max_attempts - 1).times do
+          throttle.increment!
+        end
+      end
+
+      it 'increments the throttle and returns true' do
+        expect(throttle.throttled?).to eq(false)
+        expect(throttle.throttled_else_increment_and_check?).to eq(true)
+      end
+    end
+  end
+
   describe '#expires_at' do
     let(:attempted_at) { nil }
     let(:throttle) { Throttle.new(target: '1', throttle_type: throttle_type) }


### PR DESCRIPTION
## 🎫 Ticket

LG-8742 acceptance tests

## 🛠 Summary of changes

This started as an effort to write a feature test for LG-8742 acceptance, confirming resolution throttling on update. (There are already controller tests.) 
- Add an expect statement to confirm resolution throttling on show action. 
- Add a test to confirm throttling on SSN.
- Fix a bug with analytics for triggering the SSN throttle.
- We still don't have a feature test for checking resolution throttling on update because no user action can trigger that.

Note new Throttle method throttle_else_increment_and_check? which returns true if it was incremented to throttle level, unlike throttle_else_increment? which returns false.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
