### PR TITLE
A few mods to get JavaScript-enabled specs running on my M1 MBP.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :development, :test do
   gem 'i18n-tasks', '~> 1.0'
   gem 'knapsack'
   gem 'nokogiri', '~> 1.14.0'
-  gem 'parallel_tests'
+  gem 'parallel_tests', '~> 3.8.0'
   gem 'pg_query', require: false
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
       openssl (> 2.0, < 3.1)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parallel_tests (3.7.3)
+    parallel_tests (3.8.1)
       parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -771,7 +771,7 @@ DEPENDENCIES
   newrelic_rpm (~> 8.0)
   nokogiri (~> 1.14.0)
   octokit (>= 4.25.0)
-  parallel_tests
+  parallel_tests (~> 3.8.0)
   pg
   pg_query
   phonelib

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -11,9 +11,9 @@ module DocumentCaptureStepHelper
     submit_images
   end
 
-  def attach_images(file = 'app/assets/images/logo.png')
-    attach_file t('doc_auth.headings.document_capture_front'), file
-    attach_file t('doc_auth.headings.document_capture_back'), file
+  def attach_images(file = Rails.root.join('app', 'assets', 'images', 'logo.png'))
+    attach_file t('doc_auth.headings.document_capture_front'), file, make_visible: true
+    attach_file t('doc_auth.headings.document_capture_back'), file, make_visible: true
   end
 
   def document_capture_form


### PR DESCRIPTION
## 🛠 Summary of changes

I was consistently unable to run many different feature specs, with errors like below. These mods helped get me going again, and I don't see any drawbacks for everyone else.

Unanswered question: Why only me??

```
  1) Analytics Regression GPO path records all of the events
     Got 0 failures and 2 other errors:
     1.1) Failure/Error: fill_in t('idv.form.ssn_label_html'), with: GOOD_SSN
          Capybara::ElementNotFound:
            Unable to find field "Social Security number" that is not disabled
          # ./spec/support/features/doc_auth_helper.rb:27:in `fill_out_ssn_form_ok'
          # ./spec/support/features/in_person_helper.rb:83:in `complete_ssn_step'
          # ./spec/features/idv/analytics_spec.rb:169:in `block (3 levels) in <top (required)>'
          # ./spec/features/idv/analytics_spec.rb:125:in `block (3 levels) in <top (required)>'
          # ./spec/features/idv/analytics_spec.rb:125:in `block (2 levels) in <top (required)>'
          # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
     1.2) Failure/Error: raise BrowserConsoleLogError.new(javascript_errors) if javascript_errors.present?
          BrowserConsoleLogError:
            Unexpected browser console logging:
            http://127.0.0.1:50466/account - Failed to load resource: the server responded with a status of 503 (Service Unavailable)
            blob:http://127.0.0.1:50466/5543ea10-a3ed-44d7-acc6-5f7c0e833271 - Failed to load resource: net::ERR_ACCESS_DENIED
            blob:http://127.0.0.1:50466/fbdfacaf-32c8-4636-b9d9-45155f7840f1 - Failed to load resource: net::ERR_ACCESS_DENIED
            http://127.0.0.1:50466/api/verify/images - Failed to load resource: net::ERR_ACCESS_DENIED
            webpack-internal:///./app/javascript/packages/document-capture/hooks/use-async.js 52:8 Uncaught TypeError: Failed to fetch
          # ./spec/rails_helper.rb:156:in `block (2 levels) in <top (required)>'
          # ./spec/features/idv/analytics_spec.rb:125:in `block (3 levels) in <top (required)>'
          # ./spec/features/idv/analytics_spec.rb:125:in `block (2 levels) in <top (required)>'
          # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
```