### PR TITLE
Move aws-sdk-cloudwatchlogs to default gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'aws-sdk-pinpoint'
 gem 'aws-sdk-pinpointsmsvoice'
 gem 'aws-sdk-ses', '~> 1.6'
 gem 'aws-sdk-sns'
+gem 'aws-sdk-cloudwatchlogs', require: false
 gem 'barby', '~> 0.6.8'
 gem 'base32-crockford'
 gem 'bootsnap', '~> 1.0', require: false
@@ -90,7 +91,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'brakeman', require: false
   gem 'bullet', '~> 7.0'
   gem 'capybara-webmock', git: 'https://github.com/hashrocket/capybara-webmock.git', ref: 'd3f3b7c'


### PR DESCRIPTION
## 🛠 Summary of changes

I think #8034 now requires that we have the gem available everywhere since the services are loaded by the Rails application.

```
Error: The application encountered the following error: cannot load such file -- aws-sdk-cloudwatchlogs (LoadError)
    /bundle/ruby/3.2.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require'
    /bundle/ruby/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/kernel.rb:38:in `require'
    /idp/releases/chef/lib/reporting/cloudwatch_client.rb:1:in `<main>'
    /bundle/ruby/3.2.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
    /bundle/ruby/3.2.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
    /bundle/ruby/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/kernel.rb:38:in `require'
    /idp/releases/chef/app/services/data_requests/fetch_cloudwatch_logs.rb:1:in `<main>'
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
