### PR TITLE
LG-8836: Don't log custom value for user_id in GetUspsProofingResultsJob

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -106,7 +106,6 @@ class GetUspsProofingResultsJob < ApplicationJob
   def email_analytics_attributes(enrollment)
     {
       timestamp: Time.zone.now,
-      user_id: enrollment.user_id,
       service_provider: enrollment.issuer,
       wait_until: mail_delivery_params(enrollment.proofed_at)[:wait_until],
     }

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -105,6 +105,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
   def email_analytics_attributes(enrollment)
     {
+      enrollment_code: enrollment.enrollment_code,
       timestamp: Time.zone.now,
       service_provider: enrollment.issuer,
       wait_until: mail_delivery_params(enrollment.proofed_at)[:wait_until],

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -243,7 +243,6 @@ class GetUspsProofingResultsJob < ApplicationJob
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_updated(
       **enrollment_analytics_attributes(enrollment, complete: true),
       **response_analytics_attributes(response),
-      fraud_suspected: response['fraudSuspected'],
       passed: false,
       primary_id_type: response['primaryIdType'],
       reason: 'Unsupported ID type',
@@ -262,7 +261,6 @@ class GetUspsProofingResultsJob < ApplicationJob
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_updated(
       **enrollment_analytics_attributes(enrollment, complete: true),
       **response_analytics_attributes(response[:body]),
-      fraud_suspected: response['fraudSuspected'],
       passed: false,
       reason: 'Enrollment has expired',
     )
@@ -343,7 +341,6 @@ class GetUspsProofingResultsJob < ApplicationJob
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_updated(
       **enrollment_analytics_attributes(enrollment, complete: true),
       **response_analytics_attributes(response),
-      fraud_suspected: response['fraudSuspected'],
       passed: true,
       reason: 'Successful status update',
     )

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -52,6 +52,7 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
         expect(job_analytics).to have_logged_event(
           'GetUspsProofingResultsJob: Success or failure email initiated',
           email_type: anything,
+          enrollment_code: pending_enrollment.enrollment_code,
           wait_until: anything,
           service_provider: pending_enrollment.issuer,
           timestamp: Time.zone.now,
@@ -440,6 +441,7 @@ RSpec.describe GetUspsProofingResultsJob do
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Success or failure email initiated',
               email_type: 'Success',
+              enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
               wait_until: wait_until,
@@ -464,6 +466,7 @@ RSpec.describe GetUspsProofingResultsJob do
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Success or failure email initiated',
               email_type: 'Failed',
+              enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
               wait_until: wait_until,
@@ -518,6 +521,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Success or failure email initiated',
             email_type: 'Success',
+            enrollment_code: pending_enrollment.enrollment_code,
             service_provider: anything,
             timestamp: anything,
             wait_until: nil,
@@ -559,6 +563,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Success or failure email initiated',
             email_type: 'Failed',
+            enrollment_code: pending_enrollment.enrollment_code,
             service_provider: anything,
             timestamp: anything,
             wait_until: nil,
@@ -600,6 +605,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Success or failure email initiated',
             email_type: 'Failed fraud suspected',
+            enrollment_code: pending_enrollment.enrollment_code,
             service_provider: anything,
             timestamp: anything,
             wait_until: nil,
@@ -645,6 +651,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Success or failure email initiated',
             email_type: 'Failed unsupported ID type',
+            enrollment_code: pending_enrollment.enrollment_code,
             service_provider: anything,
             timestamp: anything,
             wait_until: nil,

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -55,7 +55,6 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
           wait_until: anything,
           service_provider: pending_enrollment.issuer,
           timestamp: Time.zone.now,
-          user_id: pending_enrollment.user_id,
         )
       end
     end
@@ -443,7 +442,6 @@ RSpec.describe GetUspsProofingResultsJob do
               email_type: 'Success',
               service_provider: anything,
               timestamp: anything,
-              user_id: anything,
               wait_until: wait_until,
             )
           end
@@ -468,7 +466,6 @@ RSpec.describe GetUspsProofingResultsJob do
               email_type: 'Failed',
               service_provider: anything,
               timestamp: anything,
-              user_id: anything,
               wait_until: wait_until,
             )
           end
@@ -523,7 +520,6 @@ RSpec.describe GetUspsProofingResultsJob do
             email_type: 'Success',
             service_provider: anything,
             timestamp: anything,
-            user_id: anything,
             wait_until: nil,
           )
 
@@ -565,7 +561,6 @@ RSpec.describe GetUspsProofingResultsJob do
             email_type: 'Failed',
             service_provider: anything,
             timestamp: anything,
-            user_id: anything,
             wait_until: nil,
           )
 
@@ -607,7 +602,6 @@ RSpec.describe GetUspsProofingResultsJob do
             email_type: 'Failed fraud suspected',
             service_provider: anything,
             timestamp: anything,
-            user_id: anything,
             wait_until: nil,
           )
 
@@ -653,7 +647,6 @@ RSpec.describe GetUspsProofingResultsJob do
             email_type: 'Failed unsupported ID type',
             service_provider: anything,
             timestamp: anything,
-            user_id: anything,
             wait_until: nil,
           )
         end


### PR DESCRIPTION
[LG-8836](https://cm-jira.usa.gov/browse/LG-8836), [LG-9176](https://cm-jira.usa.gov/browse/LG-9176)

The Analytics class already logs a user's `uuid` as `user_id` if no alternative is passed; we were overwriting it in `email_analytics_attributes` with the user's `id` which made it harder to match with other events that were using `uuid`.

I also took the opportunity to remove redundant inclusion of `fraud_suspected` in three methods; all three call `response_analytics_attributes` which already includes the `fraud_suspected` value.

And, at @sheldon-b suggestion, I closed LG-9176 by also adding `enrollment_code` to the values logged in `email_analytics_attributes`.