### PR TITLE
Rephrase Spanish OTP and confirmation code messages to stay in GSM 03.38

### DIFF
--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -7,7 +7,7 @@ es:
       %{app_name} para cancelar.
     authentication_otp:
       sms: |-
-        %{app_name}: El código de un solo uso es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+        %{app_name}: La contraseña es %{code}. Esta contraseña puede usarse una vez y se vence en %{expiration} minutos. No la comparta con nadie.
 
         @%{domain} #%{code}
       voice: ¡Hola! Su código único de seis %{format_type} de %{app_name} es %{code},
@@ -15,7 +15,7 @@ es:
         Este código expira en %{expiration} minutos.
     confirmation_otp:
       sms: |-
-        %{app_name}: El código de un solo uso es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+        %{app_name}: La contraseña es %{code}. Esta contraseña puede usarse una vez y se vence en %{expiration} minutos. No la comparta con nadie.
 
         @%{domain} #%{code}
       voice: ¡Hola! Su código único de seis %{format_type} de %{app_name} es %{code},

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -328,13 +328,12 @@ RSpec.describe Telephony::OtpSender do
         end
       end
 
-      # The Spanish-language translation currently includes the 'ó', character, which is not
-      # in the GSM 03.38 character set
       context 'Spanish' do
-        it 'is sent in three parts' do
+        it 'does not contain any non-GSM characters and is less than or equal to 160 characters' do
           I18n.locale = :es
 
-          expect(Telephony.sms_parts(message)).to eq 3
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         ensure
           I18n.locale = :en
         end
@@ -406,13 +405,12 @@ RSpec.describe Telephony::OtpSender do
         end
       end
 
-      # The Spanish-language translation currently includes the 'ó', character, which is not
-      # in the GSM 03.38 character set
       context 'Spanish' do
-        it 'is sent in three parts' do
+        it 'does not contain any non-GSM characters and is sent in one part' do
           I18n.locale = :es
 
-          expect(Telephony.sms_parts(message)).to eq 3
+          expect(Telephony.sms_parts(message)).to eq 1
+          expect(Telephony.gsm_chars_only?(message)).to eq true
         ensure
           I18n.locale = :en
         end


### PR DESCRIPTION
## 🛠 Summary of changes

The average parts per-message for messages sent to Mexico is 3:1.  Digging into the problem, I found that the current OTP and verification messages are the cause and it has everything to do with the word "código" (code) and specifically the character ó, which is not part of the GSM 03.38 character set.

This PR proposes a new set of messages that should still be clear to the user but do not trigger Unicode processing and stay under 1 part in size.

Current message:
* Encoding: Unicode
* SMS parts: 3
* Characters used: 145

Proposed message
* Encoding: 7bit
* SMS parts: 1
* Characters used: 151

This change should reduce spending on Spanish language SMS by over %60.

## 📜 Testing Plan

* [x] Deploy to sandbox
* [x] Test SMS using Spanish language
* [x] Verify that parts/message == 1 - Confirmed in sandbox that message was 2 parts due to longer FDQN but will fit in 1 for shorter FQDNs
* [x] Verify that message looks good!

## 👀 Screenshots

### Sample SMS

![image](https://user-images.githubusercontent.com/59626817/221956008-7a456710-c267-4ef6-866c-b4acdcd4cb1a.png)


### Comparison analysis

(Credit: https://messente.com/documentation/tools/sms-length-calculator)

Legend:
![image](https://user-images.githubusercontent.com/59626817/221059565-868f5d94-ca6d-4385-9721-322bcbb748cd.png)

Existing language breakdown (OTP):

![image](https://user-images.githubusercontent.com/59626817/221059845-667d2a50-ea9a-42f8-9fb2-370147f96b4a.png)


Proposed new language breakdown:

![image](https://user-images.githubusercontent.com/59626817/221059690-b44737a9-6c7a-404b-8f49-dbe8b7eefe9a.png)
