### PR TITLE
LG-8947 Automatically reject users in fraud review after 30 days

### DIFF
--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -1,0 +1,18 @@
+class FraudRejectionDailyJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    fraud_review_pending_profiles.find_each do |profile|
+      profile.reject_for_fraud
+    end
+  end
+
+  private
+
+  def fraud_review_pending_profiles
+    Profile.where(
+      fraud_review_pending: true,
+      verified_at: ..30.days.ago,
+    )
+  end
+end

--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -3,6 +3,7 @@ class FraudRejectionDailyJob < ApplicationJob
 
   def perform
     fraud_review_pending_profiles.find_each do |profile|
+      analytics.automatic_fraud_rejection(verified_at: profile.verified_at)
       profile.reject_for_fraud
     end
   end

--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -2,15 +2,15 @@ class FraudRejectionDailyJob < ApplicationJob
   queue_as :default
 
   def perform
-    fraud_review_pending_profiles.find_each do |profile|
+    profiles_eligible_for_fraud_rejection.find_each do |profile|
       analytics.automatic_fraud_rejection(verified_at: profile.verified_at)
-      profile.reject_for_fraud
+      profile.reject_for_fraud(notifiy_user: false)
     end
   end
 
   private
 
-  def fraud_review_pending_profiles
+  def profiles_eligible_for_fraud_rejection
     Profile.where(
       fraud_review_pending: true,
       verified_at: ..30.days.ago,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -60,9 +60,9 @@ class Profile < ApplicationRecord
     update!(active: false, fraud_review_pending: true, fraud_rejection: false)
   end
 
-  def reject_for_fraud
+  def reject_for_fraud(notify_user:)
     update!(active: false, fraud_review_pending: false, fraud_rejection: true)
-    UserAlerts::AlertUserAboutAccountRejected.call(user)
+    UserAlerts::AlertUserAboutAccountRejected.call(user) if notify_user
   end
 
   def decrypt_pii(password)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -163,6 +163,16 @@ module AnalyticsEvents
     track_event('Authentication Confirmation: Reset selected')
   end
 
+  # @param [Date] verified_at
+  # Tracks when a profile is automatically rejected due to being under review for 30 days
+  def automatic_fraud_rejection(verified_at:, **extra)
+    track_event(
+      'Automatic Fraud Rejection',
+      verified_at: verified_at,
+      **extra,
+    )
+  end
+
   # Tracks when the user creates a set of backup mfa codes.
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   def backup_code_created(enabled_mfa_methods_count:, **extra)

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -140,6 +140,11 @@ else
         cron: cron_1w,
         args: -> { [Time.zone.now] },
       },
+      # Reject profiles that have been in fraud_review_pending for 30 days
+      fraud_rejection: {
+        class: 'FraudRejectionDailyJob',
+        chron: cron_24h,
+      },
     }
   end
   # rubocop:enable Metrics/BlockLength

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -41,7 +41,7 @@ namespace :users do
       if user.fraud_review_pending? && user.proofing_component.review_eligible?
         profile = user.fraud_review_pending_profile
 
-        profile.reject_for_fraud
+        profile.reject_for_fraud(notify_user: true)
 
         puts "User's profile has been deactivated due to fraud rejection."
       elsif !user.proofing_component.review_eligible?

--- a/spec/jobs/fraud_rejection_daily_job_spec.rb
+++ b/spec/jobs/fraud_rejection_daily_job_spec.rb
@@ -1,15 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe FraudRejectionDailyJob do
-  describe '#perform' do
-    subject(:perform) { FraudRejectionDailyJob.new.perform }
+  subject(:job) { FraudRejectionDailyJob.new }
+  let(:job_analytics) { FakeAnalytics.new }
 
+  before do
+    allow(job).to receive(:analytics).and_return(job_analytics)
+  end
+
+  describe '#perform' do
     it 'rejects profiles which have been review pending for more than 30 days' do
       create(:profile, fraud_review_pending: true, verified_at: 31.days.ago)
       create(:profile, fraud_review_pending: true, verified_at: 20.days.ago)
 
       rejected_profiles = Profile.where(fraud_rejection: true)
-      expect { perform }.to change { rejected_profiles.count }.by(1)
+
+      expect { job.perform }.to change { rejected_profiles.count }.by(1)
+      expect(job_analytics).to have_logged_event(
+        'Automatic Fraud Rejection',
+        verified_at: rejected_profiles.first.verified_at,
+      )
     end
   end
 end

--- a/spec/jobs/fraud_rejection_daily_job_spec.rb
+++ b/spec/jobs/fraud_rejection_daily_job_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe FraudRejectionDailyJob do
+  describe '#perform' do
+    subject(:perform) { FraudRejectionDailyJob.new.perform }
+
+    it 'rejects profiles which have been review pending for more than 30 days' do
+      create(:profile, fraud_review_pending: true, verified_at: 31.days.ago)
+      create(:profile, fraud_review_pending: true, verified_at: 20.days.ago)
+
+      rejected_profiles = Profile.where(fraud_rejection: true)
+      expect { perform }.to change { rejected_profiles.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-8947](https://cm-jira.usa.gov/browse/LG-8947)

## 🛠 Summary of changes
Added a cron job that automatically rejects profiles that are in fraud review for 30 days or more. Users should not be notified if they get an automated rejection.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
