### PR TITLE
Deploy RC 248

### DIFF
--- a/app/components/countdown_alert_component.rb
+++ b/app/components/countdown_alert_component.rb
@@ -1,11 +1,18 @@
 class CountdownAlertComponent < BaseComponent
-  attr_reader :show_at_remaining, :alert_options, :countdown_options, :tag_options
+  attr_reader :show_at_remaining, :alert_options, :countdown_options, :redirect_url, :tag_options
 
-  def initialize(show_at_remaining: nil, alert_options: {}, countdown_options: {}, **tag_options)
+  def initialize(
+    show_at_remaining: nil,
+    alert_options: {},
+    countdown_options: {},
+    redirect_url: nil,
+    **tag_options
+  )
     @show_at_remaining = show_at_remaining
     @alert_options = alert_options
     @countdown_options = countdown_options
     @tag_options = tag_options
+    @redirect_url = redirect_url
   end
 
   def call
@@ -15,6 +22,7 @@ class CountdownAlertComponent < BaseComponent
       **tag_options,
       class: css_class,
       'show-at-remaining': show_at_remaining&.in_milliseconds,
+      'redirect-url': redirect_url,
     )
   end
 

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -61,7 +61,15 @@ module Idv
       if in_person_flow?
         @try_again_path = idv_in_person_path
       else
-        @try_again_path = idv_doc_auth_path
+        @try_again_path = doc_auth_try_again_path
+      end
+    end
+
+    def doc_auth_try_again_path
+      if IdentityConfig.store.doc_auth_verify_info_controller_enabled
+        idv_verify_info_url
+      else
+        idv_doc_auth_path
       end
     end
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -2,7 +2,6 @@ module Idv
   class VerifyInfoController < ApplicationController
     include IdvSession
 
-    before_action :render_404_if_verify_info_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete
 
@@ -65,10 +64,6 @@ module Idv
     end
 
     private
-
-    def render_404_if_verify_info_controller_disabled
-      render_not_found unless IdentityConfig.store.doc_auth_verify_info_controller_enabled
-    end
 
     # copied from doc_auth_controller
     def flow_session

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -4,6 +4,7 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete
+    before_action :confirm_profile_not_already_confirmed
 
     def show
       increment_step_counts
@@ -117,6 +118,11 @@ module Idv
     def confirm_ssn_step_complete
       return if pii.present? && pii[:ssn].present?
       redirect_to idv_doc_auth_url
+    end
+
+    def confirm_profile_not_already_confirmed
+      return unless idv_session.profile_confirmation == true
+      redirect_to idv_review_url
     end
 
     def current_flow_step_counts

--- a/app/controllers/two_factor_authentication/otp_expired_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_expired_controller.rb
@@ -1,0 +1,15 @@
+module TwoFactorAuthentication
+  class OtpExpiredController < ApplicationController
+    before_action :confirm_two_factor_authenticated, unless: :user_signed_in?
+
+    def show
+      @otp_delivery_preference = otp_delivery_preference
+    end
+
+    private
+
+    def otp_delivery_preference
+      current_user.otp_delivery_preference
+    end
+  end
+end

