### PR TITLE
Reduce to using one primary Redis connection pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'rack-timeout', require: false
 gem 'redacted_struct'
 gem 'redis', '>= 3.2.0'
 gem 'redis-namespace'
-gem 'redis-session-store', github: '18F/redis-session-store', branch: 'margolis-use-connection-pool'
+gem 'redis-session-store', github: '18F/redis-session-store', tag: 'v0.12-18f'
 gem 'retries'
 gem 'rotp', '~> 6.1'
 gem 'rqrcode'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'rack-timeout', require: false
 gem 'redacted_struct'
 gem 'redis', '>= 3.2.0'
 gem 'redis-namespace'
-gem 'redis-session-store', '>= 0.11.4'
+gem 'redis-session-store', github: '18F/redis-session-store', branch: 'margolis-use-connection-pool'
 gem 'retries'
 gem 'rotp', '~> 6.1'
 gem 'rqrcode'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,8 +25,8 @@ GIT
 
 GIT
   remote: https://github.com/18F/redis-session-store.git
-  revision: 01742e423bd1003423daaa38d5293fad27097df3
-  branch: margolis-use-connection-pool
+  revision: 253aa4f466cf61e129625ea01d1f120fb9c8685d
+  tag: v0.12-18f
   specs:
     redis-session-store (0.12.pre.18f)
       actionpack (>= 6, < 8)
@@ -222,8 +222,8 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.2.0)
-    connection_pool (2.2.5)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.3.0)
     cose (1.3.0)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
@@ -403,7 +403,7 @@ GEM
     mini_histogram (0.3.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
-    minitest (5.17.0)
+    minitest (5.18.0)
     msgpack (1.6.0)
     multiset (0.5.3)
     nenv (0.3.0)
@@ -530,9 +530,9 @@ GEM
       ffi (~> 1.0)
     redacted_struct (1.1.0)
     redcarpet (3.6.0)
-    redis (5.0.5)
+    redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.12.0)
+    redis-client (0.14.0)
       connection_pool
     redis-namespace (1.8.1)
       redis (>= 3.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,15 @@ GIT
     identity_validations (0.7.2)
 
 GIT
+  remote: https://github.com/18F/redis-session-store.git
+  revision: 01742e423bd1003423daaa38d5293fad27097df3
+  branch: margolis-use-connection-pool
+  specs:
+    redis-session-store (0.12.pre.18f)
+      actionpack (>= 6, < 8)
+      redis (>= 3, < 6)
+
+GIT
   remote: https://github.com/18F/saml_idp.git
   revision: d8e7deb7da3aa43bae0e5b0891c8de123d492484
   tag: 0.18.1-18f
@@ -527,9 +536,6 @@ GEM
       connection_pool
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    redis-session-store (0.11.5)
-      actionpack (>= 6, < 8)
-      redis (>= 3, < 6)
     regexp_parser (2.6.1)
     reline (0.2.7)
       io-console (~> 0.5)
@@ -797,7 +803,7 @@ DEPENDENCIES
   redacted_struct
   redis (>= 3.2.0)
   redis-namespace
-  redis-session-store (>= 0.11.4)
+  redis-session-store!
   retries
   rotp (~> 6.1)
   rqrcode

--- a/app/services/encrypted_redis_struct_storage.rb
+++ b/app/services/encrypted_redis_struct_storage.rb
@@ -60,8 +60,11 @@ module EncryptedRedisStructStorage
   end
 
   def key(id, type:)
-    return [type.redis_key_prefix, id].join(':') if type.respond_to?(:redis_key_prefix)
-    raise "#{self} expected #{type.name} to have defined class method redis_key_prefix"
+    if type.respond_to?(:redis_key_prefix)
+      return ['redis-pool', type.redis_key_prefix, id].join(':')
+    else
+      raise "#{self} expected #{type.name} to have defined class method redis_key_prefix"
+    end
   end
 
   # Assigns member fields from a hash. That way, it doesn't matter

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -12,7 +12,7 @@ class OutOfBandSessionAccessor
   def ttl
     uuid = session_uuid
     session_store.instance_eval do
-      redis_pool.with { |client| client.ttl(prefixed(uuid)) }
+      with_redis { |client| client.ttl(prefixed(uuid)) }
     end
   end
 

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -11,7 +11,9 @@ class OutOfBandSessionAccessor
 
   def ttl
     uuid = session_uuid
-    session_store.instance_eval { redis.ttl(prefixed(uuid)) }
+    session_store.instance_eval do
+      redis_pool.with { |client| client.ttl(prefixed(uuid)) }
+    end
   end
 
   # @return [Pii::Attributes, nil]

--- a/app/services/proofing/mock/device_profiling_backend.rb
+++ b/app/services/proofing/mock/device_profiling_backend.rb
@@ -14,13 +14,13 @@ module Proofing
         raise ArgumentError, "unknown result=#{result}" if !RESULTS.include?(result)
 
         REDIS_POOL.with do |redis|
-          redis.setex("device_profiling:#{session_id}", RESULT_TIMEOUT, result)
+          redis.setex("redis-pool:device_profiling:#{session_id}", RESULT_TIMEOUT, result)
         end
       end
 
       def profiling_result(session_id)
         REDIS_POOL.with do |redis|
-          redis.get("device_profiling:#{session_id}")
+          redis.get("redis-pool:device_profiling:#{session_id}")
         end
       end
     end

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -3,7 +3,7 @@
 # to checking the db if no redis object is available. Following release can remove db dependence.
 # To migrate code simply replace ServiceProviderRequest with ServiceProviderRequestProxy
 class ServiceProviderRequestProxy
-  REDIS_KEY_PREFIX = 'spr:'.freeze
+  REDIS_KEY_PREFIX = 'redis-pool:spr:'.freeze
 
   # This is used to support the .last method. That method is only used in the
   # test environment
@@ -78,7 +78,7 @@ class ServiceProviderRequestProxy
   end
 
   def self.flush
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb } if Rails.env.test?
+    REDIS_POOL.with { |client| client.flushdb } if Rails.env.test?
   end
 
   def self.hash_to_spr(hash, uuid)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,5 @@
 REDIS_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_pool_size) do
