### PR TITLE
Lower max_bad_passwords

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -189,7 +189,7 @@ logins_per_ip_period: 60
 logo_upload_enabled: false
 mailer_domain_name: http://localhost:3000
 max_auth_apps_per_account: 2
-max_bad_passwords: 100
+max_bad_passwords: 5
 max_bad_passwords_window_in_seconds: 60
 max_emails_per_account: 12
 max_mail_events: 4


### PR DESCRIPTION
changelog: Internal, Attempts Api, Bugfix

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket.
[LG-8705](https://cm-jira.usa.gov/browse/LG-8705)

## 🛠 Summary of changes

lower max_bad_passwords for the session_controller to a value that is under the Rack Attack value so that Attempts Api login_rate_limited event is properly logged before a Rack Attack.

This should also make security a bit more strict, and Rack Attack will still be in place to catch attackers if the session_controller rate limit is bypassed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
