### PR TITLE
LG-8816 Implement the redo document capture action for the new verify info controller

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -20,6 +20,7 @@ module Idv
         return
       end
 
+      @had_barcode_read_failure = flow_session[:had_barcode_read_failure]
       process_async_state(load_async_state)
     end
 

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -15,6 +15,24 @@ locals:
   <!-- Needed by form steps wait javascript -->
 </div>
 
+<% if @had_barcode_read_failure %>
+  <%= render AlertComponent.new(
+        type: :warning,
+        class: 'margin-bottom-4',
+        text_tag: 'div',
+      ) do %>
+    <%= t(
+          'doc_auth.headings.capture_scan_warning_html',
+          link: render(
+            FormLinkComponent.new(
+              href: idv_doc_auth_step_path(step: :redo_document_capture),
+              method: :put,
+            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          ),
+        ) %>
+  <% end %>
+<% end %>
+
 <% title t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -68,5 +68,66 @@ feature 'doc auth redo document capture action', js: true do
         expect(page).not_to have_css('[role="status"]')
       end
     end
+
+    context 'with the doc_auth_verify_info_controller_enabled flag enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
+          and_return(true)
+      end
+
+      it 'shows a warning message to allow the user to return to upload new images' do
+        warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+        expect(page).to have_css(
+          '[role="status"]',
+          text: t('doc_auth.headings.capture_scan_warning_html', link: warning_link_text),
+        )
+        click_link warning_link_text
+
+        expect(current_path).to eq(idv_doc_auth_upload_step)
+        complete_upload_step
+        DocAuth::Mock::DocAuthMockClient.reset!
+        attach_and_submit_images
+
+        expect(current_path).to eq(idv_doc_auth_verify_step)
+        check t('forms.ssn.show')
+        expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+        expect(page).not_to have_css('[role="status"]')
+      end
+
+      it 'shows a troubleshooting option to allow the user to return to upload new images' do
+        click_idv_continue
+
+        expect(page).to have_link(
+          t('idv.troubleshooting.options.add_new_photos'),
+          href: idv_doc_auth_step_path(step: :redo_document_capture),
+        )
+
+        click_link t('idv.troubleshooting.options.add_new_photos')
+
+        expect(current_path).to eq(idv_doc_auth_upload_step)
+      end
+
+      context 'on mobile', driver: :headless_chrome_mobile do
+        it 'shows a warning message to allow the user to return to upload new images' do
+          warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+          expect(page).to have_css(
+            '[role="status"]',
+            text: t('doc_auth.headings.capture_scan_warning_html', link: warning_link_text),
+          )
+          click_link warning_link_text
+
+          expect(current_path).to eq(idv_doc_auth_document_capture_step)
+          DocAuth::Mock::DocAuthMockClient.reset!
+          attach_and_submit_images
+
+          expect(current_path).to eq(idv_doc_auth_verify_step)
+          check t('forms.ssn.show')
+          expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+          expect(page).not_to have_css('[role="status"]')
+        end
+      end
+    end
   end
 end

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -89,7 +89,7 @@ feature 'doc auth redo document capture action', js: true do
         DocAuth::Mock::DocAuthMockClient.reset!
         attach_and_submit_images
 
-        expect(current_path).to eq(idv_doc_auth_verify_step)
+        expect(page).to have_content(t('headings.verify'))
         check t('forms.ssn.show')
         expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
         expect(page).not_to have_css('[role="status"]')
@@ -122,7 +122,7 @@ feature 'doc auth redo document capture action', js: true do
           DocAuth::Mock::DocAuthMockClient.reset!
           attach_and_submit_images
 
-          expect(current_path).to eq(idv_doc_auth_verify_step)
+          expect(page).to have_content(t('headings.verify'))
           check t('forms.ssn.show')
           expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
           expect(page).not_to have_css('[role="status"]')


### PR DESCRIPTION
The verify info controller is a replacement for the verify info step. When it was being built we overlooked a feature that allowed users with barcode errors to recapture an image of their document.

This commit implements that feature for the verify info controller
