### PR TITLE
Fix schedule for Duplicate SSN report

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -143,7 +143,7 @@ else
       duplicate_ssn: {
         class: 'Reports::DuplicateSsnReport',
         cron: cron_24h,
-        args: -> { [Time.zone.today] },
+        args: -> { [Time.zone.yesterday] },
       },
     }
   end


### PR DESCRIPTION
**Why**: so it collects the previous day's data (runs at UTC midnight)
