### PR TITLE
Remove the ModuleLength rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -647,14 +647,6 @@ Metrics/BlockLength:
     - spec/**/*.rb
     - scripts/**/*
 
-Metrics/ModuleLength:
-  CountComments: false
-  Max: 200
-  Description: Avoid modules longer than 200 lines of code.
-  Enabled: true
-  Exclude:
-    - spec/**/*
-
 Metrics/ParameterLists:
   CountKeywordArgs: false
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -1,4 +1,4 @@
-module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
+module TwoFactorAuthenticatableMethods
   extend ActiveSupport::Concern
   include RememberDeviceConcern
   include SecureHeadersConcern

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module AnalyticsEvents
   # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
@@ -3545,4 +3544,3 @@ module AnalyticsEvents
     )
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module IrsAttemptsApi
   module TrackerEvents
     # @param [Boolean] success True if Account Successfully Deleted
@@ -692,4 +691,3 @@ module IrsAttemptsApi
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
There was an old PR that looks like it intended to remove this rule (ref: https://github.com/18F/identity-idp/pull/5135). It eneded up just moving it.

We have a number of modules that are over this length and I don't think it makes sense to enforce on modules and not other files.
