### PR TITLE
Add weekly Cloudwatch reports (LG-9254)

### DIFF
--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -14,7 +14,7 @@ module Reporting
   class AuthenticationReport
     include Reporting::CloudwatchQueryQuoting
 
-    attr_reader :issuer, :date_range
+    attr_reader :issuer, :time_range
 
     module Events
       OIDC_AUTH_REQUEST = 'OpenID Connect: authorization request'
@@ -29,10 +29,10 @@ module Reporting
     end
 
     # @param [String] isssuer
-    # @param [Range<Time>] date_range
-    def initialize(issuer:, date_range:, verbose: false, progress: false)
+    # @param [Range<Time>] time_range
+    def initialize(issuer:, time_range:, verbose: false, progress: false)
       @issuer = issuer
-      @date_range = date_range
+      @time_range = time_range
       @verbose = verbose
       @progress = progress
     end
@@ -48,7 +48,7 @@ module Reporting
     # rubocop:disable Metrics/BlockLength
     def to_csv
       CSV.generate do |csv|
-        csv << ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"]
+        csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
         csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
         csv << ['Issuer', issuer]
         csv << []
@@ -147,7 +147,7 @@ module Reporting
     end
 
     def fetch_results
-      cloudwatch_client.fetch(query:, from: date_range.begin, to: date_range.end)
+      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
     end
 
     def query

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -14,7 +14,7 @@ module Reporting
   class AuthenticationReport
     include Reporting::CloudwatchQueryQuoting
 
-    attr_reader :issuer, :date
+    attr_reader :issuer, :date_range
 
     module Events
       OIDC_AUTH_REQUEST = 'OpenID Connect: authorization request'
@@ -29,10 +29,10 @@ module Reporting
     end
 
     # @param [String] isssuer
-    # @param [Date] date
-    def initialize(issuer:, date:, verbose: false, progress: false)
+    # @param [Range<Time>] date_range
+    def initialize(issuer:, date_range:, verbose: false, progress: false)
       @issuer = issuer
-      @date = date
+      @date_range = date_range
       @verbose = verbose
       @progress = progress
     end
@@ -48,7 +48,7 @@ module Reporting
     # rubocop:disable Metrics/BlockLength
     def to_csv
       CSV.generate do |csv|
-        csv << ['Report Timeframe', "#{from} to #{to}"]
+        csv << ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"]
         csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
         csv << ['Issuer', issuer]
         csv << []
@@ -147,17 +147,7 @@ module Reporting
     end
 
     def fetch_results
