### PR TITLE
LG-8653: Add personal key generation date to "reactivate your account" page

### DIFF
--- a/app/controllers/reactivate_account_controller.rb
+++ b/app/controllers/reactivate_account_controller.rb
@@ -1,10 +1,20 @@
 class ReactivateAccountController < ApplicationController
   include AccountReactivationConcern
+  include RememberDeviceConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :confirm_password_reset_profile
 
-  def index; end
+  def index
+    @presenter = AccountShowPresenter.new(
+      decrypted_pii: nil,
+      personal_key: nil,
+      sp_session_request_url: sp_session_request_url_with_updated_params,
+      sp_name: decorated_session.sp_name,
+      decorated_user: current_user.decorate,
+      locked_for_session: pii_locked_for_session?(current_user),
+    )
+  end
 
   def update
     reactivate_account_session.suspend

--- a/app/controllers/reactivate_account_controller.rb
+++ b/app/controllers/reactivate_account_controller.rb
@@ -1,19 +1,11 @@
 class ReactivateAccountController < ApplicationController
   include AccountReactivationConcern
-  include RememberDeviceConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :confirm_password_reset_profile
 
   def index
-    @presenter = AccountShowPresenter.new(
-      decrypted_pii: nil,
-      personal_key: nil,
-      sp_session_request_url: sp_session_request_url_with_updated_params,
-      sp_name: decorated_session.sp_name,
-      decorated_user: current_user.decorate,
-      locked_for_session: pii_locked_for_session?(current_user),
-    )
+    @personal_key_generated_at = current_user.personal_key_generated_at
   end
 
   def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,11 @@ class User < ApplicationRecord
     profiles.gpo_verification_pending.order(created_at: :desc).first
   end
 
+  def personal_key_generated_at
+    self.encrypted_recovery_code_digest_generated_at ||
+      active_profile&.verified_at
+  end
+
   def default_phone_configuration
     phone_configurations.order('made_default_at DESC NULLS LAST, created_at').first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,8 +102,7 @@ class User < ApplicationRecord
   end
 
   def personal_key_generated_at
-    self.encrypted_recovery_code_digest_generated_at ||
-      active_profile&.verified_at
+    encrypted_recovery_code_digest_generated_at || active_profile&.verified_at
   end
 
   def default_phone_configuration

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -62,8 +62,7 @@ class AccountShowPresenter
   end
 
   def personal_key_generated_at
-    decorated_user.user.encrypted_recovery_code_digest_generated_at ||
-      decorated_user.user.active_profile&.verified_at
+    decorated_user.user.personal_key_generated_at
   end
 
   def header_personalization

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -7,10 +7,17 @@
     </div>
   </div>
   <p class="margin-bottom-105">
-    <%= t(
-          'users.personal_key.generated_on_html',
-          date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
-        ) %>
+    <% if @presenter.personal_key_generated_at %>
+      <%= t(
+            'users.personal_key.generated_on_html',
+            date: content_tag(:strong, I18n.l(@presenter.personal_key_generated_at, format: :event_date)),
+          ) %>
+    <% else %>
+      <%= t(
+            'users.personal_key.generated_on_html',
+            date: content_tag(:strong, I18n.l(Time.zone.today, format: '%B %d, %Y')),
+          ) %>
+    <% end %>
   </p>
   <% if show_save_buttons %>
     <%= render ClipboardButtonComponent.new(clipboard_text: code, unstyled: true) %>

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -7,10 +7,10 @@
     </div>
   </div>
   <p class="margin-bottom-105">
