### PR TITLE
Remove `skip_legacy_state` method

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -105,9 +105,7 @@ module Idv
         failure_reason: irs_attempts_api_tracker.parse_failure_reason(form_response),
       )
 
-      if form_response.success?
-        form_response = form_response.merge(check_ssn)
-      end
+      form_response = form_response.merge(check_ssn) if form_response.success?
       summarize_result_and_throttle_failures(form_response)
       delete_async
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -169,6 +169,11 @@ module Idv
       session[:profile_confirmation] = nil
     end
 
+    def invalidate_steps_after_verify_info!
+      address_verification_mechanism = 'phone'
+      invalidate_phone_step!
+    end
+
     def invalidate_phone_step!
       session[:vendor_phone_confirmation] = nil
       session[:user_phone_confirmation] = nil


### PR DESCRIPTION
The `skip_legacy_state` method had 2 major problems:

1. The name implies that the new state is somehow a legacy state
2. It is hidden in the `check_ssn` code which makes it difficult to understand how a user moves from the verify info controller to the phone controller

This method attempts to clean this up by removing `skip_legacy_state` method and moving its logic into more reasonable places in the verify info concern or into the `Idv::Session`.
