### PR TITLE
Add Sessions API controller implementatioin

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  class SessionsController < ApplicationController
+    include CsrfTokenConcern
+
+    prepend_before_action :skip_session_expiration
+    prepend_before_action :skip_devise_hooks
+
+    after_action :add_csrf_token_header_to_response, only: [:update]
+
+    respond_to :json
+
+    def show
+      render json: { active: active?, timeout: timeout }
+    end
+
+    def update
+      analytics.session_kept_alive if active?
+      update_last_request_at
+      render json: { active: active?, timeout: timeout }
+    end
+
+    def destroy
+      analytics.session_timed_out
+      request_id = sp_session[:request_id]
+      sign_out
+      render json: { redirect: root_url(request_id:, timeout: :session) }
+    end
+
+    private
+
+    def skip_devise_hooks
+      request.env['devise.skip_timeout'] = true
+      request.env['devise.skip_trackable'] = true
+    end
+
+    def active?
+      timeout.future?
+    end
+
+    def timeout
+      if last_request_at.present?
+        Time.zone.at(last_request_at + User.timeout_in)
+      else
+        Time.current
+      end
+    end
+
+    def last_request_at
+      warden_session['last_request_at'] if warden_session
+    end
+
+    def update_last_request_at
+      warden_session['last_request_at'] = Time.zone.now.to_i if warden_session
+    end
+
+    def warden_session
+      session['warden.user.user.session']
+    end
+  end
+end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -10,13 +10,13 @@ module Api
     respond_to :json
 
     def show
-      render json: { active: active?, timeout: timeout }
+      render json: { live: live?, timeout: timeout }
     end
 
     def update
-      analytics.session_kept_alive if active?
+      analytics.session_kept_alive if live?
       update_last_request_at
-      render json: { active: active?, timeout: timeout }
+      render json: { live: live?, timeout: timeout }
     end
 
     def destroy
@@ -33,7 +33,7 @@ module Api
       request.env['devise.skip_trackable'] = true
     end
 
-    def active?
+    def live?
       timeout.future?
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   get '/api/openid_connect/userinfo' => 'openid_connect/user_info#show'
   post '/api/risc/security_events' => 'risc/security_events#create'
   post '/api/irs_attempts_api/security_events' => 'api/irs_attempts_api#create'
+  get '/api/sessions' => 'api/sessions#show'
+  put '/api/sessions' => 'api/sessions#update'
+  delete '/api/sessions' => 'api/sessions#destroy'
 
   # SAML secret rotation paths
   SamlEndpoint.suffixes.each do |suffix|

--- a/spec/controllers/api/sessions_controller_spec.rb
+++ b/spec/controllers/api/sessions_controller_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Api::SessionsController do
   describe '#show' do
     subject(:response) { JSON.parse(get(:show).body, symbolize_names: true) }
 
-    it 'responds with active and timeout properties' do
-      expect(response).to eq(active: false, timeout: Time.zone.now.as_json)
+    it 'responds with live and timeout properties' do
+      expect(response).to eq(live: false, timeout: Time.zone.now.as_json)
     end
 
     context 'signed in' do
       let(:user) { create(:user, :signed_up) }
 
-      it 'responds with active and timeout properties' do
-        expect(response).to eq(active: true, timeout: User.timeout_in.from_now.as_json)
+      it 'responds with live and timeout properties' do
+        expect(response).to eq(live: true, timeout: User.timeout_in.from_now.as_json)
       end
 
       context 'after a delay' do
@@ -33,9 +33,9 @@ RSpec.describe Api::SessionsController do
         context 'after a delay prior to session timeout' do
           let(:delay) { User.timeout_in - 1.second }
 
-          it 'responds with active and timeout properties' do
+          it 'responds with live and timeout properties' do
             expect(response).to eq(
-              active: true,
+              live: true,
               timeout: (User.timeout_in - delay).from_now.as_json,
             )
           end
