### PR TITLE
Make SpinnerButton form-aware for invalid form submissions

### DIFF
--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -39,10 +39,14 @@ describe('CaptchaSubmitButtonElement', () => {
       const button = screen.getByRole('button', { name: 'Submit' });
       const form = document.querySelector('form')!;
 
-      sandbox.stub(form, 'submit');
+      let didSubmit = false;
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        didSubmit = true;
+      });
 
       await userEvent.click(button);
-      await waitFor(() => expect((form.submit as SinonStub).called).to.be.true());
+      await waitFor(() => expect(didSubmit).to.be.true());
     });
 
     context('with form validation errors', () => {
@@ -145,10 +149,14 @@ describe('CaptchaSubmitButtonElement', () => {
           const button = screen.getByRole('button', { name: 'Submit' });
           const form = document.querySelector('form')!;
 
-          sandbox.stub(form, 'submit');
+          let didSubmit = false;
+          form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            didSubmit = true;
+          });
 
           await userEvent.click(button);
-          await waitFor(() => expect((form.submit as SinonStub).called).to.be.true());
+          await waitFor(() => expect(didSubmit).to.be.true());
 
           expect(grecaptcha.ready).not.to.have.been.called();
         });

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -49,50 +49,6 @@ describe('CaptchaSubmitButtonElement', () => {
       await waitFor(() => expect(didSubmit).to.be.true());
     });
 
