### PR TITLE
Use Redis 7 EXPIRETIME command for calculating rate limit state

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ specs:
   services:
     - name: postgres:13.4
       alias: db-postgres
-    - name: redis
+    - name: redis:7.0
       alias: db-redis
   artifacts:
     expire_in: 31d

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,7 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: postgres:13.4
+    - name: postgres:13.9
       alias: db-postgres
     - name: redis:7.0
       alias: db-redis

--- a/app/services/throttle.rb
+++ b/app/services/throttle.rb
@@ -87,30 +87,25 @@ class Throttle
   end
 
   # Retrieve the current state of the throttle from Redis
-  # We use TTL to calculate when the action was last attempted.
-  # This approach is introduces some skew since time passes
-  # between "now" and when we fetch the TTL, but it should be low
-  # relative to the overall length of the throttle window.
-  #
-  # When we upgrade to Redis 7, we can use the EXPIRETIME command instead.
+  # We use EXPIRETIME to calculate when the action was last attempted.
   def fetch_state!
     value = nil
-    ttl = nil
+    expiretime = nil
     REDIS_THROTTLE_POOL.with do |client|
-      value, ttl = client.multi do |multi|
+      value, expiretime = client.multi do |multi|
         multi.get(key)
-        multi.ttl(key)
+        multi.expiretime(key)
       end
     end
 
     @redis_attempts = value.to_i
 
-    if ttl < 0
+    if expiretime < 0
       @redis_attempted_at = nil
     else
       @redis_attempted_at =
-        Time.zone.now -
-        Throttle.attempt_window_in_minutes(throttle_type).minutes + ttl.seconds
+        ActiveSupport::TimeZone['UTC'].at(expiretime) -
+        Throttle.attempt_window_in_minutes(throttle_type).minutes
     end
 
     self

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -11,7 +11,7 @@ We recommend using [Homebrew](https://brew.sh/), [rbenv](https://github.com/rben
 
 - Ruby ~> 3.2.0
 - [PostgreSQL](http://www.postgresql.org/download/)
-- [Redis 5+](http://redis.io/)
+- [Redis 7+](http://redis.io/)
 - [Node.js v16](https://nodejs.org)
 - [Yarn](https://yarnpkg.com/en/)
 - [chromedriver](https://formulae.brew.sh/cask/chromedriver)

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -214,15 +214,9 @@ describe Idv::PhoneErrorsController do
 
     context 'while throttled' do
       let(:user) { create(:user) }
-      let(:attempted_at) do
-        Time.zone.now.utc
-      end
-
-      before do
-        Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!
-      end
 
       it 'assigns expiration time' do
+        Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!
         get action
 
         expect(assigns(:expires_at)).to be_kind_of(Time)
@@ -230,6 +224,8 @@ describe Idv::PhoneErrorsController do
 
       it 'logs an event' do
         freeze_time do
+          attempted_at = Time.zone.now.utc
+          Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!
           throttle_window = Throttle.attempt_window_in_minutes(:proof_address).minutes
 
           get action

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -215,8 +215,7 @@ describe Idv::PhoneErrorsController do
     context 'while throttled' do
       let(:user) { create(:user) }
       let(:attempted_at) do
-        d = DateTime.now # microsecond precision failing on CI
-        Time.zone.parse(d.to_s)
+        Time.zone.now.utc
       end
 
       before do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -110,6 +110,7 @@ feature 'Sign Up' do
 
   scenario 'rate limits sign-up phone confirmation attempts' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(999)
+    allow(IdentityConfig.store).to receive(:phone_confirmation_max_attempts).and_return(1)
 
     sign_up_and_set_password
 


### PR DESCRIPTION
## 🛠 Summary of changes

Last week's infrastructure deploy included the upgrade from Redis 6 to Redis 7 (https://github.com/18F/identity-devops/pull/5751). With the upgrade complete and settled in, we can make use of the new Redis 7 command that should be a bit more stable for our usage.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
