### PR TITLE
Add sent at timestamp to email footers

### DIFF
--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -152,6 +152,9 @@
                                                   style: 'text-decoration: underline;',
                                                 ).html_safe %>
                                           </p>
+                                          <p>
+                                            Sent at <%= Time.zone.now.iso8601(6) %>
+                                          </p>
                                         </th>
                                         <th class="expander"></th>
                                       </tr>

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -153,7 +153,7 @@
                                                 ).html_safe %>
                                           </p>
                                           <p>
-                                            Sent at <%= Time.zone.now.iso8601(6) %>
+                                            <%= t('mailer.sent_at', formatted_timestamp: Time.zone.now.iso8601(6)) %>
                                           </p>
                                         </th>
                                         <th class="expander"></th>

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -8,3 +8,4 @@ en:
     logo: '%{app_name} logo'
     no_reply: Please do not reply to this message.
     privacy_policy: Privacy policy
+    sent_at: Sent at %{formatted_timestamp}

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -8,3 +8,4 @@ es:
     logo: '%{app_name} logo'
     no_reply: Por favor, no responda a este mensaje.
     privacy_policy: Póliza de privacidad
+    sent_at: Sent at %{formatted_timestamp}

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -8,4 +8,4 @@ es:
     logo: '%{app_name} logo'
     no_reply: Por favor, no responda a este mensaje.
     privacy_policy: Póliza de privacidad
-    sent_at: Sent at %{formatted_timestamp}
+    sent_at: Enviado el %{formatted_timestamp}

--- a/config/locales/mailer/fr.yml
+++ b/config/locales/mailer/fr.yml
@@ -8,3 +8,4 @@ fr:
     logo: '%{app_name} logo'
     no_reply: Veuillez ne pas répondre à ce message.
     privacy_policy: Politique de confidentialité
+    sent_at: Sent at %{formatted_timestamp}

--- a/config/locales/mailer/fr.yml
+++ b/config/locales/mailer/fr.yml
@@ -8,4 +8,4 @@ fr:
     logo: '%{app_name} logo'
     no_reply: Veuillez ne pas répondre à ce message.
     privacy_policy: Politique de confidentialité
-    sent_at: Sent at %{formatted_timestamp}
+    sent_at: Envoyé le %{formatted_timestamp}


### PR DESCRIPTION
## 🛠 Summary of changes

We need our emails to have a bit of uniqueness to improve reliability of delivery, so this is a short fix to add a "sent at" timestamp to all emails.

Translations are incoming once content is approved.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
