### PR TITLE
LG-8773 replace Throttle#throttled_else_increment with separate calls

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -28,7 +28,8 @@ module Idv
     def create
       @gpo_verify_form = build_gpo_verify_form
 
-      if throttle.throttled_else_increment?
+      throttle.increment!
+      if throttle.throttled?
         render_throttled
       else
         result = @gpo_verify_form.submit

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -36,8 +36,6 @@ module Idv
 
     def throttled
       @expires_at = Throttle.new(user: effective_user, throttle_type: :idv_doc_auth).expires_at
-      analytics.throttler_rate_limit_triggered(throttle_type: :idv_doc_auth)
-      irs_attempts_api_tracker.idv_document_upload_rate_limited
     end
 
     private

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -29,7 +29,8 @@ module Idv
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 
-      if ssn_throttle.throttled_else_increment?
+      ssn_throttle.increment!
+      if ssn_throttle.throttled?
         analytics.throttler_rate_limit_triggered(
           throttle_type: :proof_ssn,
           step_name: 'verify_info',

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -273,7 +273,8 @@ module Users
 
     def exceeded_phone_confirmation_limit?
       return false unless UserSessionContext.confirmation_context?(context)
-      phone_confirmation_throttle.throttled_else_increment?
+      phone_confirmation_throttle.increment!
+      phone_confirmation_throttle.throttled?
     end
 
     def send_user_otp(method)

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -21,7 +21,8 @@ module Users
     end
 
     def create
-      if throttle.throttled_else_increment?
+      throttle.increment!
+      if throttle.throttled?
         render_throttled
       else
         result = personal_key_form.submit

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -24,7 +24,7 @@ module Idv
     end
 
     def submit
-      throttled_else_increment
+      increment_throttle!
 
       response = FormResponse.new(
         success: valid?,
@@ -88,9 +88,10 @@ module Idv
       errors.add(:limit, t('errors.doc_auth.throttled_heading'), type: :throttled)
     end
 
-    def throttled_else_increment
+    def increment_throttle!
       return unless document_capture_session
-      @throttled = throttle.throttled_else_increment?
+      throttle.increment!
+      @throttled = throttle.throttled?
     end
 
     def throttle

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -22,7 +22,7 @@ module Idv
     end
 
     def submit
-      throttled_else_increment
+      increment_throttle!
       form_response = validate_form
 
       client_response = nil
@@ -46,9 +46,10 @@ module Idv
     attr_reader :params, :analytics, :service_provider, :form_response, :uuid_prefix,
                 :irs_attempts_api_tracker
 
-    def throttled_else_increment
+    def increment_throttle!
       return unless document_capture_session
-      @throttled = throttle.throttled_else_increment?
+      throttle.increment!
+      @throttled = throttle.throttled?
     end
 
     def validate_form

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -109,7 +109,8 @@ class RegisterUserEmailForm
 
   def send_sign_up_unconfirmed_email(request_id)
     throttler = Throttle.new(user: existing_user, throttle_type: :reg_unconfirmed_email)
-    @throttled = throttler.throttled_else_increment?
+    throttler.increment!
+    @throttled = throttler.throttled?
 
     if @throttled
       @analytics.throttler_rate_limit_triggered(
@@ -125,7 +126,8 @@ class RegisterUserEmailForm
 
   def send_sign_up_confirmed_email
     throttler = Throttle.new(user: existing_user, throttle_type: :reg_confirmed_email)
-    @throttled = throttler.throttled_else_increment?
+    throttler.increment!
+    @throttled = throttler.throttled?
 
     if @throttled
       @analytics.throttler_rate_limit_triggered(

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -64,13 +64,6 @@ module Idv
         idv_session_errors_throttled_url
       end
 
-      def throttled_else_increment
-        Throttle.new(
-          user: effective_user,
-          throttle_type: :idv_doc_auth,
-        ).throttled_else_increment?
-      end
-
       # Ideally we would not have to re-implement the EffectiveUser mixin
       # but flow_session sometimes != controller#session
       def effective_user

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -14,7 +14,8 @@ module Idv
       end
 
       def call
-        return throttled_failure if throttle.throttled_else_increment?
+        throttle.increment!
+        return throttled_failure if throttle.throttled?
         telephony_result = send_link
         failure_reason = nil
         if !telephony_result.success?

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -177,7 +177,8 @@ module Idv
             throttle_type: :proof_ssn,
           )
 
-          if throttle.throttled_else_increment?
+          throttle.increment!
+          if throttle.throttled?
             @flow.analytics.throttler_rate_limit_triggered(
               throttle_type: :proof_ssn,
               step_name: self.class,

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -21,7 +21,9 @@ RequestPasswordReset = RedactedStruct.new(
   private
 
   def send_reset_password_instructions
-    if Throttle.new(user: user, throttle_type: :reset_password_email).throttled_else_increment?
+    throttle = Throttle.new(user: user, throttle_type: :reset_password_email)
+    throttle.increment!
+    if throttle.throttled?
       analytics.throttler_rate_limit_triggered(throttle_type: :reset_password_email)
       irs_attempts_api_tracker.forgot_password_email_rate_limited(email: email)
     else

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -76,6 +76,7 @@ class Throttle
   end
 
   def increment!
+    return if throttled?
     value = nil
     REDIS_THROTTLE_POOL.with do |client|
       value, _success = client.multi do |multi|

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -39,15 +39,6 @@ class Throttle
     !expired? && maxed?
   end
 
-  def throttled_else_increment?
-    if throttled?
-      true
-    else
-      increment!
-      false
-    end
-  end
-
   def attempted_at
     return @redis_attempted_at if defined?(@redis_attempted_at)
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -563,7 +563,7 @@ test:
   verify_gpo_key_attempt_window_in_minutes: 3
   verify_gpo_key_max_attempts: 2
   verify_personal_key_attempt_window_in_minutes: 3
-  verify_personal_key_max_attempts: 1
+  verify_personal_key_max_attempts: 2
   usps_upload_sftp_directory: "/directory"
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Idv::GpoVerifyController do
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
-        ).exactly(max_attempts-1).times
+        ).exactly(max_attempts - 1).times
 
         expect(@analytics).to receive(:track_event).with(
           'Throttler Rate Limit Triggered',
@@ -319,7 +319,7 @@ RSpec.describe Idv::GpoVerifyController do
 
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_rate_limited).once
 
-        (max_attempts).times do |i|
+        max_attempts.times do |i|
           post(
             :create,
             params: {

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Idv::GpoVerifyController do
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
-        ).exactly(max_attempts).times
+        ).exactly(max_attempts-1).times
 
         expect(@analytics).to receive(:track_event).with(
           'Throttler Rate Limit Triggered',
@@ -319,7 +319,7 @@ RSpec.describe Idv::GpoVerifyController do
 
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_rate_limited).once
 
-        (max_attempts + 1).times do |i|
+        (max_attempts).times do |i|
           post(
             :create,
             params: {

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -174,7 +174,7 @@ describe Users::VerifyPersonalKeyController do
         expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited).once
 
         max_attempts = Throttle.max_attempts(:verify_personal_key)
-        (max_attempts).times { post :create, params: personal_key_bad_params }
+        max_attempts.times { post :create, params: personal_key_bad_params }
 
         expect(response).to render_template(:throttled)
       end

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -174,7 +174,7 @@ describe Users::VerifyPersonalKeyController do
         expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited).once
 
         max_attempts = Throttle.max_attempts(:verify_personal_key)
-        (max_attempts + 1).times { post :create, params: personal_key_bad_params }
+        (max_attempts).times { post :create, params: personal_key_bad_params }
 
         expect(response).to render_template(:throttled)
       end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -118,7 +118,7 @@ feature 'doc auth send link step' do
     ).with({ phone_number: '+1 415-555-0199' })
 
     freeze_time do
-      idv_send_link_max_attempts.times do
+      (idv_send_link_max_attempts - 1).times do
         expect(page).to_not have_content(
           I18n.t('errors.doc_auth.send_link_throttle', timeout: timeout),
         )

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -151,9 +151,12 @@ feature 'doc auth verify_info step', :js do
     end
 
     context 'resolution throttling' do
-      let(:max_resolution_attempts) { Throttle.max_attempts(:idv_resolution) }
+      let(:max_resolution_attempts) { 3 }
       # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
       it 'throttles resolution and continues when it expires' do
+        allow(IdentityConfig.store).to receive(:idv_max_attempts).
+        and_return(max_resolution_attempts)
+
         expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_ssn_step
@@ -188,8 +191,8 @@ feature 'doc auth verify_info step', :js do
 
     context 'ssn throttling' do
       # Simulates someone trying same SSN with second account
-      let(:max_resolution_attempts) { 5 }
-      let(:max_ssn_attempts) { 4 }
+      let(:max_resolution_attempts) { 4 }
+      let(:max_ssn_attempts) { 3 }
 
       it 'throttles ssn and continues when it expires' do
         allow(IdentityConfig.store).to receive(:idv_max_attempts).

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -6,7 +6,6 @@ feature 'doc auth verify_info step', :js do
 
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
-  let(:max_attempts) { Throttle.max_attempts(:idv_resolution) }
 
   context 'with verify_info_controller enabled' do
     before do
@@ -151,30 +150,82 @@ feature 'doc auth verify_info step', :js do
       expect(page).to have_current_path(idv_doc_auth_verify_step)
     end
 
-    it 'throttles resolution and continues when it expires' do
-      expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited)
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_ssn_step
-      fill_out_ssn_form_with_ssn_that_fails_resolution
-      click_idv_continue
-      (max_attempts - 1).times do
-        click_idv_continue
-        expect(page).to have_current_path(idv_session_errors_warning_path)
-        visit idv_doc_auth_verify_step
-      end
-      click_idv_continue
-      expect(page).to have_current_path(idv_session_errors_failure_path)
-      expect(fake_analytics).to have_logged_event(
-        'Throttler Rate Limit Triggered',
-        throttle_type: :idv_resolution,
-        step_name: 'Idv::VerifyInfoController',
-      )
-      travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
+    context 'resolution throttling' do
+      let(:max_resolution_attempts) { Throttle.max_attempts(:idv_resolution) }
+      # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
+      it 'throttles resolution and continues when it expires' do
+        expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited)
         sign_in_and_2fa_user
