### PR TITLE
Return an empty hash from `#flow_session` if it has not been created

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -9,16 +9,16 @@ module IdvStepConcern
   end
 
   def flow_session
-    user_session['idv/doc_auth']
+    user_session.fetch('idv/doc_auth', {})
   end
 
   def pii_from_doc
-    flow_session&.[]('pii_from_doc')
+    flow_session['pii_from_doc']
   end
 
   # copied from doc_auth_controller
   def flow_path
-    flow_session&.[](:flow_path)
+    flow_session[:flow_path]
   end
 
   def confirm_document_capture_complete
@@ -28,7 +28,7 @@ module IdvStepConcern
        flow_path == 'standard'
       redirect_to idv_document_capture_url
     else
-      flow_session&.delete('Idv::Steps::DocumentCaptureStep')
+      flow_session.delete('Idv::Steps::DocumentCaptureStep')
       redirect_to idv_doc_auth_url
     end
   end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -9,7 +9,7 @@ module IdvStepConcern
   end
 
   def flow_session
-    user_session.fetch('idv/doc_auth', {})
+    user_session['idv/doc_auth'] || {}
   end
 
   def pii_from_doc

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -65,7 +65,7 @@ module Idv
     end
 
     def confirm_document_capture_needed
-      pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
+      pii = flow_session['pii_from_doc'] # hash with indifferent access
       return if pii.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -106,7 +106,7 @@ module Idv
       end
 
       def pii
-        @pii = flow_session[:pii_from_user] if flow_session
+        @pii = flow_session[:pii_from_user]
       end
 
       def delete_pii
@@ -126,7 +126,7 @@ module Idv
 
       # override StepUtilitiesConcern
       def flow_session
-        user_session['idv/in_person']
+        user_session.fetch('idv/in_person', {})
       end
 
       def analytics_arguments

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -98,7 +98,7 @@ module Idv
 
     # copied from verify_step
     def pii
-      @pii = flow_session[:pii_from_doc] if flow_session
+      @pii = flow_session[:pii_from_doc]
     end
 
     def delete_pii

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -13,8 +13,8 @@ describe Idv::SsnController do
   let(:user) { create(:user) }
 
   before do
-    allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)
+    subject.user_session['idv/doc_auth'] = flow_session
     stub_analytics
     stub_attempts_tracker
     allow(@analytics).to receive(:track_event)
@@ -78,6 +78,7 @@ describe Idv::SsnController do
 
     context 'without a flow session' do
       let(:flow_session) { nil }
+
       it 'redirects to doc_auth' do
         get :show
 


### PR DESCRIPTION
We have observed a number of 500 errors that are the result of the flow session being nil. There is a new one present in the document capture controller.

This commit fixes all of these issues and hopefully prevents new ones by modifying the non-FSM implementations of `#flow_session` to return an empty hash when the flow session has not been constructed yet.
