### PR TITLE
Pre-calculate CORS domains in cache rather than calculating every time

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -121,9 +121,8 @@ module Identity
             expires_in: IdentityConfig.store.all_redirect_uris_cache_duration_minutes.minutes,
           ) do
             ServiceProvider.pluck(:redirect_uris).flatten.compact.map do |uri|
-              split_uri = uri.split('//')
-              protocol = split_uri[0]
-              domain = split_uri[1].split('/')[0] if split_uri.size > 1
+              protocol, domain_path = uri.split('//', 2)
+              domain, path = domain_path&.split('/')
               "#{protocol}//#{domain}"
             end.uniq
           end

--- a/config/application.rb
+++ b/config/application.rb
@@ -122,7 +122,7 @@ module Identity
           ) do
             ServiceProvider.pluck(:redirect_uris).flatten.compact.map do |uri|
               protocol, domain_path = uri.split('//', 2)
-              domain, path = domain_path&.split('/')
+              domain, _path = domain_path&.split('/')
               "#{protocol}//#{domain}"
             end.uniq
           end

--- a/config/application.rb
+++ b/config/application.rb
@@ -122,7 +122,7 @@ module Identity
           ) do
             ServiceProvider.pluck(:redirect_uris).flatten.compact.map do |uri|
               protocol, domain_path = uri.split('//', 2)
-              domain, _path = domain_path&.split('/')
+              domain, _path = domain_path&.split('/', 2)
               "#{protocol}//#{domain}"
             end.uniq
           end


### PR DESCRIPTION
## 🛠 Summary of changes

This PR lifts the calculation of protocols/domains to store them in the cache rather than storing the redirect URIs themselves and re-calculating on each CORS request.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
