### PR TITLE
LG-9209 Use the ExecutedStepName to group LexisNexis errors

### DIFF
--- a/app/services/proofing/lexis_nexis/verification_error_parser.rb
+++ b/app/services/proofing/lexis_nexis/verification_error_parser.rb
@@ -50,7 +50,7 @@ module Proofing
           # don't log PhoneFinder reflected PII
           product.delete('ParameterDetails') if product['ProductType'] == 'PhoneFinder'
 
-          key = product.fetch('ProductType').to_sym
+          key = product.fetch('ExecutedStepName').to_sym
           error_messages[key] = product
         end
       end

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         result_context_stages_threatmetrix = result_context_stages[:threatmetrix]
 
         expect(result[:exception]).to be_nil
-        expect(result[:errors].keys).to eq([:InstantVerify])
+        expect(result[:errors].keys).to eq([:'Execute Instant Verify'])
         expect(result[:success]).to be true
         expect(result[:timed_out]).to be false
 
@@ -79,7 +79,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         # result[:context][:stages][:resolution]
         expect(result_context_stages_resolution[:vendor_name]).
           to eq('lexisnexis:instant_verify')
-        expect(result_context_stages_resolution[:errors]).to include(:InstantVerify)
+        expect(result_context_stages_resolution[:errors]).to include(:'Execute Instant Verify')
         expect(result_context_stages_resolution[:exception]).to eq(nil)
         expect(result_context_stages_resolution[:success]).to eq(true)
         expect(result_context_stages_resolution[:timed_out]).to eq(false)
@@ -134,13 +134,16 @@ RSpec.describe ResolutionProofingJob, type: :job do
         result_context_stages_resolution = result_context_stages[:resolution]
 
         expect(result[:success]).to be false
-        expect(result[:errors].keys).to eq([:base, :InstantVerify])
+        expect(result[:errors].keys).to eq([:base, :'Execute Instant Verify'])
         expect(result[:exception]).to be_nil
         expect(result[:timed_out]).to be false
 
         # result[:context][:stages][:resolution]
         expect(result_context_stages_resolution[:success]).to eq(false)
-        expect(result_context_stages_resolution[:errors]).to include(:base, :InstantVerify)
+        expect(result_context_stages_resolution[:errors]).to include(
+          :base,
+          :'Execute Instant Verify',
+        )
         expect(result_context_stages_resolution[:exception]).to eq(nil)
         expect(result_context_stages_resolution[:timed_out]).to eq(false)
       end
@@ -162,7 +165,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         result_context_stages_state_id = result_context_stages[:state_id]
 
         expect(result[:success]).to be true
-        expect(result[:errors].keys).to eq([:base, :InstantVerify])
+        expect(result[:errors].keys).to eq([:base, :'Execute Instant Verify'])
         expect(result[:exception]).to be_nil
         expect(result[:timed_out]).to be false
 
@@ -200,7 +203,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         result_context_stages_state_id = result_context_stages[:state_id]
 
         expect(result[:success]).to be false
-        expect(result[:errors].keys).to eq([:base, :InstantVerify])
+        expect(result[:errors].keys).to eq([:base, :'Execute Instant Verify'])
         expect(result[:exception]).to be_nil
         expect(result[:timed_out]).to be false
 

--- a/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/proofing_spec.rb
@@ -44,7 +44,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         result = subject.proof(applicant)
 
         expect(result.success?).to eq(true)
-        expect(result.errors).to include(InstantVerify: include(a_kind_of(Hash)))
+        expect(result.errors).to include('Execute Instant Verify': include(a_kind_of(Hash)))
         expect(result.vendor_workflow).to(
           eq(LexisNexisFixtures.example_config.instant_verify_workflow),
         )
@@ -65,7 +65,7 @@ describe Proofing::LexisNexis::InstantVerify::Proofer do
         expect(result.success?).to eq(false)
         expect(result.errors).to include(
           base: include(a_kind_of(String)),
-          InstantVerify: include(a_kind_of(Hash)),
+          'Execute Instant Verify': include(a_kind_of(Hash)),
         )
         expect(result.transaction_id).to eq('123456')
         expect(result.reference).to eq('0987:1234-abcd')