-        complete_doc_auth_steps_before_verify_step
+        complete_doc_auth_steps_before_ssn_step
+        fill_out_ssn_form_with_ssn_that_fails_resolution
         click_idv_continue
+        (max_resolution_attempts - 1).times do
+          click_idv_continue
+          expect(page).to have_current_path(idv_session_errors_warning_path)
+          visit idv_doc_auth_verify_step
+        end
 
-        expect(page).to have_current_path(idv_phone_path)
+        click_idv_continue
+        expect(page).to have_current_path(idv_session_errors_failure_path)
+        expect(fake_analytics).to have_logged_event(
+          'Throttler Rate Limit Triggered',
+          throttle_type: :idv_resolution,
+          step_name: 'Idv::VerifyInfoController',
+        )
+
+        visit idv_verify_info_url
+        expect(page).to have_current_path(idv_session_errors_failure_path)
+
+        travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
+          sign_in_and_2fa_user
+          complete_doc_auth_steps_before_verify_step
+          click_idv_continue
+
+          expect(page).to have_current_path(idv_phone_path)
+        end
+      end
+    end
+
+    context 'ssn throttling' do
+      # Simulates someone trying same SSN with second account
+      let(:max_resolution_attempts) { 5 }
+      let(:max_ssn_attempts) { 4 }
+
+      it 'throttles ssn and continues when it expires' do
+        allow(IdentityConfig.store).to receive(:idv_max_attempts).
+          and_return(max_resolution_attempts)
+
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).
+          and_return(max_ssn_attempts)
+
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_ssn_step
+        fill_out_ssn_form_with_ssn_that_fails_resolution
+        click_idv_continue
+        (max_ssn_attempts - 1).times do
+          click_idv_continue
+          expect(page).to have_current_path(idv_session_errors_warning_path)
+          visit idv_doc_auth_verify_step
+        end
+
+        click_idv_continue
+        expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
+        expect(fake_analytics).to have_logged_event(
+          'Throttler Rate Limit Triggered',
+          throttle_type: :proof_ssn,
+          step_name: 'verify_info',
+        )
+
+        visit idv_verify_info_url
+        expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
+
+        travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
+          sign_in_and_2fa_user
+          complete_doc_auth_steps_before_verify_step
+          click_idv_continue
+
+          expect(page).to have_current_path(idv_phone_path)
+        end
       end
     end
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -249,14 +249,14 @@ feature 'Password Recovery' do
     email = user.email
 
     max_attempts = IdentityConfig.store.reset_password_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       submit_email_for_password_reset(email)
       expect(unread_emails_for(email).size).to eq(i + 1)
     end
 
