### PR TITLE
Update have_description accessibility matcher for feature spec compatility

### DIFF
--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -96,7 +96,7 @@ RSpec::Matchers.define :have_description do |description|
   def descriptors(element)
     element['aria-describedby']&.
       split(' ')&.
-      map { |descriptor_id| rendered.at_css("##{descriptor_id}")&.text }
+      map { |descriptor_id| page.find("##{descriptor_id}")&.text }
   end
 
   match { |element| descriptors(element)&.include?(description) }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the custom RSpec `have_description` matcher to support use in Capybara feature specs.

Previously, this helper assumed `rendered` would be present either as a local variable or as defined during controller specs. This meant it could not be used in Capybara feature specs. The proposed changes would continue to be valid in existing usage, while also being compatible for use in Capybara feature specs.

See previous discussion: https://github.com/18F/identity-idp/pull/7989#discussion_r1138666873

## 📜 Testing Plan

- Existing specs using this matcher should continue to pass: `rspec spec/components`