### PR TITLE
Limit subresource integrity hash to SHA512 for JavaScript compilation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
       },
       writeToDisk: true,
       integrity: isProductionEnv,
+      integrityHashes: ['sha512'],
       output: 'manifest.json',
       transform(manifest) {
         const srcIntegrity = {};


### PR DESCRIPTION
## 🛠 Summary of changes

Changes Webpack JavaScript compilation to generate only SHA512 hashes for resource, overriding [default](https://github.com/webdeveric/webpack-assets-manifest#integrityhashes) which would generate integrity for SHA256, SHA384, and SHA512.

The thinking here being that [the SRI specification requires users agents to include support for all three algorithms](https://w3c.github.io/webappsec-subresource-integrity/#hash-functions), so there should be no risk that a browser would only implement one but not other hash algorithms.

Limiting the number of algorithms could potentially allow for some marginal savings in build time by avoiding unnecessary hashing of file contents†, as well as reducing the overall size of rendered pages.

Of the three, SHA512 was chosen as being the most collision-resistant hashing algorithm.

† anecdotally seeing around 3% reduction in build time over an average of 5 runs

## 📜 Testing Plan

1. Run `NODE_ENV=production yarn build`
2. Run `rails s`
3. Visit http://localhost:3000
4. Observe no issues with JavaScript load
5. Observe SHA512 integrity hash for rendered scripts in page source