### PR TITLE
Friday test hacking/fix phone rate limiting test

### DIFF
--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -108,30 +108,27 @@ feature 'Sign Up' do
     expect(page).to have_content(I18n.t('telephony.error.friendly_message.generic'))
   end
 
-  scenario 'rate limits sign-up phone confirmation attempts' do
+  scenario 'rate limits sign-up phone confirmation attempts', js: true do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(999)
 
     sign_up_and_set_password
 
-    freeze_time do
-      (IdentityConfig.store.phone_confirmation_max_attempts + 1).times do
-        visit phone_setup_path
-        fill_in 'new_phone_form_phone', with: '2025551313'
-        click_send_one_time_code
-      end
-
-      timeout = distance_of_time_in_words(
-        Throttle.attempt_window_in_minutes(:phone_confirmation).minutes,
-      )
-
-      expect(current_path).to eq(authentication_methods_setup_path)
-      expect(page).to have_content(
-        I18n.t(
-          'errors.messages.phone_confirmation_throttled',
-          timeout: timeout,
-        ),
-      )
+    (IdentityConfig.store.phone_confirmation_max_attempts + 1).times do
+      visit phone_setup_path
+      fill_in 'new_phone_form_phone', with: '2025551313'
+      click_send_one_time_code
     end
+
+    # whether it says '9 minutes' or '10 minutes' depends on how
+    # slowly the test runs
+    throttled_message = I18n.t(
+      'errors.messages.phone_confirmation_throttled',
+      timeout: '10|9',
+    )
+
+    expect(current_path).to eq(authentication_methods_setup_path)
+
+    expect(page).to have_content(/#{throttled_message}/)
   end
 
   context 'with js', js: true do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -123,7 +123,7 @@ feature 'Sign Up' do
     # slowly the test runs
     throttled_message = I18n.t(
       'errors.messages.phone_confirmation_throttled',
-      timeout: '10|9',
+      timeout: '(10|9) minutes',
     )
 
     expect(current_path).to eq(authentication_methods_setup_path)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -108,7 +108,7 @@ feature 'Sign Up' do
     expect(page).to have_content(I18n.t('telephony.error.friendly_message.generic'))
   end
 
-  scenario 'rate limits sign-up phone confirmation attempts', js: true do
+  scenario 'rate limits sign-up phone confirmation attempts' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(999)
 
     sign_up_and_set_password

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -120,7 +120,7 @@ feature 'Sign Up' do
     end
 
     # whether it says '9 minutes' or '10 minutes' depends on how
-    # slowly the test runs
+    # slowly the test runs.
     throttled_message = I18n.t(
       'errors.messages.phone_confirmation_throttled',
       timeout: '(10|9) minutes',

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -167,6 +167,7 @@ describe 'layouts/application.html.erb' do
     it 'it render the new relic javascript' do
       allow(IdentityConfig.store).to receive(:newrelic_browser_key).and_return('foo')
       allow(IdentityConfig.store).to receive(:newrelic_browser_app_id).and_return('foo')
+      allow(BrowserSupport).to receive(:supported?).and_return(true)
 
       render
 


### PR DESCRIPTION
## 🛠 Summary of changes

The spec `spec/features/users/sign_up_spec.rb:111`, "rate limits sign-up phone confirmation attempts" was occasionally failing, because a countdown timer that should show up as '10 minutes' was occasionally showing up as ' 9 minutes'.  Investigation showed a previous attempt to fix this using `freeze_time`. This didn't work because the timer is being decremented on the client side, in JavaScript.

We corrected this by removing the call to `freeze_time` and changing the test to accept either 10 or 9.

Participants
john.maxwell@gsa.gov
sonia.connolly@gsa.gov
john.skinner@gsa.gov
alex.bradley@gsa.gov
douglas.price@gsa.gov