### PR TITLE
Update frontend.md docs to point to a file that still exists

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -192,7 +192,7 @@ yarn test
 To run a single test file:
 
 ```
-npx mocha app/javascript/packages/analytics/index.spec.ts
+yarn mocha app/javascript/packages/analytics/index.spec.ts
 ```
 
 Using `npx`, you can also pass any
@@ -201,7 +201,7 @@ Using `npx`, you can also pass any
 For example, to watch a file and rerun tests after any change:
 
 ```
-npx mocha app/javascript/packages/analytics/index.spec.ts --watch
+yarn mocha app/javascript/packages/analytics/index.spec.ts --watch
 ```
 
 #### ESLint

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -192,7 +192,7 @@ yarn test
 To run a single test file:
 
 ```
-npx mocha spec/javascripts/app/utils/ms-formatter_spec.js
+npx mocha app/javascript/packages/analytics/index.spec.ts
 ```
 
 Using `npx`, you can also pass any
@@ -201,7 +201,7 @@ Using `npx`, you can also pass any
 For example, to watch a file and rerun tests after any change:
 
 ```
-npx mocha spec/javascripts/app/utils/ms-formatter_spec.js --watch
+npx mocha app/javascript/packages/analytics/index.spec.ts --watch
 ```
 
 #### ESLint


### PR DESCRIPTION
The example file doesn't exist anymore so the command wasn't copy-pasteable. But now it is!