### PR TITLE
Add configuration for alternate Redis rate limit pool

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -257,6 +257,8 @@ recaptcha_secret_key_v3: ''
 recovery_code_length: 4
 redis_irs_attempt_api_url: redis://localhost:6379/2
 redis_throttle_url: redis://localhost:6379/1
+redis_throttle_alternate_url: ''
+redis_throttle_alternate_pool_write_enabled: false
 redis_url: redis://localhost:6379/0
 redis_pool_size: 10
 redis_session_pool_size: 10

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,3 +5,10 @@ end
 REDIS_THROTTLE_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_throttle_pool_size) do
   Redis.new(url: IdentityConfig.store.redis_throttle_url)
 end
+
+REDIS_THROTTLE_ALTERNATE_POOL =
+  if IdentityConfig.store.redis_throttle_alternate_url
+    ConnectionPool.new(size: IdentityConfig.store.redis_throttle_pool_size) do
+      Redis.new(url: IdentityConfig.store.redis_throttle_alternate_url)
+    end
+  end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -360,6 +360,8 @@ class IdentityConfig
     config.add(:redis_irs_attempt_api_url)
     config.add(:redis_irs_attempt_api_pool_size, type: :integer)
     config.add(:redis_throttle_url)
+    config.add(:redis_throttle_alternate_url)
+    config.add(:redis_throttle_alternate_pool_write_enabled, type: :boolean)
     config.add(:redis_url)
     config.add(:redis_pool_size, type: :integer)
     config.add(:redis_session_pool_size, type: :integer)


### PR DESCRIPTION
## 🛠 Summary of changes

This [PR](https://github.com/18F/identity-devops/pull/5692) creates a separate Redis instance for rate limiting because rate limiting has different usage characteristics than our primary instance generally does. There are critical rate limits in the `Throttle` service, and this PR is intended to provide a write-to-both for a period of time, switch to reading from the alternate, and then removing the usage of the primary for rate limiting.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
