### PR TITLE
Avoid writing .irb_history on deployed boxes

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,1 +1,5 @@
 IRB.conf[:USE_AUTOCOMPLETE] = false
+
+on_deployed_box = File.directory?('/srv/idp/releases/')
+
+IRB.conf[:SAVE_HISTORY] = on_deployed_box ? 0 : 1000

--- a/.irbrc
+++ b/.irbrc
@@ -2,4 +2,4 @@ IRB.conf[:USE_AUTOCOMPLETE] = false
 
 on_deployed_box = File.directory?('/srv/idp/releases/')
 
-IRB.conf[:SAVE_HISTORY] = on_deployed_box ? 0 : 1000
+IRB.conf[:SAVE_HISTORY] = on_deployed_box ? nil : 1000


### PR DESCRIPTION
**Why**: avoids file permission error

The error looks like this as you close a console, it's benign but looks scary and bad

```
irb(main):036:0> exit
/opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb/ext/save-history.rb:116:in `initialize': Permission denied @ rb_sysopen - /srv/idp/releases/chef/.irb_history (Errno::EACCES)
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb/ext/save-history.rb:116:in `open'
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb/ext/save-history.rb:116:in `save_history'
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb/ext/save-history.rb:60:in `block in extended'
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb.rb:504:in `block in run'
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb.rb:504:in `each'
	from /opt/ruby_build/versions/3.2.0/lib/ruby/3.2.0/irb.rb:504:in `run'
...
```


<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
