### PR TITLE
Use canonical URL for MarketingSite URLs

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -25,7 +25,7 @@ class MarketingSite
   end
 
   def self.security_and_privacy_practices_url
-    URI.join(BASE_URL, locale_segment, 'policy').to_s
+    URI.join(BASE_URL, locale_segment, 'policy/').to_s
   end
 
   def self.security_and_privacy_how_it_works_url
@@ -45,7 +45,7 @@ class MarketingSite
   end
 
   def self.contact_url
-    URI.join(BASE_URL, locale_segment, 'contact').to_s
+    URI.join(BASE_URL, locale_segment, 'contact/').to_s
   end
 
   def self.nice_help_url
@@ -53,7 +53,7 @@ class MarketingSite
   end
 
   def self.help_url
-    URI.join(BASE_URL, locale_segment, 'help').to_s
+    URI.join(BASE_URL, locale_segment, 'help/').to_s
   end
 
   def self.help_authentication_app_url

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -1,115 +1,147 @@
 require 'rails_helper'
 
 RSpec.describe MarketingSite do
+  shared_examples 'a marketing site URL' do
+    it 'has a path which ends with a trailing slash' do
+      path = URI.parse(url).path
+
+      expect(path).to end_with('/')
+    end
+  end
+
   describe '.base_url' do
