### PR TITLE
Update Gemfile to not load yard gem by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'view_component', '~> 2.82.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'
-gem 'yard'
+gem 'yard', require: false
 
 # This version of the zxcvbn gem matches the data and behavior of the zxcvbn NPM package.
 # It should not be updated without verifying that the behavior still matches JS version 4.4.2.


### PR DESCRIPTION
**Why**: avoids mysterious segfaults on arm machines

changelog: Internal, Development, Skip loading yard gem by default

These commands still work just fine:
- `make lint_analytics_events`
- `bundle exec rspec spec/lib/analytics_events_documenter_spec.rb`

Slack context: https://gsa-tts.slack.com/archives/C0NGESUN5/p1677722613072199