### PR TITLE
Deploy RC 271 to Prod

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -9,16 +9,16 @@ module IdvStepConcern
   end
 
   def flow_session
-    user_session['idv/doc_auth']
+    user_session['idv/doc_auth'] || {}
   end
 
   def pii_from_doc
-    flow_session&.[]('pii_from_doc')
+    flow_session['pii_from_doc']
   end
 
   # copied from doc_auth_controller
   def flow_path
-    flow_session&.[](:flow_path)
+    flow_session[:flow_path]
   end
 
   def confirm_document_capture_complete
@@ -28,7 +28,7 @@ module IdvStepConcern
        flow_path == 'standard'
       redirect_to idv_document_capture_url
     else
-      flow_session&.delete('Idv::Steps::DocumentCaptureStep')
+      flow_session.delete('Idv::Steps::DocumentCaptureStep')
       redirect_to idv_doc_auth_url
     end
   end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -65,7 +65,7 @@ module Idv
     end
 
     def confirm_document_capture_needed
-      pii = flow_session&.[]('pii_from_doc') # hash with indifferent access
+      pii = flow_session['pii_from_doc'] # hash with indifferent access
       return if pii.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -106,7 +106,7 @@ module Idv
       end
 
       def pii
-        @pii = flow_session[:pii_from_user] if flow_session
+        @pii = flow_session[:pii_from_user]
       end
 
       def delete_pii
@@ -126,7 +126,7 @@ module Idv
 
       # override StepUtilitiesConcern
       def flow_session
-        user_session['idv/in_person']
+        user_session.fetch('idv/in_person', {})
       end
 
       def analytics_arguments

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -98,7 +98,7 @@ module Idv
 
     # copied from verify_step
     def pii
-      @pii = flow_session[:pii_from_doc] if flow_session
+      @pii = flow_session[:pii_from_doc]
     end
 
     def delete_pii

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -5,6 +5,7 @@ module SignUp
     before_action :find_user_with_confirmation_token
     before_action :confirm_user_needs_sign_up_confirmation
     before_action :stop_if_invalid_token
+    before_action :store_sp_metadata_in_session, only: [:create]
 
     def create
       clear_setup_piv_cac_from_sign_in
@@ -26,10 +27,15 @@ module SignUp
         success: true,
         failure_reason: nil,
       )
-      request_id = params.fetch(:_request_id, '')
-      redirect_to sign_up_enter_password_url(
-        request_id: request_id, confirmation_token: @confirmation_token,
-      )
+      redirect_to sign_up_enter_password_url(confirmation_token: @confirmation_token)
+    end
+
+    def store_sp_metadata_in_session
+      StoreSpMetadataInSession.new(session:, request_id:).call if request_id.present?
+    end
+
+    def request_id
+      params[:_request_id]
     end
   end
 end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class ResetPasswordsController < Devise::PasswordsController
+    before_action :store_sp_metadata_in_session, only: [:edit]
+
     def new
       analytics.password_reset_visit
       @password_reset_email_form = PasswordResetEmailForm.new('')
@@ -56,6 +58,11 @@ module Users
     end
 
     protected
+
+    def store_sp_metadata_in_session
+      return if params[:request_id].blank?
+      StoreSpMetadataInSession.new(session:, request_id: params[:request_id]).call
+    end
 
     def forbidden_passwords(email_addresses)
       email_addresses.flat_map do |email_address|

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -85,18 +85,7 @@ class ResolutionProofingJob < ApplicationJob
   def add_threatmetrix_result_to_callback_result(callback_log_data:, threatmetrix_result:)
     exception = threatmetrix_result.exception.inspect if threatmetrix_result.exception
 
