### PR TITLE
Guard against a nil flow sesison in the step utilities concern

### DIFF
--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -12,7 +12,7 @@ module Idv
     end
 
     def confirm_pii_from_doc
-      @pii = flow_session['pii_from_doc'] # hash with indifferent access
+      @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
       return if @pii.present?
       flow_session.delete('Idv::Steps::DocumentCaptureStep')
       redirect_to idv_doc_auth_url


### PR DESCRIPTION
A nil flow session here can result in a 500 if the user navigates to the SSN or address path without starting proofing
