### PR TITLE
Update "You verified your identity" email to link to password reset (LG-9285)

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -43,7 +43,7 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
-            event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
+            event, _disavowal_token = create_user_event(:account_verified)
 
             if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
               redirect_to_fraud_review

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -43,7 +43,7 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
-            event, disavowal_token = create_user_event_with_disavowal(:account_verified)
+            event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
 
             if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
               redirect_to_fraud_review
@@ -52,7 +52,6 @@ module Idv
                 user: current_user,
                 date_time: event.created_at,
                 sp_name: decorated_session.sp_name,
-                disavowal_token: disavowal_token,
               )
               flash[:success] = t('account.index.verification.success')
               redirect_to next_step

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -43,7 +43,7 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
-            event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
+            event = create_user_event(:account_verified)
 
             if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
               redirect_to_fraud_review

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -43,7 +43,7 @@ module Idv
           if result.extra[:pending_in_person_enrollment]
             redirect_to idv_in_person_ready_to_verify_url
           else
-            event = create_user_event(:account_verified)
+            event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
 
             if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
               redirect_to_fraud_review

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -93,7 +93,7 @@ module Idv
       end
 
       if idv_session.profile.active?
-        event = create_user_event(:account_verified)
+        event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,
           date_time: event.created_at,

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -93,7 +93,7 @@ module Idv
       end
 
       if idv_session.profile.active?
-        event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
+        event = create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,
           date_time: event.created_at,

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -93,7 +93,7 @@ module Idv
       end
 
       if idv_session.profile.active?
-        event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
+        event, _disavowal_token = create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,
           date_time: event.created_at,

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -93,12 +93,11 @@ module Idv
       end
 
       if idv_session.profile.active?
-        event, disavowal_token = create_user_event_with_disavowal(:account_verified)
+        event, _disavowal_token = create_user_event_with_disavowal(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           user: current_user,
           date_time: event.created_at,
           sp_name: decorated_session.sp_name,
-          disavowal_token: disavowal_token,
         )
       end
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -240,13 +240,13 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def account_verified(date_time:, sp_name:, disavowal_token:)
+  # remove disavowal_token after next deploy
+  def account_verified(date_time:, sp_name:, disavowal_token: nil)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
     with_user_locale(user) do
       @date = I18n.l(date_time, format: :event_date)
       @sp_name = sp_name
