### PR TITLE
LG-8577: Prefill user's mobile number for hybrid docauth

### DIFF
--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -28,7 +28,21 @@ module Idv
         build_telephony_form_response(telephony_result)
       end
 
+      def extra_view_variables
+        {
+          idv_phone_form: create_form,
+        }
+      end
+
       private
+
+      def create_form
+        Idv::PhoneForm.new(
+          previous_params: {},
+          user: current_user,
+          delivery_methods: [:sms],
+        )
+      end
 
       def build_telephony_form_response(telephony_result)
         FormResponse.new(
@@ -76,11 +90,7 @@ module Idv
       def form_submit
         params = permit(:phone)
         params[:otp_delivery_preference] = 'sms'
-        Idv::PhoneForm.new(
-          previous_params: {},
-          user: current_user,
-          delivery_methods: [:sms],
-        ).submit(params)
+        create_form.submit(params)
       end
 
       def formatted_destination_phone

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -30,7 +30,7 @@ module Idv
 
       def extra_view_variables
         {
-          idv_phone_form: create_form,
+          idv_phone_form: build_form,
         }
       end
 
@@ -90,7 +90,7 @@ module Idv
       def form_submit
         params = permit(:phone)
         params[:otp_delivery_preference] = 'sms'
-        create_form.submit(params)
+        build_form.submit(params)
       end
 
       def formatted_destination_phone

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -36,7 +36,7 @@ module Idv
 
       private
 
-      def create_form
+      def build_form
         Idv::PhoneForm.new(
           previous_params: {},
           user: current_user,

--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -16,7 +16,8 @@
 
 <p><%= t('doc_auth.instructions.send_sms') %></p>
 <%= simple_form_for(
-      :doc_auth,
+      idv_phone_form,
+      as: :doc_auth,
       url: url_for,
       method: 'PUT',
       html: { autocomplete: 'off' },

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -19,7 +19,7 @@ feature 'doc auth send link step' do
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
   it "defaults phone to user's 2fa phone numebr" do
-    expect(page.find('input[name="doc_auth[phone]"]').value).to eql('+1 202-555-1212')
+    expect(page.find_field(t('two_factor_authentication.phone_label')).value).to eq('+1 202-555-1212')
   end
 
   it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -19,7 +19,8 @@ feature 'doc auth send link step' do
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
   it "defaults phone to user's 2fa phone numebr" do
-    expect(page.find_field(t('two_factor_authentication.phone_label')).value).to eq('+1 202-555-1212')
+    field = page.find_field(t('two_factor_authentication.phone_label'))
+    expect(field.value).to eq('+1 202-555-1212')
   end
 
   it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -18,6 +18,10 @@ feature 'doc auth send link step' do
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
+  it "defaults phone to user's 2fa phone numebr" do
+    expect(page.find('input[name="doc_auth[phone]"]').value).to eql('+1 202-555-1212')
+  end
+
   it 'proceeds to the next page with valid info' do
     expect_any_instance_of(IrsAttemptsApi::Tracker).to receive(:track_event).with(
       :idv_phone_upload_link_sent,

--- a/spec/services/idv/steps/send_link_step_spec.rb
+++ b/spec/services/idv/steps/send_link_step_spec.rb
@@ -68,6 +68,16 @@ describe Idv::Steps::SendLinkStep do
       and_return(irs_attempts_api_tracker)
   end
 
+  describe '#extra_view_variables' do
+    it 'includes form' do
+      expect(step.extra_view_variables).to include(
+        {
+          idv_phone_form: be_an_instance_of(Idv::PhoneForm),
+        },
+      )
+    end
+  end
+
   describe 'the return value from #call' do
     let(:response) { step.call }
 


### PR DESCRIPTION
If the user has a mobile number associated with their account, prefill that when showing the handoff screen for hybrid docauth.

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8577](https://cm-jira.usa.gov/browse/LG-8577)

## 🛠 Summary of changes

If the user has a phone number associated with their account (from 2fa), use that to prefill the phone number field on the doc auth hybrid handoff screen.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create an account and use SMS as your 2nd factor
- [ ] Start IDV and click on the big "Use your phone" button on the Verify your ID step.
- [ ] Verify your 2fa phone number shows up as the default value

## 👀 Screenshots

![screenshot-en](https://user-images.githubusercontent.com/364697/216480206-b5d44c3f-0665-4cb4-895a-7f43d142ee62.png)

