### PR TITLE
LG 8683 Match document title to H1

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -5,6 +5,7 @@ import { FormSteps, PromptOnNavigate } from '@18f/identity-form-steps';
 import { VerifyFlowStepIndicator, VerifyFlowPath } from '@18f/identity-verify-flow';
 import { useDidUpdateEffect } from '@18f/identity-react-hooks';
 import type { FormStep } from '@18f/identity-form-steps';
+import { getConfigValue } from '@18f/identity-config';
 import { UploadFormEntriesError } from '../services/upload';
 import DocumentsStep from './documents-step';
 import InPersonPrepareStep from './in-person-prepare-step';
@@ -60,8 +61,8 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonURL, arcgisSearchEnabled } = useContext(InPersonContext);
+  const appName = getConfigValue('appName');
 
-  const appName = document.querySelector('meta[name="description"]')?.getAttribute('content');
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -60,7 +60,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonURL, arcgisSearchEnabled } = useContext(InPersonContext);
-  const titleFormat = '%{step} - Login.gov';
+
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {
@@ -190,7 +190,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
             onStepChange={setStepName}
             onStepSubmit={trackSubmitEvent}
             autoFocus={!!submissionError}
-            titleFormat={titleFormat}
+            titleFormat="%{step} - Login.gov"
           />
         </>
       )}

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -61,6 +61,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonURL, arcgisSearchEnabled } = useContext(InPersonContext);
 
+  const appName = document.querySelector('meta[name="description"]')?.getAttribute('content');
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {
@@ -191,7 +192,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
             onStepChange={setStepName}
             onStepSubmit={trackSubmitEvent}
             autoFocus={!!submissionError}
-            titleFormat="%{step} - Login.gov"
+            titleFormat={`%{step} - ${appName}`}
           />
         </>
       )}

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -60,6 +60,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonURL, arcgisSearchEnabled } = useContext(InPersonContext);
+  const titleFormat = new String('');
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {
@@ -112,10 +113,12 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
           {
             name: 'location',
             form: arcgisSearchEnabled ? InPersonLocationPostOfficeSearchStep : InPersonLocationStep,
+            title: 'Find a participating Post Office - Login.gov',
           },
           {
             name: 'prepare',
             form: InPersonPrepareStep,
+            title: 'Verify your identity in person - Login.gov',
           },
           flowPath === 'hybrid' && {
             name: 'switch_back',
@@ -137,6 +140,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
                     pii: submissionError.pii,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
+            title: 'We could not verify your ID - Login.gov',
           },
         ] as FormStep[]
       ).concat(inPersonSteps)
@@ -186,6 +190,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
             onStepChange={setStepName}
             onStepSubmit={trackSubmitEvent}
             autoFocus={!!submissionError}
+            titleFormat={titleFormat}
           />
         </>
       )}

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -123,6 +123,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
           flowPath === 'hybrid' && {
             name: 'switch_back',
             form: InPersonSwitchBackStep,
+            title: t('in_person_proofing.headings.switch_back'),
           },
         ].filter(Boolean) as FormStep[]);
 

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -151,6 +151,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
         {
           name: 'documents',
           form: DocumentsStep,
+          title: t('doc_auth.headings.document_capture'),
         },
       ].filter(Boolean) as FormStep[]);
 

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -113,12 +113,12 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
           {
             name: 'location',
             form: arcgisSearchEnabled ? InPersonLocationPostOfficeSearchStep : InPersonLocationStep,
-            title: 'Find a participating Post Office',
+            title: t('in_person_proofing.headings.po_search.location'),
           },
           {
             name: 'prepare',
             form: InPersonPrepareStep,
-            title: 'Verify your identity in person',
+            title: t('in_person_proofing.headings.prepare'),
           },
           flowPath === 'hybrid' && {
             name: 'switch_back',
@@ -140,7 +140,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
                     pii: submissionError.pii,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
-            title: 'We could not verify your ID',
+            title: t('errors.doc_auth.throttled_heading'),
           },
         ] as FormStep[]
       ).concat(inPersonSteps)

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -60,7 +60,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonURL, arcgisSearchEnabled } = useContext(InPersonContext);
-  const titleFormat = new String('');
+  const titleFormat = '%{step} - Login.gov';
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {
@@ -113,12 +113,12 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
           {
             name: 'location',
             form: arcgisSearchEnabled ? InPersonLocationPostOfficeSearchStep : InPersonLocationStep,
-            title: 'Find a participating Post Office - Login.gov',
+            title: 'Find a participating Post Office',
           },
           {
             name: 'prepare',
             form: InPersonPrepareStep,
-            title: 'Verify your identity in person - Login.gov',
+            title: 'Verify your identity in person',
           },
           flowPath === 'hybrid' && {
             name: 'switch_back',
@@ -140,7 +140,7 @@ function DocumentCapture({ isAsyncForm = false, onStepChange = () => {} }: Docum
                     pii: submissionError.pii,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
-            title: 'We could not verify your ID - Login.gov',
+            title: 'We could not verify your ID',
           },
         ] as FormStep[]
       ).concat(inPersonSteps)

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -184,7 +184,7 @@ interface PreviousStepErrorsLookup {
 function useStepTitle(step?: FormStep<any>, titleFormat?: string) {
   useEffect(() => {
     if (titleFormat && step?.title) {
-      document.title = step.title;
+      document.title = replaceVariables(titleFormat, { step: step.title });
     }
   }, [step]);
 }

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -184,7 +184,7 @@ interface PreviousStepErrorsLookup {
 function useStepTitle(step?: FormStep<any>, titleFormat?: string) {
   useEffect(() => {
     if (titleFormat && step?.title) {
-      document.title = replaceVariables(titleFormat, { step: step.title });
+      document.title = step.title;
     }
   }, [step]);
 }


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-8683)

## 🛠 Summary of changes

Issue: page titles did not match the H1s on the following pages: 
- verify/doc_auth/document_capture
- verify/doc_auth/document_capture#location
- verify/doc_auth/document_capture#prepare

Fix: 
- `title` value added to `inPersonSteps` constant
- `titleFormat` string provided in props to `FormSteps` component

## 📜 Testing Plan
- [ ] Document title should match the H1 on /document_capture page
- [ ] Document title should match the H1 on /document_capture page#location
- [ ] Document title should match the H1 on /document_capture page#prepare
- [ ] Document titles should be translated properly
