### PR TITLE
Use existing Redis pool for Rack::Attack rate limiting

### DIFF
--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -1,3 +1,5 @@
+# This file is renamed to 01_redis.rb so that this file is loaded before rack_attack.rb.
+# This is done because rack_attack.rb needs to reference the Throttle pool defined here.
 REDIS_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_pool_size) do
   Redis.new(url: IdentityConfig.store.redis_url)
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -34,7 +34,7 @@ module Rack
     # not blocklisting & safelisting
     Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(
       namespace: 'rack-attack',
-      url: IdentityConfig.store.redis_throttle_url,
+      redis: REDIS_THROTTLE_POOL,
       expires_in: 2.weeks.to_i,
     )
 


### PR DESCRIPTION
## 🛠 Summary of changes

Along the same lines as #7968, but for a different pool of Redis connections. `ActiveSupport::Cache::RedisStore` supports taking a pool directly, so we can simply pass the existing pool into the `:redis` option.

The difficulty is the order of loading initializers becomes a problem because they are loaded alphabetically. Rails previously suggested renaming files to guarantee load order, but switched to suggesting combining the dependencies into one file. I've gone with the naming convention since the two aren't specifically related.

https://github.com/rails/rails/commit/9d87a172ca32d60526f2b4c4ace0c5dc333f8489

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
