### PR TITLE
Skip devices database query when identifier is null

### DIFF
--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -11,7 +11,10 @@ class UserEventCreator
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_user_event(event_type, user = current_user, disavowal_token = nil)
     return unless user&.id
-    existing_device = Device.find_by(user_id: user.id, cookie_uuid: cookies[:device])
+    existing_device = cookies[:device] && Device.find_by(
+      user_id: user.id,
+      cookie_uuid: cookies[:device],
+    )
     if existing_device.present?
       create_event_for_existing_device(
         event_type: event_type, user: user, device: existing_device,


### PR DESCRIPTION
## 🛠 Summary of changes

A rather small optimization, but we currently will make a database query for NULL cookie_uuid values when we don't need to since we disallow NULL values in that column. This PR skips the query if `cookie_uuid` is null.

```SQL
SELECT "devices"."id", "devices"."user_id", "devices"."cookie_uuid", "devices"."user_agent", "devices"."last_used_at", "devices"."last_ip", "devices"."created_at", "devices"."updated_at" FROM "devices"
WHERE "devices"."user_id" = $? AND "devices"."cookie_uuid" IS NULL
LIMIT $?
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
