### PR TITLE
Retain country code in phone initialization

### DIFF
--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -137,6 +137,7 @@ export class PhoneInputElement extends HTMLElement {
 
     const iti = intlTelInput(this.textInput, {
       preferredCountries: ['US', 'CA'],
+      initialCountry: this.codeInput.value,
       localizedCountries: countryCodePairs,
       onlyCountries: supportedCountryCodes,
       autoPlaceholder: 'off',

--- a/app/javascript/packages/phone-input/package.json
+++ b/app/javascript/packages/phone-input/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
-    "intl-tel-input": "^17.0.8",
+    "intl-tel-input": "^17.0.19",
     "libphonenumber-js": "^1.10.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fast-glob": "^3.2.7",
     "foundation-emails": "^2.3.1",
     "identity-style-guide": "^6.7.0",
-    "intl-tel-input": "^17.0.8",
+    "intl-tel-input": "^17.0.19",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "source-map-loader": "^4.0.0",

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -139,9 +139,14 @@ describe 'Add a new phone number' do
     )
   end
 
-  scenario 'adding a phone that is already on the user account shows error message' do
+  scenario 'adding a phone that is already on the user account shows error message', js: true do
     user = create(:user, :signed_up)
     phone = user.phone_configurations.first.phone
+
+    # Regression handling: The fake phone number generator uses well-formatted numbers, which isn't
+    # how a user would likely enter their number, and would give detail to the phone initialization
+    # which wouldn't exist for typical user input. Emulate the user input by removing format hints.
+    phone = phone.sub(/^\+1\s*/, '').gsub(/\D/, '')
 
     sign_in_and_2fa_user(user)
     within('.sidenav') do
@@ -151,6 +156,7 @@ describe 'Add a new phone number' do
     click_continue
 
     expect(page).to have_content(I18n.t('errors.messages.phone_duplicate'))
+    expect(page).to have_css('.iti__selected-flag .iti__flag.iti__us', visible: :all)
   end
 
   let(:telephony_gem_voip_number) { '+12255551000' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,10 +4026,10 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-intl-tel-input@^17.0.8:
-  version "17.0.12"
-  resolved "https://registry.yarnpkg.com/intl-tel-input/-/intl-tel-input-17.0.12.tgz#057c35b57871bd6d6932ac28428d086e63d6cc89"
-  integrity sha512-jl3DkDQg/aaIPK2hrvtgX2eYgtkz5LxCQW57Ru1Hpdt9MA9VE8PnGUllaMsAm6SeJODHBdMok7XFZR8/M1yytg==
+intl-tel-input@^17.0.19:
+  version "17.0.19"
+  resolved "https://registry.yarnpkg.com/intl-tel-input/-/intl-tel-input-17.0.19.tgz#4c277e3bf02069fac2ef3821a62a3d7e8b55740a"
+  integrity sha512-GBNoUT4JVgm2e1N+yFMaBQ24g5EQfZhDznGneCM9IEZwfKsMUAUa1dS+v0wOiKpRAZ5IPNLJMIEEFGgqlCI22A==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
## 🎫 Ticket

Related to ongoing reCAPTCHA efforts, e.g. [LG-8771](https://cm-jira.usa.gov/browse/LG-8771)

## 🛠 Summary of changes

This pull request aims to resolve an issue where the selected country associated with an entered phone number would not be preserved if the submission yielded errors, such as when trying to add a phone number already associated with an account.

This would prove problematic for reCAPTCHA efforts, where the phone number submission relies on the selected country to determine whether an exemption would apply.

## 📜 Testing Plan

1. Sign in
2. Click "Add a phone number"
3. Enter a phone number already associated with the account
4. Click "Continue"

**Before:** Country flag in phone input would show as grey box.
**After:** Selected country is maintained.

## 👀 Screenshots

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/218581444-23a64daa-aac0-4ba7-94d0-78e5b19b1099.png)|![image](https://user-images.githubusercontent.com/1779930/218581305-ba9e9755-8a50-42c0-9054-f1db1820bdca.png)
