### PR TITLE
LG-8969: Update error content for po search

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -105,7 +105,7 @@ describe('InPersonLocationStep', () => {
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
 
-      const error = await findByText('idv.failure.exceptions.try_again');
+      const error = await findByText('idv.failure.exceptions.post_office_search_error');
       expect(error).to.exist();
     });
   });
@@ -134,7 +134,7 @@ describe('InPersonLocationStep', () => {
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
 
-      const error = await findByText('idv.failure.exceptions.try_again');
+      const error = await findByText('idv.failure.exceptions.post_office_search_error');
       expect(error).to.exist();
     });
   });

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -105,7 +105,7 @@ describe('InPersonLocationStep', () => {
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
 
-      const error = await findByText('idv.failure.exceptions.internal_error');
+      const error = await findByText('idv.failure.exceptions.try_again');
       expect(error).to.exist();
     });
   });
@@ -134,7 +134,7 @@ describe('InPersonLocationStep', () => {
         await findByText('in_person_proofing.body.location.po_search.search_button'),
       );
 
-      const error = await findByText('idv.failure.exceptions.internal_error');
+      const error = await findByText('idv.failure.exceptions.try_again');
       expect(error).to.exist();
     });
   });

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
@@ -91,7 +91,7 @@ function InPersonLocationPostOfficeSearchStep({ onChange, toPreviousStep, regist
     <>
       {apiError && (
         <Alert type="error" className="margin-bottom-4">
-          {t('idv.failure.exceptions.internal_error')}
+          {t('idv.failure.exceptions.try_again')}
         </Alert>
       )}
       <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
@@ -91,7 +91,7 @@ function InPersonLocationPostOfficeSearchStep({ onChange, toPreviousStep, regist
     <>
       {apiError && (
         <Alert type="error" className="margin-bottom-4">
-          {t('idv.failure.exceptions.try_again')}
+          {t('idv.failure.exceptions.post_office_search_error')}
         </Alert>
       )}
       <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -71,8 +71,8 @@ en:
       exceptions:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
-        text_html: Please try again. If you keep getting these errors, %{link}.
         post_office_search_error: We are having technical difficulties at the moment.  Try searching for a Post Office again. If this issue continues, come back later.
+        text_html: Please try again. If you keep getting these errors, %{link}.
       phone:
         fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,
           we limit the number of times you can attempt to verify your phone

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -71,7 +71,9 @@ en:
       exceptions:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
-        post_office_search_error: We are having technical difficulties at the moment.  Try searching for a Post Office again. If this issue continues, come back later.
+        post_office_search_error: We are having technical difficulties at the
+          moment.  Try searching for a Post Office again. If this issue
+          continues, come back later.
         text_html: Please try again. If you keep getting these errors, %{link}.
       phone:
         fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -72,7 +72,7 @@ en:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
         post_office_search_error: We are having technical difficulties at the
-          moment.  Try searching for a Post Office again. If this issue
+          moment. Try searching for a Post Office again. If this issue
           continues, come back later.
         text_html: Please try again. If you keep getting these errors, %{link}.
       phone:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -72,8 +72,7 @@ en:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
         text_html: Please try again. If you keep getting these errors, %{link}.
-        try_again: We are having technical difficulties at the moment.  Try searching
-          for a Post Office again. If this issue continues, come back later.
+        post_office_search_error: We are having technical difficulties at the moment.  Try searching for a Post Office again. If this issue continues, come back later.
       phone:
         fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,
           we limit the number of times you can attempt to verify your phone

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -71,9 +71,9 @@ en:
       exceptions:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
-        post_office_search_error: We are having technical difficulties at the
-          moment. Try searching for a Post Office again. If this issue
-          continues, come back later.
+        post_office_search_error: We are having technical difficulties at the moment.
+          Try searching for a Post Office again. If this issue continues, come
+          back later.
         text_html: Please try again. If you keep getting these errors, %{link}.
       phone:
         fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -72,6 +72,8 @@ en:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
         text_html: Please try again. If you keep getting these errors, %{link}.
+        try_again: We are having technical difficulties at the moment.  Try searching
+          for a Post Office again. If this issue continues, come back later.
       phone:
         fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,
           we limit the number of times you can attempt to verify your phone

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -76,8 +76,8 @@ es:
         internal_error: Se produjo un error interno al procesar tu solicitud. Por favor,
           inténtalo de nuevo.
         link: contáctanos
-        text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
         post_office_search_error: En este momento, estamos teniendo problemas técnicos. Trate de buscar de nuevo una oficina de correos. Si el problema continúa, regrese más tarde.
+        text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
       phone:
         fail_html: '<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong> Por su
           seguridad, limitamos el número de veces que puede intentar verificar

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -77,9 +77,7 @@ es:
           inténtalo de nuevo.
         link: contáctanos
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
-        try_again: En este momento, estamos teniendo problemas técnicos. Trate de buscar
-          de nuevo una oficina de correos. Si el problema continúa, regrese más
-          tarde.
+        post_office_search_error: En este momento, estamos teniendo problemas técnicos. Trate de buscar de nuevo una oficina de correos. Si el problema continúa, regrese más tarde.
       phone:
         fail_html: '<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong> Por su
           seguridad, limitamos el número de veces que puede intentar verificar

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -76,7 +76,9 @@ es:
         internal_error: Se produjo un error interno al procesar tu solicitud. Por favor,
           inténtalo de nuevo.
         link: contáctanos
-        post_office_search_error: En este momento, estamos teniendo problemas técnicos. Trate de buscar de nuevo una oficina de correos. Si el problema continúa, regrese más tarde.
+        post_office_search_error: En este momento, estamos teniendo problemas técnicos.
+          Trate de buscar de nuevo una oficina de correos. Si el problema
+          continúa, regrese más tarde.
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
       phone:
         fail_html: '<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong> Por su

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -77,6 +77,9 @@ es:
           inténtalo de nuevo.
         link: contáctanos
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
+        try_again: En este momento, estamos teniendo problemas técnicos. Trate de buscar
+          de nuevo una oficina de correos. Si el problema continúa, regrese más
+          tarde.
       phone:
         fail_html: '<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong> Por su
           seguridad, limitamos el número de veces que puede intentar verificar

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -81,9 +81,7 @@ fr:
           demande. Veuillez réessayer.
         link: contactez-nous
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
-        try_again: Nous connaissons des difficultés techniques en ce moment. Essayez de
-          chercher à nouveau un bureau de poste. Si le problème persiste,
-          revenez plus tard.
+        post_office_search_error: Nous connaissons des difficultés techniques en ce moment. Essayez de chercher à nouveau un bureau de poste. Si le problème persiste, revenez plus tard.
       phone:
         fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -80,8 +80,8 @@ fr:
         internal_error: Une erreur interne s’est produite lors du traitement de votre
           demande. Veuillez réessayer.
         link: contactez-nous
-        text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
         post_office_search_error: Nous connaissons des difficultés techniques en ce moment. Essayez de chercher à nouveau un bureau de poste. Si le problème persiste, revenez plus tard.
+        text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       phone:
         fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -80,7 +80,9 @@ fr:
         internal_error: Une erreur interne s’est produite lors du traitement de votre
           demande. Veuillez réessayer.
         link: contactez-nous
-        post_office_search_error: Nous connaissons des difficultés techniques en ce moment. Essayez de chercher à nouveau un bureau de poste. Si le problème persiste, revenez plus tard.
+        post_office_search_error: Nous connaissons des difficultés techniques en ce
+          moment. Essayez de chercher à nouveau un bureau de poste. Si le
+          problème persiste, revenez plus tard.
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       phone:
         fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -81,6 +81,9 @@ fr:
           demande. Veuillez réessayer.
         link: contactez-nous
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
+        try_again: Nous connaissons des difficultés techniques en ce moment. Essayez de
+          chercher à nouveau un bureau de poste. Si le problème persiste,
+          revenez plus tard.
       phone:
         fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
           sécurité, nous limitons le nombre de fois où vous pouvez tenter de


### PR DESCRIPTION
## 🎫 Ticket
[LG-8969](https://cm-jira.usa.gov/browse/LG-8969)

## 🛠 Summary of changes
- Update error content for PO search (in English, Spanish, and French)
- Update tests

## 📜 Testing Plan
- [ ]  Running locally, you can throw an error in this file & method: app/services/usps_in_person_proofing/mock/proofer.rb for method: request_facilities
- [ ] run `npm test app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx` - all 755 tests are passing (including the ones I edited- see screenshots in Files changed)

## Flow
Create an account or sign in
Go to /verify
Click Continue on verify/doc_auth/welcome
Check radio button and then Continue on /verify/doc_auth/agreement
Click upload from your computer on /verify/doc_auth/upload
Upload and Submit docs to fail ID verification
Click Try in person on /verify/doc_auth/document_capture
Enter any address in the input field and Search on /verify/doc_auth/document_capture#location

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before: There was an internal error processing your request. Please try again.</summary>

![Screenshot 2023-03-06 at 1 45 21 PM](https://user-images.githubusercontent.com/125507397/223226690-d95c51c3-4c96-4528-93c7-57696f5cbc3e.png)


</details>

<details>
<summary>After: We are having technical difficulties at the moment.  Try searching for a Post Office again. If this issue continues, come back later.</summary>

![Screenshot 2023-03-06 at 9 33 27 AM](https://user-images.githubusercontent.com/125507397/223188063-2e6cbfce-98ea-4b66-9f07-09a4873b7925.png)

![Screenshot 2023-03-06 at 9 34 40 AM](https://user-images.githubusercontent.com/125507397/223188128-089abdfa-b3b5-4414-8ec4-ed89c990bab1.png)

![Screenshot 2023-03-06 at 9 33 57 AM](https://user-images.githubusercontent.com/125507397/223188092-54ecc7e7-27ed-440c-9060-f7d162f2338e.png)
 
</details>

