### PR TITLE
Add .irbrc, disable autocomplete

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,1 +1,1 @@
-IRB.conf[:USE_AUTOCOMPLETE] = true
+IRB.conf[:USE_AUTOCOMPLETE] = false

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+IRB.conf[:USE_AUTOCOMPLETE] = true


### PR DESCRIPTION
Got nerd-sniped by @tomas-nava [in Slack](https://gsa-tts.slack.com/archives/C0NGESUN5/p1675464934659899)

Verified by creating this file on an int box and loading the console

```bash
sudo echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > /srv/idp/current/.irbrc
sudo chmod +r /srv/idp/current/.irbrc
id-rails-console
```
