### PR TITLE
Disable advisory locks when using pgbouncer socket

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,7 @@ production:
     host: <%= IdentityConfig.store.database_socket.present? ?  IdentityConfig.store.database_socket : IdentityConfig.store.database_host %>
     password: <%= IdentityConfig.store.database_password %>
     pool: <%= primary_pool %>
+    advisory_locks: <%= !IdentityConfig.store.database_socket.present? %>
     prepared_statements: <%= !IdentityConfig.store.database_socket.present? %>
     sslmode: 'verify-full'
     sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'


### PR DESCRIPTION
## 🛠 Summary of changes

This disables advisory locks when a DB socket is used for the primary database connection.  `pgbouncer` does not support advisory lock use when in transaction mode.

Related PRs #7990 and #7967


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
