### PR TITLE
LG-9219: Ignore parameter errors in NewRelic logging

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -23,8 +23,10 @@ production:
     capture_source: true
     ignore_errors: "<%= %w[
       ActionController::BadRequest
+      ActionController::ParameterMissing
       ActionController::RoutingError
       ActionDispatch::Http::MimeNegotiation::InvalidType
+      ActionDispatch::Http::Parameters::ParseError
       GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
     ].join(',') %>"
   license_key: <%= IdentityConfig.store.newrelic_license_key %>


### PR DESCRIPTION
## 🎫 Ticket

[LG-9219](https://cm-jira.usa.gov/browse/LG-9219)

## 🛠 Summary of changes

Adds new entries in the NewRelic ignored set of error classes:

- `ActionController::ParameterMissing`
- `ActionDispatch::Http::Parameters::ParseError`

Rationale: We often see errors in the NewRelic errors inbox which appear to be caused by fuzzing, either submitting to an endpoint without the expected parameters, or making a JSON request with invalid JSON.

See related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1679671176539539

## 📜 Testing Plan

This is difficult to test prior to merge.

Once deployed, test to confirm that submitting a request with invalid JSON responds as expected (400 status code) and no error is logged to NewRelic:

```
curl -i -X POST -H 'Content-Type: application/json' -d '{' https://idp.int.identitysandbox.gov/not/found
```