### PR TITLE
Log an event on the verify info update action

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -25,6 +25,7 @@ module Idv
 
     def update
       return if idv_session.verify_info_step_document_capture_session_uuid
+      analytics.idv_doc_auth_verify_submitted(**analytics_arguments)
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -127,6 +127,24 @@ describe Idv::VerifyInfoController do
         and_return(true)
     end
 
+    it 'logs the correct analytics event' do
+      stub_analytics
+      stub_attempts_tracker
+
+      put :update
+
+      expect(@analytics).to have_logged_event(
+        'IdV: doc auth verify submitted',
+        {
+          analytics_id: 'Doc Auth',
+          flow_path: 'standard',
+          irs_reproofing: false,
+          step: 'verify',
+          step_count: 0,
+        },
+      )
+    end
+
     context 'when the user is ssn throttled' do
       before do
         Throttle.new(


### PR DESCRIPTION
We recently moved this out of the flow state machine and missed this event. This commit adds it.