-    response_h = Proofing::LexisNexis::Ddp::ResponseRedacter.
-      redact(threatmetrix_result.response_body)
-    callback_log_data.result[:context][:stages][:threatmetrix] = {
-      client: lexisnexis_ddp_proofer.class.vendor_name,
-      errors: threatmetrix_result.errors,
-      exception: exception,
-      success: threatmetrix_result.success?,
-      timed_out: threatmetrix_result.timed_out?,
-      transaction_id: threatmetrix_result.transaction_id,
-      review_status: threatmetrix_result.review_status,
-      response_body: response_h,
-    }
+    callback_log_data.result[:context][:stages][:threatmetrix] = threatmetrix_result.to_h
 
     if exception.present?
       callback_log_data.result.merge!(

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -97,6 +97,13 @@ class ResolutionProofingJob < ApplicationJob
       review_status: threatmetrix_result.review_status,
       response_body: response_h,
     }
+
+    if exception.present?
+      callback_log_data.result.merge!(
+        success: false,
+        exception: exception,
+      )
+    end
   end
 
   def proof_lexisnexis_ddp_with_threatmetrix_if_needed(

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -22,7 +22,7 @@ class OpenidConnectUserInfoPresenter
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     info[:ial] = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
-    info[:aal] = Saml::Idp::Constants::AUTHN_CONTEXT_AAL_TO_CLASSREF[identity.aal]
+    info[:aal] = identity.requested_aal_value
 
     scoper.filter(info)
   end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -6,12 +6,14 @@ class IdentityLinker
     @service_provider = service_provider
     @ial = nil
     @aal = nil
+    @requested_aal_value = nil
   end
 
   def link_identity(
     code_challenge: nil,
     ial: nil,
     aal: nil,
+    requested_aal_value: nil,
     nonce: nil,
     rails_session_id: nil,
     scope: nil,
@@ -28,6 +30,7 @@ class IdentityLinker
         code_challenge: code_challenge,
         ial: ial,
         aal: aal,
+        requested_aal_value: requested_aal_value,
         nonce: nonce,
         rails_session_id: rails_session_id,
         scope: scope,

--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -2,25 +2,30 @@ module Proofing
   class DdpResult
     attr_reader :exception
     attr_accessor :context,
+                  :success,
                   :transaction_id,
-                  :reference,
                   :review_status,
-                  :response_body
+                  :response_body,
+                  :client
 
     def initialize(
+        success: true,
         errors: {},
         context: {},
         exception: nil,
         transaction_id: nil,
-        reference: nil,
-        response_body: nil
+        review_status: nil,
+        response_body: nil,
+        client: nil
       )
+      @success = success
       @errors = errors
       @context = context
       @exception = exception
       @transaction_id = transaction_id
-      @reference = reference
       @response_body = response_body
+      @review_status = review_status
+      @client = client
     end
 
     # rubocop:disable Style/OptionalArguments
@@ -47,7 +52,7 @@ module Proofing
     end
 
     def success?
-      !exception? && !errors?
+      @success
     end
 
     def timed_out?
@@ -56,9 +61,14 @@ module Proofing
 
     def to_h
       {
+        client: client,
+        success: success?,
         errors: errors,
         exception: exception,
-        success: success?,
+        timed_out: timed_out?,
+        transaction_id: transaction_id,
+        review_status: review_status,
+        response_body: Proofing::LexisNexis::Ddp::ResponseRedacter.redact(response_body),
       }
     end
   end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -2,6 +2,8 @@ module Proofing
   module LexisNexis
     module Ddp
       class Proofer
+        VALID_REVIEW_STATUSES = %w[pass review reject]
+
         class << self
           def required_attributes
             [:threatmetrix_session_id,
@@ -55,11 +57,19 @@ module Proofing
           request_result = body['request_result']
           review_status = body['review_status']
 
+          validate_review_status!(review_status)
+
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
 
           result
+        end
+
+        def validate_review_status!(review_status)
+          return if VALID_REVIEW_STATUSES.include?(review_status)
+
+          raise "Unexpected ThreatMetrix review_status value: #{review_status}"
         end
       end
     end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -43,7 +43,7 @@ module Proofing
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)
-          Proofing::DdpResult.new(exception: exception)
+          Proofing::DdpResult.new(success: false, exception: exception)
         end
 
         private
@@ -62,6 +62,9 @@ module Proofing
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
+
+          result.success = !result.errors?
+          result.client = 'lexisnexis'
 
           result
         end

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -82,12 +82,11 @@ locals:
       </div>
     </dl>
     <div class='grid-auto'>
-      <%= button_to(
-            idv_doc_auth_step_url(step: :redo_address),
-            method: :put,
-            class: 'usa-button usa-button--unstyled',
+      <%= link_to(
+            t('idv.buttons.change_label'),
+            idv_address_url,
             'aria-label': t('idv.buttons.change_address_label'),
-          ) { t('idv.buttons.change_label') } %>
+          ) %>
     </div>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-top-1">

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -21,7 +21,6 @@
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
-  <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/db/primary_migrate/20230404131517_add_identities_requested_aal_value.rb
+++ b/db/primary_migrate/20230404131517_add_identities_requested_aal_value.rb
@@ -1,0 +1,5 @@
+class AddIdentitiesRequestedAalValue < ActiveRecord::Migration[7.0]
+  def change
+    add_column :identities, :requested_aal_value, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_232935) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_04_131517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -284,6 +284,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_232935) do
     t.datetime "last_ial2_authenticated_at", precision: nil
     t.datetime "deleted_at", precision: nil
     t.integer "aal"
