### PR TITLE
LG-9065 Make the DDP result class and proofer responsible for building the result hash

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -85,18 +85,7 @@ class ResolutionProofingJob < ApplicationJob
   def add_threatmetrix_result_to_callback_result(callback_log_data:, threatmetrix_result:)
     exception = threatmetrix_result.exception.inspect if threatmetrix_result.exception
 
-    response_h = Proofing::LexisNexis::Ddp::ResponseRedacter.
-      redact(threatmetrix_result.response_body)
-    callback_log_data.result[:context][:stages][:threatmetrix] = {
-      client: lexisnexis_ddp_proofer.class.vendor_name,
-      errors: threatmetrix_result.errors,
-      exception: exception,
-      success: threatmetrix_result.success?,
-      timed_out: threatmetrix_result.timed_out?,
-      transaction_id: threatmetrix_result.transaction_id,
-      review_status: threatmetrix_result.review_status,
-      response_body: response_h,
-    }
+    callback_log_data.result[:context][:stages][:threatmetrix] = threatmetrix_result.to_h
 
     if exception.present?
       callback_log_data.result.merge!(

--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -2,25 +2,30 @@ module Proofing
   class DdpResult
     attr_reader :exception
     attr_accessor :context,
+                  :success,
                   :transaction_id,
-                  :reference,
                   :review_status,
-                  :response_body
+                  :response_body,
+                  :client
 
     def initialize(
+        success: true,
         errors: {},
         context: {},
         exception: nil,
         transaction_id: nil,
-        reference: nil,
-        response_body: nil
+        review_status: nil,
+        response_body: nil,
+        client: nil
       )
+      @success = success
       @errors = errors
       @context = context
       @exception = exception
       @transaction_id = transaction_id
-      @reference = reference
       @response_body = response_body
+      @review_status = review_status
+      @client = client
     end
 
     # rubocop:disable Style/OptionalArguments
@@ -47,7 +52,7 @@ module Proofing
     end
 
     def success?
-      !exception? && !errors?
+      @success
     end
 
     def timed_out?
@@ -56,9 +61,14 @@ module Proofing
 
     def to_h
       {
+        client: client,
+        success: success?,
         errors: errors,
         exception: exception,
-        success: success?,
+        timed_out: timed_out?,
+        transaction_id: transaction_id,
+        review_status: review_status,
+        response_body: Proofing::LexisNexis::Ddp::ResponseRedacter.redact(response_body),
       }
     end
   end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -43,7 +43,7 @@ module Proofing
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)
-          Proofing::DdpResult.new(exception: exception)
+          Proofing::DdpResult.new(success: false, exception: exception)
         end
 
         private
@@ -62,6 +62,9 @@ module Proofing
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
+
+          result.success = !result.errors?
+          result.client = 'lexisnexis'
 
           result
         end

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -66,21 +66,14 @@ describe Proofing::DdpResult do
   describe '#success?' do
     subject { result.success? }
 
-    context 'when there is an error AND an exception' do
-      let(:result) do
-        Proofing::DdpResult.new(exception: StandardError.new).add_error('foobar')
-      end
-      it { is_expected.to eq(false) }
-    end
-
-    context 'when there is an error and no exception' do
-      let(:result) { Proofing::DdpResult.new.add_error('foobar') }
-      it { is_expected.to eq(false) }
-    end
-
-    context 'when there is no error and no exception' do
-      let(:result) { Proofing::DdpResult.new }
+    context 'when it is successful' do
+      let(:result) { Proofing::DdpResult.new(success: true) }
       it { is_expected.to eq(true) }
+    end
+
+    context 'when it is unsuccessful' do
+      let(:result) { Proofing::DdpResult.new(success: false) }
+      it { is_expected.to eq(false) }
     end
   end
 
@@ -121,17 +114,6 @@ describe Proofing::DdpResult do
         result = Proofing::DdpResult.new
         result.transaction_id = transaction_id
         expect(result.transaction_id).to eq(transaction_id)
-      end
-    end
-  end
-
-  describe 'reference' do
-    context 'when provided' do
-      it 'is present' do
-        reference = SecureRandom.uuid
-        result = Proofing::DdpResult.new
-        result.reference = reference
-        expect(result.reference).to eq(reference)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit the majority of our proofers returned an object with a `#to_h` method that returned a hash suitable for logging with the results of the proofing transaction. The exception was the DDP proofer. The DDP proofer's logged result needed to be constructed in the proofing job where it was invoked.

This commit makes the DDP result mirror the other result classes. This will make it easier to reconstruct the DDP class to add logic around things like whether exceptions are present (see #8149).
