### PR TITLE
Rescue external server errors in location search controllers to avoid exceptions

### DIFF
--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -1,8 +1,9 @@
 module Idv
   module InPerson
     class AddressSearchController < ApplicationController
-      rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError,
-                  Faraday::ClientError, ActionController::InvalidAuthenticityToken, StandardError,
+      rescue_from ActionController::InvalidAuthenticityToken,
+                  Faraday::Error,
+                  StandardError,
                   with: :report_errors
 
       def index
@@ -31,9 +32,7 @@ module Idv
 
       def report_errors(error)
         remapped_error = case error
-        when Faraday::ClientError,
-             Faraday::ConnectionFailed,
-             Faraday::TimeoutError,
+        when Faraday::Error,
              ActionController::InvalidAuthenticityToken
           :bad_request
         else

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -12,9 +12,8 @@ module Idv
 
       before_action :confirm_authenticated_for_api, only: [:update]
 
-      rescue_from Faraday::TimeoutError,
-                  Faraday::BadRequestError,
-                  Faraday::ForbiddenError,
+      rescue_from ActionController::InvalidAuthenticityToken,
+                  Faraday::Error,
                   StandardError,
                   with: :handle_error
 
@@ -58,9 +57,7 @@ module Idv
       def handle_error(err)
         remapped_error = case err
         when ActionController::InvalidAuthenticityToken,
-             Faraday::BadRequestError,
-             Faraday::ForbiddenError,
-             Faraday::TimeoutError
+             Faraday::Error
           :unprocessable_entity
         else
           :internal_server_error

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -186,11 +186,11 @@ describe Idv::InPerson::UspsLocationsController do
         allow(proofer).to receive(:request_facilities).with(address).and_raise(server_error)
       end
 
-      it 'returns an internal server error' do
+      it 'returns an unprocessible entity client error' do
         subject
         expect(@analytics).to have_logged_event(
           'Request USPS IPP locations: request failed',
-          api_status_code: 500,
+          api_status_code: 422,
           exception_class: server_error.class,
           exception_message: server_error.message,
           response_body_present:
@@ -200,7 +200,7 @@ describe Idv::InPerson::UspsLocationsController do
         )
 
         status = response.status
-        expect(status).to eq 500
+        expect(status).to eq 422
       end
     end
 
@@ -222,7 +222,7 @@ describe Idv::InPerson::UspsLocationsController do
         subject
         expect(@analytics).to have_logged_event(
           'Request USPS IPP locations: request failed',
-          api_status_code: 500,
+          api_status_code: 422,
           exception_class: exception.class,
           exception_message: exception.message,
           response_body_present:


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to #8060 and #7894, this adds a more general class of errors to avoid returning exceptions on in these controllers.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
