### PR TITLE
Refactor implicit calculation of two-factor authentication methods

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -91,7 +91,7 @@ module TwoFactorAuthenticatableMethods
     ).call
   end
 
-  def handle_valid_otp(next_url = nil, auth_method: nil)
+  def handle_valid_otp(next_url:, auth_method: nil)
     handle_valid_otp_for_context(auth_method)
     handle_remember_device
     next_url ||= after_otp_verification_confirmation_url

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -91,8 +91,8 @@ module TwoFactorAuthenticatableMethods
     ).call
   end
 
-  def handle_valid_otp(next_url = nil)
-    handle_valid_otp_for_context
+  def handle_valid_otp(next_url = nil, auth_method: nil)
+    handle_valid_otp_for_context(auth_method)
     handle_remember_device
     next_url ||= after_otp_verification_confirmation_url
     reset_otp_session_data
@@ -104,9 +104,9 @@ module TwoFactorAuthenticatableMethods
     save_remember_device_preference
   end
 
-  def handle_valid_otp_for_context
+  def handle_valid_otp_for_context(auth_method)
     if UserSessionContext.authentication_or_reauthentication_context?(context)
-      handle_valid_otp_for_authentication_context
+      handle_valid_otp_for_authentication_context(auth_method: auth_method)
     elsif UserSessionContext.confirmation_context?(context)
       handle_valid_otp_for_confirmation_context
     end
@@ -190,8 +190,8 @@ module TwoFactorAuthenticatableMethods
     Funnel::Registration::AddMfa.call(current_user.id, 'phone', analytics)
   end
 
-  def handle_valid_otp_for_authentication_context
-    user_session[:auth_method] = two_factor_authentication_method.to_s
+  def handle_valid_otp_for_authentication_context(auth_method:)
+    user_session[:auth_method] = auth_method
     mark_user_session_authenticated(:valid_2fa)
     bypass_sign_in current_user
     create_user_event(:sign_in_after_2fa)

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -61,7 +61,7 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
-        handle_valid_otp_for_authentication_context
+        handle_valid_otp_for_authentication_context(auth_method: 'backup_code')
         return handle_last_code if all_codes_used?
         handle_valid_backup_code
       else

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
       result = otp_verification_form.submit
       post_analytics(result)
       if result.success?
-        handle_valid_otp(nil, auth_method: params[:otp_delivery_preference])
+        handle_valid_otp(next_url: nil, auth_method: params[:otp_delivery_preference])
       else
         handle_invalid_otp(context: context, type: 'otp')
       end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
       result = otp_verification_form.submit
       post_analytics(result)
       if result.success?
-        handle_valid_otp
+        handle_valid_otp(nil, auth_method: params[:otp_delivery_preference])
       else
         handle_invalid_otp(context: context, type: 'otp')
       end

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -89,7 +89,7 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_otp
-      handle_valid_otp_for_authentication_context
+      handle_valid_otp_for_authentication_context(auth_method: 'personal_key')
       if decorated_user.identity_verified? || decorated_user.password_reset_profile.present?
         redirect_to manage_personal_key_url
       elsif MfaPolicy.new(current_user).two_factor_enabled?

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -50,7 +50,7 @@ module TwoFactorAuthentication
         presented: true,
       )
 
-      handle_valid_otp_for_authentication_context
+      handle_valid_otp_for_authentication_context(auth_method: 'piv_cac')
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
     end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthentication
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?
-        handle_valid_otp
+        handle_valid_otp(nil, auth_method: 'authenticator')
       else
         handle_invalid_otp(context: context, type: 'totp')
       end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthentication
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?
-        handle_valid_otp(nil, auth_method: 'authenticator')
+        handle_valid_otp(next_url: nil, auth_method: 'authenticator')
       else
         handle_invalid_otp(context: context, type: 'totp')
       end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -40,7 +40,7 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_webauthn
-      handle_valid_otp_for_authentication_context
+      handle_valid_otp_for_authentication_context(auth_method: 'webauthn')
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -78,7 +78,7 @@ module Users
         presented: true,
       )
 
-      handle_valid_otp(next_step, auth_method: 'piv_cac')
+      handle_valid_otp(next_url: next_step, auth_method: 'piv_cac')
     end
 
     def next_step

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -78,7 +78,7 @@ module Users
         presented: true,
       )
 
-      handle_valid_otp(next_step)
+      handle_valid_otp(next_step, auth_method: 'piv_cac')
     end
 
     def next_step


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, the implementation for this is implicitly infers from the URI path, but that limits us in renaming paths going forward, impacts logging of these values, and can make it difficult to understand the different pieces. This PR refactors some of the `auth_method` usage to pass explicit names instead. There will be a followup to remove some of the other implicit uses of the method after this PR.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
