### PR TITLE
Add logging ahead of removing Analytics logic

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -11,6 +11,19 @@ module Idv
     def index
       @presenter = GpoPresenter.new(current_user, url_options)
       @step_indicator_current_step = step_indicator_current_step
+      # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+      #   call(:usps_address, :view, true)
+      Rails.logger.info(
+        {
+          name: 'event_to_doc_auth_log_token',
+          source: 'proposed',
+          user_id: current_user.id,
+          issuer: current_sp&.issuer,
+          token: :usps_address,
+          action: :view,
+          success: true,
+        }.to_json,
+      )
       analytics.idv_gpo_address_visited(
         letter_already_sent: @presenter.resend_requested?,
       )
@@ -45,6 +58,19 @@ module Idv
     end
 
     def update_tracking
+      # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+      #   call(:usps_letter_sent, :update, true)
+      Rails.logger.info(
+        {
+          name: 'event_to_doc_auth_log_token',
+          source: 'proposed',
+          user_id: current_user.id,
+          issuer: current_sp&.issuer,
+          token: :usps_letter_sent,
+          action: :update,
+          success: true,
+        }.to_json,
+      )
       analytics.idv_gpo_address_letter_requested(resend: resend_requested?)
       irs_attempts_api_tracker.idv_gpo_letter_requested(resend: resend_requested?)
       create_user_event(:gpo_mail_sent, current_user)

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -57,7 +57,7 @@ module Idv
           issuer: current_sp&.issuer,
           token: :verify_phone,
           action: :update,
-          success: true,
+          success: result.success?,
         }.to_json,
       )
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -18,6 +18,20 @@ module Idv
 
       async_state = step.async_state
       if async_state.none?
+        # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+        #   call(:verify_phone, :view, true)
+        Rails.logger.info(
+          {
+            name: 'event_to_doc_auth_log_token',
+            source: 'proposed',
+            user_id: current_user.id,
+            issuer: current_sp&.issuer,
+            token: :verify_phone,
+            action: :view,
+            success: true,
+          }.to_json,
+        )
+
         analytics.idv_phone_of_record_visited
         render :new, locals: { gpo_letter_available: gpo_letter_available }
       elsif async_state.in_progress?
@@ -33,6 +47,20 @@ module Idv
 
     def create
       result = idv_form.submit(step_params)
