### PR TITLE
Remove ETag middleware to disable ETag for all requests

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -53,14 +53,12 @@ module Users
     end
 
     def active
-      response.headers['Etag'] = '' # clear etags to prevent caching
       session[:pinged_at] = now
       Rails.logger.debug(alive?: alive?, expires_at: expires_at)
       render json: { live: alive?, timeout: expires_at, remaining: remaining_session_time }
     end
 
     def keepalive
-      response.headers['Etag'] = '' # clear etags to prevent caching
       session[:session_expires_at] = now + Devise.timeout_in if alive?
       analytics.session_kept_alive if alive?
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -105,6 +105,8 @@ module Identity
     }
     config.action_mailer.observers = %w[EmailDeliveryObserver]
 
+    config.middleware.delete Rack::ETag
+
     require 'headers_filter'
     config.middleware.insert_before 0, HeadersFilter
     require 'utf8_sanitizer'

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -26,12 +26,6 @@ describe Users::SessionsController, devise: true do
         expect(response.status).to eq(200)
       end
 
-      it 'clears the Etag header' do
-        get :active
-
-        expect(response.headers['Etag']).to eq ''
-      end
-
       it 'renders json' do
         get :active
 
@@ -673,12 +667,6 @@ describe Users::SessionsController, devise: true do
         post :keepalive
 
         expect(response.status).to eq(200)
-      end
-
-      it 'clears the Etag header' do
-        post :keepalive
-
-        expect(response.headers['Etag']).to eq ''
       end
 
       it 'renders json' do


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the default Rack ETag middleware to avoid generating an ETag response header.

Benefits:

- Improve performance by avoiding [creating a body digest](https://github.com/rack/rack/blob/d4c159f66a0bbf92be2512df2099698097d42120/lib/rack/etag.rb#L33) for each request
- Shrink size of response
- Consistent with expectation that all routes are not to be cached ([source](https://github.com/18F/identity-idp/blob/9ab5e95189a228ced91c401ef875110d79bccc89/app/controllers/application_controller.rb#L141-L144))
- Avoid ad-hoc usage ([example](https://github.com/18F/identity-idp/blob/9ab5e95189a228ced91c401ef875110d79bccc89/app/controllers/users/sessions_controller.rb#L56))

## 📜 Testing Plan

1. `curl -I http://localhost:3000`
2. Observe there is no `ETag` response header