### PR TITLE
Deploy RC 247.1 to Production

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -26,8 +26,19 @@ module Idv
             response = proofer.request_pilot_facilities
           end
           render json: response.to_json
+        rescue Faraday::TimeoutError, Faraday::BadRequestError, Faraday::ForbiddenError => err
+          analytics.idv_in_person_locations_request_failure(
+            api_status_code: 422,
+            exception_class: err.class,
+            exception_message: err.message,
+            response_body_present: err.respond_to?(:response_body) && err.response_body.present?,
+            response_body: err.respond_to?(:response_body) && err.response_body,
+            response_status_code: err.respond_to?(:response_status) && err.response_status,
+          )
+          render json: {}, status: :unprocessable_entity
         rescue => err
           analytics.idv_in_person_locations_request_failure(
+            api_status_code: 500,
             exception_class: err.class,
             exception_message: err.message,
             response_body_present: err.respond_to?(:response_body) && err.response_body.present?,


### PR DESCRIPTION
## 🛠 Summary of changes

## Internal
- In-person proofing: Stop trigger on-call paging for expected USPS facilities failures ([#7726](https://github.com/18F/identity-idp/pull/7726))


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
