### PR TITLE
Only proactively rotate PII fingerprints when PII is decrypted

### DIFF
--- a/app/models/backup_code_configuration.rb
+++ b/app/models/backup_code_configuration.rb
@@ -1,10 +1,6 @@
 class BackupCodeConfiguration < ApplicationRecord
   NUM_WORDS = 3
 
-  include EncryptableAttribute
-
-  encrypted_attribute_without_setter(name: :code)
-
   include BackupCodeEncryptedAttributeOverrides
 
   belongs_to :user

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -45,12 +45,9 @@ describe Pii::Cacher do
       expect(user_session[:decrypted_pii]).to eq decrypted_pii_json
     end
 
-    it 'updates fingerprints when keys are rotated' do
+    it 'updates PII bundle fingerprints when keys are rotated' do
       old_ssn_signature = profile.ssn_signature
       old_compound_pii_fingerprint = profile.name_zip_birth_year_signature
-      old_email_fingerprint = user.email_addresses.first.email_fingerprint
-      old_encrypted_email = user.email_addresses.first.encrypted_email
-      old_encrypted_phone = user.phone_configurations.first.encrypted_phone
 
       rotate_all_keys
 
@@ -63,11 +60,8 @@ describe Pii::Cacher do
       user.reload
       profile.reload
 
-      expect(user.email_addresses.first.email_fingerprint).to_not eq old_email_fingerprint
-      expect(user.email_addresses.first.encrypted_email).to_not eq old_encrypted_email
       expect(profile.ssn_signature).to_not eq old_ssn_signature
       expect(profile.name_zip_birth_year_signature).to_not eq old_compound_pii_fingerprint
-      expect(user.phone_configurations.first.encrypted_phone).to_not eq old_encrypted_phone
     end
 
     it 'does not attempt to rotate nil attributes' do


### PR DESCRIPTION
## 🛠 Summary of changes

We currently check some fingerprints and encrypted attributes in the `Pii::Cacher` class to see if they need to be rotated. We should be able to rely on https://github.com/18F/identity-idp/blob/71259342275df5f565ca6b1a1a3dda5baf9222a4/lib/tasks/rotate.rake#L7-L28 for rotating encrypted attributes in a complete manner.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
