### PR TITLE
LG-9098 DocumentCaptureController#update, desktop flow, feature flagged

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -1,7 +1,9 @@
 module Idv
   module DocumentCaptureConcern
     def override_document_capture_step_csp
-      return if params[:step] != 'document_capture'
+      if !IdentityConfig.store.doc_auth_document_capture_controller_enabled
+        return if params[:step] != 'document_capture'
+      end
 
       policy = current_content_security_policy
       policy.connect_src(*policy.connect_src, 'us.acas.acuant.net')

--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -43,5 +43,15 @@ module Idv
         service_provider: current_sp,
       ).present?
     end
+
+    def document_capture_session
+      @document_capture_session ||= DocumentCaptureSession.find_by(
+        uuid: flow_session[document_capture_session_uuid_key],
+      )
+    end
+
+    def document_capture_session_uuid_key
+      :document_capture_session_uuid
+    end
   end
 end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -25,7 +25,7 @@ module Idv
       analytics.idv_doc_auth_document_capture_submitted(**analytics_arguments)
 
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
-      call('document_capture', :update, true)
+        call('document_capture', :update, true)
     end
 
     def extra_view_variables

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -6,6 +6,7 @@ module Idv
 
     before_action :render_404_if_document_capture_controller_disabled
     before_action :confirm_two_factor_authenticated
+    before_action :confirm_agreement_step_complete
 
     def show
       increment_step_counts
@@ -54,6 +55,12 @@ module Idv
 
     def render_404_if_document_capture_controller_disabled
       render_not_found unless IdentityConfig.store.doc_auth_document_capture_controller_enabled
+    end
+
+    def confirm_agreement_step_complete
+      return if flow_session['Idv::Steps::AgreementStep']
+
+      redirect_to idv_doc_auth_url
     end
 
     def analytics_arguments

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -15,6 +15,9 @@ module Idv
       render :show, locals: extra_view_variables
     end
 
+    def update
+    end
+
     def extra_view_variables
       url_builder = ImageUploadPresignedUrlGenerator.new
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -12,11 +12,19 @@ module Idv
 
       analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)
 
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+        call('document_capture', :view, true)
+
       render :show, locals: extra_view_variables
     end
 
     def update
       handle_stored_result
+
+      analytics.idv_doc_auth_document_capture_submitted(**analytics_arguments)
+
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+      call('document_capture', :update, true)
     end
 
     def extra_view_variables

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -36,7 +36,6 @@ module Idv
           transaction_id: flow_session[:document_capture_session_uuid],
         ),
       }.merge(
-        native_camera_ab_testing_variables,
         acuant_sdk_upgrade_a_b_testing_variables,
         in_person_cta_variant_testing_variables,
       )
@@ -66,13 +65,6 @@ module Idv
 
     def increment_step_counts
       current_flow_step_counts['Idv::Steps::DocumentCaptureStep'] += 1
-    end
-
-    def native_camera_ab_testing_variables
-      {
-        acuant_sdk_upgrade_ab_test_bucket:
-          AbTests::ACUANT_SDK.bucket(flow_session[:document_capture_session_uuid]),
-      }
     end
 
     def acuant_sdk_upgrade_a_b_testing_variables

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -149,10 +149,14 @@ module Idv
 
     def invalidate_steps_after_ssn!
       # Guard against unvalidated attributes from in-person flow in review controller
-      session[:applicant] = nil
+      clear_applicant!
 
       invalidate_verify_info_step!
       invalidate_phone_step!
+    end
+
+    def clear_applicant!
+      session[:applicant] = nil
     end
 
     def mark_verify_info_step_complete!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,7 @@ Rails.application.routes.draw do
       get '/forgot_password' => 'forgot_password#new'
       post '/forgot_password' => 'forgot_password#update'
       get '/document_capture' => 'document_capture#show'
+      put '/document_capture' => 'document_capture#update'
       get '/ssn' => 'ssn#show'
       put '/ssn' => 'ssn#update'
       get '/verify_info' => 'verify_info#show'

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -8,7 +8,7 @@ describe Idv::DocumentCaptureController do
       'pii_from_doc' => Idp::Constants::MOCK_IDV_APPLICANT.dup,
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'standard',
-      'Idv::Steps::AgreementStep' => true, }
+      'Idv::Steps::AgreementStep' => true }
   end
 
   let(:user) { create(:user) }
@@ -92,7 +92,6 @@ describe Idv::DocumentCaptureController do
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
       end
 
-
       it 'updates DocAuthLog document_capture_view_count' do
         doc_auth_log = DocAuthLog.create(user_id: user.id)
 
@@ -137,7 +136,6 @@ describe Idv::DocumentCaptureController do
 
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
       end
-
 
       it 'updates DocAuthLog document_capture_submit_count' do
         doc_auth_log = DocAuthLog.create(user_id: user.id)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -64,26 +64,24 @@ describe Idv::DocumentCaptureController do
         }
       end
 
-      context '#show' do
-        it 'renders the show template' do
-          get :show
+      it 'renders the show template' do
+        get :show
 
-          expect(response).to render_template :show
-        end
+        expect(response).to render_template :show
+      end
 
-        it 'sends analytics_visited event' do
-          get :show
+      it 'sends analytics_visited event' do
+        get :show
 
-          expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-        end
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
 
-        it 'sends correct step count to analytics' do
-          get :show
-          get :show
-          analytics_args[:step_count] = 2
+      it 'sends correct step count to analytics' do
+        get :show
+        get :show
+        analytics_args[:step_count] = 2
 
-          expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-        end
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
       end
     end
   end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -84,6 +84,15 @@ describe Idv::DocumentCaptureController do
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
       end
     end
+
+    describe '#update' do
+      it 'does not raise an exception when stored_result is nil' do
+        allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled?).
+          and_return(false)
+        allow(subject).to receive(:stored_result).and_return(nil)
+        put :update
+      end
+    end
   end
 
   context 'when doc_auth_document_capture_controller_enabled is false' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -139,4 +139,14 @@ feature 'doc auth document capture step', :js do
 
     expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
   end
+
+  def expect_costing_for_document
+    %i[acuant_front_image acuant_back_image acuant_result].each do |cost_type|
+      expect(costing_for(cost_type)).to be_present
+    end
+  end
+
+  def costing_for(cost_type)
+    SpCost.where(ial: 2, issuer: 'urn:gov:gsa:openidconnect:sp:server', cost_type: cost_type.to_s)
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

LG-9098

## 🛠 Summary of changes

Add code from existing DocumentCapture step to handle #update method in new DocumentCaptureController, for desktop flow only. The bulk of the document capture work is still done on the front end. Bring over feature tests and make them pass.

## 📜 Testing Plan

- [ ] Set `doc_auth_document_capture_controller_enabled` feature flag to `true` in local application.yml
- [ ] Create account
- [ ] Go to /verify and start identity verification process
- [ ] At upload step, choose "Upload from computer"
- [ ] Navigate to `/verify/document_capture` (going there automatically is a separate PR)
- [ ] Upload images or yml files and click Submit
- [ ] Expect to successfully complete verification

## 👀 Screenshots
<details>
<summary>After:</summary>
  
![DocumentCapture#update](https://user-images.githubusercontent.com/2381438/227660642-df15aaf3-f540-4bf8-bac1-b88204d41d80.png)
</details>

