### PR TITLE
Maintain request ID in password reset

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -35,7 +35,7 @@ module SignUp
     end
 
     def request_id
-      params.fetch(:_request_id)
+      params[:_request_id]
     end
   end
 end

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -5,6 +5,7 @@ module SignUp
     before_action :find_user_with_confirmation_token
     before_action :confirm_user_needs_sign_up_confirmation
     before_action :stop_if_invalid_token
+    before_action :store_sp_metadata_in_session, only: [:create]
 
     def create
       clear_setup_piv_cac_from_sign_in
@@ -26,10 +27,15 @@ module SignUp
         success: true,
         failure_reason: nil,
       )
-      request_id = params.fetch(:_request_id, '')
-      redirect_to sign_up_enter_password_url(
-        request_id: request_id, confirmation_token: @confirmation_token,
-      )
+      redirect_to sign_up_enter_password_url(confirmation_token: @confirmation_token)
+    end
+
+    def store_sp_metadata_in_session
+      StoreSpMetadataInSession.new(session:, request_id:).call if request_id.present?
+    end
+
+    def request_id
+      params.fetch(:_request_id)
     end
   end
 end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class ResetPasswordsController < Devise::PasswordsController
+    before_action :store_sp_metadata_in_session, only: [:edit]
+
     def new
       analytics.password_reset_visit
       @password_reset_email_form = PasswordResetEmailForm.new('')
@@ -56,6 +58,11 @@ module Users
     end
 
     protected
+
+    def store_sp_metadata_in_session
+      return if params[:request_id].blank?
+      StoreSpMetadataInSession.new(session:, request_id: params[:request_id]).call
+    end
 
     def forbidden_passwords(email_addresses)
       email_addresses.flat_map do |email_address|

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -21,7 +21,6 @@
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
-  <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -150,29 +150,4 @@ feature 'IRS Attempts API Event Tracking' do
       expect(received_event_types).to match_array(expected_event_types)
     end
   end
-
-  # rubocop:disable Layout/LineLength
-  scenario 'reset password from an IRS with new browser session and without request_id does not track event' do
-    freeze_time do
-      user = create(:user, :signed_up)
-      visit_idp_from_ial1_oidc_sp(
-        client_id: service_provider.issuer,
-        irs_attempts_api_session_id: 'test-session-id',
-      )
-
-      visit root_path
-      fill_forgot_password_form(user)
-      set_new_browser_session
-      click_reset_password_link_from_email
-      fill_reset_password_form(without_request_id: true)
-
-      events = irs_attempts_api_tracked_events(timestamp: Time.zone.now)
-      expected_event_types = %w[forgot-password-email-sent forgot-password-email-confirmed]
-      received_event_types = events.map(&:event_type)
-
-      expect(events.count).to eq received_event_types.count
-      expect(received_event_types).to match_array(expected_event_types)
-    end
-  end
-  # rubocop:enable Layout/LineLength
 end

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -15,7 +15,7 @@ feature 'Session Timeout' do
       visit root_url(request_id: sp_request.uuid)
 
       expect(page).to have_link sp.friendly_name
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
     end
   end
 
@@ -28,7 +28,7 @@ feature 'Session Timeout' do
       visit root_path
 
       expect(page).to have_link sp.friendly_name
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
     end
   end
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'Password Recovery' do
   include IdvHelper
   include PersonalKeyHelper
+  include SamlAuthHelper
 
   context 'user enters valid email in forgot password form', email: true do
     it 'redirects to forgot_password path and sends an email to the user' do
@@ -142,15 +143,14 @@ feature 'Password Recovery' do
     before do
       @user = create(:user, :signed_up)
 
-      visit new_user_password_path
+      visit_idp_from_sp_with_ial1(:oidc)
+      click_link t('links.passwords.forgot')
       fill_in t('account.index.email'), with: @user.email
       click_button t('forms.buttons.continue')
 
-      raw_reset_token, db_confirmation_token =
-        Devise.token_generator.generate(User, :reset_password_token)
-      UpdateUser.new(user: @user, attributes: { reset_password_token: db_confirmation_token }).call
-
-      visit edit_user_password_path(reset_password_token: raw_reset_token)
+      Capybara.current_session.reset!
+      set_current_email(last_email)
+      click_email_link_matching(Regexp.new(edit_user_password_path))
     end
 
     it 'lands on the reset password page' do
@@ -172,6 +172,23 @@ feature 'Password Recovery' do
 
         visit account_path
         expect(current_path).to eq new_user_session_path
