### PR TITLE
LG-8710: New IDV unavailable screen

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -72,15 +72,7 @@ module Idv
     def check_for_outage
       return if flow_session[:skip_vendor_outage]
 
-      return redirect_for_proofing_vendor_outage if OutageStatus.new.any_idv_vendor_outage?
       return redirect_for_gpo_only if FeatureManagement.idv_gpo_only?
-    end
-
-    def redirect_for_proofing_vendor_outage
-      session[:vendor_outage_redirect] = current_step
-      session[:vendor_outage_redirect_from_idv] = true
-
-      redirect_to vendor_outage_url
     end
 
     def redirect_for_gpo_only

--- a/app/controllers/idv/unavailable_controller.rb
+++ b/app/controllers/idv/unavailable_controller.rb
@@ -1,0 +1,34 @@
+module Idv
+  class UnavailableController < ApplicationController
+    ALLOWED_FROM_LOCATIONS = [SignUp::RegistrationsController::CREATE_ACCOUNT]
+
+    before_action :redirect_if_idv_available_and_from_create_account
+
+    def show
+      analytics.vendor_outage(
+        vendor_status: {
+          acuant: IdentityConfig.store.vendor_status_acuant,
+          lexisnexis_instant_verify: IdentityConfig.store.vendor_status_lexisnexis_instant_verify,
+          lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
+          sms: IdentityConfig.store.vendor_status_sms,
+          voice: IdentityConfig.store.vendor_status_voice,
+        },
+        redirect_from: from,
+      )
+    end
+
+    private
+
+    def from
+      params[:from] if ALLOWED_FROM_LOCATIONS.include?(params[:from])
+    end
+
+    def from_create_account?
+      from == SignUp::RegistrationsController::CREATE_ACCOUNT
+    end
+
+    def redirect_if_idv_available_and_from_create_account
+      redirect_to sign_up_email_url if FeatureManagement.idv_available? && from_create_account?
+    end
+  end
+end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -5,7 +5,7 @@ module SignUp
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     before_action :require_no_authentication
-    before_action :redirect_if_ial2_and_vendor_outage
+    before_action :redirect_if_ial2_and_idv_unavailable
 
     CREATE_ACCOUNT = 'create_account'
 
@@ -71,11 +71,10 @@ module SignUp
       ServiceProviderRequestProxy.from_uuid(request_id).uuid
     end
 
-    def redirect_if_ial2_and_vendor_outage
-      return unless ial2_requested? && OutageStatus.new.any_idv_vendor_outage?
-
-      session[:vendor_outage_redirect] = CREATE_ACCOUNT
-      return redirect_to vendor_outage_url
+    def redirect_if_ial2_and_idv_unavailable
+      if ial2_requested? && !FeatureManagement.idv_available?
+        redirect_to idv_unavailable_path(from: CREATE_ACCOUNT)
+      end
     end
   end
 end

--- a/app/controllers/vendor_outage_controller.rb
+++ b/app/controllers/vendor_outage_controller.rb
@@ -1,13 +1,8 @@
 class VendorOutageController < ApplicationController
   def show
-    vendor_status = OutageStatus.new(
-      sp: current_sp,
-      from: session.delete(:vendor_outage_redirect),
-      from_idv: session.delete(:vendor_outage_redirect_from_idv),
-    )
-    @specific_message = vendor_status.outage_message
+    @specific_message = OutageStatus.new.outage_message
     @show_gpo_option = from_idv_phone? && gpo_letter_available?
-    vendor_status.track_event(analytics)
+    OutageStatus.new.track_event(analytics)
   end
 
   private

--- a/app/controllers/vendor_outage_controller.rb
+++ b/app/controllers/vendor_outage_controller.rb
@@ -1,8 +1,10 @@
 class VendorOutageController < ApplicationController
   def show
-    @specific_message = OutageStatus.new.outage_message
+    outage_status = OutageStatus.new
+
+    @specific_message = outage_status.outage_message
     @show_gpo_option = from_idv_phone? && gpo_letter_available?
-    OutageStatus.new.track_event(analytics)
+    outage_status.track_event(analytics)
   end
 
   private

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2909,12 +2909,11 @@ module AnalyticsEvents
     track_event('User Registration: 2FA Setup visited')
   end
 
