### PR TITLE
LG-9261 update verified_at for gpo user

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -23,6 +23,7 @@ class GpoVerifyForm
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif threatmetrix_check_failed? && threatmetrix_enabled?
         pending_profile&.deactivate_for_fraud_review
+        pending_profile&.update!(verified_at: Time.zone.now)
       else
         activate_profile
       end

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -21,6 +21,7 @@ shared_examples 'gpo otp verification' do
     else
       expect(profile.active).to be(false)
       expect(profile.fraud_review_pending?).to eq(fraud_review_pending) if fraud_review_pending
+      expect(profile.verified_at).to_not eq(nil) if fraud_review_pending
     end
 
     expect(user.events.account_verified.size).to eq 1


### PR DESCRIPTION
changelog: Internal, IdV GPO, add verified_at when a user completes gpo gpo verification

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-9261](https://cm-jira.usa.gov/browse/LG-9261)Link to the relevant ticket.



## 🛠 Summary of changes

Made sure when a user goes through GPO flow and verifies their GPO code a `verified_at` timestamp gets placed. This will temporarily be used until we have timestamps for fraud_review and fraud_rejection.



## 📜 Testing Plan

- [ ] Go through IdV GPO verification flow with a review or reject TMX status.
- [ ] Verify GPO code
- [ ] Check to see if verified_at timestamp is in the user's profile.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
