### PR TITLE
Add check for loading rails application in continuous integration to catch usage of uninstalled gems

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,6 +240,7 @@ prepare_deploy:
     - cp config/application.yml.default.ci config/application.yml
     - ./deploy/build
     - ./deploy/build-post-config
+    - bundle exec rails zeitwerk:check
     - make build_artifact ARTIFACT_DESTINATION_FILE='./tmp/idp.tar.gz'
     - bundle exec ./scripts/artifact-upload './tmp/idp.tar.gz'
 


### PR DESCRIPTION
## 🛠 Summary of changes

Following up #8048 / #8052 to try catch the error we ran into before we merge it. This PR is currently opened prior to the fix, so the first CI run is expected to fail.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
