### PR TITLE
Auto-generate changelog messages for revert

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -14,10 +14,16 @@ CATEGORIES = [
 MAX_CATEGORY_DISTANCE = 3
 SKIP_CHANGELOG_MESSAGE = '[skip changelog]'
 DEPENDABOT_COMMIT_MESSAGE = 'Signed-off-by: dependabot[bot] <support@github.com>'
+REVERT_COMMIT_MESSAGE = /This reverts commit ([a-z\d]+)./
 SECURITY_CHANGELOG = {
   category: 'Internal',
   subcategory: 'Dependencies',
   change: 'Update dependencies to resolve security advisories',
+}.freeze
+REVERT_CHANGELOG = {
+  category: 'Bug Fixes',
+  subcategory: 'Code Revert',
+  change: 'Revert changes introduced in %s',
 }.freeze
 
 SquashedCommit = Struct.new(:title, :commit_messages, keyword_init: true)
@@ -29,6 +35,8 @@ CategoryDistance = Struct.new(:category, :distance)
 def build_changelog(line)
   if line == DEPENDABOT_COMMIT_MESSAGE
     SECURITY_CHANGELOG
+  elsif (commit = REVERT_COMMIT_MESSAGE.match(line)&.[](1))
+    REVERT_CHANGELOG.dup.merge(change: REVERT_CHANGELOG[:change] % [commit])
   else
     CHANGELOG_REGEX.match(line)
   end

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -42,13 +42,15 @@ def build_changelog(line, find_revert: false)
   end
 end
 
-def build_changelog_from_commit(commit, find_revert: false)
-  changelog = [*commit.commit_messages, commit.title].
+def revert_commit?(commit)
+  commit.title.start_with?('Revert ')
+end
+
+def build_changelog_from_commit(commit)
+  [*commit.commit_messages, commit.title].
     lazy.
-    map { |message| build_changelog(message, find_revert:) }.
+    map { |message| build_changelog(message, find_revert: revert_commit?(commit)) }.
     find(&:itself)
-  changelog = build_changelog_from_commit(commit, find_revert: true) if !changelog && !find_revert
-  changelog
 end
 
 def get_git_log(base_branch, source_branch)

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -40,6 +40,7 @@ squashed_commit_with_multiple_commits:
     body:* add check to see if platform is available
 
     * add alert
+    This reverts commit d964871.
 
     * changelog: User-Facing Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)
 
@@ -51,6 +52,7 @@ squashed_commit_with_multiple_commits:
   commit_messages:
     - '* add check to see if platform is available'
     - '* add alert'
+    - 'This reverts commit d964871.'
     - '* changelog: User-Facing Improvements, Webauthn, Provide better error flow for users who may not be able to leverage webauthn (LG-5515)'
     - '* fix linting, debug'
     - 'Co-authored-by: Jessica Dembe <jessica.dembe@gsa.gov>'

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -72,6 +72,19 @@ squashed_commit_with_skip:
     - '- Lets us set log level to minimize STDOUT output'
     - '  from Identity::Hostdata (downloading files from S3, etc)'
     - '[skip changelog]'
+squashed_commit_with_revert:
+  commit_log: |
+    title: Revert "LG-8653: Add personal key generation date" (#7816)
+    body:
+    This reverts commit d964871.
+    DELIMITER
+  title: 'Revert "LG-8653: Add personal key generation date" (#7816)'
+  commit_messages:
+    - 'This reverts commit d964871.'
+  category: 'Bug Fixes'
+  subcategory: 'Code Revert'
+  change: 'Revert changes introduced in d964871'
+  pr_number: '7816'
 squashed_commit_invalid:
   commit_log: |
     title: LG-5629 account buttons part 2 (#5945)

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'scripts/changelog_check' do
     it 'builds a git log into structured changelog objects' do
       git_log = git_fixtures.values.pluck('commit_log').join("\n")
       changelog_entries = generate_changelog(git_log)
-      expect(changelog_entries.length).to eq 6
+      expect(changelog_entries.length).to eq 7
       fixture_and_changelog = git_fixtures.values.filter do |x|
         x['category'].present?
       end.zip(changelog_entries)


### PR DESCRIPTION
## 🛠 Summary of changes

Auto-generates commit messages for code reverts, to avoid delays in emergency action for reverts due to changelog restrictions, and to standardize changelogs.

~**Draft:** As I was opening pull request, it occurred to me that squashed pull requests for pull requests which are not strictly intended as a revert can include the line "This reverts commit X" but which should not have their changelog auto-generated as a revert.~ ~**Edit:** Updated in 6b763e2 to search for revert message as fallback to other candidate changelog. This could still technically allow pull requests which include reverts but which should have a dedicated changelog. Another option may be to consider whether the title explicitly starts with "Revert".~ **Edit:** Further updated in a8bf15232 to search revert commits only if commit is titled as a revert.

## 📜 Testing Plan

- `rspec spec/scripts/changelog_check_spec.rb`