### PR TITLE
Fix service tests

### DIFF
--- a/spec/services/encryption/aes_cipher_spec.rb
+++ b/spec/services/encryption/aes_cipher_spec.rb
@@ -36,7 +36,7 @@ describe Encryption::AesCipher do
       cipher = subject.class.encryption_cipher
 
       expect(cipher).to be_kind_of(OpenSSL::Cipher)
-      expect(cipher.name).to eq 'id-aes256-GCM'
+      expect(cipher.name).to eq OpenSSL::Cipher.new('aes-256-gcm').name
     end
   end
 end

--- a/spec/services/frontend_logger_spec.rb
+++ b/spec/services/frontend_logger_spec.rb
@@ -7,11 +7,11 @@ describe FrontendLogger do
     end
   end
 
-  class ExampleAnalytics < FakeAnalytics
+  class ExampleAnalyticsForFL < FakeAnalytics
     include ExampleAnalyticsEvents
   end
 
-  let(:analytics) { ExampleAnalytics.new }
+  let(:analytics) { ExampleAnalyticsForFL.new }
   let(:event_map) do
     {
       'method' => ExampleAnalyticsEvents.instance_method(:example_method_handler),

--- a/spec/services/frontend_logger_spec.rb
+++ b/spec/services/frontend_logger_spec.rb
@@ -7,11 +7,13 @@ describe FrontendLogger do
     end
   end
 
-  class ExampleAnalyticsForFL < FakeAnalytics
-    include ExampleAnalyticsEvents
+  let(:analytics_class) do
+    Class.new(FakeAnalytics) do
+      include ExampleAnalyticsEvents
+    end
   end
+  let(:analytics) { analytics_class.new }
 
-  let(:analytics) { ExampleAnalyticsForFL.new }
   let(:event_map) do
     {
       'method' => ExampleAnalyticsEvents.instance_method(:example_method_handler),

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::AnalyticsEventsEnhancer do
-  class ExampleAnalytics
+  class ExampleAnalyticsForAEE
     include AnalyticsEvents
     prepend Idv::AnalyticsEventsEnhancer
 
@@ -17,7 +17,7 @@ describe Idv::AnalyticsEventsEnhancer do
   end
 
   let(:user) { build(:user) }
-  let(:analytics) { ExampleAnalytics.new(user: user) }
+  let(:analytics) { ExampleAnalyticsForAEE.new(user: user) }
 
   it 'includes decorated methods' do
     expect(analytics.methods).to include(*described_class::DECORATED_METHODS)

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Idv::AnalyticsEventsEnhancer do
-
   let(:user) { build(:user) }
   let(:analytics_class) do
     Class.new(FakeAnalytics) do
@@ -19,7 +18,7 @@ describe Idv::AnalyticsEventsEnhancer do
       end
     end
   end
-  let(:analytics) { analytics_class.new(user: user)}
+  let(:analytics) { analytics_class.new(user: user) }
 
   it 'includes decorated methods' do
     expect(analytics.methods).to include(*described_class::DECORATED_METHODS)

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -1,23 +1,25 @@
 require 'rails_helper'
 
 describe Idv::AnalyticsEventsEnhancer do
-  class ExampleAnalyticsForAEE
-    include AnalyticsEvents
-    prepend Idv::AnalyticsEventsEnhancer
-
-    def idv_final(**kwargs)
-      @called_kwargs = kwargs
-    end
-
-    attr_reader :user, :called_kwargs
-
-    def initialize(user:)
-      @user = user
-    end
-  end
 
   let(:user) { build(:user) }
-  let(:analytics) { ExampleAnalyticsForAEE.new(user: user) }
+  let(:analytics_class) do
+    Class.new(FakeAnalytics) do
+      include AnalyticsEvents
+      prepend Idv::AnalyticsEventsEnhancer
+
+      def idv_final(**kwargs)
+        @called_kwargs = kwargs
+      end
+
+      attr_reader :user, :called_kwargs
+
+      def initialize(user:)
+        @user = user
+      end
+    end
+  end
+  let(:analytics) { analytics_class.new(user: user)}
 
   it 'includes decorated methods' do
     expect(analytics.methods).to include(*described_class::DECORATED_METHODS)


### PR DESCRIPTION
## 🛠 Summary of changes

Fix two services tests that failed when the whole services test suite was run locally
- Fix aes_cipher_spec name dependence on SSL library version
- Fix classname collision between frontend_logger_spec and analytics_events_ enhancer_spec
