### PR TITLE
Remove querying from good_jobs table in heartbeat job

### DIFF
--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -5,11 +5,6 @@ class HeartbeatJob < ApplicationJob
     IdentityJobLogSubscriber.new.logger.info(
       {
         name: 'queue_metric.good_job',
-        # borrowed from: https://github.com/bensheldon/good_job/blob/main/engine/app/controllers/good_job/dashboards_controller.rb#L35
-        num_finished: GoodJob::Execution.finished.count,
-        num_unfinished: GoodJob::Execution.unfinished.count,
-        num_running: GoodJob::Execution.running.count,
-        num_errors: GoodJob::Execution.where.not(error: nil).count,
       }.to_json,
     )
 

--- a/spec/jobs/heartbeat_job_spec.rb
+++ b/spec/jobs/heartbeat_job_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe HeartbeatJob, type: :job do
         msg = JSON.parse(str, symbolize_names: true)
         expect(msg).to eq(
           name: 'queue_metric.good_job',
-          num_finished: 0,
-          num_unfinished: 0,
-          num_running: 0,
-          num_errors: 0,
         )
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

The queries in the job currently can result in pretty heavy table scans if the jobs table gets too deep. We do have other metrics that allow us to monitor the health of the job queue that scale better with load and throughput.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
