### PR TITLE
LG-8888: Remove reference to face/touch unlock on backup codes warning screen

### DIFF
--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -5,7 +5,7 @@ en:
       are_you_sure_desc_html:
         - '<strong>Backup codes are the least preferred authentication
           method</strong> because the codes can easily be lost. Try a safer
-          option, like an authentication application or a security key'
+          option, like an authentication application or a security key.'
         - We’ll give you 10 codes that you can download, print, copy or write
           down. You’ll enter one code every time you sign in.
       are_you_sure_title: Are you sure you want to use backup codes?

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -4,9 +4,8 @@ en:
     backup_code:
       are_you_sure_desc_html:
         - '<strong>Backup codes are the least preferred authentication
-          method</strong> because the codes can easily be lost. We encourage you
-          to explore other authentication options such as an authentication
-          application, or a security key.'
+          method</strong> because the codes can easily be lost. Try a safer
+          option, like an authentication application or a security key'
         - We’ll give you 10 codes that you can download, print, copy or write
           down. You’ll enter one code every time you sign in.
       are_you_sure_title: Are you sure you want to use backup codes?

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -5,8 +5,8 @@ en:
       are_you_sure_desc_html:
         - '<strong>Backup codes are the least preferred authentication
           method</strong> because the codes can easily be lost. We encourage you
-          to explore other authentication options such as face or touch unlock,
-          an authentication application, or a security key.'
+          to explore other authentication options such as an authentication
+          application, or a security key.'
         - We’ll give you 10 codes that you can download, print, copy or write
           down. You’ll enter one code every time you sign in.
       are_you_sure_title: Are you sure you want to use backup codes?

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -4,9 +4,9 @@ es:
     backup_code:
       are_you_sure_desc_html:
         - '<strong>Los códigos de respaldo son el método de autenticación menos
-          utilizado,</strong> ya que se pueden perder con facilidad. Lo animamos
-          a que descubra otras opciones de autenticación, como la aplicación de
-          autenticación o la clave de seguridad.'
+          utilizado,</strong> ya que se pueden perder con facilidad. Prueba una
+          opción más segura, como una aplicación de autenticación o una clave de
+          seguridad.'
         - Le otorgaremos 10 códigos que puede descargar, imprimir, copiar o
           escribir. Ingresará un código cada vez que inicie sesión.
       are_you_sure_title: '¿Está seguro de que desea usar códigos de respaldo?'

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -4,10 +4,9 @@ es:
     backup_code:
       are_you_sure_desc_html:
         - '<strong>Los códigos de respaldo son el método de autenticación menos
-          utilizado,</strong> ya que se pueden perder con facilidad. Le
-          recomendamos explorar otras opciones de autenticación, como el
-          desbloqueo facial o táctil, una aplicación de autenticación o una
-          clave de seguridad.'
+          utilizado,</strong> ya que se pueden perder con facilidad. Lo animamos
+          a que descubra otras opciones de autenticación, como la aplicación de
+          autenticación o la clave de seguridad.'
         - Le otorgaremos 10 códigos que puede descargar, imprimir, copiar o
           escribir. Ingresará un código cada vez que inicie sesión.
       are_you_sure_title: '¿Está seguro de que desea usar códigos de respaldo?'

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -6,8 +6,8 @@ fr:
         - '<strong>Les codes de sauvegarde sont la méthode d’authentification la
           moins recommandée,</strong> car les codes peuvent facilement être
           perdus. Nous vous encourageons à explorer d’autres options
-          d’authentification telles que le déverrouillage facial ou tactile, une
-          application d’authentification ou une clé de sécurité.'
+          d’authentification, telles qu’une application d’authentification ou
+          une clé de sécurité.'
         - Nous vous donnerons dix codes que vous pourrez télécharger, imprimer,
           copier ou noter. Vous saisirez un code chaque fois que vous vous
           connecterez.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -5,9 +5,8 @@ fr:
       are_you_sure_desc_html:
         - '<strong>Les codes de sauvegarde sont la méthode d’authentification la
           moins recommandée,</strong> car les codes peuvent facilement être
-          perdus. Nous vous encourageons à explorer d’autres options
-          d’authentification, telles qu’une application d’authentification ou
-          une clé de sécurité.'
+          perdus. Essayez une option plus sûre, comme une application
+          d’authentification ou une clé de sécurité.'
         - Nous vous donnerons dix codes que vous pourrez télécharger, imprimer,
           copier ou noter. Vous saisirez un code chaque fois que vous vous
           connecterez.


### PR DESCRIPTION
## 🎫 Ticket

[LG-8888: Remove reference to face/touch unlock on backup codes warning screen](https://cm-jira.usa.gov/browse/LG-8888)

## 🛠 Summary of changes

This PR removes a reference for users to use face/touch unlock in place of backup codes

## 📜 Testing Plan

On your local machine (https://localhost:3000)

- Click "Create your account"
- Enter your email address, select a language, mark checkbox and submit
- Go through process to confirm email address
- Create a password. Continue
- Select "Backup codes" on the authentication methods setup screen
- Observe edited copy

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/17969963/218574788-2d9d63b3-0855-43d8-b3eb-ce3b6efd49a0.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/17969963/218573694-e4a04fb6-0be3-41bc-a6d9-af2f01947a4e.png)


</details>
