### PR TITLE
LG-9065 Write an exception result when TMx has an invalid review status

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -97,6 +97,13 @@ class ResolutionProofingJob < ApplicationJob
       review_status: threatmetrix_result.review_status,
       response_body: response_h,
     }
+
+    if exception.present?
+      callback_log_data.result.merge!(
+        success: false,
+        exception: exception,
+      )
+    end
   end
 
   def proof_lexisnexis_ddp_with_threatmetrix_if_needed(

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -2,6 +2,8 @@ module Proofing
   module LexisNexis
     module Ddp
       class Proofer
+        VALID_REVIEW_STATUSES = %w[pass review reject]
+
         class << self
           def required_attributes
             [:threatmetrix_session_id,
@@ -55,11 +57,19 @@ module Proofing
           request_result = body['request_result']
           review_status = body['review_status']
 
+          validate_review_status!(review_status)
+
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
 
           result
+        end
+
+        def validate_review_status!(review_status)
+          return if VALID_REVIEW_STATUSES.include?(review_status)
+
+          raise "Unexpected ThreatMetrix review_status value: #{review_status}"
         end
       end
     end

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -29,10 +29,15 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:proofing_device_profiling) { :enabled }
+  let(:lexisnexis_threatmetrix_mock_enabled) { false }
 
   before do
     allow(IdentityConfig.store).to receive(:proofing_device_profiling).
       and_return(proofing_device_profiling)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled).
+      and_return(lexisnexis_threatmetrix_mock_enabled)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_base_url).
+      and_return('https://www.example.com')
   end
 
   describe '#perform' do
@@ -97,14 +102,12 @@ RSpec.describe ResolutionProofingJob, type: :job do
         )
 
         # result[:context][:stages][:threatmetrix]
-        expect(result_context_stages_threatmetrix[:client]).to eq('DdpMock')
+        expect(result_context_stages_threatmetrix[:client]).to eq('lexisnexis')
         expect(result_context_stages_threatmetrix[:errors]).to eq({})
         expect(result_context_stages_threatmetrix[:exception]).to eq(nil)
         expect(result_context_stages_threatmetrix[:success]).to eq(true)
         expect(result_context_stages_threatmetrix[:timed_out]).to eq(false)
