### PR TITLE
Fully sign out user when resetting password via event disavowal

### DIFF
--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -43,7 +43,11 @@ class EventDisavowalController < ApplicationController
 
   def validate_disavowed_event
     result = EventDisavowal::ValidateDisavowedEvent.new(disavowed_event).call
-    return if result.success?
+    if result.success?
+      sign_out
+      return
+    end
+
     analytics.event_disavowal_token_invalid(**result.to_h)
     flash[:error] = (result.errors[:event] || result.errors.first.last).first
     redirect_to root_url


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, when resetting your password via event disavowal, you are not signed out, which can lead to unexpected session behavior as a user may or may not be currently signed in.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
