### PR TITLE
LG-8734 direct link to update ssn from VerifyInfoController when using new SsnController

### DIFF
--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -25,7 +25,7 @@ module Idv
       if capture_session_uuid
         {
           acuant_sdk_upgrade_ab_test_bucket:
-          AbTests::ACUANT_SDK.bucket(capture_session_uuid),
+            AbTests::ACUANT_SDK.bucket(capture_session_uuid),
         }
       else
         {}

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -38,7 +38,7 @@ module Idv
         ssn: params[:doc_auth][:ssn],
       )
 
-      idv_session.ssn_updated!
+      idv_session.invalidate_steps_after_ssn!
 
       redirect_to idv_verify_info_url
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -136,7 +136,7 @@ module Idv
       session[:user_phone_confirmation_session] = new_user_phone_confirmation_session.to_h
     end
 
-    def ssn_updated!
+    def invalidate_steps_after_ssn!
       # Guard against unvalidated attributes from in-person flow in review controller
       session[:applicant] = nil
 

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -107,7 +107,7 @@ locals:
         <%= link_to(
               t('idv.buttons.change_label'),
               idv_ssn_url,
-              'aria-label': t('idv.buttons.change_ssn_label')
+              'aria-label': t('idv.buttons.change_ssn_label'),
             ) %>
       </div>
     <% else %>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -104,12 +104,11 @@ locals:
     </div>
     <% if IdentityConfig.store.doc_auth_ssn_controller_enabled %>
       <div class='grid-auto'>
-        <%= button_to(
+        <%= link_to(
+              t('idv.buttons.change_label'),
               idv_ssn_url,
-              method: :get,
-              class: 'usa-button usa-button--unstyled',
-              'aria-label': t('idv.buttons.change_ssn_label'),
-            ) { t('idv.buttons.change_label') } %>
+              'aria-label': t('idv.buttons.change_ssn_label')
+            ) %>
       </div>
     <% else %>
       <div class='grid-auto'>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -102,25 +102,25 @@ locals:
             toggle_label: t('forms.ssn.show'),
           ) %>
     </div>
-<% if IdentityConfig.store.doc_auth_ssn_controller_enabled %>
-    <div class='grid-auto'>
-      <%= button_to(
-            idv_ssn_url,
-            method: :get,
-            class: 'usa-button usa-button--unstyled',
-            'aria-label': t('idv.buttons.change_ssn_label'),
-          ) { t('idv.buttons.change_label') } %>
-    </div>
-<% else %>
-    <div class='grid-auto'>
-      <%= button_to(
-            idv_doc_auth_step_url(step: :redo_ssn),
-            method: :put,
-            class: 'usa-button usa-button--unstyled',
-            'aria-label': t('idv.buttons.change_ssn_label'),
-          ) { t('idv.buttons.change_label') } %>
-    </div>
-<% end %>
+    <% if IdentityConfig.store.doc_auth_ssn_controller_enabled %>
+      <div class='grid-auto'>
+        <%= button_to(
+              idv_ssn_url,
+              method: :get,
+              class: 'usa-button usa-button--unstyled',
+              'aria-label': t('idv.buttons.change_ssn_label'),
+            ) { t('idv.buttons.change_label') } %>
+      </div>
+    <% else %>
+      <div class='grid-auto'>
+        <%= button_to(
+              idv_doc_auth_step_url(step: :redo_ssn),
+              method: :put,
+              class: 'usa-button usa-button--unstyled',
+              'aria-label': t('idv.buttons.change_ssn_label'),
+            ) { t('idv.buttons.change_label') } %>
+      </div>
+    <% end %>
   </div>
   <div class="margin-top-5">
       <%= render SpinnerButtonComponent.new(

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -385,7 +385,7 @@ feature 'doc auth verify_info step', :js do
     end
 
     it 'uses ssn controller to enter a new ssn and displays updated info' do
-      click_button t('idv.buttons.change_ssn_label')
+      click_link t('idv.buttons.change_ssn_label')
       expect(page).to have_current_path(idv_ssn_path)
 
       fill_in t('idv.form.ssn_label_html'), with: '900456789'


### PR DESCRIPTION
## 🎫 Ticket

LG-8734

## 🛠 Summary of changes

Behind the feature flag for the new SsnController, use a direct link to update the SSN on the Verify Info page, rather than a button that looks like a link. This gets rid of a trailing `?` on the url in the browser address bar.

Also added small whitespace changes and renamed `IdvSession#ssn_updated!` to `invalidate_steps_after_ssn!` per feedback from @zachmargolis on #7810 that I saw after merging it.

Note: Once we get rid of the feature flag, a couple more tests will need to change click_button to click_link for ssn update on  the VerifyInfo view.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] In dev or some other environment where `doc_auth_ssn_controller_enabled` feature flag is set to true
- [ ] Create an account
- [ ] Navigate to /verify and go through verification steps
- [ ] On VerifyInfo step, click Update link next to the SSN and note that the url is `verify/ssn` without a `?` at the end.

## 👀 Screenshots

<details>
<summary>After:</summary>
![image](https://user-images.githubusercontent.com/2381438/219515711-d44c3ec9-226e-4333-9254-4420c7c0bf1b.png)

</details>
