### PR TITLE
LG-9099 LG-9100 Redirects to and from document capture controller

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -12,7 +12,8 @@ module IdvStepConcern
     @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
     return if @pii.present?
 
-    if IdentityConfig.store.doc_auth_document_capture_controller_enabled
+    if (IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
+      flow_session&.[](:flow_path) == 'standard')
       redirect_to idv_document_capture_url
     else
       flow_session&.delete('Idv::Steps::DocumentCaptureStep')

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -12,8 +12,12 @@ module IdvStepConcern
     @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
     return if @pii.present?
 
-    flow_session&.delete('Idv::Steps::DocumentCaptureStep')
-    redirect_to idv_doc_auth_url
+    if IdentityConfig.store.doc_auth_document_capture_controller_enabled
+      redirect_to idv_document_capture_url
+    else
+      flow_session&.delete('Idv::Steps::DocumentCaptureStep')
+      redirect_to idv_doc_auth_url
+    end
   end
 
   def confirm_verify_info_step_complete

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -12,8 +12,10 @@ module IdvStepConcern
     @pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
     return if @pii.present?
 
-    if (IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
-      flow_session&.[](:flow_path) == 'standard')
+    flow_path = flow_session&.[](:flow_path)
+
+    if IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
+       flow_path == 'standard'
       redirect_to idv_document_capture_url
     else
       flow_session&.delete('Idv::Steps::DocumentCaptureStep')

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -28,7 +28,10 @@ module Idv
       @pii = user_session.dig('idv/doc_auth', 'pii_from_doc')
       return if @pii.present?
 
-      if IdentityConfig.store.doc_auth_document_capture_controller_enabled
+      flow_path = user_session.dig('idv/doc_auth', :flow_path)
+
+      if (IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
+        flow_path == 'standard')
         redirect_to idv_document_capture_url
       else
         redirect_to idv_doc_auth_url

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -27,7 +27,12 @@ module Idv
     def confirm_document_capture_complete
       @pii = user_session.dig('idv/doc_auth', 'pii_from_doc')
       return if @pii.present?
-      redirect_to idv_doc_auth_url
+
+      if IdentityConfig.store.doc_auth_document_capture_controller_enabled
+        redirect_to idv_document_capture_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def idv_form

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -30,8 +30,8 @@ module Idv
 
       flow_path = user_session.dig('idv/doc_auth', :flow_path)
 
-      if (IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
-        flow_path == 'standard')
+      if IdentityConfig.store.doc_auth_document_capture_controller_enabled &&
+         flow_path == 'standard'
         redirect_to idv_document_capture_url
       else
         redirect_to idv_doc_auth_url

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -7,7 +7,7 @@ module Idv
 
     before_action :render_404_if_document_capture_controller_disabled
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_agreement_step_complete
+    before_action :confirm_upload_step_complete
     before_action :confirm_document_capture_needed
     before_action :override_document_capture_step_csp
 
@@ -62,8 +62,8 @@ module Idv
       render_not_found unless IdentityConfig.store.doc_auth_document_capture_controller_enabled
     end
 
-    def confirm_agreement_step_complete
-      return if flow_session['Idv::Steps::AgreementStep']
+    def confirm_upload_step_complete
+      return if flow_session['Idv::Steps::UploadStep']
 
       redirect_to idv_doc_auth_url
     end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -8,6 +8,7 @@ module Idv
     before_action :render_404_if_document_capture_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_agreement_step_complete
+    before_action :confirm_document_capture_needed
     before_action :override_document_capture_step_csp
 
     def show
@@ -65,6 +66,13 @@ module Idv
       return if flow_session['Idv::Steps::AgreementStep']
 
       redirect_to idv_doc_auth_url
+    end
+
+    def confirm_document_capture_needed
+      pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
+      return if pii.blank?
+
+      redirect_to idv_ssn_url
     end
 
     def analytics_arguments

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -70,7 +70,7 @@ module Idv
 
     def confirm_document_capture_needed
       pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
