### PR TITLE
Refactor NewPhoneForm class for clarity, consistency, conventions

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -12,14 +12,14 @@ module Users
 
     def index
       @new_phone_form = NewPhoneForm.new(
-        current_user,
+        user: current_user,
         setup_voice_preference: setup_voice_preference?,
       )
       track_phone_setup_visit
     end
 
     def create
-      @new_phone_form = NewPhoneForm.new(current_user)
+      @new_phone_form = NewPhoneForm.new(user: current_user)
       result = @new_phone_form.submit(new_phone_form_params)
       analytics.multi_factor_auth_phone_setup(**result.to_h)
 

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -8,11 +8,11 @@ module Users
 
     def add
       user_session[:phone_id] = nil
-      @new_phone_form = NewPhoneForm.new(current_user)
+      @new_phone_form = NewPhoneForm.new(user: current_user)
     end
 
     def create
-      @new_phone_form = NewPhoneForm.new(current_user)
+      @new_phone_form = NewPhoneForm.new(user: current_user)
       if @new_phone_form.submit(user_params).success?
         confirm_phone
         bypass_sign_in current_user

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -20,7 +20,7 @@ class NewPhoneForm
 
   alias_method :setup_voice_preference?, :setup_voice_preference
 
-  def initialize(user, setup_voice_preference: false)
+  def initialize(user:, setup_voice_preference: false)
     self.user = user
     self.otp_delivery_preference = user.otp_delivery_preference
     self.otp_make_default_number = false

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -15,8 +15,11 @@ class NewPhoneForm
   validate :validate_not_premium_rate
   validate :validate_allowed_carrier
 
-  attr_accessor :phone, :international_code, :otp_delivery_preference,
-                :otp_make_default_number, :setup_voice_preference
+  attr_reader :phone,
+              :international_code,
+              :otp_delivery_preference,
+              :otp_make_default_number,
+              :setup_voice_preference
 
   alias_method :setup_voice_preference?, :setup_voice_preference
 
@@ -64,7 +67,7 @@ class NewPhoneForm
 
   private
 
-  attr_accessor :user, :submitted_phone
+  attr_reader :user, :submitted_phone
 
   def ingest_phone_number(params)
     @international_code = params[:international_code]

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -21,17 +21,17 @@ class NewPhoneForm
   alias_method :setup_voice_preference?, :setup_voice_preference
 
   def initialize(user:, setup_voice_preference: false)
-    self.user = user
-    self.otp_delivery_preference = user.otp_delivery_preference
-    self.otp_make_default_number = false
-    self.setup_voice_preference = setup_voice_preference
+    @user = user
+    @otp_delivery_preference = user.otp_delivery_preference
+    @otp_make_default_number = false
+    @setup_voice_preference = setup_voice_preference
   end
 
   def submit(params)
     ingest_submitted_params(params)
 
     success = valid?
-    self.phone = submitted_phone unless success
+    @phone = submitted_phone unless success
 
     FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
@@ -67,12 +67,9 @@ class NewPhoneForm
   attr_accessor :user, :submitted_phone
 
   def ingest_phone_number(params)
-    self.international_code = params[:international_code]
-    self.submitted_phone = params[:phone]
-    self.phone = PhoneFormatter.format(
-      submitted_phone,
-      country_code: international_code,
-    )
+    @international_code = params[:international_code]
+    @submitted_phone = params[:phone]
+    @phone = PhoneFormatter.format(submitted_phone, country_code: international_code)
   end
 
   def extra_analytics_attributes
@@ -135,8 +132,8 @@ class NewPhoneForm
     delivery_prefs = params[:otp_delivery_preference]
     default_prefs = params[:otp_make_default_number]
 
-    self.otp_delivery_preference = delivery_prefs if delivery_prefs
-    self.otp_make_default_number = true if default_prefs
+    @otp_delivery_preference = delivery_prefs if delivery_prefs
+    @otp_make_default_number = true if default_prefs
   end
 
   def confirmed_phone?

--- a/spec/components/phone_input_component_spec.rb
+++ b/spec/components/phone_input_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PhoneInputComponent, type: :component do
   let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
   let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
   let(:user) { build_stubbed(:user) }
-  let(:form_object) { NewPhoneForm.new(user) }
+  let(:form_object) { NewPhoneForm.new(user:) }
   let(:form_builder) do
     SimpleForm::FormBuilder.new(form_object.model_name.param_key, form_object, view_context, {})
   end

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -23,7 +23,7 @@ describe Users::PhoneSetupController do
 
         expect(@analytics).to receive(:track_event).
           with('User Registration: phone setup visited', enabled_mfa_methods_count: 0)
