### PR TITLE
Redirect to sign in from authentication controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -305,9 +305,7 @@ class ApplicationController < ActionController::Base
     reauthn.present? && reauthn == 'true'
   end
 
-  def confirm_two_factor_authenticated(id = nil)
-    return prompt_to_sign_in_with_request_id(id) if user_needs_new_session_with_request_id?(id)
-
+  def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 
     if !two_factor_enabled?
@@ -350,10 +348,6 @@ class ApplicationController < ActionController::Base
     (session_created_at + timeout_in_minutes) < Time.zone.now
   end
 
-  def prompt_to_sign_in_with_request_id(request_id)
-    redirect_to new_user_session_url(request_id: request_id)
-  end
-
   def prompt_to_setup_mfa
     redirect_to authentication_methods_setup_url
   end
@@ -376,10 +370,6 @@ class ApplicationController < ActionController::Base
     else
       login_two_factor_piv_cac_url
     end
-  end
-
-  def user_needs_new_session_with_request_id?(id)
-    !user_signed_in? && id.present?
   end
 
   def two_factor_enabled?

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -55,7 +55,7 @@ module OpenidConnect
       bump_auth_count unless user_fully_authenticated?
       if !user_signed_in?
         redirect_to new_user_session_url
-      elsif remember_device_expired_for_sp?
+      elsif user_fully_authenticated? && remember_device_expired_for_sp?
         redirect_to user_two_factor_authentication_url
       else
         confirm_two_factor_authenticated

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -53,17 +53,13 @@ module OpenidConnect
 
     def confirm_user_is_authenticated_with_fresh_mfa
       bump_auth_count unless user_fully_authenticated?
-
-      unless user_fully_authenticated? && service_provider_mfa_policy.
-          auth_method_confirms_to_sp_request?
-        return confirm_two_factor_authenticated(request_id)
+      if !user_fully_authenticated?
+        redirect_to new_user_session_url
+      elsif remember_device_expired_for_sp?
+        redirect_to user_two_factor_authentication_url
+      else
+        confirm_two_factor_authenticated
       end
-
-      redirect_to user_two_factor_authentication_url if device_not_remembered?
-    end
-
-    def device_not_remembered?
-      remember_device_expired_for_sp?
     end
 
     def link_identity_to_service_provider

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -57,6 +57,10 @@ module OpenidConnect
       redirect_to new_user_session_url
     end
 
+    def redirect_to_reauthenticate
+      redirect_to user_two_factor_authentication_url
+    end
+
     def link_identity_to_service_provider
       @authorize_form.link_identity_to_service_provider(current_user, session.id)
     end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -15,9 +15,11 @@ module OpenidConnect
     before_action :check_sp_active, only: [:index]
     before_action :secure_headers_override, only: [:index]
     before_action :handle_banned_user
-    before_action :confirm_user_is_authenticated_with_fresh_mfa, only: :index
+    before_action :bump_auth_count, only: :index
+    before_action :redirect_to_sign_in, only: :index, unless: :user_signed_in?
+    before_action :confirm_two_factor_authenticated, only: :index
+    before_action :redirect_to_reauthenticate, only: :index, if: :remember_device_expired_for_sp?
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
-    before_action :bump_auth_count, only: [:index]
 
     def index
       return redirect_to_fraud_review if fraud_review_pending_for_ial2_request?
@@ -51,15 +53,8 @@ module OpenidConnect
       true
     end
 
-    def confirm_user_is_authenticated_with_fresh_mfa
-      bump_auth_count unless user_fully_authenticated?
-      if !user_signed_in?
-        redirect_to new_user_session_url
-      elsif user_fully_authenticated? && remember_device_expired_for_sp?
-        redirect_to user_two_factor_authentication_url
-      else
-        confirm_two_factor_authenticated
-      end
+    def redirect_to_sign_in
+      redirect_to new_user_session_url
     end
 
     def link_identity_to_service_provider

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -53,7 +53,7 @@ module OpenidConnect
 
     def confirm_user_is_authenticated_with_fresh_mfa
       bump_auth_count unless user_fully_authenticated?
-      if !user_fully_authenticated?
+      if !user_signed_in?
         redirect_to new_user_session_url
       elsif remember_device_expired_for_sp?
         redirect_to user_two_factor_authentication_url

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -87,7 +87,7 @@ class SamlIdpController < ApplicationController
     bump_auth_count unless user_fully_authenticated?
     if !user_signed_in?
       redirect_to new_user_session_url
-    elsif remember_device_expired_for_sp?
+    elsif user_fully_authenticated? && remember_device_expired_for_sp?
       redirect_to user_two_factor_authentication_url
     else
       confirm_two_factor_authenticated

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -85,7 +85,7 @@ class SamlIdpController < ApplicationController
 
   def confirm_user_is_authenticated_with_fresh_mfa
     bump_auth_count unless user_fully_authenticated?