-        expect(result_context_stages_threatmetrix[:transaction_id]).to eq(
-          'ddp-mock-transaction-id-123',
-        )
+        expect(result_context_stages_threatmetrix[:transaction_id]).to eq('1234')
         expect(result_context_stages_threatmetrix[:review_status]).to eq('pass')
         expect(result_context_stages_threatmetrix[:response_body]).to eq(
           JSON.parse(LexisNexisFixtures.ddp_success_redacted_response_json, symbolize_names: true),
@@ -320,6 +323,20 @@ RSpec.describe ResolutionProofingJob, type: :job do
         expect(result_context_stages_threatmetrix).to be_nil
 
         expect(@threatmetrix_stub).to_not have_been_requested
+      end
+    end
+
+    context 'with an invalid threatmetrix review_status value' do
+      it 'stores an exception result' do
+        threatmetrix_response = JSON.parse(LexisNexisFixtures.ddp_success_response_json).merge(
+          review_status: 'unexpected_review_status_that_causes_problems',
+        ).to_json
+        stub_vendor_requests(threatmetrix_response: threatmetrix_response)
+
+        perform
+
+
+        #binding.pry
       end
     end
 

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -335,8 +335,18 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
         perform
 
+        result = document_capture_session.load_proofing_result[:result]
+        result_context = result[:context]
+        result_context_stages = result_context[:stages]
+        result_context_stages_threatmetrix = result_context_stages[:threatmetrix]
 
-        #binding.pry
+        expect(result[:success]).to be false
+        expect(result[:exception]).to match(/unexpected_review_status_that_causes_problems/)
+        expect(result[:timed_out]).to be false
+
+        expect(result_context_stages_threatmetrix[:exception]).to match(
+          /unexpected_review_status_that_causes_problems/,
+        )
       end
     end
 

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -328,10 +328,9 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
     context 'with an invalid threatmetrix review_status value' do
       it 'stores an exception result' do
-        threatmetrix_response = JSON.parse(LexisNexisFixtures.ddp_success_response_json).merge(
-          review_status: 'unexpected_review_status_that_causes_problems',
-        ).to_json
-        stub_vendor_requests(threatmetrix_response: threatmetrix_response)
+        stub_vendor_requests(
+          threatmetrix_response: LexisNexisFixtures.ddp_unexpected_review_status_response_json,
+        )
 
         perform
 
@@ -341,11 +340,11 @@ RSpec.describe ResolutionProofingJob, type: :job do
         result_context_stages_threatmetrix = result_context_stages[:threatmetrix]
 
         expect(result[:success]).to be false
-        expect(result[:exception]).to match(/unexpected_review_status_that_causes_problems/)
+        expect(result[:exception]).to include(LexisNexisFixtures.ddp_unexpected_review_status)
         expect(result[:timed_out]).to be false
 
-        expect(result_context_stages_threatmetrix[:exception]).to match(
-          /unexpected_review_status_that_causes_problems/,
+        expect(result_context_stages_threatmetrix[:exception]).to include(
+          LexisNexisFixtures.ddp_unexpected_review_status,
         )
       end
     end

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -122,5 +122,20 @@ describe Proofing::LexisNexis::Ddp::Proofer do
         expect(result.exception).to eq(error)
       end
     end
+
+    context 'when the review status has an unexpected value' do
+      let(:response_body) do
+        JSON.parse(LexisNexisFixtures.ddp_success_response_json).merge(
+          review_status: 'unexpected_review_status_that_causes_problems',
+        ).to_json
+      end
+
+      it 'returns an exception result' do
+        result = subject.proof(applicant)
+
+        expect(result.success?).to eq(false)
+        expect(result.exception.inspect).to match(/unexpected_review_status_that_causes_problems/)
+      end
+    end
   end
 end

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -124,17 +124,13 @@ describe Proofing::LexisNexis::Ddp::Proofer do
     end
 
     context 'when the review status has an unexpected value' do
-      let(:response_body) do
-        JSON.parse(LexisNexisFixtures.ddp_success_response_json).merge(
-          review_status: 'unexpected_review_status_that_causes_problems',
-        ).to_json
-      end
+      let(:response_body) { LexisNexisFixtures.ddp_unexpected_review_status_response_json }
 
       it 'returns an exception result' do
         result = subject.proof(applicant)
 
         expect(result.success?).to eq(false)
-        expect(result.exception.inspect).to match(/unexpected_review_status_that_causes_problems/)
+        expect(result.exception.inspect).to include(LexisNexisFixtures.ddp_unexpected_review_status)
       end
     end
   end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -47,6 +47,17 @@ module LexisNexisFixtures
       JSON.parse(raw).to_json
     end
 
+    def ddp_unexpected_review_status
+      'unexpected_review_status_that_causes_problems'
+    end
+
+    def ddp_unexpected_review_status_response_json
+      raw = read_fixture_file_at_path('ddp/successful_response.json')
+      JSON.parse(raw).merge(
+        review_status: ddp_unexpected_review_status,
+      ).to_json
+    end
+
     def instant_verify_request_json
       raw = read_fixture_file_at_path('instant_verify/request.json')
       JSON.parse(raw).to_json


### PR DESCRIPTION
We use ThreatMetrix as a tool for device profiling. It gives us a `review_status` result which we store in the database as a proofing component. That proofing component is used later in the process to determine if a profile needs additional review.

We communicate with ThreatMetrix if device profiling is enabled or in collect only mode. We do not communicate with threatMetrix when device profiling is disabled.

Previously, we would write `nil` to the proofing component if we received that or an unexpected review status from ThreatMetrix. This leads to ambiguity later in the process when determining if a user passed the ThreatMetrix check. Specifically, `nil` could mean the ThreatMetrix did not run because device profiling is disabled _or_ it could mean that an error occurred and no `review_status` was provided.

This commit changes the behavior of ThreatMetrix such that if ThreatMetrix is enabled it will write a review status or the job will respond with an exception result. This exception result will result in the user seeing an error and needing to re-submit and re-run the job. This resolves the ambiguity by making `nil` mean that ThreatMetrix was not enabled.