-      return if pii.blank?
+      return if pii.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
     end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -70,7 +70,7 @@ module Idv
     def analytics_arguments
       {
         flow_path: flow_path,
-        step: 'document capture',
+        step: 'document_capture',
         step_count: current_flow_step_counts['Idv::Steps::DocumentCaptureStep'],
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -100,6 +100,10 @@ module Idv
       def bypass_send_link_steps
         mark_step_complete(:link_sent)
         mark_step_complete(:email_sent)
+        if IdentityConfig.store.doc_auth_document_capture_controller_enabled
+          flow_session[:flow_path] = @flow.flow_path
+          redirect_to idv_document_capture_url
+        end
         form_response(destination: :document_capture)
       end
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -5,7 +5,6 @@ describe Idv::DocumentCaptureController do
 
   let(:flow_session) do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      'pii_from_doc' => Idp::Constants::MOCK_IDV_APPLICANT.dup,
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'standard',
       'Idv::Steps::AgreementStep' => true }
@@ -107,6 +106,15 @@ describe Idv::DocumentCaptureController do
           get :show
 
           expect(response).to redirect_to(idv_doc_auth_url)
+        end
+      end
+
+      context 'With pii in session' do
+        it 'redirects to ssn step' do
+          flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+          get :show
+
+          expect(response).to redirect_to(idv_ssn_url)
         end
       end
     end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -7,7 +7,7 @@ describe Idv::DocumentCaptureController do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'standard',
-      'Idv::Steps::AgreementStep' => true }
+      'Idv::Steps::UploadStep' => true }
   end
 
   let(:user) { create(:user) }
@@ -42,10 +42,10 @@ describe Idv::DocumentCaptureController do
       )
     end
 
-    it 'checks that agreement step is complete' do
+    it 'checks that upload step is complete' do
       expect(subject).to have_actions(
         :before,
-        :confirm_agreement_step_complete,
+        :confirm_upload_step_complete,
       )
     end
   end
@@ -99,9 +99,9 @@ describe Idv::DocumentCaptureController do
         )
       end
 
-      context 'agreement step is not complete' do
+      context 'upload step is not complete' do
         it 'redirects to idv_doc_auth_url' do
-          flow_session['Idv::Steps::AgreementStep'] = nil
+          flow_session['Idv::Steps::UploadStep'] = nil
 
           get :show
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -67,7 +67,7 @@ describe Idv::DocumentCaptureController do
           analytics_id: 'Doc Auth',
           flow_path: 'standard',
           irs_reproofing: false,
-          step: 'document capture',
+          step: 'document_capture',
           step_count: 1,
         }
       end
@@ -118,7 +118,7 @@ describe Idv::DocumentCaptureController do
           analytics_id: 'Doc Auth',
           flow_path: 'standard',
           irs_reproofing: false,
-          step: 'document capture',
+          step: 'document_capture',
           step_count: 1,
         }
       end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -109,7 +109,7 @@ describe Idv::DocumentCaptureController do
         end
       end
 
-      context 'With pii in session' do
+      context 'with pii in session' do
         it 'redirects to ssn step' do
           flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
           get :show

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -212,5 +212,14 @@ describe Idv::SsnController do
       expect(response.status).to eq 302
       expect(response).to redirect_to idv_document_capture_url
     end
+
+    it 'in hybrid flow it does not redirect to document_capture_controller' do
+      flow_session.delete('pii_from_doc')
+      flow_session['Idv::Steps::DocumentCaptureStep'] = true
+      flow_session[:flow_path] = 'hybrid'
+      put :update
+      expect(response.status).to eq 302
+      expect(response).to redirect_to idv_doc_auth_url
+    end
   end
 end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -194,7 +194,23 @@ describe Idv::SsnController do
         put :update
         expect(flow_session['Idv::Steps::DocumentCaptureStep']).to eq nil
         expect(response.status).to eq 302
+        expect(response).to redirect_to idv_doc_auth_url
       end
+    end
+  end
+
+  describe 'doc_auth_document_capture_controller_enabled flag is true' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_document_capture_controller_enabled).
+        and_return(true)
+    end
+
+    it 'redirects to document_capture_controller when pii_from_doc is not present' do
+      flow_session.delete('pii_from_doc')
+      flow_session['Idv::Steps::DocumentCaptureStep'] = true
+      put :update
+      expect(response.status).to eq 302
+      expect(response).to redirect_to idv_document_capture_url
     end
   end
 end

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -61,17 +61,23 @@ feature 'doc auth verify step', :js do
     end
   end
 
-  context 'with document capture controller flag set' do
+  context 'with document capture controller flag set, no PII in session' do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_document_capture_controller_enabled).
         and_return(true)
       sign_in_and_2fa_user