+    t.text "requested_aal_value"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -13,8 +13,8 @@ describe Idv::SsnController do
   let(:user) { create(:user) }
 
   before do
-    allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)
+    subject.user_session['idv/doc_auth'] = flow_session
     stub_analytics
     stub_attempts_tracker
     allow(@analytics).to receive(:track_event)
@@ -78,6 +78,7 @@ describe Idv::SsnController do
 
     context 'without a flow session' do
       let(:flow_session) { nil }
+
       it 'redirects to doc_auth' do
         get :show
 

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -54,7 +54,7 @@ feature 'doc auth verify_info step', :js do
   end
 
   it 'allows the user to enter in a new address and displays updated info' do
-    click_button t('idv.buttons.change_address_label')
+    click_link t('idv.buttons.change_address_label')
     fill_in 'idv_form_zipcode', with: '12345'
     fill_in 'idv_form_address2', with: 'Apt 3E'
 

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -150,29 +150,4 @@ feature 'IRS Attempts API Event Tracking' do
       expect(received_event_types).to match_array(expected_event_types)
     end
   end
-
-  # rubocop:disable Layout/LineLength
-  scenario 'reset password from an IRS with new browser session and without request_id does not track event' do
-    freeze_time do
-      user = create(:user, :signed_up)
-      visit_idp_from_ial1_oidc_sp(
-        client_id: service_provider.issuer,
-        irs_attempts_api_session_id: 'test-session-id',
-      )
-
-      visit root_path
-      fill_forgot_password_form(user)
-      set_new_browser_session
-      click_reset_password_link_from_email
-      fill_reset_password_form(without_request_id: true)
-
-      events = irs_attempts_api_tracked_events(timestamp: Time.zone.now)
-      expected_event_types = %w[forgot-password-email-sent forgot-password-email-confirmed]
-      received_event_types = events.map(&:event_type)
-
-      expect(events.count).to eq received_event_types.count
-      expect(received_event_types).to match_array(expected_event_types)
-    end
-  end
-  # rubocop:enable Layout/LineLength
 end

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -15,7 +15,7 @@ feature 'Session Timeout' do
       visit root_url(request_id: sp_request.uuid)
 
       expect(page).to have_link sp.friendly_name
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
     end
   end
 
@@ -28,7 +28,7 @@ feature 'Session Timeout' do
       visit root_path
 
       expect(page).to have_link sp.friendly_name
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
     end
   end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -357,37 +357,19 @@ RSpec.describe OpenidConnectAuthorizeForm do
   end
 
   describe '#aal' do
