### PR TITLE
LG-9426: Update mock DDP proofer results to match the real one

### DIFF
--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -52,6 +52,8 @@ module Proofing
         result.review_status = review_status
         result.response_body = response_body
 
+        result.add_error(:review_status, review_status) unless review_status == 'pass'
+
         result
       end
 

--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -48,11 +48,13 @@ module Proofing
 
         review_status = review_status_for(session_id: applicant[:threatmetrix_session_id])
         response_body = response_body_json(review_status: review_status)
+        request_result = response_body['request_result']
 
         result.review_status = review_status
         result.response_body = response_body
 
         result.add_error(:review_status, review_status) unless review_status == 'pass'
+        result.add_error(:request_result, request_result) unless request_result == 'success'
 
         result
       end

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe Proofing::Mock::DdpMockClient do
         expect(result.review_status).to eq('pass')
         expect(result.response_body['review_status']).to eq('pass')
       end
+      it 'does not have an error on result' do
+        expect(result.errors).to eql({})
+      end
     end
 
     context 'with failed request' do

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -49,6 +49,9 @@ RSpec.describe Proofing::Mock::DdpMockClient do
         expect(result.review_status).to eq('reject')
         expect(result.response_body['review_status']).to eq('reject')
       end
+      it 'has an error on result' do
+        expect(result.errors).to eql(review_status: ['reject'])
+      end
     end
 
     context 'with pass' do

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe Proofing::Mock::DdpMockClient do
         expect(result.response_body['review_status']).to eq('pass')
       end
     end
+
+    context 'with failed request' do
+      let(:redis_result) { 'pass' }
+
+      subject(:instance) { described_class.new response_fixture_file: 'error_response.json' }
+
+      it 'records request error' do
+        expect(result.errors).to eql({ request_result: ['fail_invalid_parameter'] })
+      end
+    end
   end
 end

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe Proofing::Mock::DdpMockClient do
       end
     end
 
+    context 'with review' do
+      let(:redis_result) { 'review' }
+
+      it 'has a review status' do
+        expect(result.review_status).to eq('review')
+        expect(result.response_body['review_status']).to eq('review')
+      end
+
+      it 'has an error on result' do
+        expect(result.errors).to eql(review_status: ['review'])
+      end
+    end
+
     context 'with pass' do
       let(:redis_result) { 'pass' }
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9426](https://cm-jira.usa.gov/browse/LG-9426)

## 🛠 Summary of changes

Our production DDP proofer adds errors to its result in these cases:

- The `review_status` is not `"pass"`
- The `request_result` is not `"success"`

This PR updates the mock proofer to behave similarly.
