### PR TITLE
Add configurable request timeout for requests to ArcGIS API

### DIFF
--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -121,6 +121,11 @@ module ArcgisApi
         # Log request metrics
         conn.request :instrumentation, name: 'request_metric.faraday'
 
+        conn.options.timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
+        conn.options.read_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
+        conn.options.open_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
+        conn.options.write_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
+
         # Raise an error subclassing Faraday::Error on 4xx, 5xx, and malformed responses
         # Note: The order of this matters for parsing the error response body.
         conn.response :raise_error

--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -122,9 +122,6 @@ module ArcgisApi
         conn.request :instrumentation, name: 'request_metric.faraday'
 
         conn.options.timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
-        conn.options.read_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
-        conn.options.open_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
-        conn.options.write_timeout = IdentityConfig.store.arcgis_api_request_timeout_seconds
 
         # Raise an error subclassing Faraday::Error on 4xx, 5xx, and malformed responses
         # Note: The order of this matters for parsing the error response body.

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -49,6 +49,7 @@ arcgis_mock_fallback: true
 arcgis_api_generate_token_url: 'https://gis.gsa.gov/portal/sharing/rest/generateToken'
 arcgis_api_suggest_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/suggest'
 arcgis_api_find_address_candidates_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/findAddressCandidates'
+arcgis_api_request_timeout_seconds: 5
 asset_host: ''
 async_wait_timeout_seconds: 60
 async_stale_job_timeout_seconds: 300

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -113,6 +113,7 @@ class IdentityConfig
     config.add(:arcgis_api_generate_token_url, type: :string)
     config.add(:arcgis_api_suggest_url, type: :string)
     config.add(:arcgis_api_find_address_candidates_url, type: :string)
+    config.add(:arcgis_api_request_timeout_seconds, type: :integer)
     config.add(:aws_http_retry_limit, type: :integer)
     config.add(:aws_http_retry_max_delay, type: :integer)
     config.add(:aws_http_timeout, type: :integer)


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a configurable timeout for HTTP requests to the ArcGIS API with a default of 5 seconds.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
