### PR TITLE
Add primary database socket configuration

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -73,6 +73,7 @@ doc_auth_error_sharpness_threshold: 40
 doc_auth_error_glare_threshold: 40
 database_pool_extra_connections_for_worker: 4
 database_pool_idp: 5
+database_socket: ''
 database_statement_timeout: 2_500
 database_timeout: 5_000
 deliver_mail_async: false

--- a/config/database.yml
+++ b/config/database.yml
@@ -78,7 +78,7 @@ production:
     <<: *defaults
     database: <%= IdentityConfig.store.database_name %>
     username: <%= IdentityConfig.store.database_username %>
-    host: <%= IdentityConfig.store.database_host %>
+    host: <%= IdentityConfig.store.database_socket.present? ?  IdentityConfig.store.database_socket : IdentityConfig.store.database_host %>
     password: <%= IdentityConfig.store.database_password %>
     pool: <%= primary_pool %>
     sslmode: 'verify-full'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -139,6 +139,7 @@ class IdentityConfig
     config.add(:database_password, type: :string)
     config.add(:database_pool_extra_connections_for_worker, type: :integer)
     config.add(:database_pool_idp, type: :integer)
+    config.add(:database_socket, type: :string)
     config.add(:database_statement_timeout, type: :integer)
     config.add(:database_timeout, type: :integer)
     config.add(:database_username, type: :string)


### PR DESCRIPTION
## 🛠 Summary of changes

To continue our experiment with PgBouncer, it's been helpful to have a separate configuration key from the `database_host` to use in lieu of direct connections to the database.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
