### PR TITLE
CL-8938 - fix idv_document_upload_submitted event

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -300,20 +300,20 @@ module Idv
       stored_image_result = store_encrypted_images_if_required
 
       irs_attempts_api_tracker.idv_document_upload_submitted(
-        success:                       response.success?,
-        document_state:                pii_from_doc[:state],
-        document_number:               pii_from_doc[:state_id_number],
-        document_issued:               pii_from_doc[:state_id_issued],
-        document_expiration:           pii_from_doc[:state_id_expiration],
+        success: response.success?,
+        document_state: pii_from_doc[:state],
+        document_number: pii_from_doc[:state_id_number],
+        document_issued: pii_from_doc[:state_id_issued],
+        document_expiration: pii_from_doc[:state_id_expiration],
         document_front_image_filename: stored_image_result&.front_filename,
-        document_back_image_filename:  stored_image_result&.back_filename,
+        document_back_image_filename: stored_image_result&.back_filename,
         document_image_encryption_key: stored_image_result&.encryption_key,
-        first_name:                    pii_from_doc[:first_name],
-        last_name:                     pii_from_doc[:last_name],
-        date_of_birth:                 pii_from_doc[:dob],
-        address:                       pii_from_doc[:address1],
-        failure_reason:                response.errors&.except(:hints)&.presence,
-        )
+        first_name: pii_from_doc[:first_name],
+        last_name: pii_from_doc[:last_name],
+        date_of_birth: pii_from_doc[:dob],
+        address: pii_from_doc[:address1],
+        failure_reason: response.errors&.except(:hints)&.presence,
+      )
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -34,11 +34,33 @@ module Idv
         doc_pii_response = validate_pii_from_doc(client_response) if client_response.success?
       end
 
-      determine_response(
+      response = determine_response(
         form_response: form_response,
         client_response: client_response,
         doc_pii_response: doc_pii_response,
       )
+
+      # move this into a lil method
+      pii_from_doc = response.pii_from_doc || {}
+      stored_image_result = store_encrypted_images_if_required
+
+      irs_attempts_api_tracker.idv_document_upload_submitted(
+        success: response.success?,
+        document_state: pii_from_doc[:state],
+        document_number: pii_from_doc[:state_id_number],
+        document_issued: pii_from_doc[:state_id_issued],
+        document_expiration: pii_from_doc[:state_id_expiration],
+        document_front_image_filename: stored_image_result&.front_filename,
+        document_back_image_filename: stored_image_result&.back_filename,
+        document_image_encryption_key: stored_image_result&.encryption_key,
+        first_name: pii_from_doc[:first_name],
+        last_name: pii_from_doc[:last_name],
+        date_of_birth: pii_from_doc[:dob],
+        address: pii_from_doc[:address1],
+        failure_reason: response.errors&.except(:hints)&.presence,
+        )
+
+      response
     end
 
     private
@@ -97,25 +119,6 @@ module Idv
       response.extra.merge!(extra_attributes)
 
       analytics.idv_doc_auth_submitted_pii_validation(**response.to_h)
-
-      pii_from_doc = response.pii_from_doc || {}
-      stored_image_result = store_encrypted_images_if_required
-
-      irs_attempts_api_tracker.idv_document_upload_submitted(
-        success: response.success?,
-        document_state: pii_from_doc[:state],
-        document_number: pii_from_doc[:state_id_number],
-        document_issued: pii_from_doc[:state_id_issued],
-        document_expiration: pii_from_doc[:state_id_expiration],
-        document_front_image_filename: stored_image_result&.front_filename,
-        document_back_image_filename: stored_image_result&.back_filename,
-        document_image_encryption_key: stored_image_result&.encryption_key,
-        first_name: pii_from_doc[:first_name],
-        last_name: pii_from_doc[:last_name],
-        date_of_birth: pii_from_doc[:dob],
-        address: pii_from_doc[:address1],
-        failure_reason: response.errors&.except(:hints)&.presence,
-      )
 
       store_pii(client_response) if client_response.success? && response.success?
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -40,25 +40,7 @@ module Idv
         doc_pii_response: doc_pii_response,
       )
 
