### PR TITLE
Ignore unhandled HTTP Verb errors

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -25,6 +25,7 @@ production:
       ActionController::BadRequest
       ActionController::ParameterMissing
       ActionController::RoutingError
+      ActionController::UnknownHttpMethod
       ActionDispatch::Http::MimeNegotiation::InvalidType
       ActionDispatch::Http::Parameters::ParseError
       GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError


### PR DESCRIPTION
This error popped up twice in NewRelic for verbs like LINK, UNLINK, they're unhandled by Rails so there's not much we can do

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