-    context 'when DEFAULT_AAL passed' do
-      before do
-        default = Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
-        IdentityConfig.store.valid_authn_contexts.push(default)
-      end
-
-      after do
-        IdentityConfig.store.valid_authn_contexts.pop
-      end
-
-      let(:acr_values) { Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF }
+    context 'when no AAL passed' do
+      let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
 
       it 'returns 0' do
-        expect(form.aal).to eq(Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF)
+        expect(form.aal).to eq(0)
       end
     end
 
-    context 'when AAL1 passed' do
-      before do
-        aal1 = Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF
-        IdentityConfig.store.valid_authn_contexts.push(aal1)
-      end
+    context 'when DEFAULT_AAL passed' do
+      let(:acr_values) { Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF }
 
-      after do
-        IdentityConfig.store.valid_authn_contexts.pop
-      end
-
-      let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
-
-      it 'returns 1' do
-        expect(form.aal).to eq(1)
+      it 'returns 0' do
+        expect(form.aal).to eq(0)
       end
     end
 
@@ -430,9 +412,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(form.aal).to eq(3)
       end
     end
-  end
 
-  describe '#aal' do
     context 'when IAL and AAL passed' do
       aal2 = Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
       ial2 = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
@@ -444,6 +424,100 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it 'returns ial and aal' do
         expect(form.aal).to eq(2)
         expect(form.ial).to eq(2)
+      end
+    end
+  end
+
+  describe '#requested_aal_value' do
+    context 'when AAL2 passed' do
+      let(:acr_values) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns AAL2' do
+        expect(form.requested_aal_value).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+      end
+    end
+
+    context 'when AAL2_PHISHING_RESISTANT passed' do
+      let(:acr_values) { Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns AAL2+Phishing Resistant' do
+        expect(form.requested_aal_value).to eq(
+          Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+        )
+      end
+    end
+
+    context 'when AAL2_HSPD12 passed' do
+      let(:acr_values) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns AAL2+HSPD12' do
+        expect(form.requested_aal_value).to eq(
+          Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+        )
+      end
+    end
+
+    context 'when AAL3 passed' do
+      let(:acr_values) { Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns AAL3' do
+        expect(form.requested_aal_value).to eq(Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF)
+      end
+    end
+
+    context 'when AAL3_HSPD12 passed' do
+      let(:acr_values) { Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF }
+
+      it 'returns AAL3+HSPD12' do
+        expect(form.requested_aal_value).to eq(
+          Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF,
+        )
+      end
+    end
+
+    context 'when AAL3_HSPD12 and AAL2_HSPD12 passed' do
+      let(:acr_values) do
+        [Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF,
+         Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF].join(' ')
+      end
+
+      it 'returns AAL2+HSPD12' do
+        expect(form.requested_aal_value).to eq(
+          Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+        )
+      end
+    end
+
+    context 'when AAL2 and AAL2_PHISHING_RESISTANT passed' do
+      let(:phishing_resistant) do
+        Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF
+      end
+
+      let(:acr_values) do
+        "#{Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF}
+         #{phishing_resistant}"
+      end
+
+      it 'returns AAL2+HSPD12' do
+        expect(form.requested_aal_value).to eq(phishing_resistant)
+      end
+    end
+
+    context 'when AAL2_PHISHING_RESISTANT and AAL2 passed' do
+      # this is the same as the previous test, just reverse ordered
+      # AAL values, to ensure it doesn't just take the 2nd AAL.
+      let(:phishing_resistant) do
+        Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF
+      end
+
+      let(:acr_values) do
+        "#{phishing_resistant}
+         #{Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF}"
+      end
+
+      it 'returns AAL2+HSPD12' do
+        requested_aal_value = form.requested_aal_value
+        expect(requested_aal_value).to eq(phishing_resistant)
       end
     end
   end

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -29,10 +29,15 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:proofing_device_profiling) { :enabled }
+  let(:lexisnexis_threatmetrix_mock_enabled) { false }
 
   before do
     allow(IdentityConfig.store).to receive(:proofing_device_profiling).
       and_return(proofing_device_profiling)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled).
