### PR TITLE
Remove unused Authentication Presenter data 

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -292,10 +292,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     current_user.direct_otp_sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
   end
 
-  def personal_key_unavailable?
-    current_user.encrypted_recovery_code_digest.blank?
-  end
-
   def user_opted_remember_device_cookie
     cookies.encrypted[:user_opted_remember_device_preference]
   end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -305,15 +305,14 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def phone_view_data
-    { confirmation_for_add_phone: confirmation_for_add_phone?,
+    {
+      confirmation_for_add_phone: confirmation_for_add_phone?,
       phone_number: display_phone_to_deliver_to,
       code_value: direct_otp_code,
       otp_expiration: otp_expiration,
       otp_delivery_preference: two_factor_authentication_method,
       otp_make_default_number: selected_otp_make_default_number,
-      voice_otp_delivery_unsupported: voice_otp_delivery_unsupported?,
-      unconfirmed_phone: unconfirmed_phone?,
-      account_reset_token: account_reset_token }.merge(generic_data)
+    }.merge(generic_data)
   end
 
   def selected_otp_make_default_number
@@ -333,8 +332,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
 
   def generic_data
     {
-      personal_key_unavailable: personal_key_unavailable?,
-      reauthn: reauthn?,
       user_opted_remember_device_cookie: user_opted_remember_device_cookie,
     }
   end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -73,7 +73,6 @@ module TwoFactorAuthentication
       {
         two_factor_authentication_method: two_factor_authentication_method,
         hide_fallback_question: service_provider_mfa_policy.piv_cac_required?,
-        user_email: current_user.email_addresses.take.email,
       }.merge(generic_data)
     end
 

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -61,6 +61,6 @@ module TwoFactorAuthCode
       )
     end
 
-    attr_reader :personal_key_unavailable, :view, :user_opted_remember_device_cookie
+    attr_reader :view, :user_opted_remember_device_cookie
   end
 end

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -104,9 +104,7 @@ module TwoFactorAuthCode
 
     attr_reader(
       :phone_number,
-      :account_reset_token,
       :confirmation_for_add_phone,
-      :voice_otp_delivery_unsupported,
     )
   end
 end

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -11,10 +11,7 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       phone_number: '5555559876',
       code_value: '999999',
       otp_delivery_preference: 'sms',
-      unconfirmed_phone: true,
       totp_enabled: false,
-      personal_key_unavailable: true,
-      reauthn: false,
     }
   end
   let(:presenter) do


### PR DESCRIPTION
## 🛠 Summary of changes

The authenticator presenter classes are a little difficult to track, with unstructured data being passed in and converted to instance variables. Long-term, we may want to consider making these structures and methods more explicit, but for now this PR removes the unused data.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
