### PR TITLE
LG-8899: Add alt text to GPO header image

### DIFF
--- a/app/views/idv/come_back_later/show.html.erb
+++ b/app/views/idv/come_back_later/show.html.erb
@@ -12,7 +12,7 @@
 <%= image_tag(
       asset_url('come-back.svg'),
       size: '140', class: 'display-block margin-x-auto margin-bottom-2',
-      alt: ''
+      alt: t('idv.images.come_back_later')
     ) %>
 
 <%= render PageHeadingComponent.new(class: 'text-center').with_content(t('idv.titles.come_back_later')) %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -121,6 +121,8 @@ en:
       ssn_label_html: Social Security number
       state: State
       zipcode: ZIP Code
+    images:
+      come_back_later: Letter with a check mark
     index:
       id:
         need_html: If you’re creating an account, you’ll need a <strong>current

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -130,6 +130,8 @@ es:
       ssn_label_html: Número de Seguro Social
       state: Estado
       zipcode: Código postal
+    images:
+      come_back_later: Carta con una marca de verificación
     index:
       id:
         need_html: Si está creando una cuenta, necesitará una <strong>identificación

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -135,6 +135,8 @@ fr:
       ssn_label_html: Numéro de sécurité sociale
       state: État
       zipcode: Code postal
+    images:
+      come_back_later: Lettre avec un crochet
     index:
       id:
         need_html: Si vous créez un compte, vous aurez besoin d’un <strong>identifiant


### PR DESCRIPTION
## 🎫 Ticket

[LG-8899](https://cm-jira.usa.gov/browse/LG-8899)

## 🛠 Summary of changes

Add alt text to the big graphic in the header on this screen:

<img width="609" alt="Your letter is on the way screen" src="https://user-images.githubusercontent.com/364697/219131863-d5eb294f-0260-4df6-8564-0b281c735136.png">

