### PR TITLE
LG-8776: Change 500 response code to 422 for expected USPS failures

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -26,6 +26,16 @@ module Idv
             response = proofer.request_pilot_facilities
           end
           render json: response.to_json
+        # todo: consider which Faraday errors we actually want to catch here
+        rescue Faraday::TimeoutError, Faraday::ClientError => err
+          analytics.idv_in_person_locations_request_failure(
+            exception_class: err.class,
+            exception_message: err.message,
+            response_body_present: err.respond_to?(:response_body) && err.response_body.present?,
+            response_body: err.respond_to?(:response_body) && err.response_body,
+            response_status_code: err.respond_to?(:response_status) && err.response_status,
+          )
+          render json: {}, status: :unprocessable_entity
         rescue => err
           analytics.idv_in_person_locations_request_failure(
             exception_class: err.class,

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -27,8 +27,9 @@ module Idv
           end
           render json: response.to_json
         # todo: consider which Faraday errors we actually want to catch here
-        rescue Faraday::TimeoutError, Faraday::ClientError => err
+        rescue Faraday::TimeoutError, Faraday::BadRequestError, Faraday::ForbiddenError => err
           analytics.idv_in_person_locations_request_failure(
+            api_status_code: 422,
             exception_class: err.class,
             exception_message: err.message,
             response_body_present: err.respond_to?(:response_body) && err.response_body.present?,
@@ -38,6 +39,7 @@ module Idv
           render json: {}, status: :unprocessable_entity
         rescue => err
           analytics.idv_in_person_locations_request_failure(
+            api_status_code: 500,
             exception_class: err.class,
             exception_message: err.message,
             response_body_present: err.respond_to?(:response_body) && err.response_body.present?,

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -26,7 +26,6 @@ module Idv
             response = proofer.request_pilot_facilities
           end
           render json: response.to_json
-        # todo: consider which Faraday errors we actually want to catch here
         rescue Faraday::TimeoutError, Faraday::BadRequestError, Faraday::ForbiddenError => err
           analytics.idv_in_person_locations_request_failure(
             api_status_code: 422,

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -144,6 +144,7 @@ describe Idv::InPerson::UspsLocationsController do
           subject
           expect(@analytics).to have_logged_event(
             'Request USPS IPP locations: request failed',
+            api_status_code: 422,
             exception_class: timeout_error.class,
             exception_message: timeout_error.message,
             response_body_present:
@@ -168,6 +169,7 @@ describe Idv::InPerson::UspsLocationsController do
           subject
           expect(@analytics).to have_logged_event(
             'Request USPS IPP locations: request failed',
+            api_status_code: 500,
             exception_class: server_error.class,
             exception_message: server_error.message,
             response_body_present:
@@ -199,6 +201,7 @@ describe Idv::InPerson::UspsLocationsController do
           subject
           expect(@analytics).to have_logged_event(
             'Request USPS IPP locations: request failed',
+            api_status_code: 500,
             exception_class: exception.class,
             exception_message: exception.message,
             response_body_present:


### PR DESCRIPTION
## 🎫 Ticket

[LG-8776](https://cm-jira.usa.gov/browse/LG-8776)

## 🛠 Summary of changes

Update the POST /verify/in_person/usps_locations endpoint so that common USPS failures result in a 422 response code to the front end instead of 500. This is to prevent appdev on-call from being paged. There are so few requests to the endpoint that a very small number of common failure types cause the on-call engineer to be paged.

We attempt to rescue common USPS errors and return a 422 for them which won't cause the on-call engineer to be paged. Other types of errors will continue to raise a 500 and cause a page. I found these types of failures when looking in the prod analytics events logs over the past 6 days:

|count|exception|status code|reason|
|----|-------|----------|--------|
|16|bad request|400|access denied/Failed to establish a backside connection|
|4|timeout|
|3|forbidden|403|access denied/authentication rejected|

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Make sure that your config values are set correctly:
    * `arcgis_search_enabled: true`
- [ ] Update the app/controllers/idv/in_person/usps_locations_controller.rb controller, line 24, to raise the kind of error you want to test
    * <img width="689" alt="Screen Shot 2023-01-30 at 3 34 58 PM" src="https://user-images.githubusercontent.com/9039672/215590173-325b581f-d3e4-4c4d-8982-2deb4582f74b.png">
- [ ] Navigate to the `/verify/doc_auth/document_capture#location` page and submit any address to simulate a failure

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>User experience of timeout error (unchanged)</summary>

![localhost_3000_verify_doc_auth_document_capture (2)](https://user-images.githubusercontent.com/9039672/215588897-5a9c72fb-445c-4337-af74-013267304ef7.png)

</details>
