### PR TITLE
LG-7693: Adjust IPP CTA A/B defaults

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -127,7 +127,7 @@ idv_send_link_max_attempts: 5
 ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
 in_person_cta_variant_testing_enabled: true
-in_person_cta_variant_testing_percents: '{"A":12.5, "B":12.5, "C":75}'
+in_person_cta_variant_testing_percents: '{"A":50, "B":50}'
 in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.

## 🛠 Summary of changes

Currently, the IPP CTA A/B/C variation behavior is enabled in local environemnts by default. Most of the time (75%) it will not show IPP option. While we want this behavior in prod and even staging environments, we should have some form of IPP enabled for lower environments to permit manual testing by default without needing additional configuration.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Try in dev a few times to confirm
