### PR TITLE
Remove custom initializers from GoodJob classes

### DIFF
--- a/app/jobs/reports/daily_dropoffs_report.rb
+++ b/app/jobs/reports/daily_dropoffs_report.rb
@@ -19,11 +19,7 @@ module Reports
       verified
     ].freeze
 
-    attr_reader :report_date
-
-    def initialize(report_date = nil)
-      @report_date = report_date
-    end
+    attr_accessor :report_date
 
     def perform(report_date)
       @report_date = report_date

--- a/app/jobs/reports/duplicate_ssn_report.rb
+++ b/app/jobs/reports/duplicate_ssn_report.rb
@@ -4,11 +4,7 @@ module Reports
   class DuplicateSsnReport < BaseReport
     REPORT_NAME = 'duplicate-ssn-report'
 
-    attr_reader :report_date
-
-    def initialize(report_date = nil)
-      @report_date = report_date
-    end
+    attr_accessor :report_date
 
     def perform(report_date)
       @report_date = report_date

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -158,7 +158,7 @@ feature 'Analytics Regression', js: true do
 
       aggregate_failures 'populates data for each step of the Daily Dropoff Report' do
         row = CSV.parse(
-          Reports::DailyDropoffsReport.new(Time.zone.now).report_body,
+          Reports::DailyDropoffsReport.new.tap { |r| r.report_date = Time.zone.now }.report_body,
           headers: true,
         ).first
 

--- a/spec/jobs/reports/duplicate_ssn_report_spec.rb
+++ b/spec/jobs/reports/duplicate_ssn_report_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Reports::DuplicateSsnReport do
   subject(:report) { described_class.new.tap { |r| r.report_date = report_date } }
 
   describe '#perform' do
-
     it 'runs the report and uploads to S3' do
       expect(report).to receive(:save_report)
 

--- a/spec/jobs/reports/duplicate_ssn_report_spec.rb
+++ b/spec/jobs/reports/duplicate_ssn_report_spec.rb
@@ -4,8 +4,9 @@ require 'csv'
 RSpec.describe Reports::DuplicateSsnReport do
   let(:report_date) { Date.new(2022, 2, 2) }
 
+  subject(:report) { described_class.new.tap { |r| r.report_date = report_date } }
+
   describe '#perform' do
-    subject(:report) { described_class.new }
 
     it 'runs the report and uploads to S3' do
       expect(report).to receive(:save_report)
@@ -15,7 +16,7 @@ RSpec.describe Reports::DuplicateSsnReport do
   end
 
   describe '#report_body' do
-    subject(:report_body) { described_class.new(report_date).report_body }
+    subject(:report_body) { report.report_body }
 
     context 'with no data' do
       it 'is an empty report' do


### PR DESCRIPTION
**Why**: This messes with the jobs being instantiated by the scheduler

changelog: Internal, Reporting, Fix scheduled SSN and Daily Dropoff report jobs

**Background**

I inadvertently created a bad pattern in https://github.com/18F/identity-idp/pull/7960 and copied it to the SSN report

It results in errors like this that prevent these jobs from running

![image](https://user-images.githubusercontent.com/458784/225969475-4cb85a56-5aa3-4787-863f-cc591c8bf382.png)
