### PR TITLE
LG-9238: Test that state id jurisdiction is sent to aamva

### DIFF
--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -103,6 +103,12 @@ describe Proofing::Aamva::Request::VerificationRequest do
 
         expect(result.success?).to eq(true)
       end
+
+      it 'sends state id jurisdiction to AAMVA' do
+        applicant.state_id_data.state_id_jurisdiction = 'NY'
+
+        expect(subject.body).to match(/MessageDestinationId>NY/)
+      end
     end
 
     # rubocop:disable Layout/LineLength

--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -106,8 +106,11 @@ describe Proofing::Aamva::Request::VerificationRequest do
 
       it 'sends state id jurisdiction to AAMVA' do
         applicant.state_id_data.state_id_jurisdiction = 'NY'
-
-        expect(subject.body).to match(/MessageDestinationId>NY/)
+        expect(
+          Nokogiri::XML(subject.body) do |config|
+            config.strict
+          end.text,
+        ).to match(/NY/)
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket
[[backend] set "issuing state" on AAMVA request](https://cm-jira.usa.gov/browse/LG-9238)
This probably didn't need to be a ticket, because we already set "issuing state" on the request to AAMVA.  I did add one test for this functionality.


## 🛠 Summary of changes
- Test that we set "issuing state" on the AAMVA request



## 📜 Testing Plan
- There are no user-facing or internal changes to test.  The one new test can be verified by running it in CI or on a local machine.