-  Redis::Namespace.new(
-    'redis-pool',
-    redis: Redis.new(url: IdentityConfig.store.redis_url),
-  )
+  Redis.new(url: IdentityConfig.store.redis_url)
 end
 
 REDIS_THROTTLE_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_throttle_pool_size) do
@@ -10,11 +7,4 @@ REDIS_THROTTLE_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_thrott
     'throttle',
     redis: Redis.new(url: IdentityConfig.store.redis_throttle_url),
   )
-end
-
-REDIS_SESSION_POOL_WRAPPER = ConnectionPool::Wrapper.new(
-  size: IdentityConfig.store.redis_session_pool_size,
-) do
-  # redis-session-store does its own namespacing in session_store.rb
-  Redis.new(url: IdentityConfig.store.redis_url)
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -13,7 +13,7 @@ Rails.application.config.session_store(
     ttl: IdentityConfig.store.session_timeout_in_minutes.minutes,
 
     key_prefix: "#{IdentityConfig.store.domain_name}:session:",
-    client: REDIS_SESSION_POOL_WRAPPER,
+    client_pool: REDIS_POOL,
   },
   on_session_load_error: SessionEncryptorErrorHandler,
   on_redis_down: proc { |error, _env, _sid| raise error },

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -223,7 +223,7 @@ describe SamlIdpController do
     end
 
     it 'accepts requests with correct cert and correct session index and renders logout response' do
-      REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+      REDIS_POOL.with { |client| client.flushdb }
       session_accessor = OutOfBandSessionAccessor.new(session_id)
       session_accessor.put_pii(foo: 'bar')
       saml_request = OneLogin::RubySaml::Logoutrequest.new
@@ -260,7 +260,7 @@ describe SamlIdpController do
       logout_response = OneLogin::RubySaml::Logoutresponse.new(response.body)
       expect(logout_response.success?).to eq(true)
       expect(logout_response.in_response_to).to eq(saml_request.uuid)
-      REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+      REDIS_POOL.with { |client| client.flushdb }
     end
 
     it 'rejects requests from a correct cert but no session index' do

--- a/spec/controllers/test/device_profiling_controller_spec.rb
+++ b/spec/controllers/test/device_profiling_controller_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Test::DeviceProfilingController do
   let(:session_id) { SecureRandom.uuid }
 
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
   end
 
   describe '#index' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
     end
 
     begin
-      REDIS_POOL.with { |namespaced| namespaced.redis.info }
+      REDIS_POOL.with { |client| client.info }
     rescue RuntimeError => error
       # rubocop:disable Rails/Output
       puts error

--- a/spec/requests/redis_down_spec.rb
+++ b/spec/requests/redis_down_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'redis down session error handling' do
   context 'with bad Redis connection' do
     it 'fails loudly' do
-      allow(REDIS_SESSION_POOL_WRAPPER).to receive(:setex).and_raise(Redis::CannotConnectError)
+      allow(REDIS_POOL).to receive(:with).and_raise(Redis::CannotConnectError)
       expect do
         get forgot_password_path
       end.to raise_error(Redis::CannotConnectError)

--- a/spec/services/encrypted_redis_struct_storage_spec.rb
+++ b/spec/services/encrypted_redis_struct_storage_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe EncryptedRedisStructStorage do
 
     context 'with a struct that has a redis_key_prefix' do
       it 'prefixes the id' do
-        expect(key).to eq("example:prefix:#{id}")
+        expect(key).to eq("redis-pool:example:prefix:#{id}")
       end
     end
 

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe OutOfBandSessionAccessor do
   subject(:store) { described_class.new(session_uuid) }
 
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
   end
 
   describe '#ttl' do

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Proofing::Mock::DdpMockClient do
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
   end
 
   let(:threatmetrix_session_id) { SecureRandom.uuid }

--- a/spec/services/proofing/mock/device_profiling_backend_spec.rb
+++ b/spec/services/proofing/mock/device_profiling_backend_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Proofing::Mock::DeviceProfilingBackend do
   around do |ex|
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
     ex.run
-    REDIS_POOL.with { |namespaced| namespaced.redis.flushdb }
+    REDIS_POOL.with { |client| client.flushdb }
   end
 
   subject(:backend) { described_class.new }


### PR DESCRIPTION
## 🛠 Summary of changes

To reduce the total number of connections opened to the primary Redis instance, this PR pulls in the recently resurrected `client_pool` [pull request](https://github.com/18F/redis-session-store/pull/8) in our fork of redis-session-store.

The intersection of using the new `client_pool` and using `REDIS_POOL` everywhere for the primary instance means dropping the use of `redis-namespace`. We may want to consider moving away from the gem long-term anyway as I have an [open pull request](https://github.com/resque/redis-namespace/pull/221) to add unsupported commands to the gem that I'd like to use [elsewhere](https://github.com/18F/identity-idp/pull/7776) in our codebase.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
