### PR TITLE
Handle address line 2 coming from Acuant

### DIFF
--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -20,7 +20,7 @@ module DocAuth
 
       def initialize(id_data_fields)
         @name_to_value = {}
-        id_data_fields['Fields']&.each do |field|
+        id_data_fields['Fields'].each do |field|
           @name_to_value[field['Name']] = field['Value']
         end
       end

--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -6,6 +6,7 @@ module DocAuth
         'Middle Name' => :middle_name,
         'Surname' => :last_name,
         'Address Line 1' => :address1,
+        'Address Line 2' => :address2,
         'Address City' => :city,
         'Address State' => :state,
         'Address Postal Code' => :zipcode,

--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -20,7 +20,7 @@ module DocAuth
 
       def initialize(id_data_fields)
         @name_to_value = {}
-        id_data_fields['Fields'].each do |field|
+        id_data_fields['Fields']&.each do |field|
           @name_to_value[field['Name']] = field['Value']
         end
       end

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -54,6 +54,7 @@ module DocAuth
           alerts = processed_alerts
 
           log_alert_formatter = DocAuth::ProcessedAlertToLogAlertFormatter.new
+
           {
             vendor: 'Acuant',
             billed: result_code.billed,
@@ -64,6 +65,7 @@ module DocAuth
             image_metrics: processed_image_metrics,
             tamper_result: tamper_result_code&.name,
             classification_info: classification_info,
+            address_line2_present: !pii_from_doc[:address2].blank?,
           }
         end
 

