### PR TITLE
LG-9229 add transliteration validation to additional fields on state id pg

### DIFF
--- a/app/forms/idv/in_person/address_form.rb
+++ b/app/forms/idv/in_person/address_form.rb
@@ -19,7 +19,7 @@ module Idv
       def submit(params)
         consume_params(params)
 
-        cleaned_errors = errors.deep_dup
+        cleaned_errors = errors.dup
         cleaned_errors.delete(:city, :nontransliterable_field)
         cleaned_errors.delete(:address1, :nontransliterable_field)
         cleaned_errors.delete(:address2, :nontransliterable_field)

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -23,6 +23,9 @@ module Idv
       cleaned_errors = errors.deep_dup
       cleaned_errors.delete(:first_name, :nontransliterable_field)
       cleaned_errors.delete(:last_name, :nontransliterable_field)
+      cleaned_errors.delete(:state_id_city, :nontransliterable_field)
+      cleaned_errors.delete(:state_id_address1, :nontransliterable_field)
+      cleaned_errors.delete(:state_id_address2, :nontransliterable_field)
 
       FormResponse.new(
         success: valid?,

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -20,7 +20,7 @@ module Idv
     def submit(params)
       consume_params(params)
 
-      cleaned_errors = errors.deep_dup
+      cleaned_errors = errors.dup
       cleaned_errors.delete(:first_name, :nontransliterable_field)
       cleaned_errors.delete(:last_name, :nontransliterable_field)
       cleaned_errors.delete(:state_id_city, :nontransliterable_field)

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -11,8 +11,18 @@ module Idv
                 presence: true
 
       validates_with UspsInPersonProofing::TransliterableValidator,
-                     fields: [:first_name, :last_name],
+                     fields: [:first_name, :last_name, :state_id_city],
                      reject_chars: /[^A-Za-z\-' ]/,
+                     message: ->(invalid_chars) do
+                       I18n.t(
+                         'in_person_proofing.form.state_id.errors.unsupported_chars',
+                         char_list: invalid_chars.join(', '),
+                       )
+                     end
+
+      validates_with UspsInPersonProofing::TransliterableValidator,
+                     fields: [:state_id_address1, :state_id_address2],
+                     reject_chars: /[^A-Za-z0-9\-' .\/#]/,
                      message: ->(invalid_chars) do
                        I18n.t(
                          'in_person_proofing.form.state_id.errors.unsupported_chars',

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -420,115 +420,162 @@ RSpec.describe 'In Person Proofing', js: true do
   end
 
   context 'transliteration' do
-    let(:capture_secondary_id_enabled) { true }
-    let(:double_address_verification) { true }
-    let(:user) { user_with_2fa }
-    let(:enrollment) { InPersonEnrollment.new(capture_secondary_id_enabled:) }
-
     before(:each) do
       allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).
         and_return(true)
-      allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
-        and_return(true)
-      allow(user).to receive(:establishing_in_person_enrollment).
-        and_return(enrollment)
     end
-    it 'shows validation errors', allow_browser_log: true do
-      sign_in_and_2fa_user
-      begin_in_person_proofing
-      complete_location_step
-      complete_prepare_step
-      expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
 
-      fill_out_state_id_form_ok(double_address_verification: double_address_verification)
-      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'T0mmy "Lee"'
-      fill_in t('in_person_proofing.form.state_id.last_name'), with: 'Джейкоб'
-      fill_in t('in_person_proofing.form.state_id.address1'), with: '#1 $treet'
-      fill_in t('in_person_proofing.form.state_id.address2'), with: 'Gr@nd Lañe^'
-      fill_in t('in_person_proofing.form.state_id.city'), with: 'B3st C!ty'
-      click_idv_continue
+    context 'with double address validation' do
+      let(:capture_secondary_id_enabled) { true }
+      let(:double_address_verification) { true }
+      let(:user) { user_with_2fa }
+      let(:enrollment) { InPersonEnrollment.new(capture_secondary_id_enabled:) }
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.state_id.errors.unsupported_chars',
-          char_list: '", 0',
-        ),
-      )
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
+          and_return(true)
+        allow(user).to receive(:establishing_in_person_enrollment).
+          and_return(enrollment)
+      end
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.state_id.errors.unsupported_chars',
-          char_list: 'Д, б, е, ж, й, к, о',
-        ),
-      )
+      it 'shows validation errors when double address validation is true',
+         allow_browser_log: true do
+        sign_in_and_2fa_user
+        begin_in_person_proofing
+        complete_location_step
+        complete_prepare_step
+        expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.state_id.errors.unsupported_chars',
-          char_list: '$',
-        ),
-      )
+        fill_out_state_id_form_ok(double_address_verification: double_address_verification)
+        fill_in t('in_person_proofing.form.state_id.first_name'), with: 'T0mmy "Lee"'
+        fill_in t('in_person_proofing.form.state_id.last_name'), with: 'Джейкоб'
+        fill_in t('in_person_proofing.form.state_id.address1'), with: '#1 $treet'
+        fill_in t('in_person_proofing.form.state_id.address2'), with: 'Gr@nd Lañe^'
+        fill_in t('in_person_proofing.form.state_id.city'), with: 'B3st C!ty'
+        click_idv_continue
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.state_id.errors.unsupported_chars',
-          char_list: '@, ^',
-        ),
-      )
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: '", 0',
+          ),
+        )
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.state_id.errors.unsupported_chars',
-          char_list: '!, 3',
-        ),
-      )
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: 'Д, б, е, ж, й, к, о',
+          ),
+        )
 
