### PR TITLE
Add configuration for enabling primary database prepared statements

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,7 @@ production:
     host: <%= IdentityConfig.store.database_socket.present? ?  IdentityConfig.store.database_socket : IdentityConfig.store.database_host %>
     password: <%= IdentityConfig.store.database_password %>
     pool: <%= primary_pool %>
+    prepared_statements: <%= !IdentityConfig.store.database_socket.present? %>
     sslmode: 'verify-full'
     sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'
     migrations_paths: db/primary_migrate


### PR DESCRIPTION
## 🛠 Summary of changes

This is a followup to #7967 which was added to enable connecting to the database via a pgbouncer socket in deployed environments. Currently, our setup requires disabling prepared statements if we're using pgbouncer. I wasn't sure if this implicit configuration was a bit too clever, or if something a bit more comprehensive and explicit would be preferred.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
