### PR TITLE
LG-8947 Improve analytics for FraudRejectionDailyJob

### DIFF
--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -3,12 +3,19 @@ class FraudRejectionDailyJob < ApplicationJob
 
   def perform(_date)
     profiles_eligible_for_fraud_rejection.find_each do |profile|
-      analytics.automatic_fraud_rejection(verified_at: profile.verified_at)
+      analytics.automatic_fraud_rejection(
+        rejection_date: Time.zone.today,
+        verified_at: profile.verified_at,
+      )
       profile.reject_for_fraud(notify_user: false)
     end
   end
 
   private
+
+  def analytics(user: AnonymousUser.new)
+    Analytics.new(user: user, request: nil, session: {}, sp: nil)
+  end
 
   def profiles_eligible_for_fraud_rejection
     Profile.where(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -163,11 +163,13 @@ module AnalyticsEvents
     track_event('Authentication Confirmation: Reset selected')
   end
 
-  # @param [Date] verified_at
+  # @param [Date] rejection_date Date of the rejection
+  # @param [Date] verified_at Date when profile was verified
   # Tracks when a profile is automatically rejected due to being under review for 30 days
-  def automatic_fraud_rejection(verified_at:, **extra)
+  def automatic_fraud_rejection(rejection_date:, verified_at:, **extra)
     track_event(
       'Fraud: Automatic Fraud Rejection',
+      rejection_date: rejection_date,
       verified_at: verified_at,
       **extra,
     )

--- a/spec/jobs/fraud_rejection_daily_job_spec.rb
+++ b/spec/jobs/fraud_rejection_daily_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe FraudRejectionDailyJob do
       expect { job.perform(Time.zone.today) }.to change { rejected_profiles.count }.by(1)
       expect(job_analytics).to have_logged_event(
         'Fraud: Automatic Fraud Rejection',
+        rejection_date: Time.zone.today,
         verified_at: rejected_profiles.first.verified_at,
       )
     end


### PR DESCRIPTION
changelog: Internal, IdV Fraud, Improve analytics on FraudRejectiondailyJob

Improves the analytics to show the day the profile was rejected to compare with the day the profile entered the fraud_review_pending state

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
