### PR TITLE
LG-9272: Record in-person enrollment status check completion time

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -117,6 +117,8 @@ class GetUspsProofingResultsJob < ApplicationJob
       enrollment_code: enrollment.enrollment_code,
       enrollment_id: enrollment.id,
       minutes_since_last_status_check: enrollment.minutes_since_last_status_check,
+      minutes_since_last_status_check_completed:
+        enrollment.minutes_since_last_status_check_completed,
       minutes_since_last_status_update: enrollment.minutes_since_last_status_update,
       minutes_since_established: enrollment.minutes_since_established,
       minutes_to_completion: complete ? enrollment.minutes_since_established : nil,

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -159,6 +159,7 @@ class GetUspsProofingResultsJob < ApplicationJob
           **enrollment_analytics_attributes(enrollment, complete: false),
           response_message: response_message,
         )
+      enrollment.update(status_check_completed_at: Time.zone.now)
     elsif response_message&.match(IPP_EXPIRED_ERROR_MESSAGE)
       handle_expired_status_update(enrollment, err.response, response_message)
     elsif response_message == IPP_INVALID_ENROLLMENT_CODE_MESSAGE % enrollment.enrollment_code
@@ -250,7 +251,11 @@ class GetUspsProofingResultsJob < ApplicationJob
       primary_id_type: response['primaryIdType'],
       reason: 'Unsupported ID type',
     )
-    enrollment.update(status: :failed, proofed_at: proofed_at)
+    enrollment.update(
+      status: :failed,
+      proofed_at: proofed_at,
+      status_check_completed_at: Time.zone.now,
+    )
 
     send_failed_email(enrollment.user, enrollment)
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
@@ -267,7 +272,10 @@ class GetUspsProofingResultsJob < ApplicationJob
       passed: false,
       reason: 'Enrollment has expired',
     )
-    enrollment.update(status: :expired)
+    enrollment.update(
+      status: :expired,
+      status_check_completed_at: Time.zone.now,
+    )
 
     begin
       send_deadline_passed_email(enrollment.user, enrollment) unless enrollment.deadline_passed_sent
@@ -323,7 +331,11 @@ class GetUspsProofingResultsJob < ApplicationJob
       reason: 'Failed status',
     )
 
-    enrollment.update(status: :failed, proofed_at: proofed_at)
+    enrollment.update(
+      status: :failed,
+      proofed_at: proofed_at,
+      status_check_completed_at: Time.zone.now,
+    )
     if response['fraudSuspected']
       send_failed_fraud_email(enrollment.user, enrollment)
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
@@ -349,7 +361,11 @@ class GetUspsProofingResultsJob < ApplicationJob
       reason: 'Successful status update',
     )
     enrollment.profile.activate
-    enrollment.update(status: :passed, proofed_at: proofed_at)
+    enrollment.update(
+      status: :passed,
+      proofed_at: proofed_at,
+      status_check_completed_at: Time.zone.now,
+    )
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
       **email_analytics_attributes(enrollment),
       email_type: 'Success',

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -73,6 +73,11 @@ class InPersonEnrollment < ApplicationRecord
     (Time.zone.now - status_check_attempted_at).seconds.in_minutes.round(2)
   end
 
+  def minutes_since_last_status_check_completed
+    return unless status_check_completed_at.present?
+    (Time.zone.now - status_check_completed_at).seconds.in_minutes.round(2)
+  end
+
   def minutes_since_last_status_update
     return unless status_updated_at.present?
     (Time.zone.now - status_updated_at).seconds.in_minutes.round(2)