+      end
+
+      it 'allows the user to continue to the service provider' do
+        fill_in t('forms.passwords.edit.labels.password'), with: 'NewVal!dPassw0rd'
+        click_button t('forms.passwords.edit.buttons.submit')
+
+        expect(page).to have_content(t('devise.passwords.updated_not_active'))
+        expect_branded_experience
+
+        fill_in t('account.index.email'), with: @user.email
+        fill_in t('components.password_toggle.label'), with: 'NewVal!dPassw0rd'
+        click_button t('links.next')
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+        click_agree_and_continue
+
+        expect(current_url).to start_with('http://localhost:7654/auth/result')
       end
     end
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -143,12 +143,13 @@ feature 'Password Recovery' do
     before do
       @user = create(:user, :signed_up)
 
-      visit_idp_from_sp_with_ial1(:oidc)
-      click_link t('links.passwords.forgot')
-      fill_in t('account.index.email'), with: @user.email
-      click_button t('forms.buttons.continue')
+      perform_in_browser(:one) do
+        visit_idp_from_sp_with_ial1(:oidc)
+        click_link t('links.passwords.forgot')
+        fill_in t('account.index.email'), with: @user.email
+        click_button t('forms.buttons.continue')
+      end
 
-      Capybara.current_session.reset!
       set_current_email(last_email)
       click_email_link_matching(Regexp.new(edit_user_password_path))
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -395,33 +395,33 @@ module Features
       visit_landing_page_and_click_create_account_with_request_id(sp_request_id)
 
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_invalid_email
 
       expect(current_url).to eq sign_up_email_url
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_but_wrong_email
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       click_link_to_use_a_different_email
 
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_email(email)
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
       expect(last_email.html_part.body.raw_source).to include "?_request_id=#{sp_request_id}"
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       click_link_to_resend_the_email
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id, resend: true)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       attempt_to_confirm_email_with_invalid_token(sp_request_id)
 
@@ -435,11 +435,11 @@ module Features
     def confirm_email_in_a_different_browser(email)
       click_confirmation_link_in_email(email)
 
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_invalid_password
 
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_password
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -683,9 +683,8 @@ module Features
       expect(current_path).to eq edit_user_password_path
     end
 
-    def fill_reset_password_form(without_request_id: nil)
+    def fill_reset_password_form
       fill_in t('forms.passwords.edit.labels.password'), with: 'newVal!dPassw0rd'
-      find_field('request_id', type: :hidden).set(nil) if without_request_id
       click_button t('forms.passwords.edit.buttons.submit')
 
       expect(current_path).to eq new_user_session_path

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -692,7 +692,8 @@ module Features
     end
 
     def expect_branded_experience
-      expect(page).to have_css('.page-header--basic img ~ img')
+      # Check for branded experience as being the header containing the Login.gov and partner logos
+      expect(page).to have_css(".page-header--basic img[alt='#{APP_NAME}'] ~ img")
     end
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -690,5 +690,9 @@ module Features
 
       expect(current_path).to eq new_user_session_path
     end
+
+    def expect_branded_experience
+      expect(page).to have_css('.page-header--basic img ~ img')
+    end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the original partner request would not be maintained through password reset. For example, a user who clicks the link to reset their password on their phone after initiating the password reset on their computer would not be allowed to continue to the service provider.

The SP request ID is only persisted to the session at specific intervals. Most notably, this includes the "Sign in" screen, and the email confirmation screen, but _not_ the password reset screen. The changes here apply the same sort of logic as those other controllers.

https://github.com/18F/identity-idp/blob/3a095866041d563e8da1fc94c4060723f0940c16/app/controllers/users/sessions_controller.rb#L193-L196

https://github.com/18F/identity-idp/blob/3a095866041d563e8da1fc94c4060723f0940c16/app/controllers/sign_up/passwords_controller.rb#L62-L64

## 📜 Testing Plan

1. Start [OIDC Sample App](https://github.com/18f/identity-oidc-sinatra) in a separate terminal process
2. Go to http://localhost:9292
3. Click "Sign In"
4. Click "Forgot your password?"
5. Enter an email address for an account which already exists
6. Click Continue
7. In the email, open the "Reset your password" link **in a private/incognito tab**
   - The intent is that this simulates a common scenario where the user would click this link after receiving it on their phone, if they had initiated the password reset on their desktop computer
8. Reset your password
9. Continue signing in

**Before:** You would arrive at the account dashboard
**After:** You would arrive back at the OIDC Sample App