### PR TITLE
Removed analytics check from password visibility toggle spec.

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -220,22 +220,10 @@ feature 'Sign in' do
   end
 
   scenario 'user can see and use password visibility toggle', js: true do
-    fake_analytics = FakeAnalytics.new
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-
     visit new_user_session_path
 
     check t('components.password_toggle.toggle_label')
-
-    # Clicking the checkbox triggers a frontend event logging request. Wait for network requests to
-    # settle before continuing to avoid a race condition.
-    Capybara.current_session.server.wait_for_pending_requests
-
     expect(page).to have_css('input.password[type="text"]')
-    expect(fake_analytics).to have_logged_event(
-      'Show Password Button Clicked',
-      path: new_user_session_path,
-    )
   end
 
   scenario 'user session expires in amount of time specified by Devise config' do


### PR DESCRIPTION
The test was flaky and the flag is unused, per Andrew Duthie.

[skip changelog]
