### PR TITLE
Revert "Remove event-specific hooks in Analytics class"

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -45,9 +45,6 @@ module Idv
     end
 
     def update_tracking
-      Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp).
-        call(:usps_letter_sent, :update, true)
-
       analytics.idv_gpo_address_letter_requested(resend: resend_requested?)
       irs_attempts_api_tracker.idv_gpo_letter_requested(resend: resend_requested?)
       create_user_event(:gpo_mail_sent, current_user)

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -32,10 +32,6 @@ module Idv
 
     def create
       result = idv_form.submit(step_params)
-
-      Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp).
-        call(:verify_phone, :update, result.success?)
-
       analytics.idv_phone_confirmation_form_submitted(**result.to_h)
       irs_attempts_api_tracker.idv_phone_submitted(
         success: result.success?,

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -32,6 +32,7 @@ class Analytics
     analytics_hash.merge!(request_attributes) if request
 
     ahoy.track(event, analytics_hash)
+    register_doc_auth_step_from_analytics_event(event, attributes)
 
     # Tag NewRelic APM trace with a handful of useful metadata
     # https://www.rubydoc.info/github/newrelic/rpm/NewRelic/Agent#add_custom_attributes-instance_method
@@ -73,6 +74,12 @@ class Analytics
 
   def first_event_this_session?
     @session[:first_event]
+  end
+
+  def register_doc_auth_step_from_analytics_event(event, attributes)
+    return unless user && user.class != AnonymousUser
+    success = attributes.blank? || attributes[:success] == 'success'
+    Funnel::DocAuth::RegisterStepFromAnalyticsEvent.call(user.id, sp, event, success)
   end
 
   def track_mfa_submit_event(attributes)

--- a/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
@@ -1,0 +1,16 @@
+module Funnel
+  module DocAuth
+    class RegisterStepFromAnalyticsSubmitEvent
+      ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN = {
+        'IdV: USPS address letter requested' => :usps_letter_sent,
+        'IdV: phone confirmation form' => :verify_phone,
+      }.freeze
+
+      def self.call(user_id, issuer, event, result)
+        token = ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN[event]
+        return unless token
+        Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(token, :update, result)
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -109,14 +109,6 @@ describe Idv::GpoController do
 
         put :create
       end
-
-      it 'updates the doc auth log for the user for the usps_letter_sent event' do
-        doc_auth_log = DocAuthLog.create(user_id: user.id)
-
-        expect { put :create }.to(
-          change { doc_auth_log.reload.usps_letter_sent_submit_count }.from(0).to(1),
-        )
-      end
     end
 
     context 'resending a letter' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -253,17 +253,6 @@ describe Idv::PhoneController do
         )
       end
 
-      it 'updates the doc auth log for the user with verify_phone_submit step' do
-        user = create(:user, :with_phone, with: { phone: good_phone, confirmed_at: Time.zone.now })
-        stub_verify_steps_one_and_two(user)
-
-        doc_auth_log = DocAuthLog.create(user_id: user.id)
-
-        expect { put :create, params: { idv_phone_form: { phone: good_phone } } }.to(
-          change { doc_auth_log.reload.verify_phone_submit_count }.from(0).to(1),
-        )
-      end
-
       context 'when same as user phone' do
         before do
           user = build(


### PR DESCRIPTION
This reverts commit 1af92c522b930f38700362ef9144b1aedc2565d1 (#7685)

changelog: Internal, Reporting, Revert analytics event refactor

After some digging
- the data.login.gov proofing funnel discrepancies started with the the deploy of the reverted code [(slack thread)](https://gsa-tts.slack.com/archives/C5E7EJWF7/p1675365972982239)
- the code changes how the Phone Submit step event was logged to doc_auth_logs, which was the first 3 subsequent events that started to have off numbers

Next steps:
- take a look at the doc auth logs reports after this is deployed
- if no change: revert it back (because the refactor gets the codebase to a better spot, and it didn't affect reporting)
- if there is a change: try to understand why the refactor wasn't successful