-    context('with form validation errors', () => {
-      beforeEach(() => {
-        document.body.innerHTML = `
-          <form>
-            <input required>
-            <lg-captcha-submit-button>
-              <lg-spinner-button>
-                <button>Submit</button>
-              </lg-spinner-button>
-            </lg-captcha-submit-button>
-          </form>
-        `;
-      });
-
-      it('does not submit the form and reports validity', async () => {
-        const button = screen.getByRole('button', { name: 'Submit' });
-        const form = document.querySelector('form')!;
-        const input = document.querySelector('input')!;
-
-        let didSubmit = false;
-        form.addEventListener('submit', (event) => {
-          event.preventDefault();
-          didSubmit = true;
-        });
-
-        let didReportInvalid = false;
-        input.addEventListener('invalid', () => {
-          didReportInvalid = true;
-        });
-
-        await userEvent.click(button);
-
-        expect(didSubmit).to.be.false();
-        expect(didReportInvalid).to.be.true();
-      });
-
-      it('stops or otherwise prevents the spinner button from spinning', async () => {
-        const button = screen.getByRole('button', { name: 'Submit' });
-        await userEvent.click(button);
-
-        expect(document.querySelector('.spinner-button--spinner-active')).to.not.exist();
-      });
-    });
-
     context('with configured recaptcha', () => {
       const RECAPTCHA_TOKEN_VALUE = 'token';
       const RECAPTCHA_SITE_KEY = 'site_key';

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -1,8 +1,16 @@
 export const CAPTCHA_EVENT_NAME = 'lg:captcha-submit-button:challenge';
 
 class CaptchaSubmitButtonElement extends HTMLElement {
+  form: HTMLFormElement | null;
+
   connectedCallback() {
-    this.form?.addEventListener('submit', (event) => this.handleFormSubmit(event));
+    this.form = this.closest('form');
+
+    this.form?.addEventListener('submit', this.handleFormSubmit);
+  }
+
+  disconnectedCallback() {
+    this.form?.removeEventListener('submit', this.handleFormSubmit);
   }
 
   get button(): HTMLButtonElement {
@@ -11,10 +19,6 @@ class CaptchaSubmitButtonElement extends HTMLElement {
 
   get tokenInput(): HTMLInputElement {
     return this.querySelector('[type=hidden]')!;
-  }
-
-  get form(): HTMLFormElement | null {
-    return this.closest('form');
   }
 
   get recaptchaSiteKey(): string | null {
@@ -48,12 +52,12 @@ class CaptchaSubmitButtonElement extends HTMLElement {
     return !event.defaultPrevented;
   }
 
-  handleFormSubmit(event: SubmitEvent) {
+  handleFormSubmit = (event: SubmitEvent) => {
     if (this.shouldInvokeChallenge()) {
       event.preventDefault();
       this.invokeChallenge();
     }
-  }
+  };
 }
 
 declare global {

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -2,7 +2,7 @@ export const CAPTCHA_EVENT_NAME = 'lg:captcha-submit-button:challenge';
 
 class CaptchaSubmitButtonElement extends HTMLElement {
   connectedCallback() {
-    this.button.addEventListener('click', (event) => this.handleButtonClick(event));
+    this.form?.addEventListener('submit', (event) => this.handleFormSubmit(event));
   }
 
   get button(): HTMLButtonElement {
@@ -48,19 +48,10 @@ class CaptchaSubmitButtonElement extends HTMLElement {
     return !event.defaultPrevented;
   }
 
-  handleButtonClick(event: MouseEvent) {
-    event.preventDefault();
-
-    if (this.form && !this.form.reportValidity()) {
-      // Prevent any associated custom click handling, e.g. spinner button spinning
-      event.stopImmediatePropagation();
-      return;
-    }
-
+  handleFormSubmit(event: SubmitEvent) {
     if (this.shouldInvokeChallenge()) {
+      event.preventDefault();
       this.invokeChallenge();
-    } else {
-      this.submit();
     }
   }
 }

--- a/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
@@ -85,6 +85,17 @@ describe('SpinnerButtonElement', () => {
       expect(didSubmit).to.be.true();
       expect(button.hasAttribute('disabled')).to.be.true();
     });
+
+    it('unbinds events when disconnected', () => {
+      const wrapper = createWrapper({ tagName: 'button', inForm: true });
+      const form = wrapper.form!;
+      form.removeChild(wrapper);
+
+      sandbox.spy(wrapper, 'toggleSpinner');
+      fireEvent.submit(form);
+
+      expect(wrapper.toggleSpinner).not.to.have.been.called();
+    });
   });
 
   context('with form inside (button_to)', () => {

--- a/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
@@ -26,15 +26,24 @@ describe('SpinnerButtonElement', () => {
     inForm,
     isButtonTo,
   }: WrapperOptions = {}) {
+    let tag;
+    if (tagName === 'a') {
+      tag = '<a href="#">Click Me</a>';
+    } else {
+      tag = '<input type="submit" value="Click Me">';
+    }
+
+    if (isButtonTo) {
+      tag = `<form action="#">${tag}</form>`;
+    }
+
     let html = `
       <lg-spinner-button
         long-wait-duration-ms="${longWaitDurationMs}"
         ${spinOnClick === undefined ? '' : `spin-on-click="${spinOnClick}"`}
       >
         <div class="spinner-button__content">
-          ${isButtonTo ? '<form action="#">' : ''}
-          ${tagName === 'a' ? '<a href="#">Click Me</a>' : '<input type="submit" value="Click Me">'}
-          ${isButtonTo ? '</form>' : ''}
+          ${tag}
           <span class="spinner-dots" aria-hidden="true">
             <span class="spinner-dots__dot"></span>
             <span class="spinner-dots__dot"></span>

--- a/app/javascript/packages/spinner-button/spinner-button-element.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.ts
@@ -29,7 +29,7 @@ export class SpinnerButtonElement extends HTMLElement {
   }
 
   get form(): HTMLFormElement | null {
-    return this.closest('form');
+    return this.querySelector('form') || this.closest('form');
   }
 
   get actionMessage(): HTMLElement {

--- a/app/javascript/packs/form-steps-wait.tsx
+++ b/app/javascript/packs/form-steps-wait.tsx
@@ -99,7 +99,6 @@ export class FormStepsWait {
 
   bind() {
     this.elements.form.addEventListener('submit', (event) => this.handleSubmit(event));
-    this.elements.form.addEventListener('invalid', () => this.stopSpinner(), true);
   }
 
   /**

--- a/spec/javascripts/packs/form-steps-wait-spec.js
+++ b/spec/javascripts/packs/form-steps-wait-spec.js
@@ -161,22 +161,6 @@ describe('FormStepsWait', () => {
       });
     });
 
-    context('invalid input', () => {
-      let form;
-      let input;
-      beforeEach(() => {
-        form = createForm({ action, method });
-        input = form.querySelector('#text-name');
-        input.setAttribute('required', '');
-      });
-      it('stops spinner', (done) => {
-        new FormStepsWait(form).bind();
-        form.addEventListener('spinner.stop', () => done());
-
-        fireEvent.invalid(input);
-      });
-    });
-
     context('handled error', () => {
       context('alert not in response', () => {
         const redirect = window.location.href;


### PR DESCRIPTION
## 🛠 Summary of changes

As a follow-on to #7761, this aims to allow SpinnerButton to be self-aware of form validation issues, so that the button will not show the spinning animation if the form is prevented from submitting.

In #7761, the CaptchaSubmitButtonElement was explicitly preventing the SpinnerButton from spinning when the form was invalid, but this could be managed by the SpinnerButton itself.