### PR TITLE
LG-9086: Preemptively refresh USPS auth tokens

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -148,9 +148,15 @@ module UspsInPersonProofing
     # already cached.
     # @return [Hash] Headers to add to USPS requests
     def dynamic_headers
-      token_remaining_time = Rails.cache.redis.ttl(AUTH_TOKEN_CACHE_KEY)
-      if token_remaining_time != -2 && token_remaining_time <= AUTH_TOKEN_REFRESH_THRESHOLD
-        retrieve_token!
+      if Rails.cache.try(:redis)
+        token_remaining_time = Rails.cache.redis.ttl(AUTH_TOKEN_CACHE_KEY)
+        if token_remaining_time != -2 && token_remaining_time <= AUTH_TOKEN_REFRESH_THRESHOLD
+          retrieve_token!
+        end
+      else
+        # TODO: implement a refresh for local tokens
+        # Might have to use send and a private method to check expiration time.  I couldn't find a non-private method to detect when an items in a Rails cache expires.
+        # https://stackoverflow.com/questions/39868775/get-expiration-time-of-rails-cached-item/69159992#69159992
       end
       {
         'Authorization' => token,

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -154,9 +154,11 @@ module UspsInPersonProofing
           retrieve_token!
         end
       else
-        # TODO: implement a refresh for local tokens
-        # Might have to use send and a private method to check expiration time.  I couldn't find a non-private method to detect when an items in a Rails cache expires.
-        # https://stackoverflow.com/questions/39868775/get-expiration-time-of-rails-cached-item/69159992#69159992
+        normalized_key = Rails.cache.send(:normalize_key, AUTH_TOKEN_CACHE_KEY)
+        token_expires_at = Rails.cache.send(:read_entry, normalized_key)&.expires_at
+        if !token_expires_at.nil? && (token_expires_at <= AUTH_TOKEN_REFRESH_THRESHOLD)
+          retrieve_token!
+        end
       end
       {
         'Authorization' => token,

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -105,7 +105,11 @@ module UspsInPersonProofing
       body = request_token
       # Refresh our token early so that it won't expire while a request is in-flight. We expect 15m
       # expirys for tokens but are careful not to trim the expiry by too much, just in case
-      expires_in = [body['expires_in'] - AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES, 1.minute].max
+      expires_in = body['expires_in']
+      if expires_in - AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES > 0
+        expires_in -= AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES
+      end
+
       expires_at = Time.zone.now + expires_in
       token = "#{body['token_type']} #{body['access_token']}"
       Rails.cache.write(AUTH_TOKEN_CACHE_KEY, token, expires_at: expires_at)

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -105,7 +105,7 @@ module UspsInPersonProofing
       body = request_token
       # Refresh our token early so that it won't expire while a request is in-flight. We expect 15m
       # expirys for tokens but are careful not to trim the expiry by too much, just in case
-      expires_in = body['expires_in']
+      expires_in = body['expires_in'].seconds
       if expires_in - AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES > 0
         expires_in -= AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES
       end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -2,7 +2,7 @@ module UspsInPersonProofing
   class Proofer
     AUTH_TOKEN_CACHE_KEY = :usps_ippaas_api_auth_token
     # Automatically refresh our auth token if it is within this many minutes of expiring
-    AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES = 1.minute
+    AUTH_TOKEN_PREEMPTIVE_EXPIRY_MINUTES = 1.minute
 
     # Makes HTTP request to get nearby in-person proofing facilities
     # Requires address, city, state and zip code.
@@ -106,8 +106,8 @@ module UspsInPersonProofing
       # Refresh our token early so that it won't expire while a request is in-flight. We expect 15m
       # expirys for tokens but are careful not to trim the expiry by too much, just in case
       expires_in = body['expires_in'].seconds
-      if expires_in - AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES > 0
-        expires_in -= AUTH_TOKEN_PREMATURE_EXPIRY_MINUTES
+      if expires_in - AUTH_TOKEN_PREEMPTIVE_EXPIRY_MINUTES > 0
+        expires_in -= AUTH_TOKEN_PREEMPTIVE_EXPIRY_MINUTES
       end
 
       expires_at = Time.zone.now + expires_in

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -109,15 +109,8 @@ module UspsInPersonProofing
       if expires_in - AUTH_TOKEN_PREEMPTIVE_EXPIRY_MINUTES > 0
         expires_in -= AUTH_TOKEN_PREEMPTIVE_EXPIRY_MINUTES
       end
-
-      expires_at = Time.zone.now + expires_in
       token = "#{body['token_type']} #{body['access_token']}"
-      Rails.cache.write(AUTH_TOKEN_CACHE_KEY, token, expires_at: expires_at)
-      # If using a redis cache we have to manually set the expires_at. This is because we aren't
-      # using a dedicated Redis cache and instead are just using our existing Redis server with
-      # mixed usage patterns. Without this cache entries don't expire.
-      # More at https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html
-      Rails.cache.try(:redis)&.expireat(AUTH_TOKEN_CACHE_KEY, expires_at.to_i)
+      Rails.cache.write(AUTH_TOKEN_CACHE_KEY, token, expires_in: expires_in)
       token
     end
 

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -203,6 +203,21 @@ RSpec.describe UspsInPersonProofing::Proofer do
         check_facility(facilities[0])
       end
     end
+
+    context 'when the token is stored in an in-memory cache' do
+      before do
+        allow(Rails).to receive(:cache).and_return(
+          ActiveSupport::Cache::MemoryStore.new,
+        )
+        stub_request_token
+      end
+      it 'returns facilities' do
+        stub_request_facilities
+        facilities = subject.request_facilities(location)
+
+        check_facility(facilities[0])
+      end
+    end
   end
 
   describe '#request_enroll' do

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -12,8 +12,11 @@ RSpec.describe UspsInPersonProofing::Proofer do
   end
 
   describe '#retrieve_token!' do
+    let(:auth_token) do
+      '==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=='
+    end
     it 'sets token and expiry' do
-      expect(cache).to receive(:write).with(
+      expect(Rails.cache).to receive(:write).with(
         UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
         an_instance_of(String),
         hash_including(expires_at: an_instance_of(ActiveSupport::TimeWithZone)),
@@ -21,9 +24,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
       stub_request_token
       subject.retrieve_token!
 
-      expect(subject.token).to eq(
-        '==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7==',
-      )
+      expect(subject.token).to eq("Bearer #{auth_token}")
     end
 
     it 'calls the authenticate endpoint with the expected params' do
@@ -193,84 +194,63 @@ RSpec.describe UspsInPersonProofing::Proofer do
         zip_code: Faker::Address.zip_code,
       )
     end
-    context 'when the token is valid' do
-      before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-        )
-        stub_request_token
-      end
 
-      it 'returns facilities' do
-        stub_request_facilities
-        facilities = subject.request_facilities(location)
+    before do
+      stub_request_token
+    end
 
-        check_facility(facilities[0])
-      end
+    it 'returns facilities' do
+      stub_request_facilities
+      facilities = subject.request_facilities(location)
 
-      it 'returns facilities sorted by ascending distance' do
-        stub_request_facilities_with_unordered_distance
-        facilities = subject.request_facilities(location)
+      check_facility(facilities[0])
+    end
 
-        expect(facilities.count).to be > 1
-        facilities.each_cons(2) do |facility_a, facility_b|
-          expect(facility_a.distance).to be <= facility_b.distance
-        end
-      end
+    it 'returns facilities sorted by ascending distance' do
+      stub_request_facilities_with_unordered_distance
+      facilities = subject.request_facilities(location)
 
-      it 'does not return duplicates' do
-        stub_request_facilities_with_duplicates
-        facilities = subject.request_facilities(location)
-
-        expect(facilities.length).to eq(9)
-        expect(
-          facilities.count do |post_office|
-            post_office.address == '3775 INDUSTRIAL BLVD'
-          end,
-        ).to eq(1)
+      expect(facilities.count).to be > 1
+      facilities.each_cons(2) do |facility_a, facility_b|
+        expect(facility_a.distance).to be <= facility_b.distance
       end
     end
 
-    context 'when the token is expired' do
-      let(:cache) { double(ActiveSupport::Cache::MemoryStore) }
-      let(:redis) { double(Redis) }
+    it 'does not return duplicates' do
+      stub_request_facilities_with_duplicates
+      facilities = subject.request_facilities(location)
+
+      expect(facilities.length).to eq(9)
+      expect(
+        facilities.count do |post_office|
+          post_office.address == '3775 INDUSTRIAL BLVD'
+        end,
+      ).to eq(1)
+    end
+
+    context 'when the auth token is expired' do
+      let(:expires_in) { 15.minutes }
+
       before do
-        set_up_expired_token(cache, redis)
-        stub_request_token
         stub_request_facilities
       end
 
-      it 'fetches a new token' do
-        check_for_token_refresh_and_method_call(cache, redis)
-
-        facilities = subject.request_facilities(location)
+      it 'refreshes the auth token before making the request' do
+        subject.token
+        expired_time = Time.zone.now + expires_in
+        facilities = nil
+        travel_to(expired_time) do
+          facilities = subject.request_facilities(location)
+        end
 
         expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate").twice
-
         expect(facilities.length).to eq(10)
-        check_facility(facilities[0])
-      end
-    end
-
-    context 'when the token is stored in an in-memory cache' do
-      before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::MemoryStore.new,
-        )
-        stub_request_token
-      end
-      it 'returns facilities' do
-        stub_request_facilities
-        facilities = subject.request_facilities(location)
-
         check_facility(facilities[0])
       end
     end
   end
 
   describe '#request_enroll' do
-    let(:cache) { double(ActiveSupport::Cache::MemoryStore) }
-    let(:redis) { double(Redis) }
     let(:applicant) do
       double(
         'applicant',
@@ -284,62 +264,65 @@ RSpec.describe UspsInPersonProofing::Proofer do
         unique_id: '123456789',
       )
     end
-    context 'when the token is valid' do
-      before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-        )
-        stub_request_token
-      end
-      it 'returns enrollment information' do
-        stub_request_enroll
 
