### PR TITLE
Improve styling of partner alert content

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -23,3 +23,7 @@
     transform: translateY(-50%);
   }
 }
+
+.usa-alert__text > p:last-child {
+  margin-bottom: 0;
+}

--- a/app/views/shared/_sp_alert.html.erb
+++ b/app/views/shared/_sp_alert.html.erb
@@ -1,6 +1,6 @@
 <% alert = decorated_session.sp_alert(section) %>
 <% if alert %>
-  <%= render AlertComponent.new(text_tag: 'div') do %>
+  <%= render AlertComponent.new(text_tag: 'div', class: 'margin-bottom-4') do %>
     <%= raw sanitize(alert, tags: %w[a b strong em br p ol ul li], attributes: %w[href target]) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 🛠 Summary of changes

Follow-up to #8047

This improves the appearance of partner content shown on the sign in, forgot password, or new account setup screens.

Specifically:

- Removes excess margin from the inside bottom of the alert banner
- Adds standard margin (`2rem`) to the outside bottom of the alert banner

## 📜 Testing Plan

1. Start [OIDC sample app](https://github.com/18f/identity-oidc-sinatra/) in a separate process from IdP
2. Visit http://localhost:9292
3. Under "Options", click "Enable attempts api" checkbox
4. Click "Sign in"
5. Observe alert banner on Sign In page
6. Click "Forgot your password?"
7. Observe alert banner on Forgot Password page
8. Click "Cancel"
9. Click "Create an account"
10. Observe alert banner on Forgot Password page

## 👀 Screenshots

Screen|Before|After
---|---|---
Sign in|![localhost_3000 ](https://user-images.githubusercontent.com/1779930/227214348-9b276bc1-630e-4d35-b162-77883fa20f99.png)|![localhost_3000 (1)](https://user-images.githubusercontent.com/1779930/227214352-a0301b63-ca31-4335-9141-fbf295bc26c3.png)
Forgot password|![localhost_3000_users_password_new](https://user-images.githubusercontent.com/1779930/227214359-6f928d07-08a6-4fe5-b59f-bf0d8f0c9b71.png)|![localhost_3000_users_password_new (1)](https://user-images.githubusercontent.com/1779930/227214357-d72141e6-b7f8-44e1-8240-7ba58f4cc084.png)
Create an account|![localhost_3000_sign_up_enter_email](https://user-images.githubusercontent.com/1779930/227214355-2c242e52-125f-410f-a39f-f9e03e8e48cf.png)|![localhost_3000_sign_up_enter_email (1)](https://user-images.githubusercontent.com/1779930/227214354-d393c291-c59d-4b76-9472-a2510b2ea503.png)