### PR TITLE
Fix VerifyInfoController#delete_pii

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -114,6 +114,7 @@ module Idv
     end
 
     def delete_pii
+      flow_session.delete(:pii_from_doc)
       flow_session.delete(:pii_from_user)
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Delete :pii_from_doc (unsupervised proofing) as well as :pii_from_user (in person proofing)

It doesn't look like this is having any negative effects, but we were deleting the wrong session attribute when deleting pii after editing the SSN on the Verify step.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Confirm that editing SSN works as expected on the Verify step of unsupervised proofing
