### PR TITLE
LG-9206 | Analytics logs irs_session_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,7 @@ class ApplicationController < ActionController::Base
         sp: current_sp&.issuer,
         session: session,
         ahoy: ahoy,
+        irs_session_id: irs_attempts_api_session_id,
       )
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -4,14 +4,15 @@ class Analytics
   include AnalyticsEvents
   prepend Idv::AnalyticsEventsEnhancer
 
-  attr_reader :user, :request, :sp, :ahoy
+  attr_reader :user, :request, :sp, :ahoy, :irs_session_id
 
-  def initialize(user:, request:, sp:, session:, ahoy: nil)
+  def initialize(user:, request:, sp:, session:, ahoy: nil, irs_session_id: nil)
     @user = user
     @request = request
     @sp = sp
     @ahoy = ahoy || Ahoy::Tracker.new(request: request)
     @session = session
+    @irs_session_id = irs_session_id
   end
 
   def track_event(event, attributes = {})
@@ -26,6 +27,7 @@ class Analytics
       locale: I18n.locale,
     }
 
+    analytics_hash.merge!(irs_session_id: irs_session_id) if irs_session_id
     analytics_hash.merge!(request_attributes) if request
 
     ahoy.track(event, analytics_hash)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -27,7 +27,7 @@ class Analytics
       locale: I18n.locale,
     }
 
-    analytics_hash.merge!(irs_session_id: irs_session_id) if irs_session_id
+    analytics_hash[:irs_session_id] = irs_session_id if irs_session_id
     analytics_hash.merge!(request_attributes) if request
 
     ahoy.track(event, analytics_hash)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -237,7 +237,7 @@ describe ApplicationController do
 
         expect(Analytics).to receive(:new).
           with(user: user, request: request, sp: sp.issuer, session: match_array({}),
-               ahoy: controller.ahoy)
+               ahoy: controller.ahoy, irs_session_id: nil)
 
         controller.analytics
       end
@@ -252,7 +252,7 @@ describe ApplicationController do
 
         expect(Analytics).to receive(:new).
           with(user: user, request: request, sp: nil, session: match_array({}),
-               ahoy: controller.ahoy)
+               ahoy: controller.ahoy, irs_session_id: nil)
 
         controller.analytics
       end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -37,6 +37,7 @@ describe Analytics do
   let(:request) { FakeRequest.new }
   let(:path) { 'fake_path' }
   let(:success_state) { 'GET|fake_path|Trackable Event' }
+  let(:irs_session_id) { nil }
 
   subject(:analytics) do
     Analytics.new(
@@ -45,6 +46,7 @@ describe Analytics do
       sp: 'http://localhost:3000',
       session: {},
       ahoy: ahoy,
+      irs_session_id: irs_session_id,
     )
   end
 
@@ -81,6 +83,19 @@ describe Analytics do
       )
 
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
+    end
+
+    context 'irs_session_id' do
+      let(:irs_session_id) { 'abc123' }
+
+      it 'includes irs_session_id when present' do
+        expect(ahoy).to receive(:track).with(
+          'Trackable Event',
+          analytics_attributes.merge(irs_session_id: irs_session_id)
+        )
+
+        analytics.track_event('Trackable Event')
+      end
     end
 
     context 'tracing headers' do

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -85,15 +85,27 @@ describe Analytics do
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
     end
 
-    context 'irs_session_id' do
+    context 'with an irs_session_id' do
       let(:irs_session_id) { 'abc123' }
 
-      it 'includes irs_session_id when present' do
+      it 'includes irs_session_id' do
         expect(ahoy).to receive(:track).with(
           'Trackable Event',
-          analytics_attributes.merge(irs_session_id: irs_session_id)
+          analytics_attributes.merge(irs_session_id: irs_session_id),
         )
 
+        analytics.track_event('Trackable Event')
+      end
+    end
+
+    context 'without an irs_session_id' do
+      let(:irs_session_id) { nil }
+
+      it 'omits the irs_session_id key entirely' do
+        expect(ahoy).to receive(:track).with(
+          'Trackable Event',
+          hash_excluding(irs_session_id: irs_session_id),
+        )
         analytics.track_event('Trackable Event')
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

LG-9206

## 🛠 Summary of changes

We are going to need this information in the logs for correlation of fraud data.