### PR TITLE
Fix 500 error on phone verification warning screen

### DIFF
--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -10,8 +10,12 @@ module Idv
 
     def warning
       @remaining_attempts = throttle.remaining_count
-      @phone = idv_session.previous_phone_step_params[:phone]
-      @country_code = idv_session.previous_phone_step_params[:international_code]
+
+      if idv_session.previous_phone_step_params
+        @phone = idv_session.previous_phone_step_params[:phone]
+        @country_code = idv_session.previous_phone_step_params[:international_code]
+      end
+
       track_event(type: :warning)
     end
 

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -16,10 +16,12 @@
       ].select(&:present?),
     ) do %>
 
-      <p>
-        <%= t('idv.failure.phone.warning.you_entered') %>
-        <strong><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
-      </p>
+      <% if @phone %>
+        <p>
+          <%= t('idv.failure.phone.warning.you_entered') %>
+          <strong><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
+        </p>
+      <% end %>
 
       <p>
         <%= t('idv.failure.phone.warning.next_steps_html') %>

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -86,15 +86,19 @@ describe Idv::PhoneErrorsController do
   let(:user) { nil }
   let(:phone) { '3602345678' }
   let(:country_code) { 'US' }
+  let(:previous_phone_step_params) do
+    {
+      phone: phone,
+      international_code: country_code,
+    }
+  end
 
   before do
     allow(idv_session).to receive(:user_phone_confirmation).
       and_return(idv_session_user_phone_confirmation)
     allow(idv_session).to receive(:current_user).and_return(user)
-    allow(idv_session).to receive(:previous_phone_step_params).and_return(
-      phone: phone,
-      international_code: country_code,
-    )
+    allow(idv_session).to receive(:previous_phone_step_params).
+      and_return(previous_phone_step_params)
     allow(subject).to receive(:remaining_attempts).and_return(5)
     allow(controller).to receive(:idv_session).and_return(idv_session)
     stub_sign_in(user) if user
@@ -118,6 +122,13 @@ describe Idv::PhoneErrorsController do
     it 'assigns country_code' do
       get action
       expect(assigns(:country_code)).to eql(country_code)
+    end
+
+    context 'not knowing about a phone just entered' do
+      let(:previous_phone_step_params) { nil }
+      it 'does not crash' do
+        get action
+      end
     end
 
     context 'with throttle attempts' do

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -117,4 +117,11 @@ describe 'idv/phone_errors/warning.html.erb' do
       expect(rendered).to have_link(t('idv.failure.phone.warning.gpo.button'), href: idv_gpo_path)
     end
   end
+
+  context 'no phone' do
+    let(:phone) { nil }
+    it 'does not render "You entered:"' do
+      expect(rendered).not_to have_text(t('idv.failure.phone.warning.you_entered'))
+    end
+  end
 end


### PR DESCRIPTION
Guard against phone not being in the IDV session to avoid a `NoMethodError`. Context in Slack thread: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1680882411494599