### PR TITLE
LG-8760: Log events for visiting various IdV error routes

### DIFF
--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -13,6 +13,7 @@ module Idv
 
     def timeout
       @remaining_step_attempts = throttle.remaining_count
+      track_event(type: :timeout)
     end
 
     def jobfail

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -5,6 +5,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_phone_step_needed
     before_action :set_gpo_letter_available
+    before_action :ignore_form_step_wait_requests
 
     def warning
       @remaining_attempts = throttle.remaining_count
@@ -35,6 +36,10 @@ module Idv
     def confirm_idv_phone_step_needed
       return unless user_fully_authenticated?
       redirect_to idv_review_url if idv_session.user_phone_confirmation == true
+    end
+
+    def ignore_form_step_wait_requests
+      head(:no_content) if request.headers['HTTP_X_FORM_STEPS_WAIT']
     end
 
     def track_event(type:)

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -90,7 +90,7 @@ module Idv
 
     def log_event(based_on_throttle: nil)
       options = {
-        action: params[:action],
+        type: params[:action],
       }
 
       options[:attempts_remaining] = based_on_throttle.remaining_count if based_on_throttle

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -6,6 +6,7 @@ module Idv
     before_action :confirm_two_factor_authenticated_or_user_id_in_session
     before_action :confirm_idv_session_step_needed
     before_action :set_try_again_path, only: [:warning, :exception]
+    before_action :ignore_form_step_wait_requests
 
     def exception
       log_event
@@ -66,6 +67,10 @@ module Idv
     def confirm_idv_session_step_needed
       return unless user_fully_authenticated?
       redirect_to idv_phone_url if idv_session.profile_confirmation == true
+    end
+
+    def ignore_form_step_wait_requests
+      head(:no_content) if request.headers['HTTP_X_FORM_STEPS_WAIT']
     end
 
     def set_try_again_path

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -95,7 +95,7 @@ module Idv
 
       options[:attempts_remaining] = based_on_throttle.remaining_count if based_on_throttle
 
-      @analytics.idv_session_errors_visited(**options)
+      analytics.idv_session_errors_visited(**options)
     end
   end
 end

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -6,6 +6,7 @@ module Idv
     before_action :confirm_two_factor_authenticated_or_user_id_in_session
     before_action :confirm_idv_session_step_needed
     before_action :set_try_again_path, only: [:warning, :exception]
+    before_action :log_event
 
     def exception; end
 
@@ -73,6 +74,12 @@ module Idv
 
     def in_person_flow?
       params[:flow] == 'in_person'
+    end
+
+    def log_event
+      @analytics.idv_session_errors_visited(
+        action: params[:action],
+      )
     end
   end
 end

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -18,7 +18,7 @@ module Idv
       )
 
       @remaining_attempts = throttle.remaining_count
-      log_event based_on_throttle: throttle
+      log_event(based_on_throttle: throttle)
     end
 
     def failure
@@ -27,7 +27,7 @@ module Idv
         throttle_type: :idv_resolution,
       )
       @expires_at = throttle.expires_at
-      log_event based_on_throttle: throttle
+      log_event(based_on_throttle: throttle)
     end
 
     def ssn_failure
@@ -41,13 +41,13 @@ module Idv
         @expires_at = throttle.expires_at
       end
 
-      log_event based_on_throttle: throttle
+      log_event(based_on_throttle: throttle)
       render 'idv/session_errors/failure'
     end
 
     def throttled
       throttle = Throttle.new(user: effective_user, throttle_type: :idv_doc_auth)
-      log_event based_on_throttle: throttle
+      log_event(based_on_throttle: throttle)
       @expires_at = throttle.expires_at
     end
 

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -95,7 +95,7 @@ module Idv
 
       options[:attempts_remaining] = based_on_throttle.remaining_count if based_on_throttle
 
-      analytics.idv_session_errors_visited(**options)
+      analytics.idv_session_error_visited(**options)
     end
   end
 end

