### PR TITLE
Clean up DocAuth::ProcessedAlertToLogAlertFormatter and its specs

### DIFF
--- a/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
+++ b/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
@@ -5,32 +5,35 @@ require 'rails_helper'
 
 RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do
   let(:alerts) do
-    { passed: [{ alert: 'Alert_1', name: 'Visible Pattern', result: 'Passed' }],
-      failed:
-       [
+    {
+      passed: [
+        { alert: 'Alert_1', name: 'Visible Pattern', result: 'Passed' },
+      ],
+      failed: [
          { alert: 'Alert_1', name: '2D Barcode Read', result: 'Failed' },
          { alert: 'Alert_2', name: 'Layout Valid', result: 'Attention' },
          { alert: 'Alert_3', name: '2D Barcode Read', result: 'Failed' },
          { alert: 'Alert_4', name: 'Visible Pattern', result: 'Failed' },
          { alert: 'Alert_5', name: 'Visible Photo Characteristics', result: 'Failed' },
-       ] }
+       ],
+    }
   end
 
-  context('when ProcessedAlertToLogAlertFormatter is called') do
-    subject do
-      DocAuth::ProcessedAlertToLogAlertFormatter.new.log_alerts(alerts)
-    end
+  subject(:formatter) { DocAuth::ProcessedAlertToLogAlertFormatter.new }
+
+  describe('#log_alerts') do
+    subject(:logged_alerts) { formatter.log_alerts(alerts) }
 
     it('returns failed if both passed and failed are returned by the alert') do
-      expect(subject).to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
+      expect(logged_alerts).to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
     end
 
     it('returns the formatted log hash') do
-      expect(subject).to eq(
-        { '2d_barcode_read': { no_side: 'Failed' },
-          layout_valid: { no_side: 'Attention' },
-          visible_pattern: { no_side: 'Failed' },
-          visible_photo_characteristics: { no_side: 'Failed' } },
+      expect(logged_alerts).to eq(
+        '2d_barcode_read': { no_side: 'Failed' },
+        layout_valid: { no_side: 'Attention' },
+        visible_pattern: { no_side: 'Failed' },
+        visible_photo_characteristics: { no_side: 'Failed' }
       )
     end
   end

--- a/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
+++ b/spec/services/doc_auth/processed_alert_to_log_alert_formatter_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do
         { alert: 'Alert_1', name: 'Visible Pattern', result: 'Passed' },
       ],
       failed: [
-         { alert: 'Alert_1', name: '2D Barcode Read', result: 'Failed' },
-         { alert: 'Alert_2', name: 'Layout Valid', result: 'Attention' },
-         { alert: 'Alert_3', name: '2D Barcode Read', result: 'Failed' },
-         { alert: 'Alert_4', name: 'Visible Pattern', result: 'Failed' },
-         { alert: 'Alert_5', name: 'Visible Photo Characteristics', result: 'Failed' },
-       ],
+        { alert: 'Alert_1', name: '2D Barcode Read', result: 'Failed' },
+        { alert: 'Alert_2', name: 'Layout Valid', result: 'Attention' },
+        { alert: 'Alert_3', name: '2D Barcode Read', result: 'Failed' },
+        { alert: 'Alert_4', name: 'Visible Pattern', result: 'Failed' },
+        { alert: 'Alert_5', name: 'Visible Photo Characteristics', result: 'Failed' },
+      ],
     }
   end
 
@@ -33,7 +33,7 @@ RSpec.describe DocAuth::ProcessedAlertToLogAlertFormatter do
         '2d_barcode_read': { no_side: 'Failed' },
         layout_valid: { no_side: 'Attention' },
         visible_pattern: { no_side: 'Failed' },
-        visible_photo_characteristics: { no_side: 'Failed' }
+        visible_photo_characteristics: { no_side: 'Failed' },
       )
     end
   end


### PR DESCRIPTION
I was reading over this code to try to sort through [a question in Slack](https://gsa-tts.slack.com/archives/C5E7EJWF7/p1678378664835909), and these changes helped me read and understand better. They should be 100% no-ops