### PR TITLE
Optimize user_fully_authenticated to defer database query

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -291,13 +291,11 @@ class ApplicationController < ActionController::Base
   end
 
   def user_fully_authenticated?
-    !reauthn? && user_signed_in? &&
-      two_factor_enabled? &&
+    !reauthn? &&
+      user_signed_in? &&
       session['warden.user.user.session'] &&
-      !session['warden.user.user.session'].try(
-        :[],
-        TwoFactorAuthenticatable::NEED_AUTHENTICATION,
-      )
+      !session['warden.user.user.session'][TwoFactorAuthenticatable::NEED_AUTHENTICATION] &&
+      two_factor_enabled?
   end
 
   def reauthn?


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors `ApplicationController#user_fully_authenticated?` to defer the check to whether the user has configured two-factor methods, so that it can return early after the Warden session value has been assigned, as part of the critical login path of a user entering their password.

Practically speaking, this removes a database call when submitting the SIgn-in form and being prompted for MFA.

**Open question:** Do we need the `try` call? There was previous discussion about it at https://github.com/18F/identity-idp/pull/4456/files#r530060021, but it's unclear when the session value would be present and it would _not_ be possible to call the accessor.

## 📜 Testing Plan

1. Visit http://localhost:3000
2. Sign in