### PR TITLE
LG-9226: Update ArcGIS Geocoder Class Faraday Token request service name

### DIFF
--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -205,7 +205,7 @@ module ArcgisApi
         IdentityConfig.store.arcgis_api_generate_token_url,
         URI.encode_www_form(body),
       ) do |req|
-        req.options.context = { service_name: 'usps_token' }
+        req.options.context = { service_name: 'arcgis_token' }
       end.body
     end
   end


### PR DESCRIPTION
## [🎫 Ticket](https://cm-jira.usa.gov/browse/LG-9226)

## 🛠 Summary of changes

Uses an accurate service name for the faraday token request in geocoder class

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Check Cloudwatch to confirm new token requests are logged correctly
