### PR TITLE
LG-8796: Add recaptcha disclosure form at bottom of phone setup screen for new and existing accounts

### DIFF
--- a/app/assets/stylesheets/components/_recaptcha-badge.scss
+++ b/app/assets/stylesheets/components/_recaptcha-badge.scss
@@ -1,0 +1,1 @@
+.grecaptcha-badge { visibility: hidden; }

--- a/app/assets/stylesheets/components/_recaptcha-badge.scss
+++ b/app/assets/stylesheets/components/_recaptcha-badge.scss
@@ -1,1 +1,3 @@
-.grecaptcha-badge { visibility: hidden; }
+.grecaptcha-badge {
+  visibility: hidden;
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -23,6 +23,7 @@
 @import 'password';
 @import 'password-toggle';
 @import 'profile-section';
+@import 'recaptcha-badge';
 @import 'personal-key';
 @import 'spinner-button';
 @import 'spinner-dots';

--- a/app/views/shared/_recaptcha_disclosure.html.erb
+++ b/app/views/shared/_recaptcha_disclosure.html.erb
@@ -1,0 +1,9 @@
+<p class="margin-top-4 margin-bottom-0">
+  <%= t(
+        'two_factor_authentication.recaptcha.disclosure_statement_html',
+        app_name: APP_NAME,
+        policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
+        google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
+        login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+      ) %>
+</p>

--- a/app/views/shared/_recaptcha_disclosure.html.erb
+++ b/app/views/shared/_recaptcha_disclosure.html.erb
@@ -2,8 +2,8 @@
   <%= t(
         'two_factor_authentication.recaptcha.disclosure_statement_html',
         app_name: APP_NAME,
-        policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
-        google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
-        login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+        policy_link: new_window_link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
+        google_tos_link: new_window_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
+        login_tos_link: new_window_link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
       ) %>
 </p>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -50,14 +50,7 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
+
 <% if FeatureManagement.phone_recaptcha_enabled? %>
-  <p class="margin-top-4 margin-bottom-0">
-    <%= t(
-          'two_factor_authentication.recaptcha.disclosure_statement_html',
-          app_name: APP_NAME,
-          policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
-          google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
-          login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
-        ) %>
-  </p>
+  <%= render 'shared/recaptcha_disclosure' %>
 <% end %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -33,10 +33,11 @@
 
   <%= render 'users/shared/otp_delivery_preference_selection',
              form_obj: @new_phone_form %>
-
-  <%= link_to t('two_factor_authentication.mobile_terms_of_service'),
-              MarketingSite.messaging_practices_url,
-              class: 'display-block margin-bottom-4' %>
+  <% unless FeatureManagement.phone_recaptcha_enabled? %>
+    <%= link_to t('two_factor_authentication.mobile_terms_of_service'),
+                MarketingSite.messaging_practices_url,
+                class: 'display-block margin-bottom-4' %>
+  <% end %>
 
   <% if TwoFactorAuthentication::PhonePolicy.new(current_user).enabled? %>
     <%= render 'users/shared/otp_make_default_number',

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -51,7 +51,7 @@
 
 <%= render 'shared/cancel_or_back_to_options' %>
 <% if FeatureManagement.phone_recaptcha_enabled? %>
-  <p class="margin-top-3">
+  <p class="margin-top-4 margin-bottom-0">
     <%= t(
           'two_factor_authentication.recaptcha.disclosure_statement_html',
           app_name: APP_NAME,

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -49,3 +49,11 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
+<% if FeatureManagement.phone_recaptcha_enabled? %>
+  <p class="margin-top-3">
+    <%= t('two_factor_authentication.recaptcha.disclosure_statement_html',
+        policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
+        google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
+        login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),)%>
+  </p>
+<% end %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -51,9 +51,12 @@
 <%= render 'shared/cancel_or_back_to_options' %>
 <% if FeatureManagement.phone_recaptcha_enabled? %>
   <p class="margin-top-3">
-    <%= t('two_factor_authentication.recaptcha.disclosure_statement_html',
-        policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
-        google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
-        login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),)%>
+    <%= t(
+          'two_factor_authentication.recaptcha.disclosure_statement_html',
+          app_name: APP_NAME,
+          policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
+          google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
+          login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+        ) %>
   </p>
 <% end %>

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -42,3 +42,17 @@
 <% end %>
 
 <%= render 'shared/cancel', link: account_path %>
+
+
+<% if FeatureManagement.phone_recaptcha_enabled? %>
+  <p class="margin-top-4 margin-bottom-0">
+    <%= t(
+          'two_factor_authentication.recaptcha.disclosure_statement_html',
+          app_name: APP_NAME,
+          policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
+          google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
+          login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+        ) %>
+  </p>
+<% end %>
+

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -45,14 +45,6 @@
 
 
 <% if FeatureManagement.phone_recaptcha_enabled? %>
