### PR TITLE
Removed use of Faker email creation in user factory primary email

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,11 +6,13 @@ FactoryBot.define do
 
     transient do
       with { {} }
-      email { Faker::Internet.safe_email }
+      sequence(:email) { |n| "user#{n}@example.com" }
       confirmed_at { Time.zone.now }
       confirmation_token { nil }
       confirmation_sent_at { 5.minutes.ago }
     end
+
+
 
     accepted_terms_at { Time.zone.now if email }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,8 +12,6 @@ FactoryBot.define do
       confirmation_sent_at { 5.minutes.ago }
     end
 
-
-
     accepted_terms_at { Time.zone.now if email }
 
     after(:build) do |user, evaluator|


### PR DESCRIPTION
We suspect that using Faker email, rather than explicitly setting sequential emails, was occasionally creating collisions and leading to flaky test failures.

[skip changelog]
