### PR TITLE
Deploy RC 265.1 to Production

### DIFF
--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -30,16 +30,20 @@ module Idv
       end
 
       def report_errors(error)
-        remapped_error = {
-          Faraday::ClientError => :bad_request,
-          Faraday::ConnectionFailed => :bad_request,
-          Faraday::TimeoutError => :bad_request,
-          ActionController::InvalidAuthenticityToken => :bad_request,
-        }[error.class] || :internal_server_error
-
-        errors = if error.instance_of?(Faraday::ClientError)
-                   error.response_body && error.response_body[:details]
+        remapped_error = case error
+        when Faraday::ClientError,
+             Faraday::ConnectionFailed,
+             Faraday::TimeoutError,
+             ActionController::InvalidAuthenticityToken
+          :bad_request
+        else
+          :internal_server_error
         end
+
+        errors = if error.respond_to?(:response_body)
+                   error.response_body && error.response_body[:details]
+                 end
+
         errors ||= 'ArcGIS error performing operation'
 
         analytics.idv_in_person_locations_searched(

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -1,8 +1,9 @@
 module Idv
   module InPerson
     class AddressSearchController < ApplicationController
-      rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError,
-                  Faraday::ClientError, ActionController::InvalidAuthenticityToken, StandardError,
+      rescue_from ActionController::InvalidAuthenticityToken,
+                  Faraday::Error,
+                  StandardError,
                   with: :report_errors
 
       def index
@@ -31,9 +32,7 @@ module Idv
 
       def report_errors(error)
         remapped_error = case error
-        when Faraday::ClientError,
-             Faraday::ConnectionFailed,
-             Faraday::TimeoutError,
+        when Faraday::Error,
              ActionController::InvalidAuthenticityToken
           :bad_request
         else

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -56,12 +56,15 @@ module Idv
       protected
 
       def handle_error(err)
-        remapped_error = {
-          Faraday::TimeoutError => :unprocessable_entity,
-          Faraday::BadRequestError => :unprocessable_entity,
-          Faraday::ForbiddenError => :unprocessable_entity,
-          ActionController::InvalidAuthenticityToken => :unprocessable_entity,
-        }[err.class] || :internal_server_error
+        remapped_error = case err
+        when ActionController::InvalidAuthenticityToken,
+             Faraday::BadRequestError,
+             Faraday::ForbiddenError,
+             Faraday::TimeoutError
+          :unprocessable_entity
+        else
+          :internal_server_error
+        end
 
         analytics.idv_in_person_locations_request_failure(
           api_status_code: Rack::Utils.status_code(remapped_error),

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -12,9 +12,8 @@ module Idv
 
       before_action :confirm_authenticated_for_api, only: [:update]
 
-      rescue_from Faraday::TimeoutError,
-                  Faraday::BadRequestError,
-                  Faraday::ForbiddenError,
+      rescue_from ActionController::InvalidAuthenticityToken,
+                  Faraday::Error,
                   StandardError,
                   with: :handle_error
 
@@ -58,9 +57,7 @@ module Idv
       def handle_error(err)
         remapped_error = case err
         when ActionController::InvalidAuthenticityToken,
-             Faraday::BadRequestError,
-             Faraday::ForbiddenError,
-             Faraday::TimeoutError
+             Faraday::Error
           :unprocessable_entity
         else
           :internal_server_error

--- a/app/controllers/users/rules_of_use_controller.rb
+++ b/app/controllers/users/rules_of_use_controller.rb
@@ -1,7 +1,10 @@
 module Users
   class RulesOfUseController < ApplicationController
+    include SecureHeadersConcern
+
     before_action :confirm_signed_in
     before_action :confirm_need_to_accept_rules_of_use
+    before_action :apply_secure_headers_override
 
     def new
       analytics.rules_of_use_visit

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -186,11 +186,11 @@ describe Idv::InPerson::UspsLocationsController do
         allow(proofer).to receive(:request_facilities).with(address).and_raise(server_error)
       end
 
-      it 'returns an internal server error' do
+      it 'returns an unprocessible entity client error' do
         subject
         expect(@analytics).to have_logged_event(
           'Request USPS IPP locations: request failed',
-          api_status_code: 500,
+          api_status_code: 422,
           exception_class: server_error.class,
           exception_message: server_error.message,
           response_body_present:
@@ -200,7 +200,7 @@ describe Idv::InPerson::UspsLocationsController do
         )
 
         status = response.status
-        expect(status).to eq 500
+        expect(status).to eq 422
       end
     end
 
@@ -222,7 +222,7 @@ describe Idv::InPerson::UspsLocationsController do
         subject
         expect(@analytics).to have_logged_event(
           'Request USPS IPP locations: request failed',
-          api_status_code: 500,
+          api_status_code: 422,
           exception_class: exception.class,
           exception_message: exception.message,
           response_body_present:


### PR DESCRIPTION
## Bug Fixes
- Authentication: Fix Content Security Policy errors when redirecting to service provider ([#8063](https://github.com/18F/identity-idp/pull/8063))
- In-person Proofing: Rescue external server errors to avoid exceptions ([#8068](https://github.com/18F/identity-idp/pull/8068))

## Internal
- Source code: Update error checking to allow subclasses ([#8061](https://github.com/18F/identity-idp/pull/8061))
