### PR TITLE
Update re-authentication logic when confirming user is authenticated for 2FA setup

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -40,11 +40,7 @@ module MfaSetupConcern
 
   def confirm_user_authenticated_for_2fa_setup
     authenticate_user!(force: true)
-    if IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-      return if user_fully_authenticated? && !UserSessionContext.reauthentication_context?(context)
-    elsif user_fully_authenticated?
-      return
-    end
+    return if user_fully_authenticated?
     return unless MfaPolicy.new(current_user).two_factor_enabled?
     redirect_to user_two_factor_authentication_url
   end

--- a/app/controllers/concerns/reauthentication_required_concern.rb
+++ b/app/controllers/concerns/reauthentication_required_concern.rb
@@ -16,7 +16,9 @@ module ReauthenticationRequiredConcern
   def confirm_recently_authenticated_2fa
     @reauthn = reauthn?
     return unless user_fully_authenticated?
-    return if recently_authenticated? && user_session[:auth_method] != 'remember_device'
+    non_remembered_device_authentication = user_session[:auth_method].present? &&
+                                           user_session[:auth_method] != 'remember_device'
+    return if recently_authenticated? && non_remembered_device_authentication
     return if in_multi_mfa_selection_flow?
 
     analytics.user_2fa_reauthentication_required(

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -5,12 +5,16 @@ module Users
     include MfaSetupConcern
     include RememberDeviceConcern
     include SecureHeadersConcern
+    include ReauthenticationRequiredConcern
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :authorize_piv_cac_disable, only: :delete
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :new
     before_action :cap_piv_cac_count, only: %i[new submit_new_piv_cac]
+    before_action :confirm_recently_authenticated_2fa, if: -> do
+      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
+    end
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 describe Users::PivCacAuthenticationSetupController do
+  describe 'before_actions' do
+    it 'includes appropriate before_actions' do
+      expect(subject).to have_actions(
+        :before,
+        :authenticate_user!,
+        :confirm_user_authenticated_for_2fa_setup,
+        :confirm_recently_authenticated_2fa,
+      )
+    end
+  end
+
   describe 'when not signed in' do
     describe 'GET index' do
       it 'redirects to root url' do
@@ -64,6 +75,7 @@ describe Users::PivCacAuthenticationSetupController do
         allow(PivCacService).to receive(:decode_token).with(bad_token) { bad_token_response }
         allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
         subject.user_session[:piv_cac_nickname] = nickname
+        subject.user_session[:authn_at] = Time.zone.now
       end
 
       let(:nonce) { 'nonce' }

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -76,6 +76,7 @@ describe Users::PivCacAuthenticationSetupController do
         allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
         subject.user_session[:piv_cac_nickname] = nickname
         subject.user_session[:authn_at] = Time.zone.now
+        subject.user_session[:auth_method] = 'phone'
       end
 
       let(:nonce) { 'nonce' }

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -73,12 +73,21 @@ feature 'Changing authentication factor' do
     it 'requires 2FA authentication to manage 2FA configurations' do
       user = user_with_2fa
       sign_in_with_warden(user, auth_method: 'remember_device')
+
+      # Ensure reauthentication context does not prompt incorrectly
+      visit webauthn_setup_path
+      expect(current_path).to eq login_two_factor_options_path
+
       visit add_phone_path
       expect(current_path).to eq login_two_factor_options_path
+
       find("label[for='two_factor_options_form_selection_sms']").click
       click_on t('forms.buttons.continue')
       fill_in_code_with_last_phone_otp
       click_submit_default
+      expect(current_path).to eq add_phone_path
+
+      visit add_phone_path
       expect(current_path).to eq add_phone_path
     end
   end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -18,6 +18,7 @@ module ControllerHelper
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
+    controller.user_session[:auth_method] ||= 'phone'
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
     allow(controller).to receive(:user_fully_authenticated?).and_return(true)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -207,7 +207,7 @@ module Features
     end
 
     def sign_in_and_2fa_user(user = user_with_2fa)
-      sign_in_with_warden(user)
+      sign_in_with_warden(user, auth_method: 'phone')
       user
     end
 


### PR DESCRIPTION
Follow-up to #8037 that adds a missing controller and removes the unnecessary change to `confirm_user_authenticated_for_2fa_setup`

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
