### PR TITLE
LG-9050: Add password error handling

### DIFF
--- a/app/javascript/packages/submit-button/submit-button-element.ts
+++ b/app/javascript/packages/submit-button/submit-button-element.ts
@@ -1,7 +1,7 @@
 class SubmitButtonElement extends HTMLElement {
-  connectedCallback() {
-    this.form?.addEventListener('submit', () => this.activate());
-  }
+  // connectedCallback() {
+  //   this.form?.addEventListener('submit', () => this.activate());
+  // }
 
   get form(): HTMLFormElement | null {
     return this.closest('form');

--- a/app/javascript/packages/submit-button/submit-button-element.ts
+++ b/app/javascript/packages/submit-button/submit-button-element.ts
@@ -1,7 +1,7 @@
 class SubmitButtonElement extends HTMLElement {
-  // connectedCallback() {
-  //   this.form?.addEventListener('submit', () => this.activate());
-  // }
+  connectedCallback() {
+    this.form?.addEventListener('submit', () => this.activate());
+  }
 
   get form(): HTMLFormElement | null {
     return this.closest('form');

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -20,10 +20,8 @@ const fallback = ['pw-na', '...'];
 
 function getStrength(z) {
   // override the strength value to 2 if the password is < 12
-  if (!(z && z.password.length && z.password.length >= 12)) {
-    if (z.score >= 3) {
-      z.score = 2;
-    }
+  if (z.password.length < 12 && z.score >= 3) {
+    z.score = 2;
   }
   return z && z.password.length ? scale[z.score] : fallback;
 }
@@ -81,13 +79,6 @@ export function getFeedback(z) {
 function zScoreFeedback(password, forbiddenPasswords) {
   const z = zxcvbn(password, forbiddenPasswords);
 
-  // override the strength value to 2 if the password is < 12
-  if (!(z && z.password.length && z.password.length >= 12)) {
-    if (z.score >= 3) {
-      z.score = 2;
-    }
-  }
-
   return z;
 }
 
@@ -109,7 +100,6 @@ function analyzePw() {
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');
   const pwFeedback = document.getElementById('pw-strength-feedback');
-  // const submit = document.querySelector('[type="submit"]');
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden]');
   const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -18,13 +18,6 @@ const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').to
 // fallback if zxcvbn lookup fails / field is empty
 const fallback = ['pw-na', '...'];
 
-// function clearErrors() {
-//   const x = document.getElementsByClassName('error-message');
-//   if (x.length > 0) {
-//     x[0].innerHTML = '';
-//   }
-// }
-
 function getStrength(z) {
   // override the strength value to 2 if the password is < 12
   if (!(z && z.password.length && z.password.length >= 12)) {
@@ -84,18 +77,6 @@ export function getFeedback(z) {
 
   return `${suggestions.map((s) => lookup(s)).join('. ')}`;
 }
-
-// function disableSubmit(submitEl, length = 0, score = 0) {
-//   if (!submitEl) {
-//     return;
-//   }
-
-//   if (score < 3 || length < 12) {
-//     submitEl.setAttribute('disabled', true);
-//   } else {
-//     submitEl.removeAttribute('disabled');
-//   }
-// }
 
 function zScoreFeedback(password, forbiddenPasswords) {
   const z = zxcvbn(password, forbiddenPasswords);
@@ -161,7 +142,6 @@ function analyzePw() {
   }
 
   input.addEventListener('input', (e) => {
-    // clearErrors();
     checkPasswordStrength(e.target.value);
   });
 }

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -123,7 +123,7 @@ function analyzePw() {
   }
 
   function checkPasswordStrength(password) {
-    const z = zScoreFeedback(password, forbiddenPasswords);
+    const z = zxcvbn(password, forbiddenPasswords);
     const [cls, strength] = getStrength(z);
     const feedback = getFeedback(z);
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -18,12 +18,12 @@ const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').to
 // fallback if zxcvbn lookup fails / field is empty
 const fallback = ['pw-na', '...'];
 
-function clearErrors() {
-  const x = document.getElementsByClassName('error-message');
-  if (x.length > 0) {
-    x[0].innerHTML = '';
-  }
-}
+// function clearErrors() {
+//   const x = document.getElementsByClassName('error-message');
+//   if (x.length > 0) {
+//     x[0].innerHTML = '';
+//   }
+// }
 
 function getStrength(z) {
   // override the strength value to 2 if the password is < 12
@@ -125,7 +125,6 @@ export function getForbiddenPasswords(element) {
 
 function analyzePw() {
   const input = document.querySelector('.password-toggle__input');
-  const form = document.getElementById('new_password_form');
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');
   const pwFeedback = document.getElementById('pw-strength-feedback');
@@ -138,10 +137,18 @@ function analyzePw() {
   // thus, first step is unhiding it
   pwCntnr.className = '';
 
-  function updateUserFeedback(cls, strength, feedback) {
+  function updatePasswordFeedback(cls, strength, feedback) {
     pwCntnr.className = cls;
     pwStrength.innerHTML = strength;
     pwFeedback.innerHTML = feedback;
+  }
+
+  function validatePasswordField(score) {
+    if (score < 3) {
+      input.setCustomValidity(t('errors.messages.stronger_password'));
+    } else {
+      input.setCustomValidity('');
+    }
   }
 
   function checkPasswordStrength(password) {
@@ -149,19 +156,13 @@ function analyzePw() {
     const [cls, strength] = getStrength(z);
     const feedback = getFeedback(z);
 
-    updateUserFeedback(cls, strength, feedback);
+    validatePasswordField(z.score);
+    updatePasswordFeedback(cls, strength, feedback);
   }
 
   input.addEventListener('input', (e) => {
-    clearErrors();
+    // clearErrors();
     checkPasswordStrength(e.target.value);
-  });
-
-  form.addEventListener('submit', (e) => {
-    // TODO: Add additional check
-    e.preventDefault();
-    input.setCustomValidity(t('errors.messages.stronger_password'));
-    input.dispatchEvent(new CustomEvent('invalid'));
   });
 }
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -76,12 +76,6 @@ export function getFeedback(z) {
   return `${suggestions.map((s) => lookup(s)).join('. ')}`;
 }
 
-function zScoreFeedback(password, forbiddenPasswords) {
-  const z = zxcvbn(password, forbiddenPasswords);
-
-  return z;
-}
-
 /**
  * @param {HTMLElement?} element
  *

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -77,6 +77,7 @@ en:
         select a different number and try again.
       pwned_password: The password you entered is not safe. It’s in a list of known
         passwords exposed in data breaches.
+      stronger_password: Enter a stronger password
       too_long:
         one: is too long (maximum is 1 character)
         other: is too long (maximum is %{count} characters)

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -81,6 +81,7 @@ es:
         premium. Por favor, seleccione otro número e inténtelo de nuevo.
       pwned_password: La contraseña que ingresaste no es segura. Está en una lista de
         contraseñas conocidas expuestas en violaciones de datos.
+      stronger_password: Stronger password message Spanish
       too_long:
         one: es demasiado largo (el máximo es 1 carácter)
         other: es demasiado largo (el máximo es %{count} caracteres)

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -81,7 +81,7 @@ es:
         premium. Por favor, seleccione otro número e inténtelo de nuevo.
       pwned_password: La contraseña que ingresaste no es segura. Está en una lista de
         contraseñas conocidas expuestas en violaciones de datos.
-      stronger_password: Stronger password message Spanish
+      stronger_password: Introduzca una contraseña más segura
       too_long:
         one: es demasiado largo (el máximo es 1 carácter)
         other: es demasiado largo (el máximo es %{count} caracteres)

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -91,7 +91,7 @@ fr:
       pwned_password: Le mot de passe que vous avez entré n’est pas sécurisé. C’est
         dans une liste de mots de passe connus exposés dans les violations de
         données.
-      stronger_password: Stronger password message French
+      stronger_password: Entrez un mot de passe plus fort
       too_long:
         one: Est trop long (maximum de 1 caractère)
         other: est trop long (le maximum est de %{count} caractères)

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -91,6 +91,7 @@ fr:
       pwned_password: Le mot de passe que vous avez entré n’est pas sécurisé. C’est
         dans une liste de mots de passe connus exposés dans les violations de
         données.
+      stronger_password: Stronger password message French
       too_long:
         one: Est trop long (maximum de 1 caractère)
         other: est trop long (le maximum est de %{count} caractères)

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -180,8 +180,7 @@ feature 'Password Recovery' do
         fill_in t('forms.passwords.edit.labels.password'), with: 'invalid'
         click_button t('forms.passwords.edit.buttons.submit')
 
-        message = find('input.password-toggle__input').native.attribute('validationMessage')
-        expect(message).to eq t('errors.messages.stronger_password')
+        expect(page).to have_css('.usa-error-message', text: t('errors.messages.stronger_password'))
       end
 
       it 'displays field validation error when password fields are empty' do

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -178,13 +178,10 @@ feature 'Password Recovery' do
     context 'when password form values are invalid' do
       it 'does not allow the user to submit until password score is good', js: true do
         fill_in t('forms.passwords.edit.labels.password'), with: 'invalid'
-        expect(page).not_to have_button(t('forms.passwords.edit.buttons.submit'))
+        click_button t('forms.passwords.edit.buttons.submit')
 
-        fill_in t('forms.passwords.edit.labels.password'), with: 'password@132!'
-        expect(page).not_to have_button(t('forms.passwords.edit.buttons.submit'))
-
-        fill_in t('forms.passwords.edit.labels.password'), with: 'a unique and exciting zxjsahfas'
-        expect(page).to have_button(t('forms.passwords.edit.buttons.submit'))
+        message = find('input.password-toggle__input').native.attribute('validationMessage')
+        expect(message).to eq t('errors.messages.stronger_password')
       end
 
       it 'displays field validation error when password fields are empty' do

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -98,8 +98,7 @@ feature 'Visitor sets password during signup' do
       fill_in t('forms.password'), with: 'badpwd'
       click_button t('forms.buttons.continue')
 
-      message = find('input.password-toggle__input').native.attribute('validationMessage')
-      expect(message).to eq t('errors.messages.stronger_password')
+      expect(page).to have_css('.usa-error-message', text: t('errors.messages.stronger_password'))
     end
   end
 end

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -17,10 +17,10 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
-    it 'does not allow the user to submit the form' do
+    it 'visitor gets field is required message' do
       fill_in t('forms.password'), with: ''
-
-      expect(page).to_not have_button(t('forms.buttons.continue'))
+      click_button t('forms.buttons.continue')
+      expect(page).to have_content t('simple_form.required.text')
     end
   end
 
@@ -64,9 +64,12 @@ feature 'Visitor sets password during signup' do
   end
 
   context 'password is invalid' do
-    scenario 'visitor is redirected back to password form' do
+    before do
       create(:user, :unconfirmed)
       confirm_last_user
+    end
+
+    scenario 'visitor is redirected back to password form' do
       fill_in t('forms.password'), with: 'Q!2e'
 
       click_button t('forms.buttons.continue')
@@ -76,8 +79,6 @@ feature 'Visitor sets password during signup' do
     end
 
     scenario 'visitor gets password help message' do
-      create(:user, :unconfirmed)
-      confirm_last_user
       fill_in t('forms.password'), with: '1234567891011'
 
       click_button t('forms.buttons.continue')
@@ -86,13 +87,18 @@ feature 'Visitor sets password during signup' do
     end
 
     scenario 'visitor gets password pwned message' do
-      create(:user, :unconfirmed)
-      confirm_last_user
       fill_in t('forms.password'), with: '3.1415926535'
 
       click_button t('forms.buttons.continue')
 
       expect(page).to have_content t('errors.messages.pwned_password')
+    end
+
+    scenario 'visitor gets enter a stronger password message', js: true do
+      fill_in t('forms.password'), with: 'badpwd'
+      click_button t('forms.buttons.continue')
+      message = find('input.password-toggle__input').native.attribute('validationMessage')
+      expect(message).to eq t('errors.messages.stronger_password')
     end
   end
 end

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -97,6 +97,7 @@ feature 'Visitor sets password during signup' do
     scenario 'visitor gets enter a stronger password message', js: true do
       fill_in t('forms.password'), with: 'badpwd'
       click_button t('forms.buttons.continue')
+
       message = find('input.password-toggle__input').native.attribute('validationMessage')
       expect(message).to eq t('errors.messages.stronger_password')
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9050](https://cm-jira.usa.gov/browse/LG-9050)



## 🛠 Summary of changes

This code changes password validation feedback when a user creates a new password for their account. The submit button is no longer disabled and error feedback is immediately applied. Please see the attached Figma for more information.

## 📜 Testing Plan

Create a new account. When entering a new password that is invalid please observe the changes in feedback.