-        enrollment = subject.request_enroll(applicant)
-        expect(enrollment.enrollment_code).to be_present
-        expect(enrollment.response_message).to be_present
-      end
-
-      it 'returns 400 error' do
-        stub_request_enroll_bad_request_response
-
-        expect { subject.request_enroll(applicant) }.to raise_error(
-          an_instance_of(Faraday::BadRequestError).
-          and(having_attributes(
-            response: include(
-              body: include(
-                'responseMessage' => 'Sponsor for sponsorID 5 not found',
-              ),
-            ),
-          )),
-        )
-      end
-
-      it 'returns 500 error' do
-        stub_request_enroll_internal_server_error_response
-
-        expect { subject.request_enroll(applicant) }.to raise_error(
-          an_instance_of(Faraday::ServerError).
-          and(having_attributes(
-            response: include(
-              body: include(
-                'responseMessage' => 'An internal error occurred processing the request',
-              ),
-            ),
-          )),
-        )
-      end
+    before do
+      stub_request_token
     end
 
-    context 'when the token is expired' do
+    it 'returns enrollment information' do
+      stub_request_enroll
+
+      enrollment = subject.request_enroll(applicant)
+      expect(enrollment.enrollment_code).to be_present
+      expect(enrollment.response_message).to be_present
+    end
+
+    it 'returns 400 error' do
+      stub_request_enroll_bad_request_response
+
+      expect { subject.request_enroll(applicant) }.to raise_error(
+        an_instance_of(Faraday::BadRequestError).
+        and(having_attributes(
+          response: include(
+            body: include(
+              'responseMessage' => 'Sponsor for sponsorID 5 not found',
+            ),
+          ),
+        )),
+      )
+    end
+
+    it 'returns 500 error' do
+      stub_request_enroll_internal_server_error_response
+
+      expect { subject.request_enroll(applicant) }.to raise_error(
+        an_instance_of(Faraday::ServerError).
+        and(having_attributes(
+          response: include(
+            body: include(
+              'responseMessage' => 'An internal error occurred processing the request',
+            ),
+          ),
+        )),
+      )
+    end
+
+    context 'when the auth token is expired' do
+      let(:expires_in) { 15.minutes }
+
       before do
