### PR TITLE
Link to idv_address_url from verify_info show template

### DIFF
--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -82,12 +82,11 @@ locals:
       </div>
     </dl>
     <div class='grid-auto'>
-      <%= button_to(
-            idv_doc_auth_step_url(step: :redo_address),
-            method: :put,
-            class: 'usa-button usa-button--unstyled',
+      <%= link_to(
+            t('idv.buttons.change_label'),
+            idv_address_url,
             'aria-label': t('idv.buttons.change_address_label'),
-          ) { t('idv.buttons.change_label') } %>
+          ) %>
     </div>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -54,7 +54,7 @@ feature 'doc auth verify_info step', :js do
   end
 
   it 'allows the user to enter in a new address and displays updated info' do
-    click_button t('idv.buttons.change_address_label')
+    click_link t('idv.buttons.change_address_label')
     fill_in 'idv_form_zipcode', with: '12345'
     fill_in 'idv_form_address2', with: 'Apt 3E'
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -181,7 +181,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_doc_auth_steps_before_address_step(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step
     expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
-    click_button t('idv.buttons.change_address_label')
+    click_link t('idv.buttons.change_address_label')
   end
 
   def complete_doc_auth_steps_before_link_sent_step


### PR DESCRIPTION
## 🎫 Ticket

[LG-9435](https://cm-jira.usa.gov/browse/LG-9435)

## 🛠 Summary of changes

Link directly from VerifyInfo show template to idv_address_url. We no longer need to use the RedoAddressAction in the flow state machine. This is in preparation for deleting the RedoAddressAction.

Note: `idv_doc_auth_redo_address_submitted` analytics event is no longer called. We can add it to AddressController if needed. The same method is called by InPerson::RedoAddressAction, so we don't need to delete the method if we don't use it here.

## 📜 Testing Plan

- [ ] Create account
- [ ] Go through /verify flow
- [ ] At VerifyInfo step, click Update link next to Address
- [ ] Expect edit to be successful
