### PR TITLE
LG-9002: Add in_person_capture_secondary_id_enabled feature flag

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -577,3 +577,4 @@ test:
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass
   usps_upload_sftp_username: user
+  in_person_capture_secondary_id_enabled: false

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -337,6 +337,7 @@ voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'
 voip_block: true
 voip_allowed_phones: '[]'
+in_person_capture_secondary_id_enabled: false
 
 development:
   aamva_private_key: 123abc
@@ -577,4 +578,3 @@ test:
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass
   usps_upload_sftp_username: user
-  in_person_capture_secondary_id_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -211,6 +211,7 @@ class IdentityConfig
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
     config.add(:ie11_support_end_date, type: :timestamp)
+    config.add(:in_person_capture_secondary_id_enabled, type: :boolean)
     config.add(:in_person_cta_variant_testing_enabled, type: :boolean)
     config.add(:in_person_cta_variant_testing_percents, type: :json)
     config.add(:in_person_email_reminder_early_benchmark_in_days, type: :integer)


### PR DESCRIPTION
## 🎫 Ticket
[(5) Implement LG-8692 (collecting current address if different)](https://cm-jira.usa.gov/browse/LG-9002)
Please note, this PR does not fully complete LG-9002.  All it does is add the feature flag.


## 🛠 Summary of changes
- Added the `in_person_capture_secondary_id_enabled` feature flag



## 📜 Testing Plan
Inspect `application.yml.default` and `lib/identity_config.rb`.
Confirm that both contain the new feature flag.