### PR TITLE
Treat unsuccessful reCAPTCHA as failure, with exceptions

### DIFF
--- a/app/services/recaptcha_validator.rb
+++ b/app/services/recaptcha_validator.rb
@@ -52,7 +52,7 @@ class RecaptchaValidator
     elsif recaptcha_result['success']
       recaptcha_result['score'] >= score_threshold
     else
-      EXEMPT_ERROR_CODES.any? { |error_code| recaptcha_result['error-codes'] == [error_code] }
+      (recaptcha_result['error-codes'] - EXEMPT_ERROR_CODES).blank?
     end
   end
 

--- a/app/services/recaptcha_validator.rb
+++ b/app/services/recaptcha_validator.rb
@@ -1,6 +1,8 @@
 class RecaptchaValidator
   VERIFICATION_ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify'.freeze
 
+  EXEMPT_ERROR_CODES = ['missing-input-secret', 'invalid-input-secret']
+
   class ValidationError < StandardError; end
 
   attr_reader :score_threshold, :analytics
@@ -45,9 +47,13 @@ class RecaptchaValidator
   end
 
   def recaptcha_result_valid?(recaptcha_result)
-    !recaptcha_result ||
-      !recaptcha_result['success'] ||
+    if recaptcha_result.blank?
+      true
+    elsif recaptcha_result['success']
       recaptcha_result['score'] >= score_threshold
+    else
+      EXEMPT_ERROR_CODES.any? { |error_code| recaptcha_result['error-codes'] == [error_code] }
+    end
   end
 
   def log_analytics(recaptcha_result: nil, error: nil)

--- a/app/services/recaptcha_validator.rb
+++ b/app/services/recaptcha_validator.rb
@@ -3,8 +3,6 @@ class RecaptchaValidator
 
   EXEMPT_ERROR_CODES = ['missing-input-secret', 'invalid-input-secret']
 
-  class ValidationError < StandardError; end
-
   attr_reader :score_threshold, :analytics
 
   def initialize(score_threshold: 0.0, analytics: nil)


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-8771](https://cm-jira.usa.gov/browse/LG-8771)

## 🛠 Summary of changes

Updates reCAPTCHA validator to consider an unsuccessful reCAPTCHA response as a failure by default, with exceptions. In #7761, it was wrongly assumed that an unsuccessful result should only occur due to misconfiguration or other invalid logic in our implementation. However, there are other [error codes](https://developers.google.com/recaptcha/docs/verify#error_code_reference) which could be triggered based on user input which we would want to consider as a failure.

Note: This feature is currently disabled in deployed environments, so the enforcement logic would not apply anyways.

## 📜 Testing Plan

- `rspec spec/services/recaptcha_validator_spec.rb`