### PR TITLE
LG-9138: Allow state ID address fields in user PII

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -97,7 +97,8 @@ module Idv
         extra: {
           address_edited: !!flow_session['address_edited'],
           address_line2_present: !pii[:address2].blank?,
-          pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name]],
+          pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name],
+                              [:state_id, :state_id_jurisdiction]],
         },
       )
       log_idv_verification_submitted_event(

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -58,7 +58,7 @@ module Idv
         return {} if @flow_session[:pii_from_user][:same_address_as_id].nil?
         {
           same_address_as_id: @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true',
-          pii_like_keypaths: [[:same_address_as_id]],
+          pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
       end
     end

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -251,7 +251,8 @@ module Idv
           # todo: add other edited fields?
           extra: {
             address_edited: !!flow_session['address_edited'],
-            pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name]],
+            pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name],
+                                [:state_id, :state_id_jurisdiction]],
           },
         )
         log_idv_verification_submitted_event(

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -10,7 +10,7 @@ module Pii
     # The user's residential address
     :address1, :address2, :city, :state, :zipcode, :same_address_as_id,
     # The address on a user's state-issued ID, which may be different from their residential address
-    :state_id_address1, :state_id_address2, :state_id_city, :state_id_state, :state_id_zipcode,
+    :state_id_address1, :state_id_address2, :state_id_city, :state_id_jurisdiction, :state_id_zipcode, # rubocop:disable Layout/LineLength
     :ssn, :dob, :phone,
     *DEPRECATED_PII_ATTRIBUTES
   ) do

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -7,6 +7,8 @@ module Pii
     :first_name, :middle_name, :last_name,
     :state_id_address1, :state_id_address2, :state_id_city, :state_id_zipcode,
     :address1, :address2, :city, :state, :zipcode, :same_address_as_id,
+    # The address on a user's state-issued ID, which may be different from their residential address
+    :state_id_address1, :state_id_address2, :state_id_city, :state_id_state, :state_id_zipcode,
     :ssn, :dob, :phone,
     :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode,
     *DEPRECATED_PII_ATTRIBUTES

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -1,16 +1,17 @@
 module Pii
   DEPRECATED_PII_ATTRIBUTES = [
     :otp, # https://github.com/18F/identity-idp/pull/1661
+    # Address fields that we might be able to remove. We don't think these were ever used in prod
+    :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
   ].freeze
 
   Attributes = RedactedStruct.new(
     :first_name, :middle_name, :last_name,
-    :state_id_address1, :state_id_address2, :state_id_city, :state_id_zipcode,
+    # The user's residential address
     :address1, :address2, :city, :state, :zipcode, :same_address_as_id,
     # The address on a user's state-issued ID, which may be different from their residential address
     :state_id_address1, :state_id_address2, :state_id_city, :state_id_state, :state_id_zipcode,
     :ssn, :dob, :phone,
-    :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode,
     *DEPRECATED_PII_ATTRIBUTES
   ) do
     def self.new_from_hash(hash)

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -8,9 +8,11 @@ class SessionEncryptor
   MINIMUM_COMPRESS_LIMIT = 300
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
-    'zip_code', 'same_address_as_id', 'dob', 'phone_number', 'phone', 'ssn', 'prev_address1',
-    'prev_address2', 'prev_city', 'prev_state', 'prev_zipcode', 'pii', 'pii_from_doc',
-    'pii_from_user', 'password', 'personal_key', 'email', 'email_address', 'unconfirmed_phone'
+    'zip_code', 'state_id_address1', 'state_id_address2', 'state_id_city', 'state_id_state',
+    'state_id_zipcode', 'same_address_as_id', 'dob', 'phone_number', 'phone', 'ssn',
+    'prev_address1', 'prev_address2', 'prev_city', 'prev_state', 'prev_zipcode', 'pii',
+    'pii_from_doc', 'pii_from_user', 'password', 'personal_key', 'email', 'email_address',
+    'unconfirmed_phone'
   ].to_set.freeze
   CIPHERTEXT_KEY = 't'
   COMPRESSED_KEY = 'c'

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -8,7 +8,7 @@ class SessionEncryptor
   MINIMUM_COMPRESS_LIMIT = 300
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
-    'zip_code', 'state_id_address1', 'state_id_address2', 'state_id_city', 'state_id_state',
+    'zip_code', 'state_id_address1', 'state_id_address2', 'state_id_city', 'state_id_jurisdiction',
     'state_id_zipcode', 'same_address_as_id', 'dob', 'phone_number', 'phone', 'ssn',
     'prev_address1', 'prev_address2', 'prev_city', 'prev_state', 'prev_zipcode', 'pii',
     'pii_from_doc', 'pii_from_user', 'password', 'personal_key', 'email', 'email_address',

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -41,14 +41,14 @@ describe Pii::Attributes do
         state_id_address1: '1600 Pennsylvania Avenue',
         state_id_address2: 'Apt 2',
         state_id_city: 'Washington',
-        state_id_state: 'DC',
+        state_id_jurisdiction: 'DC',
         state_id_zipcode: '20005',
       )
 
       expect(pii.state_id_address1).to eq('1600 Pennsylvania Avenue')
       expect(pii.state_id_address2).to eq('Apt 2')
       expect(pii.state_id_city).to eq('Washington')
-      expect(pii.state_id_state).to eq('DC')
+      expect(pii.state_id_jurisdiction).to eq('DC')
       expect(pii.state_id_zipcode).to eq('20005')
     end
   end

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -35,6 +35,22 @@ describe Pii::Attributes do
 
       expect(pii.first_name).to eq('Test')
     end
+
+    it 'parses state ID address keys' do
+      pii = described_class.new_from_hash(
+        state_id_address1: '1600 Pennsylvania Avenue',
+        state_id_address2: 'Apt 2',
+        state_id_city: 'Washington',
+        state_id_state: 'DC',
+        state_id_zipcode: '20005',
+      )
+
+      expect(pii.state_id_address1).to eq('1600 Pennsylvania Avenue')
+      expect(pii.state_id_address2).to eq('Apt 2')
+      expect(pii.state_id_city).to eq('Washington')
+      expect(pii.state_id_state).to eq('DC')
+      expect(pii.state_id_zipcode).to eq('20005')
+    end
   end
 
   describe '#new_from_json' do


### PR DESCRIPTION
changelog: Upcoming features, Double address verification, Allow state ID address fields in user PII

## 🎫 Ticket

[LG-9138](https://cm-jira.usa.gov/browse/LG-9138)

## 🛠 Summary of changes

* Allows new state ID address fields to be stored in the Pii blob in the user session and user profiles

Note: security has approved us beginning development on this feature behind a feature flag. We'll complete security review before collecting this data from users.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
