### PR TITLE
LG-9391: Improve accessibility for phone dropdown

### DIFF
--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -105,6 +105,13 @@ export class PhoneInputElement extends HTMLElement {
     return this.#strings;
   }
 
+  /**
+   * Returns the element which represents the flag dropdown's currently selected value, which is
+   * rendered as a text element within the combobox. As defined by the ARIA specification, a
+   * combobox's value is determined by its contents if it is not an input element.
+   *
+   * @see https://w3c.github.io/aria/#combobox
+   */
   get valueText(): HTMLElement {
     return this.iti.selectedFlag.querySelector('.usa-sr-only')!;
   }
@@ -129,6 +136,8 @@ export class PhoneInputElement extends HTMLElement {
     if (country.iso2 && this.codeInput) {
       this.codeInput.value = country.iso2.toUpperCase();
       if (this.hasDropdown) {
+        // Move value text from title attribute to the flag's hidden text element.
+        // See: https://github.com/jackocnr/intl-tel-input/blob/d54b127/src/js/intlTelInput.js#L1191-L1197
         this.valueText.textContent = this.iti.selectedFlag.title;
         this.iti.selectedFlag.removeAttribute('title');
       }

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -64,9 +64,9 @@ export class PhoneInputElement extends HTMLElement {
 
     this.textInput = textInput;
     this.codeInput = codeInput;
-    this.iti = this.initializeIntlTelInput();
+    this.initializeIntlTelInput();
 
-    this.textInput.addEventListener('countrychange', () => this.syncCountryChangeToCodeInput());
+    this.textInput.addEventListener('countrychange', () => this.syncCountryToCodeInput());
     this.textInput.addEventListener('input', () => this.validate());
     this.codeInput.addEventListener('change', () => this.formatTextInput());
     this.codeInput.addEventListener('change', () => this.validate());
@@ -105,6 +105,14 @@ export class PhoneInputElement extends HTMLElement {
     return this.#strings;
   }
 
+  get valueText(): HTMLElement {
+    return this.iti.selectedFlag.querySelector('.usa-sr-only')!;
+  }
+
+  get hasDropdown(): boolean {
+    return Boolean(this.supportedCountryCodes && this.supportedCountryCodes.length > 1);
+  }
+
   get captchaExemptCountries(): string[] | boolean {
     try {
       return JSON.parse(this.dataset.captchaExemptCountries!);
@@ -116,17 +124,22 @@ export class PhoneInputElement extends HTMLElement {
   /**
    * Mirrors country change to the hidden select field, which holds the value for form submission.
    */
-  syncCountryChangeToCodeInput() {
+  syncCountryToCodeInput({ fireChangeEvent = true }: { fireChangeEvent?: boolean } = {}) {
     const country = this.iti.getSelectedCountryData();
     if (country.iso2 && this.codeInput) {
       this.codeInput.value = country.iso2.toUpperCase();
-      this.codeInput.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+      if (this.hasDropdown) {
+        this.valueText.textContent = this.iti.selectedFlag.title;
+        this.iti.selectedFlag.removeAttribute('title');
+      }
+      if (fireChangeEvent) {
+        this.codeInput.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+      }
     }
   }
 
   initializeIntlTelInput() {
     const { supportedCountryCodes, countryCodePairs } = this;
-    const allowDropdown = supportedCountryCodes && supportedCountryCodes.length > 1;
 
     const iti = intlTelInput(this.textInput, {
       preferredCountries: ['US', 'CA'],
@@ -134,10 +147,12 @@ export class PhoneInputElement extends HTMLElement {
       localizedCountries: countryCodePairs,
       onlyCountries: supportedCountryCodes,
       autoPlaceholder: 'off',
-      allowDropdown,
+      allowDropdown: this.hasDropdown,
     }) as IntlTelInput;
 
-    if (allowDropdown) {
+    this.iti = iti;
+
+    if (this.hasDropdown) {
       // Remove duplicate items in the country list
       const preferred: NodeListOf<HTMLLIElement> =
         iti.countryList.querySelectorAll('.iti__preferred');
@@ -152,16 +167,14 @@ export class PhoneInputElement extends HTMLElement {
       });
 
       // Improve base accessibility of intl-tel-input
-      iti.flagsContainer.setAttribute('aria-label', this.strings.country_code_label);
-      iti.selectedFlag.setAttribute('aria-haspopup', 'true');
-      iti.selectedFlag.setAttribute('role', 'button');
+      const valueText = document.createElement('div');
+      valueText.classList.add('usa-sr-only');
+      iti.selectedFlag.appendChild(valueText);
+      iti.selectedFlag.setAttribute('aria-label', this.strings.country_code_label);
       iti.selectedFlag.removeAttribute('aria-owns');
     }
 
-    const country = iti.getSelectedCountryData();
-    if (country.iso2 && this.codeInput) {
-      this.codeInput.value = country.iso2.toUpperCase();
-    }
+    this.syncCountryToCodeInput({ fireChangeEvent: false });
 
     return iti;
   }


### PR DESCRIPTION
## 🎫 Ticket

[LG-9391](https://cm-jira.usa.gov/browse/LG-9391)

## 🛠 Summary of changes

Updates the implementation for PhoneInputComponent to improve how its represented to assistive technology:

- Render as combobox to clarify role (e.g. announced as "list box pop up" in macOS VoiceOver)
- Associate named label "Country code" in addition to value
- Improve ARIA hasPopup semantics to associate as `listbox` (previously `"true"`)

Resources:

- https://w3c.github.io/aria/#combobox
- https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. Add Phone Number in account sidebar
4. Activate screen reader
5. Navigate to dropdown toggle
6. Observe proper announcement of name, role, value

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2023-04-13 at 4 52 05 PM](https://user-images.githubusercontent.com/1779930/231880328-db4b97ab-b000-4543-9aff-8564d2f71cf0.png)|![Screen Shot 2023-04-13 at 4 44 15 PM](https://user-images.githubusercontent.com/1779930/231880343-4b348e14-2f98-45dd-b733-c6d25674f216.png)