-        set_up_expired_token(cache, redis)
-        stub_request_enroll_expired_token
         stub_request_enroll
       end
 
-      it 'fetches a new token and retries the attempt' do
-        check_for_token_refresh_and_method_call(cache, redis)
-        enrollment = subject.request_enroll(applicant)
+      it 'refreshes the auth token before making the request' do
+        subject.token
+        expired_time = Time.zone.now + expires_in
+        enrollment = nil
+        travel_to(expired_time) do
+          enrollment = subject.request_enroll(applicant)
+        end
+
+        expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate").twice
 
         expect(enrollment.enrollment_code).to be_present
         expect(enrollment.response_message).to be_present
@@ -355,83 +338,72 @@ RSpec.describe UspsInPersonProofing::Proofer do
         enrollment_code: '123456789',
       )
     end
-    context 'when the token is valid' do
+
+    before do
+      stub_request_token
+    end
+
+    it 'returns failed enrollment information' do
+      stub_request_failed_proofing_results
+
+      proofing_results = subject.request_proofing_results(
+        applicant.unique_id,
+        applicant.enrollment_code,
+      )
+      expect(proofing_results['status']).to eq 'In-person failed'
+      expect(proofing_results['fraudSuspected']).to eq false
+    end
+
+    it 'returns passed enrollment information' do
+      stub_request_passed_proofing_results
+
+      proofing_results = subject.request_proofing_results(
+        applicant.unique_id,
+        applicant.enrollment_code,
+      )
+      expect(proofing_results['status']).to eq 'In-person passed'
+      expect(proofing_results['fraudSuspected']).to eq false
+    end
+
+    it 'returns in-progress enrollment information' do
+      stub_request_in_progress_proofing_results
+
+      expect do
+        subject.request_proofing_results(
+          applicant.unique_id,
+          applicant.enrollment_code,
+        )
+      end.to raise_error(
+        an_instance_of(Faraday::BadRequestError).
+        and(having_attributes(
+          response: include(
+            body: include(
+              'responseMessage' => 'Customer has not been to a post office to complete IPP',
+            ),
+          ),
+        )),
+      )
+    end
+
+    context 'when the auth token is expired' do
+      let(:expires_in) { 15.minutes }
+
       before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-        )
