### PR TITLE
LG-8976: Allow using Puerto Rico phone numbers for hybrid handoff

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -47,6 +47,7 @@ module Idv
 
     def create
       result = idv_form.submit(step_params)
+
       # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
       #   call(:verify_phone, :update, result.success?)
       Rails.logger.info(

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -47,7 +47,6 @@ module Idv
 
     def create
       result = idv_form.submit(step_params)
-
       # Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
       #   call(:verify_phone, :update, result.success?)
       Rails.logger.info(

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -26,7 +26,11 @@ module Idv
       @allowed_countries = allowed_countries
       @delivery_methods = delivery_methods
 
-      @international_code, @phone = determine_initial_values(**previous_params.symbolize_keys)
+      @international_code, @phone = determine_initial_values(
+        **previous_params.
+        symbolize_keys.
+        slice(:international_code, :phone),
+      )
     end
 
     def submit(params)
@@ -44,7 +48,7 @@ module Idv
     attr_writer :phone, :otp_delivery_preference
 
     # @return [Array<string,string>] The international_code and phone values to use.
-    def determine_initial_values(international_code: nil, phone: nil, **_)
+    def determine_initial_values(international_code: nil, phone: nil)
       if phone.nil? && international_code.nil?
         default_phone = user.default_phone_configuration&.phone
         if valid_phone?(default_phone, phone_confirmed: true)

--- a/app/javascript/packages/phone-input/index.spec.ts
+++ b/app/javascript/packages/phone-input/index.spec.ts
@@ -36,12 +36,14 @@ describe('PhoneInput', () => {
     deliveryMethods = ['sms', 'voice'],
     translatedCountryCodeNames = {},
     captchaExemptCountries = undefined,
+    phoneInputValue = undefined,
   }: {
     isSingleOption?: boolean;
     isNonUSSingleOption?: Boolean;
     deliveryMethods?: string[];
     translatedCountryCodeNames?: Record<string, string>;
     captchaExemptCountries?: string[];
+    phoneInputValue?: string;
   } = {}) {
     const element = document.createElement('lg-phone-input');
     element.setAttribute('data-delivery-methods', JSON.stringify(deliveryMethods));
@@ -52,6 +54,17 @@ describe('PhoneInput', () => {
     if (captchaExemptCountries) {
       element.setAttribute('data-captcha-exempt-countries', JSON.stringify(captchaExemptCountries));
     }
+
+    const phoneInput = document.createElement('input');
+    phoneInput.type = 'tel';
+    phoneInput.id = 'phone_form_phone';
+    phoneInput.className = 'phone-input__number validated-field__input';
+    phoneInput.setAttribute('value', phoneInputValue ?? '');
+    phoneInput.setAttribute('aria-invalid', 'false');
+    phoneInput.setAttribute('aria-describedby', 'validated-field-error-298658fb');
+    phoneInput.setAttribute('required', 'required');
+    phoneInput.setAttribute('aria-required', 'true');
+
     element.innerHTML = `
       <script type="application/json" class="phone-input__strings">
         {
@@ -77,7 +90,7 @@ describe('PhoneInput', () => {
             "valueMissing": "This field is required"
           }
         </script>
-        <input class="phone-input__number validated-field__input" aria-invalid="false" aria-describedby="validated-field-error-298658fb" required="required" aria-required="true" type="tel" id="phone_form_phone" />
+        ${phoneInput.outerHTML}
       </lg-validated-field>
     `;
 
@@ -118,6 +131,16 @@ describe('PhoneInput', () => {
     expect(phoneNumber.validationMessage).to.equal(
       'We are unable to verify phone numbers from Sri Lanka',
     );
+  });
+
+  it('sets country on initialization', () => {
+    const input = createAndConnectElement({
+      phoneInputValue: '+12502345678',
+    });
+    const countryCode = getByLabelText(input, 'Country code', {
+      selector: 'select',
+    }) as HTMLSelectElement;
+    expect(countryCode.value).to.eql('CA');
   });
 
   it('formats on country change', async () => {

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -79,7 +79,6 @@ export class PhoneInputElement extends HTMLElement {
     this.ownerDocument.addEventListener(CAPTCHA_EVENT_NAME, this.handleCaptchaChallenge);
 
     this.setExampleNumber();
-    this.syncCountryChangeToCodeInput();
     this.validate();
   }
 
@@ -164,6 +163,11 @@ export class PhoneInputElement extends HTMLElement {
       iti.selectedFlag.setAttribute('aria-haspopup', 'true');
       iti.selectedFlag.setAttribute('role', 'button');
       iti.selectedFlag.removeAttribute('aria-owns');
+    }
+
+    const country = iti.getSelectedCountryData();
+    if (country.iso2 && this.codeInput) {
+      this.codeInput.value = country.iso2.toUpperCase();
     }
 
     return iti;

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -79,6 +79,7 @@ export class PhoneInputElement extends HTMLElement {
     this.ownerDocument.addEventListener(CAPTCHA_EVENT_NAME, this.handleCaptchaChallenge);
 
     this.setExampleNumber();
+    this.syncCountryChangeToCodeInput();
     this.validate();
   }
 

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -6,7 +6,7 @@ feature 'doc auth send link step' do
   include ActionView::Helpers::DateHelper
 
   before do
-    sign_in_and_2fa_user
+    sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_send_link_step
   end
 
@@ -17,6 +17,7 @@ feature 'doc auth send link step' do
   let(:document_capture_session) { DocumentCaptureSession.create! }
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  let(:user) { user_with_2fa }
 
   it "defaults phone to user's 2fa phone numebr" do
     field = page.find_field(t('two_factor_authentication.phone_label'))
@@ -185,5 +186,40 @@ feature 'doc auth send link step' do
 
     document_capture_session.reload
     expect(document_capture_session).to have_attributes(requested_at: a_kind_of(Time))
+  end
+
+  context 'when user is from Puerto Rico' do
+    let(:area_code) {}
+    let(:phone) { "+1 #{area_code}-555-1212" }
+    let(:formatted_phone) { "+1 (#{area_code}) 555-1212" }
+    let(:user) do
+      create(
+        :user,
+        :signed_up,
+        with: { phone: phone },
+        password: Features::SessionHelper::VALID_PASSWORD,
+      )
+    end
+
+    shared_examples 'they are a person with a real telephone' do
+      it "defaults phone to user's 2fa phone number", :js do
+        field = page.find_field(t('two_factor_authentication.phone_label'))
+        expect(field.value).to eq(formatted_phone)
+      end
+      it "allows submitting to user's 2fa phone number", :js do
+        click_idv_continue
+        expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+      end
+    end
+
+    context 'with area code 787' do
+      let(:area_code) { '787' }
+      it_behaves_like 'they are a person with a real telephone'
+    end
+
+    context 'with area code 939' do
+      let(:area_code) { '939' }
+      it_behaves_like 'they are a person with a real telephone'
+    end
   end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -189,9 +189,8 @@ feature 'doc auth send link step' do
   end
 
   context 'when user is from Puerto Rico' do
-    let(:area_code) {}
-    let(:phone) { "+1 #{area_code}-555-1212" }
-    let(:formatted_phone) { "(#{area_code}) 555-1212" }
+    let(:phone) { '+1 787-555-1212' }
+    let(:formatted_phone) { '(787) 555-1212' }
     let(:user) do
       create(
         :user,
@@ -201,25 +200,13 @@ feature 'doc auth send link step' do
       )
     end
 
-    shared_examples 'they are a person with a real telephone' do
-      it "defaults phone to user's 2fa phone number", :js do
-        field = page.find_field(t('two_factor_authentication.phone_label'))
-        expect(field.value).to eq(formatted_phone)
-      end
-      it "allows submitting to user's 2fa phone number", :js do
-        click_idv_continue
-        expect(page).to have_current_path(idv_doc_auth_link_sent_step)
-      end
+    it "defaults phone to user's 2fa phone number", :js do
+      field = page.find_field(t('two_factor_authentication.phone_label'))
+      expect(field.value).to eq(formatted_phone)
     end
-
-    context 'with area code 787' do
-      let(:area_code) { '787' }
-      it_behaves_like 'they are a person with a real telephone'
-    end
-
-    context 'with area code 939' do
-      let(:area_code) { '939' }
-      it_behaves_like 'they are a person with a real telephone'
+    it "allows submitting to user's 2fa phone number", :js do
+      click_idv_continue
+      expect(page).to have_current_path(idv_doc_auth_link_sent_step)
     end
   end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -191,7 +191,7 @@ feature 'doc auth send link step' do
   context 'when user is from Puerto Rico' do
     let(:area_code) {}
     let(:phone) { "+1 #{area_code}-555-1212" }
-    let(:formatted_phone) { "+1 (#{area_code}) 555-1212" }
+    let(:formatted_phone) { "(#{area_code}) 555-1212" }
     let(:user) do
       create(
         :user,

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -194,4 +194,32 @@ describe Idv::PhoneForm do
       end
     end
   end
+
+  describe 'initialization' do
+    shared_examples 'a thing that knows about other countries' do
+      let(:user) { build_stubbed(:user, :signed_up, with: { phone: phone }) }
+      let(:optional_params) { { delivery_methods: [:sms] } }
+
+      it 'initializes international_code field properly' do
+        expect(subject.international_code).to eql(expected_country)
+      end
+      it 'initializes phone field properly' do
+        expect(subject.phone).to eql(expected_phone)
+      end
+    end
+
+    context 'US' do
+      let(:phone) { '3602345678' }
+      let(:expected_phone) { '(360) 234-5678' }
+      let(:expected_country) { 'US' }
+      it_behaves_like 'a thing that knows about other countries'
+    end
+
+    context 'PR' do
+      let(:phone) { '+17872345678' }
+      let(:expected_phone) { '+1 787 234 5678' }
+      let(:expected_country) { 'PR' }
+      it_behaves_like 'a thing that knows about other countries'
+    end
+  end
 end

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -210,7 +210,7 @@ describe Idv::PhoneForm do
 
     context 'US' do
       let(:phone) { '3602345678' }
-      let(:expected_phone) { '(360) 234-5678' }
+      let(:expected_phone) { '+1 360-234-5678' }
       let(:expected_country) { 'US' }
       it_behaves_like 'a thing that knows about other countries'
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8976](https://cm-jira.usa.gov/browse/LG-8976)

(Also a dash of [LG-8839](https://cm-jira.usa.gov/browse/LG-8839), since I was in there.)

## 🛠 Summary of changes

A user reported an issue using their Puerto Rican phone number for IdV's hybrid handoff screen. In this case, they had their phone number prefilled, since they were using it for SMS 2FA. It's likely this came in with #7762.

## 📜 Testing Plan

- [ ] Sign up using a Puerto Rican phone number for SMS 2FA ([area code 787 or 939](https://en.wikipedia.org/wiki/Telephone_numbers_in_Puerto_Rico))
- [ ] Start IdV and select the "Use your phone to take photos" path
- [ ] Leave your 2fa phone number pre-filled and click "Send Link"
- [ ] Get a link!