-      # move this into a lil method
-      pii_from_doc = response.pii_from_doc || {}
-      stored_image_result = store_encrypted_images_if_required
-
-      irs_attempts_api_tracker.idv_document_upload_submitted(
-        success: response.success?,
-        document_state: pii_from_doc[:state],
-        document_number: pii_from_doc[:state_id_number],
-        document_issued: pii_from_doc[:state_id_issued],
-        document_expiration: pii_from_doc[:state_id_expiration],
-        document_front_image_filename: stored_image_result&.front_filename,
-        document_back_image_filename: stored_image_result&.back_filename,
-        document_image_encryption_key: stored_image_result&.encryption_key,
-        first_name: pii_from_doc[:first_name],
-        last_name: pii_from_doc[:last_name],
-        date_of_birth: pii_from_doc[:dob],
-        address: pii_from_doc[:address1],
-        failure_reason: response.errors&.except(:hints)&.presence,
-        )
+      track_event(response)
 
       response
     end
@@ -311,6 +293,27 @@ module Idv
         user: document_capture_session.user,
         throttle_type: :idv_doc_auth,
       )
+    end
+
+    def track_event(response)
+      pii_from_doc        = response.pii_from_doc || {}
+      stored_image_result = store_encrypted_images_if_required
+
+      irs_attempts_api_tracker.idv_document_upload_submitted(
+        success:                       response.success?,
+        document_state:                pii_from_doc[:state],
+        document_number:               pii_from_doc[:state_id_number],
+        document_issued:               pii_from_doc[:state_id_issued],
+        document_expiration:           pii_from_doc[:state_id_expiration],
+        document_front_image_filename: stored_image_result&.front_filename,
+        document_back_image_filename:  stored_image_result&.back_filename,
+        document_image_encryption_key: stored_image_result&.encryption_key,
+        first_name:                    pii_from_doc[:first_name],
+        last_name:                     pii_from_doc[:last_name],
+        date_of_birth:                 pii_from_doc[:dob],
+        address:                       pii_from_doc[:address1],
+        failure_reason:                response.errors&.except(:hints)&.presence,
+        )
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -296,7 +296,7 @@ module Idv
     end
 
     def track_event(response)
-      pii_from_doc        = response.pii_from_doc || {}
+      pii_from_doc = response.pii_from_doc || {}
       stored_image_result = store_encrypted_images_if_required
 
       irs_attempts_api_tracker.idv_document_upload_submitted(

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -73,7 +73,7 @@ describe Idv::ImageUploadsController do
           any_args,
         )
 
-        expect(@irs_attempts_api_tracker).not_to receive(:track_event).with(
+        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
           :idv_document_upload_submitted,
           any_args,
         )
@@ -129,9 +129,21 @@ describe Idv::ImageUploadsController do
           flow_path: 'standard',
         )
 
-        expect(@irs_attempts_api_tracker).not_to receive(:track_event).with(
+        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
           :idv_document_upload_submitted,
-          any_args,
+          { address: nil,
+            date_of_birth: nil,
+            document_back_image_filename: nil,
+            document_expiration: nil,
+            document_front_image_filename: nil,
+            document_image_encryption_key: nil,
+            document_issued: nil,
+            document_number: nil,
+            document_state: nil,
+            failure_reason: { front: ['The selection was not a valid file.'] },
+            first_name: nil,
+            last_name: nil,
+            success: false },
         )
 
         expect(@analytics).not_to receive(:track_event).with(
@@ -229,9 +241,27 @@ describe Idv::ImageUploadsController do
           flow_path: 'standard',
         )
 
-        expect(@irs_attempts_api_tracker).not_to receive(:track_event).with(
+        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
+          :idv_document_upload_rate_limited,
+        )
+
+        # This is the last upload which triggers the rate limit, apparently.
+        # I do find this moderately confusing.
+        expect(@irs_attempts_api_tracker).to receive(:track_event).with(
           :idv_document_upload_submitted,
-          any_args,
+          { address: nil,
+            date_of_birth: nil,
+            document_back_image_filename: nil,
+            document_expiration: nil,
+            document_front_image_filename: nil,
+            document_image_encryption_key: nil,
+            document_issued: nil,
+            document_number: nil,
+            document_state: nil,
+            failure_reason: { limit: ['We could not verify your ID'] },
+            first_name: nil,
+            last_name: nil,
+            success: false },
         )
 
         expect(@analytics).not_to receive(:track_event).with(


### PR DESCRIPTION
## 🎫 Ticket

Found while working on [LG-8938](https://cm-jira.usa.gov/browse/LG-8938).


## 🛠 Summary of changes
Currently, these events are only logging events that are the results of a _form validation_ failures, but not to vendor errors.

There are actually multiple forms so we missed some events.
