### PR TITLE
LG-9333 Preserve the SSN when returning to the SSN controller

### DIFF
--- a/app/forms/idv/ssn_format_form.rb
+++ b/app/forms/idv/ssn_format_form.rb
@@ -8,11 +8,12 @@ module Idv
     attr_accessor :ssn
 
     def self.model_name
-      ActiveModel::Name.new(self, nil, 'Ssn')
+      ActiveModel::Name.new(self, nil, 'doc_auth')
     end
 
-    def initialize(user)
+    def initialize(user, flow_session = {})
       @user = user
+      @ssn = flow_session.dig('pii_from_doc', :ssn)
     end
 
     def submit(params)
@@ -23,6 +24,10 @@ module Idv
         errors: errors,
         extra: { pii_like_keypaths: [[:errors, :ssn], [:error_details, :ssn]] },
       )
+    end
+
+    def updating_ssn?
+      ssn.present?
     end
 
     private

--- a/app/views/idv/in_person/ssn.html.erb
+++ b/app/views/idv/in_person/ssn.html.erb
@@ -50,7 +50,7 @@ locals:
 <% end %>
 
 <%= simple_form_for(
-      :doc_auth,
+      Idv::SsnFormatForm.new(current_user),
       url: url_for,
       method: :put,
       html: { autocomplete: 'off' },

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -17,7 +17,7 @@ locals:
 
 <% title t('titles.doc_auth.ssn') %>
 
-<% if success_alert_enabled %>
+<% if !@ssn_form.updating_ssn? %>
   <%= render AlertComponent.new(
         type: :success,
         class: 'margin-bottom-4',
@@ -26,7 +26,7 @@ locals:
   <% end %>
 <% end %>
 
-<% if updating_ssn %>
+<% if @ssn_form.updating_ssn? %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn_update')) %>
 <% else %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn')) %>
@@ -66,7 +66,7 @@ locals:
 <% end %>
 
 <%= simple_form_for(
-      :doc_auth,
+      @ssn_form,
       url: idv_ssn_url,
       method: :put,
       html: { autocomplete: 'off' },
@@ -78,7 +78,7 @@ locals:
   <p><%= @error_message %></p>
 
   <%= f.submit class: 'display-block margin-y-5' do %>
-    <% if updating_ssn %>
+    <% if @ssn_form.updating_ssn? %>
       <%= t('forms.buttons.submit.update') %>
     <% else %>
       <%= t('forms.buttons.continue') %>
@@ -86,7 +86,7 @@ locals:
   <% end %>
 <% end %>
 
-<% if updating_ssn %>
+<% if @ssn_form.updating_ssn? %>
   <%= render 'idv/shared/back', fallback_path: idv_verify_info_path %>
 <% else %>
   <%= render 'idv/doc_auth/cancel', step: 'ssn' %>

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -15,7 +15,7 @@ locals:
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
         maxlength: 11,
-        input_html: { class: 'ssn-toggle usa-input', value: f.object.ssn },
+        input_html: { class: 'ssn-toggle', value: f.object.ssn },
         error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
       },
     ) %>

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -15,7 +15,7 @@ locals:
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
         maxlength: 11,
-        input_html: { class: 'ssn-toggle', value: f.object.ssn },
+        input_html: { class: 'ssn-toggle usa-input', value: f.object.ssn },
         error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
       },
     ) %>

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -15,7 +15,7 @@ locals:
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
         maxlength: 11,
-        input_html: { class: 'ssn-toggle usa-input', value: '' },
+        input_html: { class: 'ssn-toggle usa-input', value: f.object.ssn },
         error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
       },
     ) %>

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -144,7 +144,8 @@ describe Idv::SsnController do
       end
 
       it 'adds a threatmetrix session id to flow session' do
-        subject.extra_view_variables
+        put :update, params: params
+        subject.threatmetrix_view_variables
         expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
       end
 
@@ -152,7 +153,7 @@ describe Idv::SsnController do
         flow_session['pii_from_doc'][:ssn] = ssn
         put :update, params: params
         session_id = flow_session[:threatmetrix_session_id]
-        subject.extra_view_variables
+        subject.threatmetrix_view_variables
         expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
       end
     end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -75,7 +75,12 @@ feature 'doc auth verify_info step', :js do
 
   it 'allows the user to enter in a new ssn and displays updated info' do
     click_link t('idv.buttons.change_ssn_label')
+
     expect(page).to have_current_path(idv_ssn_path)
+    expect(
+      find_field(t('idv.form.ssn_label_html')).value,
+    ).to eq(DocAuthHelper::GOOD_SSN.gsub(/\D/, ''))
+
     fill_in t('idv.form.ssn_label_html'), with: '900456789'
     click_button t('forms.buttons.submit.update')
 

--- a/spec/forms/idv/ssn_format_form_spec.rb
+++ b/spec/forms/idv/ssn_format_form_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 describe Idv::SsnFormatForm do
   let(:user) { create(:user) }
-  let(:subject) { Idv::SsnFormatForm.new(user) }
   let(:ssn) { '111-11-1111' }
+  let(:flow_session) { {} }
+
+  subject { Idv::SsnFormatForm.new(user, flow_session) }
 
   describe '#submit' do
     context 'when the form is valid' do
@@ -31,6 +33,24 @@ describe Idv::SsnFormatForm do
         expect { subject.submit(ssn: '111111111', foo: 1) }.
           to raise_error(ArgumentError, 'foo is an invalid ssn attribute')
       end
+    end
+  end
+
+  describe '#updating_ssn' do
+    context 'when no flow_session value is provided' do
+      subject { Idv::SsnFormatForm.new(user) }
+
+      it { expect(subject.updating_ssn?).to eq(false) }
+    end
+
+    context 'when the pii_from_doc hash does not contain an SSN value' do
+      it { expect(subject.updating_ssn?).to eq(false) }
+    end
+
+    context 'when there is an SSN in the pii_from_doc hash' do
+      let(:flow_session) { { 'pii_from_doc' => { ssn: '900-12-3456' } } }
+
+      it { expect(subject.updating_ssn?).to eq(true) }
     end
   end
 


### PR DESCRIPTION
The SSN controller allows a user to enter or update their SSN. Prior to this commit the previous value of the SSN was not maintained when the user was updating their SSN.

This commit attempts to fix that by making use of the SSN form that is used in the controller. The template is changed to eventually read the SSN from the form.

Additionally, the form is used in a pattern that better matches the pattern you expect a form object to be used in. This was not the case before because of constraints that the flow state machine placed on HTML forms.