--- a/app/javascript/packages/countdown/countdown-alert-element.spec.ts
+++ b/app/javascript/packages/countdown/countdown-alert-element.spec.ts
@@ -5,9 +5,14 @@ import './countdown-element';
 describe('CountdownAlertElement', () => {
   const sandbox = useSandbox({ useFakeTimers: true });
 
-  function createElement({ showAtRemaining }: { showAtRemaining?: number } = {}) {
+  function createElement({
+    showAtRemaining,
+    redirectURL,
+  }: { showAtRemaining?: number; redirectURL?: string } = {}) {
     document.body.innerHTML = `
-      <lg-countdown-alert${showAtRemaining ? ` show-at-remaining="${showAtRemaining}"` : ''}>
+      <lg-countdown-alert
+        ${showAtRemaining ? `show-at-remaining="${showAtRemaining}"` : ''}
+        ${redirectURL ? `redirect-url="${redirectURL}"` : ''}>
         <div class="usa-alert usa-alert--info margin-bottom-4 usa-alert--info-time" role="status">
           <div class="usa-alert__body">
             <p class="usa-alert__text">
@@ -40,5 +45,14 @@ describe('CountdownAlertElement', () => {
       sandbox.clock.tick(1000);
       expect(element.show).to.have.been.called();
     });
+  });
+
+  it('redirects when time has expired', () => {
+    createElement({ redirectURL: '#teapot' });
+
+    sandbox.clock.tick(91000);
+    expect(window.location.hash).to.equal('');
+    sandbox.clock.tick(1000);
+    expect(window.location.hash).to.equal('#teapot');
   });
 });

--- a/app/javascript/packages/countdown/countdown-alert-element.ts
+++ b/app/javascript/packages/countdown/countdown-alert-element.ts
@@ -3,7 +3,11 @@ import type { CountdownElement } from './countdown-element';
 export class CountdownAlertElement extends HTMLElement {
   connectedCallback() {
     if (this.showAtRemaining) {
-      this.addEventListener('lg:countdown:tick', this.handleCountdownTick);
+      this.addEventListener('lg:countdown:tick', this.handleShowAtRemainingTick);
+    }
+
+    if (this.redirectURL) {
+      this.addEventListener('lg:countdown:tick', this.handleRedirectTick);
     }
   }
 
@@ -11,14 +15,25 @@ export class CountdownAlertElement extends HTMLElement {
     return Number(this.getAttribute('show-at-remaining')) || null;
   }
 
+  get redirectURL(): string | null {
+    return this.getAttribute('redirect-url') || null;
+  }
+
   get countdown(): CountdownElement {
     return this.querySelector('lg-countdown')!;
   }
 
-  handleCountdownTick = () => {
+  handleShowAtRemainingTick = () => {
     if (this.countdown.timeRemaining <= this.showAtRemaining!) {
       this.show();
-      this.removeEventListener('lg:countdown:tick', this.handleCountdownTick);
+      this.removeEventListener('lg:countdown:tick', this.handleShowAtRemainingTick);
+    }
+  };
+
+  handleRedirectTick = () => {
+    if (this.countdown.timeRemaining <= 0) {
+      window.location.href = this.redirectURL!;
+      this.removeEventListener('lg:countdown:tick', this.handleRedirectTick);
     }
   };
 

--- a/app/javascript/packages/document-capture/components/address-search.tsx
+++ b/app/javascript/packages/document-capture/components/address-search.tsx
@@ -111,10 +111,8 @@ function useUspsLocations() {
   }, []);
 
   // sends the raw text query to arcgis
-  const { data: addressCandidates, isLoading: isLoadingCandidates } = useSWR(
-    [addressQuery],
-    () => (addressQuery ? requestAddressCandidates(addressQuery) : null),
-    { keepPreviousData: true },
+  const { data: addressCandidates, isLoading: isLoadingCandidates } = useSWR([addressQuery], () =>
+    addressQuery ? requestAddressCandidates(addressQuery) : null,
   );
 
   // sets the arcgis-validated address object
@@ -143,9 +141,7 @@ function useUspsLocations() {
     data: locationResults,
     isLoading: isLoadingLocations,
     error,
-  } = useSWR([foundAddress], ([address]) => (address ? requestUspsLocations(address) : null), {
-    keepPreviousData: true,
-  });
+  } = useSWR([foundAddress], ([address]) => (address ? requestUspsLocations(address) : null));
 
   return {
     foundAddress,

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -27,6 +27,10 @@ interface DocumentCaptureTroubleshootingOptionsProps {
    * Whether to display alternative options for verifying.
    */
   showAlternativeProofingOptions?: boolean;
+
+  altInPersonCta?: string;
+  altInPersonPrompt?: string;
+  altInPersonCtaButtonText?: string;
 }
 
 function DocumentCaptureTroubleshootingOptions({
@@ -34,6 +38,9 @@ function DocumentCaptureTroubleshootingOptions({
   location = 'document_capture_troubleshooting_options',
   showDocumentTips = true,
   showAlternativeProofingOptions,
+  altInPersonCta,
+  altInPersonPrompt,
+  altInPersonCtaButtonText,
 }: DocumentCaptureTroubleshootingOptionsProps) {
   const { t } = useI18n();
   const { inPersonURL } = useContext(InPersonContext);
@@ -42,7 +49,13 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
-      {showAlternativeProofingOptions && inPersonURL && <InPersonCallToAction />}
+      {showAlternativeProofingOptions && inPersonURL && (
+        <InPersonCallToAction
+          altHeading={altInPersonCta}
+          altPrompt={altInPersonPrompt}
+          altButtonText={altInPersonCtaButtonText}
+        />
+      )}
       <TroubleshootingOptions
         heading={heading}
         options={

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.spec.tsx
@@ -1,18 +1,15 @@
 import sinon from 'sinon';
+import { computeAccessibleName } from 'dom-accessibility-api';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { computeAccessibleDescription } from 'dom-accessibility-api';
 import { AnalyticsContextProvider } from '../context/analytics';
 import InPersonCallToAction from './in-person-call-to-action';
 
 describe('InPersonCallToAction', () => {
-  it('renders a section with label and description', () => {
+  it('renders a section with an accessible heading', () => {
     const { getByRole } = render(<InPersonCallToAction />);
-
-    const section = getByRole('region', { name: 'in_person_proofing.headings.cta' });
-    const description = computeAccessibleDescription(section);
-
-    expect(description).to.equal('in_person_proofing.body.cta.new_feature');
+    const heading = getByRole('heading');
+    expect(computeAccessibleName(heading)).to.equals('in_person_proofing.headings.cta');
   });
 
   it('logs an event when clicking the call to action button', async () => {

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -1,10 +1,16 @@
 import { useContext } from 'react';
-import { Button, Tag } from '@18f/identity-components';
+import { Button } from '@18f/identity-components';
 import { useInstanceId } from '@18f/identity-react-hooks';
 import { t } from '@18f/identity-i18n';
 import AnalyticsContext from '../context/analytics';
 
-function InPersonCallToAction() {
+interface InPersonCallToActionProps {
+  altHeading?: string;
+  altPrompt?: string;
+  altButtonText?: string;
+}
+
+function InPersonCallToAction({ altHeading, altPrompt, altButtonText }: InPersonCallToActionProps) {
   const instanceId = useInstanceId();
   const { trackEvent } = useContext(AnalyticsContext);
 
@@ -14,13 +20,10 @@ function InPersonCallToAction() {
       aria-describedby={`in-person-cta-tag-${instanceId}`}
     >
       <hr className="margin-y-5" />
-      <Tag id={`in-person-cta-tag-${instanceId}`} isInformative>
-        {t('in_person_proofing.body.cta.new_feature')}
-      </Tag>
       <h2 id={`in-person-cta-heading-${instanceId}`} className="margin-y-2">
-        {t('in_person_proofing.headings.cta')}
+        {altHeading || t('in_person_proofing.headings.cta')}
       </h2>
-      <p>{t('in_person_proofing.body.cta.prompt_detail')}</p>
+      <p>{altPrompt || t('in_person_proofing.body.cta.prompt_detail')}</p>
       <Button
         isBig
         isOutline
@@ -29,7 +32,7 @@ function InPersonCallToAction() {
         className="margin-top-3 margin-bottom-1"
         onClick={() => trackEvent('IdV: verify in person troubleshooting option clicked')}
       >
-        {t('in_person_proofing.body.cta.button')}
+        {altButtonText || t('in_person_proofing.body.cta.button')}
       </Button>
     </section>
   );

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import type { SetupServerApi } from 'msw/node';
+import { SWRConfig } from 'swr';
 import { LOCATIONS_URL } from './in-person-location-step';
 import { ADDRESS_SEARCH_URL } from './address-search';
 import InPersonContext from '../context/in-person';
@@ -30,25 +31,36 @@ const DEFAULT_PROPS = {
 };
 
 describe('InPersonLocationStep', () => {
+  let server: SetupServerApi;
+
+  before(() => {
+    server = setupServer();
+    server.listen();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+  });
+
   context('initial API request throws an error', () => {
-    let server: SetupServerApi;
     beforeEach(() => {
-      server = setupServer(
+      server.use(
         rest.post(ADDRESS_SEARCH_URL, (_req, res, ctx) => res(ctx.json(DEFAULT_RESPONSE))),
         rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.status(500))),
       );
-      server.listen();
-    });
-
-    afterEach(() => {
-      server.close();
     });
 
     it('displays a 500 error if the request to the USPS API throws an error', async () => {
       const { findByText, findByLabelText } = render(
-        <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </InPersonContext.Provider>,
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
       );
 
       await userEvent.type(
@@ -66,25 +78,25 @@ describe('InPersonLocationStep', () => {
   });
 
   context('initial API request is successful', () => {
-    let server: SetupServerApi;
     beforeEach(() => {
-      server = setupServer(
-        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json([{ name: 'Baltimore' }]))),
+      server.use(
         rest.post(ADDRESS_SEARCH_URL, (_req, res, ctx) => res(ctx.json(DEFAULT_RESPONSE))),
+        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json([{ name: 'Baltimore' }]))),
       );
-      server.listen();
-    });
-
-    afterEach(() => {
-      server.close();
     });
 
     it('allows search by address when enabled', async () => {
-      const { findByText, findByLabelText } = render(
-        <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </InPersonContext.Provider>,
+      const { findAllByText, findByText, findByLabelText, queryAllByText } = render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
       );
+
+      const results = queryAllByText('in_person_proofing.body.location.location_button');
+
+      expect(results).to.be.empty();
 
       await userEvent.type(
         await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
@@ -93,14 +105,16 @@ describe('InPersonLocationStep', () => {
       await userEvent.click(
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
-      await findByText('in_person_proofing.body.location.po_search.results_description');
+      await findAllByText('in_person_proofing.body.location.location_button');
     });
 
     it('validates input and shows inline error', async () => {
       const { findByText } = render(
-        <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </InPersonContext.Provider>,
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
       );
 
       await userEvent.click(
@@ -112,9 +126,11 @@ describe('InPersonLocationStep', () => {
 
     it('displays no post office results if a successful search is followed by an unsuccessful search', async () => {
       const { findByText, findByLabelText, queryByRole } = render(
-        <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </InPersonContext.Provider>,
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
       );
 
       await userEvent.type(
@@ -134,16 +150,18 @@ describe('InPersonLocationStep', () => {
       );
 
       const results = queryByRole('status', {
-        name: 'in_person_proofing.body.location.po_search.results_description',
+        name: 'in_person_proofing.body.location.location_button',
       });
       expect(results).not.to.exist();
     });
 
     it('clicking search again after first results do not clear results', async () => {
-      const { findByText, findByLabelText } = render(
-        <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </InPersonContext.Provider>,
+      const { findAllByText, findByText, findByLabelText } = render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
       );
 
       await userEvent.type(
@@ -156,7 +174,69 @@ describe('InPersonLocationStep', () => {
       await userEvent.click(
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
-      await findByText('in_person_proofing.body.location.po_search.results_description');
+      await findAllByText('in_person_proofing.body.location.location_button');
+    });
+  });
+
+  context('subsequent network failures clear results', () => {
+    beforeEach(() => {
+      server.use(
+        rest.post(ADDRESS_SEARCH_URL, (_req, res, ctx) => res(ctx.json(DEFAULT_RESPONSE))),
+        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json([{ name: 'Baltimore' }]))),
+      );
+    });
+
+    it('subsequent failure clears previous results', async () => {
+      const { findAllByText, findByText, findByLabelText, queryAllByText } = render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <InPersonContext.Provider value={{ arcgisSearchEnabled: true }}>
+            <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
+          </InPersonContext.Provider>
+        </SWRConfig>,
+      );
+
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
+        '400 main',
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+      const result = await findAllByText('in_person_proofing.body.location.location_button');
+
+      expect(result).to.exist();
+
+      server.use(
+        rest.post(ADDRESS_SEARCH_URL, (_req, res, ctx) =>
+          res(
+            ctx.json([
+              {
+                address: '500 Main St E, Bronwood, Georgia, 39826',
+                location: {
+                  latitude: 31.831686000000005,
+                  longitude: -84.363768,
+                },
+                street_address: '500 Main St E',
+                city: 'Bronwood',
+                state: 'GA',
+                zip_code: '39826',
+              },
+            ]),
+          ),
+        ),
+        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.status(500))),
+      );
+
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
+        '500 main',
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+      const moreResults = await queryAllByText('in_person_proofing.body.location.location_button');
+
+      expect(moreResults).to.be.empty();
     });
   });
 });

--- a/app/javascript/packages/document-capture/components/warning.tsx
+++ b/app/javascript/packages/document-capture/components/warning.tsx
@@ -21,6 +21,21 @@ interface WarningProps {
   actionOnClick?: () => void;
 
   /**
+   * Secondary action button text.
+   */
+  altActionText?: string;
+
+  /**
+   * Secondary action button text.
+   */
+  altActionOnClick?: () => void;
+
+  /**
+   * Secondary action button location.
+   */
+  altHref?: string;
+
+  /**
    * Component children.
    */
   children: ReactNode;
@@ -45,6 +60,9 @@ function Warning({
   heading,
   actionText,
   actionOnClick,
+  altActionText,
+  altActionOnClick,
+  altHref,
   children,
   troubleshootingOptions,
   location,
@@ -69,6 +87,22 @@ function Warning({
         {actionText}
       </Button>,
     ];
+    if (altActionText && altActionOnClick) {
+      actionButtons.push(
+        <Button
+          isBig
+          isOutline
+          isWide
+          href={altHref}
+          onClick={() => {
+            trackEvent('IdV: warning action triggered', { location });
+            altActionOnClick();
+          }}
+        >
+          {altActionText}
+        </Button>,
+      );
+    }
   }
 
   return (

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -7,6 +7,16 @@ export interface InPersonContextProps {
   arcgisSearchEnabled?: boolean;
 
   /**
+   * Whether or not A/B testing of the in-person proofing CTA is enabled.
+   */
+  inPersonCtaVariantTestingEnabled?: boolean;
+
+  /**
+   * The specific A/B testing variant that was activated for the current user session.
+   */
+  inPersonCtaVariantActive?: string;
+
+  /**
    * URL to in-person proofing alternative flow, if enabled.
    */
   inPersonURL?: string;
@@ -14,6 +24,8 @@ export interface InPersonContextProps {
 
 const InPersonContext = createContext<InPersonContextProps>({
   arcgisSearchEnabled: false,
+  inPersonCtaVariantTestingEnabled: false,
+  inPersonCtaVariantActive: '',
 });
 
 InPersonContext.displayName = 'InPersonContext';

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -32,6 +32,8 @@ interface AppRootData {
   cancelUrl: string;
   idvInPersonUrl?: string;
   securityAndPrivacyHowItWorksUrl: string;
+  inPersonCtaVariantTestingEnabled: boolean;
+  inPersonCtaVariantActive: string;
 }
 
 const appRoot = document.getElementById('document-capture-form')!;
@@ -119,6 +121,8 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
     idvInPersonUrl: inPersonURL,
     securityAndPrivacyHowItWorksUrl: securityAndPrivacyHowItWorksURL,
     arcgisSearchEnabled,
+    inPersonCtaVariantTestingEnabled,
+    inPersonCtaVariantActive,
   } = appRoot.dataset as DOMStringMap & AppRootData;
 
   const App = composeComponents(
@@ -170,7 +174,14 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
     ],
     [
       InPersonContext.Provider,
-      { value: { arcgisSearchEnabled: arcgisSearchEnabled === 'true', inPersonURL } },
+      {
+        value: {
+          arcgisSearchEnabled: arcgisSearchEnabled === 'true',
+          inPersonCtaVariantTestingEnabled: inPersonCtaVariantTestingEnabled === true,
+          inPersonCtaVariantActive,
+          inPersonURL,
+        },
+      },
     ],
     [DocumentCapture, { isAsyncForm, onStepChange: keepAlive }],
   );

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -29,7 +29,11 @@ module Idv
             image_type: 'back',
             transaction_id: flow_session[:document_capture_session_uuid],
           ),
-        }.merge(native_camera_ab_testing_variables, acuant_sdk_upgrade_a_b_testing_variables)
+        }.merge(
+          native_camera_ab_testing_variables,
+          acuant_sdk_upgrade_a_b_testing_variables,
+          in_person_cta_variant_testing_variables,
+        )
       end
 
       private
@@ -55,6 +59,15 @@ module Idv
               testing_enabled,
           use_alternate_sdk: use_alternate_sdk,
           acuant_version: acuant_version,
+        }
+      end
+
+      def in_person_cta_variant_testing_variables
+        bucket = AbTests::IN_PERSON_CTA.bucket(flow_session[:document_capture_session_uuid])
+        {
+          in_person_cta_variant_testing_enabled:
+          IdentityConfig.store.in_person_cta_variant_testing_enabled,
+          in_person_cta_variant_active: bucket,
         }
       end
 

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -61,8 +61,6 @@ module Idv
       end
 
       def exit_flow_state_machine
-        mark_step_complete(:verify)
-        mark_step_complete(:verify_wait)
         flow_session[:flow_path] = @flow.flow_path
         redirect_to idv_verify_info_url
       end

--- a/app/views/idv/capture_doc/document_capture.html.erb
+++ b/app/views/idv/capture_doc/document_capture.html.erb
@@ -9,4 +9,6 @@
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      in_person_cta_variant_testing_enabled: in_person_cta_variant_testing_enabled,
+      in_person_cta_variant_active: in_person_cta_variant_active,
     ) %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -9,4 +9,6 @@
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      in_person_cta_variant_testing_enabled: in_person_cta_variant_testing_enabled,
+      in_person_cta_variant_active: in_person_cta_variant_active,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -44,6 +44,8 @@
       idv_in_person_url: Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,
       arcgis_search_enabled: IdentityConfig.store.arcgis_search_enabled,
+      in_person_cta_variant_testing_enabled: IdentityConfig.store.in_person_cta_variant_testing_enabled,
+      in_person_cta_variant_active: in_person_cta_variant_active,
     } %>
   <%= simple_form_for(
         :doc_auth,

--- a/app/views/two_factor_authentication/otp_expired/show.html.erb
+++ b/app/views/two_factor_authentication/otp_expired/show.html.erb
@@ -1,0 +1,35 @@
+<% title t('titles.otp_expired') %>
+
+<%= render AlertIconComponent.new(icon_name: :error, class: 'display-block margin-bottom-4') %>
+<%= render PageHeadingComponent.new.with_content(t('headings.otp_expired')) %>
+
+  <%= render ButtonComponent.new(
+        action: ->(**tag_options, &block) do
+          link_to(
+            otp_send_path(
+              otp_delivery_selection_form: {
+                otp_delivery_preference: @otp_delivery_preference,
+                resend: true,
+              },
+            ),
+            **tag_options,
+            &block
+          )
+        end,
+        big: true,
+        wide: true,
+        class: 'margin-top-3 margin-bottom-1',
+      ).with_content(t('links.two_factor_authentication.try_again')) %>
+
+<%= render(
+      'shared/troubleshooting_options',
+      heading_tag: :h2,
+      heading: t('components.troubleshooting_options.default_heading'),
+      options: [
+        {
+          url: MarketingSite.contact_url,
+          text: t('links.contact_support', app_name: APP_NAME),
+          new_tab: true,
+        },
+      ],
+    ) %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -9,6 +9,7 @@
 <% if @presenter.otp_expiration.present? %>
   <%= render CountdownAlertComponent.new(
         show_at_remaining: IdentityConfig.store.otp_expiration_warning_seconds.seconds,
+        redirect_url: login_two_factor_otp_expired_path,
         alert_options: { class: 'margin-bottom-4' },
         countdown_options: { expiration: @presenter.otp_expiration },
       ) %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -127,7 +127,7 @@ idv_send_link_max_attempts: 5
 ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
 in_person_cta_variant_testing_enabled: true
-in_person_cta_variant_testing_percents: '{"A":50, "B":50}'
+in_person_cta_variant_testing_percents: '{"A":12.5, "B":12.5, "C":75}'
 in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -126,6 +126,8 @@ idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
+in_person_cta_variant_testing_enabled: true
+in_person_cta_variant_testing_percents: '{"A":50, "B":50}'
 in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -99,6 +99,12 @@ ignore_unused:
   - 'errors.messages.*'
   - 'simple_form.*'
   - 'time.*'
+  - 'idv.failure.attempts.one'
+  - 'idv.failure.attempts.one_variant_a_html'
+  - 'idv.failure.attempts.one_variant_b_html'
+  - 'idv.failure.attempts.other'
+  - 'idv.failure.attempts.other_variant_a_html'
+  - 'idv.failure.attempts.other_variant_b_html'
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -18,4 +18,25 @@ module AbTests
         0,
     },
   )
+
+  def self.in_person_cta_variant_testing_buckets
+    buckets = Hash.new
+    percents = IdentityConfig.store.in_person_cta_variant_testing_percents
+    if IdentityConfig.store.in_person_cta_variant_testing_enabled
+      percents.each do |variant, rate|
+        bucket_name = 'in_person_variant_' + variant.to_s.downcase
+        buckets[bucket_name.to_sym] = rate
+      end
+    else
+      buckets['in_person_variant_a'] = 100
+    end
+
+    buckets
+  end
+
+  IN_PERSON_CTA = AbTestBucket.new(
+    experiment_name: 'In-Person Proofing CTA',
+    buckets: in_person_cta_variant_testing_buckets,
+    default_bucket: 'in_person_variant_a',
+  )
 end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -29,6 +29,7 @@ en:
       send_link_throttle: You tried too many times, please try again in %{timeout}.
         You can also go back and choose to use your computer instead.
       throttled_heading: We could not verify your ID
+      throttled_subheading: Try taking new pictures
       throttled_text_html: '<strong>Please try again in %{timeout}.</strong> For your
         security, we limit the number of times you can attempt to verify a
         document online.'

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -30,6 +30,7 @@ es:
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
       throttled_heading: No pudimos verificar la identificación
+      throttled_subheading: Intente tomar nuevas fotografías.
       throttled_text_html: '<strong>Por favor, inténtelo de nuevo en
         %{timeout}.</strong> Por su seguridad, limitamos el número de veces que
         puede intentar verificar un documento en línea.'

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -34,6 +34,7 @@ fr:
         %{timeout}. Vous pouvez également revenir en arrière et choisir
         d’utiliser votre ordinateur à la place.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
+      throttled_subheading: Essayez de prendre de nouvelles photos.
       throttled_text_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
         votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de
         vérifier un document en ligne.'

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -29,6 +29,7 @@ en:
     edit_info:
       password: Change your password
       phone: Manage your phone settings
+    otp_expired: Your one-time code has expired
     passwords:
       change: Change your password
       confirm: Confirm your current password to continue

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -29,6 +29,7 @@ es:
     edit_info:
       password: Cambie su contraseña
       phone: Administrar la configuración de su teléfono
+    otp_expired: Su código único ha expirado
     passwords:
       change: Cambie su contraseña
       confirm: Confirme la contraseña actual para continuar

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -29,6 +29,7 @@ fr:
     edit_info:
       password: Changez votre mot de passe
       phone: Administrer les paramètres de votre téléphone
+    otp_expired: Votre code à usage unique a expiré
     passwords:
       change: Changez votre mot de passe
       confirm: Confirmez votre mot de passe actuel pour continuer

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -55,10 +55,20 @@ en:
         zipcode: Enter a 5 or 9 digit ZIP Code
     failure:
       attempts:
-        one: For security reasons, you have one attempt remaining.
-        other: For security reasons, you have %{count} attempts remaining.
+        one: For security reasons, you have one attempt remaining to add your ID online.
+        one_variant_a_html: For security reasons, you have <strong>one attempt<strong>
+          remaining to add your ID online.
+        one_variant_b_html: Try taking new pictures. For security reasons, you have
+          <strong>one attempt<strong> remaining to add your ID online.
+        other: For security reasons, you have %{count} attempts remaining to add your ID
+          online.
+        other_variant_a_html: For security reasons, you have <strong>%{count}
+          attempts<strong> remaining to add your ID online.
+        other_variant_b_html: Try taking new pictures. For security reasons, you have
+          <strong>%{count} attempts<strong> remaining to add your ID online.
       button:
         warning: Try again
+        warning_variant: Try again online
       exceptions:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -56,10 +56,23 @@ es:
         zipcode: Ingresa un código postal de 5 o 9 dígitos
     failure:
       attempts:
-        one: Por razones de seguridad, le queda un intento.
-        other: Por razones de seguridad, le queda %{count} intentos.
+        one: Por motivos de seguridad, le quedan un intento para añadir su documento de
+          identidad en línea.
+        one_variant_a_html: Por motivos de seguridad, le quedan <strong>un
+          intento</strong> para añadir su documento de identidad en línea.
+        one_variant_b_html: Intente tomar nuevas fotografías. Por motivos de seguridad,
+          le quedan <strong>un intento</strong> para añadir su documento de
+          identidad en línea.
+        other: Por motivos de seguridad, le quedan %{count} intentos para añadir su
+          documento de identidad en línea.
+        other_variant_a_html: Por motivos de seguridad, le quedan <strong>%{count}
+          intentos</strong> para añadir su documento de identidad en línea.
+        other_variant_b_html: Intente tomar nuevas fotografías. Por motivos de
+          seguridad, le quedan <strong>%{count} intentos</strong> para añadir su
+          documento de identidad en línea.
       button:
         warning: Inténtelo de nuevo
+        warning_variant: Vuelva a intentarlo en línea
       exceptions:
         internal_error: Se produjo un error interno al procesar tu solicitud. Por favor,
           inténtalo de nuevo.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -59,10 +59,24 @@ fr:
         zipcode: Entrez un code postal à 5 ou 9 chiffres
     failure:
       attempts:
-        one: Pour des raisons de sécurité, il vous reste une tentative.
-        other: Pour des raisons de sécurité, il vous reste %{count} tentatives.
+        one: Pour des raisons de sécurité, il vous reste une tentative pour ajouter
+          votre pièce d’identité en ligne.
+        one_variant_a_html: Pour des raisons de sécurité, il vous reste <strong>une
+          tentative</strong> pour ajouter votre pièce d’identité en ligne.
+        one_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons de
+          sécurité, il vous reste <strong>une tentative</strong> pour ajouter
+          votre pièce d’identité en ligne.
+        other: Pour des raisons de sécurité, il vous reste %{count} tentatives pour
+          ajouter votre pièce d’identité en ligne.
+        other_variant_a_html: Pour des raisons de sécurité, il vous reste
+          <strong>%{count} tentatives</strong> pour ajouter votre pièce
+          d’identité en ligne.
+        other_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons
+          de sécurité, il vous reste <strong>%{count} tentatives</strong> pour
+          ajouter votre pièce d’identité en ligne.
       button:
         warning: Essayez à nouveau
+        warning_variant: Réessayer en ligne
       exceptions:
         internal_error: Une erreur interne s’est produite lors du traitement de votre
           demande. Veuillez réessayer.

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -27,10 +27,14 @@ en:
           to verify your identity. No appointment is required.
       cta:
         button: Verify your ID in person
-        new_feature: New Feature
+        button_variant: Try in person
         prompt_detail: If you are located near Washington, D.C. or Baltimore, MD, you
           may be able to verify your ID in person at limited post office
           locations.
+        prompt_detail_a: You may be able to verify your ID in person at a participating
+          Post Office near you.
+        prompt_detail_b: Alternatively, if you are having trouble adding your ID online,
+          you may be able to try in person at limited post office locations.
       location:
         contact_info_heading: Contact Information
         distance:
@@ -110,6 +114,7 @@ en:
       address: Enter your current address
       barcode: You’re ready to verify your identity in person
       cta: Having trouble verifying your ID online?
+      cta_variant: Try verifying your ID in person
       location: Select a location to verify your ID
       po_search:
         location: Find a participating Post Office

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -48,7 +48,7 @@ en:
         none_found: No locations found.
         phone: 'Phone:'
         po_search:
-          address_search_hint: 'Example: 1960 W Chelsea Ave Allentown PA 18104'
+          address_search_hint: 'Example: 1234 N Example St., Allentown, PA 12345'
           address_search_label: Enter an address to find a Post Office near you
           is_searching_message: Searching for Post Office locations…
           none_found: Sorry, there are no participating Post Offices within 50 miles of

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -51,7 +51,7 @@ es:
         none_found: No se encontraron localidades.
         phone: 'Telefono:'
         po_search:
-          address_search_hint: 'Ejemplo: 1960 W Chelsea Ave Allentown PA 18104'
+          address_search_hint: 'Ejemplo: 1234 N Example St., Allentown, PA 12345'
           address_search_label: Introduzca una dirección para encontrar una Oficina de
             Correos cercana a usted
           is_searching_message: Buscando oficinas de correos…

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -30,10 +30,14 @@ es:
           empleado en ventanilla. No es necesario pedir cita.
       cta:
         button: Verifique su identificación en persona
-        new_feature: Nuevo artículo
+        button_variant: Inténtelo en persona
         prompt_detail: Si usted está ubicado cerca de Washington, D.C. o Baltimore, MD,
           puede verificar su identificación en persona en las oficinas de
           correos seleccionadas.
+        prompt_detail_a: Es posible que pueda verificar su documento de identidad en
+          persona en una oficina de correos participante cercana.
+        prompt_detail_b: Si tiene problemas para añadir su documento de identidad en
+          línea, puede intentarlo en persona en algunas oficinas de correos.
       location:
         contact_info_heading: Información del contacto
         distance:
@@ -120,6 +124,7 @@ es:
       address: Ingrese su dirección actual
       barcode: Está listo para verificar su identidad en persona
       cta: ¿Tiene problemas para verificar su documento de identidad en línea?
+      cta_variant: Intente verificar su ID en persona
       location: Seleccione un lugar para verificar su cédula
       po_search:
         location: Encuentre una oficina de correos participante

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -53,7 +53,7 @@ fr:
         none_found: Aucun endroit trouvé.
         phone: 'Téléphone:'
         po_search:
-          address_search_hint: 'Exemple : 1960 W Chelsea Ave Allentown PA 18104'
+          address_search_hint: 'Exemple : 1234 N Example St., Allentown, PA 12345'
           address_search_label: Entrez une adresse pour trouver un bureau de poste près de chez vous.
           is_searching_message: Recherche des emplacements de bureau de poste…
           none_found: Désolé, il n’y a pas de bureaux de poste participants dans un rayon

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -31,10 +31,15 @@ fr:
           au détail pour vérifier votre identité. Aucun rendez-vous n’est exigé.
       cta:
         button: Vérifiez votre identité en personne
-        new_feature: Nouvelle fonctionnalité
+        button_variant: Essayer en personne
         prompt_detail: Si vous êtes situé près de Washington, D.C. ou de Baltimore
           (Maryland), vous pourrez peut-être vérifier votre identité en personne
           dans certains bureaux de poste.
+        prompt_detail_a: Vous pourrez peut-être faire vérifier votre pièce d’identité en
+          personne dans un bureau de poste participant près de chez vous.
+        prompt_detail_b: Ou, si vous rencontrez des difficultés pour ajouter votre pièce
+          d’identité en ligne, vous pourrez peut-être essayer de le faire en
+          personne dans certains bureaux de poste.
       location:
         contact_info_heading: Information de contact
         distance:
@@ -121,6 +126,7 @@ fr:
       address: Entrez votre adresse actuelle
       barcode: Vous êtes prêt à vérifier votre identité en personne
       cta: Vous avez des difficultés à vérifier votre identité en ligne?
+      cta_variant: Essayez de vérifier votre identité en personne
       location: Sélectionnez un lieu pour vérifier votre identité
       po_search:
         location: Trouver un bureau de poste participant

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -24,4 +24,5 @@ en:
     sign_out: Sign out
     two_factor_authentication:
       send_another_code: Send another code
+      try_again: Try again
     what_is_totp: What is an authentication app?

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -24,4 +24,5 @@ es:
     sign_out: Cerrar sesión
     two_factor_authentication:
       send_another_code: Enviar otro código
+      try_again: Inténtelo de nuevo
     what_is_totp: '¿Qué es una app de autenticación?'

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -24,4 +24,5 @@ fr:
     sign_out: Déconnexion
     two_factor_authentication:
       send_another_code: Envoyer un autre code
+      try_again: Réessayez
     what_is_totp: Qu’est-ce qu’une application d’authentification?

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -52,6 +52,7 @@ en:
     openid_connect:
       authorization: OpenID Connect Authorization
       logout: OpenID Connect Logout
+    otp_expired: Your one-time code has expired
     passwords:
       change: Change the password for your account
       confirm: Confirm the password for your account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -52,6 +52,7 @@ es:
     openid_connect:
       authorization: Autorización de OpenID Connect
       logout: Cierre de sesión de OpenID Connect
+    otp_expired: Su código único ha expirado
     passwords:
       change: Cambie la contraseña de su cuenta
       confirm: Confirme la contraseña de su cuenta

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -52,6 +52,7 @@ fr:
     openid_connect:
       authorization: Autorisation OpenID Connect
       logout: Déconnexion OpenID Connect
+    otp_expired: Votre code à usage unique a expiré
     passwords:
       change: Changez le mot de passe de votre compte
       confirm: Confirmez le mot de passe de votre compte

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
       get '/login/two_factor/sms/:opt_out_uuid/opt_in' => 'two_factor_authentication/sms_opt_in#new',
           as: :login_two_factor_sms_opt_in
       post '/login/two_factor/sms/:opt_out_uuid/opt_in' => 'two_factor_authentication/sms_opt_in#create'
+      get '/login/two_factor/otp_expired' => 'two_factor_authentication/otp_expired#show'
 
       get 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#prompt'
       post 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#decline'

--- a/lib/ab_test_bucket.rb
+++ b/lib/ab_test_bucket.rb
@@ -1,16 +1,17 @@
 class AbTestBucket
-  attr_reader :buckets, :experiment_name
+  attr_reader :buckets, :experiment_name, :default_bucket
 
-  def initialize(experiment_name:, buckets: {})
+  def initialize(experiment_name:, buckets: {}, default_bucket: :default)
     @buckets = buckets
     @experiment_name = experiment_name
+    @default_bucket = default_bucket
     raise 'invalid bucket data structure' unless valid_bucket_data_structure?
     ensure_numeric_percentages
     raise 'bucket percentages exceed 100' unless within_100_percent?
   end
 
   def bucket(discriminator = nil)
-    return :default if discriminator.blank?
+    return @default_bucket if discriminator.blank?
 
     user_value = percent(discriminator)
 
@@ -21,7 +22,7 @@ class AbTestBucket
       min = max
     end
 
-    :default
+    @default_bucket
   end
 
   private

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -205,6 +205,8 @@ class IdentityConfig
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
     config.add(:ie11_support_end_date, type: :timestamp)
+    config.add(:in_person_cta_variant_testing_enabled, type: :boolean)
+    config.add(:in_person_cta_variant_testing_percents, type: :json)
     config.add(:in_person_email_reminder_early_benchmark_in_days, type: :integer)
     config.add(:in_person_email_reminder_final_benchmark_in_days, type: :integer)
     config.add(:in_person_email_reminder_late_benchmark_in_days, type: :integer)

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?[cC]hangelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}
+  %r{^(?:\* )?changelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
 CATEGORIES = [
   'User-Facing Improvements',
   'Improvements', # Temporary for transitional period

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -16,13 +16,6 @@ describe Idv::VerifyInfoController do
   end
 
   describe 'before_actions' do
-    it 'checks that feature flag is enabled' do
-      expect(subject).to have_actions(
-        :before,
-        :render_404_if_verify_info_controller_disabled,
-      )
-    end
-
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
         :before,
@@ -114,19 +107,6 @@ describe Idv::VerifyInfoController do
 
           expect(response).to redirect_to idv_session_errors_failure_url
         end
-      end
-    end
-
-    context 'when doc_auth_verify_info_controller_enabled is false' do
-      before do
-        allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
-          and_return(false)
-      end
-
-      it 'returns 404' do
-        get :show
-
-        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -13,6 +13,8 @@ describe Idv::VerifyInfoController do
 
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
+    user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
+    stub_idv_steps_before_verify_step(user)
   end
 
   describe 'before_actions' do
@@ -44,8 +46,6 @@ describe Idv::VerifyInfoController do
     end
 
     before do
-      user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
-      stub_verify_steps_one_and_two(user)
       stub_analytics
       stub_attempts_tracker
       allow(@analytics).to receive(:track_event)
@@ -75,6 +75,16 @@ describe Idv::VerifyInfoController do
         analytics_args[:step_count] = 2
 
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      context 'when the user has already verified their info' do
+        it 'redirects to the review controller' do
+          controller.idv_session.profile_confirmation = true
+
+          get :show
+
+          expect(response).to redirect_to(idv_review_url)
+        end
       end
 
       context 'when the user is ssn throttled' do
@@ -115,8 +125,6 @@ describe Idv::VerifyInfoController do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
         and_return(true)
-      user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
-      stub_verify_steps_one_and_two(user)
     end
 
     context 'when the user is ssn throttled' do

--- a/spec/controllers/two_factor_authentication/otp_expired_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_expired_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe TwoFactorAuthentication::OtpExpiredController do
+  describe '#show' do
+    it 'receives the expected value' do
+      user = build(:user, otp_delivery_preference: 'voice')
+
+      stub_sign_in_before_2fa(user)
+
+      get :show
+
+      expect(assigns(:otp_delivery_preference)).to eq('voice')
+    end
+
+    it 'once OTP expires' do
+      user = build(:user, otp_delivery_preference: 'voice', direct_otp_sent_at: Time.zone.now)
+
+      allow(controller).to receive(:otp_expired?).and_return(true)
+      stub_sign_in_before_2fa(user)
+
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+
+    it 'shows when users navigate directly to link' do
+      user = build(:user, otp_delivery_preference: 'voice', direct_otp_sent_at: Time.zone.now)
+
+      stub_sign_in_before_2fa(user)
+
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+
+    context 'does not render' do
+      it 'when user is signed out' do
+        allow(controller).to receive(:user_signed_in?).and_return(false)
+
+        get :show
+
+        expect(response).to_not render_template(:show)
+      end
+    end
+  end
+end

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -82,7 +82,7 @@ squashed_commit_invalid:
 commit_changelog_capitalized:
   commit_log: |
     title: Improve changelog tool flexibility for commit messages (#7000)
-    body:Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages
+    body:ChAngElOg: Internal, Changelog, Improve changelog tool flexibility for commit messages
     DELIMITER
   title: Improve changelog tool flexibility for commit messages (#7000)
   category: Internal
@@ -90,7 +90,7 @@ commit_changelog_capitalized:
   change: Improve changelog tool flexibility for commit messages
   pr_number: '7000'
   commit_messages:
-    - 'Changelog: Internal, Changelog, Improve changelog tool flexibility for commit messages'
+    - 'ChAngElOg: Internal, Changelog, Improve changelog tool flexibility for commit messages'
 commit_changelog_whitespace:
   commit_log: |
     title: Improve changelog tool flexibility for commit messages (#7000)

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -501,6 +501,7 @@ describe('document-capture/components/document-capture', () => {
                 <InPersonContext.Provider
                   value={{
                     inPersonURL: '/in_person',
+                    inPersonCtaVariantActive: 'in_person_variant_a',
                   }}
                 >
                   <DocumentCapture />
@@ -532,7 +533,7 @@ describe('document-capture/components/document-capture', () => {
 
         await userEvent.click(getByText('forms.buttons.submit.default'));
 
-        const verifyInPersonButton = await findByText('in_person_proofing.body.cta.button');
+        const verifyInPersonButton = await findByText('in_person_proofing.body.cta.button_variant');
         await userEvent.click(verifyInPersonButton);
 
         expect(console).to.have.loggedError(/^Error: Uncaught/);

--- a/spec/services/idv/steps/document_capture_step_spec.rb
+++ b/spec/services/idv/steps/document_capture_step_spec.rb
@@ -125,5 +125,78 @@ describe Idv::Steps::DocumentCaptureStep do
         end
       end
     end
+
+    context 'in-person CTA variant A/B testing' do
+      let(:session_uuid) { SecureRandom.uuid }
+      let(:testing_enabled) { nil }
+      let(:active_variant) { nil }
+
+      before do
+        allow(IdentityConfig.store).
+          to receive(:in_person_cta_variant_testing_enabled).
+          and_return(testing_enabled)
+
+        flow.flow_session[:document_capture_session_uuid] = session_uuid
+
+        stub_const(
+          'AbTests::IN_PERSON_CTA',
+          FakeAbTestBucket.new.tap { |ab| ab.assign(session_uuid => active_variant) },
+        )
+      end
+
+      context 'with in-person CTA variant A/B testing disabled' do
+        let(:testing_enabled) { false }
+
+        context 'and A/B test specifies variant a' do
+          let(:active_variant) { :in_person_variant_a }
+
+          it 'passes the correct variables' do
+            expect(
+              subject.extra_view_variables[:in_person_cta_variant_testing_enabled],
+            ).to eq(false)
+            expect(
+              subject.extra_view_variables[:in_person_cta_variant_active],
+            ).to eq(:in_person_variant_a)
+          end
+        end
+      end
+
+      context 'with in-person CTA variant A/B testing enabled' do
+        let(:testing_enabled) { true }
+
+        context 'and A/B test specifies variant a' do
+          let(:active_variant) { :in_person_variant_a }
+
+          it 'passes the expected variables' do
+            expect(subject.extra_view_variables[:in_person_cta_variant_testing_enabled]).to eq(true)
+            expect(
+              subject.extra_view_variables[:in_person_cta_variant_active],
+            ).to eq(:in_person_variant_a)
+          end
+        end
+
+        context 'and A/B test specifies variant b' do
+          let(:active_variant) { :in_person_variant_b }
+
+          it 'passes the expected variables' do
+            expect(subject.extra_view_variables[:in_person_cta_variant_testing_enabled]).to eq(true)
+            expect(
+              subject.extra_view_variables[:in_person_cta_variant_active],
+            ).to eq(:in_person_variant_b)
+          end
+        end
+
+        context 'and A/B test specifies variant c' do
+          let(:active_variant) { :in_person_variant_c }
+
+          it 'passes the expected variables' do
+            expect(subject.extra_view_variables[:in_person_cta_variant_testing_enabled]).to eq(true)
+            expect(
+              subject.extra_view_variables[:in_person_cta_variant_active],
+            ).to eq(:in_person_variant_c)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -33,6 +33,25 @@ module ControllerHelper
     allow(controller).to receive(:signed_in_url).and_return(account_url)
   end
 
+  def stub_idv_steps_before_verify_step(user)
+    user_session = {}
+    stub_sign_in(user)
+    idv_session = Idv::Session.new(
+      user_session: user_session, current_user: user,
+      service_provider: nil
+    )
+    idv_session.applicant = {
+      first_name: 'Some',
+      last_name: 'One',
+      uuid: SecureRandom.uuid,
+      dob: 50.years.ago.to_date.to_s,
+      ssn: '666-12-1234',
+    }.with_indifferent_access
+    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:idv_session).and_return(idv_session)
+    allow(subject).to receive(:user_session).and_return(user_session)
+  end
+
   def stub_verify_steps_one_and_two(user)
     user_session = {}
     stub_sign_in(user)

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -16,6 +16,8 @@ describe 'idv/shared/_document_capture.html.erb' do
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
   let(:acuant_version) { '11.8.0' }
+  let(:in_person_cta_variant_testing_enabled) { false }
+  let(:in_person_cta_variant_active) { '' }
 
   before do
     decorated_session = instance_double(
@@ -50,6 +52,8 @@ describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      in_person_cta_variant_testing_enabled: in_person_cta_variant_testing_enabled,
+      in_person_cta_variant_active: in_person_cta_variant_active,
     }
   end
 

--- a/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'two_factor_authentication/otp_expired/show.html.erb' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.otp_expired'))
+
+    render
+  end
+
+  context 'when a user selects sms as their otp delivery preference' do
+    let(:otp_delivery_preference) { 'sms' }
+    it 'resends the code via sms' do
+      render
+
+      resend_path = otp_send_path(
+        otp_delivery_selection_form: {
+          otp_delivery_preference: @otp_delivery_preference,
+          resend: true,
+        },
+      )
+
+      expect(rendered).to have_link(
+        t('links.two_factor_authentication.try_again'),
+        href: resend_path,
+      )
+    end
+  end
+
+  context 'when a user selects phone as their otp delivery preference' do
+    let(:otp_delivery_preference) { 'phone' }
+    it 'resends the code via phone' do
+      render
+
+      resend_path = otp_send_path(
+        otp_delivery_selection_form: {
+          otp_delivery_preference: @otp_delivery_preference,
+          resend: true,
+        },
+      )
+
+      expect(rendered).to have_link(
+        t('links.two_factor_authentication.try_again'),
+        href: resend_path,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## User-Facing Improvements
- In-Person Proofing: Remove keepPreviousData flag for clearer UX ([#7712](https://github.com/18F/identity-idp/pull/7712))
- In-person proofing: Example search text changed to include fake address and proper grammar. ([#7711](https://github.com/18F/identity-idp/pull/7711))
- In-person proofing: Add a/b tests for improved in-person proofing calls to action and update cta to nationwide language ([#7669](https://github.com/18F/identity-idp/pull/7669))
- sms expiration timer: Redirect to sms expired ([#7577](https://github.com/18F/identity-idp/pull/7577))

## Internal
- Changelog: Improve changelog tool flexibility for commit messages ([#7716](https://github.com/18F/identity-idp/pull/7716))
- In-person proofing: Hide the in-person proofing call to action from 75% of viewers and split the rest evenly between variants A and B of the CTA (#7693) ([#7693](https://github.com/18F/identity-idp/pull/7693))
