### PR TITLE
Remove final references to send_link step

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -914,7 +914,7 @@ module AnalyticsEvents
   # The "hybrid handoff" step: Desktop user has submitted their choice to
   # either continue via desktop ("document_capture" destination) or switch
   # to mobile phone ("send_link" destination) to perform document upload.
-  # Mobile users sill log this event but with skip_upload_step = true
+  # Mobile users still log this event but with skip_upload_step = true
   def idv_doc_auth_upload_submitted(**extra)
     track_event('IdV: doc auth upload submitted', **extra)
   end

--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -10,7 +10,6 @@ module Idv
         unless flow_session[:skip_upload_step]
           mark_step_incomplete(:email_sent)
           mark_step_incomplete(:link_sent)
-          mark_step_incomplete(:send_link)
           mark_step_incomplete(:upload)
         end
       end

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -3,7 +3,7 @@ module Idv
     class LinkSentStep < DocAuthBaseStep
       STEP_INDICATOR_STEP = :verify_id
 
-      HYBRID_FLOW_STEPS = %i[upload send_link link_sent email_sent document_capture]
+      HYBRID_FLOW_STEPS = %i[upload link_sent email_sent document_capture]
 
       def self.analytics_visited_event
         :idv_doc_auth_link_sent_visited

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -72,7 +72,6 @@ module Idv
           failure_reason: failure_reason,
         )
 
-        mark_step_complete(:send_link)
         mark_step_complete(:email_sent)
 
         build_telephony_form_response(telephony_result)
@@ -91,7 +90,6 @@ module Idv
       end
 
       def send_user_to_email_sent_step
-        mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
         UserMailer.with(
           user: current_user, email_address: current_user.confirmed_email_addresses.first,


### PR DESCRIPTION
## 🎫 Ticket

Tail end of LG-8903

## 🛠 Summary of changes

The Send Link Step was removed in favor of the Combined Hybrid Handoff screen. This removes some remaining references to that step.

Note that Funnel::DocAuth::RegisterStep still refers to send_link and the doc_auth_logs table still has columns for send_link_view_at and send_link_view_count.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