-      # re-fill form with good inputs
-      fill_in t('in_person_proofing.form.state_id.first_name'),
-              with: InPersonHelper::GOOD_FIRST_NAME
-      fill_in t('in_person_proofing.form.state_id.last_name'), with: InPersonHelper::GOOD_LAST_NAME
-      fill_in t('in_person_proofing.form.state_id.address1'),
-              with: InPersonHelper::GOOD_STATE_ID_ADDRESS1
-      fill_in t('in_person_proofing.form.state_id.address2'),
-              with: InPersonHelper::GOOD_STATE_ID_ADDRESS2
-      fill_in t('in_person_proofing.form.state_id.city'), with: InPersonHelper::GOOD_STATE_ID_CITY
-      click_idv_continue
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: '$',
+          ),
+        )
 
-      expect(page).to have_current_path(idv_in_person_step_path(step: :address), wait: 10)
-      fill_out_address_form_ok(double_address_verification: double_address_verification)
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: '@, ^',
+          ),
+        )
 
-      fill_in t('idv.form.address1'), with: 'Джордж'
-      fill_in t('idv.form.address2'), with: '(Nope) = %'
-      fill_in t('idv.form.city'), with: 'Елена'
-      click_idv_continue
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: '!, 3',
+          ),
+        )
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.address.errors.unsupported_chars',
-          char_list: 'Д, д, ж, о, р',
-        ),
-      )
+        # re-fill state id form with good inputs
+        fill_in t('in_person_proofing.form.state_id.first_name'),
+                with: InPersonHelper::GOOD_FIRST_NAME
+        fill_in t('in_person_proofing.form.state_id.last_name'),
+                with: InPersonHelper::GOOD_LAST_NAME
+        fill_in t('in_person_proofing.form.state_id.address1'),
+                with: InPersonHelper::GOOD_STATE_ID_ADDRESS1
+        fill_in t('in_person_proofing.form.state_id.address2'),
+                with: InPersonHelper::GOOD_STATE_ID_ADDRESS2
+        fill_in t('in_person_proofing.form.state_id.city'), with: InPersonHelper::GOOD_STATE_ID_CITY
+        click_idv_continue
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.address.errors.unsupported_chars',
-          char_list: '%, (, ), =',
-        ),
-      )
+        expect(page).to have_current_path(idv_in_person_step_path(step: :address), wait: 10)
+      end
+    end
 
