### PR TITLE
Remove redundant "remaining" value from session timeout API (Part 2)

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -54,14 +54,14 @@ module Users
     def active
       session[:pinged_at] = now
       Rails.logger.debug(alive?: alive?, expires_at: expires_at)
-      render json: { live: alive?, timeout: expires_at, remaining: remaining_session_time }
+      render json: { live: alive?, timeout: expires_at }
     end
 
     def keepalive
       session[:session_expires_at] = now + Devise.timeout_in if alive?
       analytics.session_kept_alive if alive?
 
-      render json: { live: alive?, timeout: expires_at, remaining: remaining_session_time }
+      render json: { live: alive?, timeout: expires_at }
     end
 
     def timeout
@@ -150,10 +150,6 @@ module Users
 
     def expires_at
       session[:session_expires_at]&.to_datetime || (now - 1)
-    end
-
-    def remaining_session_time
-      expires_at.to_i - Time.zone.now.to_i
     end
 
     def browser_is_ie11?

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -50,15 +50,6 @@ describe Users::SessionsController, devise: true do
 
         expect(json['timeout'].to_datetime.to_i).to eq(timeout.to_i)
       end
-
-      it 'includes the remaining key', freeze_time: true do
-        controller.session[:session_expires_at] = Time.zone.now + 10
-        get :active
-
-        json ||= JSON.parse(response.body)
-
-        expect(json['remaining']).to eq(10)
-      end
     end
 
     context 'when user is not present' do
@@ -76,14 +67,6 @@ describe Users::SessionsController, devise: true do
         json ||= JSON.parse(response.body)
 
         expect(json['timeout'].to_datetime.to_i).to eq(Time.zone.now.to_i - 1)
-      end
-
-      it 'includes the remaining time', freeze_time: true do
-        get :active
-
-        json ||= JSON.parse(response.body)
-
-        expect(json['remaining']).to eq(-1)
       end
 
       it 'updates the pinged_at session key' do
@@ -721,17 +704,6 @@ describe Users::SessionsController, devise: true do
         )
       end
 
-      it 'resets the remaining key' do
-        controller.session[:session_expires_at] = Time.zone.now + 10
-        post :keepalive
-
-        json ||= JSON.parse(response.body)
-
-        expect(json['remaining']).to be_within(1).of(
-          IdentityConfig.store.session_timeout_in_minutes * 60,
-        )
-      end
-
       it 'tracks session refresh visit' do
         controller.session[:session_expires_at] = Time.zone.now + 10
         stub_analytics
@@ -757,14 +729,6 @@ describe Users::SessionsController, devise: true do
         json ||= JSON.parse(response.body)
 
         expect(json['timeout'].to_datetime.to_i).to be_within(1).of(Time.zone.now.to_i - 1)
-      end
-
-      it 'includes the remaining time' do
-        post :keepalive
-
-        json ||= JSON.parse(response.body)
-
-        expect(json['remaining']).to eq(-1)
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Follow-up to #8084

The work of #8084 was [split](https://github.com/18F/identity-idp/pull/8084#discussion_r1150918192) to two separate changes to avoid issues during deployment. This should only be merged after #8084 is live in production.

## 📜 Testing Plan

- `rspec spec/controllers/users/sessions_controller_spec.rb`
- This should not have any user-facing impact, since the value is no longer used as of #8084