### PR TITLE
LG-9099 IdvStepConcern updates

### DIFF
--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -19,11 +19,6 @@ module Idv
       redirect_to idv_doc_auth_url
     end
 
-    def confirm_profile_not_already_confirmed
-      return unless idv_session.verify_info_step_complete?
-      redirect_to idv_review_url
-    end
-
     # Copied from capture_doc_flow.rb
     # and from doc_auth_flow.rb
     def acuant_sdk_ab_test_analytics_args

--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -11,14 +11,6 @@ module Idv
       flow_session[:flow_path]
     end
 
-    def confirm_pii_from_doc
-      @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
-      return if @pii.present?
-
-      flow_session&.delete('Idv::Steps::DocumentCaptureStep')
-      redirect_to idv_doc_auth_url
-    end
-
     # Copied from capture_doc_flow.rb
     # and from doc_auth_flow.rb
     def acuant_sdk_ab_test_analytics_args

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -8,6 +8,14 @@ module IdvStepConcern
     before_action :confirm_idv_needed
   end
 
+  def confirm_pii_from_doc
+    @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
+    return if @pii.present?
+
+    flow_session&.delete('Idv::Steps::DocumentCaptureStep')
+    redirect_to idv_doc_auth_url
+  end
+
   def confirm_verify_info_step_complete
     return if idv_session.verify_info_step_complete?
 

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -18,7 +18,7 @@ module IdvStepConcern
     end
   end
 
-  def confirm_profile_not_already_confirmed
+  def confirm_verify_info_step_needed
     return unless idv_session.verify_info_step_complete?
     redirect_to idv_review_url
   end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -18,6 +18,11 @@ module IdvStepConcern
     end
   end
 
+  def confirm_profile_not_already_confirmed
+    return unless idv_session.verify_info_step_complete?
+    redirect_to idv_review_url
+  end
+
   def confirm_address_step_complete
     return if idv_session.address_step_complete?
 

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -8,7 +8,7 @@ module IdvStepConcern
     before_action :confirm_idv_needed
   end
 
-  def confirm_pii_from_doc
+  def confirm_document_capture_complete
     @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
     return if @pii.present?
 

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -3,7 +3,7 @@ module Idv
     include IdvSession
 
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_pii_from_doc
+    before_action :confirm_document_capture_complete
 
     def new
       analytics.idv_address_visit
@@ -24,7 +24,7 @@ module Idv
 
     private
 
-    def confirm_pii_from_doc
+    def confirm_document_capture_complete
       @pii = user_session.dig('idv/doc_auth', 'pii_from_doc')
       return if @pii.present?
       redirect_to idv_doc_auth_url

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -9,7 +9,7 @@ module Idv
       before_action :renders_404_if_flag_not_set
       before_action :confirm_two_factor_authenticated
       before_action :confirm_ssn_step_complete
-      before_action :confirm_profile_not_already_confirmed
+      before_action :confirm_verify_info_step_needed
 
       def show
         @in_person_proofing = true
@@ -107,7 +107,7 @@ module Idv
         redirect_to idv_in_person_url
       end
 
-      def confirm_profile_not_already_confirmed
+      def confirm_verify_info_step_needed
         # todo: should this instead be like so?
         # return unless idv_session.resolution_successful == true
         return unless idv_session.verify_info_step_complete?

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -1,11 +1,11 @@
 module Idv
   class SsnController < ApplicationController
     include IdvSession
+    include IdvStepConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
     include Steps::ThreatMetrixStepHelper
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_profile_not_already_confirmed
     before_action :confirm_pii_from_doc
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -6,7 +6,7 @@ module Idv
     include StepUtilitiesConcern
     include Steps::ThreatMetrixStepHelper
 
-    before_action :confirm_profile_not_already_confirmed
+    before_action :confirm_verify_info_step_needed
     before_action :confirm_pii_from_doc
 
     attr_accessor :error_message

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -7,7 +7,7 @@ module Idv
     include Steps::ThreatMetrixStepHelper
 
     before_action :confirm_verify_info_step_needed
-    before_action :confirm_pii_from_doc
+    before_action :confirm_document_capture_complete
 
     attr_accessor :error_message
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -6,7 +6,6 @@ module Idv
     include VerifyInfoConcern
     include Steps::ThreatMetrixStepHelper
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_ssn_step_complete
     before_action :confirm_profile_not_already_confirmed
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -7,7 +7,7 @@ module Idv
     include Steps::ThreatMetrixStepHelper
 
     before_action :confirm_ssn_step_complete
-    before_action :confirm_profile_not_already_confirmed
+    before_action :confirm_verify_info_step_needed
 
     def show
       @in_person_proofing = false

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -35,7 +35,7 @@ describe Idv::InPerson::VerifyInfoController do
     it 'confirms verify step not already complete' do
       expect(subject).to have_actions(
         :before,
-        :confirm_profile_not_already_confirmed,
+        :confirm_verify_info_step_needed,
       )
     end
 

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -31,7 +31,7 @@ describe Idv::SsnController do
     it 'checks that the previous step is complete' do
       expect(subject).to have_actions(
         :before,
-        :confirm_pii_from_doc,
+        :confirm_document_capture_complete,
       )
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

LG-9099

## 🛠 Summary of changes

Refactoring PR, app behavior should be unchanged. The behavior change for this ticket will go into `confirm_document_capture_step_complete` to redirect back from the SSN controller to the DocumentCaptureController for desktop flow when the feature flag is enabled.

This PR might be easier to review by individual commits.

Move and rename two methods from StepUtilitiesConcern to IdvStepConcern, since it is the new place to put before action methods that control ordering of identity verification steps outside the FSM.
- `confirm_pii_from_doc` to `confirm_document_capture_complete`
  - Separate implementation in AddressController also renamed. It should eventually call the one in IdvStepConcern.
- `confirm_profile_not_already_confirmed` to `confirm_verify_info_step_needed`
  - Separate implementation in in_person/verify_info_controller also renamed. This one will stay separate because it redirects inside the in_person flow. Or the method would need to check whether the user is in the in_person flow.

I discussed these changes with @jmhooper before he left on vacation.

## 📜 Testing Plan

- [ ] create account
- [ ] go through identity verification, checking that you can't jump ahead to verify_info.
