### PR TITLE
LG-9431 new CaptureComplete controller (feature flagged)

### DIFF
--- a/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
@@ -1,0 +1,49 @@
+module Idv
+  module HybridMobile
+    class CaptureCompleteController < ApplicationController
+      include IdvSession
+      include IdvStepConcern
+      include StepIndicatorConcern
+      include StepUtilitiesConcern
+
+      before_action :render_404_if_hybrid_mobile_controllers_disabled
+
+      def show
+        increment_step_counts
+
+        analytics.idv_doc_auth_capture_complete_visited(**analytics_arguments)
+
+        Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+          call('capture_complete', :view, true)
+
+        render :show
+      end
+
+      private
+
+      def render_404_if_hybrid_mobile_controllers_disabled
+        render_not_found unless IdentityConfig.store.doc_auth_hybrid_mobile_controllers_enabled
+      end
+
+      def analytics_arguments
+        {
+          flow_path: 'hybrid',
+          step: 'capture_complete',
+          step_count: current_flow_step_counts['Idv::Steps::CaptureCompleteStep'],
+          analytics_id: 'Doc Auth',
+          irs_reproofing: irs_reproofing?,
+        }.merge(**acuant_sdk_ab_test_analytics_args)
+      end
+
+      def current_flow_step_counts
+        user_session['idv/doc_auth_flow_step_counts'] ||= {}
+        user_session['idv/doc_auth_flow_step_counts'].default = 0
+        user_session['idv/doc_auth_flow_step_counts']
+      end
+
+      def increment_step_counts
+        current_flow_step_counts['Idv::Steps::CaptureCompleteStep'] += 1
+      end
+    end
+  end
+end

--- a/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
+++ b/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
@@ -1,0 +1,9 @@
+<% title t('titles.doc_auth.switch_back') %>
+
+<%= render AlertComponent.new(type: :success, class: 'margin-bottom-4') do %>
+  <%= t('doc_auth.headings.capture_complete') %>
+<% end %>
+
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.instructions.switch_back')) %>
+
+<%= image_tag(asset_url('idv/switch.png'), width: 193, height: 109, alt: t('doc_auth.instructions.switch_back_image')) %>

--- a/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
+++ b/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
@@ -1,3 +1,12 @@
+<% content_for(:pre_flash_content) do %>
+  <%= render StepIndicatorComponent.new(
+        steps: Idv::Flows::CaptureDocFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_id,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      ) %>
+<% end %>
+
 <% title t('titles.doc_auth.switch_back') %>
 
 <%= render AlertComponent.new(type: :success, class: 'margin-bottom-4') do %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -92,6 +92,7 @@ doc_auth_s3_request_timeout: 5
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
+doc_auth_hybrid_mobile_controllers_enabled: false
 doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_tips: 3
 doc_auth_max_capture_attempts_before_native_camera: 2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,6 +325,7 @@ Rails.application.routes.draw do
       post '/forgot_password' => 'forgot_password#update'
       get '/document_capture' => 'document_capture#show'
       put '/document_capture' => 'document_capture#update'
+      get '/hybrid_mobile/capture_complete' => 'hybrid_mobile/capture_complete#show'
       get '/ssn' => 'ssn#show'
       put '/ssn' => 'ssn#update'
       get '/verify_info' => 'verify_info#show'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -162,6 +162,7 @@ class IdentityConfig
     config.add(:doc_auth_error_glare_threshold, type: :integer)
     config.add(:doc_auth_error_sharpness_threshold, type: :integer)
     config.add(:doc_auth_extend_timeout_by_minutes, type: :integer)
