### PR TITLE
LG-9398 Add Fraud Review / Rejection Timestamp Columns

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -22,8 +22,8 @@ module Idv
       analytics.idv_personal_key_submitted(
         address_verification_method: address_verification_method,
         deactivation_reason: idv_session.profile&.deactivation_reason,
-        fraud_review_pending: idv_session.profile&.fraud_review_pending,
-        fraud_rejection: idv_session.profile&.fraud_rejection,
+        fraud_review_pending: idv_session.profile&.fraud_review_pending?,
+        fraud_rejection: idv_session.profile&.fraud_rejection?,
       )
       redirect_to next_step
     end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -53,16 +53,16 @@ module Idv
 
       analytics.idv_review_complete(
         success: true,
-        fraud_review_pending: idv_session.profile.fraud_review_pending,
-        fraud_rejection: idv_session.profile.fraud_rejection,
+        fraud_review_pending: idv_session.profile.fraud_review_pending?,
+        fraud_rejection: idv_session.profile.fraud_rejection?,
         deactivation_reason: idv_session.profile.deactivation_reason,
       )
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
         call(:verified, :view, true)
       analytics.idv_final(
         success: true,
-        fraud_review_pending: idv_session.profile.fraud_review_pending,
-        fraud_rejection: idv_session.profile.fraud_rejection,
+        fraud_review_pending: idv_session.profile.fraud_review_pending?,
+        fraud_rejection: idv_session.profile.fraud_rejection?,
         deactivation_reason: idv_session.profile.deactivation_reason,
       )
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -56,7 +56,10 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/SkipsModelValidations
 
   def activate_after_passing_review
-    update!(fraud_review_pending: false, fraud_rejection: false, fraud_review_pending_at: nil, fraud_rejection_at: nil)
+    update!(
+      fraud_review_pending: false, fraud_rejection: false, fraud_review_pending_at: nil,
+      fraud_rejection_at: nil
+    )
     track_fraud_review_adjudication(decision: 'pass')
     activate
   end
@@ -66,11 +69,17 @@ class Profile < ApplicationRecord
   end
 
   def deactivate_for_fraud_review
-    update!(active: false, fraud_review_pending: true, fraud_rejection: false, fraud_review_pending_at: Time.zone.now, fraud_rejection_at: nil)
+    update!(
+      active: false, fraud_review_pending: true, fraud_rejection: false,
+      fraud_review_pending_at: Time.zone.now, fraud_rejection_at: nil
+    )
   end
 
   def reject_for_fraud(notify_user:)
-    update!(active: false, fraud_review_pending: false, fraud_rejection: true, fraud_review_pending_at: nil, fraud_rejection_at: Time.zone.now)
+    update!(
+      active: false, fraud_review_pending: false, fraud_rejection: true,
+      fraud_review_pending_at: nil, fraud_rejection_at: Time.zone.now
+    )
     track_fraud_review_adjudication(
       decision: notify_user ? 'manual_reject' : 'automatic_reject',
     )

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -48,7 +48,7 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/SkipsModelValidations
 
   def activate_after_passing_review
-    update!(fraud_review_pending: false, fraud_rejection: false)
+    update!(fraud_review_pending: false, fraud_rejection: false, fraud_review_pending_at: nil, fraud_rejection_at: nil)
     track_fraud_review_adjudication(decision: 'pass')
     activate
   end
@@ -58,11 +58,11 @@ class Profile < ApplicationRecord
   end
 
   def deactivate_for_fraud_review
-    update!(active: false, fraud_review_pending: true, fraud_rejection: false)
+    update!(active: false, fraud_review_pending: true, fraud_rejection: false, fraud_review_pending_at: Time.zone.now, fraud_rejection_at: nil)
   end
 
   def reject_for_fraud(notify_user:)
-    update!(active: false, fraud_review_pending: false, fraud_rejection: true)
+    update!(active: false, fraud_review_pending: false, fraud_rejection: true, fraud_review_pending_at: nil, fraud_rejection_at: Time.zone.now)
     track_fraud_review_adjudication(
       decision: notify_user ? 'manual_reject' : 'automatic_reject',
     )

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -27,6 +27,14 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
+  def fraud_review_pending?
+    !!(fraud_review_pending || fraud_review_pending_at)
+  end
+
+  def fraud_rejection?
+    !!(fraud_rejection || fraud_rejection_at)
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def activate
     return if fraud_review_pending? || fraud_rejection?

--- a/db/primary_migrate/20230403201505_add_fraud_review_pending_at_to_profiles.rb
+++ b/db/primary_migrate/20230403201505_add_fraud_review_pending_at_to_profiles.rb
@@ -1,0 +1,8 @@
+class AddFraudReviewPendingAtToProfiles < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  
+  def change
+    add_column :profiles, :fraud_review_pending_at, :datetime
+    add_index :profiles, :fraud_review_pending_at, algorithm: :concurrently
+  end
+end

--- a/db/primary_migrate/20230403201954_add_fraud_rejection_at_to_profiles.rb
+++ b/db/primary_migrate/20230403201954_add_fraud_rejection_at_to_profiles.rb
@@ -1,0 +1,8 @@
+class AddFraudRejectionAtToProfiles < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  
+  def change
+    add_column :profiles, :fraud_rejection_at, :datetime
+    add_index :profiles, :fraud_rejection_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -446,7 +446,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_232935) do
     t.string "initiating_service_provider_issuer"
     t.boolean "fraud_review_pending", default: false
     t.boolean "fraud_rejection", default: false