-        stub_request_token
-      end
-      it 'returns failed enrollment information' do
-        stub_request_failed_proofing_results
-
-        proofing_results = subject.request_proofing_results(
-          applicant.unique_id,
-          applicant.enrollment_code,
-        )
-        expect(proofing_results['status']).to eq 'In-person failed'
-        expect(proofing_results['fraudSuspected']).to eq false
-      end
-
-      it 'returns passed enrollment information' do
         stub_request_passed_proofing_results
-
-        proofing_results = subject.request_proofing_results(
-          applicant.unique_id,
-          applicant.enrollment_code,
-        )
-        expect(proofing_results['status']).to eq 'In-person passed'
-        expect(proofing_results['fraudSuspected']).to eq false
       end
 
-      it 'returns in-progress enrollment information' do
-        stub_request_in_progress_proofing_results
-
-        expect do
-          subject.request_proofing_results(
+      it 'refreshes the auth token before making the request' do
+        subject.token
+        expired_time = Time.zone.now + expires_in
+        proofing_results = nil
+        travel_to(expired_time) do
+          proofing_results = subject.request_proofing_results(
             applicant.unique_id,
             applicant.enrollment_code,
           )
-        end.to raise_error(
-          an_instance_of(Faraday::BadRequestError).
-          and(having_attributes(
-            response: include(
-              body: include(
-                'responseMessage' => 'Customer has not been to a post office to complete IPP',
-              ),
-            ),
-          )),
-        )
-      end
-    end
-    context 'when the token is expired' do
-      let(:cache) { double(ActiveSupport::Cache::MemoryStore) }
-      let(:redis) { double(Redis) }
-      before do
-        set_up_expired_token(cache, redis)
-        stub_request_proofing_results_with_forbidden_error
-        stub_request_passed_proofing_results
-      end
+        end
 
-      it 'fetches a new token and retries the attempt' do
-        expect(cache).to receive(:write).with(
-          UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
-          an_instance_of(String),
-          hash_including(expires_at: an_instance_of(ActiveSupport::TimeWithZone)),
-        ).twice
-
-        expect(redis).to receive(:expireat).with(
-          UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
-          an_instance_of(Integer),
-        ).twice
-
-        expect(cache).to receive(:read).with(UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY)
-
-        proofing_results = subject.request_proofing_results(
-          applicant.unique_id,
-          applicant.enrollment_code,
-        )
-
+        expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate").twice
         expect(proofing_results['status']).to eq 'In-person passed'
         expect(proofing_results['fraudSuspected']).to eq false
       end
@@ -445,52 +417,32 @@ RSpec.describe UspsInPersonProofing::Proofer do
         unique_id: '123456789',
       )
     end
