### PR TITLE
Use Rack::Session methods when calling redis-session-store

### DIFF
--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -72,8 +72,7 @@ class OutOfBandSessionAccessor
   # @return [Hash]
   def session_data
     @session_data ||= session_store.send(
-      :find_session, {},
-      Rack::Session::SessionId.new(session_uuid)
+      :find_session, {}, Rack::Session::SessionId.new(session_uuid),
     ).last || {}
   end
 

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -72,7 +72,7 @@ class OutOfBandSessionAccessor
   # @return [Hash]
   def session_data
     @session_data ||= session_store.send(
-      :find_session, {}, Rack::Session::SessionId.new(session_uuid),
+      :find_session, {}, Rack::Session::SessionId.new(session_uuid)
     ).last || {}
   end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -9,6 +9,9 @@ Rails.application.config.session_store(
     # cookie expires with browser close
     expire_after: nil,
 
+    write_fallback: true,
+    read_fallback: true,
+
     # Redis expires session after N minutes
     ttl: IdentityConfig.store.session_timeout_in_minutes.minutes,
 

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -7,7 +7,13 @@ RSpec.describe AccessTokenVerifier do
   subject(:verifier) { AccessTokenVerifier.new(http_authorization_header) }
   let(:http_authorization_header) { "Bearer #{access_token}" }
 
-  let(:identity) { build(:service_provider_identity, access_token: SecureRandom.urlsafe_base64) }
+  let(:identity) do
+    build(
+      :service_provider_identity,
+      rails_session_id: '123',
+      access_token: SecureRandom.urlsafe_base64,
+    )
+  end
 
   describe '#submit' do
     let(:result) { verifier.submit }

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe IdTokenBuilder do
       nonce: SecureRandom.hex,
       uuid: SecureRandom.uuid,
       ial: 2,
+      rails_session_id: '123',
       # this is a known value from an example developer guide
       # https://www.pingidentity.com/content/developer/en/resources/openid-connect-developers-guide.html
       access_token: 'dNZX1hEZ9wBCzNL40Upu646bdzQA',


### PR DESCRIPTION
## 🛠 Summary of changes


Rack::Session has a [defined interface](https://github.com/rack/rack/blob/v2.2.6.4/lib/rack/session/abstract/id.rb#L433-L450), but we use some of the internal `redis-session-store` methods. I'm working on a bit of an internal refactor of our [redis-session-store fork](https://github.com/18F/redis-session-store) and this PR is a precursor to realizing some of those changes.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
