### PR TITLE
Include U.S. territories in default reCAPTCHA exempt countries

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -219,7 +219,7 @@ phone_confirmation_max_attempts: 20
 phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_service_check: true
 phone_recaptcha_score_threshold: 0.0
-phone_recaptcha_country_score_overrides: '{"US":0.0}'
+phone_recaptcha_country_score_overrides: '{"AS":0.0,"GU":0.0,"MP":0.0,"PR":0.0,"US":0.0,"VI":0.0}'
 phone_setups_per_ip_limit: 25
 phone_setups_per_ip_period: 300
 phone_setups_per_ip_track_only_mode: false


### PR DESCRIPTION
## 🛠 Summary of changes

Updates default configuration to exempt U.S. territories from reCAPTCHA challenges. Since reCAPTCHA is currently intended to apply only for international numbers, allow phones from U.S. territories to pass unchallenged.

## 📜 Testing Plan

1. Create a new reCAPTCHA site for use in your local environment: https://www.google.com/recaptcha/admin/create
2. Assign credentials as `recaptcha_site_key` and `recaptcha_secret_key` in `config/application.yml`
3. Set `phone_setup_recaptcha_score_threshold` to `1.0` in `config/application.yml`
4. Sign in
5. Add new phone number
6. Enter phone number `7875550100`
7. Click "Continue"
8. Observe that you do not see any errors