-        expect(NewPhoneForm).to receive(:new).with(user, setup_voice_preference: false)
+        expect(NewPhoneForm).to receive(:new).with(user:, setup_voice_preference: false)
 
         get :index
 

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -16,9 +16,26 @@ describe NewPhoneForm do
   it_behaves_like 'a phone form'
 
   describe 'phone validation' do
-    it do
-      should validate_inclusion_of(:international_code).
-        in_array(PhoneNumberCapabilities::INTERNATIONAL_CODES.keys)
+    context 'with valid international code' do
+      it 'is valid' do
+        PhoneNumberCapabilities::INTERNATIONAL_CODES.keys.each do |code|
+          result = subject.submit(params.clone.merge(international_code: code))
+
+          expect(result.to_h[:error_details]).not_to match(
+            hash_including(international_code: include(:inclusion)),
+          )
+        end
+      end
+    end
+
+    context 'with invalid international code' do
+      it 'is invalid' do
+        result = subject.submit(params.clone.merge(international_code: 'INVALID'))
+
+        expect(result.to_h[:error_details]).to match(
+          hash_including(international_code: include(:inclusion)),
+        )
+      end
     end
 
     it 'validates that the number matches the requested international code' do

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -52,7 +52,7 @@ describe NewPhoneForm do
 
       it 'does not update the user phone attribute' do
         user = create(:user)
-        subject = NewPhoneForm.new(user)
+        subject = NewPhoneForm.new(user:)
         params[:phone] = '+1 504 444 1643'
 
         subject.submit(params)

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -11,7 +11,7 @@ describe NewPhoneForm do
       otp_delivery_preference: 'sms',
     }
   end
-  subject(:form) { NewPhoneForm.new(user) }
+  subject(:form) { NewPhoneForm.new(user:) }
 
   it_behaves_like 'a phone form'
 
@@ -375,7 +375,7 @@ describe NewPhoneForm do
     end
 
     context 'with setup_voice_preference present' do
-      subject(:form) { NewPhoneForm.new(user, setup_voice_preference: true) }
+      subject(:form) { NewPhoneForm.new(user:, setup_voice_preference: true) }
 
       it 'is true' do
         expect(form.delivery_preference_voice?).to eq(true)

--- a/spec/views/phone_setup/index.html.erb_spec.rb
+++ b/spec/views/phone_setup/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'users/phone_setup/index.html.erb' do
 
     allow(view).to receive(:current_user).and_return(user)
 
-    @new_phone_form = NewPhoneForm.new(user)
+    @new_phone_form = NewPhoneForm.new(user:)
 
     @presenter = SetupPresenter.new(
       current_user: user,

--- a/spec/views/users/phones/add.html.erb_spec.rb
+++ b/spec/views/users/phones/add.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'users/phones/add.html.erb' do
 
   before do
     user = build_stubbed(:user)
-    @new_phone_form = NewPhoneForm.new(user)
+    @new_phone_form = NewPhoneForm.new(user:)
   end
 
   context 'phone vendor outage' do

--- a/spec/views/users/shared/_otp_delivery_preference_selection.html.erb_spec.rb
+++ b/spec/views/users/shared/_otp_delivery_preference_selection.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'users/shared/_otp_delivery_preference_selection.html.erb' do
   let(:user) { build_stubbed(:user) }
 
   subject(:rendered) do
-    render 'users/shared/otp_delivery_preference_selection', form_obj: NewPhoneForm.new(user)
+    render 'users/shared/otp_delivery_preference_selection', form_obj: NewPhoneForm.new(user:)
   end
 
   it 'renders enabled sms option' do


### PR DESCRIPTION
## 🎫 Ticket

Extracted from #7761, related to [LG-8771](https://cm-jira.usa.gov/browse/LG-8771).

## 🛠 Summary of changes

Minor revisions to `NewPhoneForm` to improve clarity and consistency of arguments, and adopt conventions of instance variable assignment.

* Change `user` from positional argument to keyword argument, so that there's not an unnecessary combination of both, and to improve the clarity of the arguments that the class is expected to receive, since it's not instinctively obvious that `user` would be the first argument of the class's constructor.
* Use `@` instead of `self.` for class instance variable assignment, since it's more conventional.

## 📜 Testing Plan

- `rspec spec/forms/new_phone_form_spec.rb`