--- a/spec/fixtures/acuant_responses/get_results_response_success.json
+++ b/spec/fixtures/acuant_responses/get_results_response_success.json
@@ -607,6 +607,24 @@
     },
     {
       "DataSource": 2,
+      "Description": "Second address line of the person's legal, residence, or mailing address",
+      "Id": "645d1c0a-eac9-4d21-a308-430205a7a49a",
+      "IsImage": false,
+      "Key": "2D Address Line 2",
+      "Name": "Address Line 2",
+      "RegionOfInterest": {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0
+      },
+      "RegionReference": "00000000-0000-0000-0000-000000000000",
+      "Reliability": 0.98,
+      "Type": "string",
+      "Value": "APT E"
+    },
+    {
+      "DataSource": 2,
       "Description": "Postal code of the person's address",
       "Id": "208d17a8-6056-4ccf-b89d-b904c27e50c1",
       "IsImage": false,
@@ -1171,7 +1189,7 @@
       "Name": "Address",
       "RegionReference": "00000000-0000-0000-0000-000000000000",
       "Type": "string",
-      "Value": "1000 E AVENUE EBISMARCK, ND 58501"
+      "Value": "1000 E AVENUE E APT E BISMARCK, ND 58501"
     },
     {
       "DataFieldReferences": [
@@ -1200,6 +1218,20 @@
       "RegionReference": "00000000-0000-0000-0000-000000000000",
       "Type": "string",
       "Value": "1000 E AVENUE E"
+    },
+    {
+      "DataFieldReferences": [
+        "645d1c0a-eac9-4d21-a308-430205a7a49a"
+      ],
+      "DataSource": 2,
+      "Description": "Second address line of the person's legal, residence, or mailing address",
+      "Id": "f541c1cc-9f98-4131-a92b-0049b6126acd",
+      "IsImage": false,
+      "Key": "Address Line 2",
+      "Name": "Address Line 2",
+      "RegionReference": "00000000-0000-0000-0000-000000000000",
+      "Type": "string",
+      "Value": "APT E"
     },
     {
       "DataFieldReferences": [

--- a/spec/jobs/document_proofing_job_spec.rb
+++ b/spec/jobs/document_proofing_job_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe DocumentProofingJob, type: :job do
           exception: nil,
           tamper_result: nil,
           classification_info: nil,
+          address_line2_present: false,
         )
 
         expect(job_analytics).to have_logged_event(
@@ -151,6 +152,7 @@ RSpec.describe DocumentProofingJob, type: :job do
           flow_path: 'standard',
           log_alert_results: {},
           classification_info: nil,
+          address_line2_present: false,
         )
 
         expect(result.pii_from_doc).to eq(applicant_pii)

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -144,6 +144,33 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
 
         expect(result.success?).to eq(true)
       end
+      it 'notes that address line 2 was present' do
+        instance_id = 'this-is-a-test-instance-id'
+        url = URI.join(assure_id_url, "/AssureIDService/Document/#{instance_id}")
+        stub_request(:get, url).to_return(body: AcuantFixtures.get_results_response_success)
+
+        result = subject.get_results(instance_id: instance_id)
+
+        expect(result.extra).to include(address_line2_present: true)
+      end
+
+      context 'when there is no address line 2' do
+        it 'notes that address line 2 was not present' do
+          instance_id = 'this-is-a-test-instance-id'
+          url = URI.join(assure_id_url, "/AssureIDService/Document/#{instance_id}")
+          stub_request(:get, url).to_return(
+            body: begin
+              json = JSON.parse(AcuantFixtures.get_results_response_success)
+              json['Fields'] = json['Fields'].select { |f| f['Name'] != 'Address Line 2' }
+              JSON.generate(json)
+            end,
+          )
+
+          result = subject.get_results(instance_id: instance_id)
+
+          expect(result.extra).to include(address_line2_present: false)
+        end
+      end
     end
 
     context 'when the result is a failure' do

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -158,13 +158,10 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
         it 'notes that address line 2 was not present' do
           instance_id = 'this-is-a-test-instance-id'
           url = URI.join(assure_id_url, "/AssureIDService/Document/#{instance_id}")
-          stub_request(:get, url).to_return(
-            body: begin
-              json = JSON.parse(AcuantFixtures.get_results_response_success)
-              json['Fields'] = json['Fields'].select { |f| f['Name'] != 'Address Line 2' }
-              JSON.generate(json)
-            end,
-          )
+          body = JSON.parse(AcuantFixtures.get_results_response_success).tap do |json|
+            json['Fields'] = json['Fields'].select { |f| f['Name'] != 'Address Line 2' }
+          end.to_json
+          stub_request(:get, url).to_return(body: body)
 
           result = subject.get_results(instance_id: instance_id)
 

--- a/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
+++ b/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DocAuth::Acuant::PiiFromDoc do
         middle_name: nil,
         last_name: 'DOE',
         address1: '1000 E AVENUE E',
+        address2: 'APT E',
         city: 'BISMARCK',
         state: 'ND',
         zipcode: '58501',

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         body: {
           Result: 5,
           Alerts: alerts,
+          Fields: [],
         }.to_json,
       )
     end
@@ -271,6 +272,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
               { Result: 1, Key: 'Birth Date Valid' },
               { Result: 2, Key: 'Document Classification' },
             ],
+            Fields: [],
           }.to_json,
         )
       end
@@ -317,7 +319,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
     let(:http_response) do
       instance_double(
         Faraday::Response,
-        body: { Result: result, Alerts: alerts }.to_json,
+        body: { Result: result, Alerts: alerts, Fields: [] }.to_json,
       )
     end
 

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         middle_name: nil,
         last_name: 'DOE',
         address1: '1000 E AVENUE E',
+        address2: 'APT E',
         city: 'BISMARCK',
         state: 'ND',
         zipcode: '58501',

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
             'IssuerName' => 'North Dakota',
           },
         },
+        address_line2_present: true,
       }
 
       processed_alerts = response_hash[:processed_alerts]


### PR DESCRIPTION
## 🎫 Ticket

[LG-9040](https://cm-jira.usa.gov/browse/LG-9040)

## 🛠 Summary of changes

* Add _Address Line 2_ to `PiiFromDoc` we generate from Acuant responses
* Log whether or not an address line 2 was present in subsequent IdV-related events (new property is `address_line2_present`

