### PR TITLE
LG-8790: Improve contrast of phone input country code

### DIFF
--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -14,6 +14,10 @@ lg-phone-input {
     }
   }
 
+  .iti__dial-code {
+    color: color('ink');
+  }
+
   .iti:not(.iti--allow-dropdown) input {
     padding-left: 36px;
     padding-right: 6px;


### PR DESCRIPTION
## 🎫 Ticket

[LG-8790](https://cm-jira.usa.gov/browse/LG-8790)

## 🛠 Summary of changes

Darkens the text used for the country code number in the phone input country dropdown menu, to improve legibility and consequently accessibility.

## 📜 Testing Plan

- Go to http://localhost:3000/components/inspect/phone_input/preview
- Click flag in phone input to expand
- Observe darker text for country code ([compare to current](https://idp.dev.identitysandbox.gov/components/inspect/phone_input/preview))

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2023-02-16 at 11 52 49 AM](https://user-images.githubusercontent.com/1779930/219434448-fa6f070e-d048-427a-8a52-40ccb8167e4c.png)|![Screen Shot 2023-02-16 at 11 53 46 AM](https://user-images.githubusercontent.com/1779930/219434459-d0a1240c-e2ab-4b0b-b581-f1210d35805d.png)