--- a/db/primary_migrate/20230403232935_add_status_check_completed_at_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20230403232935_add_status_check_completed_at_to_in_person_enrollments.rb
@@ -1,0 +1,6 @@
+class AddStatusCheckCompletedAtToInPersonEnrollments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :in_person_enrollments, :status_check_completed_at, :datetime,
+               comment: 'The last time a status check was successfully completed'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_22_000756) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_232935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -310,6 +310,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_22_000756) do
     t.boolean "deadline_passed_sent", default: false, comment: "deadline passed email sent for expired enrollment"
     t.datetime "proofed_at", precision: nil, comment: "timestamp when user attempted to proof at a Post Office"
     t.boolean "capture_secondary_id_enabled", default: false, comment: "record and proof state ID and residential addresses separately"
+    t.datetime "status_check_completed_at", comment: "The last time a status check was successfully completed"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"
     t.index ["unique_id"], name: "index_in_person_enrollments_on_unique_id", unique: true

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
       pending_enrollment.update(
         enrollment_established_at: Time.zone.now - 3.days,
         status_check_attempted_at: Time.zone.now - 15.minutes,
+        status_check_completed_at: Time.zone.now - 17.minutes,
         status_updated_at: Time.zone.now - 2.days,
       )
 
@@ -21,6 +22,7 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
         fraud_suspected: response['fraudSuspected'],
         issuer: pending_enrollment.issuer,
         minutes_since_last_status_check: 15.0,
+        minutes_since_last_status_check_completed: 17.0,
         minutes_since_last_status_update: 2.days.in_minutes,
         minutes_to_completion: 3.days.in_minutes,
         minutes_since_established: 3.days.in_minutes,

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -74,6 +74,7 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:, status:, re
       pending_enrollment.reload
       expect(pending_enrollment.status_updated_at).to eq(Time.zone.now)
       expect(pending_enrollment.status_check_attempted_at).to eq(Time.zone.now)
+      expect(pending_enrollment.status_check_completed_at).to eq(Time.zone.now)
       expect(pending_enrollment.status).to eq(status)
       expect(pending_enrollment.profile.active).to eq(passed)
     end
@@ -118,6 +119,20 @@ RSpec.shared_examples 'enrollment_encountering_an_exception' do |exception_class
       expect(pending_enrollment.status_check_attempted_at).to eq(Time.zone.now)
     end
   end
+
+  it 'does not update the status_check_completed_at timestamp' do
+    freeze_time do
+      pending_enrollment.update(
+        status_check_attempted_at: Time.zone.now - 1.day,
+        status_updated_at: Time.zone.now - 2.days,
+      )
+      job.perform(Time.zone.now)
+
+      pending_enrollment.reload
+      expect(pending_enrollment.status_updated_at).to eq(Time.zone.now - 2.days)
+      expect(pending_enrollment.status_check_completed_at).to be_nil
+    end
+  end
 end
 
 RSpec.shared_examples 'enrollment_encountering_an_error_that_has_a_nil_response' do |error_type:|
@@ -133,6 +148,14 @@ RSpec.shared_examples 'enrollment_encountering_an_error_that_has_a_nil_response'
         exception_class: error_type.to_s,
       ),
     )
+  end
+
+  it 'does not update the status_check_completed_at timestamp' do
+    freeze_time do
+      job.perform(Time.zone.now)
+      pending_enrollment.reload
+      expect(pending_enrollment.status_check_completed_at).to be_nil
+    end
   end
 end
 
@@ -229,7 +252,12 @@ RSpec.describe GetUspsProofingResultsJob do
 
         expect(pending_enrollments.pluck(:status_check_attempted_at)).to(
           all(eq nil),
-          'failed test precondition: pending enrollments must not have status check time set',
+          'failed test precondition: pending enrollments must not set status check attempted time',
+        )
+
+        expect(pending_enrollments.pluck(:status_check_completed_at)).to(
+          all(eq nil),
+          'failed test precondition: pending enrollments must not set status check completed time',
         )
 
         freeze_time do
