### PR TITLE
Remove unused styles from document capture stylesheet

### DIFF
--- a/app/javascript/packages/document-capture/components/review-issues-step.scss
+++ b/app/javascript/packages/document-capture/components/review-issues-step.scss
@@ -1,3 +1,0 @@
-.document-capture-review-issues-step__input:not(.document-capture-review-issues-step__input--unconstrained-width) {
-  max-width: 375px;
-}

--- a/app/javascript/packages/document-capture/styles.scss
+++ b/app/javascript/packages/document-capture/styles.scss
@@ -2,4 +2,3 @@
 @import './components/acuant-capture';
 @import './components/acuant-capture-canvas';
 @import './components/location-collection-item';
-@import './components/review-issues-step';


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused styles.

Unused as of #7113

See: https://github.com/18f/identity-idp/commit/21a70352962084416f54d7ee2bb5d35681cb577b#diff-9d94e7129581055