### PR TITLE
Fix flaky IdV outage spec

### DIFF
--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -70,7 +70,7 @@ feature 'IdV Outage Spec' do
 
   after do
     # Don't leave stale routes sitting around.
-    # (First clean up the stubs we wired up in `before`)
+    # Reset all the feature flags that cause route changes before reloading routes for any specs that run next.
 
     vendors.each do |service|
       vendor_status_key = "vendor_status_#{service}".to_sym

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -31,8 +31,7 @@ feature 'IdV Outage Spec' do
   let(:feature_idv_force_gpo_verification_enabled) { false }
   let(:feature_idv_hybrid_flow_enabled) { true }
 
-  before do
-    # Wire up various let()s to configuration keys
+  let(:vendors) do
     %w[
       acuant
       lexisnexis_instant_verify
@@ -40,17 +39,26 @@ feature 'IdV Outage Spec' do
       lexisnexis_trueid
       sms
       voice
-    ].each do |service|
+    ]
+  end
+
+  let(:config_flags) do
+    %w[
+      enable_usps_verification
+      feature_idv_force_gpo_verification_enabled
+      feature_idv_hybrid_flow_enabled
+    ]
+  end
+
+  before do
+    # Wire up various let()s to configuration keys
+    vendors.each do |service|
       vendor_status_key = "vendor_status_#{service}".to_sym
       allow(IdentityConfig.store).to receive(vendor_status_key).
         and_return(send(vendor_status_key))
     end
 
-    %w[
-      enable_usps_verification
-      feature_idv_force_gpo_verification_enabled
-      feature_idv_hybrid_flow_enabled
-    ].each do |key|
+    config_flags.each do |key|
       allow(IdentityConfig.store).to receive(key).
         and_return(send(key))
     end
@@ -62,6 +70,17 @@ feature 'IdV Outage Spec' do
 
   after do
     # Don't leave stale routes sitting around.
+    # (First clean up the stubs we wired up in `before`)
+
+    vendors.each do |service|
+      vendor_status_key = "vendor_status_#{service}".to_sym
+      allow(IdentityConfig.store).to receive(vendor_status_key).and_call_original
+    end
+
+    config_flags.each do |key|
+      allow(IdentityConfig.store).to receive(key).and_call_original
+    end
+
     Rails.application.reload_routes!
   end
 

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -69,8 +69,9 @@ feature 'IdV Outage Spec' do
   end
 
   after do
-    # Don't leave stale routes sitting around.
-    # Reset all the feature flags that cause route changes before reloading routes for any specs that run next.
+    # Don't leave stale routes sitting around!
+    # - Reset all the feature flags that could cause route changes
+    # - Reload routes to reset the environment for any specs that run next
 
     vendors.each do |service|
       vendor_status_key = "vendor_status_#{service}".to_sym


### PR DESCRIPTION
Changes in #8106 included configuration-dependent routing for identity verification.

To test this, the outage spec would stub relevant `IdentityConfig.store` values and call `Rails.application.reload_routes!` to update the routing table. After each test completes, it then calls `Rails.application.reload_routes` once more to clean up.

Unfortunately, the teardown of this process was not working correctly--stubs added using `allow(IdentityConfig.store).to receive(...)` had not been torn down when the routing table was updated. This meant that subsequent tests that relied on those routes being present would fail.

This PR ensures stubs are removed before reloading the routing table on cleanup.

