### PR TITLE
LG-9438 | Adds tests for correct URL redirect location

### DIFF
--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -122,6 +122,11 @@ describe Idv::InPerson::VerifyInfoController do
         put :update
       end
 
+      it 'redirects to idv_in_person_verify_info_url' do
+        put :update
+        expect(response).to redirect_to(idv_in_person_verify_info_url)
+      end
+
       context 'when pii_from_user is blank' do
         it 'redirects' do
           flow_session[:pii_from_user] = {}


### PR DESCRIPTION
@tomas-nava Apologies if I'm just making more work for you in my attempt to help. 😇

I picked up LG-9438, but may be misunderstanding, or it may have been very recently made obsolete by some other change I'm overlooking. This PR was an attempt at TDD, but seems instead to prove correct behavior. It was meant to show that it was redirecting to '/verify/in_person/verify' in error, but it is in fact already going to '/verify/in_person/verify_info' (which is the `idv_in_person_verify_info` route).

This PR probably doesn't make sense to merge, unless LG-9438 is in fact already done and this is useful additional coverage. I think it is more likely there is some missing context and this test may illustrate where I'm going wrong?
