### PR TITLE
Include deleted users in daily registrations report

### DIFF
--- a/spec/jobs/reports/daily_registration_report_spec.rb
+++ b/spec/jobs/reports/daily_registration_report_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Reports::DailyRegistrationsReport do
         create_list(:user, 1, created_at: two_days_ago).each do |user|
           RegistrationLog.create(user: user, registered_at: user.created_at)
         end
+
+        # deleted, counts as total users
+        DeletedUser.create(
+          user_created_at: two_days_ago,
+          deleted_at: two_days_ago,
+          uuid: SecureRandom.uuid,
+          user_id: -1,
+        )
       end
 
       it 'calculates users and fully registered users by day' do
@@ -85,13 +93,15 @@ RSpec.describe Reports::DailyRegistrationsReport do
               [
                 {
                   date: two_days_ago.to_date.as_json,
-                  total_users: 2,
+                  total_users: 3,
                   fully_registered_users: 1,
+                  deleted_users: 1,
                 },
                 {
                   date: yesterday.to_date.as_json,
                   total_users: 4,
                   fully_registered_users: 2,
+                  deleted_users: 0,
                 },
               ],
             )


### PR DESCRIPTION
Currently, the reports do the equivalent of a `User.count` to detect how many users were created. However, users can be deleted so that count could be inaccurate over time.

This PR attempts to use the `deleted_users` table to create a more stable number over time, by including deleted users by the date they were originally created on.

Example: I create an account Monday, but delete it on Tuesday (assuming no other users were created, etc)
- Before:  Monday's report would include me but Tuesday would have subtracted one user 
- Now: Both Monday's and Tuesday's reports would count me and the count should be consistent moving forward

**Open Question**:
- Do we want to change this? Or leave it? This changes the way we calculate total registered users, so if somebody pulled the ["total registered" users query from the handbook](https://handbook.login.gov/articles/queries.html#total-registered), the numbers would not match (I could also go back and patch that handbook page to match this)
- Do we want to count deleted users by the day they were deleted or created? (I think counting by the day they're deleted is clearer for reporting and more stable over time, so that's why I went that way)

**Notes**:
- `registration_logs` table which we use for "fully registered users" has a cascading delete meaning that number won't be stable over time as users get deleted