-    context 'when the token is valid' do
-      before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-        )
-        stub_request_token
-      end
 
-      it 'returns enrollment information' do
-        stub_request_enrollment_code
-
-        enrollment = subject.request_enrollment_code(applicant)
-        expect(enrollment['enrollmentCode']).to be_present
-        expect(enrollment['responseMessage']).to be_present
-      end
+    before do
+      stub_request_token
     end
 
-    context 'when the token is expired' do
-      let(:cache) { double(ActiveSupport::Cache::MemoryStore) }
-      let(:redis) { double(Redis) }
-      before do
-        set_up_expired_token(cache, redis)
-      end
+    it 'returns enrollment information' do
+      stub_request_enrollment_code
 
-      it 'fetches a new token and retries the attempt' do
-        expect(IdentityConfig.store).to receive(:usps_ipp_sponsor_id).
-          and_return(usps_ipp_sponsor_id)
+      enrollment = subject.request_enrollment_code(applicant)
+      expect(enrollment['enrollmentCode']).to be_present
+      expect(enrollment['responseMessage']).to be_present
+    end
 
-        stub_request_enrollment_code_with_forbidden_error
+    context 'when the auth token is expired' do
+      let(:expires_in) { 15.minutes }
+
+      it 'refreshes the auth token before making the request' do
+        subject.token
+        expired_time = Time.zone.now + expires_in
         stub_request_enrollment_code
+        enrollment = nil
+        travel_to(expired_time) do
+          enrollment = subject.request_enrollment_code(applicant)
+        end
 
-        expect(cache).to receive(:write).with(
-          UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
-          an_instance_of(String),
-          hash_including(expires_at: an_instance_of(ActiveSupport::TimeWithZone)),
-        ).twice
-
-        expect(redis).to receive(:expireat).with(
-          UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
-          an_instance_of(Integer),
-        ).twice
-
-        expect(cache).to receive(:read).with(UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY)
-
-        enrollment = subject.request_enrollment_code(applicant)
-
+        expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate").twice
         expect(enrollment['enrollmentCode']).to be_present
         expect(enrollment['responseMessage']).to be_present
       end

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
       expect(Rails.cache).to receive(:write).with(
         UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY,
         an_instance_of(String),
-        hash_including(expires_at: an_instance_of(ActiveSupport::TimeWithZone)),
+        hash_including(expires_in: an_instance_of(ActiveSupport::Duration)),
       ).twice
       stub_request_token
       subject.retrieve_token!


