### PR TITLE
Use ActiveSupport cache version 7.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,8 +54,6 @@ module Identity
     end
 
     config.load_defaults '7.0'
-    # Delete after deploying once
-    config.active_support.cache_format_version = 6.1
     config.active_record.belongs_to_required_by_default = false
     config.active_record.legacy_connection_handling = false
     config.assets.unknown_asset_fallback = true


### PR DESCRIPTION
## 🛠 Summary of changes

This could have been removed quite a bit ago.
https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format

>However Rails 6.1 applications are not able to read this new serialization format, so to ensure a seamless upgrade you must first deploy your Rails 7.0 upgrade with `config.active_support.cache_format_version = 6.1`, and then only once all Rails processes have been updated you can set `config.active_support.cache_format_version = 7.0`.

We don't need to explicitly set `7.0` though since it is the default.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
