### PR TITLE
Override tag style to leave case unchanged and make text bold

### DIFF
--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -4,6 +4,8 @@
 
 .usa-tag {
   display: inline-block;
+  text-transform: none;
+  font-weight: bold;
 }
 
 .usa-tag--informative {


### PR DESCRIPTION
## 🎫 Ticket
LG-9313

## 🛠 Summary of changes

Per Andrew Duthie the Login style for tags (like "Recommended" on the Hybrid Handoff screen) is Title case and bold, but the design system is still all caps, so override it for idp for now. This is being done as a separate PR because we'll want to undo it when the overall design system is updated.

## 👀 Screenshots

<details>
<summary>Before: "RECOMMENDED"</summary>
  
![RECOMMENDED](https://user-images.githubusercontent.com/2381438/231886933-9da8fbb9-86c6-4c90-8059-1939ba965533.png)
</details>

<details>
<summary>After: "Recommended (bold)</summary>
  
![Recommended bold](https://user-images.githubusercontent.com/2381438/231886999-3b15b304-7213-4192-99b8-426dc4031eb2.png)
</details>