-      complete_doc_auth_steps_before_document_capture_step
     end
 
-    it 'shows address guidance and hint text' do
+    it 'goes to new document capture page on standard flow' do
+      complete_doc_auth_steps_before_document_capture_step
       visit(idv_address_url)
       expect(page).to have_current_path(idv_document_capture_url)
+    end
+
+    it 'stays in FSM on hybrid flow' do
+      complete_doc_auth_steps_before_link_sent_step
+      visit(idv_address_url)
+      expect(page).to have_current_path(idv_doc_auth_link_sent_step)
     end
   end
 end

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -60,4 +60,18 @@ feature 'doc auth verify step', :js do
       expect(page).to have_current_path(idv_verify_info_path)
     end
   end
+
+  context 'with document capture controller flag set' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_document_capture_controller_enabled).
+        and_return(true)
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_document_capture_step
+    end
+
+    it 'shows address guidance and hint text' do
+      visit(idv_address_url)
+      expect(page).to have_current_path(idv_document_capture_url)
+    end
+  end
 end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -24,7 +24,6 @@ feature 'doc auth document capture step', :js do
 
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_document_capture_step
-    visit(idv_document_capture_url)
   end
 
   it 'shows the new DocumentCapture page for desktop standard flow' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -23,55 +23,132 @@ feature 'doc auth document capture step', :js do
     visit_idp_from_oidc_sp_with_ial2
 
     sign_in_and_2fa_user(user)
-    complete_doc_auth_steps_before_document_capture_step
   end
 
