### PR TITLE
Remove unused phone PATCH route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,7 +251,6 @@ Rails.application.routes.draw do
     get '/second_mfa_setup' => 'users/mfa_selection#index'
     patch '/second_mfa_setup' => 'users/mfa_selection#update'
     get '/phone_setup' => 'users/phone_setup#index'
-    patch '/phone_setup' => 'users/phone_setup#create' # TODO: Remove after next deploy
     post '/phone_setup' => 'users/phone_setup#create'
     get '/users/two_factor_authentication' => 'users/two_factor_authentication#show',
         as: :user_two_factor_authentication # route name is used by two_factor_authentication gem

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -394,7 +394,7 @@ describe 'throttling requests' do
     context 'when the number of requests is under the limit' do
       it 'does not throttle the request' do
         (phone_setups_per_ip_limit - 1).times do
-          patch '/phone_setup', headers: { REMOTE_ADDR: '1.2.3.4' }
+          post '/phone_setup', headers: { REMOTE_ADDR: '1.2.3.4' }
         end
 
         expect(response.status).to eq(302)
@@ -404,7 +404,7 @@ describe 'throttling requests' do
     context 'when the number of requests is over the limit' do
       it 'throttles the request' do
         (phone_setups_per_ip_limit + 1).times do
-          patch '/phone_setup', headers: { REMOTE_ADDR: '1.2.3.4' }
+          post '/phone_setup', headers: { REMOTE_ADDR: '1.2.3.4' }
         end
 
         expect(response.status).to eq(429)


### PR DESCRIPTION
**DO NOT MERGE** until after #7944 has been deployed to production.

## 🛠 Summary of changes

Follow-up to #7944 (and #7826) to remove the phone creation `PATCH` route, which has to be removed separately to avoid issues during deployment.