### PR TITLE
Add safeguards to early session timeout poll

### DIFF
--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -48,9 +48,6 @@ function handleTimeout(redirectURL: string) {
 }
 
 function success(data: SessionStatus) {
-  let timeRemaining = new Date(data.timeout).valueOf() - Date.now();
-  const showWarning = timeRemaining < warning;
-
   if (!data.isLive) {
     if (timeoutUrl) {
       handleTimeout(timeoutUrl);
@@ -58,6 +55,8 @@ function success(data: SessionStatus) {
     return;
   }
 
+  const timeRemaining = new Date(data.timeout).valueOf() - Date.now();
+  const showWarning = timeRemaining < warning;
   if (showWarning) {
     modal.show();
     countdownEls.forEach((countdownEl) => {
@@ -66,8 +65,7 @@ function success(data: SessionStatus) {
     });
   }
 
-  if (timeRemaining < frequency) {
-    timeRemaining = timeRemaining < 0 ? 0 : timeRemaining;
+  if (timeRemaining > 0 && timeRemaining < frequency) {
     // Disable reason: circular dependency between ping and success
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     setTimeout(ping, timeRemaining);


### PR DESCRIPTION
## 🛠 Summary of changes

Updates logic for session timeout polling to limit the instances where the next timeout polling would occur early.

When the user's session is about to time out, we schedule a polling request which would occur at the time that the session will time out. However, based on the logic, this could be prone to issues where the computed `timeRemaining` is not in the expected timeframe of 0-30 seconds, which could potentially cause an infinite loop of requests. The changes here ensure that the early timeout is only scheduled in the expected case that the session will expire within the next 0-30 seconds. In the worst case, there is still the request which would happen at [the default 30 second interval](https://github.com/18F/identity-idp/blob/5f586ce02898b469cb7c21c69f8b5d079d186f49/app/javascript/packs/session-timeout-ping.ts#L80).

Related Slack thread: https://gsa-tts.slack.com/archives/C42TZ3K5H/p1680360986593379

Maybe related to changes in #8084 (`timeRemaining` changing from server-specified to client-computed).

## 📜 Testing Plan

The specific circumstances to reproduce the original issue aren't well-understood. However, you should test to confirm that the expected behavior of being redirected upon the countdown reaching 0 should continue to work.