### PR TITLE
Refactor of USPS proofing job spec to eliminate flakey tests

### DIFF
--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -688,6 +688,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Enrollment status updated',
             hash_including(
+              passed: false,
               reason: 'Enrollment has expired',
             ),
           )

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -586,6 +586,8 @@ RSpec.describe GetUspsProofingResultsJob do
             'GetUspsProofingResultsJob: Enrollment status updated',
             hash_including(
               fraud_suspected: true,
+              passed: false,
+              reason: "Failed status",
             ),
           )
           expect(job_analytics).to have_logged_event(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -741,6 +741,7 @@ RSpec.describe GetUspsProofingResultsJob do
               'GetUspsProofingResultsJob: Unexpected response received',
               hash_including(
                 reason: 'Invalid applicant unique id',
+                response_message: /Applicant [0-9a-z]{18} does not exist/,
               ),
             )
           end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -72,7 +72,6 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
       pending_enrollment.reload
       expect(pending_enrollment.status_updated_at).to eq(Time.zone.now)
       expect(pending_enrollment.status_check_attempted_at).to eq(Time.zone.now)
-
       expect(pending_enrollment.status).to eq(status)
 
       expect(pending_enrollment.profile.active).to eq(passed)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -622,6 +622,7 @@ RSpec.describe GetUspsProofingResultsJob do
           expect(job_analytics).to have_logged_event(
             'GetUspsProofingResultsJob: Enrollment status updated',
             hash_including(
+              passed: false,
               reason: 'Unsupported ID type',
             ),
           )

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe GetUspsProofingResultsJob do
             hash_including(
               fraud_suspected: true,
               passed: false,
-              reason: "Failed status",
+              reason: 'Failed status',
             ),
           )
           expect(job_analytics).to have_logged_event(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -517,6 +517,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'GetUspsProofingResultsJob: Enrollment status updated',
             hash_including(
               reason: 'Successful status update',
+              passed: true,
             ),
           )
           expect(job_analytics).to have_logged_event(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -73,7 +73,6 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
       expect(pending_enrollment.status_updated_at).to eq(Time.zone.now)
       expect(pending_enrollment.status_check_attempted_at).to eq(Time.zone.now)
       expect(pending_enrollment.status).to eq(status)
-
       expect(pending_enrollment.profile.active).to eq(passed)
     end
   end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -22,8 +22,14 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
         issuer: pending_enrollment.issuer,
         minutes_since_last_status_check: 15.0,
         minutes_since_last_status_update: 2.days.in_minutes,
-        minutes_to_completion: range_approximating(3.days.in_minutes, vary_left: -60, vary_right: 5),
-        minutes_since_established: range_approximating(3.days.in_minutes, vary_left: -60, vary_right: 5),
+        minutes_to_completion: range_approximating(
+          3.days.in_minutes, vary_left: -60,
+                             vary_right: 5
+        ),
+        minutes_since_established: range_approximating(
+          3.days.in_minutes, vary_left: -60,
+                             vary_right: 5
+        ),
         passed: passed,
         primary_id_type: response['primaryIdType'],
         proofing_city: response['proofingCity'],
@@ -37,9 +43,9 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
         status: response['status'],
         transaction_end_date_time: anything,
         transaction_start_date_time: anything,
-        )
-      end
+      )
     end
+  end
 
   context 'email_analytics_attributes' do
     before(:each) do
@@ -86,23 +92,23 @@ RSpec.shared_examples 'enrollment_encountering_an_exception' do |exception_class
                                                                 response_message: nil,
                                                                 response_status_code: nil|
   it 'logs an error message and leaves the enrollment and profile pending' do
-      job.perform(Time.zone.now)
-      pending_enrollment.reload
+    job.perform(Time.zone.now)
+    pending_enrollment.reload
 
-      expect(pending_enrollment.pending?).to eq(true)
-      expect(pending_enrollment.profile.active).to eq(false)
-      expect(job_analytics).to have_logged_event(
-        'GetUspsProofingResultsJob: Exception raised',
-        hash_including(
-          enrollment_code: pending_enrollment.enrollment_code,
-          enrollment_id: pending_enrollment.id,
-          exception_class: exception_class,
-          exception_message: exception_message,
-          reason: reason,
-          response_message: response_message,
-          response_status_code: response_status_code,
-        ),
-      )
+    expect(pending_enrollment.pending?).to eq(true)
+    expect(pending_enrollment.profile.active).to eq(false)
+    expect(job_analytics).to have_logged_event(
+      'GetUspsProofingResultsJob: Exception raised',
+      hash_including(
+        enrollment_code: pending_enrollment.enrollment_code,
+        enrollment_id: pending_enrollment.id,
+        exception_class: exception_class,
+        exception_message: exception_message,
+        reason: reason,
+        response_message: response_message,
+        response_status_code: response_status_code,
+      ),
+    )
   end
 
   it 'updates the status_check_attempted_at timestamp' do

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -22,14 +22,8 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
         issuer: pending_enrollment.issuer,
         minutes_since_last_status_check: 15.0,
         minutes_since_last_status_update: 2.days.in_minutes,
-        minutes_to_completion: range_approximating(
-          3.days.in_minutes, vary_left: -60,
-                             vary_right: 5
-        ),
-        minutes_since_established: range_approximating(
-          3.days.in_minutes, vary_left: -60,
-                             vary_right: 5
-        ),
+        minutes_to_completion: 3.days.in_minutes,
+        minutes_since_established: 3.days.in_minutes,
         passed: passed,
         primary_id_type: response['primaryIdType'],
         proofing_city: response['proofingCity'],

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -309,6 +309,8 @@ RSpec.describe GetUspsProofingResultsJob do
             'GetUspsProofingResultsJob: Exception raised',
             hash_including(
               exception_message: error_message,
+              exception_class: 'StandardError',
+              reason: 'Request Exception',
             ),
           )
         end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe GetUspsProofingResultsJob do
             hash_including(
               exception_message: error_message,
               exception_class: 'StandardError',
-              reason: 'Request Exception',
+              reason: 'Request exception',
             ),
           )
         end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -718,6 +718,7 @@ RSpec.describe GetUspsProofingResultsJob do
               'GetUspsProofingResultsJob: Unexpected response received',
               hash_including(
                 reason: 'Invalid enrollment code',
+                response_message: /Enrollment code [0-9]{16} does not exist/,
               ),
             )
           end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -127,6 +127,7 @@ RSpec.shared_examples 'enrollment_encountering_an_error_that_has_a_nil_response'
     expect(job_analytics).to have_logged_event(
       'GetUspsProofingResultsJob: Exception raised',
       hash_including(
+        reason: 'Request exception',
         response_present: false,
         exception_class: error_type.to_s,
       ),


### PR DESCRIPTION
Refactor of USPS Proofing job spec to hopefully eliminate flakey tests.

Changes:

1. Remove "minutes_since_establishment" from "it" blocks and instead place in single location within the shared example.
2. Wrap needed tests in `freeze_time` blocks
3. Add specific fields necessary for analytics checks
4. Move some other checks from separate expectations into one expectation, where appropriate.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run tests locally many (~20) times and be sure that the tests do not error unexpectedly.

<!-- ## 🎫 Ticket

Link to the relevant ticket.

## 🛠 Summary of changes

Write a brief description of what you changed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->