### PR TITLE
LG-9237: Clean up state id translations and legend text

### DIFF
--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -193,7 +193,6 @@
             required: true,
           ) %>
     </div>
-    <h2><%= t('in_person_proofing.form.state_id.same_address_as_id') %></h2>
     <%= render ValidatedFieldComponent.new(
           as: :radio_buttons,
           checked: pii[:same_address_as_id],
@@ -202,6 +201,8 @@
             [t('in_person_proofing.form.state_id.same_address_as_id_no'), false],
           ],
           form: f,
+          label: t('in_person_proofing.form.state_id.same_address_as_id'),
+          label_html: {class: 'font-heading-2xl'},
           name: :same_address_as_id,
           required: true,
           wrapper: :uswds_radio_buttons,

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -202,7 +202,7 @@
           ],
           form: f,
           label: t('in_person_proofing.form.state_id.same_address_as_id'),
-          label_html: {class: 'font-heading-2xl'},
+          legend_html: {class: 'font-heading-lg'},
           name: :same_address_as_id,
           required: true,
           wrapper: :uswds_radio_buttons,

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -202,7 +202,7 @@
           ],
           form: f,
           label: t('in_person_proofing.form.state_id.same_address_as_id'),
-          legend_html: {class: 'font-heading-lg'},
+          legend_html: { class: 'h2' },
           name: :same_address_as_id,
           required: true,
           wrapper: :uswds_radio_buttons,

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -129,8 +129,8 @@ es:
           estatal de identidad?
         same_address_as_id_no: No, vivo en otra dirección
         same_address_as_id_yes: Sí, vivo en la misma dirección
-        state_id_jurisdiction: Estado
-        state_id_jurisdiction_hint: Seleccione el estado que aparece en su cédula
+        state_id_jurisdiction: Estado emisor
+        state_id_jurisdiction_hint: Este es el estado que emitió su identificación
         state_id_jurisdiction_prompt: '- Seleccione -'
         state_id_number: Número de cédula
         state_id_number_hint: Puede incluir letras y números

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -130,8 +130,8 @@ fr:
         same_address_as_id_no: Non, j’habite à une adresse différente
         same_address_as_id_yes: Oui, j’habite à l’adresse indiquée sur ma pièce
           d’identité émise par l’État
-        state_id_jurisdiction: État
-        state_id_jurisdiction_hint: Sélectionnez l’État figurant sur votre document d’identité
+        state_id_jurisdiction: État émetteur
+        state_id_jurisdiction_hint: Il s’agit de l’État qui a émis votre pièce d’identité
         state_id_jurisdiction_prompt: '- Sélectionnez -'
         state_id_number: Numéro d’identification
         state_id_number_hint: Peut comprendre des lettres et des chiffres


### PR DESCRIPTION
## 🎫 Ticket
[LG-9237: Collect issuing state on state id page](https://cm-jira.usa.gov/browse/LG-9237)

## 🛠 Summary of changes
This PR fixes bugs that @daviddsilvanava found during acceptance testing.
[ ] Correct Spanish and French translations for issuing state
[ ] Fix text for radio buttons questions - it previously showed "Same address as" above the actual radio buttons
[ ] Fix radio buttons so that someone using a screen reader will hear the heading


## 📜 Testing Plan
- Follow the testing plan from PR #8121 

## 👀 Screenshots
<details>
<summary>English:</summary>

<img width="1792" alt="EN_State_ID_Page" src="https://user-images.githubusercontent.com/80347702/230625424-f2096340-f5c1-4dad-8d90-f7949690c744.png">

</details>

<details>
<summary>French:</summary>

<img width="1792" alt="FR_State_ID_Page" src="https://user-images.githubusercontent.com/80347702/230625459-1bd02cea-60af-49cd-9655-0d67237ec495.png">

</details>

<details>
<summary>Spanish:</summary>

<img width="1792" alt="ES_State_ID_Page" src="https://user-images.githubusercontent.com/80347702/230625506-70188b47-acf9-4268-bbc9-e91cb3698db8.png">

</details>