### PR TITLE
Include parsed phone country code in reCAPTCHA logging

### DIFF
--- a/app/services/phone_recaptcha_validator.rb
+++ b/app/services/phone_recaptcha_validator.rb
@@ -27,7 +27,7 @@ class PhoneRecaptchaValidator
     @validator ||= validator_class.new(
       score_threshold:,
       extra_analytics_properties: {
-        country_code: parsed_phone.country,
+        phone_country_code: parsed_phone.country,
       },
       **validator_args,
     )

--- a/app/services/phone_recaptcha_validator.rb
+++ b/app/services/phone_recaptcha_validator.rb
@@ -24,7 +24,13 @@ class PhoneRecaptchaValidator
   private
 
   def validator
-    @validator ||= validator_class.new(score_threshold:, **validator_args)
+    @validator ||= validator_class.new(
+      score_threshold:,
+      extra_analytics_properties: {
+        country_code: parsed_phone.country,
+      },
+      **validator_args,
+    )
   end
 
   def score_threshold_country_override

--- a/app/services/recaptcha_validator.rb
+++ b/app/services/recaptcha_validator.rb
@@ -3,9 +3,14 @@ class RecaptchaValidator
   EXEMPT_ERROR_CODES = ['missing-input-secret', 'invalid-input-secret']
   VALID_RECAPTCHA_VERSIONS = [2, 3]
 
-  attr_reader :recaptcha_version, :score_threshold, :analytics
+  attr_reader :recaptcha_version, :score_threshold, :analytics, :extra_analytics_properties
 
-  def initialize(recaptcha_version: 3, score_threshold: 0.0, analytics: nil)
+  def initialize(
+    recaptcha_version: 3,
+    score_threshold: 0.0,
+    analytics: nil,
+    extra_analytics_properties: nil
+  )
     if !VALID_RECAPTCHA_VERSIONS.include?(recaptcha_version)
       raise ArgumentError, "Invalid reCAPTCHA version #{recaptcha_version}, expected one of " \
                            "#{VALID_RECAPTCHA_VERSIONS}"
@@ -14,6 +19,7 @@ class RecaptchaValidator
     @score_threshold = score_threshold
     @analytics = analytics
     @recaptcha_version = recaptcha_version
+    @extra_analytics_properties = extra_analytics_properties
   end
 
   def exempt?
@@ -80,6 +86,7 @@ class RecaptchaValidator
       recaptcha_version:,
       evaluated_as_valid: recaptcha_result_valid?(recaptcha_result),
       exception_class: error&.class&.name,
+      **extra_analytics_properties,
     )
   end
 

--- a/app/services/recaptcha_validator.rb
+++ b/app/services/recaptcha_validator.rb
@@ -9,7 +9,7 @@ class RecaptchaValidator
     recaptcha_version: 3,
     score_threshold: 0.0,
     analytics: nil,
-    extra_analytics_properties: nil
+    extra_analytics_properties: {}
   )
     if !VALID_RECAPTCHA_VERSIONS.include?(recaptcha_version)
       raise ArgumentError, "Invalid reCAPTCHA version #{recaptcha_version}, expected one of " \

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -238,7 +238,7 @@ describe 'Add a new phone number' do
         score_threshold: 0.6,
         recaptcha_version: 3,
         exception_class: nil,
-        country_code: 'CA',
+        phone_country_code: 'CA',
       ),
     )
 

--- a/spec/services/phone_recaptcha_validator_spec.rb
+++ b/spec/services/phone_recaptcha_validator_spec.rb
@@ -22,7 +22,7 @@ describe PhoneRecaptchaValidator do
         analytics:,
         recaptcha_version:,
         extra_analytics_properties: {
-          country_code: parsed_phone.country,
+          phone_country_code: parsed_phone.country,
         },
       ).
       and_return(recaptcha_validator)

--- a/spec/services/phone_recaptcha_validator_spec.rb
+++ b/spec/services/phone_recaptcha_validator_spec.rb
@@ -16,7 +16,16 @@ describe PhoneRecaptchaValidator do
 
   it 'passes instance variables to validator' do
     recaptcha_validator = instance_double(RecaptchaValidator, valid?: true)
-    expect(RecaptchaValidator).to receive(:new).and_return(recaptcha_validator)
+    expect(RecaptchaValidator).to receive(:new).
+      with(
+        score_threshold: score_threshold_config,
+        analytics:,
+        recaptcha_version:,
+        extra_analytics_properties: {
+          country_code: parsed_phone.country,
+        },
+      ).
+      and_return(recaptcha_validator)
 
     validator.valid?('token')
   end

--- a/spec/services/recaptcha_validator_spec.rb
+++ b/spec/services/recaptcha_validator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe RecaptchaValidator do
   let(:score_threshold) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
-  let(:extra_analytics_properties) { nil }
+  let(:extra_analytics_properties) { {} }
   let(:recaptcha_secret_key_v2) { 'recaptcha_secret_key_v2' }
   let(:recaptcha_secret_key_v3) { 'recaptcha_secret_key_v3' }
 

--- a/spec/services/recaptcha_validator_spec.rb
+++ b/spec/services/recaptcha_validator_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 describe RecaptchaValidator do
   let(:score_threshold) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
+  let(:extra_analytics_properties) { nil }
   let(:recaptcha_secret_key_v2) { 'recaptcha_secret_key_v2' }
   let(:recaptcha_secret_key_v3) { 'recaptcha_secret_key_v3' }
-  subject(:validator) { RecaptchaValidator.new(score_threshold:, analytics:) }
+
+  subject(:validator) do
+    RecaptchaValidator.new(score_threshold:, analytics:, extra_analytics_properties:)
+  end
 
   before do
     allow(IdentityConfig.store).to receive(:recaptcha_secret_key_v2).
@@ -231,6 +235,27 @@ describe RecaptchaValidator do
           recaptcha_version: 3,
           exception_class: nil,
         )
+      end
+
+      context 'with extra analytics properties' do
+        let(:extra_analytics_properties) { { extra: true } }
+
+        it 'logs analytics of the body' do
+          valid
+
+          expect(analytics).to have_logged_event(
+            'reCAPTCHA verify result received',
+            recaptcha_result: {
+              'success' => true,
+              'score' => score,
+            },
+            evaluated_as_valid: true,
+            score_threshold: score_threshold,
+            recaptcha_version: 3,
+            exception_class: nil,
+            extra: true,
+          )
+        end
       end
 
       context 'without analytics' do


### PR DESCRIPTION
## 🛠 Summary of changes

Adds parsed phone country code to event logging detail for reCAPTCHA phone validation, so that we can do regional analysis of scores.

## 📜 Testing Plan

1. Add a phone to a new or existing account, using an international phone number (e.g. `3065550100`)
2. Look at recent logs with `tail -n10 log/events.log | jq .`

Observe: 'reCAPTCHA verify result received' event includes `country_code` value corresponding to international phone number.