### PR TITLE
LG-9016 Always show Address Line 2 field in Verify Info screen

### DIFF
--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -80,12 +80,10 @@ locals:
         <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= @pii[:address1] %> </dd>
       </div>
-      <% if @pii[:address2].present? %>
-        <div>
-          <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= @pii[:address2] %> </dd>
-        </div>
-      <% end %>
+      <div>
+        <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
+        <dd class="display-inline margin-left-0"> <%= @pii[:address2] if @pii[:address2].present? %> </dd>
+      </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
         <dd class="display-inline margin-left-0"> <%= @pii[:city] %> </dd>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -82,7 +82,7 @@ locals:
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:address2] if @pii[:address2].present? %> </dd>
+        <dd class="display-inline margin-left-0"> <%= @pii[:address2].presence %> </dd>
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -90,6 +90,25 @@ describe Idv::VerifyInfoController do
       )
     end
 
+    context 'address line 2' do
+      render_views
+
+      it 'With address2 in PII, shows address line 2 input' do
+        flow_session[:pii_from_doc][:address2] = 'APT 3E'
+        get :show
+
+        expect(response.body).to have_content(t('idv.form.address2'))
+      end
+
+      it 'No address2 in PII, still shows address line 2 input' do
+        flow_session[:pii_from_doc][:address2] = nil
+
+        get :show
+
+        expect(response.body).to have_content(t('idv.form.address2'))
+      end
+    end
+
     context 'when the user has already verified their info' do
       it 'redirects to the review controller' do
         controller.idv_session.profile_confirmation = true


### PR DESCRIPTION
## 🎫 Ticket
[LG-9016](https://cm-jira.usa.gov/browse/LG-9016)

## 🛠 Summary of changes
On Verify Info screen, show Address Line2 even if it is currently blank. This lets the user split their address into two lines if needed, e.g. with Puerto Rico urbanizations.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create an account
- [ ] Navigate to /verify
- [ ] Go through proofing, and confirm Verify Info page behaves correctly with and without an Address line 2
- [ ] Edit the address to add and remove Line 2

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
  
![Without Address LIne 2](https://user-images.githubusercontent.com/2381438/222535648-4af63428-4624-4596-889f-ab93323ac507.png)
</details>

<details>
<summary>After:</summary>
  

![With blank Address Line 2](https://user-images.githubusercontent.com/2381438/222535938-526f17ef-2f2f-4882-a400-05203bb98296.png)
</details>
