### PR TITLE
LG-9345 Maintain material consistency in IPP pages

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.spec.tsx
@@ -20,8 +20,8 @@ describe('InPersonCallToAction', () => {
       </AnalyticsContextProvider>,
     );
 
-    const link = getByRole('link', { name: 'in_person_proofing.body.cta.button' });
-    await userEvent.click(link);
+    const button = getByRole('button', { name: 'in_person_proofing.body.cta.button' });
+    await userEvent.click(button);
 
     expect(trackEvent).to.have.been.calledWith(
       'IdV: verify in person troubleshooting option clicked',

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { Button } from '@18f/identity-components';
 import { useInstanceId } from '@18f/identity-react-hooks';
 import { t } from '@18f/identity-i18n';
+import useHistoryParam from '@18f/identity-form-steps/use-history-param';
 import AnalyticsContext from '../context/analytics';
 import { InPersonContext } from '../context';
 
@@ -15,6 +16,7 @@ function InPersonCallToAction({ altHeading, altPrompt, altButtonText }: InPerson
   const instanceId = useInstanceId();
   const { trackEvent } = useContext(AnalyticsContext);
   const { inPersonCtaVariantActive } = useContext(InPersonContext);
+  const [, setStepName] = useHistoryParam(undefined);
 
   return (
     <section
@@ -30,13 +32,13 @@ function InPersonCallToAction({ altHeading, altPrompt, altButtonText }: InPerson
         isBig
         isOutline
         isWide
-        href="#location"
         className="margin-top-3 margin-bottom-1"
-        onClick={() =>
+        onClick={() => {
+          setStepName('location');
           trackEvent('IdV: verify in person troubleshooting option clicked', {
             in_person_cta_variant: inPersonCtaVariantActive,
-          })
-        }
+          });
+        }}
       >
         {altButtonText || t('in_person_proofing.body.cta.button')}
       </Button>

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
@@ -112,7 +112,7 @@ function InPersonLocationPostOfficeSearchStep({ onChange, toPreviousStep, regist
           address={foundAddress?.address || ''}
         />
       )}
-      <BackButton includeBorder onClick={toPreviousStep} />
+      <BackButton role="link" includeBorder onClick={toPreviousStep} />
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
@@ -39,7 +39,7 @@ describe('InPersonPrepareStep', () => {
         { wrapper },
       );
 
-      await userEvent.click(getByRole('link', { name: 'forms.buttons.continue' }));
+      await userEvent.click(getByRole('button', { name: 'forms.buttons.continue' }));
       await waitFor(() => window.location.hash === inPersonURL);
 
       expect(trackEvent).to.have.been.calledWith('IdV: prepare submitted');
@@ -60,10 +60,10 @@ describe('InPersonPrepareStep', () => {
           { wrapper },
         );
 
-        const link = getByRole('link', { name: 'forms.buttons.continue' });
+        const button = getByRole('button', { name: 'forms.buttons.continue' });
 
-        const didFollowLinkOnFirstClick = fireEvent.click(link);
-        const didFollowLinkOnSecondClick = fireEvent.click(link);
+        const didFollowLinkOnFirstClick = fireEvent.click(button);
+        const didFollowLinkOnSecondClick = fireEvent.click(button);
 
         clock.tick(delay);
 

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -29,7 +29,8 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
       setIsSubmitting(true);
       removeUnloadProtection();
       await trackEvent('IdV: prepare submitted');
-      window.location.href = (event.target as HTMLAnchorElement).href;
+      // window.location.href = (event.target as HTMLAnchorElement).href;
+      window.location.href = inPersonURL!;
     }
   };
 
@@ -59,7 +60,7 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
       {flowPath === 'hybrid' && <FormStepsButton.Continue />}
       {inPersonURL && flowPath === 'standard' && (
         <div className="margin-y-5">
-          <SpinnerButton href={inPersonURL} onClick={onContinue} isBig isWide>
+          <SpinnerButton onClick={onContinue} isBig isWide>
             {t('forms.buttons.continue')}
           </SpinnerButton>
         </div>
@@ -78,7 +79,7 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
         )}
       </p>
       <InPersonTroubleshootingOptions />
-      <BackButton includeBorder onClick={toPreviousStep} />
+      <BackButton role="link" includeBorder onClick={toPreviousStep} />
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -29,7 +29,6 @@ function InPersonPrepareStep({ toPreviousStep, value }) {
       setIsSubmitting(true);
       removeUnloadProtection();
       await trackEvent('IdV: prepare submitted');
-      // window.location.href = (event.target as HTMLAnchorElement).href;
       window.location.href = inPersonURL!;
     }
   };

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe 'In Person Proofing', js: true do
         mock_doc_auth_attention_with_barcode
         attach_and_submit_images
 
-        click_link t('in_person_proofing.body.cta.button')
+        click_button t('in_person_proofing.body.cta.button')
         search_for_post_office
         within page.first('.location-collection-item') do
           click_spinner_button_and_wait t('in_person_proofing.body.location.location_button')

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -73,7 +73,7 @@ module InPersonHelper
     complete_doc_auth_steps_before_document_capture_step
     mock_doc_auth_attention_with_barcode
     attach_and_submit_images
-    click_link t('in_person_proofing.body.cta.button')
+    click_button t('in_person_proofing.body.cta.button')
   end
 
   def search_for_post_office


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-9345)

## 🛠 Summary of changes

- Add role=link to BackButton components  on Prepare Step page. Since the element is already a button, it has the keyboard functionality of a button, but now it is recognized by screen readers as anchor link. 
- Removed href prop for SpinnerButton and Button components rendering both as buttons, the location update occurs in the onclick callback functions.

## 📜 Testing Plan

- [ ] Confirm all JS tests pass
- [ ] Run the app locally, confirm that the Back buttons navigate to the previous page in the IPP flow
- [ ] Locally, confirm that the "Try Again in Person" button on the location page, and the "Continue" button on the prepare page both navigate you to the next page 

## 👀 Screenshots

There should be no visible changes to the UI.