### PR TITLE
LG-9176: Log email analytics attributes when emails are sent for expired enrollments

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -280,6 +280,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     else
       analytics(user: enrollment.user).
         idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated(
+          **email_analytics_attributes(enrollment),
           enrollment_id: enrollment.id,
         )
       enrollment.update(deadline_passed_sent: true)
@@ -416,6 +417,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def mail_delivery_params(proofed_at)
+    return {} if proofed_at.blank?
     mail_delay_hours = IdentityConfig.store.in_person_results_delay_in_hours ||
                        DEFAULT_EMAIL_DELAY_IN_HOURS
     wait_until = proofed_at + mail_delay_hours.hours

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -376,7 +376,11 @@ RSpec.describe GetUspsProofingResultsJob do
             expect(pending_enrollment.deadline_passed_sent).to be true
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: deadline passed email initiated',
+              enrollment_code: pending_enrollment.enrollment_code,
               enrollment_id: pending_enrollment.id,
+              service_provider: pending_enrollment.issuer,
+              timestamp: anything,
+              wait_until: nil,
             )
           end
         end


### PR DESCRIPTION
This is a follow-on to #8021 that completely closes [LG-9176](https://cm-jira.usa.gov/browse/LG-9176) by adding the enrollment code to the analytics event logged when emails are sent for expired enrollments.

## 🎫 Ticket

[LG-9176](https://cm-jira.usa.gov/browse/LG-9176)
