### PR TITLE
Skip redundant delete and save of service provider authorization requests

### DIFF
--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,6 +7,8 @@ class ServiceProviderRequestHandler
   end
 
   def call
+    return if sp_url_stored_in_session == url
+
     pull_request_id_from_current_sp_session_id
 
     delete_sp_request_if_session_has_matching_request_id
@@ -34,8 +36,19 @@ class ServiceProviderRequestHandler
   end
 
   def sp_stored_in_session
+    return if service_provider_request_proxy.blank?
+    service_provider_request_proxy.issuer
+  end
+
+  def sp_url_stored_in_session
+    return if service_provider_request_proxy.blank?
+    service_provider_request_proxy.url
+  end
+
+  def service_provider_request_proxy
     return if sp_request_id.blank?
-    ServiceProviderRequestProxy.from_uuid(sp_request_id).issuer
+    return @service_provider_request_proxy if defined?(@service_provider_request_proxy)
+    @service_provider_request_proxy = ServiceProviderRequestProxy.from_uuid(sp_request_id)
   end
 
   def pull_request_id_from_current_sp_session_id

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -36,13 +36,11 @@ class ServiceProviderRequestHandler
   end
 
   def sp_stored_in_session
-    return if service_provider_request_proxy.blank?
-    service_provider_request_proxy.issuer
+    service_provider_request_proxy&.issuer
   end
 
   def sp_url_stored_in_session
-    return if service_provider_request_proxy.blank?
-    service_provider_request_proxy.url
+    service_provider_request_proxy&.url
   end
 
   def service_provider_request_proxy


### PR DESCRIPTION
## 🛠 Summary of changes

Currently we read, delete, and re-write Service Provider requests, but in my testing so far it seems redundant. The values are based on parsing the request URL, so we should be able to skip the delete and re-write if they are the same since we'd be deleting and re-writing with the same data.

There is more invasive work that we probably could do around being more precise around when we need to save to Redis and using the session as the primary store for SP requests.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