+      and_return(lexisnexis_threatmetrix_mock_enabled)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_base_url).
+      and_return('https://www.example.com')
   end
 
   describe '#perform' do
@@ -97,14 +102,12 @@ RSpec.describe ResolutionProofingJob, type: :job do
         )
 
         # result[:context][:stages][:threatmetrix]
-        expect(result_context_stages_threatmetrix[:client]).to eq('DdpMock')
+        expect(result_context_stages_threatmetrix[:client]).to eq('lexisnexis')
         expect(result_context_stages_threatmetrix[:errors]).to eq({})
         expect(result_context_stages_threatmetrix[:exception]).to eq(nil)
         expect(result_context_stages_threatmetrix[:success]).to eq(true)
         expect(result_context_stages_threatmetrix[:timed_out]).to eq(false)
-        expect(result_context_stages_threatmetrix[:transaction_id]).to eq(
-          'ddp-mock-transaction-id-123',
-        )
+        expect(result_context_stages_threatmetrix[:transaction_id]).to eq('1234')
         expect(result_context_stages_threatmetrix[:review_status]).to eq('pass')
         expect(result_context_stages_threatmetrix[:response_body]).to eq(
           JSON.parse(LexisNexisFixtures.ddp_success_redacted_response_json, symbolize_names: true),
@@ -320,6 +323,29 @@ RSpec.describe ResolutionProofingJob, type: :job do
         expect(result_context_stages_threatmetrix).to be_nil
 
         expect(@threatmetrix_stub).to_not have_been_requested
+      end
+    end
+
+    context 'with an invalid threatmetrix review_status value' do
+      it 'stores an exception result' do
+        stub_vendor_requests(
+          threatmetrix_response: LexisNexisFixtures.ddp_unexpected_review_status_response_json,
+        )
+
+        perform
+
+        result = document_capture_session.load_proofing_result[:result]
+        result_context = result[:context]
+        result_context_stages = result_context[:stages]
+        result_context_stages_threatmetrix = result_context_stages[:threatmetrix]
+
+        expect(result[:success]).to be false
+        expect(result[:exception]).to include(LexisNexisFixtures.ddp_unexpected_review_status)
+        expect(result[:timed_out]).to be false
+
+        expect(result_context_stages_threatmetrix[:exception]).to include(
+          LexisNexisFixtures.ddp_unexpected_review_status,
+        )
       end
     end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       service_provider: service_provider.issuer,
       scope: scope,
       aal: 2,
+      requested_aal_value: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
     )
   end
 
@@ -28,7 +29,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
     it 'has basic attributes' do
       ial = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
-      aal = Saml::Idp::Constants::AUTHN_CONTEXT_AAL_TO_CLASSREF[identity.aal]
+      aal = Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF
 
       aggregate_failures do
         expect(user_info[:sub]).to eq(identity.uuid)

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -66,21 +66,14 @@ describe Proofing::DdpResult do
   describe '#success?' do
     subject { result.success? }
 
-    context 'when there is an error AND an exception' do
-      let(:result) do
-        Proofing::DdpResult.new(exception: StandardError.new).add_error('foobar')
-      end
-      it { is_expected.to eq(false) }
-    end
-
-    context 'when there is an error and no exception' do
-      let(:result) { Proofing::DdpResult.new.add_error('foobar') }
-      it { is_expected.to eq(false) }
-    end
-
-    context 'when there is no error and no exception' do
-      let(:result) { Proofing::DdpResult.new }
+    context 'when it is successful' do
+      let(:result) { Proofing::DdpResult.new(success: true) }
       it { is_expected.to eq(true) }
+    end
+
+    context 'when it is unsuccessful' do
+      let(:result) { Proofing::DdpResult.new(success: false) }
+      it { is_expected.to eq(false) }
     end
   end
 
@@ -121,17 +114,6 @@ describe Proofing::DdpResult do
         result = Proofing::DdpResult.new
         result.transaction_id = transaction_id
         expect(result.transaction_id).to eq(transaction_id)