-  it 'shows the new DocumentCapture page for desktop standard flow' do
-    expect(page).to have_current_path(idv_document_capture_url)
-
-    expect(page).to have_content(t('doc_auth.headings.document_capture'))
-    expect(page).to have_content(t('step_indicator.flows.idv.verify_id'))
-
-    expect(fake_analytics).to have_logged_event(
-      'IdV: doc auth document_capture visited',
-      flow_path: 'standard',
-      step: 'document_capture',
-      step_count: 1,
-      analytics_id: 'Doc Auth',
-      irs_reproofing: false,
-      acuant_sdk_upgrade_ab_test_bucket: :default,
-    )
-
-    visit(idv_ssn_url)
-    expect(page).to have_current_path(idv_document_capture_url)
-    visit(idv_address_url)
-    expect(page).to have_current_path(idv_document_capture_url)
-  end
-
-  it 'logs return to sp link click' do
-    new_window = window_opened_by do
-      click_on t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name)
-    end
-
-    within_window new_window do
-      expect(fake_analytics).to have_logged_event(
-        'Return to SP: Failed to proof',
-        flow: nil,
-        location: 'document_capture_troubleshooting_options',
-        redirect_url: instance_of(String),
-        step: 'document_capture',
-      )
-    end
-  end
-
-  context 'throttles calls to acuant', allow_browser_log: true do
-    let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  context 'standard desktop flow does not skip ahead' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(
-        :irs_attempts_api_tracker,
-      ).and_return(fake_attempts_tracker)
-      allow(fake_attempts_tracker).to receive(:idv_document_upload_rate_limited)
-      allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
+      visit(idv_document_capture_url)
+      expect(page).to have_current_path(idv_doc_auth_welcome_step)
+      complete_welcome_step
+      visit(idv_document_capture_url)
+      expect(page).to have_current_path(idv_doc_auth_agreement_step)
+      complete_agreement_step
+      visit(idv_document_capture_url)
+      expect(page).to have_current_path(idv_doc_auth_upload_step)
+    end
+  end
+
+  context 'standard desktop flow' do
+    before do
+      complete_doc_auth_steps_before_document_capture_step
+    end
+
+    it 'shows the new DocumentCapture page for desktop standard flow' do
+      expect(page).to have_current_path(idv_document_capture_url)
+
+      expect(page).to have_content(t('doc_auth.headings.document_capture'))
+      expect(page).to have_content(t('step_indicator.flows.idv.verify_id'))
+
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth document_capture visited',
+        flow_path: 'standard',
+        step: 'document_capture',
+        step_count: 1,
+        analytics_id: 'Doc Auth',
+        irs_reproofing: false,
+        acuant_sdk_upgrade_ab_test_bucket: :default,
+      )
+
+      visit(idv_ssn_url)
+      expect(page).to have_current_path(idv_document_capture_url)
+      visit(idv_address_url)
+      expect(page).to have_current_path(idv_document_capture_url)
+    end
+
+    it 'logs return to sp link click' do
+      new_window = window_opened_by do
+        click_on t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name)
+      end
+
+      within_window new_window do
+        expect(fake_analytics).to have_logged_event(
+          'Return to SP: Failed to proof',
+          flow: nil,
+          location: 'document_capture_troubleshooting_options',
+          redirect_url: instance_of(String),
+          step: 'document_capture',
+        )
+      end
+    end
+
+    context 'throttles calls to acuant', allow_browser_log: true do
+      let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+      before do
+        allow_any_instance_of(ApplicationController).to receive(
+          :irs_attempts_api_tracker,
+        ).and_return(fake_attempts_tracker)
+        allow(fake_attempts_tracker).to receive(:idv_document_upload_rate_limited)
+        allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
+        DocAuth::Mock::DocAuthMockClient.mock_response!(
+          method: :post_front_image,
+          response: DocAuth::Response.new(
+            success: false,
+            errors: { network: I18n.t('doc_auth.errors.general.network_error') },
+          ),
+        )
+
+        (max_attempts - 1).times do
+          attach_and_submit_images
+          click_on t('idv.failure.button.warning')
+        end
+      end
+
+      it 'redirects to the throttled error page' do
+        freeze_time do
+          attach_and_submit_images
+          timeout = distance_of_time_in_words(
+            Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
+          )
+          message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
+          expect(page).to have_content(message)
+          expect(page).to have_current_path(idv_session_errors_throttled_path)
+        end
+      end
+
+      it 'logs the throttled analytics event for doc_auth' do
+        attach_and_submit_images
+        expect(fake_analytics).to have_logged_event(
+          'Throttler Rate Limit Triggered',
+          throttle_type: :idv_doc_auth,
+        )
+      end
+
+      it 'logs irs attempts event for rate limiting' do
+        attach_and_submit_images
+        expect(fake_attempts_tracker).to have_received(:idv_document_upload_rate_limited)
+      end
+    end
+
+    it 'proceeds to the next page with valid info' do
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+      attach_and_submit_images
+
+      expect(page).to have_current_path(idv_ssn_url)
+      expect_costing_for_document
+      expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+      visit(idv_document_capture_url)
+      expect(page).to have_current_path(idv_ssn_url)
+      fill_out_ssn_form_ok
+      click_idv_continue
+      complete_verify_step
+      expect(page).to have_current_path(idv_phone_url)
+      visit(idv_document_capture_url)
+      expect(page).to have_current_path(idv_phone_url)
+    end
+
+    it 'catches network connection errors on post_front_image', allow_browser_log: true do
       DocAuth::Mock::DocAuthMockClient.mock_response!(
         method: :post_front_image,
         response: DocAuth::Response.new(
@@ -80,77 +157,46 @@ feature 'doc auth document capture step', :js do
         ),
       )
 
-      (max_attempts - 1).times do
+      attach_and_submit_images
+
+      expect(page).to have_current_path(idv_document_capture_url)
+      expect(page).to have_content(I18n.t('doc_auth.errors.general.network_error'))
+    end
+
+    it 'does not track state if state tracking is disabled' do
+      allow(IdentityConfig.store).to receive(:state_tracking_enabled).and_return(false)
+      attach_and_submit_images
+
+      expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
+    end
+  end
+
+  context 'standard mobile flow' do
+    it 'proceeds to the next page with valid info' do
+      perform_in_browser(:mobile) do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_document_capture_step
+
+        expect(page).to have_current_path(idv_document_capture_url)
+        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
         attach_and_submit_images
-        click_on t('idv.failure.button.warning')
+
+        expect(page).to have_current_path(idv_ssn_url)
+        expect_costing_for_document
+        expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+        visit(idv_document_capture_url)
+        expect(page).to have_current_path(idv_ssn_url)
+        fill_out_ssn_form_ok
+        click_idv_continue
+        complete_verify_step
+        expect(page).to have_current_path(idv_phone_url)
+        visit(idv_document_capture_url)
+        expect(page).to have_current_path(idv_phone_url)
       end
     end
