### PR TITLE
Avoid defaulting to U.S. for phone formatter

### DIFF
--- a/app/services/phone_formatter.rb
+++ b/app/services/phone_formatter.rb
@@ -1,5 +1,8 @@
 module PhoneFormatter
+  DEFAULT_COUNTRY = 'US'.freeze
+
   def self.format(phone, country_code: nil)
+    country_code = DEFAULT_COUNTRY if country_code.nil? && !phone&.start_with?('+')
     Phonelib.parse(phone, country_code)&.international
   end
 end

--- a/app/services/phone_formatter.rb
+++ b/app/services/phone_formatter.rb
@@ -1,7 +1,5 @@
 module PhoneFormatter
-  DEFAULT_COUNTRY = 'US'.freeze
-
   def self.format(phone, country_code: nil)
-    Phonelib.parse(phone, country_code || DEFAULT_COUNTRY)&.international
+    Phonelib.parse(phone, country_code)&.international
   end
 end

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -169,7 +169,7 @@ describe NewPhoneForm do
 
     context 'when the user has already added the number' do
       it 'is invalid' do
-        phone = PhoneFormatter.format('+1 (954) 525-1262', country_code: 'US')
+        phone = PhoneFormatter.format('+1 (954) 555-0100', country_code: 'US')
         params[:phone] = phone
         create(:phone_configuration, user: user, phone: phone)
 
@@ -181,10 +181,22 @@ describe NewPhoneForm do
       end
 
       it 'is invalid if database phone is not formatted' do
-        raw_phone = '+1 954 5251262'
-        phone = PhoneFormatter.format(raw_phone, country_code: 'US')
-        params[:phone] = phone
-        create(:phone_configuration, user: user, phone: raw_phone)
+        unformatted_phone = '+1 954 5550100'
+        params[:phone] = '+1 9545550100'
+        create(:phone_configuration, user: user, phone: unformatted_phone)
+
+        result = subject.submit(params)
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors[:phone]).to eq([I18n.t('errors.messages.phone_duplicate')])
+      end
+
+      it 'is invalid if existing phone is international' do
+        unformatted_phone = '+13065550100'
+        params[:phone] = '+1 3065550100'
+        params[:international_code] = 'CA'
+        create(:phone_configuration, user: user, phone: unformatted_phone)
 
         result = subject.submit(params)
 

--- a/spec/services/phone_formatter_spec.rb
+++ b/spec/services/phone_formatter_spec.rb
@@ -16,6 +16,13 @@ describe PhoneFormatter do
       expect(formatted_phone).to eq('+1 202-500-5000')
     end
 
+    it 'formats Canadian numbers correctly' do
+      phone = '+13065550100'
+      formatted_phone = PhoneFormatter.format(phone)
+
+      expect(formatted_phone).to eq('+1 306 555 0100')
+    end
+
     it 'uses +1 as the default international code' do
       phone = '2025005000'
       formatted_phone = PhoneFormatter.format(phone)

--- a/spec/services/phone_formatter_spec.rb
+++ b/spec/services/phone_formatter_spec.rb
@@ -9,6 +9,13 @@ describe PhoneFormatter do
       expect(formatted_phone).to eq('+40 21 123 4567')
     end
 
+    it 'formats ambiguous numbers as US' do
+      phone = '2025005000'
+      formatted_phone = PhoneFormatter.format(phone)
+
+      expect(formatted_phone).to eq('+1 202-500-5000')
+    end
+
     it 'formats U.S. numbers correctly' do
       phone = '+12025005000'
       formatted_phone = PhoneFormatter.format(phone)


### PR DESCRIPTION
## 🛠 Summary of changes

This aims to resolve a set of compounding issues I noticed while testing #7823:

- The default behavior of PhoneFormatter to use U.S. parsing can negate any default parsing `Phonelib` would be able to accomplish, and subsequently strip formatting for those non-U.S. numbers
   - Examples:
      - Before: `Phonelib.parse('+13065550100', 'US').international == '+13065550100'`
      - After: `Phonelib.parse('+13065550100').international == '+1 306 555 0100'`
- When adding a phone, the `NewPhoneForm` [provides](https://github.com/18F/identity-idp/blob/e28310c64d5589a4691de917d51bbc4fa5e1cd80/app/forms/new_phone_form.rb#L78) `country_code` in the initial entry of a phone number, but the `OtpDeliverySelectionForm` [does not](https://github.com/18F/identity-idp/blob/e28310c64d5589a4691de917d51bbc4fa5e1cd80/app/forms/otp_delivery_selection_form.rb#L12) during the OTP confirmation + phone record creation. This causes a loss of formatting. Furthermore, it also prevents some validation such as duplicate detection from working correctly.

**Steps to reproduce:**

1. Sign in
2. Click "Add phone number"
3. Enter `3065550100`
4. Submit
5. Confirm OTP
6. On account dashboard, click "Add phone number" again
7. Enter `3065550100`
8. Submit

Expected: Validation error about duplicate phone is shown
Actual: The submission is valid and you're prompted again for OTP confirmation

**Draft** since I suspect this may be a sensitive bit of code that could cause some follow-on effects & test failures.