+    t.datetime "fraud_review_pending_at"
+    t.datetime "fraud_rejection_at"
+    t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending"], name: "index_profiles_on_fraud_review_pending"
+    t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["reproof_at"], name: "index_profiles_on_reproof_at"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -78,6 +78,7 @@ describe 'review_profile' do
       invoke_task
       expect(user.reload.profiles.first.active).to eq(false)
       expect(user.reload.profiles.first.fraud_rejection).to eq(true)
+      expect(user.reload.profiles.first.fraud_rejection_at).to_not be_nil
     end
 
     it 'sends the user an email about their account deactivation' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -264,14 +264,13 @@ describe Profile do
     end
 
     it 'does not activate a profile if under fraud review' do
-      profile.update(fraud_review_pending: true)
+      profile.update(fraud_review_pending_at: Time.zone.today - 1.day)
       profile.activate
 
       expect(profile).to_not be_active
     end
 
     it 'does not activate a profile if rejected for fraud' do
-      profile.update(fraud_rejection: true)
       profile.update(fraud_rejection_at: Time.zone.now - 1.day)
       profile.activate
 
@@ -295,7 +294,7 @@ describe Profile do
 
   describe '#activate_after_passing_review' do
     it 'activates a profile if it passes fraud review' do
-      profile = create(:profile, user: user, active: false, fraud_review_pending: true)
+      profile = create(:profile, user: user, active: false, fraud_review_pending_at: Time.zone.today - 1.day)
       profile.activate_after_passing_review
 
       expect(profile).to be_active
@@ -308,7 +307,7 @@ describe Profile do
           :profile,
           user: user,
           active: false,
-          fraud_review_pending: true,
+          fraud_review_pending_at: Time.zone.today - 1.day,
           initiating_service_provider: sp,
         )
       end
@@ -354,7 +353,7 @@ describe Profile do
           :profile,
           user: user,
           active: false,
-          fraud_review_pending: true,
+          fraud_review_pending_at: Time.zone.today - 1.day,
           initiating_service_provider: sp,
         )
         expect(profile.initiating_service_provider.irs_attempts_api_enabled?).to be_falsey
@@ -374,6 +373,7 @@ describe Profile do
       expect(profile.fraud_review_pending).to eq(true)
       expect(profile.fraud_review_pending_at).to_not be_nil
       expect(profile.fraud_rejection).to eq(false)
+      expect(profile.fraud_rejection_at).to be_nil
     end
   end
 
@@ -391,7 +391,7 @@ describe Profile do
 
     context 'it notifies the user' do
       let(:profile) do
-        profile = create(:profile, user: user, fraud_review_pending: true)
+        profile = create(:profile, user: user, fraud_review_pending_at: Time.zone.today - 1.day)
         profile.reject_for_fraud(notify_user: true)
         profile
       end
@@ -411,7 +411,7 @@ describe Profile do
 
     context 'it does not notify the user' do
       let(:profile) do
-        profile = create(:profile, user: user, fraud_review_pending: true)
+        profile = create(:profile, user: user, fraud_review_pending_at: Time.zone.today - 1.day)
         profile.reject_for_fraud(notify_user: false)
         profile
       end
@@ -430,7 +430,7 @@ describe Profile do
           :profile,
           user: user,
           active: false,
-          fraud_review_pending: true,
+          fraud_review_pending_at: Time.zone.today - 1.day,
           initiating_service_provider: sp,
         )
       end
@@ -477,7 +477,7 @@ describe Profile do
           :profile,
           user: user,
           active: false,
-          fraud_review_pending: true,
+          fraud_review_pending_at: Time.zone.today - 1.day,
           initiating_service_provider: sp,
         )
         allow(IdentityConfig.store).to receive(:irs_attempt_api_enabled).and_return(true)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -294,7 +294,10 @@ describe Profile do
 
   describe '#activate_after_passing_review' do
     it 'activates a profile if it passes fraud review' do
-      profile = create(:profile, user: user, active: false, fraud_review_pending_at: Time.zone.today - 1.day)
+      profile = create(
+        :profile, user: user, active: false,
+                  fraud_review_pending_at: Time.zone.today - 1.day
+      )
       profile.activate_after_passing_review
 
       expect(profile).to be_active

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -371,6 +371,7 @@ describe Profile do
 
       expect(profile).to_not be_active
       expect(profile.fraud_review_pending).to eq(true)
+      expect(profile.fraud_review_pending_at).to_not be_nil
       expect(profile.fraud_rejection).to eq(false)
     end
   end
@@ -400,6 +401,10 @@ describe Profile do
 
       it 'sends an email' do
         expect { profile }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it 'sets the fraud_rejection_at timestamp' do
+        expect(profile.fraud_rejection_at).to_not be_nil
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -272,6 +272,7 @@ describe Profile do
 
     it 'does not activate a profile if rejected for fraud' do
       profile.update(fraud_rejection: true)
+      profile.update(fraud_rejection_at: Time.zone.now - 1.day)
       profile.activate
 
       expect(profile).to_not be_active


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9398](https://cm-jira.usa.gov/browse/LG-9398)


## 🛠 Summary of changes

We have added two timestamp columns to the `Profile` table:
* `fraud_review_pending_at`
* `fraud_rejection_at`
  
We have also updated the relevant helper methods on the model to use _both_ the older boolean fields (`fraud_review` and `fraud_rejection`) and these new ones. This is an interim phase, and [LG-9075](https://cm-jira.usa.gov/browse/LG-9075) describes the full story for the plan to backfill and remove the older columns.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
