### PR TITLE
Remove unused TwoFactorAuthenticatableMethods methods

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -309,10 +309,6 @@ module TwoFactorAuthenticatableMethods
     params&.dig(:otp_make_default_number)
   end
 
-  def account_reset_token
-    current_user&.account_reset_request&.request_token
-  end
-
   def authenticator_view_data
     {
       two_factor_authentication_method: two_factor_authentication_method,
@@ -331,15 +327,6 @@ module TwoFactorAuthenticatableMethods
       phone_configuration.masked_phone
     else
       user_session[:unconfirmed_phone]
-    end
-  end
-
-  def voice_otp_delivery_unsupported?
-    if UserSessionContext.authentication_or_reauthentication_context?(context)
-      PhoneNumberCapabilities.new(phone_configuration&.phone, phone_confirmed: true).supports_voice?
-    else
-      phone = user_session[:unconfirmed_phone]
-      PhoneNumberCapabilities.new(phone, phone_confirmed: false).supports_voice?
     end
   end
 

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -105,24 +105,4 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       expect(presenter.phone_call_text).to eq phone_call
     end
   end
-
-  def account_reset_cancel_link(account_reset_token)
-    I18n.t(
-      'two_factor_authentication.account_reset.pending_html', cancel_link:
-      view.link_to(
-        t('two_factor_authentication.account_reset.cancel_link'),
-        account_reset_cancel_url(token: account_reset_token),
-      )
-    )
-  end
-
-  def account_reset_delete_account_link
-    I18n.t(
-      'two_factor_authentication.account_reset.text_html', link:
-      view.link_to(
-        t('two_factor_authentication.account_reset.link'),
-        account_reset_recovery_options_path(locale: LinkLocaleResolver.locale),
-      )
-    )
-  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused methods `TwoFactorAuthenticatableMethods#voice_otp_delivery_unsupported?` and `TwoFactorAuthenticatableMethods#account_reset_token`, no longer referenced as of #7868 (see https://github.com/18F/identity-idp/pull/7868#discussion_r1117283184).

## 📜 Testing Plan

- `rspec`