-      cloudwatch_client.fetch(query:, from:, to:)
-    end
-
-    # @return [Time]
-    def from
-      date.in_time_zone('UTC').beginning_of_day
-    end
-
-    # @return [Time]
-    def to
-      date.in_time_zone('UTC').end_of_day
+      cloudwatch_client.fetch(query:, from: date_range.begin, to: date_range.end)
     end
 
     def query

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -59,7 +59,7 @@ module Reporting
         exit 1
       else
         {
-          date_range: date_range(date:, period:),
+          time_range: time_range(date:, period:),
           issuer: issuer,
           verbose: verbose,
           progress: progress,
@@ -70,7 +70,7 @@ module Reporting
 
     # @param [Date]
     # @return [Range<Time>]
-    def date_range(date:, period:)
+    def time_range(date:, period:)
       orig_beginning_of_week = Date.beginning_of_week
       Date.beginning_of_week = :sunday
 

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -7,9 +7,11 @@ module Reporting
       issuer = nil
       verbose = false
       progress = true
+      period = nil
 
       program_name = Pathname.new($PROGRAM_NAME).relative_path_from(__dir__)
 
+      # rubocop:disable Metrics/BlockLength
       parser = OptionParser.new do |opts|
         opts.banner = <<~TXT
           Usage:
@@ -21,6 +23,14 @@ module Reporting
 
         opts.on('--date=DATE', 'date to run the report in YYYY-MM-DD format') do |date_v|
           date = Date.parse(date_v)
+          period = :day
+        end
+
+        opts.on('--week=DATE', <<~STR.squish) do |date_v|
+          run the report for the week (Sun-Sat) that includes the date in YYYY-MM-DD format'
+        STR
+          date = Date.parse(date_v)
+          period = :week
         end
 
         opts.on('--issuer=ISSUER') do |issuer_v|
@@ -40,21 +50,42 @@ module Reporting
           exit 1
         end
       end
+      # rubocop:enable Metrics/BlockLength
 
       parser.parse!(argv)
 
       if !date || !issuer
         out.puts parser
         exit 1
+      else
+        {
+          date_range: date_range(date:, period:),
+          issuer: issuer,
+          verbose: verbose,
+          progress: progress,
+        }
       end
-
-      {
-        date: date,
-        issuer: issuer,
-        verbose: verbose,
-        progress: progress,
-      }
     end
     # rubocop:enable Rails/Exit
+
+    # @param [Date]
+    # @return [Range<Time>]
+    def date_range(date:, period:)
+      orig_beginning_of_week = Date.beginning_of_week
+      Date.beginning_of_week = :sunday
+
+      utc = date.in_time_zone('UTC')
+
+      case period
+      when :day
+        utc.all_day
+      when :week
+        utc.all_week
+      else
+        raise "unknown period=#{period}"
+      end
+    ensure
+      Date.beginning_of_week = orig_beginning_of_week
+    end
   end
 end

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -14,7 +14,7 @@ module Reporting
   class IdentityVerificationReport
     include Reporting::CloudwatchQueryQuoting
 
-    attr_reader :issuer, :date_range
+    attr_reader :issuer, :time_range
 
     module Events
       IDV_DOC_AUTH_IMAGE_UPLOAD = 'IdV: doc auth image upload vendor submitted'
@@ -31,9 +31,9 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] date
-    def initialize(issuer:, date_range:, verbose: false, progress: false)
+    def initialize(issuer:, time_range:, verbose: false, progress: false)
       @issuer = issuer
-      @date_range = date_range
+      @time_range = time_range
       @verbose = verbose
       @progress = progress
     end
@@ -48,7 +48,7 @@ module Reporting
 
     def to_csv
       CSV.generate do |csv|
-        csv << ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"]
+        csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
         csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
         csv << ['Issuer', issuer]
         csv << []
@@ -126,7 +126,7 @@ module Reporting
     end
 
     def fetch_results
-      cloudwatch_client.fetch(query:, from: date_range.begin, to: date_range.end)
+      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
     end
 
     def query

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -3,9 +3,9 @@ require 'reporting/authentication_report'
 
 RSpec.describe Reporting::AuthenticationReport do
   let(:issuer) { 'my:example:issuer' }
-  let(:date) { Date.new(2022, 1, 1) }
+  let(:date_range) { Date.new(2022, 1, 1).all_day }
 