To test this locally, you can use this command to run a subset of the test suite that was [previously failing in CI](https://gitlab.login.gov/lg/identity-idp/-/jobs/401929):

```shell
bundle exec rspec --seed 3610 \
    spec/features/users/sign_up_spec.rb \
    spec/features/idv/outage_spec.rb \
    spec/features/multiple_emails/add_email_spec.rb \
    spec/features/sp_cost_tracking_spec.rb \
    spec/features/remember_device/phone_spec.rb \
    spec/features/remember_device/user_opted_preference_spec.rb \
    spec/features/irs_attempts_api/event_tracking_spec.rb \
    spec/features/idv/steps/forgot_password_step_spec.rb \
    spec/features/webauthn/sign_up_spec.rb \
    spec/features/idv/phone_input_spec.rb \
    spec/features/session/timeout_spec.rb \
    spec/features/phone/remove_phone_spec.rb \
    spec/features/visitors/navigation_spec.rb \
    spec/services/usps_in_person_proofing/enrollment_helper_spec.rb \
    spec/forms/security_event_form_spec.rb \
    spec/controllers/application_controller_spec.rb \
    spec/controllers/idv/image_uploads_controller_spec.rb \
    spec/decorators/user_decorator_spec.rb \
    spec/controllers/idv/phone_errors_controller_spec.rb \
    spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb \
    spec/forms/openid_connect_logout_form_spec.rb \
    spec/services/account_reset/delete_account_spec.rb \
    spec/controllers/accounts/personal_keys_controller_spec.rb \
    spec/services/ial_context_spec.rb \
    spec/services/account_reset/cancel_request_for_user_spec.rb \
    spec/controllers/two_factor_authentication/options_controller_spec.rb \
    spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb \
    spec/lib/tasks/rotate_rake_spec.rb \
    spec/controllers/idv/forgot_password_controller_spec.rb \
    spec/services/idv/steps/in_person/verify_step_spec.rb \
    spec/views/idv/review/new.html.erb_spec.rb \
    spec/forms/verify_personal_key_form_spec.rb \
    spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb \
    spec/lib/telephony/pinpoint/sms_sender_spec.rb \
    spec/components/memorable_date_component_spec.rb \
    spec/services/iaa_reporting_helper_spec.rb \
    spec/requests/redirects_spec.rb \
    spec/models/webauthn_configuration_spec.rb \
    spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb \
    spec/lib/deploy/activate_spec.rb \
    spec/requests/page_not_found_spec.rb \
    spec/controllers/api/verify/base_controller_spec.rb \
    spec/services/pii/re_encryptor_spec.rb \
    spec/services/encryption/password_verifier_spec.rb \
    spec/lib/telephony/pinpoint/opt_out_manager_spec.rb \
    spec/jobs/reports/daily_dropoffs_report_spec.rb \
    spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb \
    spec/services/sp_return_url_resolver_spec.rb \
    spec/helpers/link_helper_spec.rb \
    spec/components/button_component_spec.rb \
    spec/services/doc_auth/acuant/requests/get_results_request_spec.rb \
    spec/services/key_rotator/attribute_encryption_spec.rb \
    spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb \
    spec/services/gpo_confirmation_uploader_spec.rb \
    spec/components/javascript_required_component_spec.rb \
    spec/components/troubleshooting_options_component_spec.rb \
    spec/services/idv/phone_confirmation_session_spec.rb \
    spec/forms/idv/doc_pii_form_spec.rb \
    spec/views/shared/_footer_lite.html.erb_spec.rb \
    spec/views/idv/session_errors/throttled.html.erb_spec.rb \
    spec/services/completions_decider_spec.rb \
    spec/services/db/monthly_auth_count/total_monthly_auth_counts_spec.rb \
    spec/controllers/health/database_controller_spec.rb \
    spec/models/event_spec.rb \
    spec/services/funnel/registration/add_mfa_spec.rb \
    spec/controllers/test/push_notification_controller_spec.rb \
    spec/services/secure_headers_allow_list_spec.rb \
    spec/services/push_notification/mfa_limit_account_locked_event_spec.rb \
    spec/lib/otp_code_generator_spec.rb \
    spec/services/push_notification/account_purged_event_spec.rb \
    spec/services/push_notification/password_reset_event_spec.rb \
    spec/lib/base16_spec.rb \
    spec/services/proofing/lexis_nexis/date_formatter_spec.rb \
    spec/services/gpo_confirmation_exporter_spec.rb \
    spec/services/piv_cac/check_config_spec.rb \
    spec/jobs/reports/query_helpers_spec.rb \
    spec/services/health_check_summary_spec.rb \
    spec/services/db/sp_return_log_spec.rb \
    spec/lib/data_requests/local/write_user_events_spec.rb \
    spec/services/time_service_spec.rb
```