-
-    it 'redirects to the throttled error page' do
-      freeze_time do
-        attach_and_submit_images
-        timeout = distance_of_time_in_words(
-          Throttle.attempt_window_in_minutes(:idv_doc_auth).minutes,
-        )
-        message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
-        expect(page).to have_content(message)
-        expect(page).to have_current_path(idv_session_errors_throttled_path)
-      end
-    end
-
-    it 'logs the throttled analytics event for doc_auth' do
-      attach_and_submit_images
-      expect(fake_analytics).to have_logged_event(
-        'Throttler Rate Limit Triggered',
-        throttle_type: :idv_doc_auth,
-      )
-    end
-
-    it 'logs irs attempts event for rate limiting' do
-      attach_and_submit_images
-      expect(fake_attempts_tracker).to have_received(:idv_document_upload_rate_limited)
-    end
-  end
-
-  it 'proceeds to the next page with valid info' do
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-
-    attach_and_submit_images
-
-    expect(page).to have_current_path(idv_ssn_url)
-    expect_costing_for_document
-    expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
-
-    visit(idv_document_capture_url)
-    expect(page).to have_current_path(idv_ssn_url)
-    fill_out_ssn_form_ok
-    click_idv_continue
-    complete_verify_step
-    expect(page).to have_current_path(idv_phone_url)
-    visit(idv_document_capture_url)
-    expect(page).to have_current_path(idv_phone_url)
-  end
-
-  it 'catches network connection errors on post_front_image', allow_browser_log: true do
-    DocAuth::Mock::DocAuthMockClient.mock_response!(
-      method: :post_front_image,
-      response: DocAuth::Response.new(
-        success: false,
-        errors: { network: I18n.t('doc_auth.errors.general.network_error') },
-      ),
-    )
-
-    attach_and_submit_images
-
-    expect(page).to have_current_path(idv_document_capture_url)
-    expect(page).to have_content(I18n.t('doc_auth.errors.general.network_error'))
-  end
-
-  it 'does not track state if state tracking is disabled' do
-    allow(IdentityConfig.store).to receive(:state_tracking_enabled).and_return(false)
-    attach_and_submit_images
-
-    expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -41,6 +41,11 @@ feature 'doc auth document capture step', :js do
       irs_reproofing: false,
       acuant_sdk_upgrade_ab_test_bucket: :default,
     )
+
+    visit(idv_ssn_url)
+    expect(page).to have_current_path(idv_document_capture_url)
+    visit(idv_address_url)
+    expect(page).to have_current_path(idv_document_capture_url)
   end
 
   it 'logs return to sp link click' do
@@ -115,6 +120,15 @@ feature 'doc auth document capture step', :js do
     expect(page).to have_current_path(idv_ssn_url)
     expect_costing_for_document
     expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+    visit(idv_document_capture_url)
+    expect(page).to have_current_path(idv_ssn_url)
+    fill_out_ssn_form_ok
+    click_idv_continue
+    complete_verify_step
+    expect(page).to have_current_path(idv_phone_url)
+    visit(idv_document_capture_url)
+    expect(page).to have_current_path(idv_phone_url)
   end
 
   it 'catches network connection errors on post_front_image', allow_browser_log: true do


### PR DESCRIPTION
## 🎫 Ticket

LG-9099
LG-9100

## 🛠 Summary of changes

When feature flag is enabled, in desktop flow only, automatically redirect to and from the new DocumentCaptureController for the Document Capture step. Added a test that confirms that mobile-only flow also works.

Notes: 
- Redirect from SSN step when PII is missing from the session goes directly to DocumentCapture if the user had previously chosen standard flow. Once the hybrid step is included we may want to go back to the Upload step instead so the user can choose which flow to use.
- This doesn't include RedoDocumentCapture (triggered by barcode read error).

## 📜 Testing Plan

- [ ] Set `doc_auth_document_capture_controller_enabled` feature flag to `true` in local application.yml
- [ ] Create account
- [ ] Go to /verify and start identity verification process
- [ ] At upload step, choose "Upload from computer"
- [ ] Check that you are now on `/verify/document_capture` (not `/verify/doc_auth/document_capture`)
- [ ] Navigate to `/verify/ssn` and expect to land back on `/verify/document_capture`
- [ ] Navigate to `verify/address` and expect to land back on `/verify/document_capture`
- [ ] Upload images or yml files and click Submit
- [ ] Navigate to `/verify/document_capture` and expect to land back on `/verify/ssn`
- [ ] Expect to successfully complete verification

