### PR TITLE
Add `#confirm_verify_info_step_complete` to the IdV step concern

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -7,10 +7,6 @@ module IdvSession
     before_action :redirect_if_sp_context_needed
   end
 
-  def confirm_idv_applicant_created
-    redirect_to idv_verify_info_url if idv_session.applicant.blank?
-  end
-
   def confirm_idv_needed
     return if effective_user.active_profile.blank? ||
               decorated_session.requested_more_recent_verification? ||

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -8,9 +8,20 @@ module IdvStepConcern
     before_action :confirm_idv_needed
   end
 
+  def confirm_verify_info_step_complete
+    return if idv_session.verify_info_step_complete?
+
+    if idv_session.in_person_enrollment?
+      idv_in_person_verify_info_url
+    else
+      redirect_to idv_verify_info_url
+    end
+
+  end
+
   def confirm_address_step_complete
     return if idv_session.address_step_complete?
 
-    redirect_to idv_otp_verification_path
+    redirect_to idv_otp_verification_url
   end
 end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -12,7 +12,7 @@ module IdvStepConcern
     return if idv_session.verify_info_step_complete?
 
     if idv_session.in_person_enrollment?
-      idv_in_person_verify_info_url
+      redirect_to idv_in_person_verify_info_url
     else
       redirect_to idv_verify_info_url
     end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -16,7 +16,6 @@ module IdvStepConcern
     else
       redirect_to idv_verify_info_url
     end
-
   end
 
   def confirm_address_step_complete

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -1,7 +1,5 @@
 module Idv
   class PhoneController < ApplicationController
-    before_action :confirm_verify_info_complete
-
     include IdvStepConcern
     include StepIndicatorConcern
     include PhoneOtpRateLimitable
@@ -9,7 +7,7 @@ module Idv
 
     attr_reader :idv_form
 
-    before_action :confirm_idv_applicant_created
+    before_action :confirm_verify_info_step_complete
     before_action :confirm_step_needed
     before_action :set_idv_form
 
@@ -54,14 +52,6 @@ module Idv
     end
 
     private
-
-    def confirm_verify_info_complete
-      return unless IdentityConfig.store.in_person_verify_info_controller_enabled
-      return unless user_fully_authenticated?
-      return if idv_session.resolution_successful
-
-      redirect_to idv_in_person_verify_info_url
-    end
 
     def throttle
       @throttle ||= Throttle.new(user: current_user, throttle_type: :proof_address)

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -6,17 +6,12 @@ module Idv
     include StepIndicatorConcern
     include PhoneConfirmation
 
-    before_action :confirm_idv_applicant_created
-    before_action :confirm_idv_steps_complete
+    before_action :confirm_verify_info_step_complete
     before_action :confirm_address_step_complete
     before_action :confirm_current_password, only: [:create]
 
     rescue_from UspsInPersonProofing::Exception::RequestEnrollException,
                 with: :handle_request_enroll_exception
-
-    def confirm_idv_steps_complete
-      return redirect_to(idv_verify_info_url) unless idv_profile_complete?
-    end
 
     def confirm_current_password
       return if valid_password?
@@ -88,14 +83,6 @@ module Idv
         )
         t('idv.messages.review.info_verified_html', phone_message: phone_of_record_msg)
       end
-    end
-
-    def idv_profile_complete?
-      !!idv_session.profile_confirmation
-    end
-
-    def idv_address_complete?
-      idv_session.address_mechanism_chosen?
     end
 
     def init_profile

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -123,6 +123,14 @@ module Idv
       session[:user_phone_confirmation_session] = new_user_phone_confirmation_session.to_h
     end
 
+    def in_person_enrollment?
+      ProofingComponent.find_by(user: current_user)&.document_check == Idp::Constants::Vendors::USPS
+    end
+
+    def verify_info_step_complete?
+      resolution_successful && profile_confirmation
+    end
+
     def address_step_complete?
       if address_verification_mechanism == 'gpo'
         true
@@ -186,10 +194,6 @@ module Idv
         user_password: user_password,
         initiating_service_provider: service_provider,
       )
-    end
-
-    def in_person_enrollment?
-      ProofingComponent.find_by(user: current_user)&.document_check == Idp::Constants::Vendors::USPS
     end
 
     def threatmetrix_failed_and_needs_review?

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -17,7 +17,7 @@ describe Idv::PhoneController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_applicant_created,
+        :confirm_verify_info_step_complete,
       )
     end
   end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -19,6 +19,7 @@ describe Idv::ReviewController do
       service_provider: nil,
     )
     idv_session.profile_confirmation = true
+    idv_session.resolution_successful = 'phone'
     idv_session.vendor_phone_confirmation = true
     idv_session.user_phone_confirmation = true
     idv_session.applicant = applicant.with_indifferent_access
@@ -35,8 +36,8 @@ describe Idv::ReviewController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_applicant_created,
-        :confirm_idv_steps_complete,
+        :confirm_verify_info_step_complete,
+        :confirm_address_step_complete,
       )
     end
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -67,6 +67,7 @@ module ControllerHelper
       ssn: '666-12-1234',
     }.with_indifferent_access
     idv_session.profile_confirmation = true
+    idv_session.resolution_successful = 'phone'
     allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)
     allow(subject).to receive(:user_session).and_return(user_session)


### PR DESCRIPTION
With the retirment of the Flow State Machine we will be using the IdV step concern to confirm that steps are completed throughout the proofing flow.

This commit adds a `#confirm_verify_info_step_complete` which can be used as a before action to confirm verify info is complete. If it is not complete it knows to redirect the user either to the remote verify info or in-person verify info depending on whether the user has a in-person enrollmemnt.
