### PR TITLE
AAMVA: Check for http errors before parsing SOAP

### DIFF
--- a/app/services/proofing/aamva/response/authentication_token_response.rb
+++ b/app/services/proofing/aamva/response/authentication_token_response.rb
@@ -6,8 +6,8 @@ module Proofing
 
         def initialize(http_response)
           @http_response = http_response
-          handle_soap_error
           handle_http_error
+          handle_soap_error
           parse_response
         end
 

--- a/app/services/proofing/aamva/response/security_token_response.rb
+++ b/app/services/proofing/aamva/response/security_token_response.rb
@@ -9,8 +9,8 @@ module Proofing
 
         def initialize(http_response)
           @http_response = http_response
-          handle_soap_error
           handle_http_error
+          handle_soap_error
           parse_response
         end
 

--- a/app/services/proofing/aamva/response/verification_response.rb
+++ b/app/services/proofing/aamva/response/verification_response.rb
@@ -33,8 +33,8 @@ module Proofing
           @missing_attributes = []
           @verification_results = {}
           @http_response = http_response
-          handle_soap_error
           handle_http_error
+          handle_soap_error
           parse_response
         end
 

--- a/spec/services/proofing/aamva/response/authentication_token_response_spec.rb
+++ b/spec/services/proofing/aamva/response/authentication_token_response_spec.rb
@@ -26,6 +26,18 @@ describe Proofing::Aamva::Response::AuthenticationTokenResponse do
       end
     end
 
+    context 'with a non-200 status code and a non-xml body' do
+      let(:status_code) { 504 }
+      let(:response_body) { '<h1>Oh no</h1><hr><p>This is not xml.' }
+
+      it 'raises a VerificationError' do
+        expect { subject }.to raise_error(
+          Proofing::Aamva::VerificationError,
+          'Unexpected status code in response: 504',
+        )
+      end
+    end
+
     context 'when the API response has an error' do
       let(:response_body) { AamvaFixtures.soap_fault_response_simplified }
 

--- a/spec/services/proofing/aamva/response/authentication_token_response_spec.rb
+++ b/spec/services/proofing/aamva/response/authentication_token_response_spec.rb
@@ -30,9 +30,9 @@ describe Proofing::Aamva::Response::AuthenticationTokenResponse do
       let(:status_code) { 504 }
       let(:response_body) { '<h1>Oh no</h1><hr><p>This is not xml.' }
 
-      it 'raises a VerificationError' do
+      it 'raises a AuthenticationError' do
         expect { subject }.to raise_error(
-          Proofing::Aamva::VerificationError,
+          Proofing::Aamva::AuthenticationError,
           'Unexpected status code in response: 504',
         )
       end

--- a/spec/services/proofing/aamva/response/security_token_response_spec.rb
+++ b/spec/services/proofing/aamva/response/security_token_response_spec.rb
@@ -30,6 +30,18 @@ describe Proofing::Aamva::Response::SecurityTokenResponse do
       end
     end
 
+    context 'with a non-200 status code and a non-xml body' do
+      let(:status_code) { 504 }
+      let(:response_body) { '<h1>Oh no</h1><hr><p>This is not xml.' }
+
+      it 'raises a VerificationError' do
+        expect { subject }.to raise_error(
+          Proofing::Aamva::VerificationError,
+          'Unexpected status code in response: 504',
+        )
+      end
+    end
+
     context 'when the API response is an error' do
       let(:response_body) { AamvaFixtures.soap_fault_response_simplified }
 

--- a/spec/services/proofing/aamva/response/security_token_response_spec.rb
+++ b/spec/services/proofing/aamva/response/security_token_response_spec.rb
@@ -34,9 +34,9 @@ describe Proofing::Aamva::Response::SecurityTokenResponse do
       let(:status_code) { 504 }
       let(:response_body) { '<h1>Oh no</h1><hr><p>This is not xml.' }
 
-      it 'raises a VerificationError' do
+      it 'raises a AuthenticationError' do
         expect { subject }.to raise_error(
-          Proofing::Aamva::VerificationError,
+          Proofing::Aamva::AuthenticationError,
           'Unexpected status code in response: 504',
         )
       end

--- a/spec/services/proofing/aamva/response/verification_response_spec.rb
+++ b/spec/services/proofing/aamva/response/verification_response_spec.rb
@@ -42,6 +42,18 @@ describe Proofing::Aamva::Response::VerificationResponse do
       end
     end
 
+    context 'with a non-200 status code and a non-xml body' do
+      let(:status_code) { 504 }
+      let(:response_body) { '<h1>Oh no</h1><hr><p>This is not xml.' }
+
+      it 'raises a VerificationError' do
+        expect { subject }.to raise_error(
+          Proofing::Aamva::VerificationError,
+          'Unexpected status code in response: 504',
+        )
+      end
+    end
+
     context 'when the API response has an error' do
       let(:response_body) { AamvaFixtures.soap_fault_response_simplified }
 


### PR DESCRIPTION
As is, if we get a non-200 back from AAMVA with a non-XML body, we blow up.

changelog: Bug Fixes, Doc auth, Handle non-200 responses from AAMVA

