### PR TITLE
LG-8834 add phone to ready to verify email

### DIFF
--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -84,7 +84,7 @@
       <%= t('date.day_names')[6] %>: <%= @presenter.selected_location_hours(:sunday) %>
     </div>
     <div>
-      <%= @presenter.selected_location_details[:phone] %>
+      <%= @presenter.selected_location_details['phone'] %>
     </div>
   </div>
 <% end %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -561,7 +561,7 @@ describe UserMailer, type: :mailer do
       create(
         :in_person_enrollment,
         :pending,
-        selected_location_details: { name: 'FRIENDSHIP' },
+        selected_location_details: { name: 'FRIENDSHIP', phone: '202-842-3332' },
         status_updated_at: Time.zone.now - 2.hours,
       )
     end
@@ -569,6 +569,12 @@ describe UserMailer, type: :mailer do
     let(:mail) do
       UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
         enrollment: enrollment,
+      )
+    end
+
+    it 'renders the phone number' do
+      expect(mail.html_part.body).to have_content(
+        '202-842-3332',
       )
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[Lg-8834](https://cm-jira.usa.gov/browse/LG-8834)


## 🛠 Summary of changes

Get phone from selected_location_details so that it is included in ready to verify email


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Visit: http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify.html?locale=en
- [ ] Verify phone # is present after hours

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="604" alt="Screen Shot 2023-02-03 at 11 12 31 AM" src="https://user-images.githubusercontent.com/20867088/216653862-cab35e38-ed9d-43df-963f-435782f052bd.png">

</details>

<details>
<summary>After:</summary>
<img width="644" alt="Screen Shot 2023-02-03 at 11 12 14 AM" src="https://user-images.githubusercontent.com/20867088/216653924-f7ad491a-f7e6-461a-b1e1-85b3757435df.png">

</details>
