### PR TITLE
LG-9135: Add logging for Help Center troubleshooting options click-through

### DIFF
--- a/app/controllers/redirect/contact_controller.rb
+++ b/app/controllers/redirect/contact_controller.rb
@@ -2,7 +2,7 @@ module Redirect
   class ContactController < RedirectController
     def show
       redirect_to_and_log(
-        IdentityConfig.store.idv_contact_url,
+        MarketingSite.contact_url,
         tracker_method: analytics.method(:contact_redirect),
       )
     end

--- a/app/controllers/redirect/help_center_controller.rb
+++ b/app/controllers/redirect/help_center_controller.rb
@@ -14,11 +14,8 @@ module Redirect
     end
 
     def article_params
-      begin
-        category, article = params.require([:category, :article])
-      rescue ActionController::ParameterMissing; end
-
-      { category:, article:, article_anchor: params[:article_anchor] }
+      category, article, article_anchor = params.values_at(:category, :article, :article_anchor)
+      { category:, article:, article_anchor: }
     end
   end
 end

--- a/app/controllers/redirect/help_center_controller.rb
+++ b/app/controllers/redirect/help_center_controller.rb
@@ -9,17 +9,16 @@ module Redirect
     private
 
     def validate_help_center_article_params
-      begin
-        return if MarketingSite.valid_help_center_article?(**article_params)
-      rescue ActionController::ParameterMissing
-      end
-
+      return if MarketingSite.valid_help_center_article?(**article_params)
       redirect_to root_url
     end
 
     def article_params
