### PR TITLE
Use the instant verify product instead of the parsed errors for get-to-yes

### DIFF
--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -17,13 +17,16 @@ module Proofing
           NewRelic::Agent.notice_error(exception)
           ResolutionResult.new(
             success: false, errors: {}, exception: exception,
-            vendor_name: 'lexisnexis:instant_verify'
+            vendor_name: 'lexisnexis:instant_verify',
+            vendor_workflow: config.instant_verify_workflow
           )
         end
 
         private
 
         def build_result_from_response(verification_response)
+          instant_verify_product = find_instant_verify_product(verification_response)
+
           Proofing::ResolutionResult.new(
             success: verification_response.verification_status == 'passed',
             errors: parse_verification_errors(verification_response),
@@ -32,11 +35,14 @@ module Proofing
             transaction_id: verification_response.conversation_id,
             reference: verification_response.reference,
             failed_result_can_pass_with_additional_verification:
-              failed_result_can_pass_with_additional_verification?(verification_response),
+              failed_result_can_pass_with_additional_verification?(
+                verification_response,
+                instant_verify_product,
+              ),
             attributes_requiring_additional_verification:
-              attributes_requiring_additional_verification(verification_response),
-            vendor_workflow: config.phone_finder_workflow,
-            drivers_license_info_matches: drivers_license_info_matches?(verification_response),
+              attributes_requiring_additional_verification(instant_verify_product),
+            vendor_workflow: config.instant_verify_workflow,
+            drivers_license_info_matches: drivers_license_info_matches?(instant_verify_product),
           )
         end
 
@@ -49,35 +55,41 @@ module Proofing
         end
 
         # rubocop:disable Layout/LineLength
-        def failed_result_can_pass_with_additional_verification?(verification_response)
+        def failed_result_can_pass_with_additional_verification?(verification_response, instant_verify_product)
           return false unless verification_response.verification_status == 'failed'
-          return false unless verification_response.verification_errors.keys.to_set == Set[:InstantVerify, :base]
-          return false unless verification_response.verification_errors[:base].match?(/(total|priority)\.scoring\.model\.verification\.fail/)
-          return false unless attributes_requiring_additional_verification(verification_response).any?
+          return false unless verification_response.transaction_reason_code.match?(/(total|priority)\.scoring\.model\.verification\.fail/)
+          return false unless instant_verify_product.present?
+          return false unless instant_verify_product['ProductStatus'] == 'fail'
+          return false unless attributes_requiring_additional_verification(instant_verify_product).any?
           true
         end
         # rubocop:enable Layout/LineLength
 
-        def attributes_requiring_additional_verification(verification_response)
-          CheckToAttributeMapper.new(
-            verification_response.verification_errors[:InstantVerify],
-          ).map_failed_checks_to_attributes
+        def attributes_requiring_additional_verification(instant_verify_product)
+          CheckToAttributeMapper.new(instant_verify_product).map_failed_checks_to_attributes
         end
 
-        def drivers_license_info_matches?(verification_response)
-          instant_verify_product = verification_response.response_body['Products']&.first
-          return false unless instant_verify_product.present?
-          return false unless instant_verify_product['ProductType'] == 'InstantVerify'
-
-          dln_products = instant_verify_product.fetch('Items', []).select do |item|
+        def drivers_license_info_matches?(instant_verify_product)
+          dln_products = instant_verify_product&.fetch('Items', [])&.select do |item|
             DRIVERS_LICENSE_CHECK_NAMES.include?(item['ItemName'])
           end
 
+          return false if dln_products.nil?
           return false unless dln_products.length == DRIVERS_LICENSE_CHECK_NAMES.length
 
           dln_products.none? do |item|
             item['ItemStatus'] != 'pass'
           end
+        end
+
+        def find_instant_verify_product(verification_response)
+          return if verification_response.product_list.length > 1
+          return if verification_response.product_list.blank?
+
+          product = verification_response.product_list.first
+          return unless product['ProductType'] == 'InstantVerify'
+
+          product
         end
       end
     end

--- a/app/services/proofing/lexis_nexis/response.rb
+++ b/app/services/proofing/lexis_nexis/response.rb
@@ -26,6 +26,10 @@ module Proofing
         @reference ||= response_body.dig('Status', 'Reference')
       end
 
+      def transaction_reason_code
+        response_body.dig('Status', 'TransactionReasonCode', 'Code')
+      end
+
       # @api private
       def response_body
         @response_body ||= JSON.parse(response.body)
@@ -37,6 +41,10 @@ module Proofing
         content_type = response.headers&.[]('Content-Type')
         error_message = "An error occured parsing the response body JSON, status=#{response.status} content_type=#{content_type}" # rubocop:disable Layout/LineLength
         raise JSON::ParserError, error_message
+      end
+
+      def product_list
+        @product_list = response_body.fetch('Products', [])
       end
 
       private

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
@@ -46,7 +46,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         expect(result.success?).to eq(true)
         expect(result.errors).to include(InstantVerify: include(a_kind_of(Hash)))
         expect(result.vendor_workflow).to(
-          eq(LexisNexisFixtures.example_config.phone_finder_workflow),
+          eq(LexisNexisFixtures.example_config.instant_verify_workflow),
         )
       end
     end
@@ -70,7 +70,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         expect(result.transaction_id).to eq('123456')
         expect(result.reference).to eq('0987:1234-abcd')
         expect(result.vendor_workflow).to(
-          eq(LexisNexisFixtures.example_config.phone_finder_workflow),
+          eq(LexisNexisFixtures.example_config.instant_verify_workflow),
         )
       end
     end
@@ -88,7 +88,9 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         expect(result.errors).to eq({})
         expect(result.exception).to be_a(Proofing::TimeoutError)
         expect(result.timed_out?).to eq(true)
-        expect(result.vendor_workflow).to be(nil)
+        expect(result.vendor_workflow).to eq(
+          LexisNexisFixtures.example_config.instant_verify_workflow,
+        )
       end
     end
 
@@ -106,7 +108,9 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         expect(result.exception).to be_a(RuntimeError)
         expect(result.exception.message).to eq('fancy test error')
         expect(result.timed_out?).to eq(false)
-        expect(result.vendor_workflow).to be(nil)
+        expect(result.vendor_workflow).to eq(
+          LexisNexisFixtures.example_config.instant_verify_workflow,
+        )
       end
     end
 
@@ -124,8 +128,8 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
 
           expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
           expect(result.attributes_requiring_additional_verification).to eq([:dob])
-          expect(result.vendor_workflow).to(
-            eq(LexisNexisFixtures.example_config.phone_finder_workflow),
+          expect(result.vendor_workflow).to eq(
+            LexisNexisFixtures.example_config.instant_verify_workflow,
           )
         end
       end
@@ -143,8 +147,8 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
 
           expect(result.failed_result_can_pass_with_additional_verification?).to eq(false)
           expect(result.attributes_requiring_additional_verification).to be_empty
-          expect(result.vendor_workflow).to(
-            eq(LexisNexisFixtures.example_config.phone_finder_workflow),
+          expect(result.vendor_workflow).to eq(
+            LexisNexisFixtures.example_config.instant_verify_workflow,
           )
         end
       end

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -83,6 +83,43 @@ describe Proofing::LexisNexis::Response do
     end
   end
 
+  describe '#product_list' do
+    context 'for a response with a product list' do
+      it 'returns the product list' do
+        product_list = subject.product_list
+
+        expect(product_list.length).to eq(1)
+        expect(product_list.first['ProductType']).to eq('InstantVerify')
+      end
+    end
+
+    context 'for a response without a product list' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_error_response_json }
+
+      it 'returns an empty array' do
+        product_list = subject.product_list
+
+        expect(product_list).to eq([])
+      end
+    end
+  end
+
+  describe '#transaction_reason_code' do
+    context 'for a response with a transaction reason code' do
+      let(:response_body) { LexisNexisFixtures.instant_verify_identity_not_found_response_json }
+
+      it 'returns the reason code' do
+        expect(subject.transaction_reason_code).to eq('total.scoring.model.verification.fail')
+      end
+    end
+
+    context 'for a response without a transaciton reason code' do
+      it 'returns nil' do
+        expect(subject.transaction_reason_code).to eq(nil)
+      end
+    end
+  end
+
   describe '#response_body' do
     context 'the result includes invalid JSON' do
       let(:response_body) { '$":^&' }

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -11,6 +11,8 @@ shared_examples 'a lexisnexis rdp proofer' do
     allow(response).to receive(:reference).and_return(reference)
     allow(response).to receive(:verification_errors).and_return(verification_errors)
     allow(response).to receive(:response_body).and_return({})
+    allow(response).to receive(:transaction_reason_code).and_return('123abc')
+    allow(response).to receive(:product_list).and_return([])
 
     allow(verification_request).to receive(:send).and_return(response)
     allow(verification_request.class).to receive(:new).


### PR DESCRIPTION
The get-to-yes with AAMVA feature was developed to allow users whose data fails a LexisNexis check to pass if the same attributes pass an AAMVA check. This was done by observing the errors from the LexisNexis transaction and determining which attributes fail and whether they can be covered by AAMVA.

This approaches to determining which attributes fail from the errors turned out to be problematic. The errors are parsed from the LexisNexis InstantVerify product portion of the RDP response and returned as a hash. The structure of that hash has changed occasionally causing this feature to quietly break.

This commit attempts to clean this up by directly inspecting the InstantVerify product instead of looking at the errors hash. This requires parsing out the product in the proofer. There is also some minor refactor to the response object to make some of the attributes in the response first class methods there.