-      expect(page).to have_content(
-        I18n.t(
-          'in_person_proofing.form.address.errors.unsupported_chars',
-          char_list: 'Е, а, е, л, н',
-        ),
-      )
+    context 'without double address validation' do
+      it 'shows validation errors when double address validation is false',
+         allow_browser_log: true do
+        sign_in_and_2fa_user
+        begin_in_person_proofing
+        complete_location_step
+        complete_prepare_step
+        expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
 
-      # re-fill form with good inputs
-      fill_in t('idv.form.address1'), with: InPersonHelper::GOOD_ADDRESS1
-      fill_in t('idv.form.address2'), with: InPersonHelper::GOOD_ADDRESS2
-      fill_in t('idv.form.city'), with: InPersonHelper::GOOD_CITY
-      click_idv_continue
-      expect(page).to have_current_path(idv_in_person_step_path(step: :ssn), wait: 10)
+        fill_out_state_id_form_ok
+        fill_in t('in_person_proofing.form.state_id.first_name'), with: 'T0mmy "Lee"'
+        fill_in t('in_person_proofing.form.state_id.last_name'), with: 'Джейкоб'
+        click_idv_continue
+        # binding.pry
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: '", 0',
+          ),
+        )
+
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: 'Д, б, е, ж, й, к, о',
+          ),
+        )
+
+        # re-fill form with good inputs
+        fill_in t('in_person_proofing.form.state_id.first_name'),
+                with: InPersonHelper::GOOD_FIRST_NAME
+        fill_in t('in_person_proofing.form.state_id.last_name'),
+                with: InPersonHelper::GOOD_LAST_NAME
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_in_person_step_path(step: :address), wait: 10)
+        fill_out_address_form_ok
+
+        fill_in t('idv.form.address1'), with: 'Джордж'
+        fill_in t('idv.form.address2_optional'), with: '(Nope) = %'
+        fill_in t('idv.form.city'), with: 'Елена'
+        click_idv_continue
+
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.address.errors.unsupported_chars',
+            char_list: 'Д, д, ж, о, р',
+          ),
+        )
+
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.address.errors.unsupported_chars',
+            char_list: '%, (, ), =',
+          ),
+        )
+
+        expect(page).to have_content(
+          I18n.t(
+            'in_person_proofing.form.address.errors.unsupported_chars',
+            char_list: 'Е, а, е, л, н',
+          ),
+        )
+
+        # re-fill form with good inputs
+        fill_in t('idv.form.address1'), with: InPersonHelper::GOOD_ADDRESS1
+        fill_in t('idv.form.address2_optional'), with: InPersonHelper::GOOD_ADDRESS2
+        fill_in t('idv.form.city'), with: InPersonHelper::GOOD_CITY
+        click_idv_continue
+        expect(page).to have_current_path(idv_in_person_step_path(step: :ssn), wait: 10)
+      end
     end
   end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -518,7 +518,7 @@ RSpec.describe 'In Person Proofing', js: true do
         fill_in t('in_person_proofing.form.state_id.first_name'), with: 'T0mmy "Lee"'
         fill_in t('in_person_proofing.form.state_id.last_name'), with: 'Джейкоб'
         click_idv_continue
-        # binding.pry
+
         expect(page).to have_content(
           I18n.t(
             'in_person_proofing.form.state_id.errors.unsupported_chars',


### PR DESCRIPTION
## 🎫 Ticket

[LG-9229](https://cm-jira.usa.gov/browse/LG-9229)


## 🛠 Summary of changes

Add transliteration validation for address line 1, address line 2 and city. 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set `in_person_capture_secondary_id_enabled` to true
- [ ] Walk through ipp flow up to the state id page
- [ ] Enter inputs with non-transliterable characters and make sure error shows after clicking continue; examples:
      * for address lines `#1 $treet lañe^` should identify `$, ^` as characters that need to be replaced
      * for city line `B3st C!ty` should identify `3, !` as characters that need to be replaced

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<img width="604" alt="Screen Shot 2023-03-30 at 10 45 21 AM" src="https://user-images.githubusercontent.com/20867088/228890686-c60daf0f-8ed7-4d84-a9b1-5587ca49ffc8.png">