+    config.add(:doc_auth_hybrid_mobile_controllers_enabled, type: :boolean)
     config.add(:doc_auth_max_attempts, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe Idv::HybridMobile::CaptureCompleteController do
+  include IdvHelper
+
+  let(:user) { create(:user) }
+  let(:service_provider) do
+    create(
+      :service_provider,
+      issuer: 'http://sp.example.com',
+      app_id: '123',
+    )
+  end
+
+  before do
+    stub_sign_in(user)
+  end
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+
+    it 'checks that feature flag is enabled' do
+      expect(subject).to have_actions(
+        :before,
+        :render_404_if_hybrid_mobile_controllers_disabled,
+      )
+    end
+  end
+
+  context 'when doc_auth_document_capture_controller_enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_hybrid_mobile_controllers_enabled).
+        and_return(true)
+      stub_analytics
+      allow(@analytics).to receive(:track_event)
+    end
+
+    describe '#show' do
+      let(:analytics_name) { 'IdV: doc auth capture_complete visited' }
+      let(:analytics_args) do
+        {
+          analytics_id: 'Doc Auth',
+          flow_path: 'hybrid',
+          irs_reproofing: false,
+          step: 'capture_complete',
+          step_count: 1,
+        }
+      end
+
+      it 'renders the show template' do
+        get :show
+
+        expect(response).to render_template :show
+      end
+
+      it 'sends analytics_visited event' do
+        get :show
+
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      it 'sends correct step count to analytics' do
+        get :show
+        get :show
+        analytics_args[:step_count] = 2
+
+        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      end
+
+      it 'updates DocAuthLog capture_complete_view_count' do
+        doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+        expect { get :show }.to(
+          change { doc_auth_log.reload.capture_complete_view_count }.from(0).to(1),
+        )
+      end
+    end
+  end
+end

--- a/spec/features/idv/hybrid_mobile/capture_complete_spec.rb
+++ b/spec/features/idv/hybrid_mobile/capture_complete_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature 'capture complete step', :js do
+  include IdvStepHelper
+  include DocAuthHelper
+  include DocCaptureHelper
+
+  let(:user) { user_with_2fa }
+
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_hybrid_mobile_controllers_enabled).
+      and_return(true)
+    complete_doc_capture_steps_before_capture_complete_step(user)
+    allow_any_instance_of(Browser).to receive(:mobile?).and_return(true)
+    sign_in_and_2fa_user(user)
+    visit(idv_hybrid_mobile_capture_complete_url)
+  end
+
+  it 'is on the correct page' do
+    expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+    expect(page).to have_content(t('doc_auth.headings.capture_complete'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+  end
+end

--- a/spec/features/idv/hybrid_mobile/capture_complete_spec.rb
+++ b/spec/features/idv/hybrid_mobile/capture_complete_spec.rb
@@ -7,7 +7,6 @@ feature 'capture complete step', :js do
 
   let(:user) { user_with_2fa }
 
-
   before do
     allow(IdentityConfig.store).to receive(:doc_auth_hybrid_mobile_controllers_enabled).
       and_return(true)


### PR DESCRIPTION
## 🎫 Ticket

[LG-9431](https://cm-jira.usa.gov/browse/LG-9431)

## 🛠 Summary of changes

This is the first part of moving the mobile part of document capture hybrid flow out of the Flow State Machine. There are two steps in the flow, Document Capture and Capture Complete.
- Add feature flag `doc_auth_hybrid_mobile_controllers_enabled` and default to false
- Add HybridMobile::CaptureCompleteController and specs to show the correct view
- Add GET route

Notes:
- Do we want the route to include `/hybrid_mobile/`? What link will we want to text for the hybrid DocumentCaptureController, since `_` causes problems?
- I had to log the user in again in the feature spec. Not sure what's missing there.
- It does not yet have before actions to check where the user is in the flow (future PR)
- This step is currently part of the CaptureDoc flow and there may be functionality provided by that controller that needs to be added (future PR)

## 📜 Testing Plan

- [ ] Set feature flag `doc_auth_hybrid_mobile_controllers_enabled` to true'
- [ ] Create an account or log in
- [ ] Navigate to `/verify/hybrid_mobile/capture_complete`

## 👀 Screenshots

Screenshot on my phone!
<details>
 
![CaptureComplete](https://user-images.githubusercontent.com/2381438/231309640-b166ec2b-efe1-42fe-8edc-53cfd08a9b37.PNG)
</details>