-  # @param [String] redirect_from
+  # @param [String,nil] redirect_from
   # @param [Hash] vendor_status
   # Tracks when vendor has outage
   def vendor_outage(
-    redirect_from:,
-    vendor_status:,
+    vendor_status:, redirect_from: nil,
     **extra
   )
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2909,11 +2909,12 @@ module AnalyticsEvents
     track_event('User Registration: 2FA Setup visited')
   end
 
-  # @param [String,nil] redirect_from
   # @param [Hash] vendor_status
+  # @param [String,nil] redirect_from
   # Tracks when vendor has outage
   def vendor_outage(
-    vendor_status:, redirect_from: nil,
+    vendor_status:,
+    redirect_from: nil,
     **extra
   )
     track_event(

--- a/app/services/outage_status.rb
+++ b/app/services/outage_status.rb
@@ -1,12 +1,6 @@
 class OutageStatus
   include ActionView::Helpers::TranslationHelper
 
-  def initialize(from: nil, from_idv: nil, sp: nil)
-    @from = from
-    @from_idv = from_idv
-    @sp = sp
-  end
-
   IDV_VENDORS = %i[acuant lexisnexis_instant_verify lexisnexis_trueid].freeze
   PHONE_VENDORS = %i[sms voice].freeze
   ALL_VENDORS = (IDV_VENDORS + PHONE_VENDORS).freeze
@@ -55,31 +49,15 @@ class OutageStatus
     all_vendor_outage?([:lexisnexis_phone_finder])
   end
 
-  def from_idv?
-    from_idv
-  end
-
   # Returns an appropriate error message based upon the type of outage or what the user was doing
   # when they encountered the outage.
   #
   # @return [String, nil] the localized message.
   def outage_message
     if any_idv_vendor_outage?
-      if from_idv?
-        if sp
-          t('vendor_outage.blocked.idv.with_sp', service_provider: sp.friendly_name)
-        else
-          t('vendor_outage.blocked.idv.without_sp')
-        end
-      else
-        t('vendor_outage.blocked.idv.generic')
-      end
+      t('vendor_outage.blocked.idv.generic')
     elsif any_phone_vendor_outage?
-      if from_idv?
-        t('vendor_outage.blocked.phone.idv')
-      else
-        t('vendor_outage.blocked.phone.default')
-      end
+      t('vendor_outage.blocked.phone.default')
     end
   end
 
@@ -94,11 +72,6 @@ class OutageStatus
         sms: IdentityConfig.store.vendor_status_sms,
         voice: IdentityConfig.store.vendor_status_voice,
       },
-      redirect_from: from,
     )
   end
-
-  private
-
-  attr_reader :from, :from_idv, :sp
 end

--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -12,6 +12,10 @@
     <% end %>
   </p>
 
