### PR TITLE
Disable "FIXME" enforcement in CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
-version: "2" # required to adjust maintainability checks
+version: '2' # required to adjust maintainability checks
 checks:
   argument-count:
     config:
@@ -36,21 +36,10 @@ plugins:
         javascript:
           mass_threshold: 50
     exclude_patterns:
-    - 'spec/**/*'
-    - 'node_modules/**/*'
-    - 'db/schema.rb'
-    - 'app/forms/password_form.rb'
-  fixme:
-    enabled: true
-    exclude_patterns:
-    - 'public/build/bundle.js'
-    - '.codeclimate.yml'
-    config:
-      strings:
-      - TODO
-      - FIXME
-      - HACK
-      - BUG
+      - 'spec/**/*'
+      - 'node_modules/**/*'
+      - 'db/schema.rb'
+      - 'app/forms/password_form.rb'
 
 exclude_patterns:
   - 'db/schema.rb'


### PR DESCRIPTION
## 🛠 Summary of changes

Removes FIXME enforcement from CodeClimate configuration, which currently prevents developers from adding terms like "TODO" in code.

While TODO comments should be generally avoided, there may be some sequential chain of pull requests where it's necessary, and the restriction could cause a developer to resort to unconventional synonyms in place of standard "TODO" terminology, thus creating a scenario where that code is even harder to track down than if it had been allowed as "TODO" in the first place.

This can also serve as an incremental step away from CodeClimate toward GitLab as the centralized CI platform.