### PR TITLE
Gyamada/lg 8861 usps locations are sorted

### DIFF
--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -17,6 +17,10 @@ module UspsInPersonProofing
         load_response_fixture('request_facilities_response.json')
       end
 
+      def self.request_facilities_response_with_unordered_distance
+        load_response_fixture('request_facilities_response_with_unordered_distance.json')
+      end
+
       def self.request_facilities_response_with_duplicates
         load_response_fixture('request_facilities_response_with_duplicates.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_facilities_response_with_unordered_distance.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_facilities_response_with_unordered_distance.json
@@ -1,0 +1,203 @@
+{
+    "postOffices": [
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "6.63 mi",
+        "streetAddress": "4750 J ST",
+        "city": "SACRAMENTO",
+        "phone": "916-227-6503",
+        "name": "CAMELLIA",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95819"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "3.87 mi",
+        "streetAddress": "660 J ST STE 170",
+        "city": "SACRAMENTO",
+        "phone": "916-498-9145",
+        "name": "DOWNTOWN PLAZA",
+        "zip4": "9996",
+        "state": "CA",
+        "zip5": "95814"
+      },
+      {
+        "parking": "Street",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "0.05 mi",
+        "streetAddress": "3775 INDUSTRIAL BLVD",
+        "city": "WEST SACRAMENTO",
+        "phone": "916-556-3406",
+        "name": "INDUSTRIAL WEST SACRAMENTO",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95799"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "4.53 mi",
+        "streetAddress": "2121 BROADWAY",
+        "city": "SACRAMENTO",
+        "name": "BROADWAY",
+        "phone": "916-227-6503",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95818"
+      },
+      {
+        "parking": "Street",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "2.77 mi",
+        "streetAddress": "900 SACRAMENTO AVE",
+        "city": "WEST SACRAMENTO",
+        "phone": "916-556-3406",
+        "name": "BRODERICK",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95605"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "5.33 mi",
+        "streetAddress": "1618 ALHAMBRA BLVD",
+        "city": "SACRAMENTO",
+        "phone": "916-227-6503",
+        "name": "FORT SUTTER",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95816"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "4.55 mi",
+        "streetAddress": "5930 S LAND PARK DR",
+        "city": "SACRAMENTO",
+        "phone": "916-262-3107",
+        "name": "LAND PARK",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95822"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 6:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 3:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "5.49 mi",
+        "streetAddress": "2929 35TH ST",
+        "city": "SACRAMENTO",
+        "phone": "916-227-6509",
+        "name": "OAK PARK",
+        "zip4": "9998",
+        "state": "CA",
+        "zip5": "95817"
+      },
+      {
+        "parking": "Lot",
+        "hours": [
+          {
+            "weekdayHours": "9:00 AM - 5:00 PM"
+          },
+          {
+            "saturdayHours": "9:00 AM - 5:00 PM"
+          },
+          {
+            "sundayHours": "Closed"
+          }
+        ],
+        "distance": "2.22 mi",
+        "streetAddress": "1601 MERKLEY AVE",
+        "city": "WEST SACRAMENTO",
+        "name": "WEST SACRAMENTO",
+        "phone": "916-556-3406",
+        "state": "CA",
+        "zip4": "9998",
+        "zip5": "95691"
+      }
+    ]
+  }
+  

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -24,8 +24,8 @@ module UspsInPersonProofing
       end.body
 
       facilities = parse_facilities(response)
-      sorted_facilities = sort_by_ascending_distance(facilities)
-      dedupe_facilities(sorted_facilities)
+      dedupe_facilities = dedupe_facilities(facilities)
+      sort_by_ascending_distance(dedupe_facilities)
     end
 
     # Temporary function to return a static set of facilities
@@ -233,7 +233,7 @@ module UspsInPersonProofing
     end
 
     def sort_by_ascending_distance(facilities)
-      facilities.sort_by { |f| f[:distance].delete_suffix(' mi').to_f }
+      facilities.sort_by { |f| f[:distance].to_f }
     end
   end
 end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -24,7 +24,8 @@ module UspsInPersonProofing
       end.body
 
       facilities = parse_facilities(response)
-      dedupe_facilities(facilities)
+      sorted_facilities = sort_by_ascending_distance(facilities)
+      dedupe_facilities(sorted_facilities)
     end
 
     # Temporary function to return a static set of facilities
@@ -229,6 +230,10 @@ module UspsInPersonProofing
       facilities.uniq do |facility|
         [facility.address, facility.city, facility.state, facility.zip_code_5]
       end
+    end
+
+    def sort_by_ascending_distance(facilities)
+      facilities.sort_by { |f | f[:distance].delete_suffix(' mi').to_f }
     end
   end
 end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -233,7 +233,7 @@ module UspsInPersonProofing
     end
 
     def sort_by_ascending_distance(facilities)
-      facilities.sort_by { |f | f[:distance].delete_suffix(' mi').to_f }
+      facilities.sort_by { |f| f[:distance].delete_suffix(' mi').to_f }
     end
   end
 end

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -161,10 +161,22 @@ RSpec.describe UspsInPersonProofing::Proofer do
         check_facility(facilities[0])
       end
 
