### PR TITLE
Move the method for allowing net connect on start to an around action

### DIFF
--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Hybrid Flow' do
+describe 'Hybrid Flow', :allow_net_connect_on_start do
   include IdvHelper
   include DocAuthHelper
 
@@ -9,8 +9,6 @@ describe 'Hybrid Flow' do
     allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).and_return(true)
     allow(Identity::Hostdata::EC2).to receive(:load).
       and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
-    # Avoid "Too many open files - socket(2)" error on some local machines
-    WebMock.allow_net_connect!(net_http_connect_on_start: true)
   end
 
   before do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -155,4 +155,18 @@ RSpec.configure do |config|
     # Consider any browser console logging as a failure.
     raise BrowserConsoleLogError.new(javascript_errors) if javascript_errors.present?
   end
+
+  config.around(:each, allow_net_connect_on_start: true) do |example|
+    # Avoid "Too many open files - socket(2)" error on some local machines
+    WebMock.allow_net_connect!(net_http_connect_on_start: true)
+    example.run
+    WebMock.disable_net_connect!(
+      allow: [
+        /localhost/,
+        /127\.0\.0\.1/,
+        /codeclimate.com/, # For uploading coverage reports
+        /chromedriver\.storage\.googleapis\.com/, # For fetching a chromedriver binary
+      ],
+    )
+  end
 end


### PR DESCRIPTION
We added code to tell Webmock to allow net connect on HTTP start. This was done to prevent too many open files errors from occuring during hybrid flow tests.

This setting stayed in place after the hybrid flow specs ran which could lead to problems with tests making external requests down the line. This commit makes it into an around action to make sure external connections get disabled after the hybrid specs run.
