### PR TITLE
LG-8896: Fix heading order for personal key reactivation

### DIFF
--- a/app/assets/stylesheets/components/_alert-icon.scss
+++ b/app/assets/stylesheets/components/_alert-icon.scss
@@ -4,25 +4,6 @@
   height: 88px;
 }
 
-// For displaying icons as "badges"
-// at the top of modals
-.iconic-modal-badge {
-  position: relative;
-  &::before {
-    background-repeat: no-repeat;
-    background-size: contain;
-    content: '';
-    position: absolute;
-    left: 50%;
-    top: 0px;
-    transform: translateX(-50%) translateY(-50%);
-    height: 88px;
-    width: 88px;
-  }
-  &.personal-key-badge::before {
-    background-image: url('status/personal-key.svg');
-  }
-}
 .alert-icon--centered-top {
   position: absolute;
   left: 50%;

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -1,8 +1,12 @@
-<%= simple_form_for('', url: create_verify_personal_key_path, method: 'post') do |f| %>
-  <div class="padding-top-6 padding-x-1 tablet:padding-x-8 iconic-modal-badge personal-key-badge border border-dashed border-secondary rounded-xl">
-    <h3 class="margin-top-0 margin-bottom-2">
-      <%= t('forms.personal_key.title') %>
-    </h3>
+<%= simple_form_for('', url: create_verify_personal_key_path, method: 'post', html: { class: 'margin-top-8' }) do |f| %>
+  <div class="padding-top-6 padding-bottom-1 padding-x-1 tablet:padding-x-4 position-relative border border-secondary rounded-xl">
+    <%= render AlertIconComponent.new(
+          icon_name: :personal_key,
+          class: 'alert-icon--centered-top',
+        ) %>
+
+    <%= render PageHeadingComponent.new.with_content(t('forms.personal_key.title')) %>
+
     <p class="margin-bottom-4">
       <%= t('forms.personal_key.instructions') %>
     </p>
@@ -10,17 +14,15 @@
     <%= render 'shared/personal_key_input', code: '', form: f %>
   </div>
 
-  <div class="margin-top-4">
-    <%= button_tag t('forms.buttons.continue'), type: 'submit', class: 'usa-button usa-button--wide' %>
-  </div>
+  <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 
-<div class="margin-top-2">
-  <%= t('forms.personal_key.alternative') %>
-  <%= button_to(
-        reactivate_account_path, method: :put,
-                                 class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1'
-      ) { t('links.reverify') } %>
-</div>
+<%= t('forms.personal_key.alternative') %>
+<%= render ButtonComponent.new(
+      action: ->(**tag_options, &block) do
+        button_to(reactivate_account_path, method: :put, **tag_options, &block)
+      end,
+      unstyled: true,
+    ).with_content(t('links.reverify')) %>
 
 <%= render 'shared/cancel', link: account_path %>


### PR DESCRIPTION
## 🎫 Ticket

[LG-8896](https://cm-jira.usa.gov/browse/LG-8896)

## 🛠 Summary of changes

This pull request fixes a number of accessibility and other visual issues on the personal key reactivation screen:

1. Ensure that headings advance in order
2. Use standard submit button (big, wide)
3. Fix incorrect paddings and margins
4. Simplify stylesheets

## 📜 Testing Plan

1. Create an identity-verified account
2. Reset your password ("Forgot your password?" from the Sign In screen)
3. After resetting password, sign in
4. Click "Reactivate your profile" from account dashboard
5. Click "Yes, I have my personal key" button

## 👀 Screenshots

Before|After
---|---
![localhost_3000_account_reactivate_verify_personal_key](https://user-images.githubusercontent.com/1779930/223490947-6a479638-2e69-4d3f-9888-3d39323828a6.png)|![localhost_3000_account_reactivate_verify_personal_key (1)](https://user-images.githubusercontent.com/1779930/223490944-07d9bbbd-d581-4afc-8300-1a77a66247da.png)