+    subject(:url) { MarketingSite.base_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the base URL' do
-      expect(MarketingSite.base_url).to eq('https://www.login.gov/')
+      expect(url).to eq('https://www.login.gov/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the base URL with the locale appended' do
-        expect(MarketingSite.base_url).to eq('https://www.login.gov/es/')
+        expect(url).to eq('https://www.login.gov/es/')
       end
     end
   end
 
   describe '.security_and_privacy_practices_url' do
+    subject(:url) { MarketingSite.security_and_privacy_practices_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the privacy page' do
-      expect(MarketingSite.security_and_privacy_practices_url).
-        to eq('https://www.login.gov/policy')
+      expect(url).to eq('https://www.login.gov/policy/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the privacy page with the locale appended' do
-        expect(MarketingSite.security_and_privacy_practices_url).
-          to eq('https://www.login.gov/es/policy')
+        expect(url).to eq('https://www.login.gov/es/policy/')
       end
     end
   end
 
   describe '.security_and_privacy_how_it_works_url' do
+    subject(:url) { MarketingSite.security_and_privacy_how_it_works_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the privacy page' do
-      expect(MarketingSite.security_and_privacy_how_it_works_url).
-        to eq('https://www.login.gov/policy/how-does-it-work/')
+      expect(url).to eq('https://www.login.gov/policy/how-does-it-work/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the privacy page with the locale appended' do
-        expect(MarketingSite.security_and_privacy_how_it_works_url).
-          to eq('https://www.login.gov/es/policy/how-does-it-work/')
+        expect(url).to eq('https://www.login.gov/es/policy/how-does-it-work/')
       end
     end
   end
 
   describe '.rules_of_use_url' do
+    subject(:url) { MarketingSite.rules_of_use_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the rules of use page' do
-      expect(MarketingSite.rules_of_use_url).
-        to eq('https://www.login.gov/policy/rules-of-use/')
+      expect(url).to eq('https://www.login.gov/policy/rules-of-use/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the rules of use page with the locale appended' do
-        expect(MarketingSite.rules_of_use_url).
-          to eq('https://www.login.gov/es/policy/rules-of-use/')
+        expect(url).to eq('https://www.login.gov/es/policy/rules-of-use/')
       end
     end
   end
 
   describe '.messaging_practices_url' do
+    subject(:url) { MarketingSite.messaging_practices_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to messaging practices section of the privacy page' do
-      expect(MarketingSite.messaging_practices_url).
-        to eq('https://www.login.gov/policy/messaging-terms-and-conditions/')
+      expect(url).to eq('https://www.login.gov/policy/messaging-terms-and-conditions/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the privacy page section with the locale appended' do
-        expect(MarketingSite.messaging_practices_url).
-          to eq('https://www.login.gov/es/policy/messaging-terms-and-conditions/')
+        expect(url).to eq('https://www.login.gov/es/policy/messaging-terms-and-conditions/')
       end
     end
   end
 
   describe '.contact_url' do
+    subject(:url) { MarketingSite.contact_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the contact page' do
-      expect(MarketingSite.contact_url).to eq('https://www.login.gov/contact')
+      expect(url).to eq('https://www.login.gov/contact/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the contact page with the locale appended' do
-        expect(MarketingSite.contact_url).to eq('https://www.login.gov/es/contact')
+        expect(url).to eq('https://www.login.gov/es/contact/')
       end
     end
   end
 
   describe '.help_url' do
+    subject(:url) { MarketingSite.help_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the help page' do
-      expect(MarketingSite.help_url).to eq('https://www.login.gov/help')
+      expect(url).to eq('https://www.login.gov/help/')
     end
 
     context 'when the user has set their locale to :es' do
       before { I18n.locale = :es }
 
       it 'points to the help page with the locale appended' do
-        expect(MarketingSite.help_url).to eq('https://www.login.gov/es/help')
+        expect(url).to eq('https://www.login.gov/es/help/')
       end
     end
   end
 
   describe '.help_authentication_app_url' do
+    subject(:url) { MarketingSite.help_authentication_app_url }
+
+    it_behaves_like 'a marketing site URL'
+
     it 'points to the authentication app section of the help page' do
-      expect(MarketingSite.help_authentication_app_url).to eq(
+      expect(url).to eq(
         'https://www.login.gov/help/creating-an-account/authentication-application/',
       )
     end
@@ -118,7 +150,7 @@ RSpec.describe MarketingSite do
       before { I18n.locale = :es }
 
       it 'points to the authentication app section of the help page with the locale appended' do
-        expect(MarketingSite.help_authentication_app_url).to eq(
+        expect(url).to eq(
           'https://www.login.gov/es/help/creating-an-account/authentication-application/',
         )
       end
@@ -129,14 +161,14 @@ RSpec.describe MarketingSite do
     let(:category) {}
     let(:article) {}
     let(:article_anchor) {}
-    let(:result) { MarketingSite.help_center_article_url(category: category, article: article) }
+    let(:url) { MarketingSite.help_center_article_url(category: category, article: article) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }
       let(:article) { 'bar' }
 
       it 'raises ArgumentError' do
-        expect { result }.to raise_error ArgumentError
+        expect { url }.to raise_error ArgumentError
       end
     end
 
@@ -144,8 +176,10 @@ RSpec.describe MarketingSite do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
 
+      it_behaves_like 'a marketing site URL'
+
       it 'returns article URL' do
-        expect(result).to eq(
+        expect(url).to eq(
           'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/',
         )
       end
@@ -155,12 +189,14 @@ RSpec.describe MarketingSite do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
       let(:article_anchor) { 'test-anchor-url' }
-      let(:result) do
+      let(:url) do
         MarketingSite.help_center_article_url(category:, article:, article_anchor:)
       end
 
+      it_behaves_like 'a marketing site URL'
+
       it 'returns article URL' do
-        expect(result).to eq(
+        expect(url).to eq(
           'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/#test-anchor-url',
         )
       end
@@ -170,28 +206,28 @@ RSpec.describe MarketingSite do
   describe '.valid_help_center_article?' do
     let(:category) {}
     let(:article) {}
-    let(:result) { MarketingSite.valid_help_center_article?(category:, article:) }
+    let(:url) { MarketingSite.valid_help_center_article?(category:, article:) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }
       let(:article) { 'bar' }
 
-      it { expect(result).to eq(false) }
+      it { expect(url).to eq(false) }
     end
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
 
-      it { expect(result).to eq(true) }
+      it { expect(url).to eq(true) }
 
       context 'with anchor' do
         let(:article_anchor) { 'test-anchor-url' }
-        let(:result) do
+        let(:url) do
           MarketingSite.valid_help_center_article?(category:, article:, article_anchor:)
         end
 
-        it { expect(result).to eq(true) }
+        it { expect(url).to eq(true) }
       end
     end
   end

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -206,28 +206,28 @@ RSpec.describe MarketingSite do
   describe '.valid_help_center_article?' do
     let(:category) {}
     let(:article) {}
-    let(:url) { MarketingSite.valid_help_center_article?(category:, article:) }
+    let(:result) { MarketingSite.valid_help_center_article?(category:, article:) }
 
     context 'with invalid article' do
       let(:category) { 'foo' }
       let(:article) { 'bar' }
 
-      it { expect(url).to eq(false) }
+      it { expect(result).to eq(false) }
     end
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
       let(:article) { 'accepted-state-issued-identification' }
 
-      it { expect(url).to eq(true) }
+      it { expect(result).to eq(true) }
 
       context 'with anchor' do
         let(:article_anchor) { 'test-anchor-url' }
-        let(:url) do
+        let(:result) do
           MarketingSite.valid_help_center_article?(category:, article:, article_anchor:)
         end
 
-        it { expect(url).to eq(true) }
+        it { expect(result).to eq(true) }
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `MarketingSite` utility methods to include a trailing slash, to avoid an unnecessary redirect hop when users follow links to these destinations.

_Before:_

```
$ curl -i --silent https://www.login.gov/contact | head -n 1
HTTP/2 301 
```

_After:_

```
$ curl -i --silent https://www.login.gov/contact/ | head -n 1
HTTP/2 200 
```

## 📜 Testing Plan

- `rspec spec/services/marketing_site_spec.rb`
- Ensure affected links to Login.gov continue to behave as expected (see links in footer, for example)