-  subject(:report) { Reporting::AuthenticationReport.new(issuer:, date:) }
+  subject(:report) { Reporting::AuthenticationReport.new(issuer:, date_range:) }
 
   before do
     cloudwatch_client = double(
@@ -47,7 +47,7 @@ RSpec.describe Reporting::AuthenticationReport do
       csv = CSV.parse(report.to_csv, headers: false)
 
       expected_csv = [
-        ['Report Timeframe', "#{report.from} to #{report.to}"],
+        ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"],
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         [],

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -3,9 +3,9 @@ require 'reporting/authentication_report'
 
 RSpec.describe Reporting::AuthenticationReport do
   let(:issuer) { 'my:example:issuer' }
-  let(:date_range) { Date.new(2022, 1, 1).all_day }
+  let(:time_range) { Date.new(2022, 1, 1).all_day }
 
-  subject(:report) { Reporting::AuthenticationReport.new(issuer:, date_range:) }
+  subject(:report) { Reporting::AuthenticationReport.new(issuer:, time_range:) }
 
   before do
     cloudwatch_client = double(
@@ -47,7 +47,7 @@ RSpec.describe Reporting::AuthenticationReport do
       csv = CSV.parse(report.to_csv, headers: false)
 
       expected_csv = [
-        ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"],
+        ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         [],

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -44,11 +44,22 @@ RSpec.describe Reporting::CommandLineOptions do
 
       it 'returns the parsed options' do
         expect(parse!).to match(
-          date: Date.new(2023, 1, 1),
+          date_range: Date.new(2023, 1, 1).in_time_zone('UTC').all_day,
           issuer: issuer,
           verbose: false,
           progress: true,
         )
+      end
+    end
+
+    context 'with --week and --issuer' do
+      let(:argv) { %W[--week 2023-1-1 --issuer #{issuer}] }
+
+      it 'uses the whole week from sun-sat' do
+        sunday = Date.new(2023, 1, 1).in_time_zone('UTC')
+        saturday = Date.new(2023, 1, 7).in_time_zone('UTC')
+
+        expect(parse![:date_range]).to eq(sunday.beginning_of_day..saturday.end_of_day)
       end
     end
 

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Reporting::CommandLineOptions do
 
       it 'returns the parsed options' do
         expect(parse!).to match(
-          date_range: Date.new(2023, 1, 1).in_time_zone('UTC').all_day,
+          time_range: Date.new(2023, 1, 1).in_time_zone('UTC').all_day,
           issuer: issuer,
           verbose: false,
           progress: true,
@@ -59,7 +59,7 @@ RSpec.describe Reporting::CommandLineOptions do
         sunday = Date.new(2023, 1, 1).in_time_zone('UTC')
         saturday = Date.new(2023, 1, 7).in_time_zone('UTC')
 
-        expect(parse![:date_range]).to eq(sunday.beginning_of_day..saturday.end_of_day)
+        expect(parse![:time_range]).to eq(sunday.beginning_of_day..saturday.end_of_day)
       end
     end
 

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -3,9 +3,9 @@ require 'reporting/identity_verification_report'
 
 RSpec.describe Reporting::IdentityVerificationReport do
   let(:issuer) { 'my:example:issuer' }
-  let(:date_range) { Date.new(2022, 1, 1).all_day }
+  let(:time_range) { Date.new(2022, 1, 1).all_day }
 
-  subject(:report) { Reporting::IdentityVerificationReport.new(issuer:, date_range:) }
+  subject(:report) { Reporting::IdentityVerificationReport.new(issuer:, time_range:) }
 
   before do
     cloudwatch_client = double(
@@ -40,7 +40,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
       csv = CSV.parse(report.to_csv, headers: false)
 
       expected_csv = [
-        ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"],
+        ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         [],

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -3,9 +3,9 @@ require 'reporting/identity_verification_report'
 
 RSpec.describe Reporting::IdentityVerificationReport do
   let(:issuer) { 'my:example:issuer' }
-  let(:date) { Date.new(2022, 1, 1) }
+  let(:date_range) { Date.new(2022, 1, 1).all_day }
 
-  subject(:report) { Reporting::IdentityVerificationReport.new(issuer:, date:) }
+  subject(:report) { Reporting::IdentityVerificationReport.new(issuer:, date_range:) }
 
   before do
     cloudwatch_client = double(
@@ -40,7 +40,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
       csv = CSV.parse(report.to_csv, headers: false)
 
       expected_csv = [
-        ['Report Timeframe', "#{report.from} to #{report.to}"],
+        ['Report Timeframe', "#{date_range.begin} to #{date_range.end}"],
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         [],


### PR DESCRIPTION
JIRA: [LG-9254](https://cm-jira.usa.gov/browse/LG-9254)

(Relies on the patterns/refactoring in https://github.com/18F/identity-idp/pull/8040, please review that first)

Adds a `--week=YYYY-MM-DD` option to both the Authentication & IdentityVerification reports

The code will take the one day and expand that to be the Sunday-Saturday that includes the date. So `--week 2023-02-21` and `--week 2023-02-22` would return the same week.

Usage:

```bash
# auth report
aws-vault exec prod-power -- bundle exec rails runner lib/reporting/authentication_report.rb --week 2023-03-16 --issuer ISSUER
# identity verification report
aws-vault exec prod-power -- bundle exec rails runner lib/reporting/identity_verification_report.rb --week 2023-03-16 --issuer ISSUER

```