### PR TITLE
Correct analytics name send_link to link_sent

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -766,8 +766,9 @@ module AnalyticsEvents
     )
   end
 
+  # @identity.idp.previous_event_name IdV: doc auth send_link submitted
   def idv_doc_auth_link_sent_submitted(**extra)
-    track_event('IdV: doc auth send_link submitted', **extra)
+    track_event('IdV: doc auth link_sent submitted', **extra)
   end
 
   def idv_doc_auth_link_sent_visited(**extra)


### PR DESCRIPTION
## 🛠 Summary of changes

The link_sent submitted analytics event was confusingly named send_link submitted. Correct this to get accurate information on whether send_link step is being accessed.

