### PR TITLE
Do not prompt for re-authentication on backup code refresh prompt

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -11,7 +11,7 @@ module Users
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
     before_action :authorize_backup_code_disable, only: [:delete]
-    before_action :confirm_recently_authenticated_2fa, if: -> do
+    before_action :confirm_recently_authenticated_2fa, except: [:reminder], if: -> do
       IdentityConfig.store.reauthentication_for_second_factor_management_enabled
     end
 

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -8,7 +8,7 @@ describe Users::BackupCodeSetupController do
         :authenticate_user!,
         :confirm_user_authenticated_for_2fa_setup,
         :apply_secure_headers_override,
-        :confirm_recently_authenticated_2fa,
+        [:confirm_recently_authenticated_2fa, except: ['reminder']],
       )
     end
   end

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -71,9 +71,7 @@ def parsed_only_action(action)
 end
 
 def parsed_except_action(action)
-  except_option = unless_option_for(action)[0]
-
-  "#{except_option.class}OptionParser".constantize.new(except_option).parse
+  unless_option_for(action)[0].instance_variable_get(:@actions).to_a
 end
 
 class ProcOptionParser


### PR DESCRIPTION
## 🛠 Summary of changes

This page is currently protected by re-authentication, which we don't want:

![image](https://user-images.githubusercontent.com/1430443/229936076-c56f8d94-befa-4e34-b1cd-27ed1f2da8e3.png)

This PR removes the re-authentication check from that action.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