-      end
-    end
-  end
-
-  describe 'reference' do
-    context 'when provided' do
-      it 'is present' do
-        reference = SecureRandom.uuid
-        result = Proofing::DdpResult.new
-        result.reference = reference
-        expect(result.reference).to eq(reference)
       end
     end
   end

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -122,5 +122,16 @@ describe Proofing::LexisNexis::Ddp::Proofer do
         expect(result.exception).to eq(error)
       end
     end
+
+    context 'when the review status has an unexpected value' do
+      let(:response_body) { LexisNexisFixtures.ddp_unexpected_review_status_response_json }
+
+      it 'returns an exception result' do
+        result = subject.proof(applicant)
+
+        expect(result.success?).to eq(false)
+        expect(result.exception.inspect).to include(LexisNexisFixtures.ddp_unexpected_review_status)
+      end
+    end
   end
 end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -181,7 +181,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   def complete_doc_auth_steps_before_address_step(expect_accessible: false)
     complete_doc_auth_steps_before_verify_step
     expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible
-    click_button t('idv.buttons.change_address_label')
+    click_link t('idv.buttons.change_address_label')
   end
 
   def complete_doc_auth_steps_before_link_sent_step

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -395,33 +395,33 @@ module Features
       visit_landing_page_and_click_create_account_with_request_id(sp_request_id)
 
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_invalid_email
 
       expect(current_url).to eq sign_up_email_url
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_but_wrong_email
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       click_link_to_use_a_different_email
 
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_email(email)
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
       expect(last_email.html_part.body.raw_source).to include "?_request_id=#{sp_request_id}"
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       click_link_to_resend_the_email
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id, resend: true)
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       attempt_to_confirm_email_with_invalid_token(sp_request_id)
 
@@ -435,11 +435,11 @@ module Features
     def confirm_email_in_a_different_browser(email)
       click_confirmation_link_in_email(email)
 
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_invalid_password
 
-      expect(page).to have_css('img[src*=sp-logos]')
+      expect_branded_experience
 
       submit_form_with_valid_password
 
@@ -683,12 +683,16 @@ module Features
       expect(current_path).to eq edit_user_password_path
     end
 
-    def fill_reset_password_form(without_request_id: nil)
+    def fill_reset_password_form
       fill_in t('forms.passwords.edit.labels.password'), with: 'newVal!dPassw0rd'
-      find_field('request_id', type: :hidden).set(nil) if without_request_id
       click_button t('forms.passwords.edit.buttons.submit')
 
       expect(current_path).to eq new_user_session_path
+    end
+
+    def expect_branded_experience
+      # Check for branded experience as being the header containing the Login.gov and partner logos
+      expect(page).to have_css(".page-header--basic img[alt='#{APP_NAME}'] ~ img")
     end
   end
 end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -47,6 +47,17 @@ module LexisNexisFixtures
       JSON.parse(raw).to_json
     end
 
+    def ddp_unexpected_review_status
+      'unexpected_review_status_that_causes_problems'
+    end
+
+    def ddp_unexpected_review_status_response_json
+      raw = read_fixture_file_at_path('ddp/successful_response.json')
+      JSON.parse(raw).merge(
+        review_status: ddp_unexpected_review_status,
+      ).to_json
+    end
+
     def instant_verify_request_json
       raw = read_fixture_file_at_path('instant_verify/request.json')
       JSON.parse(raw).to_json


### PR DESCRIPTION
## Bug Fixes
- OpenID Connect: Update AAL in userinfo response to keep specific values ([#8012](https://github.com/18F/identity-idp/pull/8012))
- Password Reset: Maintain partner request when user resets password in new session ([#8145](https://github.com/18F/identity-idp/pull/8145))

## Internal
- Verify Info step: Stop using RedoAddressAction and link directly to Address page to update address ([#8157](https://github.com/18F/identity-idp/pull/8157))