### PR TITLE
LG-9006: Double Address Verification Feature Toggle

### DIFF
--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -21,6 +21,7 @@ class InPersonEnrollment < ApplicationRecord
 
   before_save(:on_status_updated, if: :will_save_change_to_status?)
   before_create(:set_unique_id, unless: :unique_id)
+  before_create(:set_capture_secondary_id)
 
   def self.is_pending_and_established_between(early_benchmark, late_benchmark)
     where(status: :pending).
@@ -113,6 +114,12 @@ class InPersonEnrollment < ApplicationRecord
     unless profile.user == user
       errors.add :profile, I18n.t('idv.failure.exceptions.internal_error'),
                  type: :in_person_enrollment_user_profile_mismatch
+    end
+  end
+
+  def set_capture_secondary_id
+    if IdentityConfig.store.in_person_capture_secondary_id_enabled
+      self.capture_secondary_id_enabled = true
     end
   end
 end

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -35,7 +35,7 @@ module Idv
         private
 
         def capture_secondary_id_enabled
-          idv_session&.current_user&.establishing_in_person_enrollment&.capture_secondary_id_enabled
+          current_user.establishing_in_person_enrollment.capture_secondary_id_enabled
         end
 
         def updating_state_id

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -24,6 +24,7 @@ module Idv
 
         def extra_view_variables
           {
+            capture_secondary_id_enabled:,
             form:,
             pii:,
             parsed_dob:,
@@ -32,6 +33,10 @@ module Idv
         end
 
         private
+
+        def capture_secondary_id_enabled
+          idv_session&.current_user&.establishing_in_person_enrollment&.capture_secondary_id_enabled
+        end
 
         def updating_state_id
           flow_session[:pii_from_user].has_key?(:first_name)

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -97,7 +97,7 @@
         ) %>
   </div>
     
-  <% if IdentityConfig.store.in_person_capture_secondary_id_enabled %>
+  <% if capture_secondary_id_enabled %>
       <%= render ValidatedFieldComponent.new(
             name: :state_id_address1,
             form: f,
@@ -141,7 +141,7 @@
           selected: pii[:state_id_jurisdiction],
         ) %>
   </div>
-  <% if IdentityConfig.store.in_person_capture_secondary_id_enabled %>
+  <% if capture_secondary_id_enabled %>
     <div class="tablet:grid-col-8 margin-bottom-5">
       <%= render ValidatedFieldComponent.new(
             name: :state_id_zipcode,

--- a/db/primary_migrate/20230320235607_add_capture_secondary_id_enabled_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20230320235607_add_capture_secondary_id_enabled_to_in_person_enrollments.rb
@@ -1,5 +1,9 @@
 class AddCaptureSecondaryIdEnabledToInPersonEnrollments < ActiveRecord::Migration[7.0]
   def change
-    add_column :in_person_enrollments, :capture_secondary_id_enabled, :boolean, default: false
+    add_column :in_person_enrollments,
+               :capture_secondary_id_enabled,
+               :boolean,
+               default: false,
+               comment: 'record and proof state ID and residential addresses separately'
   end
 end

--- a/db/primary_migrate/20230320235607_add_capture_secondary_id_enabled_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20230320235607_add_capture_secondary_id_enabled_to_in_person_enrollments.rb
@@ -1,0 +1,5 @@
+class AddCaptureSecondaryIdEnabledToInPersonEnrollments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :in_person_enrollments, :capture_secondary_id_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_09_201053) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_235607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -299,6 +299,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_09_201053) do
     t.boolean "late_reminder_sent", default: false, comment: "late reminder to complete IPP before deadline sent"
     t.boolean "deadline_passed_sent", default: false, comment: "deadline passed email sent for expired enrollment"
     t.datetime "proofed_at", precision: nil, comment: "timestamp when user attempted to proof at a Post Office"
+    t.boolean "capture_secondary_id_enabled", default: false
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"
     t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -299,7 +299,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_235607) do
     t.boolean "late_reminder_sent", default: false, comment: "late reminder to complete IPP before deadline sent"
     t.boolean "deadline_passed_sent", default: false, comment: "deadline passed email sent for expired enrollment"
     t.datetime "proofed_at", precision: nil, comment: "timestamp when user attempted to proof at a Post Office"
-    t.boolean "capture_secondary_id_enabled", default: false
+    t.boolean "capture_secondary_id_enabled", default: false, comment: "record and proof state ID and residential addresses separately"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"
     t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -487,27 +487,72 @@ RSpec.describe 'In Person Proofing', js: true do
     end
   end
 
-  context 'validate_id_and_residential_addresses feature flag enabled', allow_browser_log: true do
+  context 'in_person_capture_secondary_id_enabled feature flag disabled, then enabled during flow',
+          allow_browser_log: true do
     let(:user) { user_with_2fa }
 
-    before do
+    before(:each) do
       allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
-        and_return(true)
-    end
+        and_return(false)
 
