### PR TITLE
LG-9232: Improve the usability of the password page

### DIFF
--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -1,7 +1,7 @@
 // password strength module
 
 $weak: #e80e0e;
-$so-so: #ffac00;
+$average: #ffac00;
 $good: #9ac056;
 $great: #00b200;
 
@@ -20,9 +20,9 @@ $great: #00b200;
   }
 }
 
-.pw-so-so {
+.pw-average {
   .pw-bar:nth-child(-n + 2) {
-    background-color: $so-so;
+    background-color: $average;
   }
 }
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -67,14 +67,15 @@ export function getFeedback(z) {
   }
 
   if (!warning && !suggestions.length) {
-    if (z.password.length < 12) {
-      return t('errors.attributes.password.too_short.other');
-    }
-
     return '&nbsp;';
   }
+
   if (warning) {
     return lookup(warning);
+  }
+
+  if (z.password.length < 12) {
+    return t('errors.attributes.password.too_short');
   }
 
   return `${suggestions.map((s) => lookup(s)).join('. ')}`;

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -67,6 +67,10 @@ export function getFeedback(z) {
   }
 
   if (!warning && !suggestions.length) {
+    if (z.password.length < 12) {
+      return t('errors.attributes.password.too_short.other');
+    }
+
     return '&nbsp;';
   }
   if (warning) {

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -101,7 +101,7 @@ function analyzePw() {
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden]');
   const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
-  const minPasswordLength = pwCntnr.getAttribute(['data-pw-min-length']);
+  const minPasswordLength = +pwCntnr.getAttribute(['data-pw-min-length']);
 
   function updatePasswordFeedback(cls, strength, feedback) {
     pwCntnr.className = cls;

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -130,4 +130,6 @@ function analyzePw() {
   });
 }
 
+document.addEventListener('keydown', analyzePw);
+document.addEventListener('touchout', analyzePw);
 document.addEventListener('focusout', analyzePw);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -17,6 +17,7 @@ const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').to
 
 // fallback if zxcvbn lookup fails / field is empty
 const fallback = ['pw-na', '...'];
+const pwMinimumLength = document.getElementById('pw-strength-cntnr').getAttribute('data-pw-length');
 
 function getStrength(z) {
   // override the strength value to 2 if the password is < 12
@@ -67,15 +68,15 @@ export function getFeedback(z) {
   }
 
   if (!warning && !suggestions.length) {
+    if (z.password.length < pwMinimumLength) {
+      return t('errors.attributes.password.too_short.other', { count: pwMinimumLength });
+    }
+
     return '&nbsp;';
   }
 
   if (warning) {
     return lookup(warning);
-  }
-
-  if (z.password.length < 12) {
-    return t('errors.attributes.password.too_short');
   }
 
   return `${suggestions.map((s) => lookup(s)).join('. ')}`;

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -119,14 +119,9 @@ function analyzePw() {
 
   function checkPasswordStrength(password) {
     const z = zxcvbn(password, forbiddenPasswords);
-    const passwordInformation = {
-      score: z.score,
-      password: z.password,
-      feedback: z.feedback,
-    };
 
     const [cls, strength] = getStrength(z);
-    const feedback = getFeedback(passwordInformation, { minimumLength: minPasswordLength });
+    const feedback = getFeedback(z, { minimumLength: minPasswordLength });
 
     validatePasswordField(z.score);
     updatePasswordFeedback(cls, strength, feedback);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -125,9 +125,13 @@ function analyzePw() {
     updatePasswordFeedback(cls, strength, feedback);
   }
 
-  input.addEventListener('input', (e) => {
-    checkPasswordStrength(e.target.value);
-  });
+  input.addEventListener(
+    'input',
+    (e) => {
+      checkPasswordStrength(e.target.value);
+    },
+    { once: true },
+  );
 }
 
 document.addEventListener('keydown', analyzePw);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -131,5 +131,3 @@ function analyzePw() {
 }
 
 document.addEventListener('keydown', analyzePw);
-document.addEventListener('touchout', analyzePw);
-document.addEventListener('focusout', analyzePw);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -27,7 +27,7 @@ function getStrength(z) {
 }
 
 export function getFeedback(z, { minimumLength }) {
-  if (!z || !z.password || z.score > 2) {
+  if (!z || !z.password) {
     return '&nbsp;';
   }
 
@@ -119,8 +119,14 @@ function analyzePw() {
 
   function checkPasswordStrength(password) {
     const z = zxcvbn(password, forbiddenPasswords);
+    const passwordInformation = {
+      score: z.score,
+      password: z.password,
+      feedback: z.feedback,
+    };
+
     const [cls, strength] = getStrength(z);
-    const feedback = getFeedback(z, { minimumLength: minPasswordLength });
+    const feedback = getFeedback(passwordInformation, { minimumLength: minPasswordLength });
 
     validatePasswordField(z.score);
     updatePasswordFeedback(cls, strength, feedback);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -101,7 +101,7 @@ function analyzePw() {
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden]');
   const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
-  const minPasswordLength = +pwCntnr.getAttribute(['data-pw-min-length']);
+  const minPasswordLength = +pwCntnr.getAttribute('data-pw-min-length');
 
   function updatePasswordFeedback(cls, strength, feedback) {
     pwCntnr.className = cls;

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -130,4 +130,4 @@ function analyzePw() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', analyzePw);
+document.addEventListener('focusout', analyzePw);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -97,11 +97,6 @@ function analyzePw() {
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden]');
   const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
 
-  // the pw strength module is hidden by default ("display-none" CSS class)
-  // (so that javascript disabled browsers won't see it)
-  // thus, first step is unhiding it
-  pwCntnr.className = '';
-
   function updatePasswordFeedback(cls, strength, feedback) {
     pwCntnr.className = cls;
     pwStrength.innerHTML = strength;
@@ -125,13 +120,9 @@ function analyzePw() {
     updatePasswordFeedback(cls, strength, feedback);
   }
 
-  input.addEventListener(
-    'input',
-    (e) => {
-      checkPasswordStrength(e.target.value);
-    },
-    { once: true },
-  );
+  input.addEventListener('input', (e) => {
+    checkPasswordStrength(e.target.value);
+  });
 }
 
-document.addEventListener('keydown', analyzePw);
+document.addEventListener('DOMContentLoaded', analyzePw);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -8,7 +8,7 @@ import { t } from '@18f/identity-i18n';
 const scale = {
   0: ['pw-very-weak', t('instructions.password.strength.i')],
   1: ['pw-weak', t('instructions.password.strength.ii')],
-  2: ['pw-so-so', t('instructions.password.strength.iii')],
+  2: ['pw-average', t('instructions.password.strength.iii')],
   3: ['pw-good', t('instructions.password.strength.iv')],
   4: ['pw-great', t('instructions.password.strength.v')],
 };
@@ -27,15 +27,13 @@ function getStrength(z) {
 }
 
 export function getFeedback(z) {
-  const pwMinimumLength = document
-    .getElementById('pw-strength-cntnr')
-    .getAttribute('data-pw-length');
-
   if (!z || !z.password || z.score > 2) {
     return '&nbsp;';
   }
 
   const { warning, suggestions } = z.feedback;
+  const pwMinimumLength =
+    document.getElementById('pw-strength-cntnr').getAttribute(['data-pw-length']) || '12';
 
   function lookup(str) {
     // i18n-tasks-use t('zxcvbn.feedback.a_word_by_itself_is_easy_to_guess')

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -17,7 +17,6 @@ const snakeCase = (string) => string.replace(/[ -]/g, '_').replace(/\W/g, '').to
 
 // fallback if zxcvbn lookup fails / field is empty
 const fallback = ['pw-na', '...'];
-const pwMinimumLength = document.getElementById('pw-strength-cntnr').getAttribute('data-pw-length');
 
 function getStrength(z) {
   // override the strength value to 2 if the password is < 12
@@ -28,6 +27,10 @@ function getStrength(z) {
 }
 
 export function getFeedback(z) {
+  const pwMinimumLength = document
+    .getElementById('pw-strength-cntnr')
+    .getAttribute('data-pw-length');
+
   if (!z || !z.password || z.score > 2) {
     return '&nbsp;';
   }

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,4 +1,4 @@
-<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
+<div id='pw-strength-cntnr' class='display-none test' aria-live='polite' aria-atomic='true'>
   <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,4 +1,4 @@
-<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
+<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-length="<%= Devise.password_length.min %>>
   <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,4 +1,4 @@
-<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-length='<%= Devise.password_length.min %>'>
+<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-min-length='<%= Devise.password_length.min %>'>
   <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,4 +1,4 @@
-<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-length="<%= Devise.password_length.min %>>
+<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-length='<%= Devise.password_length.min %>'>
   <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,4 +1,4 @@
-<div id='pw-strength-cntnr' class='display-none test' aria-live='polite' aria-atomic='true'>
+<div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true'>
   <div class="margin-bottom-4">
     <div class='clearfix margin-x-neg-05 padding-top-05'>
       <div class='pw-bar'></div>

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,5 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
   <%= simple_format(t('instructions.password.help_text')) %>
+  <%= simple_format(t('instructions.password.password_tip')) %>
 <% end %>

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,5 +1,4 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
-  <%= simple_format(t('instructions.password.help_text')) %>
-  <%= simple_format(t('instructions.password.password_tip')) %>
+  <%= simple_format(t('instructions.password.help_text'))
 <% end %>

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,4 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
-  <% simple_format(t('instructions.password.help_text')) %>
+  <%= simple_format(t('instructions.password.help_text')) %>
 <% end %>

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,4 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
-  <%= simple_format(t('instructions.password.help_text')) %>
+  <% simple_format(t('instructions.password.help_text')) %>
 <% end %>

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,4 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
   <% c.header { t('instructions.password.help_text_header') } %>
-  <%= simple_format(t('instructions.password.help_text'))
+  <%= simple_format(t('instructions.password.help_text')) %>
 <% end %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <%= render PageHeadingComponent.new.with_content(t('forms.confirmation.show_hdr')) %>
 
 <p class="margin-top-2 margin-bottom-0" id="password-description">
-  <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
+  <%= t('instructions.password.info.lead_html', min_length: Devise.password_length.first) %>
 </p>
 <%= simple_form_for(
       @password_form,

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.edit_info.password')) %>
 
 <p id="password-description">
-  <%= t('instructions.password.info.lead', min_length: Devise.password_length.first) %>
+  <%= t('instructions.password.info.lead_html', min_length: Devise.password_length.first) %>
 </p>
 
 <%= simple_form_for(

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -13,7 +13,7 @@ en:
     attributes:
       password:
         too_short:
-          one: This password is too short (minimum is 1 character)
+          one: Password must be at least one character long
           other: Password must be at least %{count} characters long
     capture_doc:
       invalid_link: This link is expired or not valid.  Please request another link to

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -14,7 +14,7 @@ en:
       password:
         too_short:
           one: This password is too short (minimum is 1 character)
-          other: This password is too short (minimum is %{count} characters)
+          other: Password must be at least %{count} characters long
     capture_doc:
       invalid_link: This link is expired or not valid.  Please request another link to
         verify your identity on a mobile phone.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -13,7 +13,7 @@ es:
     attributes:
       password:
         too_short:
-          one: Esta contraseña es demasiado corta (debe tener 1 carácter como mínimo)
+          one: La contraseña debe tener al menos un carácter
           other: La contraseña debe tener al menos %{count} caracteres de longitud.
     capture_doc:
       invalid_link: Este enlace ha caducado o no es válido. Solicite otro enlace para

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -14,7 +14,7 @@ es:
       password:
         too_short:
           one: Esta contraseña es demasiado corta (debe tener 1 carácter como mínimo)
-          other: Esta contraseña es demasiado corta (%{count} caracteres como mínimo)
+          other: La contraseña debe tener al menos %{count} caracteres de longitud.
     capture_doc:
       invalid_link: Este enlace ha caducado o no es válido. Solicite otro enlace para
         verificar su identidad en un teléfono móvil.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -15,7 +15,7 @@ fr:
     attributes:
       password:
         too_short:
-          one: Ce mot de passe est trop court (le minimum est de 1 caractère)
+          one: Le mot de passe doit comporter au moins un caractère
           other: Le mot de passe doit comporter au moins %{count} caractères
     capture_doc:
       invalid_link: Ce lien a expiré ou n’est pas valide. Veuillez demander un autre

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -16,7 +16,7 @@ fr:
       password:
         too_short:
           one: Ce mot de passe est trop court (le minimum est de 1 caractère)
-          other: Ce mot de passe est trop court (le minimum est de %{count} caractères)
+          other: Le mot de passe doit comporter au moins %{count} caractères
     capture_doc:
       invalid_link: Ce lien a expiré ou n’est pas valide. Veuillez demander un autre
         lien pour vérifier votre identité sur un téléphone mobile.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -86,9 +86,8 @@ en:
       wrong_number: Entered the wrong phone number?
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.
-      help_text: Avoid reusing passwords from your other accounts, such as your
-        banks, email and social media. Don’t include words from your email
-        address.
+      help_text: Avoid reusing passwords from your other accounts, such as your banks,
+        email and social media. Don’t include words from your email address.
       help_text_header: Password safety tips
       info:
         lead: Your password must be %{min_length} characters or longer. Don’t use common

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -86,9 +86,9 @@ en:
       wrong_number: Entered the wrong phone number?
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.
-      help_text: The longer and more unusual the password, the harder it is to guess.
-        So avoid using common phrases. Also avoid repeating passwords from other
-        online accounts such as banks, email and social media.
+      help_text: Avoid reusing passwords from your other accounts, such as your
+        banks, email and social media. Don’t include words from your email
+        address.
       help_text_header: Password safety tips
       info:
         lead: Your password must be %{min_length} characters or longer. Don’t use common
@@ -96,16 +96,13 @@ en:
       password_key: You need your 16-character personal key to reset your password if
         you verified your identity with this account. If you don’t have it, you
         can still reset your password and then reverify your identity.
-      password_tip: Avoid reusing passwords from your other accounts, such as your
-        banks, email and social media. Don’t include words from your email
-        address.
       strength:
         i: Very weak
         ii: Weak
         iii: Average
         intro: 'Password strength: '
         iv: Good
-        v: Great!
+        v: Great
     sp_handoff_bounced: Your sign in was successful, but %{sp_name} sent you back to
       %{app_name}. Please contact %{sp_link} for help.
     sp_handoff_bounced_with_no_sp: your service provider

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -91,15 +91,16 @@ en:
         online accounts such as banks, email and social media.
       help_text_header: Password safety tips
       info:
-        lead: It must be at least %{min_length} characters long and not be a commonly
-          used password. That’s it!
+        lead: Your password must be %{min_length} characters or longer. Don’t use common
+          phrases or repeated characters, like abc or 111.
       password_key: You need your 16-character personal key to reset your password if
         you verified your identity with this account. If you don’t have it, you
         can still reset your password and then reverify your identity.
+      password_tip: Avoid reusing passwords from your other accounts, such as your banks, email and social media. Don't include words from your email address. 
       strength:
         i: Very weak
         ii: Weak
-        iii: So-so
+        iii: Average
         intro: 'Password strength: '
         iv: Good
         v: Great!

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -96,7 +96,9 @@ en:
       password_key: You need your 16-character personal key to reset your password if
         you verified your identity with this account. If you don’t have it, you
         can still reset your password and then reverify your identity.
-      password_tip: Avoid reusing passwords from your other accounts, such as your banks, email and social media. Don't include words from your email address. 
+      password_tip: Avoid reusing passwords from your other accounts, such as your
+        banks, email and social media. Don’t include words from your email
+        address.
       strength:
         i: Very weak
         ii: Weak

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -90,8 +90,9 @@ en:
         email and social media. Don’t include words from your email address.
       help_text_header: Password safety tips
       info:
-        lead: Your password must be %{min_length} characters or longer. Don’t use common
-          phrases or repeated characters, like abc or 111.
+        lead_html: Your password must be <strong> %{min_length} characters </strong> or
+          longer. Don’t use common phrases or repeated characters, like abc or
+          111.
       password_key: You need your 16-character personal key to reset your password if
         you verified your identity with this account. If you don’t have it, you
         can still reset your password and then reverify your identity.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -97,16 +97,17 @@ es:
         y medios sociales.
       help_text_header: Consejos de seguridad de contraseña
       info:
-        lead: Su contraseña debe tener al menos %{min_length} caracteres y no ser una
-          contraseña común. ¡Eso es todo!
+        lead: Su contraseña deberá tener %{min_length} caracteres o más. No use
+          expresiones comunes ni caracteres repetidos, como “abc” o “111″.
       password_key: Si verificó su identidad con esta cuenta, necesita su clave
         personal de 16 caracteres para restablecer su contraseña. Si no cuenta
         con ella, de todos modos puede restablecer su contraseña y luego volver
         a verificar su identidad.
+      password_tip: Evite reutilizar las contraseñas de sus otras cuentas, como las bancarias, las de correo electrónico y las de redes sociales. No incluya palabras de su dirección de correo electrónico.
       strength:
         i: Muy débil
         ii: Débil
-        iii: Más o menos
+        iii: Promedio
         intro: 'Seguridad de la contraseña:'
         iv: Buena
         v: '¡Muy buena!'

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -103,7 +103,9 @@ es:
         personal de 16 caracteres para restablecer su contraseña. Si no cuenta
         con ella, de todos modos puede restablecer su contraseña y luego volver
         a verificar su identidad.
-      password_tip: Evite reutilizar las contraseñas de sus otras cuentas, como las bancarias, las de correo electrónico y las de redes sociales. No incluya palabras de su dirección de correo electrónico.
+      password_tip: Evite reutilizar las contraseñas de sus otras cuentas, como las
+        bancarias, las de correo electrónico y las de redes sociales. No incluya
+        palabras de su dirección de correo electrónico.
       strength:
         i: Muy débil
         ii: Débil

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -91,10 +91,9 @@ es:
       wrong_number: '¿Ingresó el número de teléfono equivocado?'
     password:
       forgot: '¿No sabe su contraseña? Restablézcala después de confirmar su email.'
-      help_text: Cuanto más larga y más inusual sea la contraseña, más difícil es de
-        adivinarla. Así que evite usar frases comunes. También evite repetir
-        contraseñas de otras cuentas en línea, por ejemplo de sus bancos, email
-        y medios sociales.
+      help_text: Evite reutilizar las contraseñas de sus otras cuentas, como las
+        bancarias, las de correo electrónico y las de redes sociales. No incluya
+        palabras de su dirección de correo electrónico.
       help_text_header: Consejos de seguridad de contraseña
       info:
         lead: Su contraseña deberá tener %{min_length} caracteres o más. No use
@@ -103,16 +102,13 @@ es:
         personal de 16 caracteres para restablecer su contraseña. Si no cuenta
         con ella, de todos modos puede restablecer su contraseña y luego volver
         a verificar su identidad.
-      password_tip: Evite reutilizar las contraseñas de sus otras cuentas, como las
-        bancarias, las de correo electrónico y las de redes sociales. No incluya
-        palabras de su dirección de correo electrónico.
       strength:
         i: Muy débil
         ii: Débil
         iii: Promedio
         intro: 'Seguridad de la contraseña:'
         iv: Buena
-        v: '¡Muy buena!'
+        v: 'Muy buena'
     sp_handoff_bounced: Su inicio de sesión fue exitoso, pero %{sp_name} lo envió de
       regreso a %{app_name}. Póngase en contacto con %{sp_link} para obtener
       ayuda.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -96,8 +96,9 @@ es:
         palabras de su dirección de correo electrónico.
       help_text_header: Consejos de seguridad de contraseña
       info:
-        lead: Su contraseña deberá tener %{min_length} caracteres o más. No use
-          expresiones comunes ni caracteres repetidos, como “abc” o “111″.
+        lead_html: Su contraseña deberá tener <strong>%{min_length} caracteres</strong>
+          o más. No use expresiones comunes ni caracteres repetidos, como “abc”
+          o “111″.
       password_key: Si verificó su identidad con esta cuenta, necesita su clave
         personal de 16 caracteres para restablecer su contraseña. Si no cuenta
         con ella, de todos modos puede restablecer su contraseña y luego volver

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -106,9 +106,9 @@ fr:
         les comptes courriel et les comptes de médias sociaux.
       help_text_header: Conseils sur la sécurité du mot de passe
       info:
-        lead: Votre mot de passe doit comporter %{min_length} caractères ou plus.
-          N’utilisez pas de phrases courantes ou de caractères répétés, comme «
-          abc » ou « 111 ».
+        lead_html: Votre mot de passe doit comporter <strong>%{min_length}
+          caractères</strong> ou plus. N’utilisez pas de phrases courantes ou de
+          caractères répétés, comme « abc » ou « 111 ».
       password_key: Vous avez besoin de votre clé personnelle de 16 caractères pour
         réinitialiser votre mot de passe si vous avez vérifié votre identité
         avec ce compte. Si vous ne l’avez pas, vous pouvez toujours

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -102,8 +102,8 @@ fr:
         confirmé votre adresse courriel.
       help_text: Évitez de réutiliser les mots de passe de vos autres comptes, tels
         que ceux de vos banques, de vos comptes de courriel et de vos réseaux
-        sociaux. N’incluez pas les mots de votre adresse de courriel.
-        bancaires, les comptes courriel et les comptes de médias sociaux.
+        sociaux. N’incluez pas les mots de votre adresse de courriel. bancaires,
+        les comptes courriel et les comptes de médias sociaux.
       help_text_header: Conseils sur la sécurité du mot de passe
       info:
         lead: Votre mot de passe doit comporter %{min_length} caractères ou plus.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -100,9 +100,9 @@ fr:
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir
         confirmé votre adresse courriel.
-      help_text: Plus long et inhabituel est le mot de passe, plus difficile il sera à
-        trouver. Évitez donc d’utiliser des phrases communes. Évitez aussi de
-        répéter des mots de passe d’autres comptes en ligne comme les comptes
+      help_text: Évitez de réutiliser les mots de passe de vos autres comptes, tels
+        que ceux de vos banques, de vos comptes de courriel et de vos réseaux
+        sociaux. N’incluez pas les mots de votre adresse de courriel.
         bancaires, les comptes courriel et les comptes de médias sociaux.
       help_text_header: Conseils sur la sécurité du mot de passe
       info:
@@ -113,16 +113,13 @@ fr:
         réinitialiser votre mot de passe si vous avez vérifié votre identité
         avec ce compte. Si vous ne l’avez pas, vous pouvez toujours
         réinitialiser votre mot de passe et ensuite revérifier votre identité.
-      password_tip: Évitez de réutiliser les mots de passe de vos autres comptes, tels
-        que ceux de vos banques, de vos comptes de courriel et de vos réseaux
-        sociaux. N’incluez pas les mots de votre adresse de courriel.
       strength:
         i: Très faible
         ii: Faible
         iii: Moyen
         intro: 'Force du mot de passe : '
         iv: Bonne
-        v: Excellente!
+        v: Excellente
     sp_handoff_bounced: Votre connexion a réussi, mais %{sp_name} vous a renvoyé à
       %{app_name}. Veuillez contacter %{sp_link} pour obtenir de l’aide.
     sp_handoff_bounced_with_no_sp: votre fournisseur de service

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -113,7 +113,9 @@ fr:
         réinitialiser votre mot de passe si vous avez vérifié votre identité
         avec ce compte. Si vous ne l’avez pas, vous pouvez toujours
         réinitialiser votre mot de passe et ensuite revérifier votre identité.
-      password_tip: Évitez de réutiliser les mots de passe de vos autres comptes, tels que ceux de vos banques, de vos comptes de courriel et de vos réseaux sociaux. N'incluez pas les mots de votre adresse de courriel.
+      password_tip: Évitez de réutiliser les mots de passe de vos autres comptes, tels
+        que ceux de vos banques, de vos comptes de courriel et de vos réseaux
+        sociaux. N’incluez pas les mots de votre adresse de courriel.
       strength:
         i: Très faible
         ii: Faible

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -106,16 +106,18 @@ fr:
         bancaires, les comptes courriel et les comptes de médias sociaux.
       help_text_header: Conseils sur la sécurité du mot de passe
       info:
-        lead: Il doit avoir une longueur minimale de %{min_length} caractères et ne pas
-          être un mot de passe couramment utilisé. C’est tout!
+        lead: Votre mot de passe doit comporter %{min_length} caractères ou plus.
+          N’utilisez pas de phrases courantes ou de caractères répétés, comme «
+          abc » ou « 111 ».
       password_key: Vous avez besoin de votre clé personnelle de 16 caractères pour
         réinitialiser votre mot de passe si vous avez vérifié votre identité
         avec ce compte. Si vous ne l’avez pas, vous pouvez toujours
         réinitialiser votre mot de passe et ensuite revérifier votre identité.
+      password_tip: Évitez de réutiliser les mots de passe de vos autres comptes, tels que ceux de vos banques, de vos comptes de courriel et de vos réseaux sociaux. N'incluez pas les mots de votre adresse de courriel.
       strength:
         i: Très faible
         ii: Faible
-        iii: Correct
+        iii: Moyen
         intro: 'Force du mot de passe : '
         iv: Bonne
         v: Excellente!

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -90,7 +90,13 @@ describe EventDisavowalController do
           'Event disavowal password reset',
           build_analytics_hash(
             success: false,
-            errors: { password: ['Password must be at least 12 characters long'] },
+            errors: {
+              password: [
+                t(
+                  'errors.attributes.password.too_short.other', count: Devise.password_length.first
+                ),
+              ],
+            },
           ),
         )
 

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -90,7 +90,7 @@ describe EventDisavowalController do
           'Event disavowal password reset',
           build_analytics_hash(
             success: false,
-            errors: { password: ['This password is too short (minimum is 12 characters)'] },
+            errors: { password: ['Password must be at least 12 characters long'] },
           ),
         )
 
@@ -107,7 +107,7 @@ describe EventDisavowalController do
           'Event disavowal password reset',
           build_analytics_hash(
             success: false,
-            errors: { password: ['This password is too short (minimum is 12 characters)'] },
+            errors: { password: ['Password must be at least 12 characters long'] },
           ),
         )
 

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -80,7 +80,7 @@ describe SignUp::PasswordsController do
         success: false,
         errors: {
           password:
-            ["This password is too short (minimum is #{Devise.password_length.first} characters)"],
+            ["Password must be at least #{Devise.password_length.first} characters long"],
         },
         error_details: password_short_error,
         user_id: user.uuid,

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Users::ResetPasswordsController, devise: true do
   let(:password_error_message) do
-    "Password must be at least #{Devise.password_length.first} characters long"
+    t('errors.attributes.password.too_short.other', count: Devise.password_length.first)
   end
   let(:success_properties) { { success: true, failure_reason: nil } }
   let(:token_expired_error) { 'token_expired' }

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Users::ResetPasswordsController, devise: true do
   let(:password_error_message) do
-    "This password is too short (minimum is #{Devise.password_length.first} characters)"
+    "Password must be at least #{Devise.password_length.first} characters long"
   end
   let(:success_properties) { { success: true, failure_reason: nil } }
   let(:token_expired_error) { 'token_expired' }

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -111,7 +111,9 @@ feature 'disavowing an action' do
     fill_in 'New password', with: 'invalid'
     click_button t('forms.passwords.edit.buttons.submit')
 
-    expect(page).to have_content('is too short (minimum is 12 characters)')
+    expect(page).to have_content t(
+      'errors.attributes.password.too_short.other', count: Devise.password_length.first
+    )
 
     fill_in 'New password', with: 'NewVal!dPassw0rd'
     click_button t('forms.passwords.edit.buttons.submit')

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -115,10 +115,10 @@ feature 'User profile' do
         click_link 'Edit', href: manage_password_path
       end
 
-      expect(page).to_not have_css('#pw-strength-cntnr.display-none')
+      expect(page).not_to have_content(t('instructions.password.strength.intro'))
 
       fill_in t('forms.passwords.edit.labels.password'), with: 'this is a great sentence'
-      expect(page).to have_content 'Great'
+      expect(page).to have_content t('instructions.password.strength.v')
 
       check t('components.password_toggle.toggle_label')
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -118,6 +118,7 @@ feature 'User profile' do
       expect(page).not_to have_content(t('instructions.password.strength.intro'))
 
       fill_in t('forms.passwords.edit.labels.password'), with: 'this is a great sentence'
+      expect(page).to have_content(t('instructions.password.strength.intro'))
       expect(page).to have_content t('instructions.password.strength.v')
 
       check t('components.password_toggle.toggle_label')

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -116,7 +116,6 @@ feature 'User profile' do
       end
 
       expect(page).to_not have_css('#pw-strength-cntnr.display-none')
-      expect(page).to have_content '...'
 
       fill_in t('forms.passwords.edit.labels.password'), with: 'this is a great sentence'
       expect(page).to have_content 'Great'

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -211,7 +211,9 @@ feature 'Password Recovery' do
         click_button t('forms.passwords.edit.buttons.submit')
 
         expect(page).
-          to have_content "is too short (minimum is #{Devise.password_length.first} characters)"
+          to have_content t(
+            'errors.attributes.password.too_short.other', count: Devise.password_length.first
+          )
       end
 
       it "does not update the user's password when password is invalid" do
@@ -226,12 +228,16 @@ feature 'Password Recovery' do
         fill_in 'New password', with: '1234'
         click_button t('forms.passwords.edit.buttons.submit')
 
-        expect(page).to have_content 'is too short'
+        expect(page).to have_content t(
+          'errors.attributes.password.too_short.other', count: Devise.password_length.first
+        )
 
         fill_in 'New password', with: '5678'
         click_button t('forms.passwords.edit.buttons.submit')
 
-        expect(page).to have_content 'is too short'
+        expect(page).to have_content t(
+          'errors.attributes.password.too_short.other', count: Devise.password_length.first
+        )
       end
     end
   end

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -38,8 +38,6 @@ feature 'Visitor sets password during signup' do
     end
 
     it 'updates strength feedback as password changes' do
-      expect(page).to have_content '...'
-
       fill_in t('forms.password'), with: 'password'
       expect(page).to have_content 'Very weak'
 
@@ -47,7 +45,7 @@ feature 'Visitor sets password during signup' do
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
 
       fill_in t('forms.password'), with: 'this is a great sentence'
-      expect(page).to have_content 'Great!'
+      expect(page).to have_content 'Great'
     end
   end
 

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -54,7 +54,7 @@ feature 'Visitor sets password during signup' do
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
 
       fill_in t('forms.password'), with: 'this is a great sentence'
-      expect(page).to have_content t('instructions.password.strength.iv')
+      expect(page).to have_content t('instructions.password.strength.v')
     end
   end
 

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -39,7 +39,7 @@ feature 'Visitor sets password during signup' do
 
     it 'updates strength feedback as password changes' do
       expect(page).not_to have_content(t('instructions.password.strength.intro'))
-      
+   
       fill_in t('forms.password'), with: 'password'
       expect(page).to have_content(t('instructions.password.strength.intro'))
       expect(page).to have_content t('instructions.password.strength.i')

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -17,10 +17,6 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
-    it 'does not have the password strength bar' do
-      expect(page).not_to have_content(t('instructions.password.strength.intro'))
-    end
-
     it 'visitor gets field is required message' do
       fill_in t('forms.password'), with: ''
       click_button t('forms.buttons.continue')

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -49,6 +49,9 @@ feature 'Visitor sets password during signup' do
 
       fill_in t('forms.password'), with: 'this is a great sentence'
       expect(page).to have_content t('instructions.password.strength.v')
+
+      fill_in t('forms.password'), with: ':b/}6tT#,'
+      expect(page).to have_content t('errors.attributes.password.too_short.other', count: 12)
     end
   end
 

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -39,7 +39,7 @@ feature 'Visitor sets password during signup' do
 
     it 'updates strength feedback as password changes' do
       expect(page).not_to have_content(t('instructions.password.strength.intro'))
-   
+
       fill_in t('forms.password'), with: 'password'
       expect(page).to have_content(t('instructions.password.strength.intro'))
       expect(page).to have_content t('instructions.password.strength.i')

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -37,13 +37,11 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
-    it 'does not have the password strength bar' do
-      fill_in t('forms.password'), with: 'howdy'
-      expect(page).to have_content(t('instructions.password.strength.intro'))
-    end
-
     it 'updates strength feedback as password changes' do
+      expect(page).not_to have_content(t('instructions.password.strength.intro'))
+      
       fill_in t('forms.password'), with: 'password'
+      expect(page).to have_content(t('instructions.password.strength.intro'))
       expect(page).to have_content t('instructions.password.strength.i')
 
       fill_in t('forms.password'), with: '123456789'

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -17,6 +17,10 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
+    it 'does not have the password strength bar' do
+      expect(page).not_to have_content(t('instructions.password.strength.intro'))
+    end
+
     it 'visitor gets field is required message' do
       fill_in t('forms.password'), with: ''
       click_button t('forms.buttons.continue')
@@ -37,15 +41,20 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
     end
 
+    it 'does not have the password strength bar' do
+      fill_in t('forms.password'), with: 'howdy'
+      expect(page).to have_content(t('instructions.password.strength.intro'))
+    end
+
     it 'updates strength feedback as password changes' do
       fill_in t('forms.password'), with: 'password'
-      expect(page).to have_content 'Very weak'
+      expect(page).to have_content t('instructions.password.strength.i')
 
       fill_in t('forms.password'), with: '123456789'
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
 
       fill_in t('forms.password'), with: 'this is a great sentence'
-      expect(page).to have_content 'Great'
+      expect(page).to have_content t('instructions.password.strength.iv')
     end
   end
 

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -33,7 +33,7 @@ describe PasswordForm, type: :model do
         password = 'invalid'
         errors = {
           password:
-            ["This password is too short (minimum is #{Devise.password_length.first} characters)"],
+            ["Password must be at least #{Devise.password_length.first} characters long"],
         }
         extra = {
           user_id: '123',

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -32,8 +32,11 @@ describe PasswordForm, type: :model do
         form = PasswordForm.new(user)
         password = 'invalid'
         errors = {
-          password:
-            ["Password must be at least #{Devise.password_length.first} characters long"],
+          password: [
+            t(
+              'errors.attributes.password.too_short.other', count: Devise.password_length.first
+            ),
+          ],
         }
         extra = {
           user_id: '123',

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -84,8 +84,9 @@ describe ResetPasswordForm, type: :model do
         password = 'short'
 
         errors = {
-          password:
-            ["Password must be at least #{Devise.password_length.first} characters long"],
+          password: [
+            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
+          ],
           reset_password_token: ['token_expired'],
         }
 

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -39,7 +39,7 @@ describe ResetPasswordForm, type: :model do
 
         errors = {
           password:
-            ["This password is too short (minimum is #{Devise.password_length.first} characters)"],
+            ["Password must be at least #{Devise.password_length.first} characters long"],
         }
 
         extra = { user_id: '123', profile_deactivated: false }
@@ -85,7 +85,7 @@ describe ResetPasswordForm, type: :model do
 
         errors = {
           password:
-            ["This password is too short (minimum is #{Devise.password_length.first} characters)"],
+            ["Password must be at least #{Devise.password_length.first} characters long"],
           reset_password_token: ['token_expired'],
         }
 

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -40,19 +40,21 @@ describe('pw-strength', () => {
     it('returns an empty result for empty password', () => {
       const z = zxcvbn('');
 
-      expect(getFeedback(z)).to.equal(EMPTY_RESULT);
+      expect(getFeedback(z, { minimumLength: 12 })).to.equal(EMPTY_RESULT);
     });
 
     it('returns an empty result for a strong password', () => {
       const z = zxcvbn('!Juq2Uk2**RBEsA8');
 
-      expect(getFeedback(z)).to.equal(EMPTY_RESULT);
+      expect(getFeedback(z, { minimumLength: 12 })).to.equal(EMPTY_RESULT);
     });
 
     it('returns feedback for a weak password', () => {
       const z = zxcvbn('password');
 
-      expect(getFeedback(z)).to.equal('zxcvbn.feedback.this_is_a_top_10_common_password');
+      expect(getFeedback(z, { minimumLength: 12 })).to.equal(
+        'zxcvbn.feedback.this_is_a_top_10_common_password',
+      );
     });
   });
 });

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -36,36 +36,6 @@ describe('pw-strength', () => {
 
   describe('getFeedback', () => {
     const EMPTY_RESULT = '&nbsp;';
-    const shortPasswordResults = {
-      password: '_3G%JMyR"',
-      guesses: 1000000001,
-      guesses_log10: 9.000000000434293,
-      sequence: [
-        {
-          pattern: 'bruteforce',
-          token: '_3G%JMyR"',
-          i: 0,
-          j: 8,
-          guesses: 1000000000,
-          guesses_log10: 8.999999999999998,
-        },
-      ],
-      calc_time: 3,
-      crack_times_seconds: {
-        online_throttling_100_per_hour: 36000000036,
-        online_no_throttling_10_per_second: 100000000.1,
-        offline_slow_hashing_1e4_per_second: 100000.0001,
-        offline_fast_hashing_1e10_per_second: 0.1000000001,
-      },
-      crack_times_display: {
-        online_throttling_100_per_hour: 'centuries',
-        online_no_throttling_10_per_second: '3 years',
-        offline_slow_hashing_1e4_per_second: '1 day',
-        offline_fast_hashing_1e10_per_second: 'less than a second',
-      },
-      score: 2,
-      feedback: { warning: '', suggestions: [] },
-    };
 
     it('returns an empty result for empty password', () => {
       const z = zxcvbn('');
@@ -89,8 +59,9 @@ describe('pw-strength', () => {
 
     it('shows feedback when a password is too short', () => {
       const minPasswordLength = 12;
+      const z = zxcvbn('_3G%JMyR"');
 
-      expect(getFeedback(shortPasswordResults, { minimumLength: minPasswordLength })).to.equal(
+      expect(getFeedback(z, { minimumLength: minPasswordLength })).to.equal(
         'errors.attributes.password.too_short.other',
         { count: minPasswordLength },
       );

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -56,5 +56,16 @@ describe('pw-strength', () => {
         'zxcvbn.feedback.this_is_a_top_10_common_password',
       );
     });
+
+    it('shows feedback when a password is too short', () => {
+      const z = zxcvbn('_3G%JMyR"');
+      const minPasswordLength = 12;
+      // console.log(z.password.length, minPasswordLength, z.score, z.feedback)
+
+      expect(getFeedback(z, { minimumLength: minPasswordLength })).to.equal(
+        'errors.attributes.password.too_short.other',
+        { count: minPasswordLength },
+      );
+    });
   });
 });

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -36,6 +36,36 @@ describe('pw-strength', () => {
 
   describe('getFeedback', () => {
     const EMPTY_RESULT = '&nbsp;';
+    const shortPasswordResults = {
+      password: '_3G%JMyR"',
+      guesses: 1000000001,
+      guesses_log10: 9.000000000434293,
+      sequence: [
+        {
+          pattern: 'bruteforce',
+          token: '_3G%JMyR"',
+          i: 0,
+          j: 8,
+          guesses: 1000000000,
+          guesses_log10: 8.999999999999998,
+        },
+      ],
+      calc_time: 3,
+      crack_times_seconds: {
+        online_throttling_100_per_hour: 36000000036,
+        online_no_throttling_10_per_second: 100000000.1,
+        offline_slow_hashing_1e4_per_second: 100000.0001,
+        offline_fast_hashing_1e10_per_second: 0.1000000001,
+      },
+      crack_times_display: {
+        online_throttling_100_per_hour: 'centuries',
+        online_no_throttling_10_per_second: '3 years',
+        offline_slow_hashing_1e4_per_second: '1 day',
+        offline_fast_hashing_1e10_per_second: 'less than a second',
+      },
+      score: 2,
+      feedback: { warning: '', suggestions: [] },
+    };
 
     it('returns an empty result for empty password', () => {
       const z = zxcvbn('');
@@ -58,11 +88,9 @@ describe('pw-strength', () => {
     });
 
     it('shows feedback when a password is too short', () => {
-      const z = zxcvbn('_3G%JMyR"');
       const minPasswordLength = 12;
-      // console.log(z.password.length, minPasswordLength, z.score, z.feedback)
 
-      expect(getFeedback(z, { minimumLength: minPasswordLength })).to.equal(
+      expect(getFeedback(shortPasswordResults, { minimumLength: minPasswordLength })).to.equal(
         'errors.attributes.password.too_short.other',
         { count: minPasswordLength },
       );

--- a/spec/views/sign_up/passwords/new.html.erb_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.erb_spec.rb
@@ -22,8 +22,10 @@ describe 'sign_up/passwords/new.html.erb' do
 
   it 'renders the proper help text' do
     expect(rendered).to have_content strip_tags(
-      t('instructions.password.info.lead_html',
-        min_length: Devise.password_length.min),
+      t(
+        'instructions.password.info.lead_html',
+        min_length: Devise.password_length.min,
+      ),
     )
   end
 

--- a/spec/views/sign_up/passwords/new.html.erb_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.erb_spec.rb
@@ -21,8 +21,9 @@ describe 'sign_up/passwords/new.html.erb' do
   end
 
   it 'renders the proper help text' do
-    expect(rendered).to have_content(
-      t('instructions.password.info.lead', min_length: Devise.password_length.first),
+    expect(rendered).to have_content strip_tags(
+      t('instructions.password.info.lead_html',
+        min_length: Devise.password_length.min),
     )
   end
 

--- a/spec/views/users/passwords/edit.html.erb_spec.rb
+++ b/spec/views/users/passwords/edit.html.erb_spec.rb
@@ -29,8 +29,10 @@ describe 'users/passwords/edit.html.erb' do
     render
 
     expect(rendered).to have_content strip_tags(
-      t('instructions.password.info.lead_html',
-        min_length: Devise.password_length.min
-    ))
+      t(
+        'instructions.password.info.lead_html',
+        min_length: Devise.password_length.min,
+      ),
+    )
   end
 end

--- a/spec/views/users/passwords/edit.html.erb_spec.rb
+++ b/spec/views/users/passwords/edit.html.erb_spec.rb
@@ -28,8 +28,9 @@ describe 'users/passwords/edit.html.erb' do
   it 'contains minimum password length requirements' do
     render
 
-    expect(rendered).to have_content t(
-      'instructions.password.info.lead', min_length: Devise.password_length.first
-    )
+    expect(rendered).to have_content strip_tags(
+      t('instructions.password.info.lead_html',
+        min_length: Devise.password_length.min
+    ))
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9232: Improve the usability of the password page](https://cm-jira.usa.gov/browse/LG-9232)

## 🛠 Summary of changes

This PR adds copy with information on how users can improve password strength. This includes

- Changing password strength from "So-so" to "Average"
- Adding copy about not reusing passwords

For this ticket, refer to the [designs in Figma](https://www.figma.com/file/dEgQ2CTh2d7AkF6AsQ2ttC/LG-8992-Design%3A-Improve-the-usability-of-the-password-page?node-id=152-1974&t=HpbxKqeqTHapdqgR-0) under "Final Design: Implementation"

## 📜 Testing Plan

On local environments:
- [ ] Go to localhost:300
- [ ] Create a new account
- [ ] Receive confirmation email. Click "Confirm email address" to continue with account creation
- [ ] First change: Password instructions now says "Your password must be 12 characters or longer. Don't use common phrases or repeated characters, like abc or 111." This change has been made in each respective language.
- [ ] On password creation, type in what could be a medium-strength password. An example password you can use is "weak_pass"
- [ ] Next change: with the example password, the strength meter is now "Average" instead of "So-so"
- [ ] Click on the "Password safety tips" accordion. Check to see that there is additional copy with information about not using reused passwords

<details>
<summary>Before:</summary>
<img width="744" alt="Screenshot of current create a strong password screen" src="https://user-images.githubusercontent.com/17969963/228273284-76583ad9-9860-4584-bf61-9213d782d844.png">

</details>

<details>
<summary>After:</summary>
<img width="702" alt="Changes to the create a strong password screen" src="https://user-images.githubusercontent.com/17969963/228272350-8a110831-59d8-497a-a815-68019fc94091.png">

</details>