--- a/app/javascript/packs/form-steps-wait.tsx
+++ b/app/javascript/packs/form-steps-wait.tsx
@@ -116,6 +116,10 @@ export class FormStepsWait {
     const response = await window.fetch(action, {
       method,
       body: new window.FormData(form),
+      headers: {
+        // Signal to backend that this request is coming from this JS.
+        'X-Form-Steps-Wait': '1',
+      },
     });
 
     this.handleResponse(response);
@@ -200,7 +204,12 @@ export class FormStepsWait {
 
   async poll() {
     const { waitStepPath } = this.options;
-    const response = await window.fetch(waitStepPath);
+    const response = await window.fetch(waitStepPath, {
+      headers: {
+        // Signal to backend that this request is coming from this JS.
+        'X-Form-Steps-Wait': '1',
+      },
+    });
     this.handleResponse(response);
   }
 }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3006,11 +3006,13 @@ module AnalyticsEvents
   # Tracks when the user visits one of the the session error pages.
   # @param [String] action
   def idv_session_errors_visited(
-    action:
+    action:,
+    attempts_remaining: nil
   )
     track_event(
       'IdV: Session Errors visited',
       action: action,
+      attempts_remaining: attempts_remaining,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3005,14 +3005,17 @@ module AnalyticsEvents
 
   # Tracks when the user visits one of the the session error pages.
   # @param [String] action
+  # @param [Integer,nil] attempts_remaining
   def idv_session_errors_visited(
     action:,
-    attempts_remaining: nil
+    attempts_remaining: nil,
+    **extra
   )
     track_event(
       'IdV: Session Errors visited',
       action: action,
       attempts_remaining: attempts_remaining,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3004,16 +3004,16 @@ module AnalyticsEvents
   end
 
   # Tracks when the user visits one of the the session error pages.
-  # @param [String] action
+  # @param [String] type
   # @param [Integer,nil] attempts_remaining
   def idv_session_errors_visited(
-    action:,
+    type:,
     attempts_remaining: nil,
     **extra
   )
     track_event(
       'IdV: Session Errors visited',
-      action: action,
+      type: type,
       attempts_remaining: attempts_remaining,
       **extra,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3003,6 +3003,17 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when the user visits one of the the session error pages.
+  # @param [String] action
+  def idv_session_errors_visited(
+    action:
+  )
+    track_event(
+      'IdV: Session Errors visited',
+      action: action,
+    )
+  end
+
   # Tracks if request to get USPS in-person proofing locations fails
   # @param [String] exception_class
   # @param [String] exception_message

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3006,13 +3006,13 @@ module AnalyticsEvents
   # Tracks when the user visits one of the the session error pages.
   # @param [String] type
   # @param [Integer,nil] attempts_remaining
-  def idv_session_errors_visited(
+  def idv_session_error_visited(
     type:,
     attempts_remaining: nil,
     **extra
   )
     track_event(
-      'IdV: Session Errors visited',
+      'IdV: session error visited',
       type: type,
       attempts_remaining: attempts_remaining,
       **extra,

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -25,6 +25,20 @@ shared_examples_for 'an idv phone errors controller action' do
       )
       get action
     end
+
+    context 'fetch() request from form-steps-wait JS' do
+      before do
+        request.headers['X-Form-Steps-Wait'] = '1'
+      end
+      it 'returns an empty response' do
+        get action
+        expect(response).to have_http_status(204)
+      end
+      it 'does not log an event' do
+        expect(@analytics).not_to receive(:track_event).with('IdV: phone error visited', anything)
+        get action
+      end
+    end
   end
 
   context 'the user is authenticated and has confirmed their phone' do

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -15,6 +15,16 @@ shared_examples_for 'an idv phone errors controller action' do
 
       expect(response).to render_template(template)
     end
+
+    it 'logs an event' do
+      expect(@analytics).to receive(:track_event).with(
+        'IdV: phone error visited',
+        hash_including(
+          type: action,
+        ),
+      )
+      get action
+    end
   end
 
   context 'the user is authenticated and has confirmed their phone' do
@@ -26,6 +36,15 @@ shared_examples_for 'an idv phone errors controller action' do
 
       expect(response).to redirect_to(idv_review_url)
     end
+    it 'does not log an event' do
+      expect(@analytics).not_to receive(:track_event).with(
+        'IdV: phone error visited',
+        hash_including(
+          type: action,
+        ),
+      )
+      get action
+    end
   end
 
   context 'the user is not authenticated and not recovering their account' do
@@ -33,6 +52,15 @@ shared_examples_for 'an idv phone errors controller action' do
       get action
 
       expect(response).to redirect_to(new_user_session_url)
+    end
+    it 'does not log an event' do
+      expect(@analytics).not_to receive(:track_event).with(
+        'IdV: phone error visited',
+        hash_including(
+          type: action,
+        ),
+      )
+      get action
     end
   end
 end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -13,7 +13,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: Session Errors visited',
-        hash_including(action: action.to_s),
+        hash_including(type: action.to_s),
       )
       get action
     end
@@ -31,7 +31,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
         'IdV: Session Errors visited',
-        hash_including(action: action.to_s),
+        hash_including(type: action.to_s),
       )
       get action
     end
@@ -50,7 +50,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: Session Errors visited',
-        hash_including(action: action.to_s),
+        hash_including(type: action.to_s),
       )
       get action
     end
@@ -65,7 +65,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
         'IdV: Session Errors visited',
-        hash_including(action: action.to_s),
+        hash_including(type: action.to_s),
       )
       get action
     end
@@ -133,7 +133,7 @@ describe Idv::SessionErrorsController do
         expect(@analytics).to receive(:track_event).with(
           'IdV: Session Errors visited',
           hash_including(
-            action: action.to_s,
+            type: action.to_s,
             attempts_remaining: 5,
           ),
         )
@@ -175,7 +175,7 @@ describe Idv::SessionErrorsController do
         expect(@analytics).to receive(:track_event).with(
           'IdV: Session Errors visited',
           hash_including(
-            action: action.to_s,
+            type: action.to_s,
             attempts_remaining: 5,
           ),
         )
@@ -216,7 +216,7 @@ describe Idv::SessionErrorsController do
         expect(@analytics).to receive(:track_event).with(
           'IdV: Session Errors visited',
           hash_including(
-            action: 'ssn_failure',
+            type: 'ssn_failure',
             attempts_remaining: 0,
           ),
         )
@@ -248,7 +248,7 @@ describe Idv::SessionErrorsController do
         expect(@analytics).to receive(:track_event).with(
           'IdV: Session Errors visited',
           hash_including(
-            action: action.to_s,
+            type: action.to_s,
             attempts_remaining: 0,
           ),
         )

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -13,7 +13,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: Session Errors visited',
-        action: action.to_s,
+        hash_including(action: action.to_s),
       )
       get action
     end
