### PR TITLE
Call reCAPTCHA CSP before_action explicitly in controller

### DIFF
--- a/app/controllers/concerns/recaptcha_concern.rb
+++ b/app/controllers/concerns/recaptcha_concern.rb
@@ -1,10 +1,6 @@
 module RecaptchaConcern
   extend ActiveSupport::Concern
 
-  included do
-    before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
-  end
-
   private
 
   RECAPTCHA_SCRIPT_SRC = [
@@ -22,9 +18,5 @@ module RecaptchaConcern
     policy.script_src(*policy.script_src, *RECAPTCHA_SCRIPT_SRC)
     policy.frame_src(*policy.frame_src, *RECAPTCHA_FRAME_SRC)
     request.content_security_policy = policy
-  end
-
-  def recaptcha_enabled?
-    false
   end
 end

--- a/app/controllers/concerns/recaptcha_concern.rb
+++ b/app/controllers/concerns/recaptcha_concern.rb
@@ -1,8 +1,4 @@
 module RecaptchaConcern
-  extend ActiveSupport::Concern
-
-  private
-
   RECAPTCHA_SCRIPT_SRC = [
     'https://www.google.com/recaptcha/',
     'https://www.gstatic.com/recaptcha/',

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -8,6 +8,7 @@ module Users
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :set_setup_presenter
+    before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -6,6 +6,7 @@ module Users
     before_action :confirm_two_factor_authenticated
     before_action :redirect_if_phone_vendor_outage
     before_action :check_max_phone_numbers_per_account, only: %i[add create]
+    before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
 
     def add
       user_session[:phone_id] = nil

--- a/spec/controllers/concerns/recaptcha_concern_spec.rb
+++ b/spec/controllers/concerns/recaptcha_concern_spec.rb
@@ -1,44 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe RecaptchaConcern, type: :controller do
-  controller ApplicationController do
-    include RecaptchaConcern
-
-    def index
-      render plain: ''
-    end
-  end
-
-  before do
-    routes.draw do
-      get 'index' => 'anonymous#index'
-    end
-  end
-
-  it 'does not modify csp' do
-    expect(controller).not_to receive(:allow_csp_recaptcha_src)
-
-    get :index
-  end
-
-  context 'with including controller enabling recaptcha' do
+  describe '#allow_csp_recaptcha_src' do
     controller ApplicationController do
       include RecaptchaConcern
+
+      before_action :allow_csp_recaptcha_src
 
       def index
         render plain: ''
       end
-
-      private
-
-      def recaptcha_enabled?
-        true
-      end
     end
 
     it 'overrides csp to add directives for recaptcha' do
-      expect(controller).to receive(:allow_csp_recaptcha_src).and_call_original
-
       get :index
 
       csp = response.request.content_security_policy

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -207,5 +207,27 @@ describe Users::PhoneSetupController do
         :authenticate_user,
       )
     end
+
+    describe 'recaptcha csp' do
+      before { stub_sign_in }
+
+      it 'does not allow recaptcha in the csp' do
+        expect(subject).not_to receive(:allow_csp_recaptcha_src)
+
+        get :index
+      end
+
+      context 'recaptcha enabled' do
+        before do
+          allow(FeatureManagement).to receive(:phone_recaptcha_enabled?).and_return(true)
+        end
+
+        it 'allows recaptcha in the csp' do
+          expect(subject).to receive(:allow_csp_recaptcha_src)
+
+          get :index
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -67,4 +67,26 @@ describe Users::PhonesController do
       expect(response).to redirect_to vendor_outage_path(from: :users_phones)
     end
   end
+
+  describe 'recaptcha csp' do
+    before { stub_sign_in }
+
+    it 'does not allow recaptcha in the csp' do
+      expect(subject).not_to receive(:allow_csp_recaptcha_src)
+
+      get :add
+    end
+
+    context 'recaptcha enabled' do
+      before do
+        allow(FeatureManagement).to receive(:phone_recaptcha_enabled?).and_return(true)
+      end
+
+      it 'allows recaptcha in the csp' do
+        expect(subject).to receive(:allow_csp_recaptcha_src)
+
+        get :add
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors reCAPTCHA Content-Security-Policy behaviors to have controllers explicitly responsible for invoking `before_action` to modify headers, rather than overriding the `recaptcha_enabled?` method. The hope is that the explicitness makes it more clear both the association to the concern and the responsibility of the controller to control the behavior based on feature flags.

## 📜 Testing Plan

1. Create a new reCAPTCHA site for use in your local environment: https://www.google.com/recaptcha/admin/create
2. In `config/application.yml`:
   1. Assign credentials as `recaptcha_site_key` and `recaptcha_secret_key`
   2. Set `phone_setup_recaptcha_score_threshold` to a number between `0.0` and `1.0`
3. Sign in
4. Add a phone
5. Observe no errors about CSP in developer tools console