### PR TITLE
Remove code for unused no-SP registration heading

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -48,10 +48,6 @@ class ServiceProviderSessionDecorator
     I18n.t('headings.sign_in_with_sp', sp: sp_name)
   end
 
-  def registration_heading
-    'sign_up/registrations/sp_registration_heading'
-  end
-
   def verification_method_choice
     I18n.t('idv.messages.select_verification_with_sp', sp_name: sp_name)
   end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -3,10 +3,6 @@ class SessionDecorator
     @view_context = view_context
   end
 
-  def registration_heading
-    'sign_up/registrations/registration_heading'
-  end
-
   def new_session_heading
     I18n.t('headings.sign_in_without_sp')
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,11 +9,7 @@
 <%= render 'shared/maintenance_window_alert' %>
 
 <% if decorated_session.sp_name %>
-  <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
-
-    <%= render decorated_session.registration_heading %>
-  </div>
+  <%= render 'sign_up/registrations/sp_registration_heading' %>
 <% else %>
   <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>

--- a/app/views/sign_up/registrations/_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_registration_heading.html.erb
@@ -1,3 +1,0 @@
-<h1 class='margin-bottom-4 text-primary text-normal'>
-  <%= t('headings.create_account_without_sp', app_name: APP_NAME) %>
-</h1>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,7 +1,7 @@
-<h1 class='margin-bottom-4 text-primary text-normal'>
-  <strong>
-    <%= decorated_session.sp_name %>
-  </strong>
-
-  <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>
-</h1>
+<div class="text-center">
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
+  <h1 class="margin-bottom-4 text-primary text-normal">
+    <strong><%= decorated_session.sp_name %></strong>
+    <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>
+  </h1>
+</div>

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -1,11 +1,7 @@
 <% title t('titles.sign_up.confirmation') %>
 
 <% if decorated_session.sp_name %>
-  <div class='text-center'>
-    <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
-
-    <%= render decorated_session.registration_heading %>
-  </div>
+  <%= render 'sign_up/registrations/sp_registration_heading' %>
 <% else %>
   <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -26,7 +26,6 @@ en:
       cta: First time using %{app_name}?
       sp_text: is using %{app_name} to allow you to sign in to your account safely and
         securely.
-    create_account_without_sp: Create a %{app_name} account
     edit_info:
       password: Change your password
       phone: Manage your phone settings

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -26,7 +26,6 @@ es:
       cta: '¿Es la primera vez que utiliza %{app_name}?'
       sp_text: está utilizando %{app_name} para permitirle iniciar sesión en su cuenta
         de forma segura.
-    create_account_without_sp: Establezca una cuenta de %{app_name}
     edit_info:
       password: Cambie su contraseña
       phone: Administrar la configuración de su teléfono

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -26,7 +26,6 @@ fr:
       cta: Première fois que vous utilisez %{app_name}?
       sp_text: utilise %{app_name} pour vous permettre de vous connecter à votre
         compte de façon sûre et sécurisée.
-    create_account_without_sp: Créer un compte %{app_name}
     edit_info:
       password: Changez votre mot de passe
       phone: Administrer les paramètres de votre téléphone

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe SessionDecorator do
     end
   end
 
-  describe '#registration_heading' do
-    it 'returns the correct partial' do
-      expect(subject.registration_heading).to eq 'sign_up/registrations/registration_heading'
-    end
-  end
-
   describe '#verification_method_choice' do
     it 'returns the correct string' do
       expect(subject.verification_method_choice).to eq(


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-9216](https://cm-jira.usa.gov/browse/LG-9216)

## 🛠 Summary of changes

Removes unreachable code for account registration headings for users not associated with a service provider.

`SessionDecorator#registration_heading` varies depending on whether there's an associated service provider, but this heading is only ever rendered in logic paths where a service provider exists. Thus, the changes here simplify to a single view for registrations associated with a service provider and removes unnecessary logic.

There should be no user-facing impact of these changes.

## 📜 Testing Plan

For `app/views/devise/sessions/new.html.erb`:

1. Start from [sample application](https://github.com/18f/identity-oidc-sinatra/)
2. Click "Sign in"
3. Observe heading "Example Sinatra App is using ..."

For `app/views/users/authorization_confirmation/new.html.erb`: See https://github.com/18F/identity-idp/pull/5735#issuecomment-998826709