### PR TITLE
Add email support test case to mailer shared examples

### DIFF
--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -7,6 +7,7 @@ shared_examples 'a system email' do
   it 'does not include markup or layout with lack of broad email support' do
     body = mail.parts.first.body
 
+    # https://www.caniemail.com/features/image-svg/
     expect(body).not_to have_css('img[src$=".svg"]')
   end
 end

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -3,6 +3,12 @@ shared_examples 'a system email' do
     expect(mail.from).to eq [IdentityConfig.store.email_from]
     expect(mail[:from].display_names).to eq [IdentityConfig.store.email_from_display_name]
   end
+
+  it 'does not include markup or layout with lack of broad email support' do
+    body = mail.parts.first.body
+
+    expect(body).not_to have_css('img[src$=".svg"]')
+  end
 end
 
 # expects there to be a let(:user) in scope


### PR DESCRIPTION
## 🛠 Summary of changes

Enhances existing mailer shared example specs to include checks for content which may not be broadly supported in email clients. Currently, this includes a check for use of SVG images, which would be encouraged in application views, but which [does not have broad support in email clients](https://www.caniemail.com/features/image-svg/).

Previously:

- https://github.com/18F/identity-idp/pull/7956#discussion_r1139212563
- #6892
- https://github.com/18F/identity-idp/pull/6585#discussion_r922457944

## 📜 Testing Plan

Trigger a failure by adding a violating image to an email template in your local copy of the branch.

Example:

```diff
diff --git a/app/views/user_mailer/add_email.html.erb b/app/views/user_mailer/add_email.html.erb
index 6b31c0f2f..527bcd73c 100644
--- a/app/views/user_mailer/add_email.html.erb
+++ b/app/views/user_mailer/add_email.html.erb
@@ -3,6 +3,7 @@
   <%= t('user_mailer.add_email.footer', confirmation_period: @confirmation_period) %>
 </p>
 
+<%= image_tag(asset_url('logo.svg')) %>
 <table class="button expanded large radius">
   <tbody>
     <tr>
```

```
$ rspec spec/mailers/user_mailer_spec.rb 

Failures:

  1) UserMailer#add_email behaves like a system email does not include markup or layout with lack of broad email support
     Failure/Error: expect(body).not_to have_css('img[src$=".svg"]')
       expected not to find visible css "img[src$=\".svg\"]", found 1 match: ""
     Shared Example Group: "a system email" called from ./spec/mailers/user_mailer_spec.rb:32
     # ./spec/support/shared_examples_for_mailer.rb:10:in `block (2 levels) in <main>'
```