### PR TITLE
Add session's doc_capture_user_id to analytics logged output

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -35,7 +35,11 @@ module Idv
 
       result = Idv::DocumentCaptureSessionForm.new(document_capture_session_uuid).submit
 
-      analytics.track_event(FLOW_STATE_MACHINE_SETTINGS[:analytics_id], result.to_h)
+      analytics.track_event(
+        FLOW_STATE_MACHINE_SETTINGS[:analytics_id],
+        doc_capture_session_result: result.to_h,
+        doc_capture_user_id: session[:doc_capture_user_id]
+      )
       process_result(result)
     end
 

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -38,7 +38,7 @@ module Idv
       analytics.track_event(
         FLOW_STATE_MACHINE_SETTINGS[:analytics_id],
         doc_capture_session_result: result.to_h,
-        doc_capture_user_id: session[:doc_capture_user_id]
+        doc_capture_user_id: session[:doc_capture_user_id],
       )
       process_result(result)
     end

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -36,7 +36,7 @@ module Idv
       result = Idv::DocumentCaptureSessionForm.new(document_capture_session_uuid).submit
       to_log = result.to_h
       # Log value used to determine session type ("hybrid flow" or not)
-      to_log[:doc_capture_user_id] = session[:doc_capture_user_id].present?
+      to_log[:doc_capture_user_id?] = session[:doc_capture_user_id].present?
 
       analytics.track_event(FLOW_STATE_MACHINE_SETTINGS[:analytics_id], to_log)
       process_result(result)

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -34,12 +34,11 @@ module Idv
                 document_capture_session_uuid.blank?
 
       result = Idv::DocumentCaptureSessionForm.new(document_capture_session_uuid).submit
+      to_log = result.to_h
+      # Log value used to determine session type ("hybrid flow" or not)
+      to_log[:doc_capture_user_id] = session[:doc_capture_user_id].present?
 
-      analytics.track_event(
-        FLOW_STATE_MACHINE_SETTINGS[:analytics_id],
-        doc_capture_session_result: result.to_h,
-        doc_capture_user_id: session[:doc_capture_user_id],
-      )
+      analytics.track_event(FLOW_STATE_MACHINE_SETTINGS[:analytics_id], to_log)
       process_result(result)
     end
 

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -180,6 +180,7 @@ feature 'doc capture document capture step', js: true do
         hash_including(
           success: false,
           user_id: 'anonymous-uuid',
+          doc_capture_user_id: false,
         ),
       )
     end

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -180,7 +180,7 @@ feature 'doc capture document capture step', js: true do
         hash_including(
           success: false,
           user_id: 'anonymous-uuid',
-          doc_capture_user_id: false,
+          doc_capture_user_id?: false,
         ),
       )
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8890](https://cm-jira.usa.gov/browse/LG-8890)


## 🛠 Summary of changes

Log boolean indication of presence or absence of doc_capture_user_id from the session, adding it to the logging already present in CaptureDocController#ensure_user_id_in_session


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
- [ ] Deploy to lower environment(s)
- [ ] Perform identity verification with desktop and mobile
- [ ] Query CloudWatch for `Doc Auth` events
- [ ] Ensure new events have `properties.event_properties.doc_capture_user_id` key