@@ -31,7 +31,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
         'IdV: Session Errors visited',
-        action: action.to_s,
+        hash_including(action: action.to_s),
       )
       get action
     end
@@ -50,7 +50,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: Session Errors visited',
-        action: action.to_s,
+        hash_including(action: action.to_s),
       )
       get action
     end
@@ -65,7 +65,7 @@ shared_examples_for 'an idv session errors controller action' do
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
         'IdV: Session Errors visited',
-        action: action.to_s,
+        hash_including(action: action.to_s),
       )
       get action
     end
@@ -129,6 +129,17 @@ describe Idv::SessionErrorsController do
         expect(assigns(:try_again_path)).to eq(idv_doc_auth_path)
       end
 
+      it 'logs an event with attempts remaining' do
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: Session Errors visited',
+          hash_including(
+            action: action.to_s,
+            attempts_remaining: 5,
+          ),
+        )
+        response
+      end
+
       context 'in in-person proofing flow' do
         let(:params) { { flow: 'in_person' } }
 
@@ -158,6 +169,17 @@ describe Idv::SessionErrorsController do
         get action
 
         expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+
+      it 'logs an event with attempts remaining' do
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: Session Errors visited',
+          hash_including(
+            action: action.to_s,
+            attempts_remaining: 5,
+          ),
+        )
+        get action
       end
     end
   end
