### PR TITLE
Deploy RC 250 to Prod

### DIFF
--- a/app/components/phone_input_component.js
+++ b/app/components/phone_input_component.js
@@ -1,3 +1,0 @@
-import { PhoneInput } from '@18f/identity-phone-input';
-
-customElements.define('lg-phone-input', PhoneInput);

--- a/app/components/phone_input_component.ts
+++ b/app/components/phone_input_component.ts
@@ -1,0 +1,1 @@
+import '@18f/identity-phone-input';

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -28,7 +28,8 @@ module Idv
     def create
       @gpo_verify_form = build_gpo_verify_form
 
-      if throttle.throttled_else_increment?
+      throttle.increment!
+      if throttle.throttled?
         render_throttled
       else
         result = @gpo_verify_form.submit

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -13,9 +13,7 @@ module Idv
       protected
 
       def addresses(search_term)
-        suggestion = geocoder.suggest(search_term).first
-        return { json: [], status: :ok } unless suggestion
-        addresses = geocoder.find_address_candidates(suggestion.magic_key).slice(0, 1)
+        addresses = geocoder.find_address_candidates(SingleLine: search_term).slice(0, 1)
         { json: addresses, status: :ok }
       rescue Faraday::ConnectionFailed => err
         analytics.idv_arcgis_request_failure(

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -36,8 +36,6 @@ module Idv
 
     def throttled
       @expires_at = Throttle.new(user: effective_user, throttle_type: :idv_doc_auth).expires_at
-      analytics.throttler_rate_limit_triggered(throttle_type: :idv_doc_auth)
-      irs_attempts_api_tracker.idv_document_upload_rate_limited
     end
 
     private

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -30,7 +30,8 @@ module Idv
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 
-      if ssn_throttle.throttled_else_increment?
+      ssn_throttle.increment!
+      if ssn_throttle.throttled?
         analytics.throttler_rate_limit_triggered(
           throttle_type: :proof_ssn,
           step_name: 'verify_info',

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -20,6 +20,7 @@ module Idv
         return
       end
 
+      @had_barcode_read_failure = flow_session[:had_barcode_read_failure]
       process_async_state(load_async_state)
     end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -273,7 +273,8 @@ module Users
 
     def exceeded_phone_confirmation_limit?
       return false unless UserSessionContext.confirmation_context?(context)
-      phone_confirmation_throttle.throttled_else_increment?
+      phone_confirmation_throttle.increment!
+      phone_confirmation_throttle.throttled?
     end
 
     def send_user_otp(method)

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -21,7 +21,8 @@ module Users
     end
 
     def create
-      if throttle.throttled_else_increment?
+      throttle.increment!
+      if throttle.throttled?
         render_throttled
       else
         result = personal_key_form.submit

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -24,7 +24,7 @@ module Idv
     end
 
     def submit
-      throttled_else_increment
+      increment_throttle!
 
       response = FormResponse.new(
         success: valid?,
@@ -88,9 +88,10 @@ module Idv
       errors.add(:limit, t('errors.doc_auth.throttled_heading'), type: :throttled)
     end
 
-    def throttled_else_increment
+    def increment_throttle!
       return unless document_capture_session
-      @throttled = throttle.throttled_else_increment?
+      throttle.increment!
+      @throttled = throttle.throttled?
     end
 
     def throttle

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -22,7 +22,7 @@ module Idv
     end
 
     def submit
-      throttled_else_increment
+      increment_throttle!
       form_response = validate_form
 
       client_response = nil
@@ -46,9 +46,10 @@ module Idv
     attr_reader :params, :analytics, :service_provider, :form_response, :uuid_prefix,
                 :irs_attempts_api_tracker
 
-    def throttled_else_increment
+    def increment_throttle!
       return unless document_capture_session
-      @throttled = throttle.throttled_else_increment?
+      throttle.increment!
+      @throttled = throttle.throttled?
     end
 
     def validate_form

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -80,6 +80,7 @@ class OpenidConnectAuthorizeForm
       nonce: nonce,
       rails_session_id: rails_session_id,
       ial: ial_context.ial,
+      aal: aal,
       scope: scope.join(' '),
       code_challenge: code_challenge,
     )
@@ -96,16 +97,20 @@ class OpenidConnectAuthorizeForm
     acr_values.filter { |acr| %r{/ial/}.match?(acr) || %r{/loa/}.match?(acr) }
   end
 
-  def aal_values
-    acr_values.filter { |acr| %r{/aal/}.match? acr }
-  end
-
   def ial_context
     @ial_context ||= IalContext.new(ial: ial, service_provider: service_provider)
   end
 
   def ial
     Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max]
+  end
+
+  def aal_values
+    acr_values.filter { |acr| %r{/aal/}.match? acr }
+  end
+
+  def aal
+    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[aal_values.sort.max]
   end
 
   def_delegators :ial_context,

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -109,7 +109,8 @@ class RegisterUserEmailForm
 
   def send_sign_up_unconfirmed_email(request_id)
     throttler = Throttle.new(user: existing_user, throttle_type: :reg_unconfirmed_email)
-    @throttled = throttler.throttled_else_increment?
+    throttler.increment!
+    @throttled = throttler.throttled?
 
     if @throttled
       @analytics.throttler_rate_limit_triggered(
@@ -125,7 +126,8 @@ class RegisterUserEmailForm
 
   def send_sign_up_confirmed_email
     throttler = Throttle.new(user: existing_user, throttle_type: :reg_confirmed_email)
-    @throttled = throttler.throttled_else_increment?
+    throttler.increment!
+    @throttled = throttler.throttled?
 
     if @throttled
       @analytics.throttler_rate_limit_triggered(

--- a/app/javascript/packages/phone-input/index.spec.ts
+++ b/app/javascript/packages/phone-input/index.spec.ts
@@ -22,8 +22,7 @@ describe('PhoneInput', () => {
   before(async () => {
     await import('intl-tel-input/build/js/utils.js');
     window.intlTelInputUtils = global.intlTelInputUtils;
-    const { PhoneInput } = await import('./index.js');
-    customElements.define('lg-phone-input', PhoneInput);
+    await import('./index');
   });
 
   function createAndConnectElement({
@@ -81,8 +80,7 @@ describe('PhoneInput', () => {
   it('validates input', async () => {
     const input = createAndConnectElement();
 
-    /** @type {HTMLInputElement} */
-    const phoneNumber = getByLabelText(input, 'Phone number');
+    const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
 
     expect(phoneNumber.validity.valueMissing).to.be.true();
 
@@ -96,10 +94,10 @@ describe('PhoneInput', () => {
   it('validates supported delivery method', async () => {
     const input = createAndConnectElement();
 
-    /** @type {HTMLInputElement} */
-    const phoneNumber = getByLabelText(input, 'Phone number');
-    /** @type {HTMLSelectElement} */
-    const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
+    const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
+    const countryCode = getByLabelText(input, 'Country code', {
+      selector: 'select',
+    }) as HTMLSelectElement;
 
     await userEvent.selectOptions(countryCode, 'LK');
     expect(phoneNumber.validationMessage).to.equal(
@@ -110,10 +108,10 @@ describe('PhoneInput', () => {
   it('formats on country change', async () => {
     const input = createAndConnectElement();
 
-    /** @type {HTMLInputElement} */
-    const phoneNumber = getByLabelText(input, 'Phone number');
-    /** @type {HTMLSelectElement} */
-    const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
+    const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
+    const countryCode = getByLabelText(input, 'Country code', {
+      selector: 'select',
+    }) as HTMLSelectElement;
 
     await userEvent.type(phoneNumber, '071');
 
@@ -134,8 +132,7 @@ describe('PhoneInput', () => {
     it('validates phone from region', async () => {
       const input = createAndConnectElement({ isNonUSSingleOption: true });
 
-      /** @type {HTMLInputElement} */
-      const phoneNumber = getByLabelText(input, 'Phone number');
+      const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
 
       await userEvent.type(phoneNumber, '513-555-1234');
       expect(phoneNumber.validationMessage).to.equal('Phone number is not valid');
@@ -146,10 +143,10 @@ describe('PhoneInput', () => {
     it('validates supported delivery method', async () => {
       const input = createAndConnectElement({ deliveryMethods: ['voice'] });
 
-      /** @type {HTMLInputElement} */
-      const phoneNumber = getByLabelText(input, 'Phone number');
-      /** @type {HTMLSelectElement} */
-      const countryCode = getByLabelText(input, 'Country code', { selector: 'select' });
+      const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
+      const countryCode = getByLabelText(input, 'Country code', {
+        selector: 'select',
+      }) as HTMLSelectElement;
 
       await userEvent.selectOptions(countryCode, 'CA');
       expect(phoneNumber.validationMessage).to.equal(
@@ -162,7 +159,7 @@ describe('PhoneInput', () => {
     it('renders the translated label', () => {
       createAndConnectElement({ translatedCountryCodeNames: { us: 'Custom USA' } });
 
-      const itiOptionName = document.querySelector('[data-country-code="us"] .iti__country-name');
+      const itiOptionName = document.querySelector('[data-country-code="us"] .iti__country-name')!;
 
       expect(itiOptionName.textContent).to.equal('Custom USA');
     });

--- a/app/javascript/packs/otp-delivery-preference.js
+++ b/app/javascript/packs/otp-delivery-preference.js
@@ -1,6 +1,6 @@
 import { t } from '@18f/identity-i18n';
 
-/** @typedef {import('@18f/identity-phone-input').PhoneInput} PhoneInput */
+/** @typedef {import('@18f/identity-phone-input').PhoneInputElement} PhoneInput */
 
 /**
  * Returns the OTP delivery preference element.

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -3,7 +3,9 @@ class GetUspsProofingResultsJob < ApplicationJob
   IPP_STATUS_PASSED = 'In-person passed'
   IPP_STATUS_FAILED = 'In-person failed'
   IPP_INCOMPLETE_ERROR_MESSAGE = 'Customer has not been to a post office to complete IPP'
-  IPP_EXPIRED_ERROR_MESSAGE = 'More than 30 days have passed since opt-in to IPP'
+  IPP_EXPIRED_ERROR_MESSAGE = /More than (?<days>\d+) days have passed since opt-in to IPP/
+  IPP_INVALID_ENROLLMENT_CODE_MESSAGE = 'Enrollment code %s does not exist'
+  IPP_INVALID_APPLICANT_MESSAGE = 'Applicant %s does not exist'
   SUPPORTED_ID_TYPES = [
     "State driver's license",
     "State non-driver's identification card",
@@ -138,18 +140,25 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def handle_bad_request_error(err, enrollment)
-    response = err.response_body
-    case response&.[]('responseMessage')
-    when IPP_INCOMPLETE_ERROR_MESSAGE
+    response_body = err.response_body
+    response_message = response_body&.[]('responseMessage')
+
+    if response_message == IPP_INCOMPLETE_ERROR_MESSAGE
       # Customer has not been to post office for IPP
       enrollment_outcomes[:enrollments_in_progress] += 1
-    when IPP_EXPIRED_ERROR_MESSAGE
-      handle_expired_status_update(enrollment, err.response)
+    elsif response_message&.match(IPP_EXPIRED_ERROR_MESSAGE)
+      handle_expired_status_update(enrollment, err.response, response_message)
+    elsif response_message == IPP_INVALID_ENROLLMENT_CODE_MESSAGE % enrollment.enrollment_code
+      handle_unexpected_response(enrollment, response_message, reason: 'Invalid enrollment code')
+    elsif response_message == IPP_INVALID_APPLICANT_MESSAGE % enrollment.unique_id
+      handle_unexpected_response(
+        enrollment, response_message, reason: 'Invalid applicant unique id'
+      )
     else
       NewRelic::Agent.notice_error(err)
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_exception(
         **enrollment_analytics_attributes(enrollment, complete: false),
-        **response_analytics_attributes(response),
+        **response_analytics_attributes(response_body),
         exception_class: err.class.to_s,
         exception_message: err.message,
         reason: 'Request exception',
@@ -231,7 +240,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     enrollment.update(status: :failed)
   end
 
-  def handle_expired_status_update(enrollment, response)
+  def handle_expired_status_update(enrollment, response, response_message)
     enrollment_outcomes[:enrollments_expired] += 1
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_updated(
       **enrollment_analytics_attributes(enrollment, complete: true),
@@ -259,6 +268,31 @@ class GetUspsProofingResultsJob < ApplicationJob
         )
       enrollment.update(deadline_passed_sent: true)
     end
+
+    # check for an unexpected number of days until expiration
+    match = response_message&.match(IPP_EXPIRED_ERROR_MESSAGE)
+    expired_after_days = match && match[:days]
+    if expired_after_days.present? &&
+       expired_after_days.to_i != IdentityConfig.store.in_person_enrollment_validity_in_days
+      handle_unexpected_response(
+        enrollment,
+        response_message,
+        reason: 'Unexpected number of days before enrollment expired',
+        cancel: false,
+      )
+    end
+  end
+
+  def handle_unexpected_response(enrollment, response_message, reason:, cancel: true)
+    enrollment.cancelled! if cancel
+
+    analytics(user: enrollment.user).
+      idv_in_person_usps_proofing_results_job_unexpected_response(
+        enrollment_code: enrollment.enrollment_code,
+        enrollment_id: enrollment.id,
+        response_message: response_message,
+        reason: reason,
+      )
   end
 
   def handle_failed_status(enrollment, response)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -21,6 +21,8 @@ class OpenidConnectUserInfoPresenter
     info.merge!(ial2_attributes) if scoper.ial2_scopes_requested?
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
+    info[:ial] = identity.ial if identity.ial.present?
+    info[:aal] = identity.aal if identity.aal.present?
 
     scoper.filter(info)
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3208,7 +3208,7 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks exceptions that are raised when initiating deadline email in GetUspsproofingResultsJob
+  # Tracks exceptions that are raised when initiating deadline email in GetUspsProofingResultsJob
   # @param [String] enrollment_id
   # @param [String] exception_class
   # @param [String] exception_message
@@ -3296,6 +3296,28 @@ module AnalyticsEvents
       'InPerson::EmailReminderJob: Reminder email initiated',
       email_type: email_type,
       enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks unexpected responses from the USPS API
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [String] response_message
+  # @param [String] reason why was this error unexpected?
+  def idv_in_person_usps_proofing_results_job_unexpected_response(
+    enrollment_code:,
+    enrollment_id:,
+    response_message:,
+    reason:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Unexpected response received',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      response_message: response_message,
+      reason: reason,
       **extra,
     )
   end

--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -13,7 +13,26 @@ module ArcgisApi
     COMMON_DEFAULT_PARAMETERS = {
       f: 'json',
       countryCode: 'USA',
-      category: 'address',
+      # See https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B
+      #   and https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#GUID-D5C1A6E8-82DE-4900-8F8D-B390C2714A1F
+      category: [
+        # A subset of a PointAddress that represents a house or building subaddress location,
+        #   such as an apartment unit, floor, or individual building within a complex.
+        #   E.g. 3836 Emerald Ave, Suite C, La Verne, CA, 91750
+        'Subaddress',
+
+        # A street address based on points that represent house and building locations.
+        #   E.g. 380 New York St, Redlands, CA, 92373
+        'Point Address',
+
+        # A street address that differs from PointAddress because the house number is interpolated
+        #   from a range of numbers. E.g. 647 Haight St, San Francisco, CA, 94117
+        'Street Address',
+
+        # Similar to a street address but without the house number.
+        #   E.g. Olive Ave, Redlands, CA, 92373.
+        'Street Name',
+      ].join(','),
     }.freeze
 
     ROOT_URL = IdentityConfig.store.arcgis_api_root_url
@@ -57,7 +76,7 @@ module ArcgisApi
 
       if supported_params.empty?
         raise ArgumentError, <<~MSG
-          Unknown parameters: #{options.except(KNOWN_FIND_ADDRESS_CANDIDATES_PARAMETERS)}.
+          Unknown parameters: #{options.except(*KNOWN_FIND_ADDRESS_CANDIDATES_PARAMETERS)}.
           See https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm
         MSG
       end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -5,11 +5,13 @@ class IdentityLinker
     @user = user
     @service_provider = service_provider
     @ial = nil
+    @aal = nil
   end
 
   def link_identity(
     code_challenge: nil,
     ial: nil,
+    aal: nil,
     nonce: nil,
     rails_session_id: nil,
     scope: nil,
@@ -18,12 +20,14 @@ class IdentityLinker
     clear_deleted_at: nil
   )
     return unless user && service_provider.present?
+
     process_ial(ial)
 
     identity.update!(
       identity_attributes.merge(
         code_challenge: code_challenge,
         ial: ial,
+        aal: aal,
         nonce: nonce,
         rails_session_id: rails_session_id,
         scope: scope,

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -64,13 +64,6 @@ module Idv
         idv_session_errors_throttled_url
       end
 
-      def throttled_else_increment
-        Throttle.new(
-          user: effective_user,
-          throttle_type: :idv_doc_auth,
-        ).throttled_else_increment?
-      end
-
       # Ideally we would not have to re-implement the EffectiveUser mixin
       # but flow_session sometimes != controller#session
       def effective_user

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -14,7 +14,8 @@ module Idv
       end
 
       def call
-        return throttled_failure if throttle.throttled_else_increment?
+        throttle.increment!
+        return throttled_failure if throttle.throttled?
         telephony_result = send_link
         failure_reason = nil
         if !telephony_result.success?

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -177,7 +177,8 @@ module Idv
             throttle_type: :proof_ssn,
           )
 
-          if throttle.throttled_else_increment?
+          throttle.increment!
+          if throttle.throttled?
             @flow.analytics.throttler_rate_limit_triggered(
               throttle_type: :proof_ssn,
               step_name: self.class,

--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -29,12 +29,12 @@ module Proofing
       def proof(applicant)
         aamva_applicant =
           Aamva::Applicant.from_proofer_applicant(OpenStruct.new(applicant))
-        verification_response = Aamva::VerificationClient.new(
+        response = Aamva::VerificationClient.new(
           config,
         ).send_verification_request(
           applicant: aamva_applicant,
         )
-        build_result_from_response(verification_response)
+        build_result_from_response(response)
       rescue => exception
         NewRelic::Agent.notice_error(exception)
         Proofing::StateIdResult.new(

--- a/app/services/proofing/address_result.rb
+++ b/app/services/proofing/address_result.rb
@@ -1,7 +1,12 @@
 module Proofing
   class AddressResult
-    attr :success, :errors, :exception, :vendor_name, :transaction_id, :reference,
-         :vendor_workflow
+    attr_reader :success,
+                :errors,
+                :exception,
+                :vendor_name,
+                :transaction_id,
+                :reference,
+                :vendor_workflow
 
     def initialize(
       success:,

--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -1,7 +1,11 @@
 module Proofing
-  class Result
+  class DdpResult
     attr_reader :exception
-    attr_accessor :context, :transaction_id, :reference, :review_status, :response_body
+    attr_accessor :context,
+                  :transaction_id,
+                  :reference,
+                  :review_status,
+                  :response_body
 
     def initialize(
         errors: {},
@@ -26,10 +30,6 @@ module Proofing
     end
     # rubocop:enable Style/OptionalArguments
 
-    def attributes_requiring_additional_verification
-      []
-    end
-
     def errors
       @errors.transform_values(&:to_a)
     end
@@ -44,10 +44,6 @@ module Proofing
 
     def failed?
       !exception? && errors?
-    end
-
-    def failed_result_can_pass_with_additional_verification?
-      false
     end
 
     def success?

--- a/app/services/proofing/lexis_nexis/config.rb
+++ b/app/services/proofing/lexis_nexis/config.rb
@@ -1,0 +1,24 @@
+module Proofing
+  module LexisNexis
+    Config = RedactedStruct.new(
+      :instant_verify_workflow,
+      :phone_finder_workflow,
+      :account_id,
+      :base_url,
+      :username,
+      :password,
+      :request_mode,
+      :request_timeout,
+      :org_id,
+      :api_key,
+      keyword_init: true,
+      allowed_members: [
+        :instant_verify_workflow,
+        :phone_finder_workflow,
+        :base_url,
+        :request_mode,
+        :request_timeout,
+      ],
+    )
+  end
+end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -30,57 +30,35 @@ module Proofing
           end
         end
 
-        Config = RedactedStruct.new(
-          :instant_verify_workflow,
-          :phone_finder_workflow,
-          :account_id,
-          :base_url,
-          :username,
-          :password,
-          :request_mode,
-          :request_timeout,
-          :org_id,
-          :api_key,
-          keyword_init: true,
-          allowed_members: [
-            :instant_verify_workflow,
-            :phone_finder_workflow,
-            :base_url,
-            :request_mode,
-            :request_timeout,
-          ],
-        )
-
         attr_reader :config
 
         def initialize(attrs)
           @config = Config.new(attrs)
         end
 
-        def send_verification_request(applicant)
-          VerificationRequest.new(config: config, applicant: applicant).send
-        end
-
         def proof(applicant)
-          response = send_verification_request(applicant)
-          process_response(response)
+          response = VerificationRequest.new(config: config, applicant: applicant).send
+          build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)
-          Proofing::Result.new(exception: exception)
+          Proofing::DdpResult.new(exception: exception)
         end
 
         private
 
-        def process_response(response)
-          result = Proofing::Result.new
-          body = response.response_body
+        def build_result_from_response(verification_response)
+          result = Proofing::DdpResult.new
+          body = verification_response.response_body
+
           result.response_body = body
           result.transaction_id = body['request_id']
           request_result = body['request_result']
           review_status = body['review_status']
+
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
+
           result
         end
       end

--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -5,7 +5,7 @@ module Proofing
         attr_reader :config
 
         def initialize(config)
-          @config = LexisNexis::Ddp::Proofer::Config.new(config)
+          @config = LexisNexis::Config.new(config)
         end
 
         def proof(applicant)

--- a/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
@@ -5,12 +5,12 @@ module Proofing
         attr_reader :config
 
         def initialize(config)
-          @config = LexisNexis::Ddp::Proofer::Config.new(config)
+          @config = LexisNexis::Config.new(config)
         end
 
         def proof(applicant)
           response = VerificationRequest.new(config: config, applicant: applicant).send
-          return build_result_from_response(response)
+          build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)
           AddressResult.new(

--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -32,7 +32,7 @@ module Proofing
       TRANSACTION_ID = 'ddp-mock-transaction-id-123'
 
       def proof(applicant)
-        result = Proofing::Result.new
+        result = Proofing::DdpResult.new
         result.transaction_id = TRANSACTION_ID
 
         response_body = File.read(

--- a/app/services/proofing/resolution_result.rb
+++ b/app/services/proofing/resolution_result.rb
@@ -1,15 +1,22 @@
 module Proofing
   class ResolutionResult
-    attr_reader :success, :errors, :exception, :vendor_name, :transaction_id, :verified_attributes,
+    attr_reader :errors,
+                :exception,
+                :success,
+                :vendor_name,
+                :transaction_id,
+                :verified_attributes,
                 :failed_result_can_pass_with_additional_verification,
                 :attributes_requiring_additional_verification,
-                :reference, :vendor_workflow, :drivers_license_check_info
+                :reference,
+                :vendor_workflow,
+                :drivers_license_check_info
 
     def initialize(
-      success:,
-      errors:,
-      exception:,
-      vendor_name:,
+      success: nil,
+      errors: {},
+      exception: nil,
+      vendor_name: nil,
       transaction_id: '',
       reference: '',
       failed_result_can_pass_with_additional_verification: false,
@@ -39,10 +46,6 @@ module Proofing
       exception.is_a?(Proofing::TimeoutError)
     end
 
-    def failed_result_can_pass_with_additional_verification?
-      failed_result_can_pass_with_additional_verification
-    end
-
     def to_h
       {
         success: success?,
@@ -57,6 +60,10 @@ module Proofing
         vendor_workflow: vendor_workflow,
         drivers_license_check_info: drivers_license_check_info,
       }
+    end
+
+    def failed_result_can_pass_with_additional_verification?
+      failed_result_can_pass_with_additional_verification
     end
   end
 end

--- a/app/services/proofing/state_id_result.rb
+++ b/app/services/proofing/state_id_result.rb
@@ -1,12 +1,17 @@
 module Proofing
   class StateIdResult
-    attr_reader :success, :errors, :exception, :vendor_name, :transaction_id, :verified_attributes
+    attr_reader :errors,
+                :exception,
+                :success,
+                :vendor_name,
+                :transaction_id,
+                :verified_attributes
 
     def initialize(
-      success:,
-      errors:,
-      exception:,
-      vendor_name:,
+      success: nil,
+      errors: {},
+      exception: nil,
+      vendor_name: nil,
       transaction_id: '',
       verified_attributes: []
     )

--- a/app/services/redis_rate_limiter.rb
+++ b/app/services/redis_rate_limiter.rb
@@ -7,7 +7,7 @@ class RedisRateLimiter
   # @param [String] key the item to throttle on
   # @param [Integer] max_requests the max number of requests allowed per interval
   # @param [Integer] interval number of seconds
-  def initialize(key:, max_requests:, interval:, redis_pool: REDIS_POOL)
+  def initialize(key:, max_requests:, interval:, redis_pool: REDIS_THROTTLE_POOL)
     @key = key
     @max_requests = max_requests
     @interval = interval.to_i

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -21,7 +21,9 @@ RequestPasswordReset = RedactedStruct.new(
   private
 
   def send_reset_password_instructions
-    if Throttle.new(user: user, throttle_type: :reset_password_email).throttled_else_increment?
+    throttle = Throttle.new(user: user, throttle_type: :reset_password_email)
+    throttle.increment!
+    if throttle.throttled?
       analytics.throttler_rate_limit_triggered(throttle_type: :reset_password_email)
       irs_attempts_api_tracker.forgot_password_email_rate_limited(email: email)
     else

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -39,15 +39,6 @@ class Throttle
     !expired? && maxed?
   end
 
-  def throttled_else_increment?
-    if throttled?
-      true
-    else
-      increment!
-      false
-    end
-  end
-
   def attempted_at
     return @redis_attempted_at if defined?(@redis_attempted_at)
 
@@ -76,6 +67,7 @@ class Throttle
   end
 
   def increment!
+    return if throttled?
     value = nil
     REDIS_THROTTLE_POOL.with do |client|
       value, _success = client.multi do |multi|

--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -49,6 +49,18 @@ module UspsInPersonProofing
         load_response_fixture('request_expired_proofing_results_response.json')
       end
 
+      def self.request_unexpected_expired_proofing_results_response
+        load_response_fixture('request_unexpected_expired_proofing_results_response.json')
+      end
+
+      def self.request_unexpected_invalid_applicant_response
+        load_response_fixture('request_unexpected_invalid_applicant_response.json')
+      end
+
+      def self.request_unexpected_invalid_enrollment_code_response
+        load_response_fixture('request_unexpected_invalid_enrollment_code_response.json')
+      end
+
       def self.request_no_post_office_proofing_results_response
         load_response_fixture('request_no_post_office_proofing_results_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_unexpected_expired_proofing_results_response.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_unexpected_expired_proofing_results_response.json
@@ -1,0 +1,3 @@
+{
+  "responseMessage": "More than 4 days have passed since opt-in to IPP"
+}

--- a/app/services/usps_in_person_proofing/mock/responses/request_unexpected_invalid_applicant_response.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_unexpected_invalid_applicant_response.json
@@ -1,0 +1,3 @@
+{
+  "responseMessage": "Applicant 123456789abcdefghi does not exist"
+}

--- a/app/services/usps_in_person_proofing/mock/responses/request_unexpected_invalid_enrollment_code_response.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_unexpected_invalid_enrollment_code_response.json
@@ -1,0 +1,3 @@
+{
+  "responseMessage": "Enrollment code 1234567890123456 does not exist"
+}

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -15,6 +15,24 @@ locals:
   <!-- Needed by form steps wait javascript -->
 </div>
 
+<% if @had_barcode_read_failure %>
+  <%= render AlertComponent.new(
+        type: :warning,
+        class: 'margin-bottom-4',
+        text_tag: 'div',
+      ) do %>
+    <%= t(
+          'doc_auth.headings.capture_scan_warning_html',
+          link: render(
+            FormLinkComponent.new(
+              href: idv_doc_auth_step_path(step: :redo_document_capture),
+              method: :put,
+            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          ),
+        ) %>
+  <% end %>
+<% end %>
+
 <% title t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -563,7 +563,7 @@ test:
   verify_gpo_key_attempt_window_in_minutes: 3
   verify_gpo_key_max_attempts: 2
   verify_personal_key_attempt_window_in_minutes: 3
-  verify_personal_key_max_attempts: 1
+  verify_personal_key_max_attempts: 2
   usps_upload_sftp_directory: "/directory"
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass

--- a/db/primary_migrate/20230126195401_add_aal_to_identities.rb
+++ b/db/primary_migrate/20230126195401_add_aal_to_identities.rb
@@ -1,0 +1,5 @@
+class AddAalToIdentities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :identities, :aal, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_13_202809) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_195401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -272,6 +272,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_202809) do
     t.datetime "last_ial1_authenticated_at", precision: nil
     t.datetime "last_ial2_authenticated_at", precision: nil
     t.datetime "deleted_at", precision: nil
+    t.integer "aal"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/cleave.js": "^1.4.7",
     "@types/dirty-chai": "^2.0.2",
+    "@types/intl-tel-input": "^17.0.6",
     "@types/mocha": "^10.0.0",
     "@types/newrelic": "^7.0.3",
     "@types/react": "^17.0.39",

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Idv::GpoVerifyController do
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
-        ).exactly(max_attempts).times
+        ).exactly(max_attempts - 1).times
 
         expect(@analytics).to receive(:track_event).with(
           'Throttler Rate Limit Triggered',
@@ -319,7 +319,7 @@ RSpec.describe Idv::GpoVerifyController do
 
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_rate_limited).once
 
-        (max_attempts + 1).times do |i|
+        max_attempts.times do |i|
           post(
             :create,
             params: {

--- a/spec/controllers/idv/in_person/address_search_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_search_controller_spec.rb
@@ -17,11 +17,6 @@ describe Idv::InPerson::AddressSearchController do
 
   describe '#index' do
     let(:geocoder) { double('Geocoder') }
-    let(:suggestions) do
-      [
-        OpenStruct.new({ magic_key: 'a' }),
-      ]
-    end
 
     let(:addresses) do
       [
@@ -36,7 +31,6 @@ describe Idv::InPerson::AddressSearchController do
     before do
       allow(controller).to receive(:geocoder).and_return(geocoder)
       allow(geocoder).to receive(:find_address_candidates).and_return(addresses)
-      allow(geocoder).to receive(:suggest).and_return(suggestions)
     end
 
     context 'with successful fetch' do
@@ -47,8 +41,8 @@ describe Idv::InPerson::AddressSearchController do
         expect(addresses.length).to eq 1
       end
 
-      context 'with no suggestions' do
-        let(:suggestions) do
+      context 'with no address candidates' do
+        let(:addresses) do
           []
         end
 
@@ -64,7 +58,7 @@ describe Idv::InPerson::AddressSearchController do
     context 'with unsuccessful fetch' do
       before do
         exception = Faraday::ConnectionFailed.new('error')
-        allow(geocoder).to receive(:suggest).and_raise(exception)
+        allow(geocoder).to receive(:find_address_candidates).and_raise(exception)
       end
 
       it 'gets an empty pilot response' do
@@ -78,7 +72,7 @@ describe Idv::InPerson::AddressSearchController do
     context 'with a timeout error' do
       before do
         exception = Faraday::TimeoutError.new
-        allow(geocoder).to receive(:suggest).and_raise(exception)
+        allow(geocoder).to receive(:find_address_candidates).and_raise(exception)
       end
 
       it 'returns an error code' do

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -174,7 +174,7 @@ describe Users::VerifyPersonalKeyController do
         expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited).once
 
         max_attempts = Throttle.max_attempts(:verify_personal_key)
-        (max_attempts + 1).times { post :create, params: personal_key_bad_params }
+        max_attempts.times { post :create, params: personal_key_bad_params }
 
         expect(response).to render_template(:throttled)
       end

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -68,5 +68,66 @@ feature 'doc auth redo document capture action', js: true do
         expect(page).not_to have_css('[role="status"]')
       end
     end
+
+    context 'with the doc_auth_verify_info_controller_enabled flag enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_verify_info_controller_enabled).
+          and_return(true)
+      end
+
+      it 'shows a warning message to allow the user to return to upload new images' do
+        warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+        expect(page).to have_css(
+          '[role="status"]',
+          text: t('doc_auth.headings.capture_scan_warning_html', link: warning_link_text),
+        )
+        click_link warning_link_text
+
+        expect(current_path).to eq(idv_doc_auth_upload_step)
+        complete_upload_step
+        DocAuth::Mock::DocAuthMockClient.reset!
+        attach_and_submit_images
+
+        expect(page).to have_content(t('headings.verify'))
+        check t('forms.ssn.show')
+        expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+        expect(page).not_to have_css('[role="status"]')
+      end
+
+      it 'shows a troubleshooting option to allow the user to return to upload new images' do
+        click_idv_continue
+
+        expect(page).to have_link(
+          t('idv.troubleshooting.options.add_new_photos'),
+          href: idv_doc_auth_step_path(step: :redo_document_capture),
+        )
+
+        click_link t('idv.troubleshooting.options.add_new_photos')
+
+        expect(current_path).to eq(idv_doc_auth_upload_step)
+      end
+
+      context 'on mobile', driver: :headless_chrome_mobile do
+        it 'shows a warning message to allow the user to return to upload new images' do
+          warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+          expect(page).to have_css(
+            '[role="status"]',
+            text: t('doc_auth.headings.capture_scan_warning_html', link: warning_link_text),
+          )
+          click_link warning_link_text
+
+          expect(current_path).to eq(idv_doc_auth_document_capture_step)
+          DocAuth::Mock::DocAuthMockClient.reset!
+          attach_and_submit_images
+
+          expect(page).to have_content(t('headings.verify'))
+          check t('forms.ssn.show')
+          expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+          expect(page).not_to have_css('[role="status"]')
+        end
+      end
+    end
   end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -118,7 +118,7 @@ feature 'doc auth send link step' do
     ).with({ phone_number: '+1 415-555-0199' })
 
     freeze_time do
-      idv_send_link_max_attempts.times do
+      (idv_send_link_max_attempts - 1).times do
         expect(page).to_not have_content(
           I18n.t('errors.doc_auth.send_link_throttle', timeout: timeout),
         )

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -962,6 +962,7 @@ describe 'OpenID Connect' do
     expect(decoded_id_token[:email]).to eq(user.email)
     expect(decoded_id_token[:given_name]).to eq('John')
     expect(decoded_id_token[:social_security_number]).to eq('111223333')
+    expect(decoded_id_token[:ial]).to eq(2)
 
     access_token = token_response[:access_token]
     expect(access_token).to be_present

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -249,14 +249,14 @@ feature 'Password Recovery' do
     email = user.email
 
     max_attempts = IdentityConfig.store.reset_password_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       submit_email_for_password_reset(email)
       expect(unread_emails_for(email).size).to eq(i + 1)
     end
 
-    expect(unread_emails_for(email).size).to eq(max_attempts)
+    expect(unread_emails_for(email).size).to eq(max_attempts - 1)
     submit_email_for_password_reset(email)
-    expect(unread_emails_for(email).size).to eq(max_attempts)
+    expect(unread_emails_for(email).size).to eq(max_attempts - 1)
   end
 
   def submit_email_for_password_reset(email)

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -24,14 +24,14 @@ feature 'Visit requests confirmation instructions again during sign up' do
     email = user.email
 
     max_attempts = IdentityConfig.store.reg_unconfirmed_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       submit_resend_email_confirmation(email)
       expect(unread_emails_for(user.email).size).to eq(i + 1)
     end
 
-    expect(unread_emails_for(user.email).size).to eq(max_attempts)
+    expect(unread_emails_for(user.email).size).to eq(max_attempts - 1)
     submit_resend_email_confirmation(email)
-    expect(unread_emails_for(user.email).size).to eq(max_attempts)
+    expect(unread_emails_for(user.email).size).to eq(max_attempts - 1)
   end
 
   scenario 'user enters email with invalid format' do

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -70,13 +70,13 @@ feature 'Visitor signs up with email address' do
 
     starting_count = unread_emails_for(email).size
     max_attempts = IdentityConfig.store.reg_unconfirmed_email_max_attempts
-    max_attempts.times do |i|
+    (max_attempts - 1).times do |i|
       sign_up_with(email)
       expect(unread_emails_for(email).size).to eq(starting_count + i + 1)
     end
 
-    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts)
+    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts - 1)
     sign_up_with(email)
-    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts)
+    expect(unread_emails_for(email).size).to eq(starting_count + max_attempts - 1)
   end
 end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -41,7 +41,7 @@ describe RegisterUserEmailForm do
 
         create(:user, :signed_up, email: 'taken@example.com')
 
-        (IdentityConfig.store.reg_confirmed_email_max_attempts + 1).times do
+        IdentityConfig.store.reg_confirmed_email_max_attempts.times do
           subject.submit(email: 'TAKEN@example.com', terms_accepted: '1')
         end
 
@@ -85,7 +85,7 @@ describe RegisterUserEmailForm do
         )
 
         create(:user, email: 'test@example.com', confirmed_at: nil, uuid: '123')
-        (IdentityConfig.store.reg_unconfirmed_email_max_attempts + 1).times do
+        IdentityConfig.store.reg_unconfirmed_email_max_attempts.times do
           subject.submit(email: 'test@example.com', terms_accepted: '1')
         end
 

--- a/spec/jobs/reports/daily_registration_report_spec.rb
+++ b/spec/jobs/reports/daily_registration_report_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Reports::DailyRegistrationsReport do
         create_list(:user, 1, created_at: two_days_ago).each do |user|
           RegistrationLog.create(user: user, registered_at: user.created_at)
         end
+
+        # deleted, counts as total users
+        DeletedUser.create(
+          user_created_at: two_days_ago,
+          deleted_at: two_days_ago,
+          uuid: SecureRandom.uuid,
+          user_id: -1,
+        )
       end
 
       it 'calculates users and fully registered users by day' do
@@ -85,13 +93,15 @@ RSpec.describe Reports::DailyRegistrationsReport do
               [
                 {
                   date: two_days_ago.to_date.as_json,
-                  total_users: 2,
+                  total_users: 3,
                   fully_registered_users: 1,
+                  deleted_users: 1,
                 },
                 {
                   date: yesterday.to_date.as_json,
                   total_users: 4,
                   fully_registered_users: 2,
+                  deleted_users: 0,
                 },
               ],
             )

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -320,9 +320,9 @@ RSpec.describe ResolutionProofingJob, type: :job do
       context 'with a successful response from the proofer' do
         before do
           expect(resolution_proofer).to receive(:proof).
-            and_return(Proofing::Result.new)
+            and_return(Proofing::ResolutionResult.new)
           expect(state_id_proofer).to receive(:proof).
-            and_return(Proofing::Result.new)
+            and_return(Proofing::StateIdResult.new)
           Proofing::Mock::DeviceProfilingBackend.new.record_profiling_result(
             session_id: threatmetrix_session_id,
             result: 'pass',
@@ -355,7 +355,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         end
 
         context 'nil response body from ddp' do
-          let(:ddp_result) { Proofing::Result.new(response_body: nil) }
+          let(:ddp_result) { Proofing::DdpResult.new(response_body: nil) }
 
           before do
             expect(ddp_proofer).to receive(:proof).and_return(ddp_result)
@@ -381,9 +381,9 @@ RSpec.describe ResolutionProofingJob, type: :job do
       context 'does call state id with an unsuccessful response from the proofer' do
         it 'posts back to the callback url' do
           expect(resolution_proofer).to receive(:proof).
-            and_return(Proofing::Result.new(exception: 'error'))
+            and_return(Proofing::ResolutionResult.new(exception: 'error'))
           expect(state_id_proofer).to receive(:proof).
-            and_return(Proofing::Result.new)
+            and_return(Proofing::StateIdResult.new)
 
           perform
         end
@@ -394,7 +394,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
         it 'does not call state_id proof if resolution proof is successful' do
           expect(resolution_proofer).to receive(:proof).
-            and_return(Proofing::Result.new)
+            and_return(Proofing::ResolutionResult.new)
 
           expect(state_id_proofer).not_to receive(:proof)
           perform

--- a/spec/jobs/risc_delivery_job_spec.rb
+++ b/spec/jobs/risc_delivery_job_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe RiscDeliveryJob do
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   describe '#perform' do
@@ -177,7 +177,9 @@ RSpec.describe RiscDeliveryJob do
 
     context 'rate limiting' do
       before do
-        REDIS_POOL.with { |r| r.set(job.rate_limiter(push_notification_url).build_key(now), 9999) }
+        REDIS_THROTTLE_POOL.with do |redis|
+          redis.set(job.rate_limiter(push_notification_url).build_key(now), 9999)
+        end
       end
 
       context 'when performed inline' do

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -84,6 +84,25 @@ RSpec.describe ArcgisApi::Geocoder do
         expect(error).to be_instance_of(ArgumentError)
       end
     end
+
+    it 'returns candidates from SingleLine' do
+      stub_request_candidates_response
+
+      first_candidate = subject.find_address_candidates(SingleLine: 'abc123').first
+
+      expect(first_candidate.address).to be_present
+    end
+
+    it 'requests candidates with correct address category filters' do
+      stub_request_candidates_response
+
+      subject.find_address_candidates(SingleLine: 'abc123')
+
+      expect(WebMock).to have_requested(:get, %r{/findAddressCandidates}).
+        with(query: hash_including(
+          { category: 'Subaddress,Point Address,Street Address,Street Name' },
+        ))
+    end
   end
 
   describe '#retrieve_token!' do

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ArcgisApi::Geocoder do
     it 'returns candidates from magic_key' do
       stub_request_candidates_response
 
-      first_candidate = subject.find_address_candidates('abc123').first
+      first_candidate = subject.find_address_candidates(magicKey: 'abc123').first
 
       expect(first_candidate.address).to be_present
       expect(first_candidate.location).to be_present
@@ -62,7 +62,7 @@ RSpec.describe ArcgisApi::Geocoder do
     it 'handles no results' do
       stub_request_candidates_empty_response
 
-      suggestions = subject.find_address_candidates('abc123')
+      suggestions = subject.find_address_candidates(magicKey: 'abc123')
 
       expect(suggestions).to be_empty
     end
@@ -70,10 +70,18 @@ RSpec.describe ArcgisApi::Geocoder do
     it 'returns an error response body but with Status coded as 200' do
       stub_request_candidates_error
 
-      expect { subject.find_address_candidates('abc123') }.to raise_error do |error|
+      expect { subject.find_address_candidates(magicKey: 'abc123') }.to raise_error do |error|
         expect(error).to be_instance_of(Faraday::ClientError)
         expect(error.message).to eq('received error code 400')
         expect(error.response).to be_kind_of(Hash)
+      end
+    end
+
+    it 'returns an error if using unknown parameter' do
+      stub_request_candidates_response
+
+      expect { subject.find_address_candidates(_unknownKey: 'abc123') }.to raise_error do |error|
+        expect(error).to be_instance_of(ArgumentError)
       end
     end
   end

--- a/spec/services/idv/steps/in_person/verify_step_spec.rb
+++ b/spec/services/idv/steps/in_person/verify_step_spec.rb
@@ -110,7 +110,7 @@ describe Idv::Steps::InPerson::VerifyStep do
       end
 
       before do
-        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(2)
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(3)
         allow(IdentityConfig.store).to receive(:proof_ssn_max_attempt_window_in_minutes).
           and_return(10)
       end

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -110,7 +110,7 @@ describe Idv::Steps::VerifyStep do
       end
 
       before do
-        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(2)
+        allow(IdentityConfig.store).to receive(:proof_ssn_max_attempts).and_return(3)
         allow(IdentityConfig.store).to receive(:proof_ssn_max_attempt_window_in_minutes).
           and_return(10)
       end

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 describe Idv::Steps::VerifyWaitStepShow do
-  TRANSACTION_ID = 'ddp-mock-transaction-id-123'
-
   include Rails.application.routes.url_helpers
 
   let(:user) { build(:user) }
   let(:issuer) { 'test_issuer' }
   let(:service_provider) { build(:service_provider, issuer: issuer) }
-  let(:resolution_transaction_id) { TRANSACTION_ID }
-  let(:threatmetrix_transaction_id) { TRANSACTION_ID }
+  let(:resolution_transaction_id) do
+    Proofing::Mock::ResolutionMockClient::TRANSACTION_ID
+  end
+  let(:threatmetrix_transaction_id) do
+    Proofing::Mock::DdpMockClient::TRANSACTION_ID
+  end
 
   let(:request) { FakeRequest.new }
 

--- a/spec/services/idv/steps/verify_wait_step_show_spec.rb
+++ b/spec/services/idv/steps/verify_wait_step_show_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 describe Idv::Steps::VerifyWaitStepShow do
+  TRANSACTION_ID = 'ddp-mock-transaction-id-123'
+
   include Rails.application.routes.url_helpers
 
   let(:user) { build(:user) }
   let(:issuer) { 'test_issuer' }
   let(:service_provider) { build(:service_provider, issuer: issuer) }
-  let(:resolution_transaction_id) { Proofing::Mock::ResolutionMockClient::TRANSACTION_ID }
-  let(:threatmetrix_transaction_id) { Proofing::Mock::DdpMockClient::TRANSACTION_ID }
+  let(:resolution_transaction_id) { TRANSACTION_ID }
+  let(:threatmetrix_transaction_id) { TRANSACTION_ID }
 
   let(:request) { FakeRequest.new }
 

--- a/spec/services/proofing/aamva/proofing_spec.rb
+++ b/spec/services/proofing/aamva/proofing_spec.rb
@@ -5,6 +5,7 @@ describe Proofing::Aamva::Proofer do
   let(:aamva_applicant) do
     Aamva::Applicant.from_proofer_applicant(OpenStruct.new(state_id_data))
   end
+
   let(:state_id_data) do
     {
       state_id_number: '1234567890',
@@ -12,6 +13,7 @@ describe Proofing::Aamva::Proofer do
       state_id_type: 'drivers_license',
     }
   end
+
   let(:verification_results) do
     {
       state_id_number: true,
@@ -25,7 +27,9 @@ describe Proofing::Aamva::Proofer do
     }
   end
 
-  subject { described_class.new(AamvaFixtures.example_config.to_h) }
+  subject do
+    described_class.new(AamvaFixtures.example_config.to_h)
+  end
 
   let(:verification_response) { AamvaFixtures.verification_response }
 

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-describe Proofing::Result do
+describe Proofing::DdpResult do
   describe '#add_error' do
     shared_examples 'add_error' do |key|
       it 'returns itself' do
-        expect(result).to be_an_instance_of(Proofing::Result)
+        expect(result).to be_an_instance_of(Proofing::DdpResult)
       end
 
       it 'adds an error under the key' do
@@ -19,12 +19,12 @@ describe Proofing::Result do
     let(:error) { 'FOOBAR' }
 
     context 'with no key' do
-      let(:result) { Proofing::Result.new.add_error(error) }
+      let(:result) { Proofing::DdpResult.new.add_error(error) }
       it_behaves_like 'add_error', :base
     end
 
     context 'with a key' do
-      let(:result) { Proofing::Result.new.add_error(:foo, error) }
+      let(:result) { Proofing::DdpResult.new.add_error(:foo, error) }
       it_behaves_like 'add_error', :foo
     end
   end
@@ -33,11 +33,11 @@ describe Proofing::Result do
     subject { result.exception? }
 
     context 'when there is an exception' do
-      let(:result) { Proofing::Result.new(exception: StandardError.new) }
+      let(:result) { Proofing::DdpResult.new(exception: StandardError.new) }
       it { is_expected.to eq(true) }
     end
     context 'when there is no exception' do
-      let(:result) { Proofing::Result.new }
+      let(:result) { Proofing::DdpResult.new }
       it { is_expected.to eq(false) }
     end
   end
@@ -47,18 +47,18 @@ describe Proofing::Result do
 
     context 'when there is an error AND an exception' do
       let(:result) do
-        Proofing::Result.new(exception: StandardError.new).add_error('foobar')
+        Proofing::DdpResult.new(exception: StandardError.new).add_error('foobar')
       end
       it { is_expected.to eq(false) }
     end
 
     context 'when there is an error and no exception' do
-      let(:result) { Proofing::Result.new.add_error('foobar') }
+      let(:result) { Proofing::DdpResult.new.add_error('foobar') }
       it { is_expected.to eq(true) }
     end
 
     context 'when there is no error' do
-      let(:result) { Proofing::Result.new }
+      let(:result) { Proofing::DdpResult.new }
       it { is_expected.to eq(false) }
     end
   end
@@ -68,18 +68,18 @@ describe Proofing::Result do
 
     context 'when there is an error AND an exception' do
       let(:result) do
-        Proofing::Result.new(exception: StandardError.new).add_error('foobar')
+        Proofing::DdpResult.new(exception: StandardError.new).add_error('foobar')
       end
       it { is_expected.to eq(false) }
     end
 
     context 'when there is an error and no exception' do
-      let(:result) { Proofing::Result.new.add_error('foobar') }
+      let(:result) { Proofing::DdpResult.new.add_error('foobar') }
       it { is_expected.to eq(false) }
     end
 
     context 'when there is no error and no exception' do
-      let(:result) { Proofing::Result.new }
+      let(:result) { Proofing::DdpResult.new }
       it { is_expected.to eq(true) }
     end
   end
@@ -88,17 +88,17 @@ describe Proofing::Result do
     subject { result.timed_out? }
 
     context 'when there is a timeout error' do
-      let(:result) { Proofing::Result.new(exception: Proofing::TimeoutError.new) }
+      let(:result) { Proofing::DdpResult.new(exception: Proofing::TimeoutError.new) }
       it { is_expected.to eq(true) }
     end
 
     context 'when there is a generic error' do
-      let(:result) { Proofing::Result.new(exception: StandardError.new) }
+      let(:result) { Proofing::DdpResult.new(exception: StandardError.new) }
       it { is_expected.to eq(false) }
     end
 
     context 'when there is no error' do
-      let(:result) { Proofing::Result.new }
+      let(:result) { Proofing::DdpResult.new }
       it { is_expected.to eq(false) }
     end
   end
@@ -107,7 +107,7 @@ describe Proofing::Result do
     context 'when provided' do
       it 'is present' do
         context = { foo: 'bar' }
-        result = Proofing::Result.new
+        result = Proofing::DdpResult.new
         result.context = context
         expect(result.context).to eq(context)
       end
@@ -118,7 +118,7 @@ describe Proofing::Result do
     context 'when provided' do
       it 'is present' do
         transaction_id = 'foo'
-        result = Proofing::Result.new
+        result = Proofing::DdpResult.new
         result.transaction_id = transaction_id
         expect(result.transaction_id).to eq(transaction_id)
       end
@@ -129,7 +129,7 @@ describe Proofing::Result do
     context 'when provided' do
       it 'is present' do
         reference = SecureRandom.uuid
-        result = Proofing::Result.new
+        result = Proofing::DdpResult.new
         result.reference = reference
         expect(result.reference).to eq(reference)
       end

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
@@ -24,19 +24,24 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
     )
   end
 
-  it_behaves_like 'a lexisnexis proofer'
+  it_behaves_like 'a lexisnexis rdp proofer'
 
-  subject(:instance) do
-    Proofing::LexisNexis::InstantVerify::Proofer.new(**LexisNexisFixtures.example_config.to_h)
+  subject do
+    described_class.new(**LexisNexisFixtures.example_config.to_h)
   end
 
   describe '#proof' do
     context 'when the response is a full match' do
       it 'is a successful result' do
-        stub_request(:post, verification_request.url).
-          to_return(body: LexisNexisFixtures.instant_verify_success_response_json, status: 200)
+        stub_request(
+          :post,
+          verification_request.url,
+        ).to_return(
+          body: LexisNexisFixtures.instant_verify_success_response_json,
+          status: 200,
+        )
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(true)
         expect(result.errors).to eq({})
@@ -55,7 +60,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
           status: 200,
         )
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to include(
@@ -72,9 +77,12 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
 
     context 'when the request times out' do
       it 'retuns a timeout result' do
-        stub_request(:post, verification_request.url).to_timeout
+        stub_request(
+          :post,
+          verification_request.url,
+        ).to_timeout
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({})
@@ -86,9 +94,12 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
 
     context 'when an error is raised' do
       it 'returns a result with an exception' do
-        stub_request(:post, verification_request.url).to_raise(RuntimeError.new('fancy test error'))
+        stub_request(
+          :post,
+          verification_request.url,
+        ).to_raise(RuntimeError.new('fancy test error'))
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({})
@@ -109,7 +120,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
             status: 200,
           )
 
-          result = instance.proof(applicant)
+          result = subject.proof(applicant)
 
           expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
           expect(result.attributes_requiring_additional_verification).to eq([:dob])
@@ -128,7 +139,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
             status: 200,
           )
 
-          result = instance.proof(applicant)
+          result = subject.proof(applicant)
 
           expect(result.failed_result_can_pass_with_additional_verification?).to eq(false)
           expect(result.attributes_requiring_additional_verification).to be_empty
@@ -139,10 +150,15 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
       end
 
       it 'logs drivers license info that is present in the response' do
-        stub_request(:post, verification_request.url).
-          to_return(body: LexisNexisFixtures.instant_verify_success_response_json, status: 200)
+        stub_request(
+          :post,
+          verification_request.url,
+        ).to_return(
+          body: LexisNexisFixtures.instant_verify_success_response_json,
+          status: 200,
+        )
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.to_h[:drivers_license_check_info]).to eq(
           'ItemName' => 'DriversLicenseVerification',

--- a/spec/services/proofing/lexis_nexis/phone_finder/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/proofing_spec.rb
@@ -20,10 +20,10 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
     )
   end
 
-  it_behaves_like 'a lexisnexis proofer'
+  it_behaves_like 'a lexisnexis rdp proofer'
 
-  subject(:instance) do
-    Proofing::LexisNexis::PhoneFinder::Proofer.new(**LexisNexisFixtures.example_config.to_h)
+  subject do
+    described_class.new(**LexisNexisFixtures.example_config.to_h)
   end
 
   describe '#proof' do
@@ -32,7 +32,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
         stub_request(:post, verification_request.url).
           to_return(body: LexisNexisFixtures.phone_finder_rdp1_success_response_json, status: 200)
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(true)
         expect(result.errors).to eq({})
@@ -45,7 +45,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
         stub_request(:post, verification_request.url).
           to_return(body: LexisNexisFixtures.phone_finder_rdp2_success_response_json, status: 200)
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(true)
         expect(result.errors).to eq({})
@@ -57,10 +57,15 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
 
     context 'when the rdp1 response is a failure' do
       it 'is a failure result' do
-        stub_request(:post, verification_request.url).
-          to_return(body: LexisNexisFixtures.phone_finder_rdp1_fail_response_json, status: 200)
+        stub_request(
+          :post,
+          verification_request.url,
+        ).to_return(
+          body: LexisNexisFixtures.phone_finder_rdp1_fail_response_json,
+          status: 200,
+        )
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to include(
@@ -69,6 +74,9 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
         )
         expect(result.transaction_id).to eq('31000000000000')
         expect(result.reference).to eq('Reference1')
+        expect(result.vendor_workflow).to(
+          eq(LexisNexisFixtures.example_config.phone_finder_workflow),
+        )
       end
     end
 
@@ -77,7 +85,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
         stub_request(:post, verification_request.url).
           to_return(body: LexisNexisFixtures.phone_finder_rdp2_fail_response_json, status: 200)
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
         result_json_hash = result.errors[:PhoneFinder].first
 
         expect(result.success?).to eq(false)
@@ -92,7 +100,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
       it 'retuns a timeout result' do
         stub_request(:post, verification_request.url).to_timeout
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({})
@@ -105,7 +113,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
       it 'returns a result with an exception' do
         stub_request(:post, verification_request.url).to_raise(RuntimeError.new('fancy test error'))
 
-        result = instance.proof(applicant)
+        result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({})

--- a/spec/services/redis_rate_limiter_spec.rb
+++ b/spec/services/redis_rate_limiter_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe RedisRateLimiter do
   let(:now) { Time.zone.now }
 
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_THROTTLE_POOL.with { |namespaced| namespaced.redis.flushdb }
   end
 
   let(:key) { 'some-unique-identifier' }
@@ -62,7 +62,7 @@ RSpec.describe RedisRateLimiter do
 
     context 'when the key exists and is under the limit' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), '1') }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), '1') }
       end
 
       it 'is false' do
@@ -72,7 +72,7 @@ RSpec.describe RedisRateLimiter do
 
     context 'when the key exists and is at the limit' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), max_requests) }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), max_requests) }
       end
 
       it 'is true' do
@@ -85,19 +85,20 @@ RSpec.describe RedisRateLimiter do
     context 'when the key does not exist in redis' do
       it 'sets the value to 1 when' do
         expect { rate_limiter.increment(now) }.to(
-          change { REDIS_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.from(nil).to('1'),
+          change { REDIS_THROTTLE_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.
+            from(nil).to('1'),
         )
       end
     end
 
     context 'when the key exists in redis' do
       before do
-        REDIS_POOL.with { |r| r.set(rate_limiter.build_key(now), '3') }
+        REDIS_THROTTLE_POOL.with { |r| r.set(rate_limiter.build_key(now), '3') }
       end
 
       it 'increments the value' do
         expect { rate_limiter.increment(now) }.to(
-          change { REDIS_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.to('4'),
+          change { REDIS_THROTTLE_POOL.with { |r| r.get(rate_limiter.build_key(now)) } }.to('4'),
         )
       end
     end
@@ -105,7 +106,7 @@ RSpec.describe RedisRateLimiter do
     it 'sets the TTL of the key to interval minus 1' do
       rate_limiter.increment(now)
 
-      ttl = REDIS_POOL.with { |r| r.ttl(rate_limiter.build_key(now)) }
+      ttl = REDIS_THROTTLE_POOL.with { |r| r.ttl(rate_limiter.build_key(now)) }
       expect(ttl).to be_within(1).of(interval - 1) # allow for some clock drift in specs
     end
   end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe RequestPasswordReset do
       it 'throttles the email sending and logs a throttle event' do
         max_attempts = IdentityConfig.store.reset_password_email_max_attempts
 
-        max_attempts.times do
+        (max_attempts - 1).times do
           expect do
             RequestPasswordReset.new(
               email: email,
@@ -202,9 +202,9 @@ RSpec.describe RequestPasswordReset do
 
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryActivatedEvent.new(user: user)).
-          exactly(max_attempts).times
+          exactly(max_attempts - 1).times
 
-        max_attempts.times do
+        (max_attempts - 1).times do
           expect do
             RequestPasswordReset.new(
               email: email,

--- a/spec/services/throttle_spec.rb
+++ b/spec/services/throttle_spec.rb
@@ -69,11 +69,25 @@ RSpec.describe Throttle do
 
   describe '#increment!' do
     subject(:throttle) { Throttle.new(target: 'aaa', throttle_type: :idv_doc_auth) }
+    let(:max_attempts) { 1 } # Picked up by before block at top of test file
 
     it 'increments attempts' do
       expect(throttle.attempts).to eq 0
       throttle.increment!
       expect(throttle.attempts).to eq 1
+    end
+
+    it 'does nothing if already throttled' do
+      expect(throttle.attempts).to eq 0
+      throttle.increment!
+      expect(throttle.attempts).to eq 1
+      expect(throttle.throttled?).to eq(true)
+      current_expiration = throttle.expires_at
+      travel 5.minutes do # move within 10 minute expiration window
+        throttle.increment!
+        expect(throttle.attempts).to eq 1
+        expect(throttle.expires_at).to eq current_expiration
+      end
     end
   end
 
@@ -108,32 +122,6 @@ RSpec.describe Throttle do
 
       travel(attempt_window_in_minutes.minutes + 1) do
         expect(throttle.throttled?).to eq(false)
-      end
-    end
-  end
-
-  describe '#throttled_else_increment?' do
-    subject(:throttle) { Throttle.new(target: 'aaaa', throttle_type: :idv_doc_auth) }
-
-    context 'throttle has hit limit' do
-      before do
-        (IdentityConfig.store.doc_auth_max_attempts + 1).times do
-          throttle.increment!
-        end
-      end
-
-      it 'is true' do
-        expect(throttle.throttled_else_increment?).to eq(true)
-      end
-    end
-
-    context 'throttle has not hit limit' do
-      it 'is false' do
-        expect(throttle.throttled_else_increment?).to eq(false)
-      end
-
-      it 'increments the throttle' do
-        expect { throttle.throttled_else_increment? }.to change { throttle.attempts }.by(1)
       end
     end
   end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -47,6 +47,13 @@ module IdvHelper
     click_select_button_and_wait t('in_person_proofing.body.location.location_button')
   end
 
+  def click_try_again
+    page.find(
+      'a',
+      text: t('idv.failure.button.warning'),
+    ).click
+  end
+
   def click_idv_otp_delivery_method_sms
     page.find(
       'label',

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module LexisNexisFixtures
   class << self
     def example_config
-      Proofing::LexisNexis::Ddp::Proofer::Config.new(
+      Proofing::LexisNexis::Config.new(
         base_url: 'https://example.com',
         request_mode: 'testing',
         account_id: 'test_account',
@@ -15,7 +15,7 @@ module LexisNexisFixtures
     end
 
     def example_ddp_config
-      Proofing::LexisNexis::Ddp::Proofer::Config.new(
+      Proofing::LexisNexis::Config.new(
         api_key: 'test_api_key',
         base_url: 'https://example.com',
         org_id: 'test_org_id',

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -1,9 +1,8 @@
-shared_examples 'a lexisnexis proofer' do
+shared_examples 'a lexisnexis rdp proofer' do
   let(:verification_status) { 'passed' }
   let(:conversation_id) { 'foo' }
   let(:reference) { SecureRandom.uuid }
   let(:verification_errors) { {} }
-  let(:result) { Proofing::Result.new }
 
   before do
     response = instance_double(Proofing::LexisNexis::Response)
@@ -15,11 +14,11 @@ shared_examples 'a lexisnexis proofer' do
 
     allow(verification_request).to receive(:send).and_return(response)
     allow(verification_request.class).to receive(:new).
-      with(applicant: applicant, config: kind_of(Proofing::LexisNexis::Ddp::Proofer::Config)).
+      with(applicant: applicant, config: kind_of(Proofing::LexisNexis::Config)).
       and_return(verification_request)
   end
 
-  describe '#proof_applicant' do
+  describe '#proof' do
     context 'when proofing succeeds' do
       it 'results in a successful result' do
         result = subject.proof(applicant)

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -68,6 +68,51 @@ module UspsIppHelper
     }
   end
 
+  def stub_request_unexpected_expired_proofing_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      **request_unexpected_expired_proofing_results_args,
+    )
+  end
+
+  def request_unexpected_expired_proofing_results_args
+    {
+      status: 400,
+      body: UspsInPersonProofing::Mock::Fixtures.
+        request_unexpected_expired_proofing_results_response,
+      headers: { 'content-type' => 'application/json' },
+    }
+  end
+
+  def stub_request_unexpected_invalid_applicant
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      **request_unexpected_invalid_applicant_args,
+    )
+  end
+
+  def request_unexpected_invalid_applicant_args
+    {
+      status: 400,
+      body: UspsInPersonProofing::Mock::Fixtures.
+        request_unexpected_invalid_applicant_response,
+      headers: { 'content-type' => 'application/json' },
+    }
+  end
+
+  def stub_request_unexpected_invalid_enrollment_code
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      **request_unexpected_invalid_enrollment_code_args,
+    )
+  end
+
+  def request_unexpected_invalid_enrollment_code_args
+    {
+      status: 400,
+      body: UspsInPersonProofing::Mock::Fixtures.
+        request_unexpected_invalid_enrollment_code_response,
+      headers: { 'content-type' => 'application/json' },
+    }
+  end
+
   def stub_request_failed_proofing_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       **request_failed_proofing_results_args,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,6 +1368,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/intl-tel-input@^17.0.6":
+  version "17.0.6"
+  resolved "https://registry.yarnpkg.com/@types/intl-tel-input/-/intl-tel-input-17.0.6.tgz#43d5fa06c3e988747670bc9f8c3ef148faf9e9a2"
+  integrity sha512-Xqkfun/71N3wqvnwFzZiBacC3JsHHgYWjOEXxzl91nXrm/b/DLhDWM7baXOZksfLwggyOsn/McT1/neJejXmVg==
+  dependencies:
+    "@types/jquery" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -1386,6 +1393,13 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jquery@*":
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.16.tgz#632131baf30951915b0317d48c98e9890bdf051d"
+  integrity sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==
+  dependencies:
+    "@types/sizzle" "*"
 
 "@types/js-levenshtein@^1.1.1":
   version "1.1.1"
@@ -1531,6 +1545,11 @@
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
+
+"@types/sizzle@*":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
 "@types/sockjs@^0.3.33":
   version "0.3.33"


### PR DESCRIPTION
## Bug Fixes
- In-person proofing: Handle unexpected API errors ([#7743](https://github.com/18F/identity-idp/pull/7743))
- OpenID Connect: Include `ial` and `aal` properties in user info response value ([#7721](https://github.com/18F/identity-idp/pull/7721))

## Internal
- In-Person Proofing: Remove redundant ArcGIS API call ([#7746](https://github.com/18F/identity-idp/pull/7746), [#7753](https://github.com/18F/identity-idp/pull/7753))
- Rate limiting: Update Redis rate limiting configuration ([#7758](https://github.com/18F/identity-idp/pull/7758))
- Rate limiting: Refactor to make rate limiting code consistent ([#7741](https://github.com/18F/identity-idp/pull/7741))
- Reporting: Include deleted users in reports on users created ([#7731](https://github.com/18F/identity-idp/pull/7731))