-  <p class="margin-top-4 margin-bottom-0">
-    <%= t(
-          'two_factor_authentication.recaptcha.disclosure_statement_html',
-          app_name: APP_NAME,
-          policy_link: link_to(t('two_factor_authentication.recaptcha.policy_link'), 'https://policies.google.com/privacy'),
-          google_tos_link: link_to(t('two_factor_authentication.recaptcha.google_tos_link'), 'https://policies.google.com/terms'),
-          login_tos_link: link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
-        ) %>
-  </p>
+  <%= render 'shared/recaptcha_disclosure' %>
 <% end %>
 

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -125,6 +125,13 @@ en:
     piv_cac_webauthn_available: Use your security key
     please_try_again_html: Please try again in <strong>%{countdown}</strong>.
     read_about_two_factor_authentication: Read about two-factor authentication
+    recaptcha:
+      disclosure_statement_html: This site is protected by reCAPTCHA and the Google
+        %{policy_link} and %{google_tos_link} apply. Read Login.gov’s
+        %{login_tos_link} .
+      google_tos_link: Terms of Service
+      login_tos_link: Mobile Terms of Use
+      policy_link: Privacy Policy
     totp_fallback:
       question: Don’t have your authenticator app?
     totp_header_text: Enter your authentication app code

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -128,7 +128,7 @@ en:
     recaptcha:
       disclosure_statement_html: This site is protected by reCAPTCHA and the Google
         %{policy_link} and %{google_tos_link} apply. Read %{app_name}’s
-        %{login_tos_link} .
+        %{login_tos_link}.
       google_tos_link: Terms of Service
       login_tos_link: Mobile Terms of Use
       policy_link: Privacy Policy

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -127,7 +127,7 @@ en:
     read_about_two_factor_authentication: Read about two-factor authentication
     recaptcha:
       disclosure_statement_html: This site is protected by reCAPTCHA and the Google
-        %{policy_link} and %{google_tos_link} apply. Read Login.gov’s
+        %{policy_link} and %{google_tos_link} apply. Read %{app_name}’s
         %{login_tos_link} .
       google_tos_link: Terms of Service
       login_tos_link: Mobile Terms of Use

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -134,6 +134,13 @@ es:
     piv_cac_webauthn_available: Utilice su llave de seguridad
     please_try_again_html: Inténtelo de nuevo en <strong>%{countdown}</strong>.
     read_about_two_factor_authentication: Conozca la autenticación de dos factores
+    recaptcha:
+      disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se
+        %{policy_link} y %{google_tos_link} de Google. Consulte
+        %{login_tos_link} de Login.gov para dispositivos móviles.
+      google_tos_link: las condiciones de servicio
+      login_tos_link: las condiciones de uso
+      policy_link: aplican la política de privacidad
     totp_fallback:
       question: '¿No tiene su aplicación de autenticación?'
     totp_header_text: Ingrese su código de la app de autenticación

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -137,7 +137,7 @@ es:
     recaptcha:
       disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se
         %{policy_link} y %{google_tos_link} de Google. Consulte
-        %{login_tos_link} de Login.gov para dispositivos móviles.
+        %{login_tos_link} de %{app_name} para dispositivos móviles.
       google_tos_link: las condiciones de servicio
       login_tos_link: las condiciones de uso
       policy_link: aplican la política de privacidad

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -140,9 +140,9 @@ fr:
     please_try_again_html: Veuillez essayer de nouveau dans <strong>%{countdown}</strong>.
     read_about_two_factor_authentication: En savoir plus sur l’authentification à deux facteurs
     recaptcha:
-      disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{policy_link} et
-        les %{google_tos_link} de Google s’appliquent. Lisez les
-        %{login_tos_link} de Login.gov pour les mobiles.
+      disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{policy_link}
+        et les %{google_tos_link} de Google s’appliquent. Lisez les
+        %{login_tos_link} de %{app_name} pour les mobiles.
       google_tos_link: conditions de service
       login_tos_link: conditions d’utilisation
       policy_link: règles de confidentialité

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -139,6 +139,13 @@ fr:
     piv_cac_webauthn_available: Utilisez votre clé de sécurité
     please_try_again_html: Veuillez essayer de nouveau dans <strong>%{countdown}</strong>.
     read_about_two_factor_authentication: En savoir plus sur l’authentification à deux facteurs
+    recaptcha:
+      disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{policy_link} et
+        les %{google_tos_link} de Google s’appliquent. Lisez les
+        %{login_tos_link} de Login.gov pour les mobiles.
+      google_tos_link: conditions de service
+      login_tos_link: conditions d’utilisation
+      policy_link: règles de confidentialité
     totp_fallback:
       question: Vous n’avez pas votre application d’authentification?
     totp_header_text: Entrez votre code d’application d’authentification


### PR DESCRIPTION

## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-8796

## 🛠 Summary of changes

This adds to the bottom of the screen a recaptcha disclosure letting the user know that this page/site has recaptcha enabled. 

## 👀 Screenshots
What it would look life after change. 
![Screen Shot 2023-02-14 at 1 44 03 PM](https://user-images.githubusercontent.com/23225522/218829840-7382248d-07fd-477b-aacd-19ee6a162884.png)