-      @disavowal_token = disavowal_token
       mail(
         to: email_address.email,
         subject: t('user_mailer.account_verified.subject', sp_name: @sp_name),

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -241,7 +241,7 @@ class UserMailer < ActionMailer::Base
   end
 
   # remove disavowal_token after next deploy
-  def account_verified(date_time:, sp_name:, disavowal_token: nil)
+  def account_verified(date_time:, sp_name:, disavowal_token: nil) # rubocop:disable Lint/UnusedMethodArgument
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
     with_user_locale(user) do

--- a/app/services/user_alerts/alert_user_about_account_verified.rb
+++ b/app/services/user_alerts/alert_user_about_account_verified.rb
@@ -1,12 +1,11 @@
 module UserAlerts
   class AlertUserAboutAccountVerified
-    def self.call(user:, date_time:, sp_name:, disavowal_token:)
+    def self.call(user:, date_time:, sp_name:)
       sp_name ||= APP_NAME
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.with(user: user, email_address: email_address).account_verified(
           date_time: date_time,
           sp_name: sp_name,
-          disavowal_token: disavowal_token,
         ).deliver_now_or_later
       end
     end

--- a/app/views/user_mailer/account_verified.html.erb
+++ b/app/views/user_mailer/account_verified.html.erb
@@ -4,9 +4,9 @@
         sp_name: @sp_name,
         app_name: APP_NAME,
         date: @date,
-        disavowal_link: link_to(
-          t('user_mailer.account_verified.disavowal_link'),
-          event_disavowal_url(disavowal_token: @disavowal_token),
+        change_password_link: link_to(
+          t('user_mailer.account_verified.change_password_link'),
+          new_user_password_url,
         ),
         contact_link: link_to(t('user_mailer.account_verified.contact_link'), MarketingSite.contact_url),
       ) %>

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -38,11 +38,11 @@ en:
         account will not be deleted until you confirm.'
       subject: How to delete your %{app_name} account
     account_verified:
+      change_password_link: change your password
       contact_link: contact us
-      disavowal_link: change your password
       intro_html: You successfully verified your identity with %{sp_name} on %{date}
         using %{app_name}. If you did not perform this action, please
-        %{contact_link} and sign in to %{disavowal_link}.
+        %{contact_link} and sign in to %{change_password_link}.
       subject: You verified your identity with %{sp_name}.
     add_email:
       footer: This link will expire in %{confirmation_period}.

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -41,11 +41,11 @@ es:
         eliminará hasta que confirme.'
       subject: Cómo eliminar su cuenta de %{app_name}
     account_verified:
+      change_password_link: cambiar tu contraseña
       contact_link: contacto con nosotros
-      disavowal_link: cambiar tu contraseña
       intro_html: Verificaste correctamente tu identidad con %{sp_name} el %{date} a
         través de %{app_name}. Si no realizaste esta acción, ponte en
-        %{contact_link} e inicia sesión para %{disavowal_link}.
+        %{contact_link} e inicia sesión para %{change_password_link}.
       subject: Verificaste tu identidad con %{sp_name}
     add_email:
       footer: Este enlace expira en %{confirmation_period}.

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -40,12 +40,12 @@ fr:
         compte ne sera pas supprimé tant que vous ne l’aurez pas confirmé.'
       subject: Comment supprimer votre compte %{app_name}
     account_verified:
+      change_password_link: changer votre mot de passe
       contact_link: nous contacter
-      disavowal_link: changer votre mot de passe
       intro_html: Vous avez vérifié avec succès votre identité auprès de %{sp_name} le
         %{date} en utilisant %{app_name}. Si vous n’avez pas effectué cette
         action, veuillez %{contact_link} et vous connecter pour
-        %{disavowal_link}.
+        %{change_password_link}.
       subject: Vous avez vérifié votre identité avec %{sp_name}
     add_email:
       footer: Ce lien expirera dans %{confirmation_period}.

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -32,7 +32,7 @@ namespace :users do
 
         if profile.active?
           event, _disavowal_token = UserEventCreator.new(current_user: user).
-            create_out_of_band_user_event_with_disavowal(:account_verified)
+            create_out_of_band_user_event(:account_verified)
 
           UserAlerts::AlertUserAboutAccountVerified.call(
             user: user,

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -31,8 +31,8 @@ namespace :users do
         profile.activate_after_passing_review
 
         if profile.active?
-          event, _disavowal_token = UserEventCreator.new(current_user: user).
-            create_out_of_band_user_event_with_disavowal(:account_verified)
+          event = UserEventCreator.new(current_user: user).
+            create_out_of_band_user_event(:account_verified)
 
           UserAlerts::AlertUserAboutAccountVerified.call(
             user: user,

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -31,14 +31,13 @@ namespace :users do
         profile.activate_after_passing_review
 
         if profile.active?
-          event, disavowal_token = UserEventCreator.new(current_user: user).
+          event, _disavowal_token = UserEventCreator.new(current_user: user).
             create_out_of_band_user_event_with_disavowal(:account_verified)
 
           UserAlerts::AlertUserAboutAccountVerified.call(
             user: user,
             date_time: event.created_at,
             sp_name: nil,
-            disavowal_token: disavowal_token,
           )
 
           STDOUT.puts "User's profile has been activated and the user has been emailed."

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -31,8 +31,8 @@ namespace :users do
         profile.activate_after_passing_review
 
         if profile.active?
-          event = UserEventCreator.new(current_user: user).
-            create_out_of_band_user_event(:account_verified)
+          event, _disavowal_token = UserEventCreator.new(current_user: user).
+            create_out_of_band_user_event_with_disavowal(:account_verified)
 
           UserAlerts::AlertUserAboutAccountVerified.call(
             user: user,

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe Idv::GpoVerifyController do
 
         action
 
-        disavowal_event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
-          where.not(disavowal_token_fingerprint: nil).count
-        expect(disavowal_event_count).to eq 1
+        event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
+          where(disavowal_token_fingerprint: nil).count
+        expect(event_count).to eq 1
         expect(response).to redirect_to(idv_personal_key_url)
       end
 
@@ -194,9 +194,9 @@ RSpec.describe Idv::GpoVerifyController do
 
             action
 
-            disavowal_event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
-              where.not(disavowal_token_fingerprint: nil).count
-            expect(disavowal_event_count).to eq 1
+            event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
+              where(disavowal_token_fingerprint: nil).count
+            expect(event_count).to eq 1
             expect(response).to redirect_to(idv_personal_key_url)
           end
         end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -328,9 +328,9 @@ describe Idv::ReviewController do
 
         it 'creates an `account_verified` event once per confirmation' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          disavowal_event_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
-            where.not(disavowal_token_fingerprint: nil).count
-          expect(disavowal_event_count).to eq 1
+          events_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0').
+            where(disavowal_token_fingerprint: nil).count
+          expect(events_count).to eq 1
         end
 
         context 'with in person profile' do

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -37,7 +37,6 @@ describe 'review_profile' do
         expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).with(
           user: user,
           date_time: Time.zone.now,
-          disavowal_token: kind_of(String),
           sp_name: nil,
         )
         invoke_task

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -554,6 +554,10 @@ describe UserMailer, type: :mailer do
         )
       expect(mail.to).to eq(nil)
     end
+
+    it 'links to the forgot password page' do
+      expect(mail.html_part.body).to have_selector("a[href='#{new_user_password_url}']")
+    end
   end
 
   describe '#in_person_ready_to_verify' do

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe UserAlerts::AlertUserAboutAccountVerified do
   describe '#call' do
     let(:user) { create(:user, :signed_up) }
-    let(:disavowal_token) { 'the_disavowal_token' }
     let(:device) { create(:device, user: user) }
     let(:date_time) { Time.zone.now }
 
@@ -16,24 +15,20 @@ describe UserAlerts::AlertUserAboutAccountVerified do
         user: user,
         date_time: date_time,
         sp_name: '',
-        disavowal_token: disavowal_token,
       )
 
       expect_delivered_email_count(3)
       expect_delivered_email(
         to: [confirmed_email_addresses[0].email],
         subject: t('user_mailer.account_verified.subject', sp_name: ''),
-        body: [disavowal_token],
       )
       expect_delivered_email(
         to: [confirmed_email_addresses[1].email],
         subject: t('user_mailer.account_verified.subject', sp_name: ''),
-        body: [disavowal_token],
       )
       expect_delivered_email(
         to: [confirmed_email_addresses[2].email],
         subject: t('user_mailer.account_verified.subject', sp_name: ''),
-        body: [disavowal_token],
       )
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9285](https://cm-jira.usa.gov/browse/LG-9285)

## 🛠 Summary of changes

Updates the link destination for "change your password" to be the "Forgot password" page instead of event disavowal

## 📜 Testing Plan

- [ ] Verify an identity
- [ ] Check the email after, the link should go to "forgot password" page

## 👀 Screenshots

| before | after |
| --- | --- |
|  <img width="918" alt="Screen Shot 2023-03-31 at 10 41 42 AM" src="https://user-images.githubusercontent.com/458784/229192338-531449ec-97fd-430e-b47a-c00f513661a0.png"> | <img width="911" alt="Screen Shot 2023-03-31 at 10 41 30 AM" src="https://user-images.githubusercontent.com/458784/229192373-210b190f-8495-4866-bed9-1c6d9391b9e8.png"> |


