### PR TITLE
Remove all of the temporary files that are created from the letter_opener gem when bin/setup is run.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -71,6 +71,8 @@ Dir.chdir APP_ROOT do
   run "rm -f log/*"
   run "rm -rf tmp/cache"
   run "rm -rf tmp/encrypted_doc_storage"
+  run "rm -rf tmp/letter_opener"
+  run "rm -rf tmp/mails"
 
   puts "\n== Restarting application server =="
   run "mkdir -p tmp"


### PR DESCRIPTION
Removes `tmp/letter_opener` and `tmp/mails` files when bin/setup is run to clean up old temporary files.
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
