### PR TITLE
Update document capture to use request utility

### DIFF
--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -12,7 +12,6 @@ const UploadContext = createContext({
   backgroundUploadURLs: {} as Record<string, string>,
   backgroundUploadEncryptKey: undefined as CryptoKey | undefined,
   flowPath: 'standard' as FlowPath,
-  csrf: null as string | null,
   formData: {} as Record<string, any>,
 });
 
@@ -45,11 +44,6 @@ interface UploadOptions {
    * Endpoint to which payload should be sent.
    */
   endpoint: string;
-
-  /**
-   * CSRF token to send as parameter to upload implementation.
-   */
-  csrf: string | null;
 }
 
 export interface UploadSuccessResponse {
@@ -101,6 +95,8 @@ export interface UploadErrorResponse {
   result_failed: boolean;
 }
 
+export type UploadResponse = UploadSuccessResponse | UploadErrorResponse;
+
 export type UploadImplementation = (
   payload: Record<string, any>,
   options: UploadOptions,
@@ -143,11 +139,6 @@ interface UploadContextProviderProps {
   statusPollInterval?: number;
 
   /**
-   * CSRF token to send as parameter to upload implementation.
-   */
-  csrf: string | null;
-
-  /**
    * Extra form data to merge into the payload before uploading
    */
   formData?: Record<string, any>;
@@ -177,27 +168,25 @@ function UploadContextProvider({
   endpoint,
   statusEndpoint,
   statusPollInterval,
-  csrf,
   formData = DEFAULT_FORM_DATA,
   flowPath,
   children,
 }: UploadContextProviderProps) {
-  const uploadWithCSRF = (payload) => upload({ ...payload, ...formData }, { endpoint, csrf });
+  const uploadWithFormData = (payload) => upload({ ...payload, ...formData }, { endpoint });
 
   const getStatus = () =>
     statusEndpoint
-      ? upload({ ...formData }, { endpoint: statusEndpoint, method: 'PUT', csrf })
+      ? upload({ ...formData }, { endpoint: statusEndpoint, method: 'PUT' })
       : Promise.reject();
 
   const value = useObjectMemo({
-    upload: uploadWithCSRF,
+    upload: uploadWithFormData,
     getStatus,
     statusPollInterval,
     backgroundUploadURLs,
     backgroundUploadEncryptKey,
     isMockClient,
     flowPath,
-    csrf,
     formData,
   });
 

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -95,8 +95,6 @@ export interface UploadErrorResponse {
   result_failed: boolean;
 }
 
-export type UploadResponse = UploadSuccessResponse | UploadErrorResponse;
-
 export type UploadImplementation = (
   payload: Record<string, any>,
   options: UploadOptions,

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -69,7 +69,12 @@ export function toFormEntryError(uploadFieldError: UploadFieldError): UploadForm
 }
 
 const upload: UploadImplementation = async function (payload, { method = 'POST', endpoint }) {
-  const response = await request(endpoint, { method, body: toFormData(payload), read: false });
+  const response = await request(endpoint, {
+    method,
+    body: toFormData(payload),
+    json: false,
+    read: false,
+  });
 
   if (!response.ok && !response.status.toString().startsWith('4')) {
     // 4xx is an expected error state, handled after JSON deserialization. Anything else not OK

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -1,5 +1,6 @@
 import { FormError } from '@18f/identity-form-steps';
 import { forceRedirect } from '@18f/identity-url';
+import { request } from '@18f/identity-request';
 import type {
   UploadSuccessResponse,
   UploadErrorResponse,
@@ -67,12 +68,8 @@ export function toFormEntryError(uploadFieldError: UploadFieldError): UploadForm
   return formEntryError;
 }
 
-const upload: UploadImplementation = async function (payload, { method = 'POST', endpoint, csrf }) {
-  const headers: HeadersInit = {};
-  if (csrf) {
-    headers['X-CSRF-Token'] = csrf;
-  }
-  const response = await window.fetch(endpoint, { method, headers, body: toFormData(payload) });
+const upload: UploadImplementation = async function (payload, { method = 'POST', endpoint }) {
+  const response = await request(endpoint, { method, body: toFormData(payload), read: false });
 
   if (!response.ok && !response.status.toString().startsWith('4')) {
     // 4xx is an expected error state, handled after JSON deserialization. Anything else not OK

--- a/app/javascript/packages/request/index.spec.ts
+++ b/app/javascript/packages/request/index.spec.ts
@@ -148,6 +148,37 @@ describe('request', () => {
     });
   });
 
+  context('with read=false option', () => {
+    it('returns the raw response', async () => {
+      sandbox.stub(window, 'fetch').resolves(new Response(JSON.stringify({})));
+      const response = await request('https://example.com', { read: false });
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  context('with unsuccessful response', () => {
+    beforeEach(() => {
+      sandbox.stub(window, 'fetch').resolves(new Response(JSON.stringify({}), { status: 400 }));
+    });
+
+    it('throws an error', async () => {
+      await request('https://example.com', { read: false })
+        .then(() => {
+          throw new Error('Unexpected promise resolution');
+        })
+        .catch((error) => {
+          expect(error).to.exist();
+        });
+    });
+
+    context('with read=false option', () => {
+      it('returns the raw response', async () => {
+        const response = await request('https://example.com', { read: false });
+        expect(response.status).to.equal(400);
+      });
+    });
+  });
+
   context('with response including csrf token', () => {
     beforeEach(() => {
       sandbox.stub(window, 'fetch').callsFake(() =>

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -14,6 +14,7 @@ import {
 import { isCameraCapableMobile } from '@18f/identity-device';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { trackEvent as baseTrackEvent } from '@18f/identity-analytics';
+import { request } from '@18f/identity-request';
 import type { FlowPath, DeviceContextValue } from '@18f/identity-document-capture';
 
 /**
@@ -81,7 +82,6 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
 (async () => {
   const backgroundUploadURLs = getBackgroundUploadURLs();
   const isAsyncForm = Object.keys(backgroundUploadURLs).length > 0;
-  const csrf = getMetaContent('csrf-token');
 
   const formData: Record<string, any> = {
     document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
@@ -104,11 +104,7 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
     formData.step = 'verify_document';
   }
 
-  const keepAlive = () =>
-    window.fetch(keepAliveEndpoint, {
-      method: 'POST',
-      headers: [csrf && ['X-CSRF-Token', csrf]].filter(Boolean) as [string, string][],
-    });
+  const keepAlive = () => request(keepAliveEndpoint, { method: 'POST' });
 
   const {
     helpCenterRedirectUrl: helpCenterRedirectURL,
@@ -155,7 +151,6 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
         endpoint: String(appRoot.getAttribute('data-endpoint')),
         statusEndpoint: String(appRoot.getAttribute('data-status-endpoint')),
         statusPollInterval: Number(appRoot.getAttribute('data-status-poll-interval-ms')),
-        csrf,
         isMockClient,
         backgroundUploadURLs,
         backgroundUploadEncryptKey,

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -275,15 +275,12 @@ describe('document-capture/components/document-capture', () => {
     sandbox
       .stub(window, 'fetch')
       .withArgs(endpoint)
-      .resolves({
-        ok: false,
-        status: 418,
-        url: endpoint,
-        json: () =>
-          Promise.resolve({
-            redirect: '#teapot',
-          }),
-      });
+      .resolves(
+        new Response(JSON.stringify({ redirect: '#teapot' }), {
+          status: 418,
+          url: endpoint,
+        }),
+      );
 
     const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
     const backImage = getByLabelText('doc_auth.headings.document_capture_back');
@@ -305,7 +302,7 @@ describe('document-capture/components/document-capture', () => {
   it('renders async upload pending progress', async () => {
     const statusChecks = 3;
     let remainingStatusChecks = statusChecks;
-    sandbox.stub(window, 'fetch').resolves({ ok: true, headers: new window.Headers() });
+    sandbox.stub(window, 'fetch').resolves(new Response());
     const upload = sinon.stub().callsFake((payload, { endpoint }) => {
       switch (endpoint) {
         case 'about:blank#upload':
@@ -393,13 +390,11 @@ describe('document-capture/components/document-capture', () => {
       sandbox.stub(window, 'fetch');
       window.fetch.withArgs('about:blank#front').returns(
         new Promise((resolve, reject) => {
-          completeUploadAsSuccess = () => resolve({ ok: true, headers: new window.Headers() });
+          completeUploadAsSuccess = () => resolve(new Response());
           completeUploadAsFailure = () => reject(new Error());
         }),
       );
-      window.fetch
-        .withArgs('about:blank#back')
-        .resolves({ ok: true, headers: new window.Headers() });
+      window.fetch.withArgs('about:blank#back').resolves(new Response());
       upload = sinon.stub().resolves({ success: true, isPending: false });
       const key = await window.crypto.subtle.generateKey(
         {
@@ -514,12 +509,12 @@ describe('document-capture/components/document-capture', () => {
         sandbox
           .stub(window, 'fetch')
           .withArgs(endpoint)
-          .resolves({
-            ok: false,
-            status: 400,
-            url: endpoint,
-            json: () => ({ success: false, remaining_attempts: 1, errors: [{}] }),
-          });
+          .resolves(
+            new Response(JSON.stringify({ success: false, remaining_attempts: 1, errors: [{}] }), {
+              status: 400,
+              url: endpoint,
+            }),
+          );
 
         expect(queryByText('idv.troubleshooting.options.verify_in_person')).not.to.exist();
         await userEvent.click(getByText('forms.buttons.submit.default'));

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -21,7 +21,6 @@ describe('document-capture/context/upload', () => {
       'backgroundUploadEncryptKey',
       'flowPath',
       'formData',
-      'csrf',
     ]);
 
     expect(result.current.upload).to.equal(defaultUpload);
@@ -30,7 +29,6 @@ describe('document-capture/context/upload', () => {
     expect(result.current.isMockClient).to.be.false();
     expect(result.current.backgroundUploadURLs).to.deep.equal({});
     expect(result.current.backgroundUploadEncryptKey).to.be.undefined();
-    expect(result.current.csrf).to.be.null();
     expect(await result.current.getStatus()).to.deep.equal({});
   });
 
@@ -72,7 +70,7 @@ describe('document-capture/context/upload', () => {
     sandbox
       .stub(window, 'fetch')
       .withArgs(statusEndpoint)
-      .resolves({ ok: true, url: statusEndpoint, json: () => Promise.resolve({ success: true }) });
+      .resolves(new Response(JSON.stringify({ success: true }), { url: statusEndpoint }));
 
     await result.current.getStatus();
     expect(result.current.statusPollInterval).to.equal(1000);
@@ -109,18 +107,16 @@ describe('document-capture/context/upload', () => {
     expect(result.current.backgroundUploadEncryptKey).to.equal(key);
   });
 
-  it('can provide endpoint and csrf to make available to uploader', async () => {
+  it('provides endpoint to custom uploader', async () => {
     const { result } = renderHook(() => useContext(UploadContext), {
       wrapper: ({ children }) => (
         <UploadContextProvider
-          upload={(payload, { endpoint, csrf }) =>
+          upload={(payload, { endpoint }) =>
             Promise.resolve({
               ...payload,
               receivedEndpoint: endpoint,
-              receivedCSRF: csrf,
             })
           }
-          csrf="example"
           endpoint="https://example.com"
         >
           {children}
@@ -132,7 +128,6 @@ describe('document-capture/context/upload', () => {
     expect(uploadResult).to.deep.equal({
       sent: true,
       receivedEndpoint: 'https://example.com',
-      receivedCSRF: 'example',
     });
   });
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates fetch usage in document capture to use the `@18f/identity-request` utility.

Why?

- For consistent handling of CSRF token
   - Simplifies behavior within document capture to remove concern for `csrf` React context value
   - Ensures that document capture keepalive behavior works the same way to refresh the global CSRF token as introduced with #8067
- Expands features of `@18f/identity-request` to support use-case of raw response handling

## 📜 Testing Plan

- Ensure no regressions in document capture submission