### PR TITLE
LG-5847: Update confirmation email language

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -84,6 +84,7 @@ class RegisterUserEmailForm
     # To prevent discovery of existing emails, we check to see if the email is
     # already taken and if so, we act as if the user registration was successful.
     if email_taken? && user_unconfirmed?
+      update_user_language_preference
       send_sign_up_unconfirmed_email(request_id)
     elsif email_taken?
       send_sign_up_confirmed_email
@@ -95,6 +96,12 @@ class RegisterUserEmailForm
         instructions: instructions,
         password_reset_requested: password_reset_requested?,
       )
+    end
+  end
+
+  def update_user_language_preference
+    if existing_user.email_language != email_language
+      existing_user.update(email_language: email_language)
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-5847](https://cm-jira.usa.gov/browse/LG-5847)


## 🛠 Summary of changes

To reproduce:
- Register a new account but do not confirm the account, note the language selected
- Register an account using the same email address as before and change the language preference
- Notice that the second email arrives in the desired language

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
