### PR TITLE
Change the regular expression we use to determine if get to yes is viable

### DIFF
--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -50,7 +50,7 @@ module Proofing
         def failed_result_can_pass_with_additional_verification?(verification_response)
           return false unless verification_response.verification_status == 'failed'
           return false unless verification_response.verification_errors.keys.to_set == Set[:InstantVerify, :base]
-          return false unless verification_response.verification_errors[:base].match?(/total\.scoring\.model\.verification\.fail/)
+          return false unless verification_response.verification_errors[:base].match?(/(total|priority)\.scoring\.model\.verification\.fail/)
           return false unless attributes_requiring_additional_verification(verification_response).any?
           true
         end

--- a/spec/fixtures/proofing/lexis_nexis/instant_verify/date_of_birth_failure_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/instant_verify/date_of_birth_failure_response.json
@@ -4,7 +4,7 @@
     "RequestId": "7890",
     "TransactionStatus": "failed",
     "TransactionReasonCode": {
-      "Code": "total.scoring.model.verification.fail"
+      "Code": "priority.scoring.model.verification.fail"
     },
     "Reference": "0987:1234-abcd"
   },
@@ -15,7 +15,7 @@
       "ProductConfigurationName": "REDACTED_CONFIGURATION",
       "ProductStatus": "fail",
       "ProductReason": {
-        "Code": "total.scoring.model.verification.fail"
+        "Code": "priority.scoring.model.verification.fail"
       },
       "Items": [
         {


### PR DESCRIPTION
Before we use the get-to-yes feature we need to make sure that the base lexis nexis error refers to the scoring model verification. This is what implies that the checks failed and we can fallback to AAMVA.

LexisNexis uses the code priority.scoring.model.verification.fail for some of its workflows. This commit changes the regex we use to match against the code to match that code.