@@ -189,6 +211,17 @@ describe Idv::SessionErrorsController do
 
         expect(assigns(:expires_at)).not_to eq(Time.zone.now)
       end
+
+      it 'logs an event with attempts remaining' do
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: Session Errors visited',
+          hash_including(
+            action: 'ssn_failure',
+            attempts_remaining: 0,
+          ),
+        )
+        get action
+      end
     end
   end
 
@@ -209,6 +242,18 @@ describe Idv::SessionErrorsController do
         get action
 
         expect(assigns(:expires_at)).to be_kind_of(Time)
+      end
+
+      it 'logs an event with attempts remaining' do
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: Session Errors visited',
+          hash_including(
+            action: action.to_s,
+            attempts_remaining: 0,
+          ),
+        )
+
+        get action
       end
     end
   end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -14,7 +14,7 @@ shared_examples_for 'an idv session errors controller action' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: session error visited',
         hash_including(type: action.to_s),
-      )
+      ).once
       get action
     end
   end
@@ -51,7 +51,7 @@ shared_examples_for 'an idv session errors controller action' do
       expect(@analytics).to receive(:track_event).with(
         'IdV: session error visited',
         hash_including(type: action.to_s),
-      )
+      ).once
       get action
     end
   end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -26,6 +26,10 @@ shared_examples_for 'an idv session errors controller action' do
         get action
         expect(response).to have_http_status(204)
       end
+      it 'does not log an event' do
+        expect(@analytics).not_to receive(:track_event).with('IdV: session error visited', anything)
+        get action
+      end
     end
   end
 
@@ -72,6 +76,10 @@ shared_examples_for 'an idv session errors controller action' do
       it 'returns an empty response' do
         get action
         expect(response).to have_http_status(204)
+      end
+      it 'does not log an event' do
+        expect(@analytics).not_to receive(:track_event).with('IdV: session error visited', anything)
+        get action
       end
     end
   end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -12,7 +12,7 @@ shared_examples_for 'an idv session errors controller action' do
 
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
-        'IdV: Session Errors visited',
+        'IdV: session error visited',
         hash_including(type: action.to_s),
       )
       get action
@@ -30,7 +30,7 @@ shared_examples_for 'an idv session errors controller action' do
     end
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
-        'IdV: Session Errors visited',
+        'IdV: session error visited',
         hash_including(type: action.to_s),
       )
       get action
@@ -49,7 +49,7 @@ shared_examples_for 'an idv session errors controller action' do
     end
     it 'logs an event' do
       expect(@analytics).to receive(:track_event).with(
-        'IdV: Session Errors visited',
+        'IdV: session error visited',
         hash_including(type: action.to_s),
       )
       get action
@@ -64,7 +64,7 @@ shared_examples_for 'an idv session errors controller action' do
     end
     it 'does not log an event' do
       expect(@analytics).not_to receive(:track_event).with(
-        'IdV: Session Errors visited',
+        'IdV: session error visited',
         hash_including(type: action.to_s),
       )
       get action
