### PR TITLE
Conditionally remove SendLink step from DocAuthFlow

### DIFF
--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -5,7 +5,8 @@ module Idv
         welcome: Idv::Steps::WelcomeStep,
         agreement: Idv::Steps::AgreementStep,
         upload: Idv::Steps::UploadStep,
-        send_link: Idv::Steps::SendLinkStep,
+        **(IdentityConfig.store.doc_auth_combined_hybrid_handoff_enabled ?
+          {} : { send_link: Idv::Steps::SendLinkStep }),
         link_sent: Idv::Steps::LinkSentStep,
         email_sent: Idv::Steps::EmailSentStep,
         document_capture: Idv::Steps::DocumentCaptureStep,


### PR DESCRIPTION
## 🎫 Ticket

LG-8903

## 🛠 Summary of changes
When the doc_auth_combined_hybrid_handoff_enabled feature flag is enabled, the SendLink step is not used. Conditionally remove it from the DocAuthFlow so that the send_link url is not accessed in the 50/50 state when the feature flag and SendLink code are fully removed.

This is an attempt to avoid the 500 errors we saw when we deployed #7929 last week. This code is a temporary bridge and will be removed when we re-deploy the big cleanup PR.

Co-authored-by: Kimball Bighorse <kimball.bighorse@gsa.gov>

[skip changelog]

<!-- Uncomment and update the sections you need for your PR! -->