-    <% if personal_key_generated_at %>
+    <% if defined? personal_key_generated_at %>
       <%= t(
             'users.personal_key.generated_on_html',
-            date: content_tag(:strong, I18n.l(personal_key_generated_at, format: :event_date)),
+            date: content_tag(:strong, I18n.l(personal_key_generated_at, format: '%B %d, %Y')),
           ) %>
     <% else %>
       <%= t(

--- a/app/views/partials/personal_key/_key.html.erb
+++ b/app/views/partials/personal_key/_key.html.erb
@@ -7,10 +7,10 @@
     </div>
   </div>
   <p class="margin-bottom-105">
-    <% if @presenter.personal_key_generated_at %>
+    <% if personal_key_generated_at %>
       <%= t(
             'users.personal_key.generated_on_html',
-            date: content_tag(:strong, I18n.l(@presenter.personal_key_generated_at, format: :event_date)),
+            date: content_tag(:strong, I18n.l(personal_key_generated_at, format: :event_date)),
           ) %>
     <% else %>
       <%= t(

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -30,7 +30,11 @@
 </p>
 
 <div class="scale-down">
-  <%= render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX', show_save_buttons: false %>
+  <%= render 'partials/personal_key/key',
+    code: 'XXXX-XXXX-XXXX-XXXX',
+    personal_key_generated_at: @presenter.personal_key_generated_at,
+    show_save_buttons: false
+  %>
 </div>
 
 <div class="grid-row">

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -32,7 +32,7 @@
 <div class="scale-down">
   <%= render 'partials/personal_key/key',
              code: 'XXXX-XXXX-XXXX-XXXX',
-             personal_key_generated_at: @presenter.personal_key_generated_at,
+             personal_key_generated_at: @personal_key_generated_at,
              show_save_buttons: false
   %>
 </div>

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -31,9 +31,9 @@
 
 <div class="scale-down">
   <%= render 'partials/personal_key/key',
-    code: 'XXXX-XXXX-XXXX-XXXX',
-    personal_key_generated_at: @presenter.personal_key_generated_at,
-    show_save_buttons: false
+             code: 'XXXX-XXXX-XXXX-XXXX',
+             personal_key_generated_at: @presenter.personal_key_generated_at,
+             show_save_buttons: false
   %>
 </div>
 

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -1,5 +1,6 @@
 <%= render PageHeadingComponent.new.with_content(t('forms.personal_key_partial.header')) %>
 <div class="full-width-box margin-y-5">
+  <!-- the following partial probably does not show the correct date !-->
   <%= render 'partials/personal_key/key', code: code, show_save_buttons: true %>
 </div>
 

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -1,6 +1,5 @@
 <%= render PageHeadingComponent.new.with_content(t('forms.personal_key_partial.header')) %>
 <div class="full-width-box margin-y-5">
-  <!-- the following partial probably does not show the correct date !-->
   <%= render 'partials/personal_key/key', code: code, show_save_buttons: true %>
 </div>
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -510,6 +510,46 @@ RSpec.describe User do
     end
   end
 
+  describe '#personal_key_generated_at' do
+    let(:user) do
+      build(:user, encrypted_recovery_code_digest_generated_at: digest_generated_at)
+    end
+    let(:digest_generated_at) { nil }
+
+    context 'the user has a encrypted_recovery_code_digest_generated_at date' do
+      let(:digest_generated_at) { 1.day.ago }
+
+      it 'returns the date in the digest' do
+        expect(
+          user.personal_key_generated_at,
+        ).to be_within(1.second).of(digest_generated_at)
+      end
+    end
+
+    context 'the user does not have a encrypted_recovery_code_digest_generated_at but is proofed' do
+      let!(:profile) do
+        create(
+          :profile,
+          :active,
+          :verified,
+          user: user,
+        )
+      end
+
+      it 'returns the date the user was proofed' do
+        expect(
+          user.personal_key_generated_at,
+        ).to be_within(1.second).of(profile.verified_at)
+      end
+    end
+
+    context 'the user has no encrypted_recovery_code_digest_generated_at and is not proofed' do
+      it 'returns nil' do
+        expect(user.personal_key_generated_at).to be_nil
+      end
+    end
+  end
+
   describe '#should_receive_in_person_completion_survey?' do
     let!(:user) { create(:user) }
     let(:service_provider) { create(:service_provider) }

--- a/spec/views/partials/personal_key/_key.html.erb_spec.rb
+++ b/spec/views/partials/personal_key/_key.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'partials/personal_key/_key.html.erb' do
+  subject(:rendered) do
+    render partial: 'key', locals: locals
+  end
+
+  let(:personal_key) { 'XXXX-XXXX-XXXX-XXXX' }
+
+  context 'with local personal_key_generated_at' do
+    let(:personal_key_generated_at) { 5.days.ago }
+    let(:locals) do
+      {
+        code: personal_key,
+        personal_key_generated_at: personal_key_generated_at,
+        show_save_buttons: false,
+      }
+    end
+
+    it 'displays the specified date' do
+      expect(rendered).to have_content(
+        t(
+          'users.personal_key.generated_on_html',
+          date: I18n.l(personal_key_generated_at, format: '%B %d, %Y'),
+        ),
+      )
+    end
+  end
+
+  context 'without local personal_key_generated_at' do
+    let(:locals) do
+      {
+        code: personal_key,
+        show_save_buttons: false,
+      }
+    end
+
+    it 'displays todays date' do
+      expect(rendered).to have_content(
+        t(
+          'users.personal_key.generated_on_html',
+          date: I18n.l(Time.zone.today, format: '%B %d, %Y'),
+        ),
+      )
+    end
+  end
+end

--- a/spec/views/reactivate_account/index.html.erb_spec.rb
+++ b/spec/views/reactivate_account/index.html.erb_spec.rb
@@ -5,23 +5,16 @@ describe 'reactivate_account/index.html.erb' do
     render
   end
 
-  let(:presenter_class) { AccountShowPresenter }
   let(:personal_key_generated_at) { Time.zone.now }
-  let(:presenter) do
-    instance_double(
-      presenter_class,
-      personal_key_generated_at: personal_key_generated_at,
-    )
-  end
 
   it 'displays a fallback warning alert when js is off' do
-    assign(:presenter, presenter)
+    assign(:personal_key_generated_at, personal_key_generated_at)
 
     expect(rendered).to have_content(t('instructions.account.reactivate.modal.copy'))
   end
 
   it 'displays the date the personal key was generated' do
-    assign(:presenter, presenter)
+    assign(:personal_key_generated_at, personal_key_generated_at)
 
     expect(rendered).to have_content(
       t(

--- a/spec/views/reactivate_account/index.html.erb_spec.rb
+++ b/spec/views/reactivate_account/index.html.erb_spec.rb
@@ -1,9 +1,33 @@
 require 'rails_helper'
 
 describe 'reactivate_account/index.html.erb' do
-  it 'displays a fallback warning alert when js is off' do
+  subject(:rendered) do
     render
+  end
+
+  let(:presenter_class) { AccountShowPresenter }
+  let(:personal_key_generated_at) { Time.zone.now }
+  let(:presenter) do
+    instance_double(
+      presenter_class,
+      personal_key_generated_at: personal_key_generated_at,
+    )
+  end
+
+  it 'displays a fallback warning alert when js is off' do
+    assign(:presenter, presenter)
 
     expect(rendered).to have_content(t('instructions.account.reactivate.modal.copy'))
+  end
+
+  it 'displays the date the personal key was generated' do
+    assign(:presenter, presenter)
+
+    expect(rendered).to have_content(
+      t(
+        'users.personal_key.generated_on_html',
+        date: I18n.l(Time.zone.today, format: '%B %d, %Y'),
+      ),
+    )
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8653](https://cm-jira.usa.gov/browse/LG-8653)



## 🛠 Summary of changes

This change adds the date the user's personal key was generated to the page "Reactivate your account".

It's worth noting that a number of other pages will only show today's date instead of the exact generation date, including:
- /views/idv/personal_key/show.html.erb
- /views/users/personal_keys/show.html.erb
- /views/users/verify_personal_key/new.html.erb
- /views/shared/_personal_key.html.erb

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

1. Create new account
2. Verify identity at /verify
3. Log out
4. Reset your password via forgot password
5. Log in and click "Reactivate your profile now"
6. Notice there is now a date displayed

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