### PR DESCRIPTION
**Note: I suggest starting by disabling whitespace changes when reviewing this PR. A lot of the spec changes were just removing a level of indentation**

## 🎫 Ticket

[LG-9086](https://cm-jira.usa.gov/browse/LG-9086)

## 🛠 Summary of changes

* Fixes a bug where attempting to retrieve a USPS auth token with a memory-backed Rails cache (eg when a dev configures their local environment to communicate with USPS) would fail with an undefined method error
* Changes the USPS preemptive refresh logic to just modify the expires_at cache attribute for the USPS auth token instead of checking when the expiry is within X minutes of expiring
* Reduces the preemptive USPS auth token refresh window from five minutes to one minute. Five minutes seems excessive to me -- that's fully a third of the lifetime of a USPS auth token. The intention of this logic is to prevent in-flight requests from expiring and I think one minute is sufficient for that
* Refactors the proofer specs to rely less on cache implementation details and instead just test that tokens are being refreshed when they should be

## 📜 Testing Plan

I've tested this feature branch in the Joy sandbox and confirmed that it automatically refreshes the auth token 14 minutes after it was acquired using this procedure:

1. Deploy feature branch to Joy sandbox
2. Open a Rails console
3. Run `UspsInPersonProofing::Proofer.new.token`, observe that an API request is made (so the cache was cold at this point) and note the time in seconds
4. Wait 13 minutes and re-run `UspsInPersonProofing::Proofer.new.token`. Confirm no API request is made and it returns the same token as 3.
5. Wait 14 minutes after the initial token and re-run `UspsInPersonProofing::Proofer.new.token`. Confirm that an API request was made and a new token is returned

You can test this caching locally using these steps:

1. Ensure caching is enabled by running `bundle exec rails dev:cache`
2. Configure your local environment to make requests to USPS
  1. Update your `config/application.yml` file to define `usps_ipp_root_url`, `usps_ipp_username`, `usps_ipp_password`, `usps_ipp_sponsor_id`, `usps_ipp_client_id`, and `usps_ipp_mock_fallback: false`
1. Restart your web server
1. Start a Rails console. Define a helper function, like so:
  1. ```
      def get_token
        puts Time.zone.now
        puts UspsInPersonProofing::Proofer.new.token
      end
      ```
1. Execute `get_token`. Observe that an API request is made (it logs a message about posting to the /authenticate endpoint). Note the time, in seconds
1. Wait 10 minutes after the time you noted. Re-run `get_token`. Observe that no API request is made this time and it prints the same token as before
1. Wait until at least 14 minutes after the time you noted. Re-run `get_token` and observe that it does make an API request and prints a new token

## 👀 Demo

```
irb(main):001:1* def get_token
irb(main):002:1*   puts Time.zone.now
irb(main):003:1*   puts UspsInPersonProofing::Proofer.new.token
irb(main):004:0> end
=> :get_token
irb(main):005:0> get_token
2023-03-22 19:02:39 UTC
{"http_method":"POST","host":"<redacted>","path":"/oauth/authenticate","duration_seconds":0.816173831,"status":200,"service":"usps_token","name":"request_metric.faraday"}
Bearer uqL<redacted>
=> nil
irb(main):055:0> get_token
2023-03-22 19:16:38 UTC
Bearer uqL<redacted>
=> nil
irb(main):056:0> get_token
2023-03-22 19:16:39 UTC
Bearer uqL<redacted>
=> nil
irb(main):057:0> get_token
2023-03-22 19:16:41 UTC
{"http_method":"POST","host":"<redacted>","path":"/oauth/authenticate","duration_seconds":0.653552645,"status":200,"service":"usps_token","name":"request_metric.faraday"}
Bearer kTa<redacted>
=> nil
```
