### PR TITLE
LG-8985 Make "Pass" the default option for mock device profiling result

### DIFF
--- a/app/javascript/packs/mock-device-profiling.tsx
+++ b/app/javascript/packs/mock-device-profiling.tsx
@@ -79,10 +79,10 @@ function MockDeviceProfilingOptions() {
   const inputId = `select-input-${instanceId}`;
 
   const options = [
-    { value: 'no_result', title: 'No Result' },
     { value: 'pass', title: 'Pass' },
     { value: 'reject', title: 'Reject' },
     { value: 'review', title: 'Review' },
+    { value: 'no_result', title: 'No Result' },
     { value: 'chaotic', title: 'Do something chaotic' },
   ];
 


### PR DESCRIPTION
The mock device profiler simulates a tool that assesses device risk. This is specifically meant to simulate the way ThreatMetrix works in deployed environments in local development and sandbox environments.

In deployed environments javascript is added to the page to assess device risk. This javascript phones home to ThreatMetrix. When the user is submitting their information we make a request on the backend to ThreatMetrix for the result.

The ThreatMetrix javascript may be blocked by the client. In this case the backed result will contain a warning code with the value `smmry_unkwx_session`. The `review_status` field, which is ultimately what is used to determine whether the user is allowed to proof without further review, will have a value of `pass`, `review`, or `reject` depending on the configuration for this case.

We simulate this behavior by loading javascript that displays a dropdown that allows the user to select the result that will come from assessing their device. This value is saved and returned on a mocked backend request. To simulate the behavior when the Javascript is blocked we have a `No Result` option which results in the mocked result being null.

At one point we assumed that when a user's client blocks the javascript the result from ThreatMetrix would be null. This, however, is not the case. ThreatMetrix can still make a determination about the session if the Javascript is blocked. Receiving a value of `null` from Threatmetrix is an invalid state and should be considered an error state.

The "No Result" case, which should be an error state, is the default state in local dev and test environments. This means that people going through proofing fail by default for unclear reasons. This commit makes the default `Pass` so this no longer happens.
