### PR TITLE
SpinnerButton: Clear timeout on disconnect

### DIFF
--- a/app/javascript/packages/spinner-button/spinner-button-element.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.ts
@@ -38,6 +38,10 @@ export class SpinnerButtonElement extends HTMLElement {
     this.addEventListener('spinner.stop', () => this.toggleSpinner(false));
   }
 
+  disconnectedCallback() {
+    window.clearTimeout(this.#longWaitTimeout);
+  }
+
   toggleSpinner(isVisible: boolean) {
     const { button, actionMessage } = this.elements;
     this.classList.toggle('spinner-button--spinner-active', isVisible);


### PR DESCRIPTION
## 🎫 Ticket

Extracted from #7761, related to [LG-8771](https://cm-jira.usa.gov/browse/LG-8771).

## 🛠 Summary of changes

Implements a `disconnectedCallback` for the `SpinnerButtonElement` to ensure that the scheduled timeout handling for the "long delay" action message is removed.

I discovered in #7761 that this is causing the test process to hang open long after tests have finished (up to 20 seconds), likely due to the fact that the process is waiting for pending timeouts. It's a good practice for the component to clean up after itself when removed anyways, even though in the real world this would usually only happen when the user moves from one page to another.

## 📜 Testing Plan

- `yarn test`
- Ensure no regressions in the behavior of spinner buttons (e.g. PIV/CAC login page)