### PR TITLE
Update NewRelic config to make errors list more readable

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -26,7 +26,9 @@ production:
       ActionController::RoutingError
       ActionDispatch::Http::MimeNegotiation::InvalidType
       GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-    ].join(',') %>"
+    ].tap do |errors|
+      errors << 'Errno::EADDRINUSE' if Identity::Hostdata.instance_role == 'worker'
+    end.join(',') %>"
   license_key: <%= IdentityConfig.store.newrelic_license_key %>
   log_level: info
   monitor_mode: true

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -21,7 +21,12 @@ production:
   error_collector:
     enabled: true
     capture_source: true
-    ignore_errors: "ActionController::RoutingError,ActionController::BadRequest,ActionDispatch::Http::MimeNegotiation::InvalidType,GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"
+    ignore_errors: "<%= %w[
+      ActionController::BadRequest
+      ActionController::RoutingError
+      ActionDispatch::Http::MimeNegotiation::InvalidType
+      GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+    ].join(',') %>"
   license_key: <%= IdentityConfig.store.newrelic_license_key %>
   log_level: info
   monitor_mode: true

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -26,9 +26,7 @@ production:
       ActionController::RoutingError
       ActionDispatch::Http::MimeNegotiation::InvalidType
       GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
-    ].tap do |errors|
-      errors << 'Errno::EADDRINUSE' if Identity::Hostdata.instance_role == 'worker'
-    end.join(',') %>"
+    ].join(',') %>"
   license_key: <%= IdentityConfig.store.newrelic_license_key %>
   log_level: info
   monitor_mode: true


### PR DESCRIPTION
We get a big spike in these errors every deploy, and they make it harder to tell if a deploy is successful or not. Ignoring them only on the worker should hopefully limit the scope

<img width="438" alt="Screen Shot 2023-03-20 at 11 43 03 AM" src="https://user-images.githubusercontent.com/458784/226436628-71b85881-6b72-476b-9f1b-aa3be7f5cd0e.png">

I opted to take advantage of the ERB in this YML file and make the section more readable across multiple lines