### PR TITLE
Remove implicit two_factor_authentication_method in favor of explicitly passing the authentication method name

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -91,7 +91,7 @@ module TwoFactorAuthenticatableMethods
   end
 
   def handle_valid_otp(next_url:, auth_method: nil)
-    handle_valid_otp_for_context(auth_method)
+    handle_valid_otp_for_context(auth_method: auth_method)
     handle_remember_device
     next_url ||= after_otp_verification_confirmation_url
     reset_otp_session_data
@@ -103,7 +103,7 @@ module TwoFactorAuthenticatableMethods
     save_remember_device_preference
   end
 
-  def handle_valid_otp_for_context(auth_method)
+  def handle_valid_otp_for_context(auth_method:)
     if UserSessionContext.authentication_or_reauthentication_context?(context)
       handle_valid_otp_for_authentication_context(auth_method: auth_method)
     elsif UserSessionContext.confirmation_context?(context)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -70,12 +70,11 @@ module TwoFactorAuthenticatableMethods
     redirect_to after_otp_verification_confirmation_url
   end
 
-  def check_sp_required_mfa_bypass
+  def check_sp_required_mfa_bypass(auth_method:)
     return unless service_provider_mfa_policy.user_needs_sp_auth_method_verification?
-    method = two_factor_authentication_method
     return if service_provider_mfa_policy.phishing_resistant_required? &&
-              ServiceProviderMfaPolicy::PHISHING_RESISTANT_METHODS.include?(method)
-    return if service_provider_mfa_policy.piv_cac_required? && method == 'piv_cac'
+              ServiceProviderMfaPolicy::PHISHING_RESISTANT_METHODS.include?(auth_method)
+    return if service_provider_mfa_policy.piv_cac_required? && auth_method == 'piv_cac'
     prompt_to_verify_sp_required_mfa
   end
 
@@ -110,14 +109,6 @@ module TwoFactorAuthenticatableMethods
     elsif UserSessionContext.confirmation_context?(context)
       handle_valid_otp_for_confirmation_context
     end
-  end
-
-  def two_factor_authentication_method
-    auth_method = params[:otp_delivery_preference] || request.path.split('/').last
-    # the above check gets a wrong value for piv_cac when there is no OTP screen
-    # so we patch it to fix LG-3228
-    auth_method = 'piv_cac' if auth_method == 'present_piv_cac'
-    auth_method
   end
 
   # Method will be renamed in the next refactor.
@@ -286,26 +277,8 @@ module TwoFactorAuthenticatableMethods
     user_session[:unconfirmed_phone] && UserSessionContext.confirmation_context?(context)
   end
 
-  def phone_view_data
-    {
-      confirmation_for_add_phone: confirmation_for_add_phone?,
-      phone_number: display_phone_to_deliver_to,
-      code_value: direct_otp_code,
-      otp_expiration: otp_expiration,
-      otp_delivery_preference: two_factor_authentication_method,
-      otp_make_default_number: selected_otp_make_default_number,
-      unconfirmed_phone: unconfirmed_phone?,
-    }.merge(generic_data)
-  end
-
   def selected_otp_make_default_number
     params&.dig(:otp_make_default_number)
-  end
-
-  def authenticator_view_data
-    {
-      two_factor_authentication_method: two_factor_authentication_method,
-    }.merge(generic_data)
   end
 
   def generic_data
@@ -328,25 +301,6 @@ module TwoFactorAuthenticatableMethods
 
   def confirmation_for_add_phone?
     UserSessionContext.confirmation_context?(context) && user_fully_authenticated?
-  end
-
-  def presenter_for_two_factor_authentication_method
-    case two_factor_authentication_method.to_sym
-    when :authenticator
-      TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(
-        data: authenticator_view_data,
-        view: view_context,
-        service_provider: current_sp,
-        remember_device_default: remember_device_default,
-      )
-    when :sms, :voice
-      TwoFactorAuthCode::PhoneDeliveryPresenter.new(
-        data: phone_view_data,
-        view: view_context,
-        service_provider: current_sp,
-        remember_device_default: remember_device_default,
-      )
-    end
   end
 
   def phone_configuration

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -3,7 +3,7 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
 
     prepend_before_action :authenticate_user
