### PR TITLE
Improve performance of 2FA verification

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -171,14 +171,7 @@ module TwoFactorAuthenticatableMethods
   end
 
   def update_invalid_user
-    current_user.second_factor_attempts_count += 1
-    attributes = {}
-    attributes[:second_factor_locked_at] = Time.zone.now if current_user.max_login_attempts?
-
-    UpdateUser.new(
-      user: current_user,
-      attributes: attributes,
-    ).call
+    current_user.increment_second_factor_attempts_count!
   end
 
   def handle_valid_otp_for_confirmation_context

--- a/app/forms/idv/phone_confirmation_otp_verification_form.rb
+++ b/app/forms/idv/phone_confirmation_otp_verification_form.rb
@@ -31,14 +31,11 @@ module Idv
     end
 
     def increment_second_factor_attempts
-      user.second_factor_attempts_count += 1
-      attributes = {}
+      user.increment_second_factor_attempts_count!
+
       if user.max_login_attempts?
-        attributes[:second_factor_locked_at] = Time.zone.now
         irs_attempts_api_tracker.idv_phone_otp_submitted_rate_limited(phone_number: user_phone)
       end
-
-      UpdateUser.new(user: user, attributes: attributes).call
     end
 
     def user_phone

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,15 +158,18 @@ class User < ApplicationRecord
 
   def increment_second_factor_attempts_count!
     User.transaction do
-      sql = <<-SQL
-      UPDATE users
-      SET second_factor_attempts_count = COALESCE(second_factor_attempts_count, 0) + 1,
-      updated_at = NOW(),
-      second_factor_locked_at = CASE
-        WHEN COALESCE(second_factor_attempts_count, 0) + 1 >= ?
-        THEN NOW()
-        ELSE NULL
-        END WHERE id = ? RETURNING second_factor_attempts_count, second_factor_locked_at;
+      sql = <<~SQL
+        UPDATE users
+        SET
+          second_factor_attempts_count = COALESCE(second_factor_attempts_count, 0) + 1,
+          updated_at = NOW(),
+          second_factor_locked_at = CASE
+            WHEN COALESCE(second_factor_attempts_count, 0) + 1 >= ?
+            THEN NOW()
+            ELSE NULL
+            END
+        WHERE id = ?
+        RETURNING second_factor_attempts_count, second_factor_locked_at;
       SQL
       query = User.sanitize_sql_array(
         [sql,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,9 +172,9 @@ class User < ApplicationRecord
         [sql,
          IdentityConfig.store.login_otp_confirmation_max_attempts, self.id],
       )
-      result = User.connection.execute(query)
-      self.second_factor_attempts_count = result.first.fetch('second_factor_attempts_count')
-      self.second_factor_locked_at = result.first.fetch('second_factor_locked_at')
+      result = User.connection.execute(query).first
+      self.second_factor_attempts_count = result.fetch('second_factor_attempts_count')
+      self.second_factor_locked_at = result.fetch('second_factor_locked_at')
       self.clear_attribute_changes([:second_factor_attempts_count, :second_factor_locked_at])
     end
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::OtpVerificationController do
-  let(:user) { build(:user) }
+  let(:user) { create(:user) }
 
   let(:phone) { '2255555000' }
   let(:user_phone_confirmation) { false }

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -78,7 +78,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
       let(:payload) { { backup_code_verification_form: backup_code } }
 
       before do
-        stub_sign_in_before_2fa(build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
+        stub_sign_in_before_2fa(create(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
         form = instance_double(BackupCodeVerificationForm)
         response = FormResponse.new(
           success: false, errors: {}, extra: { multi_factor_auth_method: 'backup_code' },
@@ -100,8 +100,8 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
 
     context 'when the user enters an invalid backup code' do
       render_views
+      let(:user) { create(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }) }
       before do
-        user = build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' })
         stub_sign_in_before_2fa(user)
         form = BackupCodeVerificationForm.new(user)
         response = FormResponse.new(
@@ -123,7 +123,9 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
       end
 
       it 'tracks the max attempts event' do
-        allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
+        user.second_factor_attempts_count =
+          IdentityConfig.store.login_otp_confirmation_max_attempts - 1
+        user.save
         properties = {
           success: false,
           errors: {},

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -177,7 +177,9 @@ describe TwoFactorAuthentication::PivCacVerificationController do
       render_views
 
       it 'tracks the event' do
-        allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
+        user.second_factor_attempts_count =
+          IdentityConfig.store.login_otp_confirmation_max_attempts - 1
+        user.save
         stub_sign_in_before_2fa(user)
 
         stub_analytics

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -78,9 +78,13 @@ describe TwoFactorAuthentication::TotpVerificationController do
 
     context 'when the user has reached the max number of TOTP attempts' do
       it 'tracks the event' do
-        allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
-        sign_in_before_2fa
-        user = subject.current_user
+        user = create(
+          :user,
+          :signed_up,
+          second_factor_attempts_count:
+            IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
+        )
+        sign_in_before_2fa(user)
         @secret = user.generate_totp_secret
         Db::AuthAppConfiguration.create(user, @secret, nil, 'foo')
 

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -28,9 +28,12 @@ feature 'Signing in via one-time use personal key' do
 
   context 'user enters incorrect personal key' do
     it 'locks user out when max login attempts has been reached' do
-      user = create(:user, :signed_up)
+      user = create(
+        :user,
+        :signed_up,
+        second_factor_attempts_count: IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
+      )
       sign_in_before_2fa(user)
-      allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
       personal_key = PersonalKeyGenerator.new(user).create
       wrong_personal_key = personal_key.split('-').reverse.join
 


### PR DESCRIPTION
## 🛠 Summary of changes

To improve the reliability and performance of 2FA code verification attempts, this PR moves the `second_factor_attempts_count` incrementing and locking into a single transaction rather than potentially doing multiple transactions.



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
