### PR TITLE
LG-9362 sad face page after personal key page in GPO flow

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -45,7 +45,7 @@ module Idv
           else
             event, _disavowal_token = create_user_event(:account_verified)
 
-            if !current_user.fraud_review_pending?
+            if !threatmetrix_check_failed?(result)
               UserAlerts::AlertUserAboutAccountVerified.call(
                 user: current_user,
                 date_time: event.created_at,
@@ -102,6 +102,10 @@ module Idv
     def confirm_verification_needed
       return if current_user.decorate.pending_profile_requires_verification?
       redirect_to account_url
+    end
+
+    def threatmetrix_check_failed?(result)
+      result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
     end
 
     def threatmetrix_enabled?

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -45,17 +45,16 @@ module Idv
           else
             event, _disavowal_token = create_user_event(:account_verified)
 
-            if result.extra[:threatmetrix_check_failed] && threatmetrix_enabled?
-              redirect_to_fraud_review
-            else
+            if !current_user.fraud_review_pending?
               UserAlerts::AlertUserAboutAccountVerified.call(
                 user: current_user,
                 date_time: event.created_at,
                 sp_name: decorated_session.sp_name,
               )
               flash[:success] = t('account.index.verification.success')
-              redirect_to next_step
             end
+
+            redirect_to next_step
           end
         else
           flash[:error] = @gpo_verify_form.errors.first.message

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -35,9 +35,7 @@ module Idv
     end
 
     def next_step
-      if pending_profile? && idv_session.address_verification_mechanism == 'gpo'
-        idv_come_back_later_url
-      elsif in_person_enrollment?
+      if in_person_enrollment?
         idv_in_person_ready_to_verify_url
       elsif blocked_by_device_profiling?
         idv_please_call_url

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -22,8 +22,7 @@ class GpoVerifyForm
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif threatmetrix_check_failed? && threatmetrix_enabled?
-        pending_profile&.deactivate_for_fraud_review
-        pending_profile&.update!(verified_at: Time.zone.now)
+        deactivate_for_fraud_review
       else
         activate_profile
       end
@@ -52,6 +51,11 @@ class GpoVerifyForm
     return if otp.blank? || pending_profile.blank?
 
     pending_profile.gpo_confirmation_codes.first_with_otp(otp)
+  end
+
+  def deactivate_for_fraud_review
+    pending_profile&.deactivate_for_fraud_review
+    pending_profile&.update!(deactivation_reason: nil, verified_at: Time.zone.now)
   end
 
   def validate_otp_not_expired

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Idv::GpoVerifyController do
             )
           end
 
-          it 'redirects to the sad face screen' do
+          it 'is reflected in analytics' do
             expect(@analytics).to receive(:track_event).with(
               'IdV: GPO verification submitted',
               success: true,
@@ -226,7 +226,7 @@ RSpec.describe Idv::GpoVerifyController do
 
             action
 
-            expect(response).to redirect_to(idv_please_call_url)
+            expect(response).to redirect_to(idv_personal_key_url)
           end
 
           it 'does not show a flash message' do
@@ -247,7 +247,7 @@ RSpec.describe Idv::GpoVerifyController do
               threatmetrix_review_status: 'review'
             )
           end
-          it 'redirects to the sad face screen' do
+          it 'is reflected in analytics' do
             expect(@analytics).to receive(:track_event).with(
               'IdV: GPO verification submitted',
               success: true,
@@ -260,7 +260,7 @@ RSpec.describe Idv::GpoVerifyController do
 
             action
 
-            expect(response).to redirect_to(idv_please_call_url)
+            expect(response).to redirect_to(idv_personal_key_url)
           end
         end
       end

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -191,12 +191,6 @@ describe Idv::PersonalKeyController do
         subject.idv_session.create_profile_from_applicant_with_password(password)
       end
 
-      it 'redirects to come back later path' do
-        patch :update
-
-        expect(response).to redirect_to idv_come_back_later_path
-      end
-
       context 'with gpo personal key after verification' do
         it 'redirects to sign up completed_url for a sp' do
           allow(subject).to receive(:pending_profile?).and_return(false)
@@ -208,18 +202,6 @@ describe Idv::PersonalKeyController do
         end
       end
 
-      context 'with in person profile' do
-        before do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
-          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-        end
-
-        it 'creates a profile and returns completion url' do
-          patch :update
-
-          expect(response).to redirect_to idv_come_back_later_path
-        end
-      end
       it 'logs key submitted event' do
         patch :update
 

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -52,7 +52,6 @@ feature 'idv gpo otp verification step', :js do
 
     context 'ThreatMetrix says "review"' do
       let(:threatmetrix_review_status) { 'review' }
-      let(:redirect_after_verification) { idv_please_call_path }
       let(:profile_should_be_active) { false }
       let(:fraud_review_pending) { true }
       it_behaves_like 'gpo otp verification'
@@ -60,7 +59,6 @@ feature 'idv gpo otp verification step', :js do
 
     context 'ThreatMetrix says "reject"' do
       let(:threatmetrix_review_status) { 'reject' }
-      let(:redirect_after_verification) { idv_please_call_path }
       let(:profile_should_be_active) { false }
       let(:fraud_review_pending) { true }
       it_behaves_like 'gpo otp verification'

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -11,8 +11,6 @@ shared_examples 'gpo otp verification' do
     fill_in t('forms.verify_profile.name'), with: otp
     click_button t('forms.verify_profile.submit')
 
-    expect(page).to have_current_path(redirect_after_verification) if redirect_after_verification
-
     profile.reload
 
     if profile_should_be_active
@@ -22,6 +20,7 @@ shared_examples 'gpo otp verification' do
       expect(profile.active).to be(false)
       expect(profile.fraud_review_pending?).to eq(fraud_review_pending) if fraud_review_pending
       expect(profile.verified_at).to_not eq(nil) if fraud_review_pending
+      expect(profile.deactivation_reason).to eq(nil) if fraud_review_pending
     end
 
     expect(user.events.account_verified.size).to eq 1


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9362](https://cm-jira.usa.gov/browse/LG-9362)

## 🛠 Summary of changes

Moved the sad face fraud review page to after the personal key page in the GPO flow.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV set threatmetrix status to 'review'
- [ ] Continue with GPO flow
- [ ] Verify that the sad face page now shows up after the personal key page.
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
