### PR TITLE
Remove reference to embedded icons in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,12 +1,3 @@
-## A few parts of this project are not in the public domain
-
-### Files licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/)
-
-The SVG elements embedded in `app/javascript/packages/components/icon.jsx` are adapted from icons
-provided by [Font Awesome](https://fontawesome.com/), licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
-
-## The rest of this project is in the worldwide public domain
-
 As a work of the United States Government, this project is in the
 public domain within the United States.
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates LICENSE.md to remove an outdated reference to icons which had previously been embedded in one of our React components:

- We no longer embed the Font Awesome icons, instead using pointers to icon names of the U.S. Web Design System ([source](https://github.com/18F/identity-idp/blob/6f6d56c9562eac19eeba069d76d70e24f001d0a8/app/javascript/packages/components/icon.tsx#L5-L246))
- The file path is inaccurate anyways, since it's been renamed from `icon.jsx` to `icon.tsx`

This restores the copy of LICENSE.md to what it had been prior to #4086