### PR TITLE
If user goes directly to identity proofing, redirect to welcome screen

### DIFF
--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -14,7 +14,7 @@ module Idv
     def confirm_pii_from_doc
       @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
       return if @pii.present?
-      flow_session.delete('Idv::Steps::DocumentCaptureStep')
+      flow_session&.delete('Idv::Steps::DocumentCaptureStep')
       redirect_to idv_doc_auth_url
     end
 

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -67,6 +67,15 @@ describe Idv::SsnController do
 
       expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
     end
+
+    context 'without a flow session' do
+      let(:flow_session) { nil }
+      it 'redirects to doc_auth' do
+        get :show
+
+        expect(response).to redirect_to(idv_doc_auth_url)
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes

We were getting a 500 if the user creates an account and then redirects to /verify/verify_info, since it tried to go to ssn_controller, which expected the flow session to exist.

changelog: Bug Fixes, Identity Verification, SSN step redirects to Welcome Step without a flow session

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
