### PR TITLE
LG-9134 Don't require users to make a selection from the device profiling dropdown

### DIFF
--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -52,7 +52,7 @@ module Proofing
       end
 
       def review_status(session_id:)
-        device_status = DeviceProfilingBackend.new.profiling_result(session_id)
+        device_status = DeviceProfilingBackend.new.profiling_result(session_id) || 'pass'
 
         case device_status
         when 'no_result'


### PR DESCRIPTION
In #7892 we made "Pass" the default option for the simulated device profiling tooling. Unfortunately the javascript there does not submit anything unless the user actually selects a value from the dropdown. This made sense in the world where "No Result" was the default. With pass as the default it causes the user to fail downstream.

This commit makes 'pass' the default value if 'nil' is submitted. Nil will still be used as the TMx review status value if "no_result" is submitted.