-      category, article = params.require([:category, :article])
-      { category: category, article: article }
+      begin
+        category, article = params.require([:category, :article])
+      rescue ActionController::ParameterMissing; end
+
+      { category:, article:, article_anchor: params[:article_anchor] }
     end
   end
 end

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -58,18 +58,22 @@ module TwoFactorAuthCode
       [
         troubleshoot_change_phone_or_method_option,
         {
-          url: MarketingSite.help_center_article_url(
+          url: help_center_redirect_path(
             category: 'get-started',
             article: 'authentication-options',
-            anchor: 'didn-t-receive-your-one-time-code',
+            article_anchor: 'didn-t-receive-your-one-time-code',
+            flow: :two_factor_authentication,
+            step: :otp_confirmation,
           ),
           text: t('two_factor_authentication.phone_verification.troubleshooting.code_not_received'),
           new_tab: true,
         },
         {
-          url: MarketingSite.help_center_article_url(
+          url: help_center_redirect_path(
             category: 'get-started',
             article: 'authentication-options',
+            flow: :two_factor_authentication,
+            step: :otp_confirmation,
           ),
           text: t('two_factor_authentication.phone_verification.troubleshooting.learn_more'),
           new_tab: true,

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -81,15 +81,15 @@ class MarketingSite
     URI.join(BASE_URL, locale_segment, 'security/').to_s
   end
 
-  def self.help_center_article_url(category:, article:, anchor: '')
-    if !valid_help_center_article?(category: category, article: article)
+  def self.help_center_article_url(category:, article:, article_anchor: '')
+    if !valid_help_center_article?(category:, article:, article_anchor:)
       raise ArgumentError.new("Unknown help center article category #{category}/#{article}")
     end
-    anchor_text = anchor.present? ? "##{anchor}" : ''
+    anchor_text = article_anchor.present? ? "##{article_anchor}" : ''
     URI.join(BASE_URL, locale_segment, "help/#{category}/#{article}/#{anchor_text}").to_s
   end
 
-  def self.valid_help_center_article?(category:, article:)
+  def self.valid_help_center_article?(category:, article:, **_article_anchor)
     HELP_CENTER_ARTICLES.include?("#{category}/#{article}")
   end
 end

--- a/app/views/two_factor_authentication/otp_expired/show.html.erb
+++ b/app/views/two_factor_authentication/otp_expired/show.html.erb
@@ -27,7 +27,7 @@
       heading: t('components.troubleshooting_options.default_heading'),
       options: [
         {
-          url: MarketingSite.contact_url,
+          url: contact_redirect_path(flow: :two_factor_authentication, step: :otp_expired),
           text: t('links.contact_support', app_name: APP_NAME),
           new_tab: true,
         },

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -44,9 +44,11 @@
        ).with_content(t('two_factor_authentication.login_options_link_text')) %>
   <% end %>
   <% c.option(
-       url: MarketingSite.help_center_article_url(
+       url: help_center_redirect_path(
          category: 'get-started',
          article: 'authentication-options',
+         flow: :two_factor_authentication,
+         step: :phone_setup_spam_protection,
        ),
        new_tab: true,
      ).with_content(t('two_factor_authentication.phone_verification.troubleshooting.learn_more')) %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -118,7 +118,6 @@ hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
 idv_attempt_window_in_hours: 6
-idv_contact_url: https://www.example.com
 idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -197,7 +197,6 @@ class IdentityConfig
     config.add(:identity_pki_disabled, type: :boolean)
     config.add(:identity_pki_local_dev, type: :boolean)
     config.add(:idv_attempt_window_in_hours, type: :integer)
-    config.add(:idv_contact_url, type: :string)
     config.add(:idv_contact_phone_number, type: :string)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)

--- a/spec/controllers/redirect/contact_controller_spec.rb
+++ b/spec/controllers/redirect/contact_controller_spec.rb
@@ -8,7 +8,7 @@ describe Redirect::ContactController do
   describe '#show' do
     let(:location_params) { { flow: 'flow', step: 'step', location: 'location', foo: 'bar' } }
     it 'redirects to contact page' do
-      redirect_url = IdentityConfig.store.idv_contact_url
+      redirect_url = MarketingSite.contact_url
 
       get :show, params: location_params
 
@@ -17,7 +17,7 @@ describe Redirect::ContactController do
         'Contact Page Redirect',
         flow: 'flow',
         location: 'location',
-        redirect_url: redirect_url,
+        redirect_url:,
         step: 'step',
       )
     end

--- a/spec/controllers/redirect/help_center_controller_spec.rb
+++ b/spec/controllers/redirect/help_center_controller_spec.rb
@@ -5,12 +5,8 @@ describe Redirect::HelpCenterController do
     stub_analytics
   end
 
-  let(:category) { nil }
-  let(:article) { nil }
-  let(:location_params) { {} }
-  subject(:response) do
-    get :show, params: { category: category, article: article, **location_params }
-  end
+  let(:params) { {} }
+  subject(:response) { get :show, params: }
 
   describe '#show' do
     context 'without help center article' do
@@ -21,8 +17,7 @@ describe Redirect::HelpCenterController do
     end
 
     context 'with invalid help center article' do
-      let(:category) { 'foo' }
-      let(:article) { 'bar' }
+      let(:params) { super().merge(category: 'foo', article: 'bar') }
 
       it 'redirects to the root url' do
         expect(response).to redirect_to root_url
@@ -33,12 +28,10 @@ describe Redirect::HelpCenterController do
     context 'with valid help center article' do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
+      let(:params) { super().merge(category:, article:) }
 
       it 'redirects to the help center article and logs' do
-        redirect_url = MarketingSite.help_center_article_url(
-          category: 'verify-your-identity',
-          article: 'accepted-state-issued-identification',
-        )
+        redirect_url = MarketingSite.help_center_article_url(category:, article:)
         expect(response).to redirect_to redirect_url
         expect(@analytics).to have_logged_event(
           'External Redirect',
@@ -46,21 +39,35 @@ describe Redirect::HelpCenterController do
         )
       end
 
+      context 'with optional anchor' do
+        let(:article_anchor) { 'heading' }
+        let(:params) { super().merge(article_anchor:) }
+
+        it 'redirects to the help center article and logs' do
+          redirect_url = MarketingSite.help_center_article_url(category:, article:, article_anchor:)
+          expect(response).to redirect_to redirect_url
+          expect(@analytics).to have_logged_event(
+            'External Redirect',
+            hash_including(redirect_url: redirect_url),
+          )
+        end
+      end
+
       context 'with location params' do
-        let(:location_params) { { flow: 'flow', step: 'step', location: 'location', foo: 'bar' } }
+        let(:flow) { 'flow' }
+        let(:step) { 'step' }
+        let(:location) { 'location' }
+        let(:params) { super().merge(flow:, step:, location:, foo: 'bar') }
 
         it 'logs with location params' do
           response
 
           expect(@analytics).to have_logged_event(
             'External Redirect',
-            redirect_url: MarketingSite.help_center_article_url(
-              category: 'verify-your-identity',
-              article: 'accepted-state-issued-identification',
-            ),
-            flow: 'flow',
-            step: 'step',
-            location: 'location',
+            redirect_url: MarketingSite.help_center_article_url(category:, article:),
+            flow:,
+            step:,
+            location:,
           )
         end
       end

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe MarketingSite do
   describe '.help_center_article_url' do
     let(:category) {}
     let(:article) {}
-    let(:anchor) {}
+    let(:article_anchor) {}
     let(:result) { MarketingSite.help_center_article_url(category: category, article: article) }
 
     context 'with invalid article' do
@@ -154,9 +154,9 @@ RSpec.describe MarketingSite do
     context 'with anchor' do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
-      let(:anchor) { 'test-anchor-url' }
+      let(:article_anchor) { 'test-anchor-url' }
       let(:result) do
-        MarketingSite.help_center_article_url(category: category, article: article, anchor: anchor)
+        MarketingSite.help_center_article_url(category:, article:, article_anchor:)
       end
 
       it 'returns article URL' do
@@ -170,7 +170,7 @@ RSpec.describe MarketingSite do
   describe '.valid_help_center_article?' do
     let(:category) {}
     let(:article) {}
-    let(:result) { MarketingSite.valid_help_center_article?(category: category, article: article) }
+    let(:result) { MarketingSite.valid_help_center_article?(category:, article:) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }
@@ -184,6 +184,15 @@ RSpec.describe MarketingSite do
       let(:article) { 'accepted-state-issued-identification' }
 
       it { expect(result).to eq(true) }
+
+      context 'with anchor' do
+        let(:article_anchor) { 'test-anchor-url' }
+        let(:result) do
+          MarketingSite.valid_help_center_article?(category:, article:, article_anchor:)
+        end
+
+        it { expect(result).to eq(true) }
+      end
     end
   end
 end

--- a/spec/views/phone_setup/spam_protection.html.erb_spec.rb
+++ b/spec/views/phone_setup/spam_protection.html.erb_spec.rb
@@ -20,7 +20,16 @@ describe 'users/phone_setup/spam_protection.html.erb' do
     expect(rendered).to have_field('new_phone_form[recaptcha_token]', type: :hidden)
   end
 
-  it 'does not render link to two factor options' do
+  it 'has expected troubleshooting options' do
+    expect(rendered).to have_link(
+      t('two_factor_authentication.phone_verification.troubleshooting.learn_more'),
+      href: help_center_redirect_path(
+        category: 'get-started',
+        article: 'authentication-options',
+        flow: :two_factor_authentication,
+        step: :phone_setup_spam_protection,
+      ),
+    )
     expect(rendered).not_to have_link(t('two_factor_authentication.login_options_link_text'))
   end
 
@@ -28,7 +37,7 @@ describe 'users/phone_setup/spam_protection.html.erb' do
     let(:two_factor_options_path) { root_path }
     let(:locals) { { two_factor_options_path: } }
 
-    it 'renders additional troubleshooting option' do
+    it 'renders additional troubleshooting option to two factor options' do
       expect(rendered).to have_link(
         t('two_factor_authentication.login_options_link_text'),
         href: two_factor_options_path,

--- a/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
@@ -7,6 +7,15 @@ describe 'two_factor_authentication/otp_expired/show.html.erb' do
     render
   end
 
+  it 'includes link to contact support' do
+    render
+
+    expect(rendered).to have_link(
+      t('links.contact_support', app_name: APP_NAME),
+      href: contact_redirect_path(flow: :two_factor_authentication, step: :otp_expired),
+    )
+  end
+
   context 'when a user selects sms as their otp delivery preference' do
     let(:otp_delivery_preference) { 'sms' }
     it 'resends the code via sms' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-9135](https://cm-jira.usa.gov/browse/LG-9135)

## 🛠 Summary of changes

Implements tracking for Help Center troubleshooting options shown on the following screens:

- OTP Confirmation
- OTP Expired
- reCAPTCHA Checkbox fallback

As part of ongoing MFA improvements, we want to understand clickthrough rate on troubleshooting flows as part of understanding drop-off on pages where troubleshooting options exist.

Controllers already exist to log redirects to the brochure site, so it's mostly a process of setting the troubleshooting options to link to these controller routes instead of the brochure site directly.

## 📜 Testing Plan

It's easiest to observe logging with a combination of `tail` and `jq` in a separate terminal instance from the IdP:

```
tail -F -n0 log/events.log | jq .
```

To simulate OTP expiration and reCAPTCHA handling, suggest the following revisions to `config/application.yml`:

```
otp_valid_for: 1
phone_recaptcha_score_threshold: 1.1
```

1. Go to http://localhost:3000
2. Sign in
3. Click "Add phone number" in account dashboard
4. Enter an international phone number (e.g. `3065550100`)
5. Click "Continue"
6. On "Protecting against spam" page, click "Learn more about troubleshooting options"
   1. Observe redirect occurs as expected and expected logged event is found in `log/events.log`
7. Click "Continue"
8. On "Enter your one-time code" page, click "I didn't receive my one-time code" and "Learn more about authentication options" links
   1. Observe redirect occurs as expected and expected logged events are found in `log/events.log`
9. Wait for OTP to expire (should be counting down if you applied suggested configuration above)
10. On "Your one-time code has expired" page, click "Contact Login.gov Support"
   1. Observe redirect occurs as expected and expected logged event is found in `log/events.log`