### PR TITLE
Remove email address from verification page for authention apps

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -315,7 +315,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def authenticator_view_data
     {
       two_factor_authentication_method: two_factor_authentication_method,
-      user_email: current_user.email_addresses.take.email,
     }.merge(generic_data)
   end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -89,7 +89,7 @@ class UserDecorator
       interval: IdentityConfig.store.totp_code_interval,
     }
     url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(
-      user.confirmed_email_addresses.take&.email,
+      EmailContext.new(user).last_sign_in_email_address.email,
     )
     qrcode = RQRCode::QRCode.new(url)
     qrcode.as_png(size: 240).to_data_url

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -12,10 +12,6 @@ class UserDecorator
     @user = user
   end
 
-  def email
-    user.email_addresses.take&.email
-  end
-
   def email_language_preference_description
     if I18n.locale_available?(user.email_language)
       # i18n-tasks-use t('account.email_language.name.en')
@@ -92,7 +88,9 @@ class UserDecorator
       digits: TwoFactorAuthenticatable::OTP_LENGTH,
       interval: IdentityConfig.store.totp_code_interval,
     }
-    url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(email)
+    url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(
+      user.confirmed_email_addresses.take&.email,
+    )
     qrcode = RQRCode::QRCode.new(url)
     qrcode.as_png(size: 240).to_data_url
   end

--- a/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
@@ -7,7 +7,6 @@ module TwoFactorAuthCode
     def help_text
       t(
         "instructions.mfa.#{two_factor_authentication_method}.confirm_code_html",
-        email: content_tag(:strong, user_email),
         app_name: content_tag(:strong, APP_NAME),
       )
     end
@@ -26,6 +25,6 @@ module TwoFactorAuthCode
 
     private
 
-    attr_reader :user_email, :two_factor_authentication_method, :phone_enabled
+    attr_reader :two_factor_authentication_method
   end
 end

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -20,7 +20,7 @@ en:
       authenticator:
         confirm_code_html: Enter the code from your authenticator app. If you have
           several accounts set up in your app, enter the code corresponding to
-          %{email} at %{app_name}.
+          %{app_name}.
         manual_entry: Or enter this code manually into your authentication app
       piv_cac:
         account_not_found_html: '<p><strong>%{sign_in}</strong> with your email address

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -22,7 +22,7 @@ es:
       authenticator:
         confirm_code_html: Ingrese el código de su app de autenticación. Si tiene varias
           cuentas configuradas en su app, ingrese el código correspondiente a
-          %{email} en %{app_name}.
+          %{app_name}.
         manual_entry: O ingrese este código manualmente en su aplicación de autenticación
       piv_cac:
         account_not_found_html: '<p><strong>%{sign_in}</strong> con su dirección de

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -24,8 +24,7 @@ fr:
       authenticator:
         confirm_code_html: Entrez le code à partir de votre application
           d’authentification. Si vous avez plusieurs comptes configurés dans
-          votre application, entrez le code correspondant à %{email} à
-          %{app_name}.
+          votre application, entrez le code correspondant à %{app_name}.
         manual_entry: Ou entrez ce code manuellement dans votre application
           d’authentification
       piv_cac:

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -15,7 +15,7 @@ describe Users::TotpSetupController, devise: true do
     context 'user is setting up authenticator app after account creation' do
       before do
         stub_analytics
-        user = build(:user, :signed_up, :with_phone, with: { phone: '703-555-1212' })
+        user = create(:user, :signed_up, :with_phone, with: { phone: '703-555-1212' })
         stub_sign_in(user)
         allow(@analytics).to receive(:track_event)
         get :new
@@ -49,8 +49,9 @@ describe Users::TotpSetupController, devise: true do
 
     context 'user is setting up authenticator app during account creation' do
       before do
+        user = create(:user)
         stub_analytics
-        stub_sign_in_before_2fa
+        stub_sign_in_before_2fa(user)
         allow(@analytics).to receive(:track_event)
         get :new
       end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -6,7 +6,7 @@ describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
 
   let(:user_email) { 'user@example.com' }
   let(:reauthn) {}
-  let(:presenter) { presenter_with(reauthn: reauthn, user_email: user_email) }
+  let(:presenter) { presenter_with(reauthn: reauthn) }
 
   let(:allow_user_to_switch_method) { false }
   let(:phishing_resistant_required) { true }

--- a/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
@@ -5,8 +5,6 @@ describe 'two_factor_authentication/totp_verification/show.html.erb' do
   let(:presenter_data) do
     attributes_for(:generic_otp_presenter).merge(
       two_factor_authentication_method: 'authenticator',
-      user_email: view.current_user.email,
-      phone_enabled: TwoFactorAuthentication::PhonePolicy.new(user).enabled?,
     )
   end
 
@@ -35,7 +33,7 @@ describe 'two_factor_authentication/totp_verification/show.html.erb' do
 
   it 'shows the correct help text' do
     expect(rendered).to have_content 'Enter the code from your authenticator app.'
-    expect(rendered).to have_content "enter the code corresponding to #{user.email}"
+    expect(rendered).to have_content "enter the code corresponding to #{APP_NAME}"
   end
 
   it 'allows the user to fallback to SMS and voice' do


### PR DESCRIPTION
## 🛠 Summary of changes

Following the work in #7868  and #7869 and a brief discussion in [Slack](https://gsa-tts.slack.com/archives/C01710KMYUB/p1677081279781629), this PR removes the email from the TOTP QR code provisioning URI and the verification page.

The provisioning URI is not quite reliable, as not all authentication apps were able to process it, and it sometimes resulted in showing only the email address without any mention of Login.gov. Accounts can have multiple email addresses and email addresses may change, so the email address that the authentication app was provisioned with may not match the email displayed on the verification page.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