-    expect(unread_emails_for(email).size).to eq(max_attempts)
+    expect(unread_emails_for(email).size).to eq(max_attempts - 1)
     submit_email_for_password_reset(email)
-    expect(unread_emails_for(email).size).to eq(max_attempts)
+    expect(unread_emails_for(email).size).to eq(max_attempts - 1)
   end
 
   def submit_email_for_password_reset(email)

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -24,14 +24,14 @@ feature 'Visit requests confirmation instructions again during sign up' do
     email = user.email
 
     max_attempts = IdentityConfig.store.reg_unconfirmed_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       submit_resend_email_confirmation(email)
       expect(unread_emails_for(user.email).size).to eq(i + 1)
     end
 
-    expect(unread_emails_for(user.email).size).to eq(max_attempts)
+    expect(unread_emails_for(user.email).size).to eq(max_attempts - 1)
     submit_resend_email_confirmation(email)
-    expect(unread_emails_for(user.email).size).to eq(max_attempts)
+    expect(unread_emails_for(user.email).size).to eq(max_attempts - 1)
   end
 
   scenario 'user enters email with invalid format' do

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -70,13 +70,13 @@ feature 'Visitor signs up with email address' do
 
     starting_count = unread_emails_for(email).size
     max_attempts = IdentityConfig.store.reg_unconfirmed_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       sign_up_with(email)
       expect(unread_emails_for(email).size).to eq(starting_count + i + 1)
     end
 
