### PR TITLE
Enforce SSN form submission in the ssn controller

### DIFF
--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -24,22 +24,21 @@ module Idv
       @error_message = nil
       form_response = form_submit
 
-      unless form_response.success?
-        @error_message = form_response.first_error_message
-        redirect_to idv_ssn_url
-      end
-
-      flow_session['pii_from_doc'][:ssn] = params[:doc_auth][:ssn]
-
-      analytics.idv_doc_auth_ssn_submitted(**analytics_arguments)
-
+      analytics.idv_doc_auth_ssn_submitted(
+        **analytics_arguments.merge(form_response.to_h),
+      )
       irs_attempts_api_tracker.idv_ssn_submitted(
         ssn: params[:doc_auth][:ssn],
       )
 
-      idv_session.invalidate_steps_after_ssn!
-
-      redirect_to idv_verify_info_url
+      if form_response.success?
+        flow_session['pii_from_doc'][:ssn] = params[:doc_auth][:ssn]
+        idv_session.invalidate_steps_after_ssn!
+        redirect_to idv_verify_info_url
+      else
+        @error_message = form_response.first_error_message
+        render :show, locals: extra_view_variables
+      end
     end
 
     def extra_view_variables

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -81,6 +81,9 @@ describe Idv::SsnController do
           irs_reproofing: false,
           step: 'ssn',
           step_count: 1,
+          success: true,
+          errors: {},
+          pii_like_keypaths: [[:errors, :ssn], [:error_details, :ssn]],
         }
       end
 
@@ -125,6 +128,37 @@ describe Idv::SsnController do
         session_id = flow_session[:threatmetrix_session_id]
         subject.extra_view_variables
         expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
+      end
+    end
+
+    context 'with invalid ssn' do
+      let(:ssn) { 'i am not an ssn' }
+      let(:params) { { doc_auth: { ssn: ssn } } }
+      let(:analytics_name) { 'IdV: doc auth ssn submitted' }
+      let(:analytics_args) do
+        {
+          analytics_id: 'Doc Auth',
+          flow_path: 'standard',
+          irs_reproofing: false,
+          step: 'ssn',
+          step_count: 0,
+          success: false,
+          errors: {
+            ssn: [t('idv.errors.pattern_mismatch.ssn')],
+          },
+          error_details: { ssn: [:invalid] },
+          pii_like_keypaths: [[:errors, :ssn], [:error_details, :ssn]],
+        }
+      end
+
+      render_views
+
+      it 'renders the show template with an error message' do
+        put :update, params: params
+
+        expect(response).to have_rendered(:show)
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+        expect(response.body).to include(t('idv.errors.pattern_mismatch.ssn'))
       end
     end
 


### PR DESCRIPTION
Prior to this commit the SSN controller submitted the SSN form but did not take any action on the result if it was unsuccessful. This commit changes the logic so the page is rendered with an error in that case.

Prior to this change the user would fail downstream on resolution. A frontend validation should prevent this from occurring with frequency.
