### PR TITLE
Configure the DDP mock client to respond with a failed result on `no_result`

### DIFF
--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -50,6 +50,8 @@ module Proofing
         response_body = response_body_json(review_status: review_status)
         request_result = response_body['request_result']
 
+        return exception_result if review_status.nil?
+
         result.review_status = review_status
         result.response_body = response_body
 
@@ -76,6 +78,13 @@ module Proofing
         JSON.parse(json).tap do |json_body|
           json_body['review_status'] = review_status
         end
+      end
+
+      def exception_result
+        Proofing::DdpResult.new(
+          success: false,
+          exception: RuntimeError.new('Unexpected ThreatMetrix review_status value'),
+        )
       end
     end
   end

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Proofing::Mock::DdpMockClient do
     context 'with explicit no_result' do
       let(:redis_result) { 'no_result' }
 
-      it 'has returns an exception result' do
+      it 'has an exception result' do
         expect(result.review_status).to be_nil
         expect(result.response_body).to be_nil
         expect(result.exception.inspect).to include('Unexpected ThreatMetrix review_status value')

--- a/spec/services/proofing/mock/ddp_mock_client_spec.rb
+++ b/spec/services/proofing/mock/ddp_mock_client_spec.rb
@@ -31,9 +31,11 @@ RSpec.describe Proofing::Mock::DdpMockClient do
     context 'with explicit no_result' do
       let(:redis_result) { 'no_result' }
 
-      it 'has a nil review status' do
+      it 'has returns an exception result' do
         expect(result.review_status).to be_nil
-        expect(result.response_body['review_status']).to be_nil
+        expect(result.response_body).to be_nil
+        expect(result.exception.inspect).to include('Unexpected ThreatMetrix review_status value')
+        expect(result.success?).to eq(false)
       end
     end
 


### PR DESCRIPTION
In a previous commit we changed the DDP proofer to respond with an exception result when the result from DDP included an unexpected status (ref: #8149). This includes when the result is nil.

This commit changes the DDP mock's behavior to align with the DDP proofer's behavior.
