### PR TITLE
LG-9237: Send USPS the state instead of jurisdiction from state ID

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -98,7 +98,7 @@ module UspsInPersonProofing
         state_id_address1: :address1,
         state_id_address2: :address2,
         state_id_city: :city,
-        state_id_jurisdiction: :state,
+        state_id_state: :state,
         state_id_zipcode: :zipcode,
       }.freeze
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
                   }",
                   city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_city],
                   state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                    :state_id_jurisdiction
+                    :state_id_state
                   ],
                   zip_code: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_zipcode],
                 )


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9237](https://cm-jira.usa.gov/browse/LG-9237)

Also see [LG-8932](https://cm-jira.usa.gov/browse/LG-8932)

## 🛠 Summary of changes

Send USPS the state from the state ID's address, instead of the state ID's state of jurisdiction (aka issuing state).

#8121 must be merged before or with this PR.

Also see #8124 for related changes.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enable feature flag `in_person_capture_secondary_id_enabled`
- [ ] (Local dev only) Add code to log the state to `app/services/usps_in_person_proofing/enrollment_helper.rb`
- [ ] Complete in in-person proofing process up to the state ID form
- [ ] Complete state ID form using a different issuing state from the address on the ID
- [ ] Complete the remainder of the in-person proofing process
- [ ] Verify with USPS that they received the state ID address, not the issuing state
  - [ ] (Local dev only) Instead check logs to ensure state was sent in call to proofer