@@ -44,9 +44,9 @@ RSpec.describe Api::SessionsController do
         context 'after a delay exceeding session timeout' do
           let(:delay) { User.timeout_in + 1.second }
 
-          it 'responds with active and timeout properties' do
+          it 'responds with live and timeout properties' do
             expect(response).to eq(
-              active: false,
+              live: false,
               timeout: (User.timeout_in - delay).from_now.as_json,
             )
           end
@@ -63,8 +63,8 @@ RSpec.describe Api::SessionsController do
           session['warden.user.user.session']['last_request_at'] = future_time.to_i
         end
 
-        it 'responds with active and timeout properties' do
-          expect(response).to eq(active: true, timeout: (future_time + User.timeout_in).as_json)
+        it 'responds with live and timeout properties' do
+          expect(response).to eq(live: true, timeout: (future_time + User.timeout_in).as_json)
         end
       end
     end

--- a/spec/controllers/api/sessions_controller_spec.rb
+++ b/spec/controllers/api/sessions_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Api::SessionsController do
+  let(:user) { nil }
+
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  before do
+    establish_warden_session if user
+  end
+
+  describe '#show' do
+    subject(:response) { JSON.parse(get(:show).body, symbolize_names: true) }
+
+    it 'responds with active and timeout properties' do
+      expect(response).to eq(active: false, timeout: Time.zone.now.as_json)
+    end
+
+    context 'signed in' do
+      let(:user) { create(:user, :signed_up) }
+
+      it 'responds with active and timeout properties' do
+        expect(response).to eq(active: true, timeout: User.timeout_in.from_now.as_json)
+      end
+
+      context 'after a delay' do
+        let(:delay) { 0.seconds }
+
+        before { travel_to delay.from_now }
+
+        context 'after a delay prior to session timeout' do
+          let(:delay) { User.timeout_in - 1.second }
+
+          it 'responds with active and timeout properties' do
+            expect(response).to eq(
+              active: true,
+              timeout: (User.timeout_in - delay).from_now.as_json,
+            )
+          end
+        end
+
+        context 'after a delay exceeding session timeout' do
+          let(:delay) { User.timeout_in + 1.second }
+
+          it 'responds with active and timeout properties' do
+            expect(response).to eq(
+              active: false,
+              timeout: (User.timeout_in - delay).from_now.as_json,
+            )
+          end
+        end
+      end
+
+      context 'when a request extends session timeout' do
+        let(:future_time) { (User.timeout_in - 1.second).from_now }
+
+        before do
+          travel_to future_time
+          # Ideally we could repeat the behavior from `establish_warden_session`, but the request
+          # and controller persist between simulated request calls.
+          session['warden.user.user.session']['last_request_at'] = future_time.to_i
+        end
+
+        it 'responds with active and timeout properties' do
+          expect(response).to eq(active: true, timeout: (future_time + User.timeout_in).as_json)
+        end
+      end
+    end
+  end
+
+  def establish_warden_session
+    sign_in(user)
+
+    # Relevant timeout session values are stored on request, but the API controller itself skips
+    # these so as not to affect the planned timeout. Send a request to some other controller to
+    # establish the session values.
+    original_controller = @controller
+    @controller = AccountsController.new
+    get :show
+    @controller = original_controller
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Extracted from #7966

This adds a new API controller for managing the user session status (retrieval, updating, and destroy). See #7966 for more context and rationale.

The reason for creating a separate pull request is to have this endpoint in place in a deployment prior to the one including JavaScript changes using the new endpoint ([see related discussion](https://github.com/18F/identity-idp/pull/8084#discussion_r1150918192)).

## 📜 Testing Plan

- `rspec spec/controllers/api/sessions_controller_spec.rb`
- `$ curl -H 'Content-Type: application/json' http://localhost:3000/api/sessions`
   - `{"live":false,"timeout":"2023-03-28T20:24:49.584Z"}`
