### PR TITLE
Add automatic CSRF refresh on session keepalive

### DIFF
--- a/app/controllers/concerns/api/csrf_token_concern.rb
+++ b/app/controllers/concerns/api/csrf_token_concern.rb
@@ -1,0 +1,7 @@
+module Api
+  module CsrfTokenConcern
+    def include_csrf_token_header
+      response.set_header('X-CSRF-Token', form_authenticity_token)
+    end
+  end
+end

--- a/app/controllers/concerns/api/csrf_token_concern.rb
+++ b/app/controllers/concerns/api/csrf_token_concern.rb
@@ -1,6 +1,6 @@
 module Api
   module CsrfTokenConcern
-    def include_csrf_token_header
+    def add_csrf_token_header_to_response
       response.set_header('X-CSRF-Token', form_authenticity_token)
     end
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,7 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
-    after_action :include_csrf_token_header, only: [:keepalive]
+    after_action :add_csrf_token_header_to_response, only: [:keepalive]
 
     def new
       analytics.sign_in_page_visit(

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,7 @@ module Users
     include SecureHeadersConcern
     include RememberDeviceConcern
     include Ial2ProfileConcern
+    include Api::CsrfTokenConcern
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
 
@@ -15,6 +16,7 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
+    after_action :include_csrf_token_header, only: [:keepalive]
 
     def new
       analytics.sign_in_page_visit(

--- a/app/javascript/packages/request/index.spec.ts
+++ b/app/javascript/packages/request/index.spec.ts
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+import type { SinonStub } from 'sinon';
 import { useSandbox } from '@18f/identity-test-helpers';
 import { request } from '.';
 
@@ -25,6 +27,7 @@ describe('request', () => {
 
     expect(window.fetch).to.have.been.calledOnce();
   });
+
   it('works even if the CSRF token is not found on the page', async () => {
     sandbox.stub(window, 'fetch').callsFake(() =>
       Promise.resolve(
@@ -38,6 +41,7 @@ describe('request', () => {
       csrf: () => undefined,
     });
   });
+
   it('does not try to send a csrf when csrf is false', async () => {
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
       const headers = init.headers as Headers;
@@ -54,6 +58,7 @@ describe('request', () => {
       csrf: false,
     });
   });
+
   it('prefers the json prop if both json and body props are provided', async () => {
     const preferredData = { prefered: 'data' };
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
@@ -71,6 +76,7 @@ describe('request', () => {
       body: JSON.stringify({ bad: 'data' }),
     });
   });
+
   it('works with the native body prop', async () => {
     const preferredData = { this: 'works' };
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
@@ -87,6 +93,7 @@ describe('request', () => {
       body: JSON.stringify(preferredData),
     });
   });
+
   it('includes additional headers supplied in options', async () => {
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
       const headers = init.headers as Headers;
@@ -105,6 +112,7 @@ describe('request', () => {
       },
     });
   });
+
   it('skips json serialization when json is a boolean', async () => {
     const preferredData = { this: 'works' };
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
@@ -122,6 +130,7 @@ describe('request', () => {
       body: JSON.stringify(preferredData),
     });
   });
+
   it('converts a POJO to a JSON string with supplied via the json property', async () => {
     const preferredData = { this: 'works' };
     sandbox.stub(window, 'fetch').callsFake((url, init = {}) => {
@@ -136,6 +145,69 @@ describe('request', () => {
 
     await request('https://example.com', {
       json: preferredData,
+    });
+  });
+
+  context('with response including csrf token', () => {
+    beforeEach(() => {
+      sandbox.stub(window, 'fetch').callsFake(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: [['X-CSRF-Token', 'new-token']],
+          }),
+        ),
+      );
+    });
+
+    it('does nothing, gracefully', async () => {
+      await request('https://example.com', {});
+    });
+
+    context('with global csrf token', () => {
+      beforeEach(() => {
+        document.head.innerHTML += `
+          <meta name="csrf-token" content="token" />
+          <meta name="csrf-param" content="authenticity_token" />
+        `;
+      });
+
+      it('replaces global csrf token with the response token', async () => {
+        await request('https://example.com', {});
+
+        const metaToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')!;
+        expect(metaToken.content).to.equal('new-token');
+      });
+
+      it('uses response token for next request', async () => {
+        await request('https://example.com', {});
+        (window.fetch as SinonStub).resetHistory();
+        await request('https://example.com', {});
+        expect(window.fetch).to.have.been.calledWith(
+          sinon.match.string,
+          sinon.match((init) => init!.headers!.get('x-csrf-token') === 'new-token'),
+        );
+      });
+
+      context('with form csrf token', () => {
+        beforeEach(() => {
+          document.body.innerHTML += `
+            <form><input name="authenticity_token" value="token"></form>
+            <form><input name="authenticity_token" value="token"></form>
+          `;
+        });
+
+        it('replaces form tokens with the response token', async () => {
+          await request('https://example.com', {});
+
+          const inputs = document.querySelectorAll('input');
+          expect(inputs).to.have.lengthOf(2);
+          expect(Array.from(inputs).map((input) => input.value)).to.deep.equal([
+            'new-token',
+            'new-token',
+          ]);
+        });
+      });
     });
   });
 });

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -103,10 +103,7 @@ function ping() {
 
 function keepalive() {
   request('/sessions/keepalive', { method: 'POST' })
-    .then((data) => {
-      success(data);
-      modal.hide();
-    })
+    .then(success)
     .catch((error) => notifyNewRelic(error, 'keepalive'));
 }
 

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -1,4 +1,5 @@
 import { forceRedirect } from '@18f/identity-url';
+import { request } from '@18f/identity-request';
 import type { CountdownElement } from '@18f/identity-countdown/countdown-element';
 import type { ModalElement } from '@18f/identity-modal';
 
@@ -48,17 +49,10 @@ const initialTime = new Date();
 const modal = document.querySelector<ModalElement>('lg-modal.session-timeout-modal')!;
 const keepaliveEl = document.getElementById('session-keepalive-btn');
 const countdownEls: NodeListOf<CountdownElement> = modal.querySelectorAll('lg-countdown');
-const csrfEl: HTMLMetaElement | null = document.querySelector('meta[name="csrf-token"]');
 
-let csrfToken = '';
-if (csrfEl) {
-  csrfToken = csrfEl.content;
-}
-
-function notifyNewRelic(request, error, actionName) {
+function notifyNewRelic(error, actionName) {
   (window as LoginGovGlobal).newrelic?.addPageAction('Session Ping Error', {
     action_name: actionName,
-    request_status: request.status,
     time_elapsed_ms: new Date().valueOf() - initialTime.valueOf(),
     error: error.message,
   });
@@ -100,36 +94,24 @@ function success(data: PingResponse) {
 }
 
 function ping() {
-  const request = new XMLHttpRequest();
-  request.open('GET', '/active', true);
+  try {
+    request('/active').then(success);
+  } catch (error) {
+    notifyNewRelic(error, 'ping');
+  }
 
-  request.onload = function () {
-    try {
-      success(JSON.parse(request.responseText));
-    } catch (error) {
-      notifyNewRelic(request, error, 'ping');
-    }
-  };
-
-  request.send();
   setTimeout(ping, frequency);
 }
 
 function keepalive() {
-  const request = new XMLHttpRequest();
-  request.open('POST', '/sessions/keepalive', true);
-  request.setRequestHeader('X-CSRF-Token', csrfToken);
-
-  request.onload = function () {
-    try {
-      success(JSON.parse(request.responseText));
+  try {
+    request('/sessions/keepalive', { method: 'POST' }).then((data) => {
+      success(data);
       modal.hide();
-    } catch (error) {
-      notifyNewRelic(request, error, 'keepalive');
-    }
-  };
-
-  request.send();
+    });
+  } catch (error) {
+    notifyNewRelic(error, 'keepalive');
+  }
 }
 
 keepaliveEl?.addEventListener('click', keepalive, false);

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -94,24 +94,20 @@ function success(data: PingResponse) {
 }
 
 function ping() {
-  try {
-    request('/active').then(success);
-  } catch (error) {
-    notifyNewRelic(error, 'ping');
-  }
+  request('/active')
+    .then(success)
+    .catch((error) => notifyNewRelic(error, 'ping'));
 
   setTimeout(ping, frequency);
 }
 
 function keepalive() {
-  try {
-    request('/sessions/keepalive', { method: 'POST' }).then((data) => {
+  request('/sessions/keepalive', { method: 'POST' })
+    .then((data) => {
       success(data);
       modal.hide();
-    });
-  } catch (error) {
-    notifyNewRelic(error, 'keepalive');
-  }
+    })
+    .catch((error) => notifyNewRelic(error, 'keepalive'));
 }
 
 keepaliveEl?.addEventListener('click', keepalive, false);

--- a/spec/controllers/concerns/api/csrf_token_concern_spec.rb
+++ b/spec/controllers/concerns/api/csrf_token_concern_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Api::CsrfTokenConcern, type: :controller do
-  describe '#include_csrf_token_header' do
+  describe '#add_csrf_token_header_to_response' do
     controller ApplicationController do
       include Api::CsrfTokenConcern
 
-      before_action :include_csrf_token_header
+      before_action :add_csrf_token_header_to_response
 
       def index; end
     end

--- a/spec/controllers/concerns/api/csrf_token_concern_spec.rb
+++ b/spec/controllers/concerns/api/csrf_token_concern_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Api::CsrfTokenConcern, type: :controller do
+  describe '#include_csrf_token_header' do
+    controller ApplicationController do
+      include Api::CsrfTokenConcern
+
+      before_action :include_csrf_token_header
+
+      def index; end
+    end
+
+    it 'includes csrf token in the response headers' do
+      get :index
+
+      expect(response.headers['X-CSRF-Token']).to be_kind_of(String)
+    end
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 feature 'Sign in' do
-  before(:all) do
-    @original_capyabara_wait = Capybara.default_max_wait_time
-    Capybara.default_max_wait_time = 5
-  end
-
-  after(:all) do
-    Capybara.default_max_wait_time = @original_capyabara_wait
-  end
-
   include SessionTimeoutWarningHelper
   include ActionView::Helpers::DateHelper
   include PersonalKeyHelper
@@ -247,14 +238,19 @@ feature 'Sign in' do
   end
 
   context 'session approaches timeout', js: true do
+    around do |example|
+      with_forgery_protection { example.run }
+    end
+
     before :each do
       allow(IdentityConfig.store).to receive(:session_check_frequency).and_return(1)
-      allow(IdentityConfig.store).to receive(:session_check_delay).and_return(2)
+      allow(IdentityConfig.store).to receive(:session_check_delay).and_return(0)
       allow(IdentityConfig.store).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in)
 
       sign_in_and_2fa_user
-      visit root_path
+      visit forget_all_browsers_path
+      expect(page).to have_css('.usa-js-modal--active', wait: 5)
     end
 
     scenario 'user sees warning before session times out' do
@@ -276,9 +272,15 @@ feature 'Sign in' do
       expect(page).to have_content(pattern2, wait: 5)
     end
 
-    scenario 'user can continue browsing' do
-      find_button(t('notices.timeout_warning.signed_in.continue')).click
+    scenario 'user can continue browsing with refreshed CSRF token' do
+      expect do
+        click_button t('notices.timeout_warning.signed_in.continue')
+        expect(page).not_to have_css('.usa-js-modal--active', wait: 5)
+      end.to change { find('[name=authenticity_token]', visible: false).value }
 
+      expect(current_path).to eq forget_all_browsers_path
+
+      click_button t('forms.buttons.confirm')
       expect(current_path).to eq account_path
     end
 
@@ -293,7 +295,7 @@ feature 'Sign in' do
   context 'user only signs in via email and password', js: true do
     it 'displays the session timeout warning with partially signed in copy' do
       allow(IdentityConfig.store).to receive(:session_check_frequency).and_return(1)
-      allow(IdentityConfig.store).to receive(:session_check_delay).and_return(2)
+      allow(IdentityConfig.store).to receive(:session_check_delay).and_return(0)
       allow(IdentityConfig.store).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in)
 
@@ -301,6 +303,7 @@ feature 'Sign in' do
       sign_in_user(user)
       visit user_two_factor_authentication_path
 
+      expect(page).to have_css('.usa-js-modal--active', wait: 5)
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.continue'))
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.sign_out'))
     end
@@ -323,12 +326,8 @@ feature 'Sign in' do
   end
 
   context 'signing back in after session timeout length' do
-    before do
-      ActionController::Base.allow_forgery_protection = true
-    end
-
-    after do
-      ActionController::Base.allow_forgery_protection = false
+    around do |example|
+      with_forgery_protection { example.run }
     end
 
     it 'fails to sign in the user, with CSRF error' do
@@ -992,5 +991,12 @@ feature 'Sign in' do
     click_submit_default
     expect(current_path).to eq login_add_piv_cac_prompt_path
     fill_in 'name', with: 'Card 1'
+  end
+
+  def with_forgery_protection
+    original_allow_forgery_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    yield
+    ActionController::Base.allow_forgery_protection = original_allow_forgery_protection
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Extracted from #7966

This pull request seek to refresh the form authenticity token when a user's session is renewed by clicking the "Keep me signed in" button when the session expiration modal is shown.

This seeks to be an incremental step toward larger changes in #7966, where this enhances the `request` fetch helper utility without introducing new API endpoints like in #7966.

Related discussions:

- https://github.com/18F/identity-idp/pull/7966/files#r1143978139
- https://gsa-tts.slack.com/archives/C0NGESUN5/p1678740248343529?thread_ts=1678739597.630529&cid=C0NGESUN5
- https://gsa-tts.slack.com/archives/C0NGESUN5/p1679492599039539

## 📜 Testing Plan

1. Sign in
2. Visit a page which has a form to submit (e.g. first step of identity verification)
3. Wait for session timeout modal to appear
4. Click "Keep me signed in"
5. Submit form
6. Observe no errors in form submission (an error would be shown if the submitted authenticity token was invalid)