### PR TITLE
LG-9025 Go to new SsnController from hybrid flow when feature flag is set

### DIFF
--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -42,7 +42,9 @@ module Idv
 
       def exit_flow_state_machine
         flow_session[:flow_path] = @flow.flow_path
-        redirect_to idv_ssn_url
+        if @flow.class == 'Idv::Flows::DocAuthFlow'
+          redirect_to idv_ssn_url
+        end
       end
 
       def native_camera_ab_testing_variables

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -42,9 +42,7 @@ module Idv
 
       def exit_flow_state_machine
         flow_session[:flow_path] = @flow.flow_path
-        if @flow.class == 'Idv::Flows::DocAuthFlow'
-          redirect_to idv_ssn_url
-        end
+        redirect_to idv_ssn_url if @flow.instance_of?('Idv::Flows::DocAuthFlow')
       end
 
       def native_camera_ab_testing_variables

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -42,7 +42,7 @@ module Idv
 
       def exit_flow_state_machine
         flow_session[:flow_path] = @flow.flow_path
-        redirect_to idv_ssn_url if @flow.instance_of?('Idv::Flows::DocAuthFlow')
+        redirect_to idv_ssn_url if @flow.instance_of?(Idv::Flows::DocAuthFlow)
       end
 
       def native_camera_ab_testing_variables

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -24,10 +24,16 @@ module Idv
 
       private
 
+      def exit_flow_state_machine
+        flow_session[:flow_path] = @flow.flow_path
+        redirect_to idv_ssn_url
+      end
+
       def handle_document_verification_success(get_results_response)
         save_proofing_components
         extract_pii_from_doc(get_results_response, store_in_session: true)
         mark_steps_complete
+        exit_flow_state_machine if IdentityConfig.store.doc_auth_ssn_controller_enabled
       end
 
       def render_document_capture_cancelled

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -60,6 +60,55 @@ describe 'Hybrid Flow' do
     end
   end
 
+  context 'with ssn controller enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_ssn_controller_enabled).and_return(true)
+    end
+
+    it 'proofs and hands off to mobile', js: true do
+      user = nil
+
+      perform_in_browser(:desktop) do
+        user = sign_in_and_2fa_user
+        complete_doc_auth_steps_before_send_link_step
+        fill_in :doc_auth_phone, with: '415-555-0199'
+        click_idv_continue
+
+        expect(page).to have_content(t('doc_auth.headings.text_message'))
+      end
+
+      expect(@sms_link).to be_present
+
+      perform_in_browser(:mobile) do
+        visit @sms_link
+        attach_and_submit_images
+        expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+      end
+
+      perform_in_browser(:desktop) do
+        expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
+        expect(page).to have_current_path(idv_ssn_path)
+        
+        fill_out_ssn_form_ok
+        click_idv_continue
+
+        expect(page).to have_content(t('headings.verify'))
+        click_idv_continue
+
+        fill_out_phone_form_ok
+        verify_phone_otp
+
+        fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
+        click_idv_continue
+
+        acknowledge_and_confirm_personal_key
+
+        expect(page).to have_current_path(account_path)
+        expect(page).to have_content(t('headings.account.verified_account'))
+      end
+    end
+  end
+
   it 'shows the waiting screen correctly after cancelling from mobile and restarting', js: true do
     user = nil
 

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -88,7 +88,7 @@ describe 'Hybrid Flow' do
       perform_in_browser(:desktop) do
         expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
         expect(page).to have_current_path(idv_ssn_path)
-        
+
         fill_out_ssn_form_ok
         click_idv_continue
 


### PR DESCRIPTION
## 🎫 Ticket

LG-9025

## 🛠 Summary of changes

From the DocumentCaptureStep, we only want to redirect to the new SsnController if we are in the DocAuthFlow. This step is reused from the Hybrid Flow, and we don't want to go to the SsnController on mobile. In hybrid flow, we don't return to the DocumentCaptureStep, so redirect to SsnController from LinkSentStep when the feature flag is true as well.

Duplicate the hybrid flow test with doc_auth_ssn_controller_enabled flag set to true and make sure it passes. Note that on my machine even on main without the feature flag I have to set a binding.pry and delay the mobile browser part of the test to get it to pass.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
