### PR TITLE
LG-8930 VerifyInfo, show DOB with full month name

### DIFF
--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -55,7 +55,7 @@ locals:
       <div>
         <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
         <dd class="display-inline margin-left-0">
-          <%= DateParser.parse_legacy(@pii[:dob]).to_formatted_s(:long) %>
+          <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
         </dd>
       </div>
       <% if @in_person_proofing %>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -54,7 +54,9 @@ locals:
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:dob] %> </dd>
+        <dd class="display-inline margin-left-0">
+          <%= DateParser.parse_legacy(@pii[:dob]).to_formatted_s(:long) %>
+        </dd>
       </div>
       <% if @in_person_proofing %>
         <div>

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -42,6 +42,9 @@ feature 'doc auth verify_info step', :js do
     expect(page).to have_content(t('headings.verify'))
     expect(page).to have_content(t('step_indicator.flows.idv.verify_info'))
 
+    # DOB is in full month format (October)
+    expect(page).to have_text(t('date.month_names')[10])
+
     # SSN is masked until revealed
     expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
     expect(page).not_to have_text(DocAuthHelper::GOOD_SSN)

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true do
     expect(page).to have_content(t('headings.verify'))
     expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
     expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_DOB)
+    i18n_dob = I18n.l(
+      Date.parse(InPersonHelper::GOOD_DOB),
+      format: I18n.t('time.formats.event_date'),
+    )
+    expect(page).to have_text(i18n_dob)
     expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
     expect(page).to have_text(InPersonHelper::GOOD_ADDRESS1)
     expect(page).to have_text(InPersonHelper::GOOD_CITY)


### PR DESCRIPTION
## 🎫 Ticket

[LG-8930](https://cm-jira.usa.gov/browse/LG-8930)

## 🛠 Summary of changes

On Verifying Your Information screen, show Date of Birth in full month format. Use the same DateParser being used on Review and Account screens.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create an account
- [ ] Go through identity verification
- [ ] Note date of birth format on VerifyInfo screen.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
  
![Birthdate before](https://user-images.githubusercontent.com/2381438/223204751-0cbdbbf0-b5cb-4fef-84d0-0ff3c530953c.png)
</details>

<details>
<summary>After:</summary>
  
![Birthdate after](https://user-images.githubusercontent.com/2381438/223204785-b06b120e-cb0e-4fa5-8df6-57beb4d8eb21.png)
</details>
