### PR TITLE
Remove phone_confirmed column from profiles table

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,4 @@
 class Profile < ApplicationRecord
-  self.ignored_columns = %w[phone_confirmed]
-
   belongs_to :user
   # rubocop:disable Rails/InverseOf
   belongs_to :initiating_service_provider,

--- a/db/migrate/20230411160948_remove_phone_confirmed_from_profiles.rb
+++ b/db/migrate/20230411160948_remove_phone_confirmed_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemovePhoneConfirmedFromProfiles < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :profiles, :phone_confirmed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -440,7 +440,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_131517) do
     t.string "ssn_signature", limit: 64
     t.text "encrypted_pii_recovery"
     t.integer "deactivation_reason"
-    t.boolean "phone_confirmed", default: false, null: false
     t.jsonb "proofing_components"
     t.string "name_zip_birth_year_signature"
     t.date "reproof_at"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Part of addressing:
https://cm-jira.usa.gov/browse/LG-9399

## 🛠 Summary of changes

The `phone_confirmed` column [was ignored/removed from the `Profile` model in the code nearly 5 years ago](https://github.com/18F/identity-idp/pull/2369). This change actually removes the column from the database.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
