### PR TITLE
Switch RedisRateLimiter's redis instance

### DIFF
--- a/app/services/redis_rate_limiter.rb
+++ b/app/services/redis_rate_limiter.rb
@@ -7,7 +7,7 @@ class RedisRateLimiter
   # @param [String] key the item to throttle on
   # @param [Integer] max_requests the max number of requests allowed per interval
   # @param [Integer] interval number of seconds
-  def initialize(key:, max_requests:, interval:, redis_pool: REDIS_POOL)
+  def initialize(key:, max_requests:, interval:, redis_pool: REDIS_THROTTLE_POOL)
     @key = key
     @max_requests = max_requests
     @interval = interval.to_i

--- a/spec/jobs/risc_delivery_job_spec.rb
+++ b/spec/jobs/risc_delivery_job_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe RiscDeliveryJob do
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   describe '#perform' do
@@ -177,7 +177,9 @@ RSpec.describe RiscDeliveryJob do
 
     context 'rate limiting' do
       before do
-        REDIS_POOL.with { |r| r.set(job.rate_limiter(push_notification_url).build_key(now), 9999) }
+        REDIS_THROTTLE_POOL.with do |redis|
+          redis.set(job.rate_limiter(push_notification_url).build_key(now), 9999)
+        end
       end
 
       context 'when performed inline' do

--- a/spec/services/redis_rate_limiter_spec.rb
+++ b/spec/services/redis_rate_limiter_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe RedisRateLimiter do
   let(:now) { Time.zone.now }
 
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   let(:key) { 'some-unique-identifier' }
@@ -62,7 +62,7 @@ RSpec.describe RedisRateLimiter do
 
     context 'when the key exists and is under the limit' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), '1') }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), '1') }
       end
 
       it 'is false' do
@@ -72,7 +72,7 @@ RSpec.describe RedisRateLimiter do
 
     context 'when the key exists and is at the limit' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), max_requests) }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), max_requests) }
       end
 
       it 'is true' do
@@ -85,19 +85,20 @@ RSpec.describe RedisRateLimiter do
     context 'when the key does not exist in redis' do
       it 'sets the value to 1 when' do
         expect { rate_limiter.increment(now) }.to(
-          change { REDIS_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.from(nil).to('1'),
+          change { REDIS_THROTTLE_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.
+            from(nil).to('1'),
         )
       end
     end
 
     context 'when the key exists in redis' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), '3') }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), '3') }
       end
 
       it 'increments the value' do
         expect { rate_limiter.increment(now) }.to(
-          change { REDIS_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.to('4'),
+          change { REDIS_THROTTLE_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.to('4'),
         )
       end
     end
@@ -105,7 +106,7 @@ RSpec.describe RedisRateLimiter do
     it 'sets the TTL of the key to interval minus 1' do
       rate_limiter.increment(now)
 
-      ttl = REDIS_POOL.with { |r| r.ttl(rate_limiter.build_key(now)) }
+      ttl = REDIS_THROTTLE_POOL.with { |r| r.ttl(rate_limiter.build_key(now)) }
       expect(ttl).to be_within(1).of(interval - 1) # allow for some clock drift in specs
     end
   end


### PR DESCRIPTION
**Why**: So that throttles/short lived things live in the same instance

**Notes**:
I confirmed that the keyspace for this is empty in prod (it's only used in RISC outgoing notifications which are not super frequent right now), so this should be a very safe migration

```
REDIS_POOL.with { |r| r.scan(0, match: 'redis-rate-limiter*') }
=> ["1152", []]
```