-    it 'captures the address, address line 2, city, state and zip code' do
       sign_in_and_2fa_user(user)
       begin_in_person_proofing(user)
-      search_for_post_office
+      complete_location_step(user)
 
-      # location page
-      location = page.find_all('.location-collection-item')[1]
-      location.click_button(t('in_person_proofing.body.location.location_button'))
+      expect(page).to have_content(
+        t('in_person_proofing.headings.prepare'),
+      )
+    end
 
+    it 'does not capture separate state id address from residential address' do
+      allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
+        and_return(true)
+      # prepare page
+      complete_prepare_step(user)
+      complete_state_id_step(user)
+      complete_address_step(user)
+      complete_ssn_step(user)
+    end
+  end
+
+  context 'in_person_capture_secondary_id_enabled feature flag enabled', allow_browser_log: true do
+    let(:user) { user_with_2fa }
+
+    before(:each) do
+      allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
+        and_return(true)
+
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_location_step(user)
+
+      expect(page).to have_content(
+        t('in_person_proofing.headings.prepare'),
+      )
+    end
+
+    def it_captures_address_with_state_id
       # prepare page
       complete_prepare_step(user)
 
       complete_state_id_step(user, same_address_as_id: false, include_address: true)
+    end
+
+    context 'flag remains enabled' do
+      it 'captures the address, address line 2, city, state and zip code' do
+        it_captures_address_with_state_id
+      end
+    end
+
+    context 'flag is then disabled' do
+      before(:each) do
+        allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
+          and_return(false)
+      end
+
+      it 'captures the address, address line 2, city, state and zip code' do
+        it_captures_address_with_state_id
+      end
     end
   end
 end

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -79,6 +79,15 @@ describe Idv::Steps::InPerson::StateIdStep do
     let(:first_name) { 'First name' }
     let(:pii_from_user) { flow.flow_session[:pii_from_user] }
     let(:params) { ActionController::Parameters.new }
+    let(:capture_secondary_id_enabled) { true }
+    let(:enrollment) { InPersonEnrollment.new(capture_secondary_id_enabled:) }
+
+    before(:each) do
+      allow(step).to receive(:current_user).
+        and_return(user)
+      allow(user).to receive(:establishing_in_person_enrollment).
+        and_return(enrollment)
+    end
 
     context 'first name and dob are set' do
       it 'returns extra view variables' do
@@ -120,6 +129,23 @@ describe Idv::Steps::InPerson::StateIdStep do
           ),
           parsed_dob: Date.parse(dob),
           updating_state_id: false,
+        )
+      end
+    end
+
+    context 'with secondary capture enabled' do
+      it 'returns capture enabled = true' do
+        expect(step.extra_view_variables).to include(
+          capture_secondary_id_enabled: true,
+        )
+      end
+    end
+
+    context 'with secondary capture disabled' do
+      let(:capture_secondary_id_enabled) { false }
+      it 'returns capture enabled = false' do
+        expect(step.extra_view_variables).to include(
+          capture_secondary_id_enabled: false,
         )
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-9006](https://cm-jira.usa.gov/browse/LG-9006)

## 🛠 Summary of changes

- Create new boolean field `in_person_enrollments.capture_secondary_id_enabled`
  - Initialized to `true` if `in_person_capture_secondary_id_enabled` is truthy, otherwise false
  - Note: Enrollment creation currently occurs when a PO location is selected
- Display and capture separate state ID address fields if `capture_secondary_id_enabled` is true for the user's `establishing` enrollment
  - Was previously determined globally by `in_person_capture_secondary_id_enabled`
- Merging this story will require updates to [LG-9139](https://cm-jira.usa.gov/browse/LG-9139), and vice versa
  - https://github.com/18F/identity-idp/pull/8041
  - i.e. the feature flag will need to be checked in a different manner than before

## 📜 Testing Plan

Note that the scope of applicable testing depends on what stories from the same Epic are implemented before this is merged. This is assuming that some changes to the address and verify pages have not yet been merged.

### Feature Flag - Off
- [x] Disable feature flag `in_person_capture_secondary_id_enabled`
- [x] Complete flow up to and including selecting a location
- [x] Enable feature flag `in_person_capture_secondary_id_enabled`
- [x] Continue to state ID page
- [x] Verify that state ID page does not show address fields
- [x] Verify that state ID form can be submitted & displays properly on "verify" page
- [x] Verify that page to update state ID does not show address fields & properly updates the "verify" page

### Feature Flag - On
- [x] Enable feature flag `in_person_capture_secondary_id_enabled`
- [x] Complete flow up to and including selecting a location
- [x] Disable feature flag `in_person_capture_secondary_id_enabled`
- [x] Continue to state ID page
- [x] Verify that state ID page does shows additional address fields
- [x] Verify that state ID form can be submitted & displays currently supported details properly on "verify" page
- [x] Verify that page to update state ID shows additional address fields & properly updates the "verify" page

## 👀 Screenshots

N/A, this does not entail any visual changes.