-    before_action :check_sp_required_mfa_bypass
+    before_action :check_sp_required_mfa
 
     def show
       analytics.multi_factor_auth_enter_backup_code_visit(context: context)
@@ -76,6 +76,10 @@ module TwoFactorAuthentication
     def handle_valid_backup_code
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
+    end
+
+    def check_sp_required_mfa
+      check_sp_required_mfa_bypass(auth_method: 'backup_code')
     end
   end
 end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -3,7 +3,7 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
     include MfaSetupConcern
 
-    before_action :check_sp_required_mfa_bypass
+    before_action :check_sp_required_mfa
     before_action :confirm_multiple_factors_enabled
     before_action :redirect_if_blank_phone, only: [:show]
     before_action :confirm_voice_capability, only: [:show]
@@ -62,7 +62,7 @@ module TwoFactorAuthentication
     end
 
     def confirm_voice_capability
-      return if two_factor_authentication_method == 'sms'
+      return if params[:otp_delivery_preference] == 'sms'
 
       phone_is_confirmed = UserSessionContext.authentication_or_reauthentication_context?(context)
 
@@ -133,6 +133,31 @@ module TwoFactorAuthentication
         in_multi_mfa_selection_flow: in_multi_mfa_selection_flow?,
         enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
       }
+    end
+
+    def presenter_for_two_factor_authentication_method
+      TwoFactorAuthCode::PhoneDeliveryPresenter.new(
+        data: phone_view_data,
+        view: view_context,
+        service_provider: current_sp,
+        remember_device_default: remember_device_default,
+      )
+    end
+
+    def phone_view_data
+      {
+        confirmation_for_add_phone: confirmation_for_add_phone?,
+        phone_number: display_phone_to_deliver_to,
+        code_value: direct_otp_code,
+        otp_expiration: otp_expiration,
+        otp_delivery_preference: params[:otp_delivery_preference],
+        otp_make_default_number: selected_otp_make_default_number,
+        unconfirmed_phone: unconfirmed_phone?,
+      }.merge(generic_data)
+    end
+
+    def check_sp_required_mfa
+      check_sp_required_mfa_bypass(auth_method: params[:otp_delivery_preference])
     end
   end
 end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -71,7 +71,7 @@ module TwoFactorAuthentication
 
     def piv_cac_view_data
       {
-        two_factor_authentication_method: two_factor_authentication_method,
+        two_factor_authentication_method: 'piv_cac',
         hide_fallback_question: service_provider_mfa_policy.piv_cac_required?,
       }.merge(generic_data)
     end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -2,6 +2,7 @@ module TwoFactorAuthentication
   class TotpVerificationController < ApplicationController
     include TwoFactorAuthenticatable
 
+    before_action :check_sp_required_mfa
     before_action :confirm_totp_enabled
 
     def show
@@ -34,6 +35,25 @@ module TwoFactorAuthentication
       return if current_user.auth_app_configurations.any?
 
       redirect_to user_two_factor_authentication_url
+    end
+
+    def presenter_for_two_factor_authentication_method
+      TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(
+        data: authenticator_view_data,
+        view: view_context,
+        service_provider: current_sp,
+        remember_device_default: remember_device_default,
+      )
+    end
+
+    def authenticator_view_data
+      {
+        two_factor_authentication_method: 'authenticator',
+      }.merge(generic_data)
+    end
+
+    def check_sp_required_mfa
+      check_sp_required_mfa_bypass(auth_method: 'authenticator')
     end
   end
 end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -3,7 +3,7 @@ module TwoFactorAuthentication
   class WebauthnVerificationController < ApplicationController
     include TwoFactorAuthenticatable
 
-    before_action :check_sp_required_mfa_bypass
+    before_action :check_sp_required_mfa
     before_action :confirm_webauthn_enabled, only: :show
 
     def show
@@ -131,6 +131,10 @@ module TwoFactorAuthentication
         credential_id: params[:credential_id],
         webauthn_error: params[:webauthn_error],
       )
+    end
+
+    def check_sp_required_mfa
+      check_sp_required_mfa_bypass(auth_method: 'webauthn')
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This PR is the followup mentioned in #8172 to remove the `two_factor_authentication_method` that infers the 2FA method from a couple different places. The method is replaced by explicitly passing the methods used and moving dynamic calculation of `presenter_for_two_factor_authentication_method` to the controllers where the presenters are used.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
