### PR TITLE
Update DocAuthLog on VerifyInfo show and update

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -9,6 +9,8 @@ module Idv
     def show
       increment_step_counts
       analytics.idv_doc_auth_verify_visited(**analytics_arguments)
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+        call('verify', :view, true)
 
       if ssn_throttle.throttled?
         redirect_to idv_session_errors_ssn_failure_url
@@ -27,6 +29,8 @@ module Idv
     def update
       return if idv_session.verify_info_step_document_capture_session_uuid
       analytics.idv_doc_auth_verify_submitted(**analytics_arguments)
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+        call('verify', :update, true)
 
       pii[:uuid_prefix] = ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -11,9 +11,10 @@ describe Idv::VerifyInfoController do
       :flow_path => 'standard' }
   end
 
+  let(:user) { create(:user) }
+
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
-    user = build(:user, :with_phone, with: { phone: '+1 (415) 555-0130' })
     stub_idv_steps_before_verify_step(user)
   end
 
@@ -75,6 +76,14 @@ describe Idv::VerifyInfoController do
         analytics_args[:step_count] = 2
 
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      it 'updates DocAuthLog verify_view_count' do
+        doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+        expect { get :show }.to(
+          change { doc_auth_log.reload.verify_view_count }.from(0).to(1),
+        )
       end
 
       context 'when the user has already verified their info' do
@@ -142,6 +151,14 @@ describe Idv::VerifyInfoController do
           step: 'verify',
           step_count: 0,
         },
+      )
+    end
+
+    it 'updates DocAuthLog verify_submit_count' do
+      doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+      expect { put :update }.to(
+        change { doc_auth_log.reload.verify_submit_count }.from(0).to(1),
       )
     end
 


### PR DESCRIPTION
@zachmargolis pointed out that DocAuthLog needs to be updated in controllers that are extracted from the Flow State Machine. Add the calls and tests to VerifyInfoController.