-    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts)
+    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts - 1)
     sign_up_with(email)
-    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts)
+    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts - 1)
   end
 end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -41,7 +41,7 @@ describe RegisterUserEmailForm do
 
         create(:user, :signed_up, email: 'taken@example.com')
 
-        (IdentityConfig.store.reg_confirmed_email_max_attempts).times do
+        IdentityConfig.store.reg_confirmed_email_max_attempts.times do
           subject.submit(email: 'TAKEN@example.com', terms_accepted: '1')
         end
 
@@ -85,7 +85,7 @@ describe RegisterUserEmailForm do
         )
 
         create(:user, email: 'test@example.com', confirmed_at: nil, uuid: '123')
-        (IdentityConfig.store.reg_unconfirmed_email_max_attempts).times do
+        IdentityConfig.store.reg_unconfirmed_email_max_attempts.times do
           subject.submit(email: 'test@example.com', terms_accepted: '1')
         end
 

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -41,7 +41,7 @@ describe RegisterUserEmailForm do
 
         create(:user, :signed_up, email: 'taken@example.com')
 
-        (IdentityConfig.store.reg_confirmed_email_max_attempts + 1).times do
+        (IdentityConfig.store.reg_confirmed_email_max_attempts).times do
           subject.submit(email: 'TAKEN@example.com', terms_accepted: '1')
         end
 
@@ -85,7 +85,7 @@ describe RegisterUserEmailForm do
         )
 
         create(:user, email: 'test@example.com', confirmed_at: nil, uuid: '123')
-        (IdentityConfig.store.reg_unconfirmed_email_max_attempts + 1).times do
+        (IdentityConfig.store.reg_unconfirmed_email_max_attempts).times do
           subject.submit(email: 'test@example.com', terms_accepted: '1')
         end
 

--- a/spec/services/idv/steps/in_person/verify_step_spec.rb
+++ b/spec/services/idv/steps/in_person/verify_step_spec.rb
@@ -110,7 +110,7 @@ describe Idv::Steps::InPerson::VerifyStep do
       end
 
       before do
-        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(2)
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(3)
         allow(IdentityConfig.store).to receive(:proof_ssn_max_attempt_window_in_minutes).
           and_return(10)
       end

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -110,7 +110,7 @@ describe Idv::Steps::VerifyStep do
       end
 
       before do
-        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(2)
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(3)
         allow(IdentityConfig.store).to receive(:proof_ssn_max_attempt_window_in_minutes).
           and_return(10)
       end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe RequestPasswordReset do
       it 'throttles the email sending and logs a throttle event' do
         max_attempts = IdentityConfig.store.reset_password_email_max_attempts
 
