### PR TITLE
Revert Add ial and aal to OIDC userinfo response

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -80,7 +80,6 @@ class OpenidConnectAuthorizeForm
       nonce: nonce,
       rails_session_id: rails_session_id,
       ial: ial_context.ial,
-      aal: aal,
       scope: scope.join(' '),
       code_challenge: code_challenge,
     )
@@ -97,20 +96,16 @@ class OpenidConnectAuthorizeForm
     acr_values.filter { |acr| %r{/ial/}.match?(acr) || %r{/loa/}.match?(acr) }
   end
 
+  def aal_values
+    acr_values.filter { |acr| %r{/aal/}.match? acr }
+  end
+
   def ial_context
     @ial_context ||= IalContext.new(ial: ial, service_provider: service_provider)
   end
 
   def ial
     Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max]
-  end
-
-  def aal_values
-    acr_values.filter { |acr| %r{/aal/}.match? acr }
-  end
-
-  def aal
-    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[aal_values.sort.max]
   end
 
   def_delegators :ial_context,

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -21,8 +21,6 @@ class OpenidConnectUserInfoPresenter
     info.merge!(ial2_attributes) if scoper.ial2_scopes_requested?
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
-    info[:ial] = identity.ial if identity.ial.present?
-    info[:aal] = identity.aal if identity.aal.present?
 
     scoper.filter(info)
   end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -5,13 +5,11 @@ class IdentityLinker
     @user = user
     @service_provider = service_provider
     @ial = nil
-    @aal = nil
   end
 
   def link_identity(
     code_challenge: nil,
     ial: nil,
-    aal: nil,
     nonce: nil,
     rails_session_id: nil,
     scope: nil,
@@ -20,14 +18,12 @@ class IdentityLinker
     clear_deleted_at: nil
   )
     return unless user && service_provider.present?
-
     process_ial(ial)
 
     identity.update!(
       identity_attributes.merge(
         code_challenge: code_challenge,
         ial: ial,
-        aal: aal,
         nonce: nonce,
         rails_session_id: rails_session_id,
         scope: scope,

--- a/db/primary_migrate/20230126195401_add_aal_to_identities.rb
+++ b/db/primary_migrate/20230126195401_add_aal_to_identities.rb
@@ -1,5 +1,0 @@
-class AddAalToIdentities < ActiveRecord::Migration[7.0]
-  def change
-    add_column :identities, :aal, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_195401) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_202809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -272,7 +272,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_195401) do
     t.datetime "last_ial1_authenticated_at", precision: nil
     t.datetime "last_ial2_authenticated_at", precision: nil
     t.datetime "deleted_at", precision: nil
-    t.integer "aal"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -962,7 +962,6 @@ describe 'OpenID Connect' do
     expect(decoded_id_token[:email]).to eq(user.email)
     expect(decoded_id_token[:given_name]).to eq('John')
     expect(decoded_id_token[:social_security_number]).to eq('111223333')
-    expect(decoded_id_token[:ial]).to eq(2)
 
     access_token = token_response[:access_token]
     expect(access_token).to be_present


### PR DESCRIPTION
This update created a problem for a partner (https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1675804144125749) so this will revert the changes made so we can review and decide the best path to implement the changes without causing problems for existing partners.