### PR TITLE
Fix Content Security Policy errors when redirecting to service provider

### DIFF
--- a/app/controllers/users/rules_of_use_controller.rb
+++ b/app/controllers/users/rules_of_use_controller.rb
@@ -1,7 +1,10 @@
 module Users
   class RulesOfUseController < ApplicationController
+    include SecureHeadersConcern
+
     before_action :confirm_signed_in
     before_action :confirm_need_to_accept_rules_of_use
+    before_action :apply_secure_headers_override
 
     def new
       analytics.rules_of_use_visit


### PR DESCRIPTION
## 🛠 Summary of changes

Bug reported [here](https://gsa-tts.slack.com/archives/C20J64X6V/p1679589807361779) where a user received a CSP error because we redirect back to the relying party in the chain of redirects from the Rules of Use submission request.

This adds the SP domain headers to the response to avoid this error case.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
