### PR TITLE
LG-8510: Don't display the same post office multiple times

### DIFF
--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -13,6 +13,10 @@ module UspsInPersonProofing
         load_response_fixture('request_facilities_response.json')
       end
 
+      def self.request_facilities_response_with_duplicates
+        load_response_fixture('request_facilities_response_with_duplicates.json')
+      end
+
       def self.request_show_usps_location_response
         load_response_fixture('request_show_usps_location_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_facilities_response_with_duplicates.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_facilities_response_with_duplicates.json
@@ -1,0 +1,224 @@
+{
+  "postOffices": [
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "0.05 mi",
+      "streetAddress": "3775 INDUSTRIAL BLVD",
+      "city": "WEST SACRAMENTO",
+      "phone": "916-556-3406",
+      "name": "INDUSTRIAL WEST SACRAMENTO",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95799"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "0.05 mi",
+      "streetAddress": "3775 INDUSTRIAL BLVD",
+      "city": "WEST SACRAMENTO",
+      "phone": "916-373-8157",
+      "name": "WEST SACRAMENTO P\u0026DC",
+      "zip4": "0102",
+      "state": "CA",
+      "zip5": "95799"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 5:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 5:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "2.22 mi",
+      "streetAddress": "1601 MERKLEY AVE",
+      "city": "WEST SACRAMENTO",
+      "name": "WEST SACRAMENTO",
+      "phone": "916-556-3406",
+      "state": "CA",
+      "zip4": "9998",
+      "zip5": "95691"
+    },
+    {
+      "parking": "Street",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "2.77 mi",
+      "streetAddress": "900 SACRAMENTO AVE",
+      "city": "WEST SACRAMENTO",
+      "phone": "916-556-3406",
+      "name": "BRODERICK",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95605"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "3.87 mi",
+      "streetAddress": "660 J ST STE 170",
+      "city": "SACRAMENTO",
+      "phone": "916-498-9145",
+      "name": "DOWNTOWN PLAZA",
+      "zip4": "9996",
+      "state": "CA",
+      "zip5": "95814"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "4.53 mi",
+      "streetAddress": "2121 BROADWAY",
+      "city": "SACRAMENTO",
+      "name": "BROADWAY",
+      "phone": "916-227-6503",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95818"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "4.55 mi",
+      "streetAddress": "5930 S LAND PARK DR",
+      "city": "SACRAMENTO",
+      "phone": "916-262-3107",
+      "name": "LAND PARK",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95822"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "5.33 mi",
+      "streetAddress": "1618 ALHAMBRA BLVD",
+      "city": "SACRAMENTO",
+      "phone": "916-227-6503",
+      "name": "FORT SUTTER",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95816"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "5.49 mi",
+      "streetAddress": "2929 35TH ST",
+      "city": "SACRAMENTO",
+      "phone": "916-227-6509",
+      "name": "OAK PARK",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95817"
+    },
+    {
+      "parking": "Lot",
+      "hours": [
+        {
+          "weekdayHours": "9:00 AM - 6:00 PM"
+        },
+        {
+          "saturdayHours": "9:00 AM - 3:00 PM"
+        },
+        {
+          "sundayHours": "Closed"
+        }
+      ],
+      "distance": "6.63 mi",
+      "streetAddress": "4750 J ST",
+      "city": "SACRAMENTO",
+      "phone": "916-227-6503",
+      "name": "CAMELLIA",
+      "zip4": "9998",
+      "state": "CA",
+      "zip5": "95819"
+    }
+  ]
+}

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -18,11 +18,12 @@ module UspsInPersonProofing
         zipCode: location.zip_code,
       }.to_json
 
-      parse_facilities(
+      facilities = parse_facilities(
         faraday.post(url, body, dynamic_headers) do |req|
           req.options.context = { service_name: 'usps_facilities' }
         end.body,
       )
+      dedupe_facilities(facilities)
     end
 
     # Temporary function to return a static set of facilities
@@ -216,6 +217,12 @@ module UspsInPersonProofing
           zip_code_5: post_office['zip5'],
           is_pilot: post_office['isPilot'],
         )
+      end
+    end
+
+    def dedupe_facilities(facilities)
+      facilities.uniq do |facility|
+        [facility.address, facility.city, facility.state, facility.zip_code_5]
       end
     end
   end

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -106,20 +106,36 @@ RSpec.describe UspsInPersonProofing::Proofer do
   end
 
   describe '#request_facilities' do
-    it 'returns facilities' do
+    before do
       stub_request_token
-      stub_request_facilities
-      location = double(
+    end
+    let(:location) do
+      double(
         'Location',
         address: Faker::Address.street_address,
         city: Faker::Address.city,
         state: Faker::Address.state_abbr,
         zip_code: Faker::Address.zip_code,
       )
+    end
 
+    it 'returns facilities' do
+      stub_request_facilities
       facilities = subject.request_facilities(location)
 
       check_facility(facilities[0])
+    end
+
+    it 'does not return duplicates' do
+      stub_request_facilities_with_duplicates
+      facilities = subject.request_facilities(location)
+
+      expect(facilities.length).to eq(9)
+      expect(
+        facilities.count do |post_office|
+          post_office.address == '3775 INDUSTRIAL BLVD'
+        end,
+      ).to eq(1)
     end
   end
 

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -15,6 +15,14 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_facilities_with_duplicates
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::Fixtures.request_facilities_response_with_duplicates,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_enroll
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
       status: 200,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[Deduplicate Post Offices with the same street address for display](https://cm-jira.usa.gov/browse/LG-8510)



## 🛠 Summary of changes

Previously, if the USPS API returned the same post office multiple times, our search feature would display duplicate post offices.  This bug was obvious when the user searched for `3775 INDUSTRIAL BLVD WEST SACRAMENTO CA 95799`.

Now, our search feature will only return each post office one time.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Navigate to the post office search page
- [ ] Search for `3775 INDUSTRIAL BLVD WEST SACRAMENTO CA 95799`
- [ ] Observe that no duplicate post offices are returned



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

https://user-images.githubusercontent.com/80347702/217022796-b532e8f5-6710-4b0e-8b77-d1b619138945.mov


</details>

<details>
<summary>After:</summary>

https://user-images.githubusercontent.com/80347702/217023635-ca7ee9d3-53d5-470b-9ece-1acfce3db9ca.mov


</details>

