### PR TITLE
Add `#confirm_address_step_complete` to the Idv Step Concern

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -7,4 +7,10 @@ module IdvStepConcern
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
   end
+
+  def confirm_address_step_complete
+    return if idv_session.address_step_complete?
+
+    redirect_to idv_otp_verification_path
+  end
 end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -8,7 +8,7 @@ module Idv
 
     before_action :confirm_idv_applicant_created
     before_action :confirm_idv_steps_complete
-    before_action :confirm_idv_phone_confirmed
+    before_action :confirm_address_step_complete
     before_action :confirm_current_password, only: [:create]
 
     rescue_from UspsInPersonProofing::Exception::RequestEnrollException,
@@ -16,13 +16,6 @@ module Idv
 
     def confirm_idv_steps_complete
       return redirect_to(idv_verify_info_url) unless idv_profile_complete?
-      return redirect_to(idv_phone_url) unless idv_address_complete?
-    end
-
-    def confirm_idv_phone_confirmed
-      return unless idv_session.address_verification_mechanism == 'phone'
-      return if idv_session.phone_confirmed?
-      redirect_to idv_otp_verification_path
     end
 
     def confirm_current_password

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -96,10 +96,6 @@ module Idv
       user_session.delete(:idv)
     end
 
-    def phone_confirmed?
-      vendor_phone_confirmation == true && user_phone_confirmation == true
-    end
-
     def associate_in_person_enrollment_with_profile
       return unless in_person_enrollment? && current_user.establishing_in_person_enrollment
       current_user.establishing_in_person_enrollment.update(profile: profile)
@@ -117,10 +113,6 @@ module Idv
       @gpo_otp = confirmation_maker.otp
     end
 
-    def address_mechanism_chosen?
-      vendor_phone_confirmation == true || address_verification_mechanism == 'gpo'
-    end
-
     def user_phone_confirmation_session
       session_value = session[:user_phone_confirmation_session]
       return if session_value.blank?
@@ -129,6 +121,22 @@ module Idv
 
     def user_phone_confirmation_session=(new_user_phone_confirmation_session)
       session[:user_phone_confirmation_session] = new_user_phone_confirmation_session.to_h
+    end
+
+    def address_step_complete?
+      if address_verification_mechanism == 'gpo'
+        true
+      else
+        phone_confirmed?
+      end
+    end
+
+    def address_mechanism_chosen?
+      vendor_phone_confirmation == true || address_verification_mechanism == 'gpo'
+    end
+
+    def phone_confirmed?
+      vendor_phone_confirmation == true && user_phone_confirmation == true
     end
 
     def invalidate_steps_after_ssn!

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -9,16 +9,16 @@ describe 'IdvStepConcern' do
   module Idv
     class StepController < ApplicationController
       include IdvStepConcern
+
+      def show
+        render plain: 'Hello'
+      end
     end
   end
 
   describe '#confirm_idv_needed' do
     controller Idv::StepController do
       before_action :confirm_idv_needed
-
-      def show
-        render plain: 'Hello'
-      end
     end
 
     before(:each) do
@@ -52,6 +52,64 @@ describe 'IdvStepConcern' do
         expect(response.body).to eq 'Hello'
         expect(response).to_not redirect_to idv_activated_url
         expect(response.status).to eq 200
+      end
+    end
+  end
+
+  describe '#confirm_address_step_complete' do
+    controller Idv::StepController do
+      before_action :confirm_address_step_complete
+    end
+
+    before(:each) do
+      sign_in(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'the user has completed phone confirmation' do
+      it 'does not redirect' do
+        idv_session.vendor_phone_confirmation = true
+        idv_session.user_phone_confirmation = true
+
+        get :show
+
+        expect(response.body).to eq('Hello')
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'the user has not confirmed their phone OTP' do
+      it 'redirects to OTP confirmation' do
+        idv_session.vendor_phone_confirmation = true
+        idv_session.user_phone_confirmation = false
+
+        get :show
+
+        expect(response).to redirect_to(idv_otp_verification_url)
+      end
+    end
+
+    context 'the user has not confirmed their phone with the vendor' do
+      it 'redirects to phone confirmation' do
+        idv_session.vendor_phone_confirmation = false
+        idv_session.user_phone_confirmation = false
+
+        get :show
+
+        expect(response).to redirect_to(idv_otp_verification_url)
+      end
+    end
+
+    context 'the user has selected GPO for address confirmation' do
+      it 'does not redirect' do
+        idv_session.address_verification_mechanism = 'gpo'
+
+        get :show
+
+        expect(response.body).to eq('Hello')
+        expect(response.status).to eq(200)
       end
     end
   end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -20,6 +20,7 @@ describe Idv::ReviewController do
     )
     idv_session.profile_confirmation = true
     idv_session.vendor_phone_confirmation = true
+    idv_session.user_phone_confirmation = true
     idv_session.applicant = applicant.with_indifferent_access
     idv_session
   end
@@ -68,63 +69,7 @@ describe Idv::ReviewController do
       it 'redirects to address step' do
         get :show
 
-        expect(response).to redirect_to idv_phone_path
-      end
-    end
-  end
-
-  describe '#confirm_idv_phone_confirmed' do
-    controller do
-      before_action :confirm_idv_phone_confirmed
-
-      def show
-        render plain: 'Hello'
-      end
-    end
-
-    before(:each) do
-      stub_sign_in(user)
-      allow(subject).to receive(:idv_session).and_return(idv_session)
-      routes.draw do
-        get 'show' => 'idv/review#show'
-      end
-    end
-
-    context 'user is verifying by mail' do
-      before do
-        allow(idv_session).to receive(:address_verification_mechanism).and_return('gpo')
-      end
-
-      it 'does not redirect' do
-        get :show
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-
-    context 'user phone is confirmed' do
-      before do
-        allow(idv_session).to receive(:address_verification_mechanism).and_return('phone')
-        allow(idv_session).to receive(:phone_confirmed?).and_return(true)
-      end
-
-      it 'does not redirect' do
-        get :show
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-
-    context 'user phone is not confirmed' do
-      before do
-        allow(idv_session).to receive(:address_verification_mechanism).and_return('phone')
-        allow(idv_session).to receive(:phone_confirmed?).and_return(false)
-      end
-
-      it 'redirects to phone confirmation' do
-        get :show
-
-        expect(response).to redirect_to idv_otp_verification_path
+        expect(response).to redirect_to idv_otp_verification_url
       end
     end
   end


### PR DESCRIPTION
The IdV step concern is intended to be used to make certain that previous IdV steps have been completed before allowing a user to complete a step. This commit start the process of implementing these steps by adding an available before action to ensure the address step is complete and using that in the review controller
