### PR TITLE
Do not return 500 for CSRF token failures for address search controller

### DIFF
--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -2,7 +2,7 @@ module Idv
   module InPerson
     class AddressSearchController < ApplicationController
       rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError,
-                  Faraday::ClientError, StandardError,
+                  Faraday::ClientError, ActionController::InvalidAuthenticityToken, StandardError,
                   with: :report_errors
 
       def index
@@ -34,6 +34,7 @@ module Idv
           Faraday::ClientError => :bad_request,
           Faraday::ConnectionFailed => :bad_request,
           Faraday::TimeoutError => :bad_request,
+          ActionController::InvalidAuthenticityToken => :bad_request,
         }[error.class] || :internal_server_error
 
         errors = if error.instance_of?(Faraday::ClientError)


### PR DESCRIPTION
## 🎫 Ticket - No Ticket Created

## 🛠 Summary of changes

`ActionController::InvalidAuthenticityToken` is now processed as a [400 error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) in the Address Search Controller. This will prevent server side errors from firing and triggering alarms. 

## 📜 Testing Plan

- [ ] Run `address_search_controller_spec.rb` tests and confirm they pass.