### PR TITLE
Do not return HTTP 500 when cross-site request forgery token is invalid for in-person proofing API

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -65,6 +65,7 @@ module Idv
           Faraday::TimeoutError => :unprocessable_entity,
           Faraday::BadRequestError => :unprocessable_entity,
           Faraday::ForbiddenError => :unprocessable_entity,
+          ActionController::InvalidAuthenticityToken => :unprocessable_entity,
         }[err.class] || :internal_server_error
 
         analytics.idv_in_person_locations_request_failure(


### PR DESCRIPTION
## 🛠 Summary of changes

We've seen a handful of these recently, and I think it's an error we want to avoid returning a 500 status on.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