@@ -131,7 +131,7 @@ describe Idv::SessionErrorsController do
 
       it 'logs an event with attempts remaining' do
         expect(@analytics).to receive(:track_event).with(
-          'IdV: Session Errors visited',
+          'IdV: session error visited',
           hash_including(
             type: action.to_s,
             attempts_remaining: 5,
@@ -173,7 +173,7 @@ describe Idv::SessionErrorsController do
 
       it 'logs an event with attempts remaining' do
         expect(@analytics).to receive(:track_event).with(
-          'IdV: Session Errors visited',
+          'IdV: session error visited',
           hash_including(
             type: action.to_s,
             attempts_remaining: 5,
@@ -214,7 +214,7 @@ describe Idv::SessionErrorsController do
 
       it 'logs an event with attempts remaining' do
         expect(@analytics).to receive(:track_event).with(
-          'IdV: Session Errors visited',
+          'IdV: session error visited',
           hash_including(
             type: 'ssn_failure',
             attempts_remaining: 0,
@@ -246,7 +246,7 @@ describe Idv::SessionErrorsController do
 
       it 'logs an event with attempts remaining' do
         expect(@analytics).to receive(:track_event).with(
-          'IdV: Session Errors visited',
+          'IdV: session error visited',
           hash_including(
             type: action.to_s,
             attempts_remaining: 0,

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -6,7 +6,6 @@ shared_examples_for 'an idv session errors controller action' do
 
     it 'renders the error' do
       get action
-
       expect(response).to render_template(template)
     end
 
@@ -16,6 +15,17 @@ shared_examples_for 'an idv session errors controller action' do
         hash_including(type: action.to_s),
       ).once
       get action
+    end
+
+    context 'fetch() request from form-steps-wait JS' do
+      before do
+        request.headers['X-Form-Steps-Wait'] = '1'
+      end
+
+      it 'returns an empty response' do
+        get action
+        expect(response).to have_http_status(204)
+      end
     end
   end
 
@@ -44,7 +54,6 @@ shared_examples_for 'an idv session errors controller action' do
     end
     it 'renders the error' do
       get action
-
       expect(response).to render_template(template)
     end
     it 'logs an event' do
@@ -53,6 +62,17 @@ shared_examples_for 'an idv session errors controller action' do
         hash_including(type: action.to_s),
       ).once
       get action
+    end
+
+    context 'fetch() request from form-steps-wait JS' do
+      before do
+        request.headers['X-Form-Steps-Wait'] = '1'
+      end
+
+      it 'returns an empty response' do
+        get action
+        expect(response).to have_http_status(204)
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-8760](https://cm-jira.usa.gov/browse/LG-8760)

## 🛠 Summary of changes

This PR adds event logging to `Idv::SessionErrorsController` and one action of `Idv::PhoneErrorsController`. It also augments the associated controller spec to do more checking for logging / lack-of-logging of events.

During testing, we encountered an issue where two "visited" events would be logged: the first due to [a `fetch()` request made by the form-steps-wait JS](https://github.com/18F/identity-idp/blob/main/app/javascript/packs/form-steps-wait.tsx#L203) and the second made when the user was then sent to the error page [via JS](https://github.com/18F/identity-idp/blob/main/app/javascript/packs/form-steps-wait.tsx#L144).

A long-term fix for that will involve reworking IdV and the form-steps infra to use JSON-based API endpoints (see [LG-8706](https://cm-jira.usa.gov/browse/LG-8706)). In the short term, this PR:

* Augments `fetch()` requests made by the form-steps-wait module with a header, `X-Form-Steps-Wait: 1`
* Updates `Idv::PhoneErrorsController` and `Idv::SessionErrorsController` to return empty [`204 No Content`](https://http.cat/204) responses when the header is present (and not log the event).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Sign up and start verifying yourself
- [ ] Enter an invalid SSN
- [ ] Get warned about how your SSN was invalid and you have `N` tries left
- [ ] Observe that your `log/events.log` has an appropriate `IdV: session error visited` event logged to it, with `type: warning` and an appropriate `attempts_remaining` value:

```jsonc
{
  "name": "IdV: session error visited",
  "properties": {
    "event_properties": {
      "type": "warning",
      "attempts_remaining": 4
    }
    /* etc */
}
```

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
