### PR TITLE
Add IRB history file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .databag_secret
 .env
 .idea
+.irb_history
 .powrc
 .sass-cache
 .zeus.sock

--- a/.irbrc
+++ b/.irbrc
@@ -1,2 +1,1 @@
 IRB.conf[:USE_AUTOCOMPLETE] = false
-IRB.conf[:SAVE_HISTORY] = nil

--- a/.irbrc
+++ b/.irbrc
@@ -1,1 +1,2 @@
 IRB.conf[:USE_AUTOCOMPLETE] = false
+IRB.conf[:SAVE_HISTORY] = nil


### PR DESCRIPTION
## 🛠 Summary of changes

~Updates the `.irbrc` configuration added in #7770 to avoid `irb` saving history, which is [the default behavior](https://docs.ruby-lang.org/en/master/IRB.html#module-IRB-label-History).~ Saving history is not gitignore'd, so could be accidentally committed, and risks the chance that history contains sensitive information. Alternatively, we could gitignore, though I'm not sure that having history provides much value anyways.

**Edit:** Per discussion at https://github.com/18F/identity-idp/pull/7783#discussion_r1098765287, we're keeping the default history behavior, but adding the history file to `.gitignore` (the "alternatively" option mentioned above).

## 📜 Testing Plan

- Run `irb`
- Enter a command (e.g. `1+1`)
- Observe no `.irb_history` file in project root directory