### PR TITLE
LG-8910 Remove the 404 from the SSN controller

### DIFF
--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -5,7 +5,6 @@ module Idv
     include StepUtilitiesConcern
     include Steps::ThreatMetrixStepHelper
 
-    before_action :render_404_if_ssn_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_pii_from_doc
 
@@ -52,10 +51,6 @@ module Idv
     end
 
     private
-
-    def render_404_if_ssn_controller_disabled
-      render_not_found unless IdentityConfig.store.doc_auth_ssn_controller_enabled
-    end
 
     def analytics_arguments
       {

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -15,16 +15,12 @@ describe Idv::SsnController do
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)
+    stub_analytics
+    stub_attempts_tracker
+    allow(@analytics).to receive(:track_event)
   end
 
   describe 'before_actions' do
-    it 'checks that feature flag is enabled' do
-      expect(subject).to have_actions(
-        :before,
-        :render_404_if_ssn_controller_disabled,
-      )
-    end
-
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
         :before,
@@ -40,17 +36,44 @@ describe Idv::SsnController do
     end
   end
 
-  context 'when doc_auth_ssn_controller_enabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_ssn_controller_enabled).
-        and_return(true)
-      stub_analytics
-      stub_attempts_tracker
-      allow(@analytics).to receive(:track_event)
+  describe '#show' do
+    let(:analytics_name) { 'IdV: doc auth ssn visited' }
+    let(:analytics_args) do
+      {
+        analytics_id: 'Doc Auth',
+        flow_path: 'standard',
+        irs_reproofing: false,
+        step: 'ssn',
+        step_count: 1,
+      }
     end
 
-    describe '#show' do
-      let(:analytics_name) { 'IdV: doc auth ssn visited' }
+    it 'renders the show template' do
+      get :show
+
+      expect(response).to render_template :show
+    end
+
+    it 'sends analytics_visited event' do
+      get :show
+
+      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+    end
+
+    it 'sends correct step count to analytics' do
+      get :show
+      get :show
+      analytics_args[:step_count] = 2
+
+      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+    end
+  end
+
+  describe '#update' do
+    context 'with valid ssn' do
+      let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
+      let(:params) { { doc_auth: { ssn: ssn } } }
+      let(:analytics_name) { 'IdV: doc auth ssn submitted' }
       let(:analytics_args) do
         {
           analytics_id: 'Doc Auth',
@@ -61,115 +84,58 @@ describe Idv::SsnController do
         }
       end
 
-      context 'when doc_auth_ssn_controller_enabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:doc_auth_ssn_controller_enabled).
-            and_return(true)
-        end
+      it 'merges ssn into pii session value' do
+        put :update, params: params
 
-        it 'renders the show template' do
-          get :show
-
-          expect(response).to render_template :show
-        end
-
-        it 'sends analytics_visited event' do
-          get :show
-
-          expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-        end
-
-        it 'sends correct step count to analytics' do
-          get :show
-          get :show
-          analytics_args[:step_count] = 2
-
-          expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-        end
+        expect(flow_session['pii_from_doc'][:ssn]).to eq(ssn)
       end
-    end
 
-    describe '#update' do
-      context 'with valid ssn' do
-        let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
-        let(:params) { { doc_auth: { ssn: ssn } } }
-        let(:analytics_name) { 'IdV: doc auth ssn submitted' }
-        let(:analytics_args) do
-          {
-            analytics_id: 'Doc Auth',
-            flow_path: 'standard',
-            irs_reproofing: false,
-            step: 'ssn',
-            step_count: 1,
-          }
-        end
+      it 'sends analytics_submitted event with correct step count' do
+        get :show
+        put :update, params: params
 
-        it 'merges ssn into pii session value' do
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      it 'logs attempts api event' do
+        expect(@irs_attempts_api_tracker).to receive(:idv_ssn_submitted).with(
+          ssn: ssn,
+        )
+        put :update, params: params
+      end
+
+      context 'with existing session applicant' do
+        it 'clears applicant' do
+          subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT
+
           put :update, params: params
 
-          expect(flow_session['pii_from_doc'][:ssn]).to eq(ssn)
-        end
-
-        it 'sends analytics_submitted event with correct step count' do
-          get :show
-          put :update, params: params
-
-          expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-        end
-
-        it 'logs attempts api event' do
-          expect(@irs_attempts_api_tracker).to receive(:idv_ssn_submitted).with(
-            ssn: ssn,
-          )
-          put :update, params: params
-        end
-
-        context 'with existing session applicant' do
-          it 'clears applicant' do
-            subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT
-
-            put :update, params: params
-
-            expect(subject.idv_session.applicant).to be_blank
-          end
-        end
-
-        it 'adds a threatmetrix session id to flow session' do
-          subject.extra_view_variables
-          expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
-        end
-
-        it 'does not change threatmetrix_session_id when updating ssn' do
-          flow_session['pii_from_doc'][:ssn] = ssn
-          put :update, params: params
-          session_id = flow_session[:threatmetrix_session_id]
-          subject.extra_view_variables
-          expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
+          expect(subject.idv_session.applicant).to be_blank
         end
       end
 
-      context 'when pii_from_doc is not present' do
-        it 'marks previous step as incomplete' do
-          flow_session.delete('pii_from_doc')
-          flow_session['Idv::Steps::DocumentCaptureStep'] = true
-          put :update
-          expect(flow_session['Idv::Steps::DocumentCaptureStep']).to eq nil
-          expect(response.status).to eq 302
-        end
+      it 'adds a threatmetrix session id to flow session' do
+        subject.extra_view_variables
+        expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
+      end
+
+      it 'does not change threatmetrix_session_id when updating ssn' do
+        flow_session['pii_from_doc'][:ssn] = ssn
+        put :update, params: params
+        session_id = flow_session[:threatmetrix_session_id]
+        subject.extra_view_variables
+        expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
       end
     end
-  end
 
-  context 'when doc_auth_ssn_controller_enabled is false' do
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_ssn_controller_enabled).
-        and_return(false)
-    end
-
-    it 'returns 404' do
-      get :show
-
-      expect(response.status).to eq(404)
+    context 'when pii_from_doc is not present' do
+      it 'marks previous step as incomplete' do
+        flow_session.delete('pii_from_doc')
+        flow_session['Idv::Steps::DocumentCaptureStep'] = true
+        put :update
+        expect(flow_session['Idv::Steps::DocumentCaptureStep']).to eq nil
+        expect(response.status).to eq 302
+      end
     end
   end
 end


### PR DESCRIPTION
This commit removes the 404 from the SSN controller. After this change users can use either the old path or the new path for entering their SSN. This enables continuity in the 50/50 state during deploys.
