### PR TITLE
Remove unused configuration redis_throttle_alternate_url and redis_throttle_alternate_pool_write_enabled configurations

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -261,8 +261,6 @@ recaptcha_secret_key_v3: ''
 recovery_code_length: 4
 redis_irs_attempt_api_url: redis://localhost:6379/2
 redis_throttle_url: redis://localhost:6379/1
-redis_throttle_alternate_url: ''
-redis_throttle_alternate_pool_write_enabled: false
 redis_url: redis://localhost:6379/0
 redis_pool_size: 10
 redis_session_pool_size: 10

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -7,10 +7,3 @@ end
 REDIS_THROTTLE_POOL = ConnectionPool.new(size: IdentityConfig.store.redis_throttle_pool_size) do
   Redis.new(url: IdentityConfig.store.redis_throttle_url)
 end
-
-REDIS_THROTTLE_ALTERNATE_POOL =
-  if IdentityConfig.store.redis_throttle_alternate_url
-    ConnectionPool.new(size: IdentityConfig.store.redis_throttle_pool_size) do
-      Redis.new(url: IdentityConfig.store.redis_throttle_alternate_url)
-    end
-  end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -359,8 +359,6 @@ class IdentityConfig
     config.add(:redis_irs_attempt_api_url)
     config.add(:redis_irs_attempt_api_pool_size, type: :integer)
     config.add(:redis_throttle_url)
-    config.add(:redis_throttle_alternate_url)
-    config.add(:redis_throttle_alternate_pool_write_enabled, type: :boolean)
     config.add(:redis_url)
     config.add(:redis_pool_size, type: :integer)
     config.add(:redis_session_pool_size, type: :integer)


### PR DESCRIPTION
## 🛠 Summary of changes

The migration described in #8000 has been complete for a bit, so we can remove the configuration values for it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
