### PR TITLE
Remove Doc Auth Duplicate Alert Logging

### DIFF
--- a/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
+++ b/app/services/doc_auth/processed_alert_to_log_alert_formatter.rb
@@ -12,8 +12,6 @@ module DocAuth
 
           side = alert[:side] || 'no_side'
 
-          check_for_dupe!(log_alert_results, side, alert_name_key, alert[:result])
-
           log_alert_results[alert_name_key] = {
             "#{side}": alert[:result],
           }
@@ -21,15 +19,6 @@ module DocAuth
       end
 
       log_alert_results
-    end
-
-    private
-
-    def check_for_dupe!(log_alert_results, side, alert_name_key, result)
-      alert_value = log_alert_results.dig(alert_name_key, side.to_sym)
-      if alert_value.present?
-        Rails.logger.info("ALERT ALREADY HAS A VALUE: #{alert_value}, #{result}")
-      end
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

I see a lot of these ALERTs in the logs, but I couldn't find any reference to using these results and I think we could work on a more comprehensive way to include this in the existing `IdV: doc auth image upload vendor submitted` event if this logging is needed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
