### PR TITLE
Refactor sp_alert to pass section identifier

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -19,15 +19,6 @@ class ServiceProviderSessionDecorator
     @sp.redirect_uris
   end
 
-  def custom_alert(section)
-    return if sp.help_text.nil?
-    language = I18n.locale.to_s
-    alert = sp.help_text.dig(section, language)
-    if alert.present?
-      format(alert, sp_name: sp_name, sp_create_link: sp_create_link, app_name: APP_NAME)
-    end
-  end
-
   def sp_logo
     sp.logo.presence || DEFAULT_LOGO
   end
@@ -85,11 +76,13 @@ class ServiceProviderSessionDecorator
     view_context.new_user_session_url(request_id: sp_session[:request_id])
   end
 
-  def sp_alert(path)
-    path_to_section_map = { new_user_session_path => 'sign_in',
-                            sign_up_email_path => 'sign_up',
-                            new_user_password_path => 'forgot_password' }
-    custom_alert(path_to_section_map[path])
+  def sp_alert(section)
+    return if sp.help_text.nil?
+    language = I18n.locale.to_s
+    alert = sp.help_text.dig(section, language)
+    if alert.present?
+      format(alert, sp_name: sp_name, sp_create_link: sp_create_link, app_name: APP_NAME)
+    end
   end
 
   def mfa_expiration_interval

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -39,7 +39,7 @@ class SessionDecorator
 
   def requested_attributes; end
 
-  def sp_alert(_path); end
+  def sp_alert(_section); end
 
   def requested_more_recent_verification?
     false

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.passwords.forgot') %>
 <% request_id = params[:request_id] || sp_session[:request_id] %>
 
-<%= render 'shared/sp_alert' %>
+<%= render 'shared/sp_alert', section: 'forgot_password' %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.forgot')) %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,7 +17,7 @@
 <% else %>
   <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>
-<%= render 'shared/sp_alert' %>
+<%= render 'shared/sp_alert', section: 'sign_in' %>
 
 <%= simple_form_for(
       resource,

--- a/app/views/shared/_sp_alert.html.erb
+++ b/app/views/shared/_sp_alert.html.erb
@@ -1,4 +1,4 @@
-<% alert = decorated_session.sp_alert(request.path) %>
+<% alert = decorated_session.sp_alert(section) %>
 <% if alert %>
   <%= render AlertComponent.new(text_tag: 'div') do %>
     <%= raw sanitize(alert, tags: %w[a b strong em br p ol ul li], attributes: %w[href target]) %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.registrations.new') %>
 
-<%= render 'shared/sp_alert' %>
+<%= render 'shared/sp_alert', section: 'sign_up' %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.registrations.new')) %>
 

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -1,7 +1,5 @@
 <% title t('titles.registrations.new') %>
 
-<%= render 'shared/sp_alert' %>
-
 <%= render PageHeadingComponent.new.with_content(t('headings.add_email')) %>
 
 <div class="margin-bottom-6">

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#custom_alert' do
+  describe '#sp_alert' do
     context 'sp has custom alert' do
       it 'uses the custom template' do
-        expect(subject.custom_alert('sign_in')).
+        expect(subject.sp_alert('sign_in')).
           to eq "<b>custom sign in help text for #{sp.friendly_name}</b>"
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe ServiceProviderSessionDecorator do
       let(:sp) { build_stubbed(:service_provider_without_help_text) }
 
       it 'returns nil' do
-        expect(subject.custom_alert('sign_in')).
+        expect(subject.sp_alert('sign_in')).
           to be_nil
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe ServiceProviderSessionDecorator do
       let(:sp) { build(:service_provider, help_text: nil) }
 
       it 'returns nil' do
-        expect(subject.custom_alert('sign_in')).
+        expect(subject.sp_alert('sign_in')).
           to be_nil
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe ServiceProviderSessionDecorator do
       let(:sp) { build_stubbed(:service_provider, :with_blank_help_text) }
 
       it 'returns nil' do
-        expect(subject.custom_alert('sign_in')).
+        expect(subject.sp_alert('sign_in')).
           to be_nil
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

This changes the logic of service provider alert messaging to explicitly pass the "section" identifier when rendering the alert banner. The expected benefits are:

- This is clearer, since it avoids magic of a path-based mapping in favor of explicitness
- Performance, since it doesn't require generate a hash of all possible routes to match against
- Less error-prone, since there is no risk that the generated hash includes unused section, or that views render the alert where no content would be expected

## 📜 Testing Plan

- Confirm that the service provider banner shows when expected on the sign in, sign up, or password reset pages