### PR TITLE
Remove unused `#alive?` method from the idv session

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -117,10 +117,6 @@ module Idv
       @gpo_otp = confirmation_maker.otp
     end
 
-    def alive?
-      session.present?
-    end
-
     def address_mechanism_chosen?
       vendor_phone_confirmation == true || address_verification_mechanism == 'gpo'
     end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -131,7 +131,6 @@ describe IdvController do
         get :activated
 
         expect(response).to render_template(:activated)
-        expect(subject.idv_session.alive?).to eq false
       end
     end
 


### PR DESCRIPTION
This method is not used at all, so I cleaned it up

[skip changelog]
