### PR TITLE
[LG-8794] Actually count phone_submit correctly in daily_dropoffs_report

### DIFF
--- a/app/jobs/reports/daily_dropoffs_report.rb
+++ b/app/jobs/reports/daily_dropoffs_report.rb
@@ -117,7 +117,9 @@ module Reports
             COALESCE(CASE WHEN doc_auth_logs.verify_submit_count > 0 THEN 1 else null END)
           ) AS verify_submit
         , COUNT(doc_auth_logs.verify_phone_view_at) AS phone
-        , COUNT(doc_auth_logs.verify_phone_submit_at) AS phone_submit
+        , COUNT(
+            COALESCE(CASE WHEN doc_auth_logs.verify_phone_submit_count > 0 THEN 1 else null END)
+          ) AS phone_submit
         , COUNT(doc_auth_logs.encrypt_view_at) AS encrypt
         , COUNT(doc_auth_logs.verified_view_at) AS personal_key
         , COUNT(profiles.id) AS verified

--- a/spec/jobs/reports/daily_dropoffs_report_spec.rb
+++ b/spec/jobs/reports/daily_dropoffs_report_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Reports::DailyDropoffsReport do
             verify_view_at: timestamp,
             verify_submit_count: 1,
             verify_phone_view_at: timestamp,
-            verify_phone_submit_at: timestamp,
+            verify_phone_submit_count: 1,
             encrypt_view_at: timestamp,
             verified_view_at: timestamp,
           )


### PR DESCRIPTION
Resolves LG-8794

[skip changelog]

I think I was counting this wrong - this is in line with how we're handling the other submit steps. Once this is merged and deployed I'll backfill the data again and then we'll want to invalidate the CloudFront cache.

```ruby
(Date.new(2020, 9, 28)..Date.yesterday).each { |date| Reports::DailyDropoffsReport.perform_later(date) }
```


<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