-    if !user_fully_authenticated?
+    if !user_signed_in?
       redirect_to new_user_session_url
     elsif remember_device_expired_for_sp?
       redirect_to user_two_factor_authentication_url

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -85,10 +85,13 @@ class SamlIdpController < ApplicationController
 
   def confirm_user_is_authenticated_with_fresh_mfa
     bump_auth_count unless user_fully_authenticated?
-    return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated? &&
-                                                               service_provider_mfa_policy.
-                                                                 auth_method_confirms_to_sp_request?
-    redirect_to user_two_factor_authentication_url if remember_device_expired_for_sp?
+    if !user_fully_authenticated?
+      redirect_to new_user_session_url
+    elsif remember_device_expired_for_sp?
+      redirect_to user_two_factor_authentication_url
+    else
+      confirm_two_factor_authenticated
+    end
   end
 
   def saml_metadata

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -89,6 +89,10 @@ class SamlIdpController < ApplicationController
     redirect_to new_user_session_url
   end
 
+  def redirect_to_reauthenticate
+    redirect_to user_two_factor_authentication_url
+  end
+
   def saml_metadata
     SamlEndpoint.new(request).saml_metadata
   end

--- a/app/policies/service_provider_mfa_policy.rb
+++ b/app/policies/service_provider_mfa_policy.rb
@@ -40,10 +40,6 @@ class ServiceProviderMfaPolicy
     false
   end
 
-  def auth_method_confirms_to_sp_request?
-    !user_needs_sp_auth_method_setup? && !user_needs_sp_auth_method_verification?
-  end
-
   def phishing_resistant_required?
     if phishing_resistant_requested? || aal_requested?
       !!phishing_resistant_requested?

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -443,7 +443,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
         action
         sp_request_id = ServiceProviderRequestProxy.last.uuid
 
-        expect(response).to redirect_to new_user_session_url(request_id: sp_request_id)
+        expect(response).to redirect_to new_user_session_url
+        expect(controller.session[:sp][:request_id]).to eq(sp_request_id)
       end
 
       it 'sets sp information in the session and does not transmit ial2 attrs for ial1' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -689,11 +689,13 @@ describe 'OpenID Connect' do
     it 'displays the branded page' do
       visit_idp_from_ial1_oidc_sp
 
-      expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
+      expect(current_url).to eq(root_url)
+      expect_branded_experience
 
       visit_idp_from_ial1_oidc_sp
 
-      expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
+      expect(current_url).to eq(root_url)
+      expect_branded_experience
     end
   end
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -158,14 +158,15 @@ feature 'IAL1 Single Sign On' do
   end
 
   context 'visiting IdP via SP, then using the language selector' do
-    it 'preserves the request_id in the url' do
+    it 'displays the branded page' do
       visit saml_authn_request_url
 
       within(first('.language-picker', visible: false)) do
         find_link(t('i18n.locale.es'), visible: false).click
       end
 
