### PR TITLE
Use POST route consistently for phone creation

### DIFF
--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -18,8 +18,8 @@
 
 <%= simple_form_for(
       @new_phone_form,
-      html: { autocomplete: 'off', method: :patch },
-      data: { international_phone_form: true },
+      method: :post,
+      html: { autocomplete: 'off' },
       url: phone_setup_path,
     ) do |f| %>
 

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -16,8 +16,8 @@
 
 <%= simple_form_for(
       @new_phone_form,
-      html: { autocomplete: 'off', method: :post },
-      data: { international_phone_form: true },
+      method: :post,
+      html: { autocomplete: 'off' },
       url: add_phone_path,
     ) do |f| %>
 


### PR DESCRIPTION
## 🛠 Summary of changes

This pull request aims to address some incomplete refactoring started in #7826 and work toward reconciling (and hopefully consolidating) phone creation routes.

In #7826, the new spam protection screen reused POST routes for phone creation with the expectation that we would remove PATCH as a supported verb, reflected in `routes.rb` on `main`:

https://github.com/18F/identity-idp/blob/3a3b3a9de5bf5b6f50e297dbae6e07757222d258/config/routes.rb#L254-L255

However, we never updated the existing reference to the PATCH route in `app/views/users/phone_setup/index.html.erb`, which is updated here.

This also removes a `data-` attribute which, as best I can tell, is not used. (It was added in #3253, though was never used from what I can see)

## 📜 Testing Plan

1. Navigate to http://localhost:3000
2. Create a new account
3. Select phone as MFA
4. Observe no issues in submitting phone number entry page