### PR TITLE
Refactor the IdV step concern to no longer check for an applicant

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -7,7 +7,7 @@ module IdvSession
     before_action :redirect_if_sp_context_needed
   end
 
-  def confirm_idv_session_started
+  def confirm_idv_applicant_created
     redirect_to idv_verify_info_url if idv_session.applicant.blank?
   end
 

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -6,6 +6,5 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
-    before_action :confirm_idv_session_started
   end
 end

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -7,6 +7,7 @@ module Idv
 
     attr_reader :idv_form
 
+    before_action :confirm_idv_applicant_created
     before_action :confirm_step_needed
     before_action :set_idv_form
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -6,6 +6,7 @@ module Idv
     include StepIndicatorConcern
     include PhoneConfirmation
 
+    before_action :confirm_idv_applicant_created
     before_action :confirm_idv_steps_complete
     before_action :confirm_idv_phone_confirmed
     before_action :confirm_current_password, only: [:create]

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -1,6 +1,6 @@
 module Idv
   class VerifyInfoController < ApplicationController
-    include IdvSession
+    include IdvStepConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -12,44 +12,6 @@ describe 'IdvStepConcern' do
     end
   end
 
-  describe '#confirm_idv_session_started' do
-    controller Idv::StepController do
-      before_action :confirm_idv_session_started
-
-      def show
-        render plain: 'Hello'
-      end
-    end
-
-    before(:each) do
-      stub_sign_in(user)
-      routes.draw do
-        get 'show' => 'idv/step#show'
-      end
-    end
-
-    context 'user has not started IdV session' do
-      it 'redirects to a previous step url' do
-        get :show
-
-        expect(response).to redirect_to(idv_verify_info_url)
-      end
-    end
-
-    context 'user has started IdV session' do
-      before do
-        idv_session.applicant = { first_name: 'Jane' }
-        allow(subject).to receive(:idv_session).and_return(idv_session)
-      end
-
-      it 'allows request' do
-        get :show
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-  end
-
   describe '#confirm_idv_needed' do
     controller Idv::StepController do
       before_action :confirm_idv_needed
@@ -70,7 +32,6 @@ describe 'IdvStepConcern' do
       before do
         allow(user).to receive(:active_profile).and_return(Profile.new)
         allow(subject).to receive(:current_user).and_return(user)
-        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
       end
 
       it 'redirects to activated page' do
@@ -83,7 +44,6 @@ describe 'IdvStepConcern' do
     context 'user does not have active profile' do
       before do
         allow(subject).to receive(:current_user).and_return(user)
-        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
       end
 
       it 'does not redirect to activated page' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -17,7 +17,7 @@ describe Idv::PhoneController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started,
+        :confirm_idv_applicant_created,
       )
     end
   end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -66,6 +66,22 @@ describe Idv::PhoneController do
       end
     end
 
+    context 'when the user has not finished the verify step' do
+      before do
+        subject.idv_session.applicant = nil
+        subject.idv_session.profile_confirmation = nil
+        subject.idv_session.resolution_successful = nil
+
+        allow(controller).to receive(:confirm_idv_applicant_created).and_call_original
+      end
+
+      it 'redirects to the verify step' do
+        get :new
+
+        expect(response).to redirect_to idv_verify_info_url
+      end
+    end
+
     context 'when the user is throttled' do
       before do
         Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -34,7 +34,7 @@ describe Idv::ReviewController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started,
+        :confirm_idv_applicant_created,
         :confirm_idv_steps_complete,
       )
     end
@@ -192,7 +192,7 @@ describe Idv::ReviewController do
   describe '#new' do
     before do
       stub_sign_in(user)
-      allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     end
 
     context 'user has completed all steps' do
@@ -264,7 +264,7 @@ describe Idv::ReviewController do
   describe '#create' do
     before do
       stub_sign_in(user)
-      allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     end
 
     context 'user fails to supply correct password' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -47,7 +47,7 @@ module ControllerHelper
       dob: 50.years.ago.to_date.to_s,
       ssn: '666-12-1234',
     }.with_indifferent_access
-    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)
     allow(subject).to receive(:user_session).and_return(user_session)
   end
@@ -67,7 +67,7 @@ module ControllerHelper
       ssn: '666-12-1234',
     }.with_indifferent_access
     idv_session.profile_confirmation = true
-    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)
     allow(subject).to receive(:user_session).and_return(user_session)
   end
@@ -81,7 +81,7 @@ module ControllerHelper
     )
     idv_session.applicant = applicant.with_indifferent_access
     idv_session.profile_confirmation = true
-    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)
     allow(subject).to receive(:user_session).and_return(user_session)
   end


### PR DESCRIPTION
Prior to the introduction of the flow state machine, the "applicant" value in the IdV session was created when the proofing process was started. After the introduction of the FSM the applicant was created once the FSM flow was complete.

The IdvStepConcern is intended to route users to the correct step based on the state of proofing. Currently it is empty because the Flow State Machine primarily handles this logic. There is a desire to re-introduce the logic to route users to the correct step to this concern.

The IdvStepConcern has a before action to verify that proofing has started. It does that by checking for the applicant which, as described above, does not make sense in the post-FSM world. This commit removes that before action and adds it explicitly to controllers that require an applicant to function.