@@ -241,7 +269,16 @@ RSpec.describe GetUspsProofingResultsJob do
               pluck(:status_check_attempted_at),
           ).to(
             all(eq Time.zone.now),
-            'job must update status check time for all pending enrollments',
+            'job must update status check attempted time for all pending enrollments',
+          )
+
+          expect(
+            pending_enrollments.
+              map(&:reload).
+              pluck(:status_check_completed_at),
+          ).to(
+            all(eq Time.zone.now),
+            'job must update status check completed time for all pending enrollments',
           )
         end
       end
@@ -887,6 +924,7 @@ RSpec.describe GetUspsProofingResultsJob do
             expect(pending_enrollment.enrollment_established_at).to eq(Time.zone.now - 3.days)
             expect(pending_enrollment.status_updated_at).to eq(Time.zone.now - 1.day)
             expect(pending_enrollment.status_check_attempted_at).to eq(Time.zone.now)
+            expect(pending_enrollment.status_check_completed_at).to eq(Time.zone.now)
           end
 
           expect(pending_enrollment.profile.active).to eq(false)

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -219,6 +219,24 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
   end
 
+  describe 'minutes_since_last_status_check_completed' do
+    let(:enrollment) do
+      create(
+        :in_person_enrollment, :passed, status_check_completed_at: Time.zone.now - 2.hours
+      )
+    end
+
+    it 'returns number of minutes since last status check was completed' do
+      expect(enrollment.minutes_since_last_status_check_completed).to be_within(0.01).of(120)
+    end
+
+    it 'returns nil if enrollment has not completed a status check' do
+      enrollment.status_check_completed_at = nil
+
+      expect(enrollment.minutes_since_last_status_check_completed).to eq(nil)
+    end
+  end
+
   describe 'minutes_since_status_updated' do
     let(:enrollment) do
       enrollment = create(:in_person_enrollment, :passed)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9272](https://cm-jira.usa.gov/browse/LG-9272)

## 🛠 Summary of changes

- Create DateTime database field `in_person_enrollments.status_check_completed_at`
- Create method `InPersonEnrollment.minutes_since_last_status_check_completed`
- Set `status_check_completed_at` after `GetUspsProofingResultsJob` checks the enrollment status successfully
  - Includes:
    - Specific 4xx Bad Request errors:
      - Enrollment incomplete
      - Enrollment expired
    - Unsupported ID type
    - Enrollment failed
    - Enrollment success
  - Excludes (except where mentioned above):
    - Unsupported status
    - Non-hash response
    - Standard error
    - Faraday error
    - Client error
    - Server error
    - Specific 4xx Bad Request errors:
      - Invalid enrollment code
      - Invalid applicant
- Log `minutes_since_last_status_check_completed` while running `GetUspsProofingResultsJob`

This is intended to be merged and deployed prior to other monitoring-related changes for this story.

## 📜 Testing Plan

- [ ] Complete the in-person enrollment process
  - USPS API or mock API must treat enrollment as valid
- [ ] Trigger/wait for USPS proofing results job to process the enrollment at least twice
  - May require more than two job executions depending on environment config
  - You can run the following to trigger the job:
    ```
    $ rails c
    Loading development environment (Rails 7.0.4.3)
    [1] pry(main)> GetUspsProofingResultsJob.perform_now(Time.zone.now)
    ```
- [ ] Wait a few minutes for the logs to propagate to CloudWatch
  - (Local dev only) Use the `logs/event.log` file instead of CloudWatch
- [ ] Verify that the logs for the first status check include do not have a time set for `minutes_since_last_status_check_completed` on the enrollment
- [ ] Verify that the logs from the second status check include `minutes_since_last_status_check_completed` that correctly indicates the first time the enrollment status check completed
- [ ] Update the enrollment record or USPS/mock API so that the API will respond with an error while attempting to check the enrollment record
- [ ]  Trigger/wait for USPS proofing results job twice and for logs to sync
- [ ] Verify that the logs from the most recent status check include `minutes_since_last_status_check_completed` that predates the two most enrollment status checks