### PR TITLE
Remove build prestep from JavaScript Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,11 @@ public/packs/manifest.json: yarn.lock $(shell find app/javascript -type f) ## Bu
 
 test: export RAILS_ENV := test
 test: $(CONFIG) ## Runs RSpec and yarn tests in parallel
-	bundle exec rake parallel:spec && yarn build && yarn test
+	bundle exec rake parallel:spec && yarn test
 
 test_serial: export RAILS_ENV := test
 test_serial: $(CONFIG) ## Runs RSpec and yarn tests serially
-	bundle exec rake spec && yarn build && yarn test
+	bundle exec rake spec && yarn test
 
 fast_test: export RAILS_ENV := test
 fast_test: ## Abbreviated test run, runs RSpec tests without accessibility specs


### PR DESCRIPTION
## 🛠 Summary of changes

Avoids running unnecessary `yarn build` in `make test` before starting JavaScript tests. JavaScript tests should not require built assets.

Discovered while tracing `yarn build` usage for unrelated work.

## 📜 Testing Plan

- `make test`