+      it 'returns facilities sorted by ascending distance' do
+        stub_request_facilities_with_unorderd_distance
+        facilities = subject.request_facilities(location)
+
+        previous_post_office_distance = 0
+        facilities.count do |post_office|
+          current_distance = post_office.distance.delete_suffix(' mi').to_f
+          expect(previous_post_office_distance).to be <= current_distance
+          previous_post_office_distance = current_distance
+        end
+      end
+
       it 'does not return duplicates' do
         stub_request_facilities_with_duplicates
         facilities = subject.request_facilities(location)
-
+        
         expect(facilities.length).to eq(9)
         expect(
           facilities.count do |post_office|

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -165,11 +165,9 @@ RSpec.describe UspsInPersonProofing::Proofer do
         stub_request_facilities_with_unorderd_distance
         facilities = subject.request_facilities(location)
 
-        previous_post_office_distance = 0
-        facilities.count do |post_office|
-          current_distance = post_office.distance.delete_suffix(' mi').to_f
-          expect(previous_post_office_distance).to be <= current_distance
-          previous_post_office_distance = current_distance
+        expect(facilities.count).to be > 1
+        facilities.each_cons(2) do |facility_a, facility_b|
+          expect(facility_a.distance).to be <= facility_b.distance
         end
       end
 

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
       it 'does not return duplicates' do
         stub_request_facilities_with_duplicates
         facilities = subject.request_facilities(location)
-        
+
         expect(facilities.length).to eq(9)
         expect(
           facilities.count do |post_office|

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
       end
 
       it 'returns facilities sorted by ascending distance' do
-        stub_request_facilities_with_unorderd_distance
+        stub_request_facilities_with_unordered_distance
         facilities = subject.request_facilities(location)
 
         expect(facilities.count).to be > 1

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -23,7 +23,7 @@ module UspsIppHelper
     )
   end
 
-  def stub_request_facilities_with_unorderd_distance
+  def stub_request_facilities_with_unordered_distance
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
       status: 200,
       body:

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -26,7 +26,8 @@ module UspsIppHelper
   def stub_request_facilities_with_unorderd_distance
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
       status: 200,
-      body: UspsInPersonProofing::Mock::Fixtures.request_facilities_response_with_unordered_distance,
+      body:
+        UspsInPersonProofing::Mock::Fixtures.request_facilities_response_with_unordered_distance,
       headers: { 'content-type' => 'application/json' },
     )
   end

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -23,6 +23,14 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_facilities_with_unorderd_distance
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::Fixtures.request_facilities_response_with_unordered_distance,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_facilities_with_duplicates
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
       status: 200,


### PR DESCRIPTION
## 🎫 Ticket
[LG-8861](https://cm-jira.usa.gov/browse/LG-8861)

## 🛠 Summary of changes
- Sort USPS facilities by ascending distance from the user's address
- Added a tests to check the order

## Question for invidual doing review
- Best not to assume API will always return a distance?  I can add a ternary and +1000 for the else which will move any facilities without a distance to the bottom of the list. 
Current:    facilities.sort_by { |f| f[:distance].delete_suffix(' mi').to_f } 
Thoughts: facilities.sort_by { |s | s[:distance] ? s[:distance].delete_suffix(' mi').to_f : +1000 }

## 📜 Testing Plan
Provide a checklist of steps to confirm the changes.
- [ ] Run tests in path/file: `spec/services/usps_in_person_proofing/proofer_spec.rb`
- [ ] Locally, set `arcgis_search_enabled` to` false` inside `config/application.yml`. Run through flow described above (It looks like the list is coming from ipp_pilot_usps_facitilites.json.  All of the distances are null and my code is not breaking.)
- [ ] Locally, set `arcgis_search_enabled` to `true` inside `config/application.yml`. Edit the location distances in `request_faciltities_response.json` to be out of order. Run through flow described below.

Flow:
1. Go to `/verify/doc_auth/welcome`
2. Get started verifying your identify flow
3. Upload .yml files to fail ID verification
4. Click Try in person button
5. Type in a few characters for Enter an address to find a Post Office near you on `verify/doc_auth/document_capture#location`
4.  When taken to `/verify/doc_auth/document_capture#location` you should have ordered list

## 👀 Screenshots
Test Results for spec/services/usps_in_person_proofing/proofer_spec.rb 
<img width="534" alt="Screenshot 2023-02-27 at 3 04 04 PM" src="https://user-images.githubusercontent.com/125507397/221714717-020dafa4-3880-4a69-957c-1c5414d527fa.png">

My branch returned 3 different failure results so I ran the pipeline on Gitlab.
run 1: 7776 examples, 1022 failures, 7 pending
run 2: 7776 examples, 1068 failures, 7 pending
run 3: 7776 examples, 1042 failures, 7 pending
Pipeline Results on GitLab
![Screenshot 2023-02-27 at 4 32 09 PM](https://user-images.githubusercontent.com/125507397/221714655-ca96a1e0-3158-4456-9ad3-e8469b50b2fd.png)





