### PR TITLE
Avoid caching for webpack dev server resources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,11 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
       watch: false,
     },
     port: devServerPort,
-    headers: { 'Access-Control-Allow-Origin': '*' },
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+      Vary: '*',
+    },
     hot: false,
   },
   entry: entries.reduce((result, path) => {


### PR DESCRIPTION
## 🛠 Summary of changes

Adds caching headers to Webpack development server responses, to help resolve issues where Safari can reload infinitely when live-reloading assets after a change.

Solution via: https://github.com/nuxt/nuxt/issues/3828#issuecomment-658774154

## 📜 Testing Plan

1. `make run`
2. Visit http://localhost:3000 in Safari
3. Edit and save a JavaScript file
4. Observe that Safari reloads, once