### PR TITLE
View Components: Recursively add scripts for subclass's parent component

### DIFF
--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -10,7 +10,7 @@ class BaseComponent < ViewComponent::Base
   def self.scripts
     @scripts ||= begin
       scripts = _sidecar_files(['js', 'ts']).map { |file| File.basename(file, '.*') }
-      scripts.concat superclass.scripts if superclass != BaseComponent
+      scripts.concat superclass.scripts if superclass.respond_to?(:scripts)
       scripts
     end
   end

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -8,7 +8,11 @@ class BaseComponent < ViewComponent::Base
   end
 
   def self.scripts
-    @scripts ||= _sidecar_files(['js', 'ts']).map { |file| File.basename(file, '.*') }
+    @scripts ||= begin
+      scripts = _sidecar_files(['js', 'ts']).map { |file| File.basename(file, '.*') }
+      scripts.concat superclass.scripts if superclass != BaseComponent
+      scripts
+    end
   end
 
   def unique_id


### PR DESCRIPTION
## 🎫 Ticket

Extracted from #7761, related to [LG-8771](https://cm-jira.usa.gov/browse/LG-8771).

## 🛠 Summary of changes

Revises behavior of base script component to add scripts for the current class implementation, as well as any parent class scripts if the current component is subclassing another.

Essentially, given the following:

```
/components/parent_class_component.rb
/components/parent_class_component.ts
/components/child_class_component.rb
/components/child_class_component.ts
```

**Before:** When rendering `ChildClassComponent`, only `child_class_component.ts` would be added to the page
**After:** Both `child_class_component.ts` and `parent_class_component.ts` would be added to the page

Note that this seemed like an "obvious" behavior to me on Friday, though I'm of a less-strong opinion today, so happy to hear any dissenting opinion on whether it should work this way.

This should not impact any existing component, since while we do have some subclassing (e.g. `DownloadButtonComponent < ButtonComponent`), the parent classes in those cases do not have any associated scripts. This was discovered to be an issue while implementing #7761.

## 📜 Testing Plan

- `rspec spec/components/base_component_spec.rb`