--- a/spec/services/proofing/lexis_nexis/phone_finder/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/proofing_spec.rb
@@ -49,7 +49,7 @@ describe Proofing::LexisNexis::PhoneFinder::Proofer do
 
         expect(result.success?).to eq(true)
         expect(result.errors).to include(
-          PhoneFinder: include(a_kind_of(Hash)),
+          Execute_PhoneFinder: include(a_kind_of(Hash)),
         )
         expect(result.vendor_workflow).to(
           eq(LexisNexisFixtures.example_config.phone_finder_workflow),

--- a/spec/services/proofing/lexis_nexis/response_spec.rb
+++ b/spec/services/proofing/lexis_nexis/response_spec.rb
@@ -33,7 +33,7 @@ describe Proofing::LexisNexis::Response do
         errors = subject.verification_errors
 
         expect(errors).to be_a(Hash)
-        expect(errors).to include(:base, :InstantVerify)
+        expect(errors).to include(:base, :'Execute Instant Verify')
       end
     end
 
@@ -41,7 +41,7 @@ describe Proofing::LexisNexis::Response do
       it 'returns a hash of error' do
         errors = subject.verification_errors
 
-        expect(errors).to have_key(:InstantVerify)
+        expect(errors).to have_key(:'Execute Instant Verify')
       end
     end
   end
@@ -76,7 +76,7 @@ describe Proofing::LexisNexis::Response do
           errors = subject.verification_errors
 
           expect(errors).to be_a(Hash)
-          expect(errors).to include(:base, :InstantVerify)
+          expect(errors).to include(:base, :'Execute Instant Verify')
           expect(errors[:base]).to eq("Invalid status in response body: 'fake_status'")
         end
       end

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -11,29 +11,31 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
 
     it 'should return an array of errors from the response' do
       expect(errors[:base]).to start_with('Verification failed with code:')
-      expect(errors[:InstantVerify]).to eq(response_body['Products'].first) # log product error
+      expect(errors[:'Execute Instant Verify']).to eq(response_body['Products'].first)
     end
 
     it 'should not log a passing response containing no important information' do
+      response_body['Products'].first['ExecutedStepName'] = 'Executed Fake Product'
       response_body['Products'].first['ProductType'] = 'Fake Product'
       response_body['Products'].first['ProductStatus'] = 'pass'
       response_body['Products'].first['Items'].map { |i| i.delete('ItemReason') }
 
-      expect(errors[:'Fake Product']).to eq(nil)
+      expect(errors[:'Executed Fake Product']).to eq(nil)
     end
 
     it 'should log any Instant Verify response, including a pass' do
       response_body['Products'].first['ProductStatus'] = 'pass'
       response_body['Products'].first['Items'].map { |i| i.delete('ItemReason') }
 
-      expect(errors[:InstantVerify]).to be_a Hash
+      expect(errors[:'Execute Instant Verify']).to be_a Hash
     end
 
     it 'should log any response with an ItemReason, including a pass' do
+      response_body['Products'].first['ExecutedStepName'] = 'Executed Fake Product'
       response_body['Products'].first['ProductType'] = 'Fake Product'
       response_body['Products'].first['ProductStatus'] = 'pass'
 
-      expect(errors[:'Fake Product']).to be_a Hash
+      expect(errors[:'Executed Fake Product']).to be_a Hash
     end
   end
 end


### PR DESCRIPTION
Previously we used the `ProductType` key in the LexisNexis verification error parser as the key for errors. This was done to support the get-to-yes feature with AAMVA. #8176 changes the get-to-yes feature to inspect the response body instead of the errors hash so this is not longer needed to support get-to-yes.

The `ProductType` key is problematic because the LexisNexis response can have multiple products with the same product type. We have observed this with PhoneFinder where responses may contain 2 PhoneFinder products with different `ExecutedStepName` values. Grouping by `ProductType` causes one of the products to be overwritten. This commit attempts to address that issue by grouping by `ExecutedStepName`.
