### PR TITLE
Removed use of Faker email creation in user factory primary email

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,11 +6,13 @@ FactoryBot.define do
 
     transient do
       with { {} }
-      email { Faker::Internet.safe_email }
+      sequence(:email) { |n| "user#{n}@example.com" }
       confirmed_at { Time.zone.now }
       confirmation_token { nil }
       confirmation_sent_at { 5.minutes.ago }
     end
+
+
 
     accepted_terms_at { Time.zone.now if email }
 


### PR DESCRIPTION
We suspect that using Faker email, rather than explicitly setting sequential emails, was occasionally creating collisions and leading to flaky test failures.

[skip changelog]

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