-      expect(current_url).to match(%r{http://www.example.com/es/\?request_id=.+})
+      expect(current_url).to eq('http://www.example.com/es/')
+      expect_branded_experience
     end
   end
 
@@ -174,11 +175,13 @@ feature 'IAL1 Single Sign On' do
       request_url = saml_authn_request_url
       visit request_url
 
-      expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
+      expect(current_url).to eq('http://www.example.com/')
+      expect_branded_experience
 
       visit request_url
 
-      expect(current_url).to match(%r{http://www.example.com/\?request_id=.+})
+      expect(current_url).to eq('http://www.example.com/')
+      expect_branded_experience
     end
   end
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -165,7 +165,7 @@ feature 'IAL1 Single Sign On' do
         find_link(t('i18n.locale.es'), visible: false).click
       end
 
-      expect(current_url).to eq('http://www.example.com/es/')
+      expect(current_url).to eq root_url(locale: :es, trailing_slash: true)
       expect_branded_experience
     end
   end
@@ -175,12 +175,12 @@ feature 'IAL1 Single Sign On' do
       request_url = saml_authn_request_url
       visit request_url
 
-      expect(current_url).to eq('http://www.example.com/')
+      expect(current_url).to eq root_url
       expect_branded_experience
 
       visit request_url
 
-      expect(current_url).to eq('http://www.example.com/')
+      expect(current_url).to eq root_url
       expect_branded_experience
     end
   end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -655,6 +655,8 @@ feature 'Sign in' do
     end
   end
 
+  it_behaves_like 'signing in from service provider', :saml
+  it_behaves_like 'signing in from service provider', :oidc
   it_behaves_like 'signing in as IAL1 with personal key', :saml
   it_behaves_like 'signing in as IAL1 with personal key', :oidc
   it_behaves_like 'signing in as IAL2 with personal key', :saml

--- a/spec/policies/service_provider_mfa_policy_spec.rb
+++ b/spec/policies/service_provider_mfa_policy_spec.rb
@@ -197,50 +197,6 @@ describe ServiceProviderMfaPolicy do
     end
   end
 
-  describe '#auth_method_confirms_to_sp_request?' do
-    context 'the user used the required MFA' do
-      before do
-        setup_user_phone
-        setup_user_webauthn_token
-      end
-
-      let(:aal_level_requested) { 3 }
-      let(:auth_method) { 'webauthn' }
-
-      it { expect(policy.auth_method_confirms_to_sp_request?).to eq(true) }
-    end
-
-    context 'the user did not use the required MFA' do
-      before do
-        setup_user_phone
-        setup_user_webauthn_token
-      end
-
-      let(:aal_level_requested) { 3 }
-      let(:auth_method) { 'phone' }
-
-      it { expect(policy.auth_method_confirms_to_sp_request?).to eq(false) }
-    end
-
-    context 'the user has not setup the required MFA' do
-      before { setup_user_phone }
-
-      let(:aal_level_requested) { 3 }
-      let(:auth_method) { 'phone' }
-
-      it { expect(policy.auth_method_confirms_to_sp_request?).to eq(false) }
-    end
-
-    context 'there are no MFA requirements' do
-      before { setup_user_phone }
-
-      let(:aal_level_requested) { 1 }
-      let(:auth_method) { 'phone' }
-
-      it { expect(policy.auth_method_confirms_to_sp_request?).to eq(true) }
-    end
-  end
-
   describe '#allow_user_to_switch_method?' do
     context 'phishing-resistant required' do
       let(:aal_level_requested) { 3 }

--- a/spec/requests/openid_connect_authorize_spec.rb
+++ b/spec/requests/openid_connect_authorize_spec.rb
@@ -13,7 +13,8 @@ describe 'user signs in partially and visits openid_connect/authorize' do
   it 'prompts the user to 2FA if prompt is login' do
     openid_test('login')
     sp_request_id = ServiceProviderRequestProxy.last.uuid
-    expect(response).to redirect_to new_user_session_path(request_id: sp_request_id)
+    expect(response).to redirect_to new_user_session_path
+    expect(controller.session[:sp]['request_id']).to eq(sp_request_id)
   end
 
   it 'prompts the user to 2FA if prompt is not given' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -386,7 +386,8 @@ module Features
     def sign_up_user_from_sp_without_confirming_email(email)
       sp_request_id = ServiceProviderRequestProxy.last.uuid
 
-      expect(current_url).to eq new_user_session_url(request_id: sp_request_id)
+      expect(current_url).to eq new_user_session_url
+      expect_branded_experience
 
       click_sign_in_from_landing_page_then_click_create_account
 

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -29,6 +29,14 @@ shared_examples 'signing in with the site in Spanish' do |sp|
   end
 end
 
+shared_examples 'signing in from service provider' do |sp|
+  it 'does not display session timeout alert on sign in page' do
+    visit_idp_from_sp_with_ial1(sp)
+
+    expect(page).to_not have_content t('devise.failure.timeout')
+  end
+end
+
 shared_examples 'signing in as IAL1 with personal key' do |sp|
   it 'redirects to the SP after acknowledging new personal key', email: true do
     ial1_sign_in_with_personal_key_goes_to_sp(sp)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the logic for redirecting during a partner-initiated authentication in order to remove the `request_id` query parameter, since the request ID will have already been saved to the session at this point.

This is a follow-up to https://github.com/18F/identity-idp/pull/8137#issuecomment-1503250527 :

> I started exploring removing the `request_id` from the redirects initiated by `SamlIdpController` and `OpenidConnect::AuthorizationController`, since the `request_id` will have already been stored at those points, via [`store_saml_request`](https://github.com/18F/identity-idp/blob/111dfd9e6592373488cfe56dabc9f5ccbd2a5ec6/app/controllers/concerns/saml_idp_auth_concern.rb#L75-L82) and [`store_request`](https://github.com/18F/identity-idp/blob/111dfd9e6592373488cfe56dabc9f5ccbd2a5ec6/app/controllers/openid_connect/authorization_controller.rb#L159-L166) respectively. I think there's definitely some simplification that can be done here, particularly with removing [the argument to `confirm_two_factor_authenticated`](https://github.com/18F/identity-idp/blob/111dfd9e6592373488cfe56dabc9f5ccbd2a5ec6/app/controllers/application_controller.rb#L308) and maybe even the [first line of that method](https://github.com/18F/identity-idp/blob/111dfd9e6592373488cfe56dabc9f5ccbd2a5ec6/app/controllers/application_controller.rb#L309). But it's a bit more involved since the Warden `authenticate_user!` will cause an alert banner to be shown on the Sign In screen without that first line of the method.

## 📜 Testing Plan

- Confirm that you can sign in from a service provider, and that the Sign In screen maintains the branded experience and does not include any unexpected alert banners (e.g. "Your session has expired")