### PR TITLE
LG-9131 Remove DocumentCaptureController 404 before action

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -6,7 +6,6 @@ module Idv
     include StepUtilitiesConcern
     include DocumentCaptureConcern
 
-    before_action :render_404_if_document_capture_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_upload_step_complete
     before_action :confirm_document_capture_needed
@@ -58,10 +57,6 @@ module Idv
     end
 
     private
-
-    def render_404_if_document_capture_controller_disabled
-      render_not_found unless IdentityConfig.store.doc_auth_document_capture_controller_enabled
-    end
 
     def confirm_upload_step_complete
       return if flow_session['Idv::Steps::UploadStep']

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -28,13 +28,6 @@ describe Idv::DocumentCaptureController do
   end
 
   describe 'before_actions' do
-    it 'checks that feature flag is enabled' do
-      expect(subject).to have_actions(
-        :before,
-        :render_404_if_document_capture_controller_disabled,
-      )
-    end
-
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
         :before,
@@ -152,19 +145,6 @@ describe Idv::DocumentCaptureController do
           change { doc_auth_log.reload.document_capture_submit_count }.from(0).to(1),
         )
       end
-    end
-  end
-
-  context 'when doc_auth_document_capture_controller_enabled is false' do
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_document_capture_controller_enabled).
-        and_return(false)
-    end
-
-    it 'returns 404' do
-      get :show
-
-      expect(response.status).to eq(404)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-9131](https://cm-jira.usa.gov/browse/LG-9131)

## 🛠 Summary of changes

Remove 404 action that guards DocumentCaptureController against being used when the feature flag is off.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