+  <p>
+    <%= t('idv.unavailable.technical_difficulties') %>
+  </p>
+
   <p class="margin-bottom-5">
     <%= t(
           'idv.unavailable.next_steps_html',

--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -1,0 +1,38 @@
+<% title t('idv.titles.unavailable') %>
+
+<%= render StatusPageComponent.new(status: :error) do |c| %>
+
+  <% c.header { t('idv.titles.unavailable') } %>
+
+  <p>
+    <% if decorated_session.sp_name.present? %>
+      <%= t('idv.unavailable.idv_explanation.with_sp_html', sp: decorated_session.sp_name) %>
+    <% else %>
+      <%= t('idv.unavailable.idv_explanation.without_sp') %>
+    <% end %>
+  </p>
+
+  <p class="margin-bottom-5">
+    <%= t(
+          'idv.unavailable.next_steps_html',
+          app_name: APP_NAME,
+          status_page_link: new_window_link_to(
+            t('idv.unavailable.status_page_link'),
+            StatusPage.base_url,
+          ),
+        ) %>
+  </p>
+
+  <% c.action_button(
+       action: ->(**tag_options, &block) do
+         link_to(
+           return_to_sp_failure_to_proof_path(location: :unavailable),
+           **tag_options,
+           &block
+         )
+       end,
+       big: true,
+       wide: true,
+     ).with_content(t('idv.unavailable.exit_button', app_name: APP_NAME)) %>
+
+<% end %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -120,6 +120,7 @@ hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
 idv_attempt_window_in_hours: 6
+idv_available: true
 idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -249,10 +249,10 @@ en:
           someone pretending to be you.'
         without_sp: 'The agency that you are trying to access needs to make sure you are
           you — not someone pretending to be you.'
-      next_steps_html: 'Unfortunately, we are having technical difficulties and cannot
-        verify your identity at this time. %{status_page_link} or exit
-        %{app_name} and try again later.'
+      next_steps_html: '%{status_page_link} or exit %{app_name} and try again later.'
       status_page_link: 'Get updates on our status page'
+      technical_difficulties: Unfortunately, we are having technical difficulties and
+        cannot verify your identity at this time.
     welcome:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -225,6 +225,7 @@ en:
       session:
         phone: Enter your phone number
         review: Re-enter your %{app_name} password to protect your data
+      unavailable: 'We are working to resolve an error'
     troubleshooting:
       headings:
         missing_required_items: Are you missing one of these items?
@@ -241,6 +242,17 @@ en:
         learn_more_verify_in_person: Learn more about verifying in person
         supported_documents: See a list of accepted state-issued IDs
         verify_by_mail: Verify your address by mail instead
+    unavailable:
+      exit_button: 'Exit %{app_name}'
+      idv_explanation:
+        with_sp_html: '<strong>%{sp}</strong> needs to make sure you are you — not
+          someone pretending to be you.'
+        without_sp: 'The agency that you are trying to access needs to make sure you are
+          you — not someone pretending to be you.'
+      next_steps_html: 'Unfortunately, we are having technical difficulties and cannot
+        verify your identity at this time. %{status_page_link} or exit
+        %{app_name} and try again later.'
+      status_page_link: 'Get updates on our status page'
     welcome:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -266,11 +266,11 @@ es:
           realmente y no alguien que se hace pasar por usted.'
         without_sp: 'La agencia a la que está intentando acceder debe asegurarse de que
           usted sea quien dice ser, y no alguien que se hace pasar por usted.'
-      next_steps_html: 'Lamentablemente, debido a problemas técnicos por nuestra
-        parte, tal vez no podamos verificar su identidad en estos momentos.
-        %{status_page_link} o salga de %{app_name} y vuelva a intentarlo más
-        tarde.'
+      next_steps_html: '%{status_page_link} o salga de %{app_name} y vuelva a
+        intentarlo más tarde.'
       status_page_link: 'Consulte las actualizaciones en nuestra página de estado'
+      technical_difficulties: Lamentablemente, debido a problemas técnicos por nuestra
+        parte, tal vez no podamos verificar su identidad en estos momentos.
     welcome:
       no_js_header: Debe habilitar JavaScript para verificar su identidad.
       no_js_intro: '%{sp_name} requiere que usted verifique su identidad. Debe

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -240,6 +240,7 @@ es:
       session:
         phone: Introduzca su número de teléfono
         review: Vuelve a ingresar tu contraseña de %{app_name} para encriptar tus datos
+      unavailable: Estamos trabajando para resolver un error
     troubleshooting:
       headings:
         missing_required_items: '¿Le falta alguno de estos puntos?'
@@ -258,6 +259,18 @@ es:
         supported_documents: Vea la lista de documentos de identidad emitidos por el
           estado que son aceptados
         verify_by_mail: Verifique su dirección por correo
+    unavailable:
+      exit_button: 'Salir de %{app_name}'
+      idv_explanation:
+        with_sp_html: '<strong>%{sp}</strong> necesita asegurarse de que es usted
+          realmente y no alguien que se hace pasar por usted.'
+        without_sp: 'La agencia a la que está intentando acceder debe asegurarse de que
+          usted sea quien dice ser, y no alguien que se hace pasar por usted.'
+      next_steps_html: 'Lamentablemente, debido a problemas técnicos por nuestra
+        parte, tal vez no podamos verificar su identidad en estos momentos.
+        %{status_page_link} o salga de %{app_name} y vuelva a intentarlo más
+        tarde.'
+      status_page_link: 'Consulte las actualizaciones en nuestra página de estado'
     welcome:
       no_js_header: Debe habilitar JavaScript para verificar su identidad.
       no_js_intro: '%{sp_name} requiere que usted verifique su identidad. Debe

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -281,11 +281,11 @@ fr:
         without_sp: 'L’agence à laquelle vous essayez d’accéder doit s’assurer qu’il
           s’agit bien de vous, et non de quelqu’un qui se fait passer pour
           vous.'
-      next_steps_html: 'Malheureusement, nous rencontrons des difficultés techniques
-        et ne pouvons pas vérifier votre identité pour le moment.
-        %{status_page_link} ou quittez le site %{app_name} et réessayez plus
-        tard.'
+      next_steps_html: '%{status_page_link} ou quittez le site %{app_name} et
+        réessayez plus tard.'
       status_page_link: 'Obtenez des mises à jour sur notre page de statut'
+      technical_difficulties: Malheureusement, nous rencontrons des difficultés
+        techniques et ne pouvons pas vérifier votre identité pour le moment.
     welcome:
       no_js_header: Vous devez activer JavaScript pour vérifier votre identité.
       no_js_intro: '%{sp_name} a besoin de vous pour vérifier votre identité. Vous

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -254,6 +254,7 @@ fr:
       session:
         phone: Entrez votre numéro de téléphone
         review: Entrez à nouveau votre mot de passe %{app_name} pour crypter vos données
+      unavailable: Nous travaillons à la résolution d’une erreur
     troubleshooting:
       headings:
         missing_required_items: Est-ce qu’il vous manque un de ces éléments?
@@ -272,6 +273,19 @@ fr:
         learn_more_verify_in_person: En savoir plus sur la vérification en personne
         supported_documents: Voir la liste des pièces d’identité acceptées et délivrées par l’État
         verify_by_mail: Vérifiez plutôt votre adresse par courrier
+    unavailable:
+      exit_button: 'Quitter %{app_name}'
+      idv_explanation:
+        with_sp_html: '<strong>%{sp}</strong> doit s’assurer que c’est bien vous — et
+          non quelqu’un qui se fait passer pour vous.'
+        without_sp: 'L’agence à laquelle vous essayez d’accéder doit s’assurer qu’il
+          s’agit bien de vous, et non de quelqu’un qui se fait passer pour
+          vous.'
+      next_steps_html: 'Malheureusement, nous rencontrons des difficultés techniques
+        et ne pouvons pas vérifier votre identité pour le moment.
+        %{status_page_link} ou quittez le site %{app_name} et réessayez plus
+        tard.'
+      status_page_link: 'Obtenez des mises à jour sur notre page de statut'
     welcome:
       no_js_header: Vous devez activer JavaScript pour vérifier votre identité.
       no_js_intro: '%{sp_name} a besoin de vous pour vérifier votre identité. Vous

--- a/config/locales/vendor_outage/en.yml
+++ b/config/locales/vendor_outage/en.yml
@@ -36,18 +36,8 @@ en:
       idv:
         generic: We are having technical difficulties on our end and cannot verify your
           identity at this time. Please try again later.
-        with_sp: '%{service_provider} needs to make sure you are you — not someone
-          pretending to be you. Unfortunately, we are having technical
-          difficulties and cannot verify your identity at this time. Please try
-          again later.'
-        without_sp: The agency that you are trying to access needs to make sure you are
-          you — not someone pretending to be you. Unfortunately, we are having
-          technical difficulties and cannot verify your identity at this time.
-          Please try again later.
       phone:
         default: We cannot verify phones at this time. Please try again later.
-        idv: We cannot verify phones at this time. Please try again later or verify your
-          address by mail instead.
     get_updates: Get updates
     get_updates_on_status_page: Get updates on our status page
     working: We are working to resolve an error

--- a/config/locales/vendor_outage/es.yml
+++ b/config/locales/vendor_outage/es.yml
@@ -42,22 +42,9 @@ es:
         generic: Debido a problemas técnicos por nuestra parte, no podemos verificar su
           identidad en estos momentos. Por favor, inténtelo nuevamente más
           tarde.
-        with_sp: '%{service_provider} necesita asegurarse de que es usted realmente y no
-          alguien que se hace pasar por usted. Lamentablemente, debido a
-          problemas técnicos por nuestra parte, tal vez no podamos verificar su
-          identidad en estos momentos. Por favor, inténtelo nuevamente más
-          tarde.'
-        without_sp: La agencia a la que está intentando acceder debe asegurarse de que
-          usted sea quien dice ser, y no alguien que se hace pasar por usted.
-          Lamentablemente, debido a problemas técnicos por nuestra parte, tal
-          vez no podamos verificar su identidad en estos momentos. Por favor,
-          inténtelo nuevamente más tarde.
       phone:
         default: No podemos verificar teléfonos en estos momentos. Por favor, inténtelo
           nuevamente más tarde.
-        idv: No podemos verificar teléfonos en estos momentos. Por favor, inténtelo
-          nuevamente más tarde o, en lugar de ello, verifique su dirección por
-          correo.
     get_updates: Obtenga actualizaciones
     get_updates_on_status_page: Reciba actualizaciones en nuestra página de estado
     working: Estamos trabajando para corregir un error

--- a/config/locales/vendor_outage/fr.yml
+++ b/config/locales/vendor_outage/fr.yml
@@ -40,20 +40,9 @@ fr:
       idv:
         generic: Nous rencontrons des difficultés techniques et ne pouvons pas vérifier
           votre identité pour le moment. Veuillez réessayer plus tard.
-        with_sp: '%{service_provider} doit s’assurer que c’est bien vous — et non
-          quelqu’un qui se fait passer pour vous. Malheureusement, nous
-          rencontrons des difficultés techniques et ne pouvons pas vérifier
-          votre identité pour le moment. Veuillez réessayer plus tard.'
-        without_sp: L’agence à laquelle vous essayez d’accéder doit s’assurer qu’il
-          s’agit bien de vous, et non de quelqu’un qui se fait passer pour vous.
-          Malheureusement, nous rencontrons des difficultés techniques et ne
-          pouvons pas vérifier votre identité pour le moment. Veuillez réessayer
-          plus tard.
       phone:
         default: Nous ne pouvons pas vérifier les téléphones pour le moment. Veuillez
           réessayer plus tard.
-        idv: Nous ne pouvons pas vérifier les téléphones pour le moment. Veuillez
-          réessayer plus tard ou vérifier votre adresse par la poste.
     get_updates: Obtenir des mises à jour
     get_updates_on_status_page: Obtenez des mises à jour sur notre page de statut
     working: Nous travaillons à la résolution d’une erreur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,11 +305,18 @@ Rails.application.routes.draw do
 
     get '/restricted' => 'banned_user#show', as: :banned_user
 
+    get '/errors/idv_unavailable' => 'idv/unavailable#show', as: :idv_unavailable
+
     scope '/verify', as: 'idv' do
       get '/' => 'idv#index'
       get '/activated' => 'idv#activated'
     end
     scope '/verify', module: 'idv', as: 'idv' do
+      if !FeatureManagement.idv_available?
+        # IdV has been disabled.
+        match '/*path' => 'unavailable#show', via: %i[get post]
+      end
+
       get '/mail_only_warning' => 'gpo_only_warning#show'
       get '/come_back_later' => 'come_back_later#show'
       get '/personal_key' => 'personal_key#show'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -15,6 +15,11 @@ class FeatureManagement
       !IdentityConfig.store.piv_cac_verify_token_url
   end
 
+  def self.idv_available?
+    return false if !IdentityConfig.store.idv_available
+    !OutageStatus.new.any_idv_vendor_outage?
+  end
+
   def self.development_and_identity_pki_disabled?
     # This controls if we try to hop over to identity-pki or just throw up
     # a screen asking for a Subject or one of a list of error conditions.

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -199,6 +199,7 @@ class IdentityConfig
     config.add(:identity_pki_disabled, type: :boolean)
     config.add(:identity_pki_local_dev, type: :boolean)
     config.add(:idv_attempt_window_in_hours, type: :integer)
+    config.add(:idv_available, type: :boolean)
     config.add(:idv_contact_phone_number, type: :string)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+describe Idv::UnavailableController, type: :controller do
+  let(:idv_available) { false }
+
+  before do
+    allow(IdentityConfig.store).to receive(:idv_available).and_return(idv_available)
+  end
+
+  describe '#show' do
+    let(:params) { nil }
+
+    before do
+      stub_analytics
+      get :show, params: params
+    end
+
+    it 'returns 200 OK' do
+      # https://http.cat/200
+      expect(response.status).to eql(200)
+    end
+
+    it 'logs an analytics event' do
+      expect(@analytics).to have_logged_event(
+        'Vendor Outage',
+        redirect_from: nil,
+        vendor_status: {
+          acuant: :operational,
+          lexisnexis_instant_verify: :operational,
+          lexisnexis_trueid: :operational,
+          sms: :operational,
+          voice: :operational,
+        },
+      )
+    end
+
+    it 'renders the view' do
+      expect(response).to render_template('idv/unavailable/show')
+    end
+
+    context 'coming from the create account page' do
+      let(:params) do
+        { from: SignUp::RegistrationsController::CREATE_ACCOUNT }
+      end
+      it 'logs an analytics event' do
+        expect(@analytics).to have_logged_event(
+          'Vendor Outage',
+          redirect_from: SignUp::RegistrationsController::CREATE_ACCOUNT,
+          vendor_status: {
+            acuant: :operational,
+            lexisnexis_instant_verify: :operational,
+            lexisnexis_trueid: :operational,
+            sms: :operational,
+            voice: :operational,
+          },
+        )
+      end
+      it 'renders the view' do
+        expect(response).to render_template('idv/unavailable/show')
+      end
+    end
+
+    context 'IdV is enabled' do
+      let(:idv_available) { true }
+
+      it 'renders the view' do
+        expect(response).to render_template('idv/unavailable/show')
+      end
+
+      it 'returns a 200' do
+        expect(response.status).to eql(200)
+      end
+
+      context 'coming from the create account page' do
+        let(:params) { { from: SignUp::RegistrationsController::CREATE_ACCOUNT } }
+        it 'redirects back to create account' do
+          expect(response).to redirect_to(sign_up_email_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -63,7 +63,7 @@ describe Idv::UnavailableController, type: :controller do
     context 'IdV is enabled' do
       let(:idv_available) { true }
 
-      it 'renders the view' do
+      it 'renders the view  when from: is nil' do
         expect(response).to render_template('idv/unavailable/show')
       end
 

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -20,7 +20,7 @@ describe Idv::UnavailableController, type: :controller do
       expect(response.status).to eql(200)
     end
 
-    it 'logs an analytics event' do
+    it 'logs an analytics event with redirect_from nil' do
       expect(@analytics).to have_logged_event(
         'Vendor Outage',
         redirect_from: nil,

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -42,7 +42,7 @@ describe Idv::UnavailableController, type: :controller do
       let(:params) do
         { from: SignUp::RegistrationsController::CREATE_ACCOUNT }
       end
-      it 'logs an analytics event' do
+      it 'logs an analytics event with redirect_from CREATE_ACCOUNT' do
         expect(@analytics).to have_logged_event(
           'Vendor Outage',
           redirect_from: SignUp::RegistrationsController::CREATE_ACCOUNT,

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -25,6 +25,19 @@ describe SignUp::RegistrationsController, devise: true do
       expect { get :new }.
         to raise_error(Mime::Type::InvalidMimeType)
     end
+
+    context 'IdV unavailable' do
+      before do
+        allow(IdentityConfig.store).to receive(:idv_available).and_return(false)
+      end
+      it 'redirects to idv vendor outage page when ial2 requested' do
+        allow(controller).to receive(:ial2_requested?).and_return(true)
+        get :new
+        expect(response).to redirect_to(
+          idv_unavailable_path(from: SignUp::RegistrationsController::CREATE_ACCOUNT),
+        )
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -235,8 +235,7 @@ feature 'IdV Outage Spec' do
       it 'prevents a user from creating an account' do
         visit_idp_from_sp_with_ial2(:oidc)
         click_link t('links.create_account')
-        expect(current_path).to eq vendor_outage_path
-        expect(page).to have_content(t('vendor_outage.blocked.idv.generic'))
+        expect(page).to have_content(t('idv.unavailable.idv_explanation.with_sp', sp: 'Test SP'))
       end
     end
   end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -495,12 +495,6 @@ describe 'FeatureManagement' do
           expect(FeatureManagement.idv_available?).to eql(false)
         end
       end
-      context "#{service} is in :partial_outage" do
-        let("vendor_status_#{service}".to_sym) { :partial_outage }
-        it 'returns false' do
-          expect(FeatureManagement.idv_available?).to eql(false)
-        end
-      end
     end
   end
 end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -461,4 +461,46 @@ describe 'FeatureManagement' do
       end
     end
   end
+
+  describe '#idv_available?' do
+    let(:idv_available) { true }
+    let(:vendor_status_acuant) { :operational }
+    let(:vendor_status_lexisnexis_instant_verify) { :operational }
+    let(:vendor_status_lexisnexis_trueid) { :operational }
+
+    before do
+      allow(IdentityConfig.store).to receive(:idv_available).and_return(idv_available)
+      allow(IdentityConfig.store).to receive(:vendor_status_acuant).and_return(vendor_status_acuant)
+      allow(IdentityConfig.store).to receive(:vendor_status_lexisnexis_instant_verify).
+        and_return(vendor_status_lexisnexis_instant_verify)
+      allow(IdentityConfig.store).to receive(:vendor_status_lexisnexis_trueid).
+        and_return(vendor_status_lexisnexis_trueid)
+    end
+
+    it 'returns true by default' do
+      expect(FeatureManagement.idv_available?).to eql(true)
+    end
+
+    context 'idv has been disabled using config flag' do
+      let(:idv_available) { false }
+      it 'returns false' do
+        expect(FeatureManagement.idv_available?).to eql(false)
+      end
+    end
+
+    %w[acuant lexisnexis_instant_verify lexisnexis_trueid].each do |service|
+      context "#{service} is in :full_outage" do
+        let("vendor_status_#{service}".to_sym) { :full_outage }
+        it 'returns false' do
+          expect(FeatureManagement.idv_available?).to eql(false)
+        end
+      end
+      context "#{service} is in :partial_outage" do
+        let("vendor_status_#{service}".to_sym) { :partial_outage }
+        it 'returns false' do
+          expect(FeatureManagement.idv_available?).to eql(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/outage_status_spec.rb
+++ b/spec/services/outage_status_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 describe OutageStatus do
-  let(:from) { nil }
-  let(:from_idv) { nil }
-  let(:sp) { nil }
   subject(:vendor_status) do
-    OutageStatus.new(from: from, from_idv: from_idv, sp: sp)
+    OutageStatus.new
   end
 
   it 'raises an error if passed an unknown vendor' do
@@ -52,38 +49,8 @@ describe OutageStatus do
       expect(subject.any_idv_vendor_outage?).to be
     end
 
-    context 'user coming from create_account' do
-      let(:from) { SignUp::RegistrationsController::CREATE_ACCOUNT }
-
-      it 'returns the correct message' do
-        expect(subject.outage_message).to eq I18n.t('vendor_outage.blocked.idv.generic')
-      end
-    end
-
-    context 'user coming from idv flow' do
-      let(:from) { :welcome }
-      let(:from_idv) { true }
-
-      context 'no service_provider in session' do
-        it 'returns the correct message' do
-          expect(subject.outage_message).to eq(
-            I18n.t('vendor_outage.blocked.idv.without_sp'),
-          )
-        end
-      end
-
-      context 'with service_provider in session' do
-        let(:sp) { create(:service_provider) }
-
-        it 'returns the correct message tailored to the service provider' do
-          expect(subject.outage_message).to eq(
-            I18n.t(
-              'vendor_outage.blocked.idv.with_sp',
-              service_provider: sp.friendly_name,
-            ),
-          )
-        end
-      end
+    it 'returns the correct message' do
+      expect(subject.outage_message).to eq I18n.t('vendor_outage.blocked.idv.generic')
     end
   end
 
@@ -171,14 +138,6 @@ describe OutageStatus do
       it 'returns default phone outage message' do
         expect(outage_message).to eq(t('vendor_outage.blocked.phone.default'))
       end
-
-      context 'from idv' do
-        let(:from_idv) { true }
-
-        it 'returns idv phone outage message' do
-          expect(outage_message).to eq(t('vendor_outage.blocked.phone.idv'))
-        end
-      end
     end
   end
 
@@ -187,7 +146,7 @@ describe OutageStatus do
       analytics = FakeAnalytics.new
       expect(analytics).to receive(:track_event).with(
         'Vendor Outage',
-        redirect_from: from,
+        redirect_from: nil,
         vendor_status: OutageStatus::ALL_VENDORS.index_with do |_vendor|
           satisfy { |status| IdentityConfig::VENDOR_STATUS_OPTIONS.include?(status) }
         end,

--- a/spec/views/idv/unavailable/show.html.erb_spec.rb
+++ b/spec/views/idv/unavailable/show.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'idv/unavailable/show.html.erb' do
+  let(:sp_name) { nil }
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:decorated_session).and_return(
+      instance_double(ServiceProviderSessionDecorator, sp_name: sp_name),
+    )
+  end
+
+  it 'sets a title' do
+    expect(view).to receive(:title).with(t('idv.titles.unavailable'))
+    render
+  end
+  it 'has an h1' do
+    expect(rendered).to have_selector('h1', text: t('idv.titles.unavailable'))
+  end
+  it 'links to the status page in a new window' do
+    expect(rendered).to have_selector(
+      'a[target=_blank]',
+      text: t('idv.unavailable.status_page_link'),
+    )
+  end
+
+  describe('exit button') do
+    it 'is rendered' do
+      expect(rendered).to have_selector(
+        'a',
+        text: t('idv.unavailable.exit_button', app_name: APP_NAME),
+      )
+    end
+    it 'links to the right place' do
+      expect(rendered).to have_link(
+        t('idv.unavailable.exit_button', app_name: APP_NAME),
+        href: return_to_sp_failure_to_proof_path(location: 'unavailable'),
+      )
+    end
+  end
+
+  it 'does not render any l13n markers' do
+    expect(rendered).not_to include('%{')
+  end
+
+  context 'with sp' do
+    let(:sp_name) { 'Department of Ice Cream' }
+    it 'renders the explanation with the sp name' do
+      expect(rendered).to include(sp_name)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

(This is a do-over of #7970. I took the final state of the PR, cleaned up and re-did the commits against `main`)

## 🎫 Ticket

[LG-8710](https://cm-jira.usa.gov/browse/LG-8710)

## 🛠 Summary of changes

**Provide a way to disable IdV independent of vendor status flags**

There was a desire to be able to keep our existing `vendor_status_*` config infrastructure, but also provide a means for on-call engineers to completely disable identity verification independent of that.

So now, in addition to marking a required vendor as `:full_outage`, setting `idv_available: false` will disable IdV completely.

In code, `FeatureManagement.idv_available?` should be the preferred way of establishing whether identity verification is available to end users.

**Add a new page explaining that Idv is down**

The new page (see screenshots below) includes language related to identity verification, and so is not appropriate to be used as a generic error page. There are instances where [the old vendor outage page](https://secure.login.gov/errors/vendor) were being used by non-IdV code—these are unmodified.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set `idv_available: false` in your config and restart your server
- [ ] Try to verify
- [ ] Get an error message

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>English</summary>

![errors-idv_unavailable-en](https://user-images.githubusercontent.com/364697/228988027-260a18c7-5269-43a5-9420-d973ac462e03.png)


</details>

<details>
<summary>Spanish</summary>

![errors-idv_unavailable-es](https://user-images.githubusercontent.com/364697/228988034-18841ca9-d18f-4a54-bdb0-92f3b8576edf.png)


</details>

<details>
<summary>French</summary>

![errors-idv_unavailable-fr](https://user-images.githubusercontent.com/364697/228988041-0ce0b273-4dea-48e3-b75b-cd152366e02f.png)


</details>