### PR TITLE
Remove parallel usage in setup and test commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,6 @@ group :development, :test do
   gem 'i18n-tasks', '~> 1.0'
   gem 'knapsack'
   gem 'nokogiri', '~> 1.14.0'
-  gem 'parallel_tests', '~> 3.8.0'
   gem 'pg_query', require: false
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,8 +435,6 @@ GEM
       openssl (> 2.0, < 3.1)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parallel_tests (3.8.1)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
@@ -776,7 +774,6 @@ DEPENDENCIES
   newrelic_rpm (~> 8.0)
   nokogiri (~> 1.14.0)
   octokit (>= 4.25.0)
-  parallel_tests (~> 3.8.0)
   pg
   pg_query
   phonelib

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ browsers.json: yarn.lock .browserslistrc ## Generates browsers.json browser supp
 	yarn generate-browsers-json
 
 test: export RAILS_ENV := test
-test: $(CONFIG) ## Runs RSpec and yarn tests in parallel
-	bundle exec rake parallel:spec && yarn test
+test: $(CONFIG) ## Runs RSpec and yarn tests
+	bundle exec rspec && yarn test
 
 test_serial: export RAILS_ENV := test
 test_serial: $(CONFIG) ## Runs RSpec and yarn tests serially

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -63,8 +63,6 @@ Dir.chdir APP_ROOT do
   run "docker-compose run --rm app bundle exec rake db:environment:set"
   # This populates the dev database with sample data
   run "docker-compose run --rm app bundle exec rake dev:prime"
-  # Create all parallel test databases
-  run "docker-compose run --rm app bundle exec rake parallel:setup"
 
   puts "== Shut down cluster =="
   run "docker-compose down"

--- a/bin/setup
+++ b/bin/setup
@@ -61,7 +61,6 @@ Dir.chdir APP_ROOT do
   run 'bin/rake db:reset'
   run 'bin/rake db:environment:set'
   run 'bin/rake dev:prime'
-  run 'bin/rake parallel:setup'
 
   puts "\n== Cleaning up old assets =="
   run "bin/rake assets:clobber"


### PR DESCRIPTION
## 🛠 Summary of changes

Based on discussion at yesterday's Engineering Huddle and people running into issues with the parallel testing being used by default, this PR removes `parallel_tests` usage from the setup and test commands. It is still available for those who use it, but it will have to be run directly. I've also updated the gem.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