-        max_attempts.times do
+        (max_attempts - 1).times do
           expect do
             RequestPasswordReset.new(
               email: email,
@@ -202,9 +202,9 @@ RSpec.describe RequestPasswordReset do
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryActivatedEvent.new(user: user)).
-          exactly(max_attempts).times
+          exactly(max_attempts - 1).times
 
-        max_attempts.times do
+        (max_attempts - 1).times do
           expect do
             RequestPasswordReset.new(
               email: email,

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Throttle do
 
   describe '#increment!' do
     subject(:throttle) { Throttle.new(target: 'aaa', throttle_type: :idv_doc_auth) }
-    let(:max_attempts) { 1 }
+    let(:max_attempts) { 1 } # Picked up by before block at top of test file
 
     it 'increments attempts' do
       expect(throttle.attempts).to eq 0
@@ -82,8 +82,12 @@ RSpec.describe Throttle do
       throttle.increment!
       expect(throttle.attempts).to eq 1
       expect(throttle.throttled?).to eq(true)
-      throttle.increment!
-      expect(throttle.attempts).to eq 1
+      current_expiration = throttle.expires_at
+      travel 5.minutes do # move within 10 minute expiration window
+        throttle.increment!
+        expect(throttle.attempts).to eq 1
+        expect(throttle.expires_at).to eq current_expiration
+      end
     end
   end
 

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -122,32 +122,6 @@ RSpec.describe Throttle do
     end
   end
 
-  describe '#throttled_else_increment?' do
-    subject(:throttle) { Throttle.new(target: 'aaaa', throttle_type: :idv_doc_auth) }
-
-    context 'throttle has hit limit' do
-      before do
-        (IdentityConfig.store.doc_auth_max_attempts + 1).times do
-          throttle.increment!
-        end
-      end
-
-      it 'is true' do
-        expect(throttle.throttled_else_increment?).to eq(true)
-      end
-    end
-
-    context 'throttle has not hit limit' do
-      it 'is false' do
-        expect(throttle.throttled_else_increment?).to eq(false)
-      end
-
-      it 'increments the throttle' do
-        expect { throttle.throttled_else_increment? }.to change { throttle.attempts }.by(1)
-      end
-    end
-  end
-
   describe '#expires_at' do
     let(:attempted_at) { nil }
     let(:throttle) { Throttle.new(target: '1', throttle_type: throttle_type) }

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -69,9 +69,19 @@ RSpec.describe Throttle do
 
   describe '#increment!' do
     subject(:throttle) { Throttle.new(target: 'aaa', throttle_type: :idv_doc_auth) }
+    let(:max_attempts) { 1 }
 
     it 'increments attempts' do
       expect(throttle.attempts).to eq 0
+      throttle.increment!
+      expect(throttle.attempts).to eq 1
+    end
+
+    it 'does nothing if already throttled' do
+      expect(throttle.attempts).to eq 0
+      throttle.increment!
+      expect(throttle.attempts).to eq 1
+      expect(throttle.throttled?).to eq(true)
       throttle.increment!
       expect(throttle.attempts).to eq 1
     end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -47,6 +47,13 @@ module IdvHelper
     click_select_button_and_wait t('in_person_proofing.body.location.location_button')
   end
 
+  def click_try_again
+    page.find(
+      'a',
+      text: t('idv.failure.button.warning'),
+    ).click
+  end
+
   def click_idv_otp_delivery_method_sms
     page.find(
       'label',


### PR DESCRIPTION
## 🎫 Ticket

LG-8773

## 🛠 Summary of changes

Replace `Throttle#throttled_else_increment?` everywhere with a call to `increment!` followed by a call to `throttled?` to make the code and usage consistent. 

Since we are now checking if we're throttled after increment rather than before, there may be one less attempt allowed. Adjust specs to match. We can consider raising the related max_attempts config settings to keep the user experience unchanged.

@eric-gade Note that I undid your change in Idv::SessionErrorsController because the analytics and tracking were now happening twice.

Each commit has code changes with related tests, except the feature tests are at the end. Added the VerifyInfoController feature test that was pending in #7720.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Confirm that unsupervised proofing flow still throttles as expected at each step
- [ ] Confirm that in person proofing flow still throttles as expected at each step
- [ ] Confirm that throttler rate limit analytics and irs_attempts_api_trackers are received as expected, especially the recently fixed document_upload_rate_limited call.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
