### PR TITLE
LG-8783 Update IPP CTA with nationwide language on barcode attention error page

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -23,7 +23,7 @@ function InPersonCallToAction({ altHeading, altPrompt, altButtonText }: InPerson
       <h2 id={`in-person-cta-heading-${instanceId}`} className="margin-y-2">
         {altHeading || t('in_person_proofing.headings.cta')}
       </h2>
-      <p>{altPrompt}</p>
+      <p>{altPrompt || t('in_person_proofing.body.cta.prompt_detail')}</p>
       <Button
         isBig
         isOutline

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -23,7 +23,7 @@ function InPersonCallToAction({ altHeading, altPrompt, altButtonText }: InPerson
       <h2 id={`in-person-cta-heading-${instanceId}`} className="margin-y-2">
         {altHeading || t('in_person_proofing.headings.cta')}
       </h2>
-      <p>{altPrompt || t('in_person_proofing.body.cta.prompt_detail')}</p>
+      <p>{altPrompt}</p>
       <Button
         isBig
         isOutline

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -159,7 +159,7 @@ function ReviewIssuesStep({
               showAlternativeProofingOptions={!isFailedResult}
               heading={t('components.troubleshooting_options.ipp_heading')}
               altInPersonCta={t('in_person_proofing.headings.cta_variant')}
-              altInPersonPrompt={t('in_person_proofing.body.cta.prompt_detail_a')}
+              altInPersonPrompt={t('in_person_proofing.body.cta.prompt_detail')}
               altInPersonCtaButtonText={t('in_person_proofing.body.cta.button_variant')}
             />
           }

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -159,7 +159,6 @@ function ReviewIssuesStep({
               showAlternativeProofingOptions={!isFailedResult}
               heading={t('components.troubleshooting_options.ipp_heading')}
               altInPersonCta={t('in_person_proofing.headings.cta_variant')}
-              altInPersonPrompt={t('in_person_proofing.body.cta.prompt_detail')}
               altInPersonCtaButtonText={t('in_person_proofing.body.cta.button_variant')}
             />
           }

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -28,10 +28,7 @@ en:
       cta:
         button: Verify your ID in person
         button_variant: Try in person
-        prompt_detail: If you are located near Washington, D.C. or Baltimore, MD, you
-          may be able to verify your ID in person at limited post office
-          locations.
-        prompt_detail_a: You may be able to verify your ID in person at a participating
+        prompt_detail: You may be able to verify your ID in person at a participating
           Post Office near you.
         prompt_detail_b: Alternatively, if you are having trouble adding your ID online,
           you may be able to try in person at limited post office locations.

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -31,10 +31,7 @@ es:
       cta:
         button: Verifique su identificación en persona
         button_variant: Inténtelo en persona
-        prompt_detail: Si usted está ubicado cerca de Washington, D.C. o Baltimore, MD,
-          puede verificar su identificación en persona en las oficinas de
-          correos seleccionadas.
-        prompt_detail_a: Es posible que pueda verificar su documento de identidad en
+        prompt_detail: Es posible que pueda verificar su documento de identidad en
           persona en una oficina de correos participante cercana.
         prompt_detail_b: Si tiene problemas para añadir su documento de identidad en
           línea, puede intentarlo en persona en algunas oficinas de correos.

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -32,10 +32,7 @@ fr:
       cta:
         button: Vérifiez votre identité en personne
         button_variant: Essayer en personne
-        prompt_detail: Si vous êtes situé près de Washington, D.C. ou de Baltimore
-          (Maryland), vous pourrez peut-être vérifier votre identité en personne
-          dans certains bureaux de poste.
-        prompt_detail_a: Vous pourrez peut-être faire vérifier votre pièce d’identité en
+        prompt_detail: Vous pourrez peut-être faire vérifier votre pièce d’identité en
           personne dans un bureau de poste participant près de chez vous.
         prompt_detail_b: Ou, si vous rencontrez des difficultés pour ajouter votre pièce
           d’identité en ligne, vous pourrez peut-être essayer de le faire en


### PR DESCRIPTION
## 🎫 Ticket? [TICKET.](https://cm-jira.usa.gov/browse/LG-8783)

## 🛠 Summary of changes

With the advent of the nationwide launch, the default state of the IPP CTA has changed. The previous language referring to D.C. and Baltimore only P.O. locations is irrelevant. So this is a minor change to make the default language that of CTA version A. 

## 📜 Testing Plan

Since the changes to the frontend have already been made, there shouldn't be any changes to the text displayed. 
- [ ] Confirm that the text "You may be able to verify your ID in person at a participating Post Office near you." is displayed on the failure to verify ID page for IPP CTA Version A
- [ ] Confirm that the text "Alternatively, if you are having trouble adding your ID online, you may be able to try in person at limited post office locations." is displayed on the failure to verify ID page for IPP CTA Version B
- [ ] Confirm that the relevant text is displayed for each translation

## 👀 ~Screenshots~