### PR TITLE
LG-7832: Support multiple characters for USPS transliteration

### DIFF
--- a/app/services/usps_in_person_proofing/transliterator.rb
+++ b/app/services/usps_in_person_proofing/transliterator.rb
@@ -25,13 +25,15 @@ module UspsInPersonProofing
     # @return [TransliterationResult] The transliterated value
     def transliterate(value)
       stripped = value.to_s.gsub(/\s+/, ' ').strip
-      transliterated = I18n.transliterate(stripped, locale: :en)
-
       unsupported_chars = []
-      unless stripped.count(REPLACEMENT) == transliterated.count(REPLACEMENT)
-        transliterated.chars.zip(stripped.chars).each do |val, stripped|
-          unsupported_chars.append(stripped) if val == REPLACEMENT && stripped != REPLACEMENT
-        end
+      transliterated = ''
+
+      # Some transliterations result in more than one character, so length is
+      # not always guaranteed to match
+      stripped.chars.each do |char|
+        tl_char = I18n.transliterate(char, locale: :en)
+        unsupported_chars.append(char) if tl_char == REPLACEMENT && char != REPLACEMENT
+        transliterated += tl_char
       end
 
       # Using struct instead of exception here to reduce likelihood of logging PII


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-7832](https://cm-jira.usa.gov/browse/LG-7832)

## 🛠 Summary of changes

- Support multiple characters to be returned from transliteration
- Test behavior around non-ASCII spaces

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Complete IdV flow up to in-person state ID page
- [ ] Enter a character that converts to multiple characters into a name field (see [mappings here](https://github.com/ruby-i18n/i18n/blob/master/lib/i18n/backend/transliterator.rb#L43))
- [ ] Enter an unsupported character (e.g. Cyrillic) into the same name field after that character
- [ ] Complete remainder of form
- [ ] Submit form
- [ ] Verify that form response identifies the unsupported character correctly

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
