### PR TITLE
Deploy RC 270 to Production

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,1 +1,5 @@
 IRB.conf[:USE_AUTOCOMPLETE] = false
+
+on_deployed_box = File.directory?('/srv/idp/releases/')
+
+IRB.conf[:SAVE_HISTORY] = on_deployed_box ? nil : 1000

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -10,8 +10,12 @@ module Idv
 
     def warning
       @remaining_attempts = throttle.remaining_count
-      @phone = idv_session.previous_phone_step_params[:phone]
-      @country_code = idv_session.previous_phone_step_params[:international_code]
+
+      if idv_session.previous_phone_step_params
+        @phone = idv_session.previous_phone_step_params[:phone]
+        @country_code = idv_session.previous_phone_step_params[:international_code]
+      end
+
       track_event(type: :warning)
     end
 

--- a/app/services/backup_code_generator.rb
+++ b/app/services/backup_code_generator.rb
@@ -24,6 +24,7 @@ class BackupCodeGenerator
 
   # @return [Boolean]
   def verify(plaintext_code)
+    return false unless plaintext_code.present?
     backup_code = RandomPhrase.normalize(plaintext_code)
     code = BackupCodeConfiguration.find_with_code(code: backup_code, user_id: @user.id)
     return false unless code_usable?(code)

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -193,7 +193,6 @@
             required: true,
           ) %>
     </div>
-    <h2><%= t('in_person_proofing.form.state_id.same_address_as_id') %></h2>
     <%= render ValidatedFieldComponent.new(
           as: :radio_buttons,
           checked: pii[:same_address_as_id],
@@ -202,6 +201,8 @@
             [t('in_person_proofing.form.state_id.same_address_as_id_no'), false],
           ],
           form: f,
+          label: t('in_person_proofing.form.state_id.same_address_as_id'),
+          legend_html: { class: 'h2' },
           name: :same_address_as_id,
           required: true,
           wrapper: :uswds_radio_buttons,

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -16,10 +16,12 @@
       ].select(&:present?),
     ) do %>
 
-      <p>
-        <%= t('idv.failure.phone.warning.you_entered') %>
-        <strong><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
-      </p>
+      <% if @phone %>
+        <p>
+          <%= t('idv.failure.phone.warning.you_entered') %>
+          <strong><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
+        </p>
+      <% end %>
 
       <p>
         <%= t('idv.failure.phone.warning.next_steps_html') %>

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -129,8 +129,8 @@ es:
           estatal de identidad?
         same_address_as_id_no: No, vivo en otra dirección
         same_address_as_id_yes: Sí, vivo en la misma dirección
-        state_id_jurisdiction: Estado
-        state_id_jurisdiction_hint: Seleccione el estado que aparece en su cédula
+        state_id_jurisdiction: Estado emisor
+        state_id_jurisdiction_hint: Este es el estado que emitió su identificación
         state_id_jurisdiction_prompt: '- Seleccione -'
         state_id_number: Número de cédula
         state_id_number_hint: Puede incluir letras y números

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -130,8 +130,8 @@ fr:
         same_address_as_id_no: Non, j’habite à une adresse différente
         same_address_as_id_yes: Oui, j’habite à l’adresse indiquée sur ma pièce
           d’identité émise par l’État
-        state_id_jurisdiction: État
-        state_id_jurisdiction_hint: Sélectionnez l’État figurant sur votre document d’identité
+        state_id_jurisdiction: État émetteur
+        state_id_jurisdiction_hint: Il s’agit de l’État qui a émis votre pièce d’identité
         state_id_jurisdiction_prompt: '- Sélectionnez -'
         state_id_number: Numéro d’identification
         state_id_number_hint: Peut comprendre des lettres et des chiffres

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -86,15 +86,19 @@ describe Idv::PhoneErrorsController do
   let(:user) { nil }
   let(:phone) { '3602345678' }
   let(:country_code) { 'US' }
+  let(:previous_phone_step_params) do
+    {
+      phone: phone,
+      international_code: country_code,
+    }
+  end
 
   before do
     allow(idv_session).to receive(:user_phone_confirmation).
       and_return(idv_session_user_phone_confirmation)
     allow(idv_session).to receive(:current_user).and_return(user)
-    allow(idv_session).to receive(:previous_phone_step_params).and_return(
-      phone: phone,
-      international_code: country_code,
-    )
+    allow(idv_session).to receive(:previous_phone_step_params).
+      and_return(previous_phone_step_params)
     allow(subject).to receive(:remaining_attempts).and_return(5)
     allow(controller).to receive(:idv_session).and_return(idv_session)
     stub_sign_in(user) if user
@@ -118,6 +122,13 @@ describe Idv::PhoneErrorsController do
     it 'assigns country_code' do
       get action
       expect(assigns(:country_code)).to eql(country_code)
+    end
+
+    context 'not knowing about a phone just entered' do
+      let(:previous_phone_step_params) { nil }
+      it 'does not crash' do
+        get action
+      end
     end
 
     context 'with throttle attempts' do

--- a/spec/services/backup_code_generator_spec.rb
+++ b/spec/services/backup_code_generator_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe BackupCodeGenerator do
     expect(success).to eq false
   end
 
+  it 'should reject nil codes' do
+    success = generator.verify(nil)
+    expect(success).to eq false
+  end
+
   it 'creates codes with the same salt for that batch' do
     generator.create
 

--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -103,6 +103,15 @@ describe Proofing::Aamva::Request::VerificationRequest do
 
         expect(result.success?).to eq(true)
       end
+
+      it 'sends state id jurisdiction to AAMVA' do
+        applicant.state_id_data.state_id_jurisdiction = 'NY'
+        expect(
+          Nokogiri::XML(subject.body) do |config|
+            config.strict
+          end.text,
+        ).to match(/NY/)
+      end
     end
 
     # rubocop:disable Layout/LineLength

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -117,4 +117,11 @@ describe 'idv/phone_errors/warning.html.erb' do
       expect(rendered).to have_link(t('idv.failure.phone.warning.gpo.button'), href: idv_gpo_path)
     end
   end
+
+  context 'no phone' do
+    let(:phone) { nil }
+    it 'does not render "You entered:"' do
+      expect(rendered).not_to have_text(t('idv.failure.phone.warning.you_entered'))
+    end
+  end
 end


### PR DESCRIPTION
## Bug Fixes
- Backup Codes: Fix error when verifying nil backup code ([#8148](https://github.com/18F/identity-idp/pull/8148))
- Identity verification: Prevent a 500 error on the phone warning screen. ([#8152](https://github.com/18F/identity-idp/pull/8152))
- In-person proofing: Fix translations and heading for state id page ([#8150](https://github.com/18F/identity-idp/pull/8150))

## Internal
- Configuration: Stop recording IRB console history ([#8147](https://github.com/18F/identity-idp/pull/8147))
- In-person proofing: Test state id jurisdiction is sent to aamva ([#8138](https://github.com/18F/identity-idp/pull/8138))