+      # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+      #   call(:verify_phone, :update, result.success?)
+      Rails.logger.info(
+        {
+          name: 'event_to_doc_auth_log_token',
+          source: 'proposed',
+          user_id: current_user.id,
+          issuer: current_sp&.issuer,
+          token: :verify_phone,
+          action: :update,
+          success: true,
+        }.to_json,
+      )
+
       analytics.idv_phone_confirmation_form_submitted(**result.to_h)
       irs_attempts_api_tracker.idv_phone_submitted(
         success: result.success?,

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -37,6 +37,19 @@ module Idv
 
     def new
       @applicant = idv_session.applicant
+      # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+      #   call(:encrypt, :view, true)
+      Rails.logger.info(
+        {
+          name: 'event_to_doc_auth_log_token',
+          source: 'proposed',
+          user_id: current_user.id,
+          issuer: current_sp&.issuer,
+          token: :encrypt,
+          action: :view,
+          success: true,
+        }.to_json,
+      )
       analytics.idv_review_info_visited(address_verification_method: address_verification_method)
 
       gpo_mail_service = Idv::GpoMail.new(current_user)
@@ -62,6 +75,19 @@ module Idv
       analytics.idv_review_complete(
         success: true,
         deactivation_reason: idv_session.profile.deactivation_reason,
+      )
+      # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
+      #   call(:verified, :view, true)
+      Rails.logger.info(
+        {
+          name: 'event_to_doc_auth_log_token',
+          source: 'proposed',
+          user_id: current_user.id,
+          issuer: current_sp&.issuer,
+          token: :verified,
+          action: :view,
+          success: true,
+        }.to_json,
       )
       analytics.idv_final(
         success: true,

--- a/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
@@ -9,6 +9,17 @@ module Funnel
       def self.call(user_id, issuer, event, result)
         token = ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN[event]
         return unless token
+        Rails.logger.info(
+          {
+            name: 'event_to_doc_auth_log_token',
+            source: 'original',
+            user_id: user_id,
+            issuer: issuer,
+            token: token,
+            action: :update,
+            success: result,
+          }.to_json,
+        )
         Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(token, :update, result)
       end
     end

--- a/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
@@ -10,7 +10,19 @@ module Funnel
 
       def self.call(user_id, issuer, event, result)
         token = ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN[event]
-        Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(token, :view, result) if token
+        return unless token
+        Rails.logger.info(
+          {
+            name: 'event_to_doc_auth_log_token',
+            source: 'original',
+            user_id: user_id,
+            issuer: issuer,
+            token: token,
+            action: :view,
+            success: result,
+          }.to_json,
+        )
+        Funnel::DocAuth::RegisterStep.new(user_id, issuer).call(token, :view, result)
       end
     end
   end

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -4,7 +4,7 @@ describe Idv::GpoController do
   let(:user) { create(:user) }
 
   before do
-    stub_analytics(user: user)
+    stub_analytics
     stub_attempts_tracker
   end
 
@@ -39,6 +39,7 @@ describe Idv::GpoController do
     end
 
     it 'updates the doc auth log for the user for the usps_address_view event' do
+      unstub_analytics
       doc_auth_log = DocAuthLog.create(user_id: user.id)
 
       expect { get :index }.to(
@@ -119,6 +120,7 @@ describe Idv::GpoController do
       end
 
       it 'updates the doc auth log for the user for the usps_letter_sent event' do
+        unstub_analytics
         doc_auth_log = DocAuthLog.create(user_id: user.id)
 
         expect { put :create }.to(

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -235,10 +235,6 @@ describe Idv::PhoneController do
     end
 
     context 'when form is valid' do
-      let(:user) do
-        create(:user, :with_phone, with: { phone: good_phone, confirmed_at: Time.zone.now })
-      end
-
       before do
         stub_analytics
         stub_attempts_tracker
@@ -246,6 +242,7 @@ describe Idv::PhoneController do
       end
 
       it 'tracks events with valid phone' do
+        user = build(:user, :with_phone, with: { phone: good_phone, confirmed_at: Time.zone.now })
         stub_verify_steps_one_and_two(user)
 
         expect(@irs_attempts_api_tracker).to receive(:idv_phone_submitted).with(
@@ -282,6 +279,7 @@ describe Idv::PhoneController do
       end
 
       it 'updates the doc auth log for the user with verify_phone_submit step' do
+        user = create(:user, :with_phone, with: { phone: good_phone, confirmed_at: Time.zone.now })
         unstub_analytics
         stub_verify_steps_one_and_two(user)
 
@@ -293,14 +291,12 @@ describe Idv::PhoneController do
       end
 
       context 'when same as user phone' do
-        let(:user) do
-          build(
+        before do
+          user = build(
             :user, :with_phone, with: {
               phone: good_phone, confirmed_at: Time.zone.now
             }
           )
-        end
-        before do
           stub_verify_steps_one_and_two(user)
         end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -41,6 +41,7 @@ describe Idv::PhoneController do
     end
 
     it 'updates the doc auth log for the user for the usps_letter_sent event' do
+      unstub_analytics
       doc_auth_log = DocAuthLog.create(user_id: user.id)
 
       expect { get :new }.to(
@@ -239,7 +240,7 @@ describe Idv::PhoneController do
       end
 
       before do
-        stub_analytics(user: user)
+        stub_analytics
         stub_attempts_tracker
         allow(@analytics).to receive(:track_event)
       end
@@ -281,7 +282,7 @@ describe Idv::PhoneController do
       end
 
       it 'updates the doc auth log for the user with verify_phone_submit step' do
-        allow(@analytics).to receive(:track_event).and_call_original
+        unstub_analytics
         stub_verify_steps_one_and_two(user)
 
         doc_auth_log = DocAuthLog.create(user_id: user.id)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -40,6 +40,14 @@ describe Idv::PhoneController do
       stub_verify_steps_one_and_two(user)
     end
 
+    it 'updates the doc auth log for the user for the usps_letter_sent event' do
+      doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+      expect { get :new }.to(
+        change { doc_auth_log.reload.verify_phone_view_count }.from(0).to(1),
+      )
+    end
+
     context 'when the phone number has been confirmed as user 2FA phone' do
       before do
         subject.idv_session.user_phone_confirmation = true

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -219,6 +219,15 @@ describe Idv::ReviewController do
           ),
         )
       end
+
+      it 'updates the doc auth log for the user for the encrypt view event' do
+        unstub_analytics
+        doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+        expect { get :new }.to(
+          change { doc_auth_log.reload.encrypt_view_count }.from(0).to(1),
+        )
+      end
     end
 
     context 'user has not requested too much mail' do
@@ -628,6 +637,17 @@ describe Idv::ReviewController do
               'IdV: final resolution', success: true,
                                        proofing_components: nil,
                                        deactivation_reason: 'threatmetrix_review_pending'
+            )
+          end
+
+          it 'updates the doc auth log for the user for the verified view event' do
+            unstub_analytics
+            doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+            expect do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            end.to(
+              change { doc_auth_log.reload.verified_view_count }.from(0).to(1),
             )
           end
         end

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,6 +1,11 @@
 module AnalyticsHelper
-  def stub_analytics(user: AnonymousUser.new)
-    controller.analytics = FakeAnalytics.new(user: user)
+  def stub_analytics
+    controller.analytics = FakeAnalytics.new
     @analytics = controller.analytics
+  end
+
+  def unstub_analytics
+    controller.analytics = nil
+    @analytics = nil
   end
 end

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,6 +1,6 @@
 module AnalyticsHelper
-  def stub_analytics
-    controller.analytics = FakeAnalytics.new
+  def stub_analytics(user: AnonymousUser.new)
+    controller.analytics = FakeAnalytics.new(user: user)
     @analytics = controller.analytics
   end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -80,6 +80,8 @@ class FakeAnalytics < Analytics
   end
 
   def track_event(event, attributes = {})
+    register_doc_auth_step_from_analytics_event(event, attributes) # to help verify doc auth tracking
+
     if attributes[:proofing_components].instance_of?(Idv::ProofingComponentsLogging)
       attributes[:proofing_components] = attributes[:proofing_components].as_json.symbolize_keys
     end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -80,8 +80,6 @@ class FakeAnalytics < Analytics
   end
 
   def track_event(event, attributes = {})
-    register_doc_auth_step_from_analytics_event(event, attributes) # to help verify doc auth tracking
-
     if attributes[:proofing_components].instance_of?(Idv::ProofingComponentsLogging)
       attributes[:proofing_components] = attributes[:proofing_components].as_json.symbolize_keys
     end


### PR DESCRIPTION
This is a redo of #7833, but first:

1. Adds tests ahead of time
2. Finds 4 new callsites that were missing analytics hookds
    - Before, only two "submit" events in [`register_step_from_analytics_submit_event.rb`](https://github.com/18F/identity-idp/blob/f226bddb2477ef19c2b04ccd32f056c3a5a57dad/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb) were included
    - Now, 4 more that I missed in a second file [`register_step_from_analytics_view_event.rb`](https://github.com/18F/identity-idp/blob/f226bddb2477ef19c2b04ccd32f056c3a5a57dad/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb) are included too
3. In terms of the database, this should be a no-op in production, it does not touch anything, but it adds `Rails.logger.info` logging we can check to verify (basically the `original` and `proposed` counts at each spot should match)
   - We can run a CW query along the lines of this to see if there are any differences and dig in
   ```bash
   fields @message
   | filter name = 'event_to_doc_auth_log_token'
   | stats count(*) by source, token, action
   ```

