### PR TITLE
Include protocol when checking internal domain for cross-origin resource sharing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -114,7 +114,7 @@ module Identity
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins do |source, _env|
-          next if source == IdentityConfig.store.domain_name
+          next if source == "https://#{IdentityConfig.store.domain_name}"
 
           redirect_uris = Rails.cache.fetch(
             'all_service_provider_redirect_uris',

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   describe 'domain name as the origin' do
     it 'leaves the Access-Control-Allow-Origin header blank' do
       get openid_connect_configuration_path,
-          headers: { 'HTTP_ORIGIN' => IdentityConfig.store.domain_name.dup }
+          headers: { 'HTTP_ORIGIN' => "https://#{IdentityConfig.store.domain_name}" }
 
       aggregate_failures do
         expect(response).to be_ok


### PR DESCRIPTION
## 🛠 Summary of changes

I noticed when working on https://github.com/18F/identity-idp/pull/7785, that internal requests were not being skipped as intended, and it seems to be due to the request source including protocol AND domain, and us only comparing it against the domain. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) has a fuller explanation, but the format and a few examples are:

```
Origin: null
Origin: <scheme>://<hostname>
Origin: <scheme>://<hostname>:<port>

Origin: https://developer.mozilla.org
```

On secure.login.gov, `IdentityConfig.store.domain_name` returns `secure.login.gov`, and I pulled the request headers:

```
Origin: https://secure.login.gov
```

which will never match 🙂

This PR adds `https://` so that we